### PR TITLE
Add initial support for structured settings references (yaml)

### DIFF
--- a/docs/source/elastic/reference/index.md
+++ b/docs/source/elastic/reference/index.md
@@ -2,10 +2,7 @@
 title: Automated Settings Reference
 ---
 
-Elastic docs v3 supports automatically generated configuration documentation OOTB.
-Simply supply a yaml spec and corresponding template file and content will be automatically built and updated.
 
-This section includes one example yaml file and two auto-generated outputs based on that file:
 
-* [example `yaml` file](source.md)
-* [generated output](generated.md)
+```{settings} kibana-alerting-action-settings.yml
+```

--- a/docs/source/elastic/reference/kibana-alerting-action-settings.yml
+++ b/docs/source/elastic/reference/kibana-alerting-action-settings.yml
@@ -67,22 +67,22 @@ groups:
 
       - setting: xpack.actions.customHostSettings[n].url
         description: |
-          - "A URL associated with this custom host setting.  Should be in the form of `protocol://hostname:port`, where `protocol` is `https` or `smtp`.  If the port is not provided, 443 is used for `https` and 25 is used for `smtp`.  The `smtp` URLs are used for the Email actions that use this server, and the `https` URLs are used for actions which use `https` to connect to services."
-          - "Entries with `https` URLs can use the `ssl` options, and entries with `smtp` URLs can use both the `ssl` and `smtp` options."
-          - "No other URL values should be part of this URL, including paths, query strings, and authentication information.  When an http or smtp request is made as part of running an action, only the protocol, hostname, and port of the URL for that request are used to look up these configuration values."
+          A URL associated with this custom host setting.  Should be in the form of `protocol://hostname:port`, where `protocol` is `https` or `smtp`.  If the port is not provided, 443 is used for `https` and 25 is used for `smtp`.  The `smtp` URLs are used for the Email actions that use this server, and the `https` URLs are used for actions which use `https` to connect to services.
+          Entries with `https` URLs can use the `ssl` options, and entries with `smtp` URLs can use both the `ssl` and `smtp` options.
+          No other URL values should be part of this URL, including paths, query strings, and authentication information.  When an http or smtp request is made as part of running an action, only the protocol, hostname, and port of the URL for that request are used to look up these configuration values.
         platforms:
           - cloud
 
       - setting: xpack.actions.customHostSettings[n].smtp.ignoreTLS
         description: |
-          - "A boolean value indicating that TLS must not be used for this connection. The options `smtp.ignoreTLS` and `smtp.requireTLS` can not both be set to true."
+          A boolean value indicating that TLS must not be used for this connection. The options `smtp.ignoreTLS` and `smtp.requireTLS` can not both be set to true.
         default: false
         platforms:
           - cloud
 
       - setting: xpack.actions.customHostSettings[n].smtp.requireTLS
         description: |
-          - "A boolean value indicating that TLS must be used for this connection. The options `smtp.ignoreTLS` and `smtp.requireTLS` can not both be set to true."
+          A boolean value indicating that TLS must be used for this connection. The options `smtp.ignoreTLS` and `smtp.requireTLS` can not both be set to true.
         default: false
         platforms:
           - cloud
@@ -90,31 +90,31 @@ groups:
       - setting: xpack.actions.customHostSettings[n].ssl.verificationMode
         id: action-config-custom-host-verification-mode
         description: |
-          - "Controls the verification of the server certificate that Kibana receives when making an outbound SSL/TLS connection to the host server. Valid values are `full`, `certificate`, and `none`. Use `full` to perform hostname verification, `certificate` to skip hostname verification, and `none` to skip verification. Default: `full`. <<elasticsearch-ssl-verificationMode,Equivalent Kibana setting>>. Overrides the general `xpack.actions.ssl.verificationMode` configuration for requests made for this hostname/port."
+          Controls the verification of the server certificate that Kibana receives when making an outbound SSL/TLS connection to the host server. Valid values are `full`, `certificate`, and `none`. Use `full` to perform hostname verification, `certificate` to skip hostname verification, and `none` to skip verification. Default: `full`. <<elasticsearch-ssl-verificationMode,Equivalent Kibana setting>>. Overrides the general `xpack.actions.ssl.verificationMode` configuration for requests made for this hostname/port.
         platforms:
           - cloud
 
       - setting: xpack.actions.customHostSettings[n].ssl.certificateAuthoritiesFiles
         description: |
-          - "A file name or list of file names of PEM-encoded certificate files to use to validate the server."
+          A file name or list of file names of PEM-encoded certificate files to use to validate the server.
 
       - setting: xpack.actions.customHostSettings[n].ssl.certificateAuthoritiesData
         description: |
-          - "The contents of one or more PEM-encoded certificate files in multiline format. This configuration can be used for environments where the files cannot be made available."
+          The contents of one or more PEM-encoded certificate files in multiline format. This configuration can be used for environments where the files cannot be made available.
         platforms:
           - cloud
 
       - setting: xpack.actions.email.domain_allowlist
         id: action-config-email-domain-allowlist
         description: |
-          - "A list of allowed email domains which can be used with the email connector. When this setting is not used, all email domains are allowed. When this setting is used, if any email is attempted to be sent that (a) includes an addressee with an email domain that is not in the allowlist, or (b) includes a from address domain that is not in the allowlist, it will fail with a message indicating the email is not allowed."
+          A list of allowed email domains which can be used with the email connector. When this setting is not used, all email domains are allowed. When this setting is used, if any email is attempted to be sent that (a) includes an addressee with an email domain that is not in the allowlist, or (b) includes a from address domain that is not in the allowlist, it will fail with a message indicating the email is not allowed.
         warning: "This feature is available in Kibana 7.17.4 and 8.3.0 onwards but is not supported in Kibana 8.0, 8.1 or 8.2. As such, this setting should be removed before upgrading from 7.17 to 8.0, 8.1 or 8.2. It is possible to configure the settings in 7.17.4 and then upgrade to 8.3.0 directly."
         platforms:
           - cloud
 
       - setting: xpack.actions.enableFooterInEmail
         description: |
-          - "A boolean value indicating that a footer with a relevant link should be added to emails sent as alerting actions."
+          A boolean value indicating that a footer with a relevant link should be added to emails sent as alerting actions.
         default: true
         platforms:
           - cloud
@@ -122,32 +122,32 @@ groups:
       - setting: xpack.actions.enabledActionTypes
         description: |
           - 'A list of action types that are enabled. It defaults to `["*"]`, enabling all types. The names for built-in Kibana action types are prefixed with a `.` and include: `.email`, `.index`, `.jira`, `.opsgenie`, `.pagerduty`, `.resilient`, `.server-log`, `.servicenow`, .`servicenow-itom`, `.servicenow-sir`, `.slack`, `.swimlane`, `.teams`, `.tines`, `.torq`, `.xmatters`,  `.gen-ai`,  `.bedrock`, `.gemini`,  `.d3security`, and `.webhook`. An empty list `[]` will disable all action types.'
-          - "Disabled action types will not appear as an option when creating new connectors, but existing connectors and actions of that type will remain in Kibana and will not function."
+          Disabled action types will not appear as an option when creating new connectors, but existing connectors and actions of that type will remain in Kibana and will not function.
         important: "<<pre-configured-connectors,Preconfigured connectors>> are not affected by this setting."
         platforms:
           - cloud
 
       - setting: xpack.actions.microsoftExchangeUrl
         description: |
-          - "The URL for the Microsoft Azure Active Directory endpoint to use for MS Exchange email authentication."
+          The URL for the Microsoft Azure Active Directory endpoint to use for MS Exchange email authentication.
         default: https://login.microsoftonline.com
         
       - setting: xpack.actions.microsoftGraphApiUrl
         description: |
-          - "The URL for the Microsoft Graph API endpoint to use for MS Exchange email authentication."
+          The URL for the Microsoft Graph API endpoint to use for MS Exchange email authentication.
         default: https://graph.microsoft.com/v1.0
 
       - setting: xpack.actions.microsoftGraphApiScope
         description: |
-          - "The URL for the Microsoft Graph API scope endpoint to use for MS Exchange email authentication."
+          The URL for the Microsoft Graph API scope endpoint to use for MS Exchange email authentication.
         default: https://graph.microsoft.com/.default
         
       - setting: xpack.actions.proxyUrl
         description: |
-          - "Specifies the proxy URL to use, if using a proxy for actions. By default, no proxy is used."
+          Specifies the proxy URL to use, if using a proxy for actions. By default, no proxy is used.
           - 'Proxies may be used to proxy http or https requests through a proxy using the http or https protocol.  Kibana only uses proxies in "CONNECT" mode (sometimes referred to as "tunneling" TCP mode, compared to HTTP mode).  That is, Kibana will always make requests through a proxy using the HTTP `CONNECT` method.'
-          - "If your proxy is using the https protocol (vs the http protocol), the setting `xpack.actions.ssl.proxyVerificationMode: none` will likely be needed, unless your proxy's certificates are signed using a publicly available certificate authority."
-          - "There is currently no support for using basic authentication with a proxy (authentication for the proxy itself, not the URL being requested through the proxy)."
+          If your proxy is using the https protocol (vs the http protocol), the setting `xpack.actions.ssl.proxyVerificationMode: none` will likely be needed, unless your proxy's certificates are signed using a publicly available certificate authority.
+          There is currently no support for using basic authentication with a proxy (authentication for the proxy itself, not the URL being requested through the proxy).
         platforms:
           - cloud
         example: |
@@ -161,8 +161,8 @@ groups:
 
       - setting: xpack.actions.proxyBypassHosts
         description: |
-          - "Specifies hostnames which should not use the proxy, if using a proxy for actions. The value is an array of hostnames as strings."
-          - "By default, all hosts will use the proxy, but if an action's hostname is in this list, the proxy will not be used.  The settings `xpack.actions.proxyBypassHosts` and `xpack.actions.proxyOnlyHosts` cannot be used at the same time."
+          Specifies hostnames which should not use the proxy, if using a proxy for actions. The value is an array of hostnames as strings.
+          By default, all hosts will use the proxy, but if an action's hostname is in this list, the proxy will not be used.  The settings `xpack.actions.proxyBypassHosts` and `xpack.actions.proxyOnlyHosts` cannot be used at the same time.
         platforms:
           - cloud
         example: |
@@ -177,8 +177,8 @@ groups:
 
       - setting: xpack.actions.proxyOnlyHosts
         description: |
-          - "Specifies hostnames which should only use the proxy, if using a proxy for actions. The value is an array of hostnames as strings."
-          - "By default, no hosts will use the proxy, but if an action's hostname is in this list, the proxy will be used.  The settings `xpack.actions.proxyBypassHosts` and `xpack.actions.proxyOnlyHosts` cannot be used at the same time."
+          Specifies hostnames which should only use the proxy, if using a proxy for actions. The value is an array of hostnames as strings.
+          By default, no hosts will use the proxy, but if an action's hostname is in this list, the proxy will be used.  The settings `xpack.actions.proxyBypassHosts` and `xpack.actions.proxyOnlyHosts` cannot be used at the same time.
         platforms:
           - cloud
         example: |
@@ -194,7 +194,7 @@ groups:
       - setting: xpack.actions.proxyHeaders
 
         description: |
-          - "Specifies HTTP headers for the proxy, if using a proxy for actions."
+          Specifies HTTP headers for the proxy, if using a proxy for actions.
         default: '{}'
         platforms:
           - cloud
@@ -202,9 +202,9 @@ groups:
       - setting: xpack.actions.ssl.proxyVerificationMode
         id: action-config-proxy-verification-mode
         description: |
-          - "Controls the verification for the proxy server certificate that Kibana receives when making an outbound SSL/TLS connection to the proxy server."
-          - "Use `full` to perform hostname verification, `certificate` to skip hostname verification, and `none` to skip verification."
-          - "<<elasticsearch-ssl-verificationMode,Equivalent Kibana setting>>"
+          Controls the verification for the proxy server certificate that Kibana receives when making an outbound SSL/TLS connection to the proxy server.
+          Use `full` to perform hostname verification, `certificate` to skip hostname verification, and `none` to skip verification.
+          <<elasticsearch-ssl-verificationMode,Equivalent Kibana setting>>
         default: full
         options:
           - option: full
@@ -216,9 +216,9 @@ groups:
       - setting: xpack.actions.ssl.verificationMode
         id: action-config-verification-mode
         description: |
-          - "Controls the verification for the server certificate that Elastic Maps Server receives when making an outbound SSL/TLS connection for actions. Valid values are `full`, `certificate`, and `none`. Use `full` to perform hostname verification, `certificate` to skip hostname verification, and `none` to skip verification."
-          - "<<elasticsearch-ssl-verificationMode,Equivalent Kibana setting>>"
-          - "This setting can be overridden for specific URLs by using the setting `xpack.actions.customHostSettings[n].ssl.verificationMode` (described above) to a different value."
+          Controls the verification for the server certificate that Elastic Maps Server receives when making an outbound SSL/TLS connection for actions. Valid values are `full`, `certificate`, and `none`. Use `full` to perform hostname verification, `certificate` to skip hostname verification, and `none` to skip verification.
+          <<elasticsearch-ssl-verificationMode,Equivalent Kibana setting>>
+          This setting can be overridden for specific URLs by using the setting `xpack.actions.customHostSettings[n].ssl.verificationMode` (described above) to a different value.
         default: full
         options:
           - option: full
@@ -229,21 +229,21 @@ groups:
 
       - setting: xpack.actions.maxResponseContentLength
         description: |
-          - "Specifies the max number of bytes of the http response for requests to external resources."
+          Specifies the max number of bytes of the http response for requests to external resources.
         default: 1000000 (1MB)
         platforms:
           - cloud
 
       - setting: xpack.actions.responseTimeout
         description: |
-          - "Specifies the time allowed for requests to external resources. Requests that take longer are canceled. The time is formatted as a number and a time unit (`ms`, `s`, `m`, `h`, `d`, `w`, `M`, or `Y`). For example, `20m`, `24h`, `7d`, `1w`. Default: `60s`."
+          Specifies the time allowed for requests to external resources. Requests that take longer are canceled. The time is formatted as a number and a time unit (`ms`, `s`, `m`, `h`, `d`, `w`, `M`, or `Y`). For example, `20m`, `24h`, `7d`, `1w`. Default: `60s`.
         platforms:
           - cloud
 
       - setting: xpack.actions.run.maxAttempts
 
         description: |
-          - "Specifies the maximum number of times an action can be attempted to run."
+          Specifies the maximum number of times an action can be attempted to run.
         options:
           - option: minimum 1 and maximum 10
         platforms:
@@ -251,7 +251,7 @@ groups:
 
       - setting: xpack.actions.run.connectorTypeOverrides
         description: |
-          - "Overrides the configs under `xpack.actions.run` for the connector type with the given ID. List the connector type identifier and its settings in an array of objects."
+          Overrides the configs under `xpack.actions.run` for the connector type with the given ID. List the connector type identifier and its settings in an array of objects.
         platforms:
           - cloud
         example: |
