### PR TITLE
Ensure live reload picks up changes to docset and newly created files again

### DIFF
--- a/docs/source/docset.yml
+++ b/docs/source/docset.yml
@@ -45,4 +45,5 @@ toc:
     children:
       - folder: content
       - file: index.md
+      - file: test.md
   - folder: versioning

--- a/src/Elastic.Markdown/IO/MarkdownFile.cs
+++ b/src/Elastic.Markdown/IO/MarkdownFile.cs
@@ -72,6 +72,11 @@ public record MarkdownFile : DocumentationFile
 			Title = YamlFrontMatter.Title;
 			NavigationTitle = YamlFrontMatter.NavigationTitle;
 		}
+		else
+		{
+			Title = RelativePath;
+			NavigationTitle = RelativePath;
+		}
 
 		var contents = document
 			.Where(block => block is HeadingBlock { Level: 2 })

--- a/src/Elastic.Markdown/Myst/Directives/VersionBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/VersionBlock.cs
@@ -28,9 +28,8 @@ public class VersionBlock(DirectiveBlockParser parser, string directive, Diction
 		if (!SemVersion.TryParse(tokens[0], out var version))
 		{
 			var numbers = tokens[0].Split('.', RemoveEmptyEntries);
-			if (numbers.Length != 2 || !SemVersion.TryParse($"{numbers[0]}.{numbers[1]}", out version))
+			if (numbers.Length != 2 || !SemVersion.TryParse($"{numbers[0]}.{numbers[1]}.0", out version))
 				EmitError(context, $"'{tokens[0]}' is not a valid version");
-			return;
 		}
 
 		Version = version;

--- a/src/Elastic.Markdown/Myst/Directives/VersionBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/VersionBlock.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using Elastic.Markdown.Helpers;
+using static System.StringSplitOptions;
 
 namespace Elastic.Markdown.Myst.Directives;
 
@@ -17,7 +18,7 @@ public class VersionBlock(DirectiveBlockParser parser, string directive, Diction
 
 	public override void FinalizeAndValidate(ParserContext context)
 	{
-		var tokens = Arguments?.Split(" ", 2, StringSplitOptions.RemoveEmptyEntries) ?? [];
+		var tokens = Arguments?.Split(" ", 2, RemoveEmptyEntries) ?? [];
 		if (tokens.Length < 1)
 		{
 			EmitError(context, $"{directive} needs exactly 2 arguments: <version> <title>");
@@ -26,7 +27,9 @@ public class VersionBlock(DirectiveBlockParser parser, string directive, Diction
 
 		if (!SemVersion.TryParse(tokens[0], out var version))
 		{
-			EmitError(context, $"{tokens[0]} is not a valid version");
+			var numbers = tokens[0].Split('.', RemoveEmptyEntries);
+			if (numbers.Length != 2 || !SemVersion.TryParse($"{numbers[0]}.{numbers[1]}", out version))
+				EmitError(context, $"'{tokens[0]}' is not a valid version");
 			return;
 		}
 

--- a/src/docs-builder/Http/ReloadGeneratorService.cs
+++ b/src/docs-builder/Http/ReloadGeneratorService.cs
@@ -66,6 +66,8 @@ public class ReloadGeneratorService(
 
 		if (e.FullPath.EndsWith("docset.yml"))
 			Reload();
+		if (e.FullPath.EndsWith(".md"))
+			Reload();
 
 		Logger.LogInformation($"Changed: {e.FullPath}");
 	}

--- a/tests/Elastic.Markdown.Tests/Directives/VersionTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/VersionTests.cs
@@ -50,3 +50,32 @@ public class VersionDeprectatedTests(ITestOutputHelper output) : VersionTests(ou
 	[Fact]
 	public void SetsTitle() => Block!.Title.Should().Be("Deprecated (1.0.1-beta1): more information");
 }
+
+public abstract class VersionValidationTests(ITestOutputHelper output, string version) : DirectiveTest<VersionBlock>(output,
+$$"""
+```{versionchanged} {{version}} more information
+Version brief summary 
+```
+A regular paragraph.
+"""
+);
+
+public class SimpleVersion(ITestOutputHelper output) : VersionValidationTests(output, "7.17")
+{
+	[Fact]
+	public void SetsVersion() => Block!.Version.Should().Be(new SemVersion(7, 17, 0));
+}
+
+public class MajorVersionOnly(ITestOutputHelper output) : VersionValidationTests(output, "8")
+{
+	[Fact]
+	public void HasError() => Collector.Diagnostics.Should().HaveCount(1)
+		.And.Contain(d => d.Message.Contains("'8' is not a valid version"));
+}
+
+public class BranchVersion(ITestOutputHelper output) : VersionValidationTests(output, "8.x")
+{
+	[Fact]
+	public void HasError() => Collector.Diagnostics.Should().HaveCount(1)
+		.And.Contain(d => d.Message.Contains("'8.x' is not a valid version"));
+}

--- a/tests/Elastic.Markdown.Tests/Directives/VersionTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/VersionTests.cs
@@ -54,7 +54,7 @@ public class VersionDeprectatedTests(ITestOutputHelper output) : VersionTests(ou
 public abstract class VersionValidationTests(ITestOutputHelper output, string version) : DirectiveTest<VersionBlock>(output,
 $$"""
 ```{versionchanged} {{version}} more information
-Version brief summary 
+Version brief summary
 ```
 A regular paragraph.
 """
@@ -64,6 +64,9 @@ public class SimpleVersion(ITestOutputHelper output) : VersionValidationTests(ou
 {
 	[Fact]
 	public void SetsVersion() => Block!.Version.Should().Be(new SemVersion(7, 17, 0));
+
+	[Fact]
+	public void HasNoError() => Collector.Diagnostics.Should().BeEmpty();
 }
 
 public class MajorVersionOnly(ITestOutputHelper output) : VersionValidationTests(output, "8")


### PR DESCRIPTION
- Relax version directive argument, allow for major.minor format
- Fix failing test
- Fallback to relative path for title and navigation title
