### PR TITLE
Run dotnet format ahead of automation 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -199,6 +199,11 @@ resharper_explicit_caller_info_argument_highlighting=hint
 
 dotnet_diagnostic.IDE0057.severity = none
 
+[DocumentationWebHost.cs]
+dotnet_diagnostic.IL3050.severity = none
+dotnet_diagnostic.IL2026.severity = none
+
+
 [*.{sh,bat,ps1}]
 trim_trailing_whitespace=true
 insert_final_newline=true

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -38,7 +38,7 @@ app.Add("publish", async (Cancel _) =>
 app.Add("notices", async Task<int> (Cancel ctx) =>
 {
 	var packages = await "dotnet thirdlicense --project src/docs-builder/docs-builder.csproj --output NOTICE.txt";
-	var packageLines = packages.Split(Environment.NewLine).Where(l=>l.StartsWith("+"));
+	var packageLines = packages.Split(Environment.NewLine).Where(l => l.StartsWith("+"));
 
 	await File.WriteAllTextAsync("NOTICE.txt",
 		$"""

--- a/src/Elastic.Markdown/BuildContext.cs
+++ b/src/Elastic.Markdown/BuildContext.cs
@@ -52,7 +52,7 @@ public record BuildContext
 			: WriteFileSystem.DirectoryInfo.New(Path.Combine(Paths.Root.FullName, ".artifacts/docs/html"));
 
 		ConfigurationPath =
-		    ReadFileSystem.FileInfo.New(Path.Combine(SourcePath.FullName, "docset.yml"));
+			ReadFileSystem.FileInfo.New(Path.Combine(SourcePath.FullName, "docset.yml"));
 
 		if (ConfigurationPath.FullName != SourcePath.FullName)
 			SourcePath = ConfigurationPath.Directory!;
@@ -63,7 +63,7 @@ public record BuildContext
 	private IDirectoryInfo FindDocsFolderFromRoot(IDirectoryInfo rootPath)
 	{
 		if (rootPath.Exists &&
-		    ReadFileSystem.File.Exists(Path.Combine(rootPath.FullName, "docset.yml")))
+			ReadFileSystem.File.Exists(Path.Combine(rootPath.FullName, "docset.yml")))
 			return rootPath;
 
 		var docsFolder = rootPath.EnumerateFiles("docset.yml", SearchOption.AllDirectories).FirstOrDefault();

--- a/src/Elastic.Markdown/Diagnostics/DiagnosticsChannel.cs
+++ b/src/Elastic.Markdown/Diagnostics/DiagnosticsChannel.cs
@@ -73,7 +73,7 @@ public class DiagnosticsCollector(ILoggerFactory loggerFactory, IReadOnlyCollect
 	: IHostedService
 {
 	private readonly IReadOnlyCollection<IDiagnosticsOutput> _outputs =
-		[new LogDiagnosticOutput(loggerFactory.CreateLogger<LogDiagnosticOutput>()), ..outputs];
+		[new LogDiagnosticOutput(loggerFactory.CreateLogger<LogDiagnosticOutput>()), .. outputs];
 
 	public DiagnosticsChannel Channel { get; } = new();
 
@@ -88,7 +88,8 @@ public class DiagnosticsCollector(ILoggerFactory loggerFactory, IReadOnlyCollect
 
 	public Task StartAsync(Cancel ctx)
 	{
-		if (_started is not null) return _started;
+		if (_started is not null)
+			return _started;
 		_started = Task.Run(async () =>
 		{
 			await Channel.WaitToWrite();

--- a/src/Elastic.Markdown/Diagnostics/ProcessorDiagnosticExtensions.cs
+++ b/src/Elastic.Markdown/Diagnostics/ProcessorDiagnosticExtensions.cs
@@ -15,7 +15,8 @@ public static class ProcessorDiagnosticExtensions
 	public static void EmitError(this InlineProcessor processor, int line, int column, int length, string message)
 	{
 		var context = processor.GetContext();
-		if (context.SkipValidation) return;
+		if (context.SkipValidation)
+			return;
 		var d = new Diagnostic
 		{
 			Severity = Severity.Error,
@@ -32,7 +33,8 @@ public static class ProcessorDiagnosticExtensions
 	public static void EmitWarning(this InlineProcessor processor, int line, int column, int length, string message)
 	{
 		var context = processor.GetContext();
-		if (context.SkipValidation) return;
+		if (context.SkipValidation)
+			return;
 		var d = new Diagnostic
 		{
 			Severity = Severity.Warning,
@@ -47,7 +49,8 @@ public static class ProcessorDiagnosticExtensions
 
 	public static void EmitError(this ParserContext context, int line, int column, int length, string message, Exception? e = null)
 	{
-		if (context.SkipValidation) return;
+		if (context.SkipValidation)
+			return;
 		var d = new Diagnostic
 		{
 			Severity = Severity.Error,
@@ -62,7 +65,8 @@ public static class ProcessorDiagnosticExtensions
 
 	public static void EmitWarning(this ParserContext context, int line, int column, int length, string message)
 	{
-		if (context.SkipValidation) return;
+		if (context.SkipValidation)
+			return;
 		var d = new Diagnostic
 		{
 			Severity = Severity.Warning,
@@ -99,7 +103,8 @@ public static class ProcessorDiagnosticExtensions
 
 	public static void EmitError(this IBlockExtension block, string message, Exception? e = null)
 	{
-		if (block.SkipValidation) return;
+		if (block.SkipValidation)
+			return;
 
 		var d = new Diagnostic
 		{
@@ -115,7 +120,8 @@ public static class ProcessorDiagnosticExtensions
 
 	public static void EmitWarning(this IBlockExtension block, string message)
 	{
-		if (block.SkipValidation) return;
+		if (block.SkipValidation)
+			return;
 
 		var d = new Diagnostic
 		{

--- a/src/Elastic.Markdown/DocumentationGenerator.cs
+++ b/src/Elastic.Markdown/DocumentationGenerator.cs
@@ -61,7 +61,8 @@ public class DocumentationGenerator
 	{
 		var stateFile = DocumentationSet.OutputStateFile;
 		stateFile.Refresh();
-		if (!stateFile.Exists) return null;
+		if (!stateFile.Exists)
+			return null;
 		var contents = stateFile.FileSystem.File.ReadAllText(stateFile.FullName);
 		return JsonSerializer.Deserialize(contents, SourceGenerationContext.Default.GenerationState);
 	}
@@ -177,7 +178,7 @@ public class DocumentationGenerator
 		else if (DocumentationSet.LastWrite <= outputSeenChanges)
 		{
 			_logger.LogInformation($"No compilation: no changes since last observed: {generationState.LastSeenChanges} "
-			                       + "Pass --force to force a full regeneration");
+								   + "Pass --force to force a full regeneration");
 			return true;
 		}
 

--- a/src/Elastic.Markdown/IO/ConfigurationFile.cs
+++ b/src/Elastic.Markdown/IO/ConfigurationFile.cs
@@ -86,7 +86,7 @@ public record ConfigurationFile : DocumentationFile
 					break;
 			}
 		}
-		Globs = ImplicitFolders.Select(f=> Glob.Parse($"{f}/*.md")).ToArray();
+		Globs = ImplicitFolders.Select(f => Glob.Parse($"{f}/*.md")).ToArray();
 	}
 
 	private List<ITocItem> ReadChildren(KeyValuePair<YamlNode, YamlNode> entry, string parentPath)
@@ -167,7 +167,8 @@ public record ConfigurationFile : DocumentationFile
 	{
 		found = false;
 		var file = ReadString(entry);
-		if (file is null) return null;
+		if (file is null)
+			return null;
 
 		var path = Path.Combine(_rootPath.FullName, parentPath.TrimStart('/'), file);
 		if (!_context.ReadFileSystem.FileInfo.New(path).Exists)

--- a/src/Elastic.Markdown/IO/DocumentationFolder.cs
+++ b/src/Elastic.Markdown/IO/DocumentationFolder.cs
@@ -46,7 +46,7 @@ public class DocumentationFolder
 			{
 				var children = folder.Children;
 				if (children.Count == 0
-				    && folderLookup.TryGetValue(folder.Path, out var documentationFiles))
+					&& folderLookup.TryGetValue(folder.Path, out var documentationFiles))
 				{
 					children = documentationFiles
 						.Select(d => new TocFile(d.RelativePath, true, []))
@@ -61,7 +61,7 @@ public class DocumentationFolder
 		Index ??= FilesInOrder.FirstOrDefault();
 		if (Index != null)
 			FilesInOrder = FilesInOrder.Except(new[] { Index }).ToList();
-		OwnFiles = [..FilesInOrder];
+		OwnFiles = [.. FilesInOrder];
 	}
 
 	public bool HoldsCurrent(MarkdownFile current) =>
@@ -71,7 +71,8 @@ public class DocumentationFolder
 
 	public async Task Resolve(Cancel ctx = default)
 	{
-		if (_resolved) return;
+		if (_resolved)
+			return;
 
 		await Parallel.ForEachAsync(FilesInOrder, ctx, async (file, token) => await file.MinimalParse(token));
 		await Parallel.ForEachAsync(GroupsInOrder, ctx, async (group, token) => await group.Resolve(token));

--- a/src/Elastic.Markdown/IO/DocumentationSet.cs
+++ b/src/Elastic.Markdown/IO/DocumentationSet.cs
@@ -54,7 +54,7 @@ public class DocumentationSet
 		FlatMappedFiles = Files.ToDictionary(file => file.RelativePath, file => file);
 		var folderFiles = Files
 			.GroupBy(file => file.RelativeFolder)
-			.ToDictionary(g=>g.Key, g=>g.ToArray());
+			.ToDictionary(g => g.Key, g => g.ToArray());
 
 		Tree = new DocumentationFolder(Configuration.TableOfContents, FlatMappedFiles, folderFiles);
 	}

--- a/src/Elastic.Markdown/IO/MarkdownFile.cs
+++ b/src/Elastic.Markdown/IO/MarkdownFile.cs
@@ -97,11 +97,11 @@ public record MarkdownFile : DocumentationFile
 			_tableOfContent[t.Slug] = t;
 
 		var labels = document.Descendants<DirectiveBlock>()
-			.Select(b=>b.CrossReferenceName)
-			.Where(l=>!string.IsNullOrWhiteSpace(l))
+			.Select(b => b.CrossReferenceName)
+			.Where(l => !string.IsNullOrWhiteSpace(l))
 			.Select(_slugHelper.GenerateSlug)
 			.ToArray();
-		foreach(var label in labels)
+		foreach (var label in labels)
 		{
 			if (!string.IsNullOrEmpty(label))
 				_additionalLabels.Add(label);

--- a/src/Elastic.Markdown/IO/Paths.cs
+++ b/src/Elastic.Markdown/IO/Paths.cs
@@ -9,7 +9,7 @@ public static class Paths
 	{
 		var directory = new DirectoryInfo(Directory.GetCurrentDirectory());
 		while (directory != null &&
-		       (directory.GetFiles("*.sln").Length == 0 || directory.GetDirectories(".git").Length == 0))
+			   (directory.GetFiles("*.sln").Length == 0 || directory.GetDirectories(".git").Length == 0))
 			directory = directory.Parent;
 		return directory ?? new DirectoryInfo(Directory.GetCurrentDirectory());
 	}

--- a/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockParser.cs
+++ b/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockParser.cs
@@ -123,7 +123,7 @@ public class EnhancedCodeBlockParser : FencedBlockParserBase<EnhancedCodeBlock>
 
 				var newSpan = line.Slice.AsSpan()[..callout.SliceStart];
 				var s = new StringSlice(newSpan.ToString());
-				lines.Lines[callout.Line -1 ] = new StringLine(ref s);
+				lines.Lines[callout.Line - 1] = new StringLine(ref s);
 
 			}
 		}
@@ -178,10 +178,12 @@ public class EnhancedCodeBlockParser : FencedBlockParserBase<EnhancedCodeBlock>
 	{
 		foreach (var match in matches)
 		{
-			if (match.Length == 0) continue;
+			if (match.Length == 0)
+				continue;
 
 			var startIndex = span.LastIndexOf("<");
-			if (!inlineCodeAnnotation && startIndex <= 0) continue;
+			if (!inlineCodeAnnotation && startIndex <= 0)
+				continue;
 			if (inlineCodeAnnotation)
 			{
 				startIndex = Math.Max(span.LastIndexOf("//"), span.LastIndexOf('#'));

--- a/src/Elastic.Markdown/Myst/Comments/CommentBlockParser.cs
+++ b/src/Elastic.Markdown/Myst/Comments/CommentBlockParser.cs
@@ -84,7 +84,10 @@ public class CommentBlockParser : BlockParser
 			// Move to the content
 			var headingBlock = new CommentBlock(this)
 			{
-				CommentChar = matchingChar, Level = leadingCount, Column = column, Span = { Start = sourcePosition },
+				CommentChar = matchingChar,
+				Level = leadingCount,
+				Column = column,
+				Span = { Start = sourcePosition },
 			};
 
 			if (processor.TrackTrivia)
@@ -106,8 +109,8 @@ public class CommentBlockParser : BlockParser
 			var countClosingTags = 0;
 			var sourceEnd = processor.Line.End;
 			for (var i = processor.Line.End;
-			     i >= processor.Line.Start - 1;
-			     i--) // Go up to Start - 1 in order to match the space after the first ###
+				 i >= processor.Line.Start - 1;
+				 i--) // Go up to Start - 1 in order to match the space after the first ###
 			{
 				c = processor.Line.Text[i];
 				if (endState == 0)

--- a/src/Elastic.Markdown/Myst/Directives/AdmonitionBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/AdmonitionBlock.cs
@@ -13,7 +13,7 @@ public class AdmonitionBlock(DirectiveBlockParser parser, string admonition, Par
 	public override string Directive => Admonition;
 
 	public string? Classes { get; protected set; }
-	public bool? DropdownOpen  { get; private set; }
+	public bool? DropdownOpen { get; private set; }
 
 	public string Title
 	{

--- a/src/Elastic.Markdown/Myst/Directives/AppliesBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/AppliesBlock.cs
@@ -78,7 +78,7 @@ public class AppliesBlock(DirectiveBlockParser parser, ParserContext context) : 
 		bool TryGetAvailability(string key, out ProductAvailability? semVersion)
 		{
 			semVersion = null;
-			return Prop(key) is {} v && ProductAvailability.TryParse(v, out semVersion);
+			return Prop(key) is { } v && ProductAvailability.TryParse(v, out semVersion);
 		}
 	}
 }

--- a/src/Elastic.Markdown/Myst/Directives/DirectiveBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/DirectiveBlock.cs
@@ -51,59 +51,60 @@ public abstract class DirectiveBlock(
 
 	public abstract string Directive { get; }
 
-	public string? CrossReferenceName  { get; protected set; }
+	public string? CrossReferenceName { get; protected set; }
 
 	/// <inheritdoc />
 	public char FencedChar { get; set; }
 
-    /// <inheritdoc />
-    public int OpeningFencedCharCount { get; set; }
+	/// <inheritdoc />
+	public int OpeningFencedCharCount { get; set; }
 
-    /// <inheritdoc />
-    public StringSlice TriviaAfterFencedChar { get; set; }
+	/// <inheritdoc />
+	public StringSlice TriviaAfterFencedChar { get; set; }
 
-    /// <inheritdoc />
-    public string? Info { get; set; }
+	/// <inheritdoc />
+	public string? Info { get; set; }
 
-    /// <inheritdoc />
-    public StringSlice UnescapedInfo { get; set; }
+	/// <inheritdoc />
+	public StringSlice UnescapedInfo { get; set; }
 
-    /// <inheritdoc />
-    public StringSlice TriviaAfterInfo { get; set; }
+	/// <inheritdoc />
+	public StringSlice TriviaAfterInfo { get; set; }
 
-    /// <inheritdoc />
-    public string? Arguments { get; set; }
+	/// <inheritdoc />
+	public string? Arguments { get; set; }
 
-    /// <inheritdoc />
-    public StringSlice UnescapedArguments { get; set; }
+	/// <inheritdoc />
+	public StringSlice UnescapedArguments { get; set; }
 
-    /// <inheritdoc />
-    public StringSlice TriviaAfterArguments { get; set; }
+	/// <inheritdoc />
+	public StringSlice TriviaAfterArguments { get; set; }
 
-    /// <inheritdoc />
-    public NewLine InfoNewLine { get; set; }
+	/// <inheritdoc />
+	public NewLine InfoNewLine { get; set; }
 
-    /// <inheritdoc />
-    public StringSlice TriviaBeforeClosingFence { get; set; }
+	/// <inheritdoc />
+	public StringSlice TriviaBeforeClosingFence { get; set; }
 
-    /// <inheritdoc />
-    public int ClosingFencedCharCount { get; set; }
+	/// <inheritdoc />
+	public int ClosingFencedCharCount { get; set; }
 
-    /// <summary>
-    /// Allows blocks to finalize setting properties once fully parsed
-    /// </summary>
-    /// <param name="context"></param>
-    public abstract void FinalizeAndValidate(ParserContext context);
+	/// <summary>
+	/// Allows blocks to finalize setting properties once fully parsed
+	/// </summary>
+	/// <param name="context"></param>
+	public abstract void FinalizeAndValidate(ParserContext context);
 
-    internal void AddProperty(string key, string value)
-    {
-	    _properties ??= new Dictionary<string, string>();
-	    _properties[key] = value;
-    }
+	internal void AddProperty(string key, string value)
+	{
+		_properties ??= new Dictionary<string, string>();
+		_properties[key] = value;
+	}
 
-    protected bool PropBool(params string[] keys)
-    {
-	    if (Properties is null) return false;
+	protected bool PropBool(params string[] keys)
+	{
+		if (Properties is null)
+			return false;
 		var value = Prop(keys);
 		if (string.IsNullOrEmpty(value))
 			return keys.Any(k => Properties.ContainsKey(k));
@@ -113,7 +114,8 @@ public abstract class DirectiveBlock(
 
 	protected bool? TryPropBool(params string[] keys)
 	{
-	    if (Properties is null) return null;
+		if (Properties is null)
+			return null;
 		var value = Prop(keys);
 		if (string.IsNullOrEmpty(value))
 			return keys.Any(k => Properties.ContainsKey(k)) ? true : null;
@@ -124,7 +126,8 @@ public abstract class DirectiveBlock(
 
 	protected string? Prop(params string[] keys)
 	{
-	    if (Properties is null) return null;
+		if (Properties is null)
+			return null;
 		foreach (var key in keys)
 		{
 			if (Properties.TryGetValue(key, out var value))

--- a/src/Elastic.Markdown/Myst/Directives/DirectiveBlockParser.cs
+++ b/src/Elastic.Markdown/Myst/Directives/DirectiveBlockParser.cs
@@ -19,20 +19,20 @@ namespace Elastic.Markdown.Myst.Directives;
 public class DirectiveBlockParser : FencedBlockParserBase<DirectiveBlock>
 {
 	/// <summary>
-    /// Initializes a new instance of the <see cref="DirectiveBlockParser"/> class.
-    /// </summary>
-    public DirectiveBlockParser()
-    {
-        OpeningCharacters = [':', '`'];
-        // We don't need a prefix
-        InfoPrefix = null;
-    }
+	/// Initializes a new instance of the <see cref="DirectiveBlockParser"/> class.
+	/// </summary>
+	public DirectiveBlockParser()
+	{
+		OpeningCharacters = [':', '`'];
+		// We don't need a prefix
+		InfoPrefix = null;
+	}
 
-	private readonly string[] _admonitions = [ "important", "warning", "note", "tip" ];
+	private readonly string[] _admonitions = ["important", "warning", "note", "tip"];
 
-	private readonly string[] _versionBlocks = [ "versionadded", "versionchanged", "versionremoved", "deprecated" ];
+	private readonly string[] _versionBlocks = ["versionadded", "versionchanged", "versionremoved", "deprecated"];
 
-	private readonly string[] _codeBlocks = [ "code", "code-block", "sourcecode"];
+	private readonly string[] _codeBlocks = ["code", "code-block", "sourcecode"];
 
 	private readonly FrozenDictionary<string, int> _unsupportedBlocks = new Dictionary<string, int>
 	{
@@ -63,119 +63,119 @@ public class DirectiveBlockParser : FencedBlockParserBase<DirectiveBlock>
 		{ "seealso", 3 }
 	}.ToFrozenDictionary();
 
-    protected override DirectiveBlock CreateFencedBlock(BlockProcessor processor)
-    {
-	    var info = processor.Line.AsSpan();
+	protected override DirectiveBlock CreateFencedBlock(BlockProcessor processor)
+	{
+		var info = processor.Line.AsSpan();
 
 		if (processor.Context is not ParserContext context)
 			throw new Exception("Expected parser context to be of type ParserContext");
 
-	    // TODO alternate lookup .NET 9
-	    var directive = info.ToString().Trim(['{', '}', '`']);
-	    if (_unsupportedBlocks.TryGetValue(directive, out var issueId))
-		    return new UnsupportedDirectiveBlock(this, directive, issueId, context);
+		// TODO alternate lookup .NET 9
+		var directive = info.ToString().Trim(['{', '}', '`']);
+		if (_unsupportedBlocks.TryGetValue(directive, out var issueId))
+			return new UnsupportedDirectiveBlock(this, directive, issueId, context);
 
-	    if (info.IndexOf("{tab-set}") > 0)
-		    return new TabSetBlock(this, context);
+		if (info.IndexOf("{tab-set}") > 0)
+			return new TabSetBlock(this, context);
 
-	    if (info.IndexOf("{tab-item}") > 0)
-		    return new TabItemBlock(this, context);
+		if (info.IndexOf("{tab-item}") > 0)
+			return new TabItemBlock(this, context);
 
-	    if (info.IndexOf("{dropdown}") > 0)
-		    return new DropdownBlock(this, context);
+		if (info.IndexOf("{dropdown}") > 0)
+			return new DropdownBlock(this, context);
 
-	    if (info.IndexOf("{image}") > 0)
-		    return new ImageBlock(this, context);
+		if (info.IndexOf("{image}") > 0)
+			return new ImageBlock(this, context);
 
-	    if (info.IndexOf("{figure}") > 0)
-		    return new FigureBlock(this, context);
+		if (info.IndexOf("{figure}") > 0)
+			return new FigureBlock(this, context);
 
-	    if (info.IndexOf("{figure-md}") > 0)
-		    return new FigureBlock(this, context);
+		if (info.IndexOf("{figure-md}") > 0)
+			return new FigureBlock(this, context);
 
-	    // this is currently listed as unsupported
-	    // leaving the parsing in until we are confident we don't want this
-	    // for dev-docs
-	    if (info.IndexOf("{mermaid}") > 0)
-		    return new MermaidBlock(this, context);
+		// this is currently listed as unsupported
+		// leaving the parsing in until we are confident we don't want this
+		// for dev-docs
+		if (info.IndexOf("{mermaid}") > 0)
+			return new MermaidBlock(this, context);
 
-	    if (info.IndexOf("{include}") > 0)
+		if (info.IndexOf("{include}") > 0)
 			return new IncludeBlock(this, context);
 
-	    if (info.IndexOf("{literalinclude}") > 0)
+		if (info.IndexOf("{literalinclude}") > 0)
 			return new LiteralIncludeBlock(this, context);
 
-	    if (info.IndexOf("{applies}") > 0)
+		if (info.IndexOf("{applies}") > 0)
 			return new AppliesBlock(this, context);
 
-	    if (info.IndexOf("{settings}") > 0)
+		if (info.IndexOf("{settings}") > 0)
 			return new SettingsBlock(this, context);
 
-	    foreach (var admonition in _admonitions)
-	    {
-		    if (info.IndexOf($"{{{admonition}}}") > 0)
-			    return new AdmonitionBlock(this, admonition, context);
-	    }
+		foreach (var admonition in _admonitions)
+		{
+			if (info.IndexOf($"{{{admonition}}}") > 0)
+				return new AdmonitionBlock(this, admonition, context);
+		}
 
-	    foreach (var version in _versionBlocks)
-	    {
-		    if (info.IndexOf($"{{{version}}}") > 0)
-			    return new VersionBlock(this, version, context);
-	    }
+		foreach (var version in _versionBlocks)
+		{
+			if (info.IndexOf($"{{{version}}}") > 0)
+				return new VersionBlock(this, version, context);
+		}
 
-	    return new UnknownDirectiveBlock(this, info.ToString(), context);
-    }
+		return new UnknownDirectiveBlock(this, info.ToString(), context);
+	}
 
-    public override bool Close(BlockProcessor processor, Block block)
-    {
-	    if (block is DirectiveBlock directiveBlock)
-		    directiveBlock.FinalizeAndValidate(processor.GetContext());
+	public override bool Close(BlockProcessor processor, Block block)
+	{
+		if (block is DirectiveBlock directiveBlock)
+			directiveBlock.FinalizeAndValidate(processor.GetContext());
 
 		return base.Close(processor, block);
-    }
+	}
 
-    public override BlockState TryOpen(BlockProcessor processor)
-    {
+	public override BlockState TryOpen(BlockProcessor processor)
+	{
 		if (processor.Context is not ParserContext)
 			throw new Exception("Expected parser context to be of type ParserContext");
 
-        // We expect no indentation for a fenced code block.
-        if (processor.IsCodeIndent)
-            return BlockState.None;
+		// We expect no indentation for a fenced code block.
+		if (processor.IsCodeIndent)
+			return BlockState.None;
 
-        var line = processor.Line;
+		var line = processor.Line;
 
-	    foreach (var code in _codeBlocks)
-	    {
-		    if (line.IndexOf($"{{{code}}}") > 0)
-			    return BlockState.None;
-	    }
+		foreach (var code in _codeBlocks)
+		{
+			if (line.IndexOf($"{{{code}}}") > 0)
+				return BlockState.None;
+		}
 
 		if (line.IndexOf("{") == -1)
-		    return BlockState.None;
+			return BlockState.None;
 
-	    return base.TryOpen(processor);
-    }
+		return base.TryOpen(processor);
+	}
 
-    public override BlockState TryContinue(BlockProcessor processor, Block block)
-    {
-	    var line = processor.Line.AsSpan();
+	public override BlockState TryContinue(BlockProcessor processor, Block block)
+	{
+		var line = processor.Line.AsSpan();
 
-	    if (!line.StartsWith(":"))
-		    return base.TryContinue(processor, block);
+		if (!line.StartsWith(":"))
+			return base.TryContinue(processor, block);
 
-	    if (block is not DirectiveBlock directiveBlock)
-		    return base.TryContinue(processor, block);
+		if (block is not DirectiveBlock directiveBlock)
+			return base.TryContinue(processor, block);
 
-	    var tokens = line.ToString().Split(':', 3, RemoveEmptyEntries | TrimEntries);
-	    if (tokens.Length < 1)
-		    return base.TryContinue(processor, block);
+		var tokens = line.ToString().Split(':', 3, RemoveEmptyEntries | TrimEntries);
+		if (tokens.Length < 1)
+			return base.TryContinue(processor, block);
 
-	    var name = tokens[0];
-	    var data = tokens.Length > 1 ? string.Join(":", tokens[1..]) : string.Empty;
-	    directiveBlock.AddProperty(name, data);
+		var name = tokens[0];
+		var data = tokens.Length > 1 ? string.Join(":", tokens[1..]) : string.Empty;
+		directiveBlock.AddProperty(name, data);
 
-	    return BlockState.Continue;
+		return BlockState.Continue;
 
-    }
+	}
 }

--- a/src/Elastic.Markdown/Myst/Directives/DirectiveHtmlRenderer.cs
+++ b/src/Elastic.Markdown/Myst/Directives/DirectiveHtmlRenderer.cs
@@ -107,7 +107,7 @@ public class DirectiveHtmlRenderer : HtmlObjectRenderer<DirectiveBlock>
 	private void WriteFigure(HtmlRenderer renderer, ImageBlock block)
 	{
 		var imageUrl = block.ImageUrl != null &&
-		               (block.ImageUrl.StartsWith("/_static") || block.ImageUrl.StartsWith("_static"))
+					   (block.ImageUrl.StartsWith("/_static") || block.ImageUrl.StartsWith("_static"))
 			? $"{block.Build.UrlPathPrefix}/{block.ImageUrl.TrimStart('/')}"
 			: block.ImageUrl;
 		var slice = Slices.Directives.Figure.Create(new ImageViewModel
@@ -131,7 +131,9 @@ public class DirectiveHtmlRenderer : HtmlObjectRenderer<DirectiveBlock>
 	{
 		var slice = Slices.Directives.Version.Create(new VersionViewModel
 		{
-			Directive = block.Directive, Title = block.Title, VersionClass = block.Class
+			Directive = block.Directive,
+			Title = block.Title,
+			VersionClass = block.Class
 		});
 		RenderRazorSlice(slice, renderer, block);
 	}
@@ -187,7 +189,9 @@ public class DirectiveHtmlRenderer : HtmlObjectRenderer<DirectiveBlock>
 	{
 		var slice = TabItem.Create(new TabItemViewModel
 		{
-			Index = block.Index, Title = block.Title, TabSetIndex = block.TabSetIndex
+			Index = block.Index,
+			Title = block.Title,
+			TabSetIndex = block.TabSetIndex
 		});
 		RenderRazorSlice(slice, renderer, block);
 	}
@@ -205,7 +209,9 @@ public class DirectiveHtmlRenderer : HtmlObjectRenderer<DirectiveBlock>
 		{
 			var slice = Code.Create(new CodeViewModel
 			{
-				CrossReferenceName = null, Language = block.Language, Caption = null
+				CrossReferenceName = null,
+				Language = block.Language,
+				Caption = null
 			});
 			RenderRazorSlice(slice, renderer, content);
 		}

--- a/src/Elastic.Markdown/Myst/Directives/IncludeBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/IncludeBlock.cs
@@ -57,7 +57,7 @@ public class IncludeBlock(DirectiveBlockParser parser, ParserContext context) : 
 		var includePath = Arguments;
 		if (string.IsNullOrWhiteSpace(includePath))
 		{
-			context.EmitError(Line, Column, $"```{{{Directive}}}".Length , "include requires an argument.");
+			context.EmitError(Line, Column, $"```{{{Directive}}}".Length, "include requires an argument.");
 			return;
 		}
 

--- a/src/Elastic.Markdown/Myst/Directives/TabSetBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/TabSetBlock.cs
@@ -17,7 +17,8 @@ public class TabSetBlock(DirectiveBlockParser parser, ParserContext context)
 	private int _index = -1;
 	public int FindIndex()
 	{
-		if (_index > -1) return _index;
+		if (_index > -1)
+			return _index;
 		var siblings = Parent!.OfType<TabSetBlock>().ToList();
 		_index = siblings.IndexOf(this);
 		return _index;

--- a/src/Elastic.Markdown/Myst/Directives/UnsupportedDirectiveBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/UnsupportedDirectiveBlock.cs
@@ -14,5 +14,5 @@ public class UnsupportedDirectiveBlock(DirectiveBlockParser parser, string direc
 	public string IssueUrl => $"https://github.com/elastic/docs-builder/issues/{issueId}";
 
 	public override void FinalizeAndValidate(ParserContext context) =>
-		context.EmitWarning(line:1, column:1, length:directive.Length, message: $"Directive block '{directive}' is unsupported. See {IssueUrl} for more information.");
+		context.EmitWarning(line: 1, column: 1, length: directive.Length, message: $"Directive block '{directive}' is unsupported. See {IssueUrl} for more information.");
 }

--- a/src/Elastic.Markdown/Myst/FrontMatter/AllVersions.cs
+++ b/src/Elastic.Markdown/Myst/FrontMatter/AllVersions.cs
@@ -11,7 +11,7 @@ namespace Elastic.Markdown.Myst.FrontMatter;
 
 public class AllVersions() : SemVersion(9999, 9999, 9999)
 {
-	public static AllVersions Instance { get; } = new ();
+	public static AllVersions Instance { get; } = new();
 }
 
 public class SemVersionConverter : IYamlTypeConverter

--- a/src/Elastic.Markdown/Myst/FrontMatter/ProductAvailability.cs
+++ b/src/Elastic.Markdown/Myst/FrontMatter/ProductAvailability.cs
@@ -15,7 +15,8 @@ public record ProductAvailability
 
 	public static ProductAvailability GenerallyAvailable { get; } = new()
 	{
-		Lifecycle = ProductLifecycle.GenerallyAvailable, Version = AllVersions.Instance
+		Lifecycle = ProductLifecycle.GenerallyAvailable,
+		Version = AllVersions.Instance
 	};
 
 	// <lifecycle> [version]

--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -37,7 +37,8 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 	public override bool Match(InlineProcessor processor, ref StringSlice slice)
 	{
 		var match = base.Match(processor, ref slice);
-		if (!match) return false;
+		if (!match)
+			return false;
 
 		if (processor.Inline is not LinkInline link)
 			return match;
@@ -96,7 +97,7 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 			if (!string.IsNullOrEmpty(anchor))
 			{
 				if (markdown == null || (!markdown.TableOfContents.TryGetValue(anchor, out var heading)
-				    && !markdown.AdditionalLabels.Contains(anchor)))
+					&& !markdown.AdditionalLabels.Contains(anchor)))
 					processor.EmitError(line, column, length, $"`{anchor}` does not exist in {markdown?.FileName}.");
 
 				else if (link.FirstChild == null && heading != null)

--- a/src/Elastic.Markdown/Myst/ParserContext.cs
+++ b/src/Elastic.Markdown/Myst/ParserContext.cs
@@ -47,7 +47,7 @@ public class ParserContext : MarkdownParserContext
 				Properties[key] = value;
 		}
 
-		if (frontMatter?.Title is {} title)
+		if (frontMatter?.Title is { } title)
 			Properties["page_title"] = title;
 	}
 

--- a/src/Elastic.Markdown/Myst/Substitution/SubstitutionParser.cs
+++ b/src/Elastic.Markdown/Myst/Substitution/SubstitutionParser.cs
@@ -35,37 +35,37 @@ public static class StringSliceExtensions
 
 internal struct LazySubstring
 {
-    private string _text;
-    public int Offset;
-    public int Length;
+	private string _text;
+	public int Offset;
+	public int Length;
 
-    public LazySubstring(string text)
-    {
-        _text = text;
-        Offset = 0;
-        Length = text.Length;
-    }
+	public LazySubstring(string text)
+	{
+		_text = text;
+		Offset = 0;
+		Length = text.Length;
+	}
 
-    public LazySubstring(string text, int offset, int length)
-    {
-        Debug.Assert((ulong)offset + (ulong)length <= (ulong)text.Length, $"{offset}-{length} in {text}");
-        _text = text;
-        Offset = offset;
-        Length = length;
-    }
+	public LazySubstring(string text, int offset, int length)
+	{
+		Debug.Assert((ulong)offset + (ulong)length <= (ulong)text.Length, $"{offset}-{length} in {text}");
+		_text = text;
+		Offset = offset;
+		Length = length;
+	}
 
-    public ReadOnlySpan<char> AsSpan() => _text.AsSpan(Offset, Length);
+	public ReadOnlySpan<char> AsSpan() => _text.AsSpan(Offset, Length);
 
-    public override string ToString()
-    {
-        if (Offset != 0 || Length != _text.Length)
-        {
-            _text = _text.Substring(Offset, Length);
-            Offset = 0;
-        }
+	public override string ToString()
+	{
+		if (Offset != 0 || Length != _text.Length)
+		{
+			_text = _text.Substring(Offset, Length);
+			Offset = 0;
+		}
 
-        return _text;
-    }
+		return _text;
+	}
 }
 
 [DebuggerDisplay("{GetType().Name} Line: {Line}, {Lines} Level: {Level}")]

--- a/src/Elastic.Markdown/Slices/Directives/_ViewModels.cs
+++ b/src/Elastic.Markdown/Slices/Directives/_ViewModels.cs
@@ -59,8 +59,10 @@ public class ImageViewModel
 		get
 		{
 			var sb = new StringBuilder();
-			if (Height != null) sb.Append($"height: {Height};");
-			if (Width != null) sb.Append($"width: {Width};");
+			if (Height != null)
+				sb.Append($"height: {Height};");
+			if (Width != null)
+				sb.Append($"width: {Width};");
 			return sb.ToString();
 		}
 	}

--- a/src/docs-builder/Diagnostics/ErrorCollector.cs
+++ b/src/docs-builder/Diagnostics/ErrorCollector.cs
@@ -30,7 +30,8 @@ public class GithubAnnotationOutput(ICoreService githubActions) : IDiagnosticsOu
 {
 	public void Write(Diagnostic diagnostic)
 	{
-		if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("GITHUB_ACTION"))) return;
+		if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("GITHUB_ACTION")))
+			return;
 		var properties = new AnnotationProperties
 		{
 			File = diagnostic.File,

--- a/src/docs-builder/Http/DocumentationWebHost.cs
+++ b/src/docs-builder/Http/DocumentationWebHost.cs
@@ -1,6 +1,7 @@
 // Licensed to Elasticsearch B.V under one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
+using System.Diagnostics.CodeAnalysis;
 using System.IO.Abstractions;
 using Documentation.Builder.Diagnostics;
 using Elastic.Markdown;
@@ -43,13 +44,13 @@ public class DocumentationWebHost
 		builder.Logging.SetMinimumLevel(LogLevel.Warning);
 
 		_staticFilesDirectory = Path.Combine(context.SourcePath.FullName, "_static");
-		#if DEBUG
+#if DEBUG
 		// this attempts to serve files directly from their source rather than the embedded resourses during development.
 		// this allows us to change js/css files without restarting the webserver
 		var solutionRoot = Paths.GetSolutionDirectory();
 		if (solutionRoot != null)
 			_staticFilesDirectory = Path.Combine(solutionRoot.FullName, "src", "Elastic.Markdown", "_static");
-		#endif
+#endif
 
 		_webApplication = builder.Build();
 		SetUpRoutes();
@@ -85,11 +86,11 @@ public class DocumentationWebHost
 		switch (documentationFile)
 		{
 			case MarkdownFile markdown:
-			{
-				await markdown.ParseFullAsync(ctx);
-				var rendered = await generator.RenderLayout(markdown, ctx);
-				return Results.Content(rendered, "text/html");
-			}
+				{
+					await markdown.ParseFullAsync(ctx);
+					var rendered = await generator.RenderLayout(markdown, ctx);
+					return Results.Content(rendered, "text/html");
+				}
 			case ImageFile image:
 				return Results.File(image.SourceFile.FullName, image.MimeType);
 			default:

--- a/src/docs-builder/Http/ReloadGeneratorService.cs
+++ b/src/docs-builder/Http/ReloadGeneratorService.cs
@@ -101,7 +101,8 @@ public class ReloadGeneratorService(
 
 	private void PrintException(Exception? ex)
 	{
-		if (ex == null) return;
+		if (ex == null)
+			return;
 		Logger.LogError($"Message: {ex.Message}");
 		Logger.LogError("Stacktrace:");
 		Logger.LogError(ex.StackTrace);

--- a/src/docs-generator/Cli/Commands.cs
+++ b/src/docs-generator/Cli/Commands.cs
@@ -150,9 +150,11 @@ internal class Commands(ILoggerFactory logger, ICoreService githubActionsService
 
 	private void LoadStateFromFile(FileInfo fileInfo, bool? clear, ref int? seedFs, ref bool cleanOutput)
 	{
-		if (!fileInfo.Exists) return;
+		if (!fileInfo.Exists)
+			return;
 		var state = File.ReadAllText(fileInfo.FullName).Split("|");
-		if (state.Length != 2) return;
+		if (state.Length != 2)
+			return;
 		seedFs ??= int.TryParse(state[0], out var seed) ? seed : seedFs;
 		_logger.LogInformation($"Seeding with {seedFs} from previous run {fileInfo.FullName}");
 		cleanOutput = clear ?? false;

--- a/src/docs-generator/Domain/Determinism.cs
+++ b/src/docs-generator/Domain/Determinism.cs
@@ -28,7 +28,7 @@ public record Determinism
 	public Randomizer Contents { get; }
 
 	public float ContentProbability { get; }
-	public float FileProbability { get;  }
+	public float FileProbability { get; }
 
 	public static Determinism Random { get; set; } = new(null, null);
 }

--- a/src/docs-generator/Domain/Generators.cs
+++ b/src/docs-generator/Domain/Generators.cs
@@ -32,7 +32,8 @@ public static class Generators
 	public static IEnumerable<string> CreateSubPaths(string parent, int maxDepth, int currentDepth)
 	{
 		yield return parent;
-		if (currentDepth == maxDepth) yield break;
+		if (currentDepth == maxDepth)
+			yield break;
 		var subFolders = FolderName.Generate(Determinism.Random.FileSystem.Number(0, 4));
 		foreach (var subFolder in subFolders)
 		{

--- a/src/docs-generator/Domain/Path.cs
+++ b/src/docs-generator/Domain/Path.cs
@@ -10,7 +10,7 @@ public static class Paths
 	{
 		var directory = new DirectoryInfo(Directory.GetCurrentDirectory());
 		while (directory != null &&
-		       (directory.GetFiles("*.sln").Length == 0 || directory.GetDirectories(".git").Length == 0))
+			   (directory.GetFiles("*.sln").Length == 0 || directory.GetDirectories(".git").Length == 0))
 			directory = directory.Parent;
 		return directory ?? new DirectoryInfo(Directory.GetCurrentDirectory());
 	}

--- a/src/docs-generator/Program.cs
+++ b/src/docs-generator/Program.cs
@@ -1,7 +1,7 @@
 // Licensed to Elasticsearch B.V under one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
-﻿// Licensed to Elasticsearch B.V under one or more agreements.
+// Licensed to Elasticsearch B.V under one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 

--- a/tests/Elastic.Markdown.Tests/CodeBlocks/CallOutTests.cs
+++ b/tests/Elastic.Markdown.Tests/CodeBlocks/CallOutTests.cs
@@ -46,7 +46,7 @@ var z = y - 2; // another callout
 	public void ParsesMagicCallOuts() => Block!.CallOuts
 		.Should().NotBeNullOrEmpty()
 		.And.HaveCount(2)
-		.And.NotContain(c=>c.Text.Contains("not a callout"));
+		.And.NotContain(c => c.Text.Contains("not a callout"));
 
 	[Fact]
 	public void HasNoErrors() => Collector.Diagnostics.Should().HaveCount(0);
@@ -64,11 +64,11 @@ var z = y - 2; <2>
 	public void ParsesMagicCallOuts() => Block!.CallOuts
 		.Should().NotBeNullOrEmpty()
 		.And.HaveCount(2)
-		.And.OnlyContain(c=>c.Text.StartsWith("<"));
+		.And.OnlyContain(c => c.Text.StartsWith("<"));
 
 	[Fact]
 	public void RequiresContentToFollow() => Collector.Diagnostics.Should().HaveCount(1)
-		.And.OnlyContain(c=> c.Message.StartsWith("Code block with annotations is not followed by any content"));
+		.And.OnlyContain(c => c.Message.StartsWith("Code block with annotations is not followed by any content"));
 }
 
 public class ClassicCallOutsNotFollowedByList(ITestOutputHelper output) : CodeBlockCallOutTests(output, "csharp",
@@ -87,11 +87,11 @@ var z = y - 2; <2>
 	public void ParsesMagicCallOuts() => Block!.CallOuts
 		.Should().NotBeNullOrEmpty()
 		.And.HaveCount(2)
-		.And.OnlyContain(c=>c.Text.StartsWith("<"));
+		.And.OnlyContain(c => c.Text.StartsWith("<"));
 
 	[Fact]
 	public void RequiresContentToFollow() => Collector.Diagnostics.Should().HaveCount(1)
-		.And.OnlyContain(c=> c.Message.StartsWith("Code block with annotations is not followed by a list"));
+		.And.OnlyContain(c => c.Message.StartsWith("Code block with annotations is not followed by a list"));
 }
 
 public class ClassicCallOutsFollowedByListWithWrongCoung(ITestOutputHelper output) : CodeBlockCallOutTests(output, "csharp",
@@ -110,11 +110,11 @@ var z = y - 2; <2>
 	public void ParsesMagicCallOuts() => Block!.CallOuts
 		.Should().NotBeNullOrEmpty()
 		.And.HaveCount(2)
-		.And.OnlyContain(c=>c.Text.StartsWith("<"));
+		.And.OnlyContain(c => c.Text.StartsWith("<"));
 
 	[Fact]
 	public void RequiresContentToFollow() => Collector.Diagnostics.Should().HaveCount(1)
-		.And.OnlyContain(c=> c.Message.StartsWith("Code block has 2 callouts but the following list only has 1"));
+		.And.OnlyContain(c => c.Message.StartsWith("Code block has 2 callouts but the following list only has 1"));
 }
 
 public class ClassicCallOutWithTheRightListItems(ITestOutputHelper output) : CodeBlockCallOutTests(output, "csharp",
@@ -134,7 +134,7 @@ var z = y - 2; <2>
 	public void ParsesMagicCallOuts() => Block!.CallOuts
 		.Should().NotBeNullOrEmpty()
 		.And.HaveCount(2)
-		.And.OnlyContain(c=>c.Text.StartsWith("<"));
+		.And.OnlyContain(c => c.Text.StartsWith("<"));
 
 	[Fact]
 	public void HasNoErrors() => Collector.Diagnostics.Should().HaveCount(0);

--- a/tests/Elastic.Markdown.Tests/Directives/AdmonitionTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/AdmonitionTests.cs
@@ -43,8 +43,8 @@ public class TipTests(ITestOutputHelper output) : AdmonitionTests(output, "tip")
 
 public class ImportantTests(ITestOutputHelper output) : AdmonitionTests(output, "important")
 {
-    [Fact]
-    public void SetsTitle() => Block!.Title.Should().Be("Important");
+	[Fact]
+	public void SetsTitle() => Block!.Title.Should().Be("Important");
 }
 
 public class NoteTitleTests(ITestOutputHelper output) : DirectiveTest<AdmonitionBlock>(output,

--- a/tests/Elastic.Markdown.Tests/Directives/DirectiveBaseTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/DirectiveBaseTests.cs
@@ -14,7 +14,7 @@ using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests.Directives;
 
-public abstract class DirectiveTest<TDirective>(ITestOutputHelper output, [LanguageInjection("markdown")]string content)
+public abstract class DirectiveTest<TDirective>(ITestOutputHelper output, [LanguageInjection("markdown")] string content)
 	: DirectiveTest(output, content)
 	where TDirective : DirectiveBlock
 {
@@ -54,7 +54,7 @@ public abstract class DirectiveTest : IAsyncLifetime
 	protected DocumentationSet Set { get; set; }
 
 
-	protected DirectiveTest(ITestOutputHelper output, [LanguageInjection("markdown")]string content)
+	protected DirectiveTest(ITestOutputHelper output, [LanguageInjection("markdown")] string content)
 	{
 		var logger = new TestLoggerFactory(output);
 		FileSystem = new MockFileSystem(new Dictionary<string, MockFileData>

--- a/tests/Elastic.Markdown.Tests/Directives/TabTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/TabTests.cs
@@ -40,7 +40,7 @@ Frank Herbert  |Dune           |604            |1965-06-01T00:00:00.000Z
 )
 {
 	[Fact]
-	public void ParsesBlock () => Block.Should().NotBeNull();
+	public void ParsesBlock() => Block.Should().NotBeNull();
 
 	[Fact]
 	public void ParsesTabItems()

--- a/tests/Elastic.Markdown.Tests/FrontMatter/ProductConstraintTests.cs
+++ b/tests/Elastic.Markdown.Tests/FrontMatter/ProductConstraintTests.cs
@@ -33,11 +33,11 @@ applies:
 		appliesTo.Should().NotBeNull();
 		appliesTo!.Cloud.Should().NotBeNull();
 		appliesTo.Cloud!.Serverless.Should().BeEquivalentTo(new ProductAvailability { Lifecycle = TechnicalPreview });
-		appliesTo.Cloud!.Hosted.Should().BeEquivalentTo(new ProductAvailability { Lifecycle = Beta, Version = new (8,1,1)});
+		appliesTo.Cloud!.Hosted.Should().BeEquivalentTo(new ProductAvailability { Lifecycle = Beta, Version = new(8, 1, 1) });
 		appliesTo.SelfManaged.Should().NotBeNull();
-		appliesTo.SelfManaged!.Eck.Should().BeEquivalentTo(new ProductAvailability { Lifecycle = Beta, Version = new (3,0,2)});
+		appliesTo.SelfManaged!.Eck.Should().BeEquivalentTo(new ProductAvailability { Lifecycle = Beta, Version = new(3, 0, 2) });
 		appliesTo.SelfManaged!.Ece.Should().BeEquivalentTo(new ProductAvailability { Lifecycle = Unavailable });
-		appliesTo.SelfManaged!.Stack.Should().BeEquivalentTo(new ProductAvailability { Lifecycle = GenerallyAvailable, Version = new (8,1,0)});
+		appliesTo.SelfManaged!.Stack.Should().BeEquivalentTo(new ProductAvailability { Lifecycle = GenerallyAvailable, Version = new(8, 1, 0) });
 	}
 }
 
@@ -64,20 +64,20 @@ applies:
 	}
 }
 
-public class ParsesGa(ITestOutputHelper output) : ParsingTests(output, "ga", new () { Lifecycle = GenerallyAvailable }) ;
-public class ParsesDev(ITestOutputHelper output) : ParsingTests(output, "dev", new () { Lifecycle = Development }) ;
-public class ParsesDevelopment(ITestOutputHelper output) : ParsingTests(output, "development", new () { Lifecycle = Development }) ;
-public class ParsesBeta(ITestOutputHelper output) : ParsingTests(output, "beta", new () { Lifecycle = Beta }) ;
-public class ParsesComing(ITestOutputHelper output) : ParsingTests(output, "coming", new () { Lifecycle = Coming }) ;
-public class ParsesDeprecated(ITestOutputHelper output) : ParsingTests(output, "deprecated", new () { Lifecycle = Deprecated }) ;
-public class ParsesDiscontinued(ITestOutputHelper output) : ParsingTests(output, "discontinued", new () { Lifecycle = Discontinued }) ;
-public class ParsesUnavailable(ITestOutputHelper output) : ParsingTests(output, "unavailable", new () { Lifecycle = Unavailable }) ;
-public class ParsesTechnicalPreview(ITestOutputHelper output) : ParsingTests(output, "tech-preview", new () { Lifecycle = TechnicalPreview }) ;
-public class ParsesPreview(ITestOutputHelper output) : ParsingTests(output, "preview", new () { Lifecycle = TechnicalPreview }) ;
-public class ParsesEmpty(ITestOutputHelper output) : ParsingTests(output, "", ProductAvailability.GenerallyAvailable) ;
-public class ParsesAll(ITestOutputHelper output) : ParsingTests(output, "all", ProductAvailability.GenerallyAvailable) ;
-public class ParsesWithVersion(ITestOutputHelper output) : ParsingTests(output, "ga 7.7.0", new () { Lifecycle = GenerallyAvailable, Version = new (7,7,0) });
-public class ParsesWithAllVersion(ITestOutputHelper output) : ParsingTests(output, "ga all", new () { Lifecycle = GenerallyAvailable, Version = AllVersions.Instance });
+public class ParsesGa(ITestOutputHelper output) : ParsingTests(output, "ga", new() { Lifecycle = GenerallyAvailable });
+public class ParsesDev(ITestOutputHelper output) : ParsingTests(output, "dev", new() { Lifecycle = Development });
+public class ParsesDevelopment(ITestOutputHelper output) : ParsingTests(output, "development", new() { Lifecycle = Development });
+public class ParsesBeta(ITestOutputHelper output) : ParsingTests(output, "beta", new() { Lifecycle = Beta });
+public class ParsesComing(ITestOutputHelper output) : ParsingTests(output, "coming", new() { Lifecycle = Coming });
+public class ParsesDeprecated(ITestOutputHelper output) : ParsingTests(output, "deprecated", new() { Lifecycle = Deprecated });
+public class ParsesDiscontinued(ITestOutputHelper output) : ParsingTests(output, "discontinued", new() { Lifecycle = Discontinued });
+public class ParsesUnavailable(ITestOutputHelper output) : ParsingTests(output, "unavailable", new() { Lifecycle = Unavailable });
+public class ParsesTechnicalPreview(ITestOutputHelper output) : ParsingTests(output, "tech-preview", new() { Lifecycle = TechnicalPreview });
+public class ParsesPreview(ITestOutputHelper output) : ParsingTests(output, "preview", new() { Lifecycle = TechnicalPreview });
+public class ParsesEmpty(ITestOutputHelper output) : ParsingTests(output, "", ProductAvailability.GenerallyAvailable);
+public class ParsesAll(ITestOutputHelper output) : ParsingTests(output, "all", ProductAvailability.GenerallyAvailable);
+public class ParsesWithVersion(ITestOutputHelper output) : ParsingTests(output, "ga 7.7.0", new() { Lifecycle = GenerallyAvailable, Version = new(7, 7, 0) });
+public class ParsesWithAllVersion(ITestOutputHelper output) : ParsingTests(output, "ga all", new() { Lifecycle = GenerallyAvailable, Version = AllVersions.Instance });
 
 public class CanSpecifyAllForProductVersions(ITestOutputHelper output) : DirectiveTest(output,
 """
@@ -145,7 +145,7 @@ applies:
 		File.YamlFrontMatter!.AppliesTo!.SelfManaged!.Eck.Should()
 			.BeEquivalentTo(ProductAvailability.GenerallyAvailable);
 		File.YamlFrontMatter!.AppliesTo!.SelfManaged!.Stack.Should()
-			.BeEquivalentTo(new ProductAvailability { Lifecycle = Deprecated, Version = new (9,0,0) });
+			.BeEquivalentTo(new ProductAvailability { Lifecycle = Deprecated, Version = new(9, 0, 0) });
 	}
 }
 

--- a/tests/Elastic.Markdown.Tests/FrontMatter/YamlFrontMatterTests.cs
+++ b/tests/Elastic.Markdown.Tests/FrontMatter/YamlFrontMatterTests.cs
@@ -46,5 +46,5 @@ public class EmptyFileWarnsNeedingATitle(ITestOutputHelper output) : DirectiveTe
 	[Fact]
 	public void WarnsOfNoTitle() =>
 		Collector.Diagnostics.Should().NotBeEmpty()
-			.And.Contain(d=>d.Message.Contains("Missing yaml front-matter block defining a title"));
+			.And.Contain(d => d.Message.Contains("Missing yaml front-matter block defining a title"));
 }

--- a/tests/Elastic.Markdown.Tests/Inline/InlneBaseTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/InlneBaseTests.cs
@@ -12,7 +12,7 @@ using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests.Inline;
 
-public abstract class LeafTest<TDirective>(ITestOutputHelper output, [LanguageInjection("markdown")]string content)
+public abstract class LeafTest<TDirective>(ITestOutputHelper output, [LanguageInjection("markdown")] string content)
 	: InlineTest(output, content)
 	where TDirective : LeafInline
 {
@@ -31,7 +31,7 @@ public abstract class LeafTest<TDirective>(ITestOutputHelper output, [LanguageIn
 
 }
 
-public abstract class BlockTest<TDirective>(ITestOutputHelper output, [LanguageInjection("markdown")]string content)
+public abstract class BlockTest<TDirective>(ITestOutputHelper output, [LanguageInjection("markdown")] string content)
 	: InlineTest(output, content)
 	where TDirective : Block
 {
@@ -50,7 +50,7 @@ public abstract class BlockTest<TDirective>(ITestOutputHelper output, [LanguageI
 
 }
 
-public abstract class InlineTest<TDirective>(ITestOutputHelper output, [LanguageInjection("markdown")]string content)
+public abstract class InlineTest<TDirective>(ITestOutputHelper output, [LanguageInjection("markdown")] string content)
 	: InlineTest(output, content)
 	where TDirective : ContainerInline
 {
@@ -78,7 +78,7 @@ public abstract class InlineTest : IAsyncLifetime
 	protected DocumentationSet Set { get; }
 
 
-	protected InlineTest(ITestOutputHelper output, [LanguageInjection("markdown")]string content)
+	protected InlineTest(ITestOutputHelper output, [LanguageInjection("markdown")] string content)
 	{
 		var logger = new TestLoggerFactory(output);
 		FileSystem = new MockFileSystem(new Dictionary<string, MockFileData>

--- a/tests/Elastic.Markdown.Tests/TestLogger.cs
+++ b/tests/Elastic.Markdown.Tests/TestLogger.cs
@@ -9,7 +9,7 @@ namespace Elastic.Markdown.Tests;
 
 public class TestLogger(ITestOutputHelper output) : ILogger
 {
-	private class NullScope  : IDisposable
+	private class NullScope : IDisposable
 	{
 		public void Dispose() { }
 	}


### PR DESCRIPTION
- Run dotnet format ahead of enforcing it through build automation
- ensure we do not run format analyzers for DocumentationWebHost which is adding attributes erroneously