@@ -268,7 +268,7 @@ groups:
 
       - setting: xpack.actions.queued.max
         description: |
-          - "Specifies the maximum number of actions that can be queued."
+          Specifies the maximum number of actions that can be queued.
         default: 1000000
         platforms:
           - cloud
@@ -276,7 +276,7 @@ groups:
   - group: Preconfigured connector settings
     id: preconfigured-connector-settings
     description: |
-      - "These settings vary depending on which type of preconfigured connector you're adding."
+      These settings vary depending on which type of preconfigured connector you're adding.
     example: |
       For example:
       
@@ -294,18 +294,18 @@ groups:
 
       - setting: xpack.actions.preconfiguredAlertHistoryEsIndex
         description: |
-          - "Enables a preconfigured alert history Elasticsearch <<index-action-type, Index>> connector."
+          Enables a preconfigured alert history Elasticsearch <<index-action-type, Index>> connector.
         default: false
         platforms:
           - cloud
 
       - setting: xpack.actions.preconfigured
         description: |
-          - "Specifies configuration details that are specific to the type of preconfigured connector."
+          Specifies configuration details that are specific to the type of preconfigured connector.
   
       - setting: xpack.actions.preconfigured.<connector-id>.actionTypeId
         description: |
-          - "The type of preconfigured connector."
+          The type of preconfigured connector.
         options:
           - option: .email
           - option: .index
@@ -317,12 +317,12 @@ groups:
             
       - setting: xpack.actions.preconfigured.<connector-id>.config
         description: |
-          - "The configuration details, which are specific to the type of preconfigured connector."
+          The configuration details, which are specific to the type of preconfigured connector.
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.apiProvider
 
         description: |
-          - "For a <<openai-action-type,OpenAI connector>>, specifies the OpenAI API provider."
+          For a <<openai-action-type,OpenAI connector>>, specifies the OpenAI API provider.
 
         options:
           - option: OpenAI
@@ -330,42 +330,42 @@ groups:
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.apiUrl
         description: |
-          - "A configuration URL that varies by connector:"
-          - "* For an <<bedrock-action-type,{bedrock} connector>>, specifies the {bedrock} request URL."
-          - "* For an <<gemini-action-type,{gemini} connector>>, specifies the {gemini} request URL."
-          - "* For a <<openai-action-type,OpenAI connector>>, specifies the OpenAI request URL."
-          - "* For a <<resilient-action-type,{ibm-r} connector>>, specifies the {ibm-r} instance URL."
-          - "* For a <<jira-action-type,Jira connector>>, specifies the Jira instance URL."
-          - "* For an <<opsgenie-action-type,{opsgenie} connector>>, specifies the {opsgenie} URL. For example, `https://api.opsgenie.com` or `https://api.eu.opsgenie.com`."
-          - "* For a <<pagerduty-action-type,PagerDuty connector>>, specifies the PagerDuty event URL. Defaults to `https://events.pagerduty.com/v2/enqueue`."
-          - "* For a <<servicenow-action-type,{sn-itsm}>>, <<servicenow-sir-action-type,{sn-sir}>>, or <<servicenow-itom-action-type,{sn-itom} connector>> specifies the ServiceNow instance URL."
-          - "* For a <<swimlane-action-type,{swimlane} connector>>, specifies the {swimlane} instance URL."
+          A configuration URL that varies by connector:
+          * For an <<bedrock-action-type,{bedrock} connector>>, specifies the {bedrock} request URL.
+          * For an <<gemini-action-type,{gemini} connector>>, specifies the {gemini} request URL.
+          * For a <<openai-action-type,OpenAI connector>>, specifies the OpenAI request URL.
+          * For a <<resilient-action-type,{ibm-r} connector>>, specifies the {ibm-r} instance URL.
+          * For a <<jira-action-type,Jira connector>>, specifies the Jira instance URL.
+          * For an <<opsgenie-action-type,{opsgenie} connector>>, specifies the {opsgenie} URL. For example, `https://api.opsgenie.com` or `https://api.eu.opsgenie.com`.
+          * For a <<pagerduty-action-type,PagerDuty connector>>, specifies the PagerDuty event URL. Defaults to `https://events.pagerduty.com/v2/enqueue`.
+          * For a <<servicenow-action-type,{sn-itsm}>>, <<servicenow-sir-action-type,{sn-sir}>>, or <<servicenow-itom-action-type,{sn-itom} connector>> specifies the ServiceNow instance URL.
+          * For a <<swimlane-action-type,{swimlane} connector>>, specifies the {swimlane} instance URL.
 
         note: "If you are using the `xpack.actions.allowedHosts` setting, make sure the hostname in the URL is added to the allowed hosts."
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.appId
         description: |
-          - "An application ID that varies by connector:"
-          - "* For a <<swimlane-action-type,{swimlane} connector>>, specifies a {swimlane} application identifier."
+          An application ID that varies by connector:
+          * For a <<swimlane-action-type,{swimlane} connector>>, specifies a {swimlane} application identifier.
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.clientId
         description: |
-          - "A client identifier that varies by connector:"
-          - "* For an <<email-action-type,email connector>>, specifies a GUID format value that corresponds to the client ID, which is a part of OAuth 2.0 client credentials authentication."
-          - "* For a <<servicenow-itom-action-type,{sn-itom}>>, <<servicenow-action-type,{sn-itsm}>>, or <<servicenow-sir-action-type,{sn-sir} connector>> specifies the client identifier assigned to the OAuth application."
+          A client identifier that varies by connector:
+          * For an <<email-action-type,email connector>>, specifies a GUID format value that corresponds to the client ID, which is a part of OAuth 2.0 client credentials authentication.
+          * For a <<servicenow-itom-action-type,{sn-itom}>>, <<servicenow-action-type,{sn-itsm}>>, or <<servicenow-sir-action-type,{sn-sir} connector>> specifies the client identifier assigned to the OAuth application.
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.configUrl
         description: |
-          - "For an <<xmatters-action-type,xMatters connector>> with basic authentication, specifies the request URL for the Elastic Alerts trigger in xMatters."
+          For an <<xmatters-action-type,xMatters connector>> with basic authentication, specifies the request URL for the Elastic Alerts trigger in xMatters.
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.createCommentJson
         description: |
-          - "For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a stringified JSON payload with Mustache variables that is sent to the create comment URL to create a case comment. The required variable is `case.description`."
+          For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a stringified JSON payload with Mustache variables that is sent to the create comment URL to create a case comment. The required variable is `case.description`.
         note: "The JSON is validated after the Mustache variables have been placed when the REST method runs. You should manually ensure that the JSON is valid, disregarding the Mustache variables, so the later validation will pass."
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.createCommentMethod
         description: |
-          - "For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies the REST API HTTP request method to create a case comment in the third-party system."
+          For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies the REST API HTTP request method to create a case comment in the third-party system.
         default: put
         options:
           - option: post
@@ -374,18 +374,18 @@ groups:
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.createCommentUrl
         description: |
-          - "For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a REST API URL string to create a case comment by ID in the third-party system."
+          For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a REST API URL string to create a case comment by ID in the third-party system.
         note: "If you are using the `xpack.actions.allowedHosts` setting, make sure the hostname in the URL is added to the allowed hosts."
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.createIncidentJson
         description: |
-          - "For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a stringified JSON payload with Mustache variables that is sent to the create case URL to create a case. Required variables are `case.title` and `case.description`."
+          For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a stringified JSON payload with Mustache variables that is sent to the create case URL to create a case. Required variables are `case.title` and `case.description`.
 
         note: "The JSON is validated after the Mustache variables have been placed when the REST method runs. You should manually ensure that the JSON is valid, disregarding the Mustache variables, so the later validation will pass."
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.createIncidentMethod
         description: |
-          - "For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies the REST API HTTP request method to create a case in the third-party system"
+          For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies the REST API HTTP request method to create a case in the third-party system
 
         default: post
         options:
@@ -395,131 +395,131 @@ groups:
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.createIncidentUrl
         description: |
-          - "For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a REST API URL string to create a case in the third-party system."
+          For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a REST API URL string to create a case in the third-party system.
         note: "If you are using the `xpack.actions.allowedHosts` setting, make sure the hostname in the URL is added to the allowed hosts."
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.createIncidentResponseKey
         description: |
-          - "For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a string from the response body of the create case method that corresponds to the external service identifier."
+          For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a string from the response body of the create case method that corresponds to the external service identifier.
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.defaultModel
         description: |
-          - "The default model to use for requests, which varies by connector:"
-          - "* For an <<bedrock-action-type,{bedrock} connector>>, current support is for the Anthropic Claude models. Defaults to `anthropic.claude-3-5-sonnet-20240620-v1:0`."
-          - "* For a <<gemini-action-type,{gemini} connector>>, current support is for the Gemini models. Defaults to `gemini-1.5-pro-002`."
-          - "* For a <<openai-action-type,OpenAI connector>>, it is optional and applicable only when `xpack.actions.preconfigured.<connector-id>.config.apiProvider` is `OpenAI`."
+          The default model to use for requests, which varies by connector:
+          * For an <<bedrock-action-type,{bedrock} connector>>, current support is for the Anthropic Claude models. Defaults to `anthropic.claude-3-5-sonnet-20240620-v1:0`.
+          * For a <<gemini-action-type,{gemini} connector>>, current support is for the Gemini models. Defaults to `gemini-1.5-pro-002`.
+          * For a <<openai-action-type,OpenAI connector>>, it is optional and applicable only when `xpack.actions.preconfigured.<connector-id>.config.apiProvider` is `OpenAI`.
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.executionTimeField
         description: |
-          - "For an <<index-action-type,index connector>>, a field that indicates when the document was indexed."
+          For an <<index-action-type,index connector>>, a field that indicates when the document was indexed.
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.from
         description: |
-          - "For an <<email-action-type,email connector>>, specifies the from address for all emails sent by the connector. It must be specified in `user@host-name` format."
+          For an <<email-action-type,email connector>>, specifies the from address for all emails sent by the connector. It must be specified in `user@host-name` format.
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.getIncidentResponseExternalTitleKey
         description: |
-          - "For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a string from the response body of the get case method that corresponds to the external service title."
+          For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a string from the response body of the get case method that corresponds to the external service title.
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.getIncidentUrl
         description: |
-          - "For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a REST API URL string with an external service ID Mustache variable to get the case from the third-party system."
+          For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a REST API URL string with an external service ID Mustache variable to get the case from the third-party system.
         note: "If you are using the `xpack.actions.allowedHosts` setting, make sure the hostname in the URL is added to the allowed hosts. "
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.hasAuth
         description: |
-          - "For an <<email-action-type,email>>, <<webhook-action-type,webhook>>, or <<cases-webhook-action-type,{webhook-cm} connector>>, specifies whether a user and password are required inside the secrets configuration."
+          For an <<email-action-type,email>>, <<webhook-action-type,webhook>>, or <<cases-webhook-action-type,{webhook-cm} connector>>, specifies whether a user and password are required inside the secrets configuration.
         default: true
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.headers
         description: |
-          - "For a <<webhook-action-type,webhook>> or <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a set of key-value pairs sent as headers with the request."
+          For a <<webhook-action-type,webhook>> or <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a set of key-value pairs sent as headers with the request.
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.host
         description: |
-          - "For an <<email-action-type,email connector>>, specifies the host name of the service provider."
+          For an <<email-action-type,email connector>>, specifies the host name of the service provider.
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.index
         description: |
-          - "For an <<index-action-type,index connector>>, specifies the Elasticsearch index."
+          For an <<index-action-type,index connector>>, specifies the Elasticsearch index.
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.isOAuth
         description: |
-          - "For a <<servicenow-action-type,{sn-itsm}>>, <<servicenow-sir-action-type,{sn-sir}>>, or <<servicenow-itom-action-type,{sn-itom} connector>>, specifies whether to use basic or OAuth authentication."
+          For a <<servicenow-action-type,{sn-itsm}>>, <<servicenow-sir-action-type,{sn-sir}>>, or <<servicenow-itom-action-type,{sn-itom} connector>>, specifies whether to use basic or OAuth authentication.
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.jwtKeyId
         description: |
-          - "For a <<servicenow-action-type,{sn-itsm}>>, <<servicenow-sir-action-type,{sn-sir}>>, or <<servicenow-itom-action-type,{sn-itom} connector>>, specifies the key ID assigned to the JWT verifier map of your OAuth application. It is required when `xpack.actions.preconfigured.<connector-id>.config.isOAuth` is `true`."
+          For a <<servicenow-action-type,{sn-itsm}>>, <<servicenow-sir-action-type,{sn-sir}>>, or <<servicenow-itom-action-type,{sn-itom} connector>>, specifies the key ID assigned to the JWT verifier map of your OAuth application. It is required when `xpack.actions.preconfigured.<connector-id>.config.isOAuth` is `true`.
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.mappings
         description: |
-          - "For a <<swimlane-action-type,Swimlane connector>>, specifies field mappings."
+          For a <<swimlane-action-type,Swimlane connector>>, specifies field mappings.
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.mappings.alertIdConfig
         description: |
-          - "For a <<swimlane-action-type,Swimlane connector>>, field mapping for the alert identifier. You must provide `fieldtype`, `id`, `key`, and `name` values."
+          For a <<swimlane-action-type,Swimlane connector>>, field mapping for the alert identifier. You must provide `fieldtype`, `id`, `key`, and `name` values.
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.mappings.caseIdConfig
         description: |
-          - "For a <<swimlane-action-type,Swimlane connector>>, field mapping for the case identifier. You must provide `fieldtype`, `id`, `key`, and `name` values."
+          For a <<swimlane-action-type,Swimlane connector>>, field mapping for the case identifier. You must provide `fieldtype`, `id`, `key`, and `name` values.
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.mappings.caseNameConfig
         description: |
-          - "For a <<swimlane-action-type,Swimlane connector>>, field mapping for the case name. You must provide `fieldtype`, `id`, `key`, and `name` values."
+          For a <<swimlane-action-type,Swimlane connector>>, field mapping for the case name. You must provide `fieldtype`, `id`, `key`, and `name` values.
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.mappings.commentsConfig
         description: |
-          - "For a <<swimlane-action-type,Swimlane connector>>, field mapping for the case comments. You must provide `fieldtype`, `id`, `key`, and `name` values."
+          For a <<swimlane-action-type,Swimlane connector>>, field mapping for the case comments. You must provide `fieldtype`, `id`, `key`, and `name` values.
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.mappings.descriptionConfig
         description: |
-          - "For a <<swimlane-action-type,Swimlane connector>>, field mapping for the case description. You must provide `fieldtype`, `id`, `key`, and `name` values."
+          For a <<swimlane-action-type,Swimlane connector>>, field mapping for the case description. You must provide `fieldtype`, `id`, `key`, and `name` values.
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.mappings.ruleNameConfig
         description: |
