### PR TITLE
Introduce toc.yml, allows toc's to be split one directory deep

### DIFF
--- a/docs-builder.sln.DotSettings
+++ b/docs-builder.sln.DotSettings
@@ -1,3 +1,4 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=docset/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=linenos/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=literalinclude/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/docs/source/development/index.md
+++ b/docs/source/development/index.md
@@ -1,0 +1,6 @@
+---
+title: Development Guide
+navigation_title: Development
+---
+
+TODO write development documentation here

--- a/docs/source/development/toc.yml
+++ b/docs/source/development/toc.yml
@@ -1,0 +1,2 @@
+toc:
+  - file: index.md

--- a/docs/source/docset.yml
+++ b/docs/source/docset.yml
@@ -69,6 +69,9 @@ toc:
       - file: tabs.md
       - file: tagged_regions.md
       - file: titles.md
+  # nested TOCs are only allowed from docset.yml
+  # to prevent them from being nested deeply arbitrarily
+  - toc: development
   - folder: testing
     children:
       - file: index.md

--- a/src/Elastic.Markdown/IO/DocumentationFolder.cs
+++ b/src/Elastic.Markdown/IO/DocumentationFolder.cs
@@ -33,10 +33,7 @@ public class DocumentationFolder
 		Index = index ?? foundIndex;
 
 		if (Index is not null)
-		{
 			FilesInOrder = FilesInOrder.Except([Index]).ToList();
-			Index.Parent ??= this;
-		}
 
 		OwnFiles = [.. FilesInOrder];
 	}
