### PR TITLE
Introduce product type markers to applies blocks/metadata

### DIFF
--- a/docs/source/markup/applies.md
+++ b/docs/source/markup/applies.md
@@ -49,12 +49,16 @@ Are equivalent, note `all` just means we won't be rendering the version portion 
 
 
 ## This section has its own applies annotations
-```{applies}
+:::{applies}
 :stack: unavailable
 :serverless: tech-preview
-```
+:cloud: ga
+:::
 
-This section describes a feature that's unavailable in `stack` and in tech preview on `serverless`
-
-
+:::{note}
 the `{applies}` directive **MUST** be preceded by a heading.
+:::
+
+
+This section describes a feature that's unavailable in `stack` and `ga` in all cloud products
+however its tech preview on `serverless` since it overrides what `cloud` specified.

--- a/src/Elastic.Markdown/Myst/Directives/AppliesBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/AppliesBlock.cs
@@ -16,7 +16,23 @@ public class AppliesBlock(DirectiveBlockParser parser, Dictionary<string, string
 
 	public override void FinalizeAndValidate(ParserContext context)
 	{
-		if (TryGetAvailability("stack", out var version))
+		if (TryGetAvailability("cloud", out var version))
+		{
+			Deployment ??= new Deployment();
+			Deployment.Cloud ??= new CloudManagedDeployment();
+			Deployment.Cloud.Serverless = version;
+			Deployment.Cloud.Hosted = version;
+		}
+		if (TryGetAvailability("self", out version))
+		{
+			Deployment ??= new Deployment();
+			Deployment.SelfManaged ??= new SelfManagedDeployment();
+			Deployment.SelfManaged.Ece = version;
+			Deployment.SelfManaged.Eck = version;
+			Deployment.SelfManaged.Stack = version;
+		}
+
+		if (TryGetAvailability("stack", out version))
 		{
 			Deployment ??= new Deployment();
 			Deployment.SelfManaged ??= new SelfManagedDeployment();

--- a/src/Elastic.Markdown/Myst/FrontMatter/Deployment.cs
+++ b/src/Elastic.Markdown/Myst/FrontMatter/Deployment.cs
@@ -74,12 +74,27 @@ public class DeploymentConverter : IYamlTypeConverter
 			if (string.Equals(value.Value, "all", StringComparison.InvariantCultureIgnoreCase))
 				return Deployment.All;
 		}
-		var x = rootDeserializer.Invoke(typeof(Dictionary<string, string>));
-		if (x is not Dictionary<string, string> { Count: > 0 } dictionary)
+		var deserialized = rootDeserializer.Invoke(typeof(Dictionary<string, string>));
+		if (deserialized is not Dictionary<string, string> { Count: > 0 } dictionary)
 			return null;
 
 		var deployment = new Deployment();
-		if (TryGetAvailability("stack", out var version))
+
+		if (TryGetAvailability("cloud", out var version))
+		{
+			deployment.Cloud ??= new CloudManagedDeployment();
+			deployment.Cloud.Serverless = version;
+			deployment.Cloud.Hosted = version;
+		}
+		if (TryGetAvailability("self", out version))
+		{
+			deployment.SelfManaged ??= new SelfManagedDeployment();
+			deployment.SelfManaged.Ece = version;
+			deployment.SelfManaged.Eck = version;
+			deployment.SelfManaged.Stack = version;
+		}
+
+		if (TryGetAvailability("stack", out version))
 		{
 			deployment.SelfManaged ??= new SelfManagedDeployment();
 			deployment.SelfManaged.Stack = version;

--- a/tests/Elastic.Markdown.Tests/FrontMatter/ProductConstraintTests.cs
+++ b/tests/Elastic.Markdown.Tests/FrontMatter/ProductConstraintTests.cs
@@ -111,13 +111,13 @@ applies:
 		File.YamlFrontMatter!.AppliesTo!.SelfManaged!.Stack.Should().BeEquivalentTo(ProductAvailability.GenerallyAvailable);
 }
 
-public class EmptyCloudSetsAllProductsToAll(ITestOutputHelper output) : DirectiveTest(output,
+public class EmptyCloudSetsAllCloudProductsToAll(ITestOutputHelper output) : DirectiveTest(output,
 """
 ---
 title: Elastic Docs v3
 navigation_title: "Documentation Guide"
 applies:
-  hosted:
+  cloud:
 ---
 """
 )
@@ -126,3 +126,42 @@ applies:
 	public void Assert() =>
 		File.YamlFrontMatter!.AppliesTo!.Cloud!.Hosted.Should().BeEquivalentTo(ProductAvailability.GenerallyAvailable);
 }
+
+public class EmptySelfSetsAllSelfManagedProductsToAll(ITestOutputHelper output) : DirectiveTest(output,
+"""
+---
+title: Elastic Docs v3
+navigation_title: "Documentation Guide"
+applies:
+  self:
+  stack: deprecated 9.0.0
+---
+"""
+)
+{
+	[Fact]
+	public void Assert()
+	{
+		File.YamlFrontMatter!.AppliesTo!.SelfManaged!.Eck.Should()
+			.BeEquivalentTo(ProductAvailability.GenerallyAvailable);
+		File.YamlFrontMatter!.AppliesTo!.SelfManaged!.Stack.Should()
+			.BeEquivalentTo(new ProductAvailability { Lifecycle = Deprecated, Version = new (9,0,0) });
+	}
+}
+
+public class CloudProductsOverwriteDeploymentType(ITestOutputHelper output) : DirectiveTest(output,
+"""
+---
+title: Elastic Docs v3
+navigation_title: "Documentation Guide"
+applies:
+  cloud:
+---
+"""
+)
+{
+	[Fact]
+	public void Assert() =>
+		File.YamlFrontMatter!.AppliesTo!.Cloud!.Hosted.Should().BeEquivalentTo(ProductAvailability.GenerallyAvailable);
+}
+


### PR DESCRIPTION
```yaml
applies:
 cloud: ga
 self: beta
```

is analogous to:

```yaml
applies:
  hosted: ga
  serverless: ga
  stack: beta
  eck: beta
  ece: beta
```

products can always overwrite a product's type availability:

```yaml
applies:
  cloud: ga
  serverless: preview
```


I think we can also use this clean up the page level admonitions #95 so that we can limit the amount of badges a page header has if all products under a deployment type have the same product availability.