-          - "For a <<swimlane-action-type,Swimlane connector>>, field mapping for the rule name. You must provide `fieldtype`, `id`, `key`, and `name` values."
+          For a <<swimlane-action-type,Swimlane connector>>, field mapping for the rule name. You must provide `fieldtype`, `id`, `key`, and `name` values.
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.mappings.severityConfig
         description: |
-          - "For a <<swimlane-action-type,Swimlane connector>>, specifies a field mapping for the severity. You must provide `fieldtype`, `id`, `key`, and `name` values."
+          For a <<swimlane-action-type,Swimlane connector>>, specifies a field mapping for the severity. You must provide `fieldtype`, `id`, `key`, and `name` values.
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.method
         description: |
-          - "For a <<webhook-action-type,webhook connector>>, specifies the HTTP request method, either `post` or `put`. Defaults to `post`."
+          For a <<webhook-action-type,webhook connector>>, specifies the HTTP request method, either `post` or `put`. Defaults to `post`.
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.orgId
         description: |
-          - "For an <<resilient-action-type,{ibm-r} connector>>, specifies the {ibm-r} organization identifier."
+          For an <<resilient-action-type,{ibm-r} connector>>, specifies the {ibm-r} organization identifier.
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.port
         description: |
-          - "For an <<email-action-type,email connector>>, specifies the port to connect to on the service provider."
+          For an <<email-action-type,email connector>>, specifies the port to connect to on the service provider.
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.projectKey
         description: |
-          - "For a <<jira-action-type,Jira connector>>, specifies the Jira project key."
+          For a <<jira-action-type,Jira connector>>, specifies the Jira project key.
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.secure
         description: |
-          - "For an <<email-action-type,email connector>>, specifies whether the connection will use TLS when connecting to the service provider. If not true, the connection will initially connect over TCP then attempt to switch to TLS via the SMTP STARTTLS command."
+          For an <<email-action-type,email connector>>, specifies whether the connection will use TLS when connecting to the service provider. If not true, the connection will initially connect over TCP then attempt to switch to TLS via the SMTP STARTTLS command.
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.service
         description: |
-          - "For an <<email-action-type,email connector>>, specifies the name of the email service. For example, `elastic_cloud`, `exchange_server`, `gmail`, `other`, `outlook365`, or `ses`."
+          For an <<email-action-type,email connector>>, specifies the name of the email service. For example, `elastic_cloud`, `exchange_server`, `gmail`, `other`, `outlook365`, or `ses`.
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.tenantId
         description: |
-          - "For an <<email-action-type,email connector>>, specifies a GUID format value that corresponds to a tenant ID, which is a part of OAuth 2.0 client credentials authentication."
+          For an <<email-action-type,email connector>>, specifies a GUID format value that corresponds to a tenant ID, which is a part of OAuth 2.0 client credentials authentication.
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.updateIncidentJson
         description: |
-          - "For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a stringified JSON payload with Mustache variables that is sent to the update case URL to update a case. Required variables are `case.title` and `case.description`."
+          For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a stringified JSON payload with Mustache variables that is sent to the update case URL to update a case. Required variables are `case.title` and `case.description`.
 
         note: "The JSON is validated after the Mustache variables have been placed when the REST method runs. You should manually ensure that the JSON is valid, disregarding the Mustache variables, so the later validation will pass."
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.updateIncidentMethod
         description: |
-          - "For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies the REST API HTTP request method to update the case in the third-party system."
+          For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies the REST API HTTP request method to update the case in the third-party system.
         default: put
         options:
           - option: post
@@ -528,139 +528,139 @@ groups:
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.updateIncidentUrl
         description: |
-          - "For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies the REST API URL to update the case by ID in the third-party system."
+          For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies the REST API URL to update the case by ID in the third-party system.
         note: "If you are using the `xpack.actions.allowedHosts` setting, make sure the hostname in the URL is added to the allowed hosts."
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.url
         description: |
-          - "A configuration URL that varies by connector:"
-          - "* For a <<d3security-action-type,D3 Security connector>>, specifies the D3 Security API request URL."
-          - "* For a <<tines-action-type,Tines connector>>, specifies the Tines tenant URL."
-          - "* For a <<webhook-action-type,webhook connector>>, specifies the web service request URL."
+          A configuration URL that varies by connector:
+          * For a <<d3security-action-type,D3 Security connector>>, specifies the D3 Security API request URL.
+          * For a <<tines-action-type,Tines connector>>, specifies the Tines tenant URL.
+          * For a <<webhook-action-type,webhook connector>>, specifies the web service request URL.
         note: "If you are using the `xpack.actions.allowedHosts` setting, make sure this hostname is added to the allowed hosts."
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.userIdentifierValue
         description: |
-          - "For a <<servicenow-action-type,{sn-itsm}>>, <<servicenow-sir-action-type,{sn-sir}>>, or <<servicenow-itom-action-type,{sn-itom} connector>>, specifies the user identifier. It is required when required when `xpack.actions.preconfigured.<connector-id>.config.isOAuth` is `true`."
+          For a <<servicenow-action-type,{sn-itsm}>>, <<servicenow-sir-action-type,{sn-sir}>>, or <<servicenow-itom-action-type,{sn-itom} connector>>, specifies the user identifier. It is required when required when `xpack.actions.preconfigured.<connector-id>.config.isOAuth` is `true`.
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.usesBasic
         description: |
-          - "For an <<xmatters-action-type,xMatters connector>>, specifies whether it uses HTTP basic authentication."
+          For an <<xmatters-action-type,xMatters connector>>, specifies whether it uses HTTP basic authentication.
         default: true
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.usesTableApi
         description: |
-          - "For a <<servicenow-action-type,{sn-itsm}>> or <<servicenow-sir-action-type,{sn-sir} connector>>, specifies whether the connector uses the Table API or the Import Set API. If set to `false`, the Elastic application should be installed in ServiceNow."
+          For a <<servicenow-action-type,{sn-itsm}>> or <<servicenow-sir-action-type,{sn-sir} connector>>, specifies whether the connector uses the Table API or the Import Set API. If set to `false`, the Elastic application should be installed in ServiceNow.
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.viewIncidentUrl
         description: |
-          - "For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a URL string with either the external service ID or external service title Mustache variable to view a case in the external system."
+          For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a URL string with either the external service ID or external service title Mustache variable to view a case in the external system.
 
       - setting: xpack.actions.preconfigured.<connector-id>.config.webhookIntegrationUrl
         description: |
-          - "For a <<torq-action-type,Torq connector>>, specifies the endpoint URL of the Elastic Security integration in Torq."
+          For a <<torq-action-type,Torq connector>>, specifies the endpoint URL of the Elastic Security integration in Torq.
 
       - setting: xpack.actions.preconfigured.<connector-id>.name
         description: |
-          - "The name of the preconfigured connector."
+          The name of the preconfigured connector.
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets
         description: |
-          - "Sensitive configuration details, such as username, password, and keys, which are specific to the connector type."
+          Sensitive configuration details, such as username, password, and keys, which are specific to the connector type.
         tip: "Sensitive properties, such as passwords, should be stored in the <<creating-keystore,Kibana keystore>>."
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.accessKey
         description: |
-          - "For an <<bedrock-action-type,{bedrock} connector>>, specifies the AWS access key for authentication."
+          For an <<bedrock-action-type,{bedrock} connector>>, specifies the AWS access key for authentication.
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.apikey
         description: |
-          - "An API key secret that varies by connector."
+          An API key secret that varies by connector.
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.credentialsJson
         description: |
-          - "For an <<gemini-action-type,{gemini} connector>>, specifies the GCP service account credentials JSON file for authentication."
-          - "* For a <<openai-action-type,OpenAI connector>>, specifies the OpenAI or Azure OpenAI API key for authentication."
-          - "* For an <<opsgenie-action-type,{opsgenie} connector>>, specifies the {opsgenie} API authentication key for HTTP basic authentication."
+          For an <<gemini-action-type,{gemini} connector>>, specifies the GCP service account credentials JSON file for authentication.
+          * For a <<openai-action-type,OpenAI connector>>, specifies the OpenAI or Azure OpenAI API key for authentication.
+          * For an <<opsgenie-action-type,{opsgenie} connector>>, specifies the {opsgenie} API authentication key for HTTP basic authentication.
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.apiKeyId
         description: |
-          - "For an <<resilient-action-type,{ibm-r} connector>>, specifies the authentication key ID for HTTP basic authentication."
+          For an <<resilient-action-type,{ibm-r} connector>>, specifies the authentication key ID for HTTP basic authentication.
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.apiKeySecret
         description: |
-          - "For an <<resilient-action-type,{ibm-r} connector>>, specifies the authentication key secret for HTTP basic authentication."
+          For an <<resilient-action-type,{ibm-r} connector>>, specifies the authentication key secret for HTTP basic authentication.
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.apiToken
         description: |
-          - "For a <<jira-action-type,Jira>> or <<swimlane-action-type,{swimlane} connector>>, specifies the API authentication token for HTTP basic authentication."
+          For a <<jira-action-type,Jira>> or <<swimlane-action-type,{swimlane} connector>>, specifies the API authentication token for HTTP basic authentication.
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.clientSecret
         description: |
-          - "A client secret that varies by connector:"
-          - "* For an <<email-action-type,email connector>>, specifies the client secret that you generated for your app in the app registration portal. It is required when the email service is `exchange_server`, which uses OAuth 2.0 client credentials authentication."
-          - "* For a <<servicenow-action-type,{sn-itsm}>>, <<servicenow-sir-action-type,{sn-sir}>>, or <<servicenow-itom-action-type,{sn-itom} connector>>, specifies the client secret assigned to the OAuth application. It is required when `xpack.actions.preconfigured.<connector-id>.config.isOAuth` is `true`."
+          A client secret that varies by connector:
+          * For an <<email-action-type,email connector>>, specifies the client secret that you generated for your app in the app registration portal. It is required when the email service is `exchange_server`, which uses OAuth 2.0 client credentials authentication.
+          * For a <<servicenow-action-type,{sn-itsm}>>, <<servicenow-sir-action-type,{sn-sir}>>, or <<servicenow-itom-action-type,{sn-itom} connector>>, specifies the client secret assigned to the OAuth application. It is required when `xpack.actions.preconfigured.<connector-id>.config.isOAuth` is `true`.
 
         note: "The client secret must be URL-encoded."
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.email
         description: |
-          - "An email address that varies by connector:"
-          - "* For a <<jira-action-type,Jira connector>>, specifies the account email for HTTP basic authentication."
-          - "* For a <<tines-action-type,Tines connector>>, specifies the email used to sign in to Tines."
+          An email address that varies by connector:
+          * For a <<jira-action-type,Jira connector>>, specifies the account email for HTTP basic authentication.
+          * For a <<tines-action-type,Tines connector>>, specifies the email used to sign in to Tines.
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.password
         description: |
-          - "A password secret that varies by connector:"
-          - "* For an <<email-action-type,email>>, <<webhook-action-type,webhook>>, or <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a password that is required when `xpack.actions.preconfigured.<connector-id>.config.hasAuth` is `true`."
-          - "* For a <<servicenow-action-type,{sn-itsm}>>, <<servicenow-sir-action-type,{sn-sir}>>, or <<servicenow-itom-action-type,{sn-itom} connector>>, specifies a password that is required when `xpack.actions.preconfigured.<connector-id>.config.isOAuth` is `false`."
-          - "* For an <<xmatters-action-type,xMatters connector>>, specifies a password that is required when `xpack.actions.preconfigured.<connector-id>.config.usesBasic` is `true`."
+          A password secret that varies by connector:
+          * For an <<email-action-type,email>>, <<webhook-action-type,webhook>>, or <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a password that is required when `xpack.actions.preconfigured.<connector-id>.config.hasAuth` is `true`.
+          * For a <<servicenow-action-type,{sn-itsm}>>, <<servicenow-sir-action-type,{sn-sir}>>, or <<servicenow-itom-action-type,{sn-itom} connector>>, specifies a password that is required when `xpack.actions.preconfigured.<connector-id>.config.isOAuth` is `false`.
+          * For an <<xmatters-action-type,xMatters connector>>, specifies a password that is required when `xpack.actions.preconfigured.<connector-id>.config.usesBasic` is `true`.
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.privateKey
         description: |
-          - "For a <<servicenow-action-type,{sn-itsm}>>, <<servicenow-sir-action-type,{sn-sir}>>, or <<servicenow-itom-action-type,{sn-itom} connector>>, specifies the RSA private key. It is required when `xpack.actions.preconfigured.<connector-id>.config.isOAuth` is `true`."
+          For a <<servicenow-action-type,{sn-itsm}>>, <<servicenow-sir-action-type,{sn-sir}>>, or <<servicenow-itom-action-type,{sn-itom} connector>>, specifies the RSA private key. It is required when `xpack.actions.preconfigured.<connector-id>.config.isOAuth` is `true`.
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.privateKeyPassword
         description: |
-          - "For a <<servicenow-action-type,{sn-itsm}>>, <<servicenow-sir-action-type,{sn-sir}>>, or <<servicenow-itom-action-type,{sn-itom} connector>>, specifies the password for the RSA private key."
+          For a <<servicenow-action-type,{sn-itsm}>>, <<servicenow-sir-action-type,{sn-sir}>>, or <<servicenow-itom-action-type,{sn-itom} connector>>, specifies the password for the RSA private key.
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.routingKey
         description: |
-          - "For a <<pagerduty-action-type,PagerDuty connector>>, specifies the 32 character PagerDuty Integration Key for an integration on a service, also referred to as the routing key."
+          For a <<pagerduty-action-type,PagerDuty connector>>, specifies the 32 character PagerDuty Integration Key for an integration on a service, also referred to as the routing key.
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.secret
         description: |
-          - "For an <<bedrock-action-type,{bedrock} connector>>, specifies the AWS secret for authentication."
+          For an <<bedrock-action-type,{bedrock} connector>>, specifies the AWS secret for authentication.
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.secretsUrl
         description: |
-          - "For an <<xmatters-action-type,xMatters connector>> with URL authentication, specifies the request URL for the Elastic Alerts trigger in xMatters with the API key included in the URL. It is used only when `xpack.actions.preconfigured.<connector-id>.config.usesBasic` is `false`."
+          For an <<xmatters-action-type,xMatters connector>> with URL authentication, specifies the request URL for the Elastic Alerts trigger in xMatters with the API key included in the URL. It is used only when `xpack.actions.preconfigured.<connector-id>.config.usesBasic` is `false`.
         note: "If you are using the `xpack.actions.allowedHosts` setting, make sure this hostname is added to the allowed hosts."
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.token
         description: |
