### PR TITLE
Add external links to links.json artifact

### DIFF
--- a/docs/source/docset.yml
+++ b/docs/source/docset.yml
@@ -74,3 +74,4 @@ toc:
       - file: index.md
       - file: req.md
       - folder: nested
+      - file: external-links.md

--- a/docs/source/testing/external-links.md
+++ b/docs/source/testing/external-links.md
@@ -1,0 +1,9 @@
+---
+title: "External Links"
+---
+
+[inline external link](kibana://path/to/file.md)
+
+[reference external link][1]
+
+[1]: kibana://path/to/another/file.md

--- a/src/Elastic.Markdown/IO/LinkReference.cs
+++ b/src/Elastic.Markdown/IO/LinkReference.cs
@@ -14,19 +14,24 @@ public record LinkReference
 	[JsonPropertyName("url_path_prefix")]
 	public required string? UrlPathPrefix { get; init; }
 
-	[JsonPropertyName("links")]
-	public required string[] Links { get; init; } = [];
+	[JsonPropertyName("internal_links")]
+	public required string[] InternalLinks { get; init; } = [];
+
+	[JsonPropertyName("external_links")]
+	public required string[] ExternalLinks { get; init; } = [];
 
 	public static LinkReference Create(DocumentationSet set)
 	{
-		var links = set.FlatMappedFiles.Values
-			.OfType<MarkdownFile>()
-			.Select(m => m.RelativePath).ToArray();
+		var markdownFiles = set.FlatMappedFiles.Values.OfType<MarkdownFile>().ToArray();
+		var internalLinks = markdownFiles.Select(m => m.RelativePath).ToArray();
+		var externalLinks = markdownFiles.SelectMany(m => m.Links).ToHashSet().ToArray();
 		return new LinkReference
 		{
 			UrlPathPrefix = set.Context.UrlPathPrefix,
 			Origin = set.Context.Git,
-			Links = links
+			InternalLinks = internalLinks,
+			ExternalLinks = externalLinks
 		};
 	}
+
 }

--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -44,6 +44,7 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 			return match;
 
 		var url = link.Url;
+		var uri = Uri.TryCreate(url, UriKind.Absolute, out var u) ? u : null;
 		var line = link.Line + 1;
 		var column = link.Column;
 		var length = url?.Length ?? 1;
@@ -58,7 +59,12 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 			return match;
 		}
 
-		if (Uri.TryCreate(url, UriKind.Absolute, out var uri) && uri.Scheme.StartsWith("http"))
+		if (uri != null && !MarkdownFile.ExcludedExternalLinkSchemes.Contains(uri.Scheme))
+		{
+			return match;
+		}
+
+		if (uri != null && uri.Scheme.StartsWith("http"))
 		{
 			var baseDomain = uri.Host == "localhost" ? "localhost" : string.Join('.', uri.Host.Split('.')[^2..]);
 			if (!context.Configuration.ExternalLinkHosts.Contains(baseDomain))
@@ -128,8 +134,5 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 			link.Url += $"#{anchor}";
 
 		return match;
-
-
-
 	}
 }


### PR DESCRIPTION
## Context

For our Links Validation Service, we need to generate a list of external links (links pointing to external documentation in our system) that will be uploaded to the Link Index.

## Changes

Add external links  to the links.json

Resulting JSON file:

```json
{
  "origin": {
    "branch": "feature/add-external-links",
    "remote": "elastic/docs-builder-unknown",
    "ref": "03c22a29e6585b72f64a0aa64f087dd5664c939f"
  },
  "url_path_prefix": "",
  "internal_links": [
    "index.md",
    "configure/index.md",
    "configure/page.md",
    "testing/external-links.md",
    "...",
  ],
  "external_links": [
    "kibana://path/to/file.md",
    "kibana://path/to/another/file.md"
  ]
}
```