### PR TITLE
Add inline link/image validation

### DIFF
--- a/src/Elastic.Markdown/Diagnostics/ProcessorDiagnosticExtensions.cs
+++ b/src/Elastic.Markdown/Diagnostics/ProcessorDiagnosticExtensions.cs
@@ -28,7 +28,7 @@ public static class ProcessorDiagnosticExtensions
 	}
 
 
-	public static void EmitWarning(this BlockProcessor processor, int line, int column, int length, string message)
+	public static void EmitWarning(this InlineProcessor processor, int line, int column, int length, string message)
 	{
 		var context = processor.GetContext();
 		if (context.SkipValidation) return;

--- a/src/Elastic.Markdown/Elastic.Markdown.csproj
+++ b/src/Elastic.Markdown/Elastic.Markdown.csproj
@@ -26,8 +26,4 @@
     <PackageReference Include="System.IO.Abstractions" Version="21.0.29" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Myst\Inline\" />
-  </ItemGroup>
-
 </Project>

--- a/src/Elastic.Markdown/Myst/Directives/DirectiveHtmlRenderer.cs
+++ b/src/Elastic.Markdown/Myst/Directives/DirectiveHtmlRenderer.cs
@@ -208,7 +208,7 @@ public class DirectiveHtmlRenderer : HtmlObjectRenderer<DirectiveBlock>
 		if (!block.Found || block.IncludePath is null)
 			return;
 
-		var parser = new MarkdownParser(block.DocumentationSourcePath, block.Build);
+		var parser = new MarkdownParser(block.DocumentationSourcePath, block.Build, block.GetTitle);
 		var file = block.FileSystem.FileInfo.New(block.IncludePath);
 		var document = parser.ParseAsync(file, block.FrontMatter, default).GetAwaiter().GetResult();
 		var html = document.ToHtml(parser.Pipeline);

--- a/src/Elastic.Markdown/Myst/Directives/IncludeBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/IncludeBlock.cs
@@ -13,6 +13,8 @@ public class IncludeBlock(DirectiveBlockParser parser, Dictionary<string, string
 
 	public BuildContext Build { get; } = context.Build;
 
+	public Func<string, string?>? GetTitle { get; } = context.GetTitle;
+
 	public IFileSystem FileSystem { get; } = context.Build.ReadFileSystem;
 
 	public IDirectoryInfo DocumentationSourcePath { get; } = context.Parser.SourcePath;

--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -1,0 +1,87 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Markdown.Diagnostics;
+using Elastic.Markdown.Myst.Directives;
+using Markdig;
+using Markdig.Helpers;
+using Markdig.Parsers;
+using Markdig.Parsers.Inlines;
+using Markdig.Renderers;
+using Markdig.Syntax.Inlines;
+
+namespace Elastic.Markdown.Myst.InlineParsers;
+
+public static class DirectiveMarkdownBuilderExtensions
+{
+	public static MarkdownPipelineBuilder UseDiagnosticLinks(this MarkdownPipelineBuilder pipeline)
+	{
+		pipeline.Extensions.AddIfNotAlready<DiagnosticLinkInlineExtensions>();
+		return pipeline;
+	}
+}
+
+public class DiagnosticLinkInlineExtensions : IMarkdownExtension
+{
+	public void Setup(MarkdownPipelineBuilder pipeline) =>
+		pipeline.InlineParsers.Replace<LinkInlineParser>(new DiagnosticLinkInlineParser());
+
+	public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer) { }
+}
+
+public class DiagnosticLinkInlineParser : LinkInlineParser
+{
+	public override bool Match(InlineProcessor processor, ref StringSlice slice)
+	{
+		var match = base.Match(processor, ref slice);
+		if (!match) return false;
+
+		if (processor.Inline is not LinkInline link)
+			return match;
+
+		var url = link.Url;
+		var line = link.Line + 1;
+		var column = link.Column;
+		var length = url?.Length ?? 1;
+
+		var context = processor.GetContext();
+		if (processor.GetContext().SkipValidation)
+			return match;
+
+		if (string.IsNullOrEmpty(url))
+		{
+			processor.EmitWarning(line, column, length, $"Found empty url");
+			return match;
+		}
+
+		if (Uri.TryCreate(url, UriKind.Absolute, out var uri) && uri.Scheme.StartsWith("http"))
+		{
+			processor.EmitWarning(line, column, length, $"external URI: {uri} ");
+			return match;
+		}
+
+		var includeFrom = context.Path.Directory!.FullName;
+		if (url.StartsWith('/'))
+			includeFrom = context.Parser.SourcePath.FullName;
+
+		var pathOnDisk = Path.Combine(includeFrom, url.TrimStart('/'));
+		if (!context.Build.ReadFileSystem.File.Exists(pathOnDisk))
+			processor.EmitError(line, column, length, $"`{url}` does not exist. resolved to `{pathOnDisk}");
+
+		if (link.FirstChild == null)
+		{
+			var title = context.GetTitle?.Invoke(url);
+			if (!string.IsNullOrEmpty(title))
+				link.AppendChild(new LiteralInline(title));
+		}
+
+		if (url.EndsWith(".md"))
+			link.Url = Path.ChangeExtension(url, ".html");
+
+		return match;
+
+
+
+	}
+}

--- a/src/Elastic.Markdown/Myst/ParserContext.cs
+++ b/src/Elastic.Markdown/Myst/ParserContext.cs
@@ -52,4 +52,5 @@ public class ParserContext : MarkdownParserContext
 	public YamlFrontMatter? FrontMatter { get; }
 	public BuildContext Build { get; }
 	public bool SkipValidation { get; init; }
+	public Func<string, string?>? GetTitle { get; init; }
 }