-          - "A token secret that varies by connector:"
-          - "* For a <<d3security-action-type,D3 Security conector>>, specifies the D3 Security token."
-          - "* For a <<slack-action-type,Slack connector>>, specifies the Slack bot user OAuth token."
-          - "* For a <<tines-action-type,Tines connector>>, specifies the Tines API token."
-          - "* For a <<torq-action-type,Torq connector>>, specifies the secret of the webhook authentication header."
+          A token secret that varies by connector:
+          * For a <<d3security-action-type,D3 Security conector>>, specifies the D3 Security token.
+          * For a <<slack-action-type,Slack connector>>, specifies the Slack bot user OAuth token.
+          * For a <<tines-action-type,Tines connector>>, specifies the Tines API token.
+          * For a <<torq-action-type,Torq connector>>, specifies the secret of the webhook authentication header.
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.user
         description: |
-          - "A user name secret that varies by connector:"
-          - "* For an <<email-action-type,email>>, <<webhook-action-type,webhook>>, or <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a user name that is required when `xpack.actions.preconfigured.<connector-id>.config.hasAuth` is `true`."
-          - "* For an <<xmatters-action-type,xMatters connector>>, specifies a user name that is required when `xpack.actions.preconfigured.<connector-id>.config.usesBasic` is `true`."
+          A user name secret that varies by connector:
+          * For an <<email-action-type,email>>, <<webhook-action-type,webhook>>, or <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a user name that is required when `xpack.actions.preconfigured.<connector-id>.config.hasAuth` is `true`.
+          * For an <<xmatters-action-type,xMatters connector>>, specifies a user name that is required when `xpack.actions.preconfigured.<connector-id>.config.usesBasic` is `true`.
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.webhookUrl
         description: |
-          - "A URL that varies by connector:"
-          - "* For a <<teams-action-type,Microsoft Teams>>, specifies the URL of the incoming webhook."
-          - "* For a <<slack-action-type,Slack connector>>, specifies the Slack webhook URL."
+          A URL that varies by connector:
+          * For a <<teams-action-type,Microsoft Teams>>, specifies the URL of the incoming webhook.
+          * For a <<slack-action-type,Slack connector>>, specifies the Slack webhook URL.
         note: "If you are using the `xpack.actions.allowedHosts` setting, make sure the hostname is added to the allowed hosts."
 
       - setting: xpack.actions.preconfigured.<connector-id>.secrets.username
         description: |
-          - "For a <<servicenow-action-type,{sn-itsm}>>, <<servicenow-sir-action-type,{sn-sir}>>, or <<servicenow-itom-action-type,{sn-itom} connector>>, specifies a user name that is required when `xpack.actions.preconfigured.<connector-id>.config.isOAuth` is `false`."
+          For a <<servicenow-action-type,{sn-itsm}>>, <<servicenow-sir-action-type,{sn-sir}>>, or <<servicenow-itom-action-type,{sn-itom} connector>>, specifies a user name that is required when `xpack.actions.preconfigured.<connector-id>.config.isOAuth` is `false`.
 
   - group: Alerting settings
     id: alert-settings
@@ -669,40 +669,40 @@ groups:
 
       - setting: xpack.alerting.cancelAlertsOnRuleTimeout
         description: |
-          - "Specifies whether to skip writing alerts and scheduling actions if rule processing was cancelled due to a timeout. This setting can be overridden by individual rule types."
+          Specifies whether to skip writing alerts and scheduling actions if rule processing was cancelled due to a timeout. This setting can be overridden by individual rule types.
         default: true
         platforms:
           - cloud
 
       - setting: xpack.alerting.rules.maxScheduledPerMinute
         description: |
-          - "Specifies the maximum number of rules to run per minute."
+          Specifies the maximum number of rules to run per minute.
         default: 10000
 
       - setting: xpack.alerting.rules.minimumScheduleInterval.value
         description: |
-          - "Specifies the minimum schedule interval for rules. This minimum is applied to all rules created or updated after you set this value. The time is formatted as a number and a time unit (`s`, `m`, `h`, or `d`). For example, `20m`, `24h`, `7d`. This duration cannot exceed `1d`."
+          Specifies the minimum schedule interval for rules. This minimum is applied to all rules created or updated after you set this value. The time is formatted as a number and a time unit (`s`, `m`, `h`, or `d`). For example, `20m`, `24h`, `7d`. This duration cannot exceed `1d`.
         default: 1m
         platforms:
           - cloud
 
       - setting: xpack.alerting.rules.minimumScheduleInterval.enforce
         description: |
-          - "Specifies the behavior when a new or changed rule has a schedule interval less than the value defined in `xpack.alerting.rules.minimumScheduleInterval.value`. If `false`, rules with schedules less than the interval will be created but warnings will be logged. If `true`, rules with schedules less than the interval cannot be created."
+          Specifies the behavior when a new or changed rule has a schedule interval less than the value defined in `xpack.alerting.rules.minimumScheduleInterval.value`. If `false`, rules with schedules less than the interval will be created but warnings will be logged. If `true`, rules with schedules less than the interval cannot be created.
         default: false
         platforms:
           - cloud
 
       - setting: xpack.alerting.rules.run.actions.max
         description: |
-          - "Specifies the maximum number of actions that a rule can generate each time detection checks run."
+          Specifies the maximum number of actions that a rule can generate each time detection checks run.
 
         platforms:
           - cloud
 
       - setting: xpack.alerting.rules.run.alerts.max
         description: |
-          - "Specifies the maximum number of alerts that a rule can generate each time detection checks run."
+          Specifies the maximum number of alerts that a rule can generate each time detection checks run.
         warning: "The exact number of alerts your cluster can safely handle depends on your cluster configuration and workload, however setting a value higher than the default (`1000`) is not recommended or supported. Doing so could strain system resources and lead to performance issues, delays in alert processing, and potential disruptions during high alert activity periods."
         default: 1000
         platforms:
@@ -710,13 +710,13 @@ groups:
 
       - setting: xpack.alerting.rules.run.timeout
         description: |
-          - "Specifies the default timeout for tasks associated with all types of rules. The time is formatted as a number and a time unit (`ms`, `s`, `m`, `h`, `d`, `w`, `M`, or `Y`). For example, `20m`, `24h`, `7d`, `1w`. Default: `5m`."
+          Specifies the default timeout for tasks associated with all types of rules. The time is formatted as a number and a time unit (`ms`, `s`, `m`, `h`, `d`, `w`, `M`, or `Y`). For example, `20m`, `24h`, `7d`, `1w`. Default: `5m`.
         platforms:
           - cloud
 
       - setting: xpack.alerting.rules.run.ruleTypeOverrides
         description: |
-          - "Overrides the configs under `xpack.alerting.rules.run` for the rule type with the given ID. List the rule identifier and its settings in an array of objects."
+          Overrides the configs under `xpack.alerting.rules.run` for the rule type with the given ID. List the rule identifier and its settings in an array of objects.
         platforms:
           - cloud
         example: |
@@ -733,7 +733,7 @@ groups:
 
       - setting: xpack.alerting.rules.run.actions.connectorTypeOverrides
         description: |
-          - "Overrides the configs under `xpack.alerting.rules.run.actions` for the connector type with the given ID. List the connector type identifier and its settings in an array of objects."
+          Overrides the configs under `xpack.alerting.rules.run.actions` for the connector type with the given ID. List the connector type identifier and its settings in an array of objects.
         platforms:
           - cloud
         example: |

--- a/docs/source/elastic/reference/kibana-alerting-action-settings.yml
+++ b/docs/source/elastic/reference/kibana-alerting-action-settings.yml
@@ -33,6 +33,7 @@ groups:
         default: an empty list
         platforms:
           - cloud
+        # language=markdown
         example: |
           In the following example, two custom host settings
           are defined.  The first provides a custom host setting for mail server

