### PR TITLE
Callouts should not be parsed from nested code blocks

### DIFF
--- a/docs/source/markup/callout.md
+++ b/docs/source/markup/callout.md
@@ -13,6 +13,7 @@ project:
     content: CC-BY-4.0 <1>
   subject: MyST Markdown 
 ```
+1. The license
 
 
 ### C#

--- a/docs/source/markup/substitutions.md
+++ b/docs/source/markup/substitutions.md
@@ -18,9 +18,9 @@ Substitutions should work in code blocks too.
 ```{code} sh
 wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{version}}-linux-x86_64.tar.gz
 wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{version}}-linux-x86_64.tar.gz.sha512
-shasum -a 512 -c elasticsearch-{{version}}-linux-x86_64.tar.gz.sha512 <1>
+shasum -a 512 -c elasticsearch-{{version}}-linux-x86_64.tar.gz.sha512
 tar -xzf elasticsearch-{{version}}-linux-x86_64.tar.gz
-cd elasticsearch-{{version}}/ <2>
+cd elasticsearch-{{version}}/
 ```
 
 

--- a/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockParser.cs
+++ b/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockParser.cs
@@ -94,6 +94,9 @@ public class EnhancedCodeBlockParser : FencedBlockParserBase<EnhancedCodeBlock>
 				span = lines.Lines[index].Slice.AsSpan();
 			}
 
+			if (codeBlock.OpeningFencedCharCount > 3)
+				continue;
+
 			var matchClassicCallout = CallOutParser.CallOutNumber().EnumerateMatches(span);
 			var callOut = EnumerateAnnotations(matchClassicCallout, ref span, ref callOutIndex, originatingLine, false);
 


### PR DESCRIPTION
Don't validate callouts that are in a nested code block 

e.g

`````markdown
```` javascript
```
let x = 1; <1>
```
````
`````

Should not be validated to be followed by a list and 

`````markdown
```` javascript
```
let x = 1; // comment
```
````
`````

Should not append a list magically either. 