@@ -55,7 +52,7 @@ public class DocumentationFolder
 		MarkdownFile? index = null;
 		foreach (var tocItem in toc)
 		{
-			if (tocItem is TocFile file)
+			if (tocItem is FileReference file)
 			{
 				if (!lookup.TryGetValue(file.Path, out var d) || d is not MarkdownFile md)
 					continue;
@@ -76,14 +73,14 @@ public class DocumentationFolder
 				if (file.Path.EndsWith("index.md") && d is MarkdownFile i)
 					index ??= i;
 			}
-			else if (tocItem is TocFolder folder)
+			else if (tocItem is FolderReference folder)
 			{
 				var children = folder.Children;
 				if (children.Count == 0
 					&& folderLookup.TryGetValue(folder.Path, out var documentationFiles))
 				{
 					children = documentationFiles
-						.Select(d => new TocFile(d.RelativePath, true, []))
+						.Select(d => new FileReference(d.RelativePath, true, []))
 						.ToArray();
 				}
 

--- a/src/Elastic.Markdown/IO/ITocItem.cs
+++ b/src/Elastic.Markdown/IO/ITocItem.cs
@@ -6,6 +6,8 @@ namespace Elastic.Markdown.IO;
 
 public interface ITocItem;
 
-public record TocFile(string Path, bool Found, IReadOnlyCollection<ITocItem> Children) : ITocItem;
+public record FileReference(string Path, bool Found, IReadOnlyCollection<ITocItem> Children) : ITocItem;
 
-public record TocFolder(string Path, bool Found, IReadOnlyCollection<ITocItem> Children) : ITocItem;
+public record FolderReference(string Path, bool Found, IReadOnlyCollection<ITocItem> Children) : ITocItem;
+
+public record TocReference(string Path, bool Found, IReadOnlyCollection<ITocItem> Children) : ITocItem;

--- a/src/Elastic.Markdown/IO/MarkdownFile.cs
+++ b/src/Elastic.Markdown/IO/MarkdownFile.cs
@@ -31,7 +31,11 @@ public record MarkdownFile : DocumentationFile
 
 	private DiagnosticsCollector Collector { get; }
 
-	public DocumentationFolder? Parent { get; set; }
+	public DocumentationFolder? Parent
+	{
+		get => FileName == "index.md" ? _parent?.Parent : _parent;
+		set => _parent = value;
+	}
 
 	public string? UrlPathPrefix { get; }
 	private MarkdownParser MarkdownParser { get; }
@@ -55,6 +59,7 @@ public record MarkdownFile : DocumentationFile
 	public string Url => $"{UrlPathPrefix}/{RelativePath.Replace(".md", ".html")}";
 
 	private bool _instructionsParsed;
+	private DocumentationFolder? _parent;
 
 	public MarkdownFile[] YieldParents()
 	{

--- a/tests/Elastic.Markdown.Tests/DocSet/BreadCrumbTests.cs
+++ b/tests/Elastic.Markdown.Tests/DocSet/BreadCrumbTests.cs
@@ -6,7 +6,7 @@ using Elastic.Markdown.IO;
 using FluentAssertions;
 using Xunit.Abstractions;
 
-namespace Elastic.Markdown.Tests.SiteMap;
+namespace Elastic.Markdown.Tests.DocSet;
 
 public class BreadCrumbTests(ITestOutputHelper output) : NavigationTestsBase(output)
 {

--- a/tests/Elastic.Markdown.Tests/DocSet/LinkReferenceTests.cs
+++ b/tests/Elastic.Markdown.Tests/DocSet/LinkReferenceTests.cs
@@ -6,7 +6,7 @@ using Elastic.Markdown.IO;
 using FluentAssertions;
 using Xunit.Abstractions;
 
-namespace Elastic.Markdown.Tests.SiteMap;
+namespace Elastic.Markdown.Tests.DocSet;
 
 public class LinkReferenceTests(ITestOutputHelper output) : NavigationTestsBase(output)
 {

--- a/tests/Elastic.Markdown.Tests/DocSet/NavigationTests.cs
+++ b/tests/Elastic.Markdown.Tests/DocSet/NavigationTests.cs
@@ -5,7 +5,7 @@
 using FluentAssertions;
 using Xunit.Abstractions;
 
-namespace Elastic.Markdown.Tests.SiteMap;
+namespace Elastic.Markdown.Tests.DocSet;
 
 public class NavigationTests(ITestOutputHelper output) : NavigationTestsBase(output)
 {

--- a/tests/Elastic.Markdown.Tests/DocSet/NavigationTestsBase.cs
+++ b/tests/Elastic.Markdown.Tests/DocSet/NavigationTestsBase.cs
@@ -9,7 +9,7 @@ using Elastic.Markdown.IO;
 using FluentAssertions;
 using Xunit.Abstractions;
 
-namespace Elastic.Markdown.Tests.SiteMap;
+namespace Elastic.Markdown.Tests.DocSet;
 
 public class NavigationTestsBase : IAsyncLifetime
 {

--- a/tests/Elastic.Markdown.Tests/DocSet/NestedTocTests.cs
+++ b/tests/Elastic.Markdown.Tests/DocSet/NestedTocTests.cs
@@ -1,0 +1,31 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Markdown.IO;
+using FluentAssertions;
+using Xunit.Abstractions;
+
+namespace Elastic.Markdown.Tests.DocSet;
+
+public class NestedTocTests(ITestOutputHelper output) : NavigationTestsBase(output)
+{
+	[Fact]
+	public void InjectsNestedTocsIntoDocumentationSet()
+	{
+		var doc = Generator.DocumentationSet.Files.FirstOrDefault(f => f.RelativePath == "development/index.md") as MarkdownFile;
+
+		doc.Should().NotBeNull();
+
+		// ensure we link back up to main toc in docset yaml
+		doc!.Parent.Should().NotBeNull();
+
+		// its parent should be null
+		doc.Parent!.Parent.Should().BeNull();
+
+		// its parent should point to an index
+		doc.Parent.Index.Should().NotBeNull();
+		doc.Parent.Index!.RelativePath.Should().Be("index.md");
+
+	}
+}


### PR DESCRIPTION
This allows sub folders one level deep to introduce their own toc.yml file. 

This will be used heavily by https://github.com/elastic/docs-content/

Where each sub folder will be a major section in the new IA