--- a/docs/source/elastic/reference/kibana-alerting-action-settings.yml
+++ b/docs/source/elastic/reference/kibana-alerting-action-settings.yml
@@ -1,0 +1,749 @@
+---
+# This file is used to generate "Alert and action settings" page in the product docs
+
+product: Kibana
+collection: Alerting and action settings in Kibana
+
+groups:
+  - group: General settings
+    id: general-alert-action-settings
+    settings:
+      - setting: xpack.encryptedSavedObjects.encryptionKey
+        description: |
+          A string of 32 or more characters used to encrypt sensitive properties on alerting rules and actions before they're stored in Elasticsearch. Third party credentials &mdash; such as the username and password used to connect to an SMTP service &mdash; are an example of encrypted properties.
+          Kibana offers a <<kibana-encryption-keys, CLI tool>> to help generate this encryption key.
+          If not set, Kibana will generate a random key on startup, but all alerting and action functions will be blocked. Generated keys are not allowed for alerting and actions because when a new key is generated on restart, existing encrypted data becomes inaccessible. For the same reason, alerting and actions in high-availability deployments of Kibana will behave unexpectedly if the key isn't the same on all instances of Kibana.
+          Although the key can be specified in clear text in `kibana.yml`, it's recommended to store this key securely in the <<secure-settings,Kibana Keystore>>. Be sure to back up the encryption key value somewhere safe, as your alerting rules and actions will cease to function due to decryption failures should you lose it.  If you want to rotate the encryption key, be sure to follow the instructions on <<encryption-key-rotation, encryption key rotation>>.
+
+  - group: Action settings
+    id: action-settings
+    settings:
+      - setting: xpack.actions.allowedHosts
+        description: |
+          A list of hostnames that Kibana is allowed to connect to when built-in actions are triggered. It defaults to `["*"]`, allowing any host, but keep in mind the potential for SSRF attacks when hosts are not explicitly added to the allowed hosts. An empty list `[]` can be used to block built-in actions from making any external connections.
+          Note that hosts associated with built-in actions, such as Slack and PagerDuty, are not automatically added to allowed hosts. If you are not using the default `["*"]` setting, you must ensure that the corresponding endpoints are added to the allowed hosts as well.
+        platforms:
+          - cloud
+
+      - setting: xpack.actions.customHostSettings
+        description: |
+          A list of custom host settings to override existing global settings.
+          Each entry in the list must have a `url` property, to associate a connection type (mail or https), hostname and port with the remaining options in the entry.
+          The settings in `xpack.actions.customHostSettings` can be used to override the global option `xpack.actions.ssl.verificationMode` and provide customized TLS settings on a per-server basis. Set `xpack.actions.ssl.verificationMode` to the value to be used by default for all servers, then add an entry in `xpack.actions.customHostSettings` for every server that requires customized settings.
+        default: an empty list
+        platforms:
+          - cloud
+        example: |
+          In the following example, two custom host settings
+          are defined.  The first provides a custom host setting for mail server
+          `mail.example.com` using port 465 that supplies server certificate authentication
+          data from both a file and inline, and requires TLS for the
+          connection.  The second provides a custom host setting for https server
+          `webhook.example.com` which turns off server certificate authentication,
+          that will allow Kibana to connect to the server if it's using a self-signed
+          certificate.  The individual properties that can be used in the settings are
+          documented below.
+
+          [source,yaml]
+          --
+          xpack.actions.customHostSettings:
+            - url: smtp://mail.example.com:465
+              ssl:
+                verificationMode: 'full'
+                certificateAuthoritiesFiles: [ 'one.crt' ]
+                certificateAuthoritiesData: |
+                    -----BEGIN CERTIFICATE-----
+                    MIIDTD...
+                    CwUAMD...
+                    ... multiple lines of certificate data ...
+                    -----END CERTIFICATE-----
+              smtp:
+                requireTLS: true
+            - url: https://webhook.example.com
+              ssl:
+                verificationMode: 'none'
+          --
+
+      - setting: xpack.actions.customHostSettings[n].url
+        description: |
+          - "A URL associated with this custom host setting.  Should be in the form of `protocol://hostname:port`, where `protocol` is `https` or `smtp`.  If the port is not provided, 443 is used for `https` and 25 is used for `smtp`.  The `smtp` URLs are used for the Email actions that use this server, and the `https` URLs are used for actions which use `https` to connect to services."
+          - "Entries with `https` URLs can use the `ssl` options, and entries with `smtp` URLs can use both the `ssl` and `smtp` options."
+          - "No other URL values should be part of this URL, including paths, query strings, and authentication information.  When an http or smtp request is made as part of running an action, only the protocol, hostname, and port of the URL for that request are used to look up these configuration values."
+        platforms:
+          - cloud
+
+      - setting: xpack.actions.customHostSettings[n].smtp.ignoreTLS
+        description: |
+          - "A boolean value indicating that TLS must not be used for this connection. The options `smtp.ignoreTLS` and `smtp.requireTLS` can not both be set to true."
+        default: false
+        platforms:
+          - cloud
+
+      - setting: xpack.actions.customHostSettings[n].smtp.requireTLS
+        description: |
+          - "A boolean value indicating that TLS must be used for this connection. The options `smtp.ignoreTLS` and `smtp.requireTLS` can not both be set to true."
+        default: false
+        platforms:
+          - cloud
+
+      - setting: xpack.actions.customHostSettings[n].ssl.verificationMode
+        id: action-config-custom-host-verification-mode
+        description: |
+          - "Controls the verification of the server certificate that Kibana receives when making an outbound SSL/TLS connection to the host server. Valid values are `full`, `certificate`, and `none`. Use `full` to perform hostname verification, `certificate` to skip hostname verification, and `none` to skip verification. Default: `full`. <<elasticsearch-ssl-verificationMode,Equivalent Kibana setting>>. Overrides the general `xpack.actions.ssl.verificationMode` configuration for requests made for this hostname/port."
+        platforms:
+          - cloud
+
+      - setting: xpack.actions.customHostSettings[n].ssl.certificateAuthoritiesFiles
+        description: |
+          - "A file name or list of file names of PEM-encoded certificate files to use to validate the server."
+
+      - setting: xpack.actions.customHostSettings[n].ssl.certificateAuthoritiesData
+        description: |
+          - "The contents of one or more PEM-encoded certificate files in multiline format. This configuration can be used for environments where the files cannot be made available."
+        platforms:
+          - cloud
+
+      - setting: xpack.actions.email.domain_allowlist
+        id: action-config-email-domain-allowlist
+        description: |
+          - "A list of allowed email domains which can be used with the email connector. When this setting is not used, all email domains are allowed. When this setting is used, if any email is attempted to be sent that (a) includes an addressee with an email domain that is not in the allowlist, or (b) includes a from address domain that is not in the allowlist, it will fail with a message indicating the email is not allowed."
+        warning: "This feature is available in Kibana 7.17.4 and 8.3.0 onwards but is not supported in Kibana 8.0, 8.1 or 8.2. As such, this setting should be removed before upgrading from 7.17 to 8.0, 8.1 or 8.2. It is possible to configure the settings in 7.17.4 and then upgrade to 8.3.0 directly."
+        platforms:
+          - cloud
+
+      - setting: xpack.actions.enableFooterInEmail
+        description: |
+          - "A boolean value indicating that a footer with a relevant link should be added to emails sent as alerting actions."
+        default: true
+        platforms:
+          - cloud
+
+      - setting: xpack.actions.enabledActionTypes
+        description: |
+          - 'A list of action types that are enabled. It defaults to `["*"]`, enabling all types. The names for built-in Kibana action types are prefixed with a `.` and include: `.email`, `.index`, `.jira`, `.opsgenie`, `.pagerduty`, `.resilient`, `.server-log`, `.servicenow`, .`servicenow-itom`, `.servicenow-sir`, `.slack`, `.swimlane`, `.teams`, `.tines`, `.torq`, `.xmatters`,  `.gen-ai`,  `.bedrock`, `.gemini`,  `.d3security`, and `.webhook`. An empty list `[]` will disable all action types.'
+          - "Disabled action types will not appear as an option when creating new connectors, but existing connectors and actions of that type will remain in Kibana and will not function."
+        important: "<<pre-configured-connectors,Preconfigured connectors>> are not affected by this setting."
+        platforms:
+          - cloud
+
+      - setting: xpack.actions.microsoftExchangeUrl
+        description: |
+          - "The URL for the Microsoft Azure Active Directory endpoint to use for MS Exchange email authentication."
+        default: https://login.microsoftonline.com
+        
+      - setting: xpack.actions.microsoftGraphApiUrl
+        description: |
+          - "The URL for the Microsoft Graph API endpoint to use for MS Exchange email authentication."
+        default: https://graph.microsoft.com/v1.0
+
+      - setting: xpack.actions.microsoftGraphApiScope
+        description: |
+          - "The URL for the Microsoft Graph API scope endpoint to use for MS Exchange email authentication."
+        default: https://graph.microsoft.com/.default
+        
+      - setting: xpack.actions.proxyUrl
+        description: |
+          - "Specifies the proxy URL to use, if using a proxy for actions. By default, no proxy is used."
+          - 'Proxies may be used to proxy http or https requests through a proxy using the http or https protocol.  Kibana only uses proxies in "CONNECT" mode (sometimes referred to as "tunneling" TCP mode, compared to HTTP mode).  That is, Kibana will always make requests through a proxy using the HTTP `CONNECT` method.'
+          - "If your proxy is using the https protocol (vs the http protocol), the setting `xpack.actions.ssl.proxyVerificationMode: none` will likely be needed, unless your proxy's certificates are signed using a publicly available certificate authority."
+          - "There is currently no support for using basic authentication with a proxy (authentication for the proxy itself, not the URL being requested through the proxy)."
+        platforms:
+          - cloud
+        example: |
+          To help diagnose problems using a proxy, you can use the `curl` command with options to use your proxy, and log debug information, with the following command, replacing the proxy and target URLs as appropriate.  This will force the request to be made to the
+          proxy in tunneling mode, and display some of the interaction between the client and the proxy.
+          
+          [source,sh]
+          --
+          curl --verbose --proxytunnel --proxy http://localhost:8080 http://example.com
+          --
+
+      - setting: xpack.actions.proxyBypassHosts
+        description: |
+          - "Specifies hostnames which should not use the proxy, if using a proxy for actions. The value is an array of hostnames as strings."
+          - "By default, all hosts will use the proxy, but if an action's hostname is in this list, the proxy will not be used.  The settings `xpack.actions.proxyBypassHosts` and `xpack.actions.proxyOnlyHosts` cannot be used at the same time."
+        platforms:
+          - cloud
+        example: |
+          For example:
+          
+          [source,yaml]
+          ----
+          xpack.actions.proxyBypassHosts: [ "events.pagerduty.com" ]
+          ----
+          
+          If applicable, include the subdomain in the hostname
+
+      - setting: xpack.actions.proxyOnlyHosts
+        description: |
+          - "Specifies hostnames which should only use the proxy, if using a proxy for actions. The value is an array of hostnames as strings."
+          - "By default, no hosts will use the proxy, but if an action's hostname is in this list, the proxy will be used.  The settings `xpack.actions.proxyBypassHosts` and `xpack.actions.proxyOnlyHosts` cannot be used at the same time."
+        platforms:
+          - cloud
+        example: |
+          For example:
+          
+          [source,yaml]
+          ----
+          xpack.actions.proxyOnlyHosts: [ "events.pagerduty.com" ]
+          ----
+
+          If applicable, include the subdomain in the hostname
+
+      - setting: xpack.actions.proxyHeaders
+
+        description: |
+          - "Specifies HTTP headers for the proxy, if using a proxy for actions."
+        default: '{}'
+        platforms:
+          - cloud
+
+      - setting: xpack.actions.ssl.proxyVerificationMode
+        id: action-config-proxy-verification-mode
+        description: |
+          - "Controls the verification for the proxy server certificate that Kibana receives when making an outbound SSL/TLS connection to the proxy server."
+          - "Use `full` to perform hostname verification, `certificate` to skip hostname verification, and `none` to skip verification."
+          - "<<elasticsearch-ssl-verificationMode,Equivalent Kibana setting>>"
+        default: full
+        options:
+          - option: full
+          - option: certificate
+          - option: none
+        platforms:
+          - cloud
+
+      - setting: xpack.actions.ssl.verificationMode
+        id: action-config-verification-mode
+        description: |
+          - "Controls the verification for the server certificate that Elastic Maps Server receives when making an outbound SSL/TLS connection for actions. Valid values are `full`, `certificate`, and `none`. Use `full` to perform hostname verification, `certificate` to skip hostname verification, and `none` to skip verification."
+          - "<<elasticsearch-ssl-verificationMode,Equivalent Kibana setting>>"
+          - "This setting can be overridden for specific URLs by using the setting `xpack.actions.customHostSettings[n].ssl.verificationMode` (described above) to a different value."
+        default: full
+        options:
+          - option: full
+          - option: certificate
+          - option: none
+        platforms:
+          - cloud
+
+      - setting: xpack.actions.maxResponseContentLength
+        description: |
+          - "Specifies the max number of bytes of the http response for requests to external resources."
+        default: 1000000 (1MB)
+        platforms:
+          - cloud
+
+      - setting: xpack.actions.responseTimeout
+        description: |
+          - "Specifies the time allowed for requests to external resources. Requests that take longer are canceled. The time is formatted as a number and a time unit (`ms`, `s`, `m`, `h`, `d`, `w`, `M`, or `Y`). For example, `20m`, `24h`, `7d`, `1w`. Default: `60s`."
+        platforms:
+          - cloud
+
+      - setting: xpack.actions.run.maxAttempts
+
+        description: |
+          - "Specifies the maximum number of times an action can be attempted to run."
+        options:
+          - option: minimum 1 and maximum 10
+        platforms:
+          - cloud
+
+      - setting: xpack.actions.run.connectorTypeOverrides
+        description: |
+          - "Overrides the configs under `xpack.actions.run` for the connector type with the given ID. List the connector type identifier and its settings in an array of objects."
+        platforms:
+          - cloud
+        example: |
+          For example:
+
+          [source,yaml]
+          --
+          xpack.actions.run:
+              maxAttempts: 1
+              connectorTypeOverrides:
+                  - id: '.server-log'
+                    maxAttempts: 5
+          --
+
+      - setting: xpack.actions.queued.max
+        description: |
+          - "Specifies the maximum number of actions that can be queued."
+        default: 1000000
+        platforms:
+          - cloud
+
+  - group: Preconfigured connector settings
+    id: preconfigured-connector-settings
+    description: |
+      - "These settings vary depending on which type of preconfigured connector you're adding."
+    example: |
+      For example:
+      
+      [source,yaml]
+      ----------------------------------------
+      xpack.actions.preconfigured:
+        my-server-log:
+          name: preconfigured-server-log-connector-type
+          actionTypeId: .server-log
+      ----------------------------------------
+      
+      For more examples, go to <<pre-configured-connectors>>.
+
+    settings:
+
+      - setting: xpack.actions.preconfiguredAlertHistoryEsIndex
+        description: |
+          - "Enables a preconfigured alert history Elasticsearch <<index-action-type, Index>> connector."
+        default: false
+        platforms:
+          - cloud
+
+      - setting: xpack.actions.preconfigured
+        description: |
+          - "Specifies configuration details that are specific to the type of preconfigured connector."
+  
+      - setting: xpack.actions.preconfigured.<connector-id>.actionTypeId
+        description: |
+          - "The type of preconfigured connector."
+        options:
+          - option: .email
+          - option: .index
+          - option: .opsgenie
+          - option: .server-log
+          - option: .resilient
+          - option: .slack
+          - option: .webhook
+            
+      - setting: xpack.actions.preconfigured.<connector-id>.config
+        description: |
+          - "The configuration details, which are specific to the type of preconfigured connector."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.apiProvider
+
+        description: |
+          - "For a <<openai-action-type,OpenAI connector>>, specifies the OpenAI API provider."
+
+        options:
+          - option: OpenAI
+          - option: Azure OpenAI
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.apiUrl
+        description: |
+          - "A configuration URL that varies by connector:"
+          - "* For an <<bedrock-action-type,{bedrock} connector>>, specifies the {bedrock} request URL."
+          - "* For an <<gemini-action-type,{gemini} connector>>, specifies the {gemini} request URL."
+          - "* For a <<openai-action-type,OpenAI connector>>, specifies the OpenAI request URL."
+          - "* For a <<resilient-action-type,{ibm-r} connector>>, specifies the {ibm-r} instance URL."
+          - "* For a <<jira-action-type,Jira connector>>, specifies the Jira instance URL."
+          - "* For an <<opsgenie-action-type,{opsgenie} connector>>, specifies the {opsgenie} URL. For example, `https://api.opsgenie.com` or `https://api.eu.opsgenie.com`."
+          - "* For a <<pagerduty-action-type,PagerDuty connector>>, specifies the PagerDuty event URL. Defaults to `https://events.pagerduty.com/v2/enqueue`."
+          - "* For a <<servicenow-action-type,{sn-itsm}>>, <<servicenow-sir-action-type,{sn-sir}>>, or <<servicenow-itom-action-type,{sn-itom} connector>> specifies the ServiceNow instance URL."
+          - "* For a <<swimlane-action-type,{swimlane} connector>>, specifies the {swimlane} instance URL."
+
+        note: "If you are using the `xpack.actions.allowedHosts` setting, make sure the hostname in the URL is added to the allowed hosts."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.appId
+        description: |
+          - "An application ID that varies by connector:"
+          - "* For a <<swimlane-action-type,{swimlane} connector>>, specifies a {swimlane} application identifier."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.clientId
+        description: |
+          - "A client identifier that varies by connector:"
+          - "* For an <<email-action-type,email connector>>, specifies a GUID format value that corresponds to the client ID, which is a part of OAuth 2.0 client credentials authentication."
+          - "* For a <<servicenow-itom-action-type,{sn-itom}>>, <<servicenow-action-type,{sn-itsm}>>, or <<servicenow-sir-action-type,{sn-sir} connector>> specifies the client identifier assigned to the OAuth application."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.configUrl
+        description: |
+          - "For an <<xmatters-action-type,xMatters connector>> with basic authentication, specifies the request URL for the Elastic Alerts trigger in xMatters."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.createCommentJson
+        description: |
+          - "For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a stringified JSON payload with Mustache variables that is sent to the create comment URL to create a case comment. The required variable is `case.description`."
+        note: "The JSON is validated after the Mustache variables have been placed when the REST method runs. You should manually ensure that the JSON is valid, disregarding the Mustache variables, so the later validation will pass."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.createCommentMethod
+        description: |
+          - "For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies the REST API HTTP request method to create a case comment in the third-party system."
+        default: put
+        options:
+          - option: post
+          - option: put
+          - option: patch
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.createCommentUrl
+        description: |
+          - "For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a REST API URL string to create a case comment by ID in the third-party system."
+        note: "If you are using the `xpack.actions.allowedHosts` setting, make sure the hostname in the URL is added to the allowed hosts."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.createIncidentJson
+        description: |
+          - "For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a stringified JSON payload with Mustache variables that is sent to the create case URL to create a case. Required variables are `case.title` and `case.description`."
+
+        note: "The JSON is validated after the Mustache variables have been placed when the REST method runs. You should manually ensure that the JSON is valid, disregarding the Mustache variables, so the later validation will pass."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.createIncidentMethod
+        description: |
+          - "For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies the REST API HTTP request method to create a case in the third-party system"
+
+        default: post
+        options:
+          - option: post
+          - option: put
+          - option: patch
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.createIncidentUrl
+        description: |
+          - "For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a REST API URL string to create a case in the third-party system."
+        note: "If you are using the `xpack.actions.allowedHosts` setting, make sure the hostname in the URL is added to the allowed hosts."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.createIncidentResponseKey
+        description: |
+          - "For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a string from the response body of the create case method that corresponds to the external service identifier."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.defaultModel
+        description: |
+          - "The default model to use for requests, which varies by connector:"
+          - "* For an <<bedrock-action-type,{bedrock} connector>>, current support is for the Anthropic Claude models. Defaults to `anthropic.claude-3-5-sonnet-20240620-v1:0`."
+          - "* For a <<gemini-action-type,{gemini} connector>>, current support is for the Gemini models. Defaults to `gemini-1.5-pro-002`."
+          - "* For a <<openai-action-type,OpenAI connector>>, it is optional and applicable only when `xpack.actions.preconfigured.<connector-id>.config.apiProvider` is `OpenAI`."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.executionTimeField
+        description: |
+          - "For an <<index-action-type,index connector>>, a field that indicates when the document was indexed."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.from
+        description: |
+          - "For an <<email-action-type,email connector>>, specifies the from address for all emails sent by the connector. It must be specified in `user@host-name` format."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.getIncidentResponseExternalTitleKey
+        description: |
+          - "For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a string from the response body of the get case method that corresponds to the external service title."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.getIncidentUrl
+        description: |
+          - "For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a REST API URL string with an external service ID Mustache variable to get the case from the third-party system."
+        note: "If you are using the `xpack.actions.allowedHosts` setting, make sure the hostname in the URL is added to the allowed hosts. "
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.hasAuth
+        description: |
+          - "For an <<email-action-type,email>>, <<webhook-action-type,webhook>>, or <<cases-webhook-action-type,{webhook-cm} connector>>, specifies whether a user and password are required inside the secrets configuration."
+        default: true
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.headers
+        description: |
+          - "For a <<webhook-action-type,webhook>> or <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a set of key-value pairs sent as headers with the request."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.host
+        description: |
+          - "For an <<email-action-type,email connector>>, specifies the host name of the service provider."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.index
+        description: |
+          - "For an <<index-action-type,index connector>>, specifies the Elasticsearch index."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.isOAuth
+        description: |
+          - "For a <<servicenow-action-type,{sn-itsm}>>, <<servicenow-sir-action-type,{sn-sir}>>, or <<servicenow-itom-action-type,{sn-itom} connector>>, specifies whether to use basic or OAuth authentication."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.jwtKeyId
+        description: |
+          - "For a <<servicenow-action-type,{sn-itsm}>>, <<servicenow-sir-action-type,{sn-sir}>>, or <<servicenow-itom-action-type,{sn-itom} connector>>, specifies the key ID assigned to the JWT verifier map of your OAuth application. It is required when `xpack.actions.preconfigured.<connector-id>.config.isOAuth` is `true`."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.mappings
+        description: |
+          - "For a <<swimlane-action-type,Swimlane connector>>, specifies field mappings."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.mappings.alertIdConfig
+        description: |
+          - "For a <<swimlane-action-type,Swimlane connector>>, field mapping for the alert identifier. You must provide `fieldtype`, `id`, `key`, and `name` values."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.mappings.caseIdConfig
+        description: |
+          - "For a <<swimlane-action-type,Swimlane connector>>, field mapping for the case identifier. You must provide `fieldtype`, `id`, `key`, and `name` values."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.mappings.caseNameConfig
+        description: |
+          - "For a <<swimlane-action-type,Swimlane connector>>, field mapping for the case name. You must provide `fieldtype`, `id`, `key`, and `name` values."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.mappings.commentsConfig
+        description: |
+          - "For a <<swimlane-action-type,Swimlane connector>>, field mapping for the case comments. You must provide `fieldtype`, `id`, `key`, and `name` values."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.mappings.descriptionConfig
+        description: |
+          - "For a <<swimlane-action-type,Swimlane connector>>, field mapping for the case description. You must provide `fieldtype`, `id`, `key`, and `name` values."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.mappings.ruleNameConfig
+        description: |
+          - "For a <<swimlane-action-type,Swimlane connector>>, field mapping for the rule name. You must provide `fieldtype`, `id`, `key`, and `name` values."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.mappings.severityConfig
+        description: |
+          - "For a <<swimlane-action-type,Swimlane connector>>, specifies a field mapping for the severity. You must provide `fieldtype`, `id`, `key`, and `name` values."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.method
+        description: |
+          - "For a <<webhook-action-type,webhook connector>>, specifies the HTTP request method, either `post` or `put`. Defaults to `post`."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.orgId
+        description: |
+          - "For an <<resilient-action-type,{ibm-r} connector>>, specifies the {ibm-r} organization identifier."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.port
+        description: |
+          - "For an <<email-action-type,email connector>>, specifies the port to connect to on the service provider."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.projectKey
+        description: |
+          - "For a <<jira-action-type,Jira connector>>, specifies the Jira project key."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.secure
+        description: |
+          - "For an <<email-action-type,email connector>>, specifies whether the connection will use TLS when connecting to the service provider. If not true, the connection will initially connect over TCP then attempt to switch to TLS via the SMTP STARTTLS command."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.service
+        description: |
+          - "For an <<email-action-type,email connector>>, specifies the name of the email service. For example, `elastic_cloud`, `exchange_server`, `gmail`, `other`, `outlook365`, or `ses`."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.tenantId
+        description: |
+          - "For an <<email-action-type,email connector>>, specifies a GUID format value that corresponds to a tenant ID, which is a part of OAuth 2.0 client credentials authentication."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.updateIncidentJson
+        description: |
+          - "For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a stringified JSON payload with Mustache variables that is sent to the update case URL to update a case. Required variables are `case.title` and `case.description`."
+
+        note: "The JSON is validated after the Mustache variables have been placed when the REST method runs. You should manually ensure that the JSON is valid, disregarding the Mustache variables, so the later validation will pass."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.updateIncidentMethod
+        description: |
+          - "For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies the REST API HTTP request method to update the case in the third-party system."
+        default: put
+        options:
+          - option: post
+          - option: put
+          - option: patch
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.updateIncidentUrl
+        description: |
+          - "For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies the REST API URL to update the case by ID in the third-party system."
+        note: "If you are using the `xpack.actions.allowedHosts` setting, make sure the hostname in the URL is added to the allowed hosts."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.url
+        description: |
+          - "A configuration URL that varies by connector:"
+          - "* For a <<d3security-action-type,D3 Security connector>>, specifies the D3 Security API request URL."
+          - "* For a <<tines-action-type,Tines connector>>, specifies the Tines tenant URL."
+          - "* For a <<webhook-action-type,webhook connector>>, specifies the web service request URL."
+        note: "If you are using the `xpack.actions.allowedHosts` setting, make sure this hostname is added to the allowed hosts."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.userIdentifierValue
+        description: |
+          - "For a <<servicenow-action-type,{sn-itsm}>>, <<servicenow-sir-action-type,{sn-sir}>>, or <<servicenow-itom-action-type,{sn-itom} connector>>, specifies the user identifier. It is required when required when `xpack.actions.preconfigured.<connector-id>.config.isOAuth` is `true`."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.usesBasic
+        description: |
+          - "For an <<xmatters-action-type,xMatters connector>>, specifies whether it uses HTTP basic authentication."
+        default: true
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.usesTableApi
+        description: |
+          - "For a <<servicenow-action-type,{sn-itsm}>> or <<servicenow-sir-action-type,{sn-sir} connector>>, specifies whether the connector uses the Table API or the Import Set API. If set to `false`, the Elastic application should be installed in ServiceNow."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.viewIncidentUrl
+        description: |
+          - "For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a URL string with either the external service ID or external service title Mustache variable to view a case in the external system."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.config.webhookIntegrationUrl
+        description: |
+          - "For a <<torq-action-type,Torq connector>>, specifies the endpoint URL of the Elastic Security integration in Torq."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.name
+        description: |
+          - "The name of the preconfigured connector."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.secrets
+        description: |
+          - "Sensitive configuration details, such as username, password, and keys, which are specific to the connector type."
+        tip: "Sensitive properties, such as passwords, should be stored in the <<creating-keystore,Kibana keystore>>."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.secrets.accessKey
+        description: |
+          - "For an <<bedrock-action-type,{bedrock} connector>>, specifies the AWS access key for authentication."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.secrets.apikey
+        description: |
+          - "An API key secret that varies by connector."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.secrets.credentialsJson
+        description: |
+          - "For an <<gemini-action-type,{gemini} connector>>, specifies the GCP service account credentials JSON file for authentication."
+          - "* For a <<openai-action-type,OpenAI connector>>, specifies the OpenAI or Azure OpenAI API key for authentication."
+          - "* For an <<opsgenie-action-type,{opsgenie} connector>>, specifies the {opsgenie} API authentication key for HTTP basic authentication."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.secrets.apiKeyId
+        description: |
+          - "For an <<resilient-action-type,{ibm-r} connector>>, specifies the authentication key ID for HTTP basic authentication."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.secrets.apiKeySecret
+        description: |
+          - "For an <<resilient-action-type,{ibm-r} connector>>, specifies the authentication key secret for HTTP basic authentication."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.secrets.apiToken
+        description: |
+          - "For a <<jira-action-type,Jira>> or <<swimlane-action-type,{swimlane} connector>>, specifies the API authentication token for HTTP basic authentication."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.secrets.clientSecret
+        description: |
+          - "A client secret that varies by connector:"
+          - "* For an <<email-action-type,email connector>>, specifies the client secret that you generated for your app in the app registration portal. It is required when the email service is `exchange_server`, which uses OAuth 2.0 client credentials authentication."
+          - "* For a <<servicenow-action-type,{sn-itsm}>>, <<servicenow-sir-action-type,{sn-sir}>>, or <<servicenow-itom-action-type,{sn-itom} connector>>, specifies the client secret assigned to the OAuth application. It is required when `xpack.actions.preconfigured.<connector-id>.config.isOAuth` is `true`."
+
+        note: "The client secret must be URL-encoded."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.secrets.email
+        description: |
+          - "An email address that varies by connector:"
+          - "* For a <<jira-action-type,Jira connector>>, specifies the account email for HTTP basic authentication."
+          - "* For a <<tines-action-type,Tines connector>>, specifies the email used to sign in to Tines."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.secrets.password
+        description: |
+          - "A password secret that varies by connector:"
+          - "* For an <<email-action-type,email>>, <<webhook-action-type,webhook>>, or <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a password that is required when `xpack.actions.preconfigured.<connector-id>.config.hasAuth` is `true`."
+          - "* For a <<servicenow-action-type,{sn-itsm}>>, <<servicenow-sir-action-type,{sn-sir}>>, or <<servicenow-itom-action-type,{sn-itom} connector>>, specifies a password that is required when `xpack.actions.preconfigured.<connector-id>.config.isOAuth` is `false`."
+          - "* For an <<xmatters-action-type,xMatters connector>>, specifies a password that is required when `xpack.actions.preconfigured.<connector-id>.config.usesBasic` is `true`."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.secrets.privateKey
+        description: |
+          - "For a <<servicenow-action-type,{sn-itsm}>>, <<servicenow-sir-action-type,{sn-sir}>>, or <<servicenow-itom-action-type,{sn-itom} connector>>, specifies the RSA private key. It is required when `xpack.actions.preconfigured.<connector-id>.config.isOAuth` is `true`."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.secrets.privateKeyPassword
+        description: |
+          - "For a <<servicenow-action-type,{sn-itsm}>>, <<servicenow-sir-action-type,{sn-sir}>>, or <<servicenow-itom-action-type,{sn-itom} connector>>, specifies the password for the RSA private key."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.secrets.routingKey
+        description: |
+          - "For a <<pagerduty-action-type,PagerDuty connector>>, specifies the 32 character PagerDuty Integration Key for an integration on a service, also referred to as the routing key."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.secrets.secret
+        description: |
+          - "For an <<bedrock-action-type,{bedrock} connector>>, specifies the AWS secret for authentication."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.secrets.secretsUrl
+        description: |
+          - "For an <<xmatters-action-type,xMatters connector>> with URL authentication, specifies the request URL for the Elastic Alerts trigger in xMatters with the API key included in the URL. It is used only when `xpack.actions.preconfigured.<connector-id>.config.usesBasic` is `false`."
+        note: "If you are using the `xpack.actions.allowedHosts` setting, make sure this hostname is added to the allowed hosts."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.secrets.token
+        description: |
+          - "A token secret that varies by connector:"
+          - "* For a <<d3security-action-type,D3 Security conector>>, specifies the D3 Security token."
+          - "* For a <<slack-action-type,Slack connector>>, specifies the Slack bot user OAuth token."
+          - "* For a <<tines-action-type,Tines connector>>, specifies the Tines API token."
+          - "* For a <<torq-action-type,Torq connector>>, specifies the secret of the webhook authentication header."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.secrets.user
+        description: |
+          - "A user name secret that varies by connector:"
+          - "* For an <<email-action-type,email>>, <<webhook-action-type,webhook>>, or <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a user name that is required when `xpack.actions.preconfigured.<connector-id>.config.hasAuth` is `true`."
+          - "* For an <<xmatters-action-type,xMatters connector>>, specifies a user name that is required when `xpack.actions.preconfigured.<connector-id>.config.usesBasic` is `true`."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.secrets.webhookUrl
+        description: |
+          - "A URL that varies by connector:"
+          - "* For a <<teams-action-type,Microsoft Teams>>, specifies the URL of the incoming webhook."
+          - "* For a <<slack-action-type,Slack connector>>, specifies the Slack webhook URL."
+        note: "If you are using the `xpack.actions.allowedHosts` setting, make sure the hostname is added to the allowed hosts."
+
+      - setting: xpack.actions.preconfigured.<connector-id>.secrets.username
+        description: |
+          - "For a <<servicenow-action-type,{sn-itsm}>>, <<servicenow-sir-action-type,{sn-sir}>>, or <<servicenow-itom-action-type,{sn-itom} connector>>, specifies a user name that is required when `xpack.actions.preconfigured.<connector-id>.config.isOAuth` is `false`."
+
+  - group: Alerting settings
+    id: alert-settings
+
+    settings:
+
+      - setting: xpack.alerting.cancelAlertsOnRuleTimeout
+        description: |
+          - "Specifies whether to skip writing alerts and scheduling actions if rule processing was cancelled due to a timeout. This setting can be overridden by individual rule types."
+        default: true
+        platforms:
+          - cloud
+
+      - setting: xpack.alerting.rules.maxScheduledPerMinute
+        description: |
+          - "Specifies the maximum number of rules to run per minute."
+        default: 10000
+
+      - setting: xpack.alerting.rules.minimumScheduleInterval.value
+        description: |
+          - "Specifies the minimum schedule interval for rules. This minimum is applied to all rules created or updated after you set this value. The time is formatted as a number and a time unit (`s`, `m`, `h`, or `d`). For example, `20m`, `24h`, `7d`. This duration cannot exceed `1d`."
+        default: 1m
+        platforms:
+          - cloud
+
+      - setting: xpack.alerting.rules.minimumScheduleInterval.enforce
+        description: |
+          - "Specifies the behavior when a new or changed rule has a schedule interval less than the value defined in `xpack.alerting.rules.minimumScheduleInterval.value`. If `false`, rules with schedules less than the interval will be created but warnings will be logged. If `true`, rules with schedules less than the interval cannot be created."
+        default: false
+        platforms:
+          - cloud
+
+      - setting: xpack.alerting.rules.run.actions.max
+        description: |
+          - "Specifies the maximum number of actions that a rule can generate each time detection checks run."
+
+        platforms:
+          - cloud
+
+      - setting: xpack.alerting.rules.run.alerts.max
+        description: |
+          - "Specifies the maximum number of alerts that a rule can generate each time detection checks run."
+        warning: "The exact number of alerts your cluster can safely handle depends on your cluster configuration and workload, however setting a value higher than the default (`1000`) is not recommended or supported. Doing so could strain system resources and lead to performance issues, delays in alert processing, and potential disruptions during high alert activity periods."
+        default: 1000
+        platforms:
+          - cloud
+
+      - setting: xpack.alerting.rules.run.timeout
+        description: |
+          - "Specifies the default timeout for tasks associated with all types of rules. The time is formatted as a number and a time unit (`ms`, `s`, `m`, `h`, `d`, `w`, `M`, or `Y`). For example, `20m`, `24h`, `7d`, `1w`. Default: `5m`."
+        platforms:
+          - cloud
+
+      - setting: xpack.alerting.rules.run.ruleTypeOverrides
+        description: |
+          - "Overrides the configs under `xpack.alerting.rules.run` for the rule type with the given ID. List the rule identifier and its settings in an array of objects."
+        platforms:
+          - cloud
+        example: |
+          For example:
+          
+          [source,yaml]
+          --
+          xpack.alerting.rules.run:
+              timeout: '5m'
+              ruleTypeOverrides:
+                  - id: '.index-threshold'
+                    timeout: '15m'
+          --
+
+      - setting: xpack.alerting.rules.run.actions.connectorTypeOverrides
+        description: |
+          - "Overrides the configs under `xpack.alerting.rules.run.actions` for the connector type with the given ID. List the connector type identifier and its settings in an array of objects."
+        platforms:
+          - cloud
+        example: |
+          For example:
+          
+          [source,yaml]
+          --
+          xpack.alerting.rules.run:
+              actions:
+                  max: 10
+                  connectorTypeOverrides:
+                      - id: '.server-log'
+                        max: 5
+          --

