### PR TITLE
Refactor directive blocks to simplify properties handling.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,7 @@ spelling_exclusion_path = "./build/exclusion.dic"
 
 [*.{fs,fsx,cs,vb}]
 file_header_template=Licensed to Elasticsearch B.V under one or more agreements.\nElasticsearch B.V licenses this file to you under the Apache 2.0 License.\nSee the LICENSE file in the project root for more information
+max_line_length = 160
 
 [*.{fs,fsx}]
 indent_style = space

--- a/src/Elastic.Markdown/Myst/Directives/AdmonitionBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/AdmonitionBlock.cs
@@ -3,12 +3,10 @@
 // See the LICENSE file in the project root for more information
 namespace Elastic.Markdown.Myst.Directives;
 
-public class AdmonitionBlock(
-	DirectiveBlockParser parser,
-	string admonition,
-	Dictionary<string, string> properties,
-	ParserContext context)
-	: DirectiveBlock(parser, properties, context)
+public class DropdownBlock(DirectiveBlockParser parser, ParserContext context) : AdmonitionBlock(parser, "admonition", context);
+
+public class AdmonitionBlock(DirectiveBlockParser parser, string admonition, ParserContext context)
+	: DirectiveBlock(parser, context)
 {
 	public string Admonition => admonition == "admonition" ? Classes?.Trim() ?? "note" : admonition;
 
@@ -33,7 +31,7 @@ public class AdmonitionBlock(
 
 	public override void FinalizeAndValidate(ParserContext context)
 	{
-		CrossReferenceName = Properties.GetValueOrDefault("name");
+		CrossReferenceName = Prop("name");
 		DropdownOpen = TryPropBool("open");
 		if (DropdownOpen.HasValue)
 			Classes = "dropdown";
@@ -41,5 +39,3 @@ public class AdmonitionBlock(
 }
 
 
-public class DropdownBlock(DirectiveBlockParser parser, Dictionary<string, string> properties, ParserContext context)
-	: AdmonitionBlock(parser, "admonition", properties, context);

--- a/src/Elastic.Markdown/Myst/Directives/AppliesBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/AppliesBlock.cs
@@ -8,8 +8,7 @@ using Markdig.Syntax;
 
 namespace Elastic.Markdown.Myst.Directives;
 
-public class AppliesBlock(DirectiveBlockParser parser, Dictionary<string, string> properties, ParserContext context)
-	: DirectiveBlock(parser, properties, context)
+public class AppliesBlock(DirectiveBlockParser parser, ParserContext context) : DirectiveBlock(parser, context)
 {
 	public override string Directive => "mermaid";
 

--- a/src/Elastic.Markdown/Myst/Directives/DirectiveHtmlRenderer.cs
+++ b/src/Elastic.Markdown/Myst/Directives/DirectiveHtmlRenderer.cs
@@ -162,18 +162,6 @@ public class DirectiveHtmlRenderer : HtmlObjectRenderer<DirectiveBlock>
 		RenderRazorSlice(slice, renderer, block);
 	}
 
-	private void WriteCode(HtmlRenderer renderer, EnhancedCodeBlock block)
-	{
-		var slice = Code.Create(new CodeViewModel
-		{
-			CrossReferenceName = string.Empty,// block.CrossReferenceName,
-			Language = block.Language,
-			Caption = string.Empty
-		});
-		//RenderRazorSliceRawContent(slice, renderer, block);
-	}
-
-
 	private void WriteTabSet(HtmlRenderer renderer, TabSetBlock block)
 	{
 		var slice = TabSet.Create(new TabSetViewModel());
@@ -232,7 +220,7 @@ public class DirectiveHtmlRenderer : HtmlObjectRenderer<DirectiveBlock>
 			block.Configuration);
 		var file = block.FileSystem.FileInfo.New(block.IncludePath);
 		var document = parser.ParseAsync(file, block.FrontMatter, default).GetAwaiter().GetResult();
-		var html = document.ToHtml(parser.Pipeline);
+		var html = document.ToHtml(MarkdownParser.Pipeline);
 		renderer.Write(html);
 		//var slice = Include.Create(new IncludeViewModel { Html = html });
 		//RenderRazorSlice(slice, renderer, block);
@@ -270,7 +258,7 @@ public class DirectiveHtmlRenderer : HtmlObjectRenderer<DirectiveBlock>
 			RenderMarkdown = s =>
 			{
 				var document = parser.Parse(s, block.IncludeFrom, block.FrontMatter);
-				var html = document.ToHtml(parser.Pipeline);
+				var html = document.ToHtml(MarkdownParser.Pipeline);
 				return html;
 			}
 		});

--- a/src/Elastic.Markdown/Myst/Directives/ImageBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/ImageBlock.cs
@@ -6,8 +6,10 @@ using Elastic.Markdown.Diagnostics;
 
 namespace Elastic.Markdown.Myst.Directives;
 
-public class ImageBlock(DirectiveBlockParser parser, Dictionary<string, string> properties, ParserContext context)
-	: DirectiveBlock(parser, properties, context)
+public class FigureBlock(DirectiveBlockParser parser, ParserContext context) : ImageBlock(parser, context);
+
+public class ImageBlock(DirectiveBlockParser parser, ParserContext context)
+	: DirectiveBlock(parser, context)
 {
 	public override string Directive => "image";
 
@@ -100,5 +102,3 @@ public class ImageBlock(DirectiveBlockParser parser, Dictionary<string, string> 
 }
 
 
-public class FigureBlock(DirectiveBlockParser parser, Dictionary<string, string> properties, ParserContext context)
-	: ImageBlock(parser, properties, context);

--- a/src/Elastic.Markdown/Myst/Directives/IncludeBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/IncludeBlock.cs
@@ -8,8 +8,15 @@ using Elastic.Markdown.Myst.FrontMatter;
 
 namespace Elastic.Markdown.Myst.Directives;
 
-public class IncludeBlock(DirectiveBlockParser parser, Dictionary<string, string> properties, ParserContext context)
-	: DirectiveBlock(parser, properties, context)
+public class LiteralIncludeBlock : IncludeBlock
+{
+	public LiteralIncludeBlock(DirectiveBlockParser parser, ParserContext context) : base(parser, context) =>
+		Literal = true;
+
+	public override string Directive => "literalinclude";
+}
+
+public class IncludeBlock(DirectiveBlockParser parser, ParserContext context) : DirectiveBlock(parser, context)
 {
 	public override string Directive => "include";
 
@@ -64,14 +71,4 @@ public class IncludeBlock(DirectiveBlockParser parser, Dictionary<string, string
 		else
 			this.EmitError($"`{IncludePath}` does not exist.");
 	}
-}
-
-
-public class LiteralIncludeBlock : IncludeBlock
-{
-	public LiteralIncludeBlock(DirectiveBlockParser parser, Dictionary<string, string> properties, ParserContext context)
-		: base(parser, properties, context) => Literal = true;
-
-	public override string Directive => "literalinclude";
-
 }

--- a/src/Elastic.Markdown/Myst/Directives/MermaidBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/MermaidBlock.cs
@@ -3,8 +3,7 @@
 // See the LICENSE file in the project root for more information
 namespace Elastic.Markdown.Myst.Directives;
 
-public class MermaidBlock(DirectiveBlockParser parser, Dictionary<string, string> properties, ParserContext context)
-	: DirectiveBlock(parser, properties, context)
+public class MermaidBlock(DirectiveBlockParser parser, ParserContext context) : DirectiveBlock(parser, context)
 {
 	public override string Directive => "mermaid";
 

--- a/src/Elastic.Markdown/Myst/Directives/SettingsBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/SettingsBlock.cs
@@ -8,8 +8,7 @@ using Elastic.Markdown.Myst.FrontMatter;
 
 namespace Elastic.Markdown.Myst.Directives;
 
-public class SettingsBlock(DirectiveBlockParser parser, Dictionary<string, string> properties, ParserContext context)
-	: DirectiveBlock(parser, properties, context)
+public class SettingsBlock(DirectiveBlockParser parser, ParserContext context) : DirectiveBlock(parser, context)
 {
 	public override string Directive => "settings";
 
@@ -32,10 +31,7 @@ public class SettingsBlock(DirectiveBlockParser parser, Dictionary<string, strin
 
 	//TODO add all options from
 	//https://mystmd.org/guide/directives#directive-include
-	public override void FinalizeAndValidate(ParserContext context)
-	{
-		ExtractInclusionPath(context);
-	}
+	public override void FinalizeAndValidate(ParserContext context) => ExtractInclusionPath(context);
 
 	private void ExtractInclusionPath(ParserContext context)
 	{

--- a/src/Elastic.Markdown/Myst/Directives/TabSetBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/TabSetBlock.cs
@@ -6,8 +6,8 @@ using Elastic.Markdown.Diagnostics;
 
 namespace Elastic.Markdown.Myst.Directives;
 
-public class TabSetBlock(DirectiveBlockParser parser, Dictionary<string, string> properties, ParserContext context)
-	: DirectiveBlock(parser, properties, context)
+public class TabSetBlock(DirectiveBlockParser parser, ParserContext context)
+	: DirectiveBlock(parser, context)
 {
 	public override string Directive => "tab-set";
 
@@ -23,8 +23,8 @@ public class TabSetBlock(DirectiveBlockParser parser, Dictionary<string, string>
 		return _index;
 	}
 }
-public class TabItemBlock(DirectiveBlockParser parser, Dictionary<string, string> properties, ParserContext context)
-	: DirectiveBlock(parser, properties, context)
+public class TabItemBlock(DirectiveBlockParser parser, ParserContext context)
+	: DirectiveBlock(parser, context)
 {
 	public override string Directive => "tab-item";
 

--- a/src/Elastic.Markdown/Myst/Directives/UnknownDirectiveBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/UnknownDirectiveBlock.cs
@@ -4,12 +4,8 @@
 
 namespace Elastic.Markdown.Myst.Directives;
 
-public class UnknownDirectiveBlock(
-	DirectiveBlockParser parser,
-	string directive,
-	Dictionary<string, string> properties,
-	ParserContext context)
-	: DirectiveBlock(parser, properties, context)
+public class UnknownDirectiveBlock(DirectiveBlockParser parser, string directive, ParserContext context)
+	: DirectiveBlock(parser, context)
 {
 	public override string Directive => directive;
 

--- a/src/Elastic.Markdown/Myst/Directives/UnsupportedDirectiveBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/UnsupportedDirectiveBlock.cs
@@ -6,13 +6,8 @@ using Elastic.Markdown.Diagnostics;
 
 namespace Elastic.Markdown.Myst.Directives;
 
-public class UnsupportedDirectiveBlock(
-	DirectiveBlockParser parser,
-	string directive,
-	Dictionary<string, string> properties,
-	int issueId,
-	ParserContext context)
-	: DirectiveBlock(parser, properties, context)
+public class UnsupportedDirectiveBlock(DirectiveBlockParser parser, string directive, int issueId, ParserContext context)
+	: DirectiveBlock(parser, context)
 {
 	public override string Directive => directive;
 

--- a/src/Elastic.Markdown/Myst/Directives/VersionBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/VersionBlock.cs
@@ -8,12 +8,8 @@ using static System.StringSplitOptions;
 
 namespace Elastic.Markdown.Myst.Directives;
 
-public class VersionBlock(
-	DirectiveBlockParser parser,
-	string directive,
-	Dictionary<string, string> properties,
-	ParserContext context)
-	: DirectiveBlock(parser, properties, context)
+public class VersionBlock(DirectiveBlockParser parser, string directive, ParserContext context)
+	: DirectiveBlock(parser, context)
 {
 	public override string Directive => directive;
 	public string Class => directive.Replace("version", "");

--- a/src/Elastic.Markdown/Myst/MarkdownParser.cs
+++ b/src/Elastic.Markdown/Myst/MarkdownParser.cs
@@ -27,7 +27,6 @@ public class MarkdownParser(
 
 	private BuildContext Context { get; } = context;
 
-	//TODO directive properties are stateful, rewrite this so we can cache builders
 	public static MarkdownPipeline MinimalPipeline { get; } =
 		new MarkdownPipelineBuilder()
 			.UseDiagnosticLinks()

--- a/src/Elastic.Markdown/Myst/MarkdownParser.cs
+++ b/src/Elastic.Markdown/Myst/MarkdownParser.cs
@@ -28,7 +28,7 @@ public class MarkdownParser(
 	private BuildContext Context { get; } = context;
 
 	//TODO directive properties are stateful, rewrite this so we can cache builders
-	public MarkdownPipeline MinimalPipeline =>
+	public static MarkdownPipeline MinimalPipeline { get; } =
 		new MarkdownPipelineBuilder()
 			.UseDiagnosticLinks()
 			.UseYamlFrontMatter()
@@ -36,7 +36,7 @@ public class MarkdownParser(
 			.UseSubstitution()
 			.Build();
 
-	public MarkdownPipeline Pipeline =>
+	public static MarkdownPipeline Pipeline { get; } =
 		new MarkdownPipelineBuilder()
 			.EnableTrackTrivia()
 			.UsePreciseSourceLocation()

--- a/tests/Elastic.Markdown.Tests/Directives/AdmonitionUnsupportedTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/AdmonitionUnsupportedTests.cs
@@ -10,12 +10,12 @@ namespace Elastic.Markdown.Tests.Directives;
 
 public abstract class AdmonitionUnsupportedTests(ITestOutputHelper output, string directive)
 	: DirectiveTest<UnsupportedDirectiveBlock>(output,
-		$$"""
-		  ```{{{directive}}}
-		  This is an attention block
-		  ```
-		  A regular paragraph.
-		  """
+$$"""
+  ```{{{directive}}}
+  This is an attention block
+  ```
+  A regular paragraph.
+  """
 	)
 {
 	[Fact]


### PR DESCRIPTION
This allows us to reuse a single instance of MarkdownPipeline which should aid with performance
