### PR TITLE
Introduce the notion of minimal parsing

### DIFF
--- a/src/Elastic.Markdown/DocumentationGenerator.cs
+++ b/src/Elastic.Markdown/DocumentationGenerator.cs
@@ -124,7 +124,7 @@ public class DocumentationGenerator
 			var outputFile = OutputFile(file.RelativePath);
 			if (file is MarkdownFile markdown)
 			{
-				await markdown.ParseAsync(token);
+				await markdown.ParseFullAsync(token);
 				await HtmlWriter.WriteAsync(outputFile, markdown, token);
 			}
 			else

--- a/src/Elastic.Markdown/IO/ConfigurationFile.cs
+++ b/src/Elastic.Markdown/IO/ConfigurationFile.cs
@@ -10,7 +10,7 @@ using YamlDotNet.RepresentationModel;
 
 namespace Elastic.Markdown.IO;
 
-public class ConfigurationFile : DocumentationFile
+public record ConfigurationFile : DocumentationFile
 {
 	private readonly IFileInfo _sourceFile;
 	private readonly IDirectoryInfo _rootPath;

--- a/src/Elastic.Markdown/IO/DocumentationFile.cs
+++ b/src/Elastic.Markdown/IO/DocumentationFile.cs
@@ -5,24 +5,17 @@ using System.IO.Abstractions;
 
 namespace Elastic.Markdown.IO;
 
-public abstract class DocumentationFile(IFileInfo sourceFile, IDirectoryInfo rootPath)
+public abstract record DocumentationFile(IFileInfo SourceFile, IDirectoryInfo RootPath)
 {
-	public IFileInfo SourceFile { get; } = sourceFile;
-	public string RelativePath { get; } = Path.GetRelativePath(rootPath.FullName, sourceFile.FullName);
-	public string RelativeFolder { get; } = Path.GetRelativePath(rootPath.FullName, sourceFile.Directory!.FullName);
-
-	public FileInfo OutputFile(IDirectoryInfo outputPath) =>
-		new(Path.Combine(outputPath.FullName, RelativePath.Replace(".md", ".html")));
+	public string RelativePath { get; } = Path.GetRelativePath(RootPath.FullName, SourceFile.FullName);
+	public string RelativeFolder { get; } = Path.GetRelativePath(RootPath.FullName, SourceFile.Directory!.FullName);
 }
 
-public class ImageFile(IFileInfo sourceFile, IDirectoryInfo rootPath, string mimeType = "image/png")
-	: DocumentationFile(sourceFile, rootPath)
-{
-	public string MimeType { get; } = mimeType;
-}
+public record ImageFile(IFileInfo SourceFile, IDirectoryInfo RootPath, string MimeType = "image/png")
+	: DocumentationFile(SourceFile, RootPath);
 
-public class StaticFile(IFileInfo sourceFile, IDirectoryInfo rootPath)
-	: DocumentationFile(sourceFile, rootPath);
+public record StaticFile(IFileInfo SourceFile, IDirectoryInfo RootPath)
+	: DocumentationFile(SourceFile, RootPath);
 
-public class ExcludedFile(IFileInfo sourceFile, IDirectoryInfo rootPath)
-	: DocumentationFile(sourceFile, rootPath);
+public record ExcludedFile(IFileInfo SourceFile, IDirectoryInfo RootPath)
+	: DocumentationFile(SourceFile, RootPath);

--- a/src/Elastic.Markdown/IO/DocumentationFolder.cs
+++ b/src/Elastic.Markdown/IO/DocumentationFolder.cs
@@ -2,8 +2,6 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-using Markdig.Helpers;
-
 namespace Elastic.Markdown.IO;
 
 public class DocumentationFolder
@@ -75,10 +73,10 @@ public class DocumentationFolder
 	{
 		if (_resolved) return;
 
-		await Parallel.ForEachAsync(FilesInOrder, ctx, async (file, token) => await file.ParseAsync(token));
+		await Parallel.ForEachAsync(FilesInOrder, ctx, async (file, token) => await file.MinimalParse(token));
 		await Parallel.ForEachAsync(GroupsInOrder, ctx, async (group, token) => await group.Resolve(token));
 
-		await (Index?.ParseAsync(ctx) ?? Task.CompletedTask);
+		await (Index?.MinimalParse(ctx) ?? Task.CompletedTask);
 
 		_resolved = true;
 	}

--- a/src/Elastic.Markdown/IO/DocumentationSet.cs
+++ b/src/Elastic.Markdown/IO/DocumentationSet.cs
@@ -1,9 +1,8 @@
 // Licensed to Elasticsearch B.V under one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
-using System.Globalization;
+
 using System.IO.Abstractions;
-using System.Text.Json;
 using Elastic.Markdown.Diagnostics;
 using Elastic.Markdown.Myst;
 

--- a/src/Elastic.Markdown/Myst/FrontMatterParser.cs
+++ b/src/Elastic.Markdown/Myst/FrontMatterParser.cs
@@ -22,9 +22,9 @@ public class YamlFrontMatter
 	public Dictionary<string, string>? Properties { get; set; }
 }
 