--- a/docs/source/markup/substitutions.md
+++ b/docs/source/markup/substitutions.md
@@ -2,14 +2,16 @@
 title: Substitutions
 sub:
   frontmatter_key: "Front Matter Value"
+  a-key-with-dashes: "A key with dashes"
   version: 7.17.0
 ---
 
 Here are some variable substitutions:
 
-| Value               | Source       |
-| ------------------- | ------------ |
-| {{frontmatter_key}} | Front Matter |
+| Variable              | Defined in   |
+|-----------------------|--------------|
+| {{frontmatter_key}}   | Front Matter |
+| {{a-key-with-dashes}} | Front Matter |
 
 Substitutions should work in code blocks too.
 
@@ -20,3 +22,6 @@ shasum -a 512 -c elasticsearch-{{version}}-linux-x86_64.tar.gz.sha512 <1>
 tar -xzf elasticsearch-{{version}}-linux-x86_64.tar.gz
 cd elasticsearch-{{version}}/ <2>
 ```
+
+
+Here is a variable with dashes: {{a-key-with-dashes}}

--- a/src/Elastic.Markdown/IO/MarkdownFile.cs
+++ b/src/Elastic.Markdown/IO/MarkdownFile.cs
@@ -75,7 +75,7 @@ public record MarkdownFile : DocumentationFile
 		if (document.FirstOrDefault() is YamlFrontMatterBlock yaml)
 		{
 			var raw = string.Join(Environment.NewLine, yaml.Lines.Lines);
-			YamlFrontMatter = FrontMatterParser.Deserialize(raw);
+			YamlFrontMatter = YamlSerialization.Deserialize<YamlFrontMatter>(raw);
 			Title = YamlFrontMatter.Title;
 			NavigationTitle = YamlFrontMatter.NavigationTitle;
 		}

--- a/src/Elastic.Markdown/Myst/Directives/AdmonitionBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/AdmonitionBlock.cs
@@ -3,8 +3,12 @@
 // See the LICENSE file in the project root for more information
 namespace Elastic.Markdown.Myst.Directives;
 
-public class AdmonitionBlock(DirectiveBlockParser parser, string admonition, Dictionary<string, string> properties)
-	: DirectiveBlock(parser, properties)
+public class AdmonitionBlock(
+	DirectiveBlockParser parser,
+	string admonition,
+	Dictionary<string, string> properties,
+	ParserContext context)
+	: DirectiveBlock(parser, properties, context)
 {
 	public string Admonition => admonition == "admonition" ? Classes?.Trim() ?? "note" : admonition;
 
@@ -36,8 +40,8 @@ public class AdmonitionBlock(DirectiveBlockParser parser, string admonition, Dic
 }
 
 
-public class DropdownBlock(DirectiveBlockParser parser, Dictionary<string, string> properties)
-	: AdmonitionBlock(parser, "admonition", properties)
+public class DropdownBlock(DirectiveBlockParser parser, Dictionary<string, string> properties, ParserContext context)
+	: AdmonitionBlock(parser, "admonition", properties, context)
 {
 	// ReSharper disable once RedundantOverriddenMember
 	public override void FinalizeAndValidate(ParserContext context)

--- a/src/Elastic.Markdown/Myst/Directives/AppliesBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/AppliesBlock.cs
@@ -2,13 +2,14 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using Elastic.Markdown.Diagnostics;
 using Elastic.Markdown.Myst.FrontMatter;
 using Markdig.Syntax;
 
 namespace Elastic.Markdown.Myst.Directives;
 
-public class AppliesBlock(DirectiveBlockParser parser, Dictionary<string, string> properties)
-	: DirectiveBlock(parser, properties)
+public class AppliesBlock(DirectiveBlockParser parser, Dictionary<string, string> properties, ParserContext context)
+	: DirectiveBlock(parser, properties, context)
 {
 	public override string Directive => "mermaid";
 
@@ -48,7 +49,7 @@ public class AppliesBlock(DirectiveBlockParser parser, Dictionary<string, string
 		}
 
 		if (Deployment is null)
-			EmitError(context, "{applies} block with no product availability specified");
+			this.EmitError("{applies} block with no product availability specified");
 
 		var index = Parent?.IndexOf(this);
 		if (Parent is not null && index > 0)
@@ -56,7 +57,7 @@ public class AppliesBlock(DirectiveBlockParser parser, Dictionary<string, string
 			var i = index - 1 ?? 0;
 			var prevSib = Parent[i];
 			if (prevSib is not HeadingBlock)
-				EmitError(context, "{applies} should follow a heading");
+				this.EmitError("{applies} should follow a heading");
 		}
 
 		bool TryGetAvailability(string key, out ProductAvailability? semVersion)

--- a/src/Elastic.Markdown/Myst/Directives/CodeBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/CodeBlock.cs
@@ -3,8 +3,12 @@
 // See the LICENSE file in the project root for more information
 namespace Elastic.Markdown.Myst.Directives;
 
-public class CodeBlock(DirectiveBlockParser parser, string directive, Dictionary<string, string> properties)
-	: DirectiveBlock(parser, properties)
+public class CodeBlock(
+	DirectiveBlockParser parser,
+	string directive,
+	Dictionary<string, string> properties,
+	ParserContext context)
+	: DirectiveBlock(parser, properties, context)
 {
 	public override string Directive => directive;
 	public string? Caption { get; private set; }

--- a/src/Elastic.Markdown/Myst/Directives/DirectiveBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/DirectiveBlock.cs
@@ -5,6 +5,7 @@
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
+using System.IO.Abstractions;
 using Elastic.Markdown.Diagnostics;
 using Markdig.Helpers;
 using Markdig.Syntax;
@@ -22,10 +23,22 @@ namespace Elastic.Markdown.Myst.Directives;
 /// <param name="parser">The parser used to create this block.</param>
 /// <param name="properties"></param>
 /// <param name="context"></param>
-public abstract class DirectiveBlock(DirectiveBlockParser parser, Dictionary<string, string> properties)
+public abstract class DirectiveBlock(
+	DirectiveBlockParser parser,
+	Dictionary<string, string> properties,
+	ParserContext context
+	)
 	: ContainerBlock(parser), IFencedBlock
 {
-	public IReadOnlyDictionary<string, string> Properties { get; } = properties;
+	protected IReadOnlyDictionary<string, string> Properties { get; } = properties;
+
+	public BuildContext Build { get; } = context.Build;
+
+	public IFileInfo CurrentFile { get; } = context.Path;
+
+	public bool SkipValidation { get; } = context.SkipValidation;
+
+	public abstract string Directive { get; }
 
 	public string? CrossReferenceName  { get; protected set; }
 
@@ -90,14 +103,5 @@ public abstract class DirectiveBlock(DirectiveBlockParser parser, Dictionary<str
 
 		return default;
 	}
-
-	public abstract string Directive { get; }
-
-	protected void EmitError(ParserContext context, string message) =>
-		context.EmitError(Line + 1, 1, Directive.Length + 4 , message);
-
-	protected void EmitWarning(ParserContext context, string message) =>
-		context.EmitWarning(Line + 1, 1, Directive.Length + 4 , message);
-
 
 }

--- a/src/Elastic.Markdown/Myst/Directives/DirectiveBlockParser.cs
+++ b/src/Elastic.Markdown/Myst/Directives/DirectiveBlockParser.cs
@@ -74,21 +74,21 @@ public class DirectiveBlockParser : FencedBlockParserBase<DirectiveBlock>
 			throw new Exception("Expected parser context to be of type ParserContext");
 
 		if (info.IndexOf("{") == -1)
-		    return new CodeBlock(this, "raw", _admonitionData);
+		    return new CodeBlock(this, "raw", _admonitionData, context);
 
 	    // TODO alternate lookup .NET 9
 	    var directive = info.ToString().Trim(['{', '}', '`']);
 	    if (_unsupportedBlocks.TryGetValue(directive, out var issueId))
