### PR TITLE
Ensure uncaught yaml parsing errors are recoverable

### DIFF
--- a/src/Elastic.Markdown/Diagnostics/DiagnosticsChannel.cs
+++ b/src/Elastic.Markdown/Diagnostics/DiagnosticsChannel.cs
@@ -141,13 +141,16 @@ public class DiagnosticsCollector(ILoggerFactory loggerFactory, IReadOnlyCollect
 	}
 
 
-	public void EmitError(string file, string message)
+	public void EmitError(string file, string message, Exception? e = null)
 	{
 		var d = new Diagnostic
 		{
 			Severity = Severity.Error,
 			File = file,
-			Message = message,
+			Message = message
+			          + (e != null ? Environment.NewLine + e : string.Empty)
+			          + (e?.InnerException != null ? Environment.NewLine + e.InnerException : string.Empty),
+
 		};
 		Channel.Write(d);
 	}

--- a/src/Elastic.Markdown/Diagnostics/DiagnosticsChannel.cs
+++ b/src/Elastic.Markdown/Diagnostics/DiagnosticsChannel.cs
@@ -148,8 +148,8 @@ public class DiagnosticsCollector(ILoggerFactory loggerFactory, IReadOnlyCollect
 			Severity = Severity.Error,
 			File = file,
 			Message = message
-			          + (e != null ? Environment.NewLine + e : string.Empty)
-			          + (e?.InnerException != null ? Environment.NewLine + e.InnerException : string.Empty),
+					  + (e != null ? Environment.NewLine + e : string.Empty)
+					  + (e?.InnerException != null ? Environment.NewLine + e.InnerException : string.Empty),
 
 		};
 		Channel.Write(d);


### PR DESCRIPTION
We emit quite a few manual validations during parsing but this __should__ ensure if something happens we didn't for see while parsing yaml in docset.yml or the front matters we:

1. Recover and continue compilation
2. Ensure we emit the exception through the regular error collector.
3. Ensure the error holds the originating file path.

The actual error will still be cryptic (yaml.net is just pretty cryptic) for uncaught exceptions. We'll continue to pre-empt these as we discover them to emit better error messages.