-public class FrontMatterParser
+public static class FrontMatterParser
 {
-	public YamlFrontMatter Deserialize(string yaml)
+	public static YamlFrontMatter Deserialize(string yaml)
 	{
 		var input = new StringReader(yaml);
 

--- a/src/Elastic.Markdown/Slices/HtmlWriter.cs
+++ b/src/Elastic.Markdown/Slices/HtmlWriter.cs
@@ -40,7 +40,8 @@ public class HtmlWriter
 
 	public async Task<string> RenderLayout(MarkdownFile markdown, Cancel ctx = default)
 	{
-		var html = await markdown.CreateHtmlAsync(markdown.YamlFrontMatter, ctx);
+		var document = await markdown.ParseFullAsync(ctx);
+		var html = markdown.CreateHtml(document);
 		await DocumentationSet.Tree.Resolve(ctx);
 		var navigationHtml = await RenderNavigation(markdown, ctx);
 		var slice = Index.Create(new IndexViewModel

--- a/src/docs-builder/Http/DocumentationWebHost.cs
+++ b/src/docs-builder/Http/DocumentationWebHost.cs
@@ -70,7 +70,7 @@ public class DocumentationWebHost
 		{
 			case MarkdownFile markdown:
 			{
-				await markdown.ParseAsync(ctx);
+				await markdown.ParseFullAsync(ctx);
 				var rendered = await generator.RenderLayout(markdown, ctx);
 				return Results.Content(rendered, "text/html");
 			}

--- a/tests/Elastic.Markdown.Tests/Directives/DirectiveBaseTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/DirectiveBaseTests.cs
@@ -84,7 +84,7 @@ public abstract class DirectiveTest : IAsyncLifetime
 		var collectTask =  Task.Run(async () => await Collector.StartAsync(default), default);
 
 		Document = await File.ParseFullAsync(default);
-		Html = await File.CreateHtmlAsync(File.YamlFrontMatter, default);
+		Html = File.CreateHtml(Document);
 		Collector.Channel.TryComplete();
 
 		await collectTask;

--- a/tests/Elastic.Markdown.Tests/Directives/ImageTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/ImageTests.cs
@@ -20,7 +20,7 @@ public class ImageBlockTests(ITestOutputHelper output) : DirectiveTest<ImageBloc
 {
 	public override Task InitializeAsync()
 	{
-		FileSystem.AddFile(@"img/observability.png", "");
+		FileSystem.AddFile(@"docs/source/img/observability.png", "");
 		return base.InitializeAsync();
 	}
 

--- a/tests/Elastic.Markdown.Tests/Inline/InlneBaseTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/InlneBaseTests.cs
@@ -95,7 +95,7 @@ public abstract class InlineTest : IAsyncLifetime
 	public virtual async Task InitializeAsync()
 	{
 		Document = await File.ParseFullAsync(default);
-		Html = await File.CreateHtmlAsync(File.YamlFrontMatter, default);
+		Html = File.CreateHtml(Document);
 	}
 
 	public Task DisposeAsync() => Task.CompletedTask;


### PR DESCRIPTION
This will only read document instructions (yaml front matter, page TOC) from the document while initially resolving links and navigational structures.