-		    return new UnsupportedDirectiveBlock(this, directive, _admonitionData, issueId);
+		    return new UnsupportedDirectiveBlock(this, directive, _admonitionData, issueId, context);
 
 	    if (info.IndexOf("{tab-set}") > 0)
-		    return new TabSetBlock(this, _admonitionData);
+		    return new TabSetBlock(this, _admonitionData, context);
 
 	    if (info.IndexOf("{tab-item}") > 0)
-		    return new TabItemBlock(this, _admonitionData);
+		    return new TabItemBlock(this, _admonitionData, context);
 
 	    if (info.IndexOf("{dropdown}") > 0)
-		    return new DropdownBlock(this, _admonitionData);
+		    return new DropdownBlock(this, _admonitionData, context);
 
 	    if (info.IndexOf("{image}") > 0)
 		    return new ImageBlock(this, _admonitionData, context);
@@ -103,7 +103,7 @@ public class DirectiveBlockParser : FencedBlockParserBase<DirectiveBlock>
 	    // leaving the parsing in until we are confident we don't want this
 	    // for dev-docs
 	    if (info.IndexOf("{mermaid}") > 0)
-		    return new MermaidBlock(this, _admonitionData);
+		    return new MermaidBlock(this, _admonitionData, context);
 
 	    if (info.IndexOf("{include}") > 0)
 			return new IncludeBlock(this, _admonitionData, context);
@@ -112,26 +112,29 @@ public class DirectiveBlockParser : FencedBlockParserBase<DirectiveBlock>
 			return new LiteralIncludeBlock(this, _admonitionData, context);
 
 	    if (info.IndexOf("{applies}") > 0)
-			return new AppliesBlock(this, _admonitionData);
+			return new AppliesBlock(this, _admonitionData, context);
+
+	    if (info.IndexOf("{settings}") > 0)
+			return new SettingsBlock(this, _admonitionData, context);
 
 	    foreach (var admonition in _admonitions)
 	    {
 		    if (info.IndexOf($"{{{admonition}}}") > 0)
-			    return new AdmonitionBlock(this, admonition, _admonitionData);
+			    return new AdmonitionBlock(this, admonition, _admonitionData, context);
 	    }
 
 	    foreach (var version in _versionBlocks)
 	    {
 		    if (info.IndexOf($"{{{version}}}") > 0)
-			    return new VersionBlock(this, version, _admonitionData);
+			    return new VersionBlock(this, version, _admonitionData, context);
 	    }
 
 	    foreach (var code in _codeBlocks)
 	    {
 		    if (info.IndexOf($"{{{code}}}") > 0)
-			    return new CodeBlock(this, code, _admonitionData);
+			    return new CodeBlock(this, code, _admonitionData, context);
 	    }
-	    return new UnknownDirectiveBlock(this, info.ToString(), _admonitionData);
+	    return new UnknownDirectiveBlock(this, info.ToString(), _admonitionData, context);
     }
 
     public override bool Close(BlockProcessor processor, Block block)

--- a/src/Elastic.Markdown/Myst/Directives/ImageBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/ImageBlock.cs
@@ -1,14 +1,15 @@
 // Licensed to Elasticsearch B.V under one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
+
+using Elastic.Markdown.Diagnostics;
+
 namespace Elastic.Markdown.Myst.Directives;
 
 public class ImageBlock(DirectiveBlockParser parser, Dictionary<string, string> properties, ParserContext context)
