### PR TITLE
ci: pin actions version commits and add verified creator notes

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout the repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Check license headers
         run: |

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -12,6 +12,8 @@ jobs:
 
     steps:
       - name: Checkout the repo
+        # Verified creator: https://github.com/marketplace/actions/checkout
+        # GitHub Action for checking out a repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Check license headers

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
+        # Verified creator: https://github.com/marketplace/actions/checkout
+        # GitHub Action for checking out a repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Bootstrap Action Workspace

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,7 +18,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout the repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Bootstrap Action Workspace
         id: bootstrap

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -26,22 +26,23 @@ jobs:
     steps:
       - id: repo-basename
         run: 'echo "value=`basename ${{ github.repository }}`" >> $GITHUB_OUTPUT'
-      - uses: actions/checkout@v4
+      - name: Checkout the repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5.0.0
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - name: Build documentation
         uses: elastic/docs-builder@main
         with:
           prefix: '${{ steps.repo-basename.outputs.value }}'
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3.0.1
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: .artifacts/docs/html
           
       - name: Deploy artifact
         id: deployment
-        uses: actions/deploy-pages@v4.0.5 
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
         
   build:
     runs-on: ubuntu-latest
@@ -50,14 +51,15 @@ jobs:
       major-version: ${{ steps.bootstrap.outputs.major-version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout the repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Bootstrap Action Workspace
         id: bootstrap
         uses: ./.github/actions/bootstrap
         
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -27,21 +27,29 @@ jobs:
       - id: repo-basename
         run: 'echo "value=`basename ${{ github.repository }}`" >> $GITHUB_OUTPUT'
       - name: Checkout the repo
+        # Verified creator: https://github.com/marketplace/actions/checkout
+        # GitHub Action for checking out a repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Pages
         id: pages
+        # Verified creator: https://github.com/marketplace/actions/configure-github-pages
+        # A GitHub Action to enable Pages and extract various metadata about a site.
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - name: Build documentation
         uses: elastic/docs-builder@main
         with:
           prefix: '${{ steps.repo-basename.outputs.value }}'
       - name: Upload artifact
+        # Verified creator: https://github.com/marketplace/actions/upload-github-pages-artifact
+        # A composite action for packaging and uploading an artifact that can be deployed to GitHub Pages.
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: .artifacts/docs/html
           
       - name: Deploy artifact
         id: deployment
+        # Verified creator: https://github.com/marketplace/actions/deploy-github-pages-site
+        # GitHub Action to publish artifacts to GitHub Pages for deployments
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
         
   build:
@@ -52,6 +60,8 @@ jobs:
 
     steps:
       - name: Checkout the repo
+        # Verified creator: https://github.com/marketplace/actions/checkout
+        # GitHub Action for checking out a repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Bootstrap Action Workspace
@@ -59,6 +69,8 @@ jobs:
         uses: ./.github/actions/bootstrap
         
       - name: Login to GitHub Container Registry
+        # Verified creator: https://github.com/marketplace/actions/docker-login
+        # GitHub Action to login against a Docker registry
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: ghcr.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,14 +16,15 @@ jobs:
       major-version: ${{ steps.bootstrap.outputs.major-version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout the repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Bootstrap Action Workspace
         id: bootstrap
         uses: ./.github/actions/bootstrap
         
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -47,7 +48,8 @@ jobs:
       major-version: ${{ steps.bootstrap.outputs.major-version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout the repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Bootstrap Action Workspace
         id: bootstrap

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
       - name: Checkout the repo
+        # Verified creator: https://github.com/marketplace/actions/checkout
+        # GitHub Action for checking out a repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Bootstrap Action Workspace
@@ -24,6 +26,8 @@ jobs:
         uses: ./.github/actions/bootstrap
         
       - name: Login to GitHub Container Registry
+        # Verified creator: https://github.com/marketplace/actions/docker-login
+        # GitHub Action to login against a Docker registry
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: ghcr.io
@@ -49,6 +53,8 @@ jobs:
 
     steps:
       - name: Checkout the repo
+        # Verified creator: https://github.com/marketplace/actions/checkout
+        # GitHub Action for checking out a repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Bootstrap Action Workspace


### PR DESCRIPTION
The purpose of this PR is to improve the baseline security for using GitHub Actions with the docs-builder; mainly to improve user awareness as they use this `elastic/docs-builder` repo to deploy documentation using GitHub Actions.

This PR pins the GitHub actions to the commit SHA, with a comment including the version.
* For reference, see https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

This also adds notes to the workflow with a link to the action in the GitHub Marketplace.

This is related to https://github.com/elastic/docs-builder/pull/146 and https://github.com/elastic/docs-builder-example/pull/12