### PR TITLE
Add license header to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,9 @@ indent_size = 4
 # Spell checker configuration
 spelling_exclusion_path = "./build/exclusion.dic"
 
+[*.{fs,fsx,cs,vb}]
+file_header_template=Licensed to Elasticsearch B.V under one or more agreements.\nElasticsearch B.V licenses this file to you under the Apache 2.0 License.\nSee the LICENSE file in the project root for more information
+
 [*.{fs,fsx}]
 indent_style = space
 indent_size = 4

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -1,6 +1,7 @@
 // Licensed to Elasticsearch B.V under one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
+
 using ConsoleAppFramework;
 using ProcNet;
 using Zx;

--- a/src/Elastic.Markdown/Diagnostics/DiagnosticsChannel.cs
+++ b/src/Elastic.Markdown/Diagnostics/DiagnosticsChannel.cs
@@ -1,3 +1,7 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
 using System.Threading.Channels;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;

--- a/src/Elastic.Markdown/Diagnostics/ProcessorDiagnosticExtensions.cs
+++ b/src/Elastic.Markdown/Diagnostics/ProcessorDiagnosticExtensions.cs
@@ -1,3 +1,7 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
 using Elastic.Markdown.Myst;
 using Markdig.Helpers;
 using Markdig.Parsers;

--- a/src/Elastic.Markdown/Myst/ParserContext.cs
+++ b/src/Elastic.Markdown/Myst/ParserContext.cs
@@ -1,3 +1,7 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
 using System.IO.Abstractions;
 using Markdig;
 using Markdig.Parsers;

--- a/src/docs-builder/Diagnostics/ErrorCollector.cs
+++ b/src/docs-builder/Diagnostics/ErrorCollector.cs
@@ -1,3 +1,7 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Actions.Core;


### PR DESCRIPTION
Ensures new files will always be bootstrapped with the Elastic license header and thus satisfy our CI check for it