-	: DirectiveBlock(parser, properties)
+	: DirectiveBlock(parser, properties, context)
 {
 	public override string Directive => "image";
-
-	public BuildContext Build { get; } = context.Build;
 
 	/// <summary>
 	/// Alternate text: a short description of the image, displayed by applications that cannot display images,
@@ -73,13 +74,13 @@ public class ImageBlock(DirectiveBlockParser parser, Dictionary<string, string> 
 		var imageUrl = Arguments;
 		if (string.IsNullOrWhiteSpace(imageUrl))
 		{
-			EmitError(context , $"{Directive} requires an argument.");
+			this.EmitError($"{Directive} requires an argument.");
 			return;
 		}
 
 		if (Uri.TryCreate(imageUrl, UriKind.Absolute, out var uri) && uri.Scheme.StartsWith("http"))
 		{
-			EmitWarning(context, $"{Directive} is using an external URI: {uri} ");
+			this.EmitWarning($"{Directive} is using an external URI: {uri} ");
 			Found = true;
 			ImageUrl = imageUrl;
 			return;
@@ -94,7 +95,7 @@ public class ImageBlock(DirectiveBlockParser parser, Dictionary<string, string> 
 		if (context.Build.ReadFileSystem.File.Exists(imagePath))
 			Found = true;
 		else
-			EmitError(context, $"`{imageUrl}` does not exist. resolved to `{imagePath}");
+			this.EmitError($"`{imageUrl}` does not exist. resolved to `{imagePath}");
 	}
 }
 

--- a/src/Elastic.Markdown/Myst/Directives/MermaidBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/MermaidBlock.cs
@@ -3,8 +3,8 @@
 // See the LICENSE file in the project root for more information
 namespace Elastic.Markdown.Myst.Directives;
 
-public class MermaidBlock(DirectiveBlockParser parser, Dictionary<string, string> properties)
-	: DirectiveBlock(parser, properties)
+public class MermaidBlock(DirectiveBlockParser parser, Dictionary<string, string> properties, ParserContext context)
+	: DirectiveBlock(parser, properties, context)
 {
 	public override string Directive => "mermaid";
 

--- a/src/Elastic.Markdown/Myst/Directives/SettingsBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/SettingsBlock.cs
@@ -8,16 +8,18 @@ using Elastic.Markdown.Myst.FrontMatter;
 
 namespace Elastic.Markdown.Myst.Directives;
 
-public class IncludeBlock(DirectiveBlockParser parser, Dictionary<string, string> properties, ParserContext context)
+public class SettingsBlock(DirectiveBlockParser parser, Dictionary<string, string> properties, ParserContext context)
 	: DirectiveBlock(parser, properties, context)
 {
-	public override string Directive => "include";
+	public override string Directive => "settings";
 
 	public Func<IFileInfo, DocumentationFile?>? GetDocumentationFile { get; } = context.GetDocumentationFile;
 
 	public ConfigurationFile Configuration { get; } = context.Configuration;
 
 	public IFileSystem FileSystem { get; } = context.Build.ReadFileSystem;
+
+	public IFileInfo IncludeFrom { get; } = context.Path;
 
 	public IDirectoryInfo DocumentationSourcePath { get; } = context.Parser.SourcePath;
 
@@ -27,21 +29,11 @@ public class IncludeBlock(DirectiveBlockParser parser, Dictionary<string, string
 
 	public bool Found { get; private set; }
 
-	public bool Literal { get; protected set; }
-	public string? Language { get; private set; }
-	public string? Caption { get; private set; }
-	public string? Label { get; private set; }
-
 
 	//TODO add all options from
 	//https://mystmd.org/guide/directives#directive-include
 	public override void FinalizeAndValidate(ParserContext context)
 	{
-		Literal |= PropBool("literal");
-		Language = Prop("lang", "language", "code");
-		Caption = Prop("caption");
-		Label = Prop("label");
-
 		ExtractInclusionPath(context);
 	}
 
@@ -50,7 +42,7 @@ public class IncludeBlock(DirectiveBlockParser parser, Dictionary<string, string
 		var includePath = Arguments;
 		if (string.IsNullOrWhiteSpace(includePath))
 		{
-			context.EmitError(Line, Column, $"```{{{Directive}}}".Length , "include requires an argument.");
+			this.EmitError("include requires an argument.");
 			return;
 		}
 
@@ -67,11 +59,3 @@ public class IncludeBlock(DirectiveBlockParser parser, Dictionary<string, string
 }
 
 
-public class LiteralIncludeBlock : IncludeBlock
-{
-	public LiteralIncludeBlock(DirectiveBlockParser parser, Dictionary<string, string> properties, ParserContext context)
-		: base(parser, properties, context) => Literal = true;
-
-	public override string Directive => "literalinclude";
-
-}

--- a/src/Elastic.Markdown/Myst/Directives/TabSetBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/TabSetBlock.cs
@@ -2,10 +2,12 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using Elastic.Markdown.Diagnostics;
+
 namespace Elastic.Markdown.Myst.Directives;
 
-public class TabSetBlock(DirectiveBlockParser parser, Dictionary<string, string> properties)
-	: DirectiveBlock(parser, properties)
+public class TabSetBlock(DirectiveBlockParser parser, Dictionary<string, string> properties, ParserContext context)
+	: DirectiveBlock(parser, properties, context)
 {
 	public override string Directive => "tab-set";
 
@@ -21,8 +23,8 @@ public class TabSetBlock(DirectiveBlockParser parser, Dictionary<string, string>
 		return _index;
 	}
 }
-public class TabItemBlock(DirectiveBlockParser parser, Dictionary<string, string> properties)
-	: DirectiveBlock(parser, properties)
+public class TabItemBlock(DirectiveBlockParser parser, Dictionary<string, string> properties, ParserContext context)
+	: DirectiveBlock(parser, properties, context)
 {
 	public override string Directive => "tab-item";
 
@@ -36,7 +38,7 @@ public class TabItemBlock(DirectiveBlockParser parser, Dictionary<string, string
 	public override void FinalizeAndValidate(ParserContext context)
 	{
 		if (string.IsNullOrWhiteSpace(Arguments))
-			EmitError(context, "{tab-item} requires an argument to name the tab.");
+			this.EmitError("{tab-item} requires an argument to name the tab.");
 
 		Title = Arguments ?? "{undefined}";
 		Index = Parent!.IndexOf(this);

--- a/src/Elastic.Markdown/Myst/Directives/UnknownDirectiveBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/UnknownDirectiveBlock.cs
@@ -4,8 +4,12 @@
 
 namespace Elastic.Markdown.Myst.Directives;
 
-public class UnknownDirectiveBlock(DirectiveBlockParser parser, string directive, Dictionary<string, string> properties)
-	: DirectiveBlock(parser, properties)
+public class UnknownDirectiveBlock(
+	DirectiveBlockParser parser,
+	string directive,
+	Dictionary<string, string> properties,
+	ParserContext context)
+	: DirectiveBlock(parser, properties, context)
 {
 	public override string Directive => directive;
 

--- a/src/Elastic.Markdown/Myst/Directives/UnsupportedDirectiveBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/UnsupportedDirectiveBlock.cs
@@ -6,8 +6,13 @@ using Elastic.Markdown.Diagnostics;
 
 namespace Elastic.Markdown.Myst.Directives;
 
-public class UnsupportedDirectiveBlock(DirectiveBlockParser parser, string directive, Dictionary<string, string> properties, int issueId)
-	: DirectiveBlock(parser, properties)
+public class UnsupportedDirectiveBlock(
+	DirectiveBlockParser parser,
+	string directive,
+	Dictionary<string, string> properties,
+	int issueId,
+	ParserContext context)
+	: DirectiveBlock(parser, properties, context)
 {
 	public override string Directive => directive;
 

--- a/src/Elastic.Markdown/Myst/Directives/VersionBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/VersionBlock.cs
@@ -2,13 +2,18 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using Elastic.Markdown.Diagnostics;
 using Elastic.Markdown.Helpers;
 using static System.StringSplitOptions;
 
 namespace Elastic.Markdown.Myst.Directives;
 
-public class VersionBlock(DirectiveBlockParser parser, string directive, Dictionary<string, string> properties)
-	: DirectiveBlock(parser, properties)
+public class VersionBlock(
+	DirectiveBlockParser parser,
+	string directive,
+	Dictionary<string, string> properties,
+	ParserContext context)
+	: DirectiveBlock(parser, properties, context)
 {
 	public override string Directive => directive;
 	public string Class => directive.Replace("version", "");
@@ -21,7 +26,7 @@ public class VersionBlock(DirectiveBlockParser parser, string directive, Diction
 		var tokens = Arguments?.Split(" ", 2, RemoveEmptyEntries) ?? [];
 		if (tokens.Length < 1)
 		{
-			EmitError(context, $"{directive} needs exactly 2 arguments: <version> <title>");
+			this.EmitError($"{directive} needs exactly 2 arguments: <version> <title>");
 			return;
 		}
 
@@ -29,7 +34,7 @@ public class VersionBlock(DirectiveBlockParser parser, string directive, Diction
 		{
 			var numbers = tokens[0].Split('.', RemoveEmptyEntries);
 			if (numbers.Length != 2 || !SemVersion.TryParse($"{numbers[0]}.{numbers[1]}.0", out version))
-				EmitError(context, $"'{tokens[0]}' is not a valid version");
+				this.EmitError($"'{tokens[0]}' is not a valid version");
 		}
 
 		Version = version;

--- a/src/Elastic.Markdown/Myst/FrontMatter/FrontMatterParser.cs
+++ b/src/Elastic.Markdown/Myst/FrontMatter/FrontMatterParser.cs
@@ -6,9 +6,6 @@ using YamlDotNet.Serialization;
 
 namespace Elastic.Markdown.Myst.FrontMatter;
 
-[YamlStaticContext]
-public partial class YamlFrontMatterStaticContext;
-
 [YamlSerializable]
 public class YamlFrontMatter
 {
@@ -25,22 +22,3 @@ public class YamlFrontMatter
 	[YamlMember(Alias = "applies")]
 	public Deployment? AppliesTo { get; set; }
 }
-
-public static class FrontMatterParser
-{
-	public static YamlFrontMatter Deserialize(string yaml)
-	{
-		var input = new StringReader(yaml);
-
-		var deserializer = new StaticDeserializerBuilder(new YamlFrontMatterStaticContext())
-			.IgnoreUnmatchedProperties()
-			.WithTypeConverter(new SemVersionConverter())
-			.WithTypeConverter(new DeploymentConverter())
-			.Build();
-
-		var frontMatter = deserializer.Deserialize<YamlFrontMatter>(input);
-		return frontMatter;
-
-	}
-}
-

--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -3,12 +3,14 @@
 // See the LICENSE file in the project root for more information
 
 using Elastic.Markdown.Diagnostics;
+using Elastic.Markdown.IO;
 using Elastic.Markdown.Myst.Directives;
 using Markdig;
 using Markdig.Helpers;
 using Markdig.Parsers;
 using Markdig.Parsers.Inlines;
 using Markdig.Renderers;
+using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
 
 namespace Elastic.Markdown.Myst.InlineParsers;
@@ -88,7 +90,7 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 		{
 			var file = string.IsNullOrWhiteSpace(url) ? context.Path
 				: context.Build.ReadFileSystem.FileInfo.New(Path.Combine(context.Build.SourcePath.FullName, url.TrimStart('/')));
-			var markdown = context.GetMarkdownFile?.Invoke(file);
+			var markdown = context.GetDocumentationFile?.Invoke(file) as MarkdownFile;
 			var title = markdown?.Title;
 
 			if (!string.IsNullOrEmpty(anchor))

--- a/src/Elastic.Markdown/Myst/ParserContext.cs
+++ b/src/Elastic.Markdown/Myst/ParserContext.cs
@@ -57,5 +57,5 @@ public class ParserContext : MarkdownParserContext
 	public YamlFrontMatter? FrontMatter { get; }
 	public BuildContext Build { get; }
 	public bool SkipValidation { get; init; }
-	public Func<IFileInfo, MarkdownFile?>? GetMarkdownFile { get; init; }
+	public Func<IFileInfo, DocumentationFile?>? GetDocumentationFile { get; init; }
 }

--- a/src/Elastic.Markdown/Myst/Settings/StructuredSettings.cs
+++ b/src/Elastic.Markdown/Myst/Settings/StructuredSettings.cs
@@ -1,0 +1,63 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Markdown.Myst.FrontMatter;
+using YamlDotNet.Serialization;
+
+namespace Elastic.Markdown.Myst.Settings;
+
+[YamlSerializable]
+public record SettingsCollection
+{
+	[YamlMember(Alias = "product")]
+	public string? Product { get; set; }
+	[YamlMember(Alias = "collection")]
+	public string? Collection { get; set; }
+	[YamlMember(Alias = "groups")]
+	public SettingsGrouping[] Groups { get; set; } = [];
+}
+
+[YamlSerializable]
+public record SettingsGrouping
+{
+	[YamlMember(Alias = "group")]
+	public string? Name { get; set; }
+	[YamlMember(Alias = "self")]
+	public string? Id { get; set; }
+	[YamlMember(Alias = "settings")]
+	public Setting[] Settings { get; set; } = [];
+}
+
+[YamlSerializable]
+public record Setting
+{
+	[YamlMember(Alias = "setting")]
+	public string? Name { get; set; }
+	[YamlMember(Alias = "description")]
+	public string? Description { get; set; }
+	[YamlMember(Alias = "applies")]
+	public ProductAvailability? Applies { get; set; }
+	[YamlMember(Alias = "type")]
+	public SettingMutability Mutability { get; set; }
+	[YamlMember(Alias = "options")]
+	public AllowedValue[]? Options { get; set; }
+}
+
+[YamlSerializable]
+public record AllowedValue
+{
+	[YamlMember(Alias = "option")]
+	public string? Option { get; set; }
+	[YamlMember(Alias = "description")]
+	public string? Description { get; set; }
+}
+
+[YamlSerializable]
+public enum SettingMutability
+{
+	[YamlMember(Alias = "static")]
+	Static,
+	[YamlMember(Alias = "dynamic")]
+	Dynamic
+}

--- a/src/Elastic.Markdown/Myst/YamlSerialization.cs
+++ b/src/Elastic.Markdown/Myst/YamlSerialization.cs
@@ -1,0 +1,39 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Markdown.Myst.FrontMatter;
+using Elastic.Markdown.Myst.Settings;
+using YamlDotNet.Serialization;
+
+namespace Elastic.Markdown.Myst;
+
+public static class YamlSerialization
+{
+	public static T Deserialize<T>(string yaml)
+	{
+		var input = new StringReader(yaml);
+
+		var deserializer = new StaticDeserializerBuilder(new DocsBuilderYamlStaticContext())
+			.IgnoreUnmatchedProperties()
+			.WithTypeConverter(new SemVersionConverter())
+			.WithTypeConverter(new DeploymentConverter())
+			.Build();
+
+		var frontMatter = deserializer.Deserialize<T>(input);
+		return frontMatter;
+
+	}
+}
+
+[YamlStaticContext]
+[YamlSerializable(typeof(SettingsCollection))]
+[YamlSerializable(typeof(SettingsGrouping))]
+[YamlSerializable(typeof(SettingsCollection))]
+[YamlSerializable(typeof(SettingsGrouping))]
+[YamlSerializable(typeof(Setting))]
+[YamlSerializable(typeof(AllowedValue))]
+[YamlSerializable(typeof(SettingMutability))]
+
+public partial class DocsBuilderYamlStaticContext;
+

--- a/src/Elastic.Markdown/Slices/Directives/Settings.cshtml
+++ b/src/Elastic.Markdown/Slices/Directives/Settings.cshtml
@@ -1,0 +1,29 @@
+@using Elastic.Markdown.Myst.FrontMatter
+@using Elastic.Markdown.Myst.Settings
+@inherits RazorSlice<SettingsViewModel>
+
+@foreach (var group in Model.SettingsCollection.Groups)
+{
+	@RenderGroup(group)
+}
+@functions {
+
+	private IHtmlContent RenderGroup(SettingsGrouping group)
+	{
+		<h2>@group.Name</h2>
+		foreach (var setting in group.Settings)
+		{
+			@RenderSetting(setting)
+		}
+		return HtmlString.Empty;
+	}
+	private IHtmlContent RenderSetting(Setting setting)
+	{
+		<h4>@setting.Name</h4>
+		if (setting.Description is not null)
+		{
+			@(new HtmlString(Model.RenderMarkdown(setting.Description)))
+		}
+		return HtmlString.Empty;
+	}
+}

--- a/src/Elastic.Markdown/Slices/Directives/_ViewModels.cs
+++ b/src/Elastic.Markdown/Slices/Directives/_ViewModels.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 using System.Text;
+using Elastic.Markdown.Myst.Settings;
 
 namespace Elastic.Markdown.Slices.Directives;
 
@@ -63,6 +64,14 @@ public class ImageViewModel
 			return sb.ToString();
 		}
 	}
+}
+
+
+public class SettingsViewModel
+{
+	public required SettingsCollection SettingsCollection { get; init; }
+
+	public required Func<string, string> RenderMarkdown { get; init; }
 }
 
 public class MermaidViewModel;


### PR DESCRIPTION
Prioritized this work in the context of #94 where @lcawl and I are debating if we need the inline product applicability annotation. 

Since most of these are in settings it'd be good to start supporting these earlier so writers can validate that this feature set is rich enough. 

@bmorelli25 @KOTungseth do we need to be able to link to each individual setting directly? I assume so in which case I'll need to add these to the linkmap docs builder produces.


@kilfoyle I made some changes to your format that is part of:

https://github.com/elastic/kibana/pull/191787


Primarily each `description` field now uses a multiline string. Your format used a string array. 

A multiline string has two benefits. 

- I don't need to create a markdown parser for each line
- You can annotate these strings as markdown in IDE's (IntelliJ and I think VsCode). 

<img width="768" alt="image" src="https://github.com/user-attachments/assets/23c3cd16-29c2-433d-80e3-e20f3a6e2887" />

Compare the first un-annotated description with the 2nd.

Note I did not go over all the settings to change from `asciidoc` to `markdown` in the example. 

Secondly this changes the product applicability format to match #95 and #103


```
- setting: x
  applies:
    stack: ga 8.1
    serverless: tech-preview
    hosted: beta 8.1.1
    eck: beta 3.0.2
    ece: unavailable
```


Instead of 


```
- setting: x
  platforms:
    - cloud
```


@lcawl what would be the equivalent of the latter in the new format? Do we need a shorthand notation for cloud vs self managed?

Thirdly, I do not think we should expose `id:` let docs builder generate the slug for each of these settings. 

WDYT: @kilfoyle @bmorelli25 @KOTungseth ?

### Example output


Not all properties of a setting are rendered out yet, will tackle that in a follow up PR.

<img width="1022" alt="image" src="https://github.com/user-attachments/assets/55f40296-2171-48a9-a38a-848b127b001e" />