--- a/tests/Elastic.Markdown.Tests/Directives/ImageTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/ImageTests.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.IO.Abstractions.TestingHelpers;
 using Elastic.Markdown.Diagnostics;
 using Elastic.Markdown.Myst.Directives;
 using FluentAssertions;
@@ -18,11 +19,8 @@ public class ImageBlockTests(ITestOutputHelper output) : DirectiveTest<ImageBloc
 """
 )
 {
-	public override Task InitializeAsync()
-	{
-		FileSystem.AddFile(@"docs/source/img/observability.png", "");
-		return base.InitializeAsync();
-	}
+	protected override void AddToFileSystem(MockFileSystem fileSystem) =>
+		fileSystem.AddFile(@"docs/source/img/observability.png", "");
 
 	[Fact]
 	public void ParsesBlock() => Block.Should().NotBeNull();

--- a/tests/Elastic.Markdown.Tests/FileInclusion/IncludeTests.cs
+++ b/tests/Elastic.Markdown.Tests/FileInclusion/IncludeTests.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.IO.Abstractions.TestingHelpers;
 using Elastic.Markdown.Diagnostics;
 using Elastic.Markdown.Myst.Directives;
 using Elastic.Markdown.Tests.Directives;
@@ -18,12 +19,11 @@ public class IncludeTests(ITestOutputHelper output) : DirectiveTest<IncludeBlock
 """
 )
 {
-	public override Task InitializeAsync()
+	protected override void AddToFileSystem(MockFileSystem fileSystem)
 	{
 		// language=markdown
 		var inclusion = "*Hello world*";
-		FileSystem.AddFile(@"docs/source/_snippets/test.md", inclusion);
-		return base.InitializeAsync();
+		fileSystem.AddFile(@"docs/source/_snippets/test.md", inclusion);
 	}
 
 	[Fact]
@@ -50,12 +50,11 @@ sub:
 """
 )
 {
-	public override Task InitializeAsync()
+	protected override void AddToFileSystem(MockFileSystem fileSystem)
 	{
 		// language=markdown
 		var inclusion = "*Hello {{foo}}*";
-		FileSystem.AddFile(@"docs/source/_snippets/test.md", inclusion);
-		return base.InitializeAsync();
+		fileSystem.AddFile(@"docs/source/_snippets/test.md", inclusion);
 	}
 
 	[Fact]

--- a/tests/Elastic.Markdown.Tests/FileInclusion/LiteralIncludeTests.cs
+++ b/tests/Elastic.Markdown.Tests/FileInclusion/LiteralIncludeTests.cs
@@ -1,6 +1,8 @@
 // Licensed to Elasticsearch B.V under one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions.TestingHelpers;
 using Elastic.Markdown.Myst.Directives;
 using Elastic.Markdown.Tests.Directives;
 using FluentAssertions;
@@ -17,12 +19,11 @@ public class LiteralIncludeUsingPropertyTests(ITestOutputHelper output) : Direct
 """
 )
 {
-	public override Task InitializeAsync()
+	protected override void AddToFileSystem(MockFileSystem fileSystem)
 	{
 		// language=markdown
 		var inclusion = "*Hello world*";
-		FileSystem.AddFile(@"docs/source/_snippets/test.txt", inclusion);
-		return base.InitializeAsync();
+		fileSystem.AddFile(@"docs/source/_snippets/test.txt", inclusion);
 	}
 
 	[Fact]
@@ -43,12 +44,11 @@ public class LiteralIncludeTests(ITestOutputHelper output) : DirectiveTest<Inclu
 """
 )
 {
-	public override Task InitializeAsync()
+	protected override void AddToFileSystem(MockFileSystem fileSystem)
 	{
 		// language=markdown
 		var inclusion = "*Hello world*";
-		FileSystem.AddFile(@"docs/source/_snippets/test.md", inclusion);
-		return base.InitializeAsync();
+		fileSystem.AddFile(@"docs/source/_snippets/test.md", inclusion);
 	}
 
 	[Fact]

--- a/tests/Elastic.Markdown.Tests/Inline/InlineLinkTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/InlineLinkTests.cs
@@ -1,0 +1,85 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions.TestingHelpers;
+using FluentAssertions;
+using JetBrains.Annotations;
+using Markdig.Syntax.Inlines;
+using Xunit.Abstractions;
+
+namespace Elastic.Markdown.Tests.Inline;
+
+public abstract class LinkTestBase(ITestOutputHelper output, [LanguageInjection("markdown")] string content)
+	: InlineTest<LinkInline>(output, content)
+{
+	[Fact]
+	public void ParsesBlock() => Block.Should().NotBeNull();
+
+	protected override void AddToFileSystem(MockFileSystem fileSystem)
+	{
+		// language=markdown
+		var inclusion =
+"""
+---
+title: Special Requirements
+---
+
+To follow this tutorial you will need to install the following components:
+""";
+		fileSystem.AddFile(@"docs/source/elastic/search-labs/search/req.md", inclusion);
+		fileSystem.AddFile(@"docs/source/_static/img/observability.png", new MockFileData(""));
+	}
+
+}
+
+public class InlineLinkTests(ITestOutputHelper output) : LinkTestBase(output,
+"""
+[Elasticsearch](/_static/img/observability.png)
+"""
+)
+{
+	[Fact]
+	public void GeneratesHtml() =>
+		// language=html
+		Html.Should().Contain(
+			"""<p><a href="/_static/img/observability.png">Elasticsearch</a></p>"""
+		);
+
+	[Fact]
+	public void HasNoErrors() => Collector.Diagnostics.Should().HaveCount(0);
+}
+
+public class LinkToPageTests(ITestOutputHelper output) : LinkTestBase(output,
+"""
+[Requirements](elastic/search-labs/search/req.md)
+"""
+)
+{
+	[Fact]
+	public void GeneratesHtml() =>
+		// language=html
+		Html.Should().Contain(
+			"""<p><a href="elastic/search-labs/search/req.html">Requirements</a></p>"""
+		);
+
+	[Fact]
+	public void HasNoErrors() => Collector.Diagnostics.Should().HaveCount(0);
+}
+
+public class InsertPageTitleTests(ITestOutputHelper output) : LinkTestBase(output,
+"""
+[](elastic/search-labs/search/req.md)
+"""
+)
+{
+	[Fact]
+	public void GeneratesHtml() =>
+		// language=html
+		Html.Should().Contain(
+			"""<p><a href="elastic/search-labs/search/req.html">Special Requirements</a></p>"""
+		);
+
+	[Fact]
+	public void HasNoErrors() => Collector.Diagnostics.Should().HaveCount(0);
+}

--- a/tests/Elastic.Markdown.Tests/MockFileSystemExtensions.cs
+++ b/tests/Elastic.Markdown.Tests/MockFileSystemExtensions.cs
@@ -1,0 +1,27 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
+
+namespace Elastic.Markdown.Tests;
+
+public static class MockFileSystemExtensions
+{
+	public static void GenerateDocSetYaml(this MockFileSystem fileSystem, IDirectoryInfo root)
+	{
+		// language=yaml
+		var yaml = new StringWriter();
+		yaml.WriteLine("toc:");
+		var markdownFiles = fileSystem.Directory
+			.EnumerateFiles(root.FullName, "*.md", SearchOption.AllDirectories);
+		foreach (var markdownFile in markdownFiles)
+		{
+			var relative = fileSystem.Path.GetRelativePath(root.FullName, markdownFile);
+			yaml.WriteLine($" - file: {relative}");
+		}
+		fileSystem.AddFile(Path.Combine(root.FullName, "docset.yml"), new MockFileData(yaml.ToString()));
+	}
+
+}

--- a/tests/Elastic.Markdown.Tests/SiteMap/NavigationTestsBase.cs
+++ b/tests/Elastic.Markdown.Tests/SiteMap/NavigationTestsBase.cs
@@ -43,7 +43,7 @@ public class NavigationTestsBase : IAsyncLifetime
 
 	public async Task InitializeAsync()
 	{
-		await Generator.GenerateAll(default);
+		await Generator.ResolveDirectoryTree(default);
 		Configuration = Generator.DocumentationSet.Configuration;
 	}
 


### PR DESCRIPTION
This also adds support for injecting page titles e.g


```markdown
[](path/to/doc.md
```

Will automatically insert that page's title as the link text.

Cc @KOTungseth @bmorelli25 