### PR TITLE
Remove diagnostic link and sub parsing from the minimal parse routine

### DIFF
--- a/src/Elastic.Markdown/Myst/MarkdownParser.cs
+++ b/src/Elastic.Markdown/Myst/MarkdownParser.cs
@@ -29,10 +29,8 @@ public class MarkdownParser(
 
 	public static MarkdownPipeline MinimalPipeline { get; } =
 		new MarkdownPipelineBuilder()
-			.UseDiagnosticLinks()
 			.UseYamlFrontMatter()
 			.UseDirectives()
-			.UseSubstitution()
 			.Build();
 
 	public static MarkdownPipeline Pipeline { get; } =


### PR DESCRIPTION
Minimal parse pipeline is used primarily to quickly scan for a files own TOC and the overall TOC.

Directives are still needed because they can be deeplinked.