### PR TITLE
Example VS Code setup through build tasks

### DIFF
--- a/docs/.vscode/tasks.json
+++ b/docs/.vscode/tasks.json
@@ -6,7 +6,7 @@
         {
             "label": "Build Documentation",
             "type": "shell",
-            "command": "docker run -v .:/app/docs -v ./../.artifacts:/app/.artifacts ghcr.io/mpdreamz/docs-builder:edge",
+            "command": "docker run -v .:/app/docs -v ./../.artifacts:/app/.artifacts ghcr.io/mpdreamz/docset-builder:edge",
             "problemMatcher": [],
             "group": {
                 "kind": "build",
@@ -16,7 +16,7 @@
         {
             "label": "Serve Documentation",
             "type": "shell",
-            "command": "docker run --expose 8080 -v .:/app/docs -v ./../.artifacts:/app/.artifacts ghcr.io/mpdreamz/docs-builder:edge serve",
+            "command": "docker run --expose 8080 -v .:/app/docs -v ./../.artifacts:/app/.artifacts ghcr.io/mpdreamz/docset-builder:edge serve",
             "problemMatcher": [],
             "group": {
                 "kind": "build",


### PR DESCRIPTION
This example allows any one to open the `docs` folder and build/serve the documentation without installing any dependencies.

Just pressing CMD+SHIFT+B should suffice

<img width="735" alt="image" src="https://github.com/user-attachments/assets/49b523f0-5ac2-420d-82f2-9bc4745ddaae">
