### PR TITLE
Add cross-links to links.json

### DIFF
--- a/docs/source/docset.yml
+++ b/docs/source/docset.yml
@@ -77,3 +77,4 @@ toc:
       - file: index.md
       - file: req.md
       - folder: nested
+      - file: external-links.md

--- a/docs/source/docset.yml
+++ b/docs/source/docset.yml
@@ -77,4 +77,4 @@ toc:
       - file: index.md
       - file: req.md
       - folder: nested
-      - file: external-links.md
+      - file: cross-links.md

--- a/docs/source/testing/cross-links.md
+++ b/docs/source/testing/cross-links.md
@@ -1,5 +1,5 @@
 ---
-title: External Links
+title: Cross Links
 ---
 
 [Elasticsearch](elasticsearch://index.md)

--- a/docs/source/testing/external-links.md
+++ b/docs/source/testing/external-links.md
@@ -2,6 +2,8 @@
 title: External Links
 ---
 
+[Elasticsearch](elasticsearch://index.md)
+
 [Kibana][1]
 
-[1] kibana://index.md
+[1]: kibana://index.md

--- a/docs/source/testing/external-links.md
+++ b/docs/source/testing/external-links.md
@@ -1,0 +1,7 @@
+---
+title: External Links
+---
+
+[Kibana][1]
+
+[1] kibana://index.md

--- a/src/Elastic.Markdown/Diagnostics/DiagnosticsChannel.cs
+++ b/src/Elastic.Markdown/Diagnostics/DiagnosticsChannel.cs
@@ -87,7 +87,7 @@ public class DiagnosticsCollector(ILoggerFactory loggerFactory, IReadOnlyCollect
 
 	public HashSet<string> OffendingFiles { get; } = new();
 
-	public ConcurrentDictionary<string, bool> CrossLinks { get; } = new();
+	public ConcurrentBag<string> CrossLinks { get; } = new();
 
 	public Task StartAsync(Cancel ctx)
 	{
@@ -143,7 +143,7 @@ public class DiagnosticsCollector(ILoggerFactory loggerFactory, IReadOnlyCollect
 		await Channel.Reader.Completion;
 	}
 
-	public void EmitCrossLink(string link) => CrossLinks.TryAdd(link, true);
+	public void EmitCrossLink(string link) => CrossLinks.Add(link);
 
 	public void EmitError(string file, string message, Exception? e = null)
 	{

--- a/src/Elastic.Markdown/Diagnostics/DiagnosticsChannel.cs
+++ b/src/Elastic.Markdown/Diagnostics/DiagnosticsChannel.cs
@@ -143,7 +143,7 @@ public class DiagnosticsCollector(ILoggerFactory loggerFactory, IReadOnlyCollect
 		await Channel.Reader.Completion;
 	}
 
-	public void EmitExternalLink(string link) => CrossLinks.TryAdd(link, true);
+	public void EmitCrossLink(string link) => CrossLinks.TryAdd(link, true);
 
 	public void EmitError(string file, string message, Exception? e = null)
 	{

--- a/src/Elastic.Markdown/Diagnostics/DiagnosticsChannel.cs
+++ b/src/Elastic.Markdown/Diagnostics/DiagnosticsChannel.cs
@@ -87,7 +87,7 @@ public class DiagnosticsCollector(ILoggerFactory loggerFactory, IReadOnlyCollect
 
 	public HashSet<string> OffendingFiles { get; } = new();
 
-	public ConcurrentDictionary<string, bool> ExternalLinks { get; } = new();
+	public ConcurrentDictionary<string, bool> CrossLinks { get; } = new();
 
 	public Task StartAsync(Cancel ctx)
 	{
@@ -143,7 +143,7 @@ public class DiagnosticsCollector(ILoggerFactory loggerFactory, IReadOnlyCollect
 		await Channel.Reader.Completion;
 	}
 
-	public void EmitExternalLink(string link) => ExternalLinks.TryAdd(link, true);
+	public void EmitExternalLink(string link) => CrossLinks.TryAdd(link, true);
 
 	public void EmitError(string file, string message, Exception? e = null)
 	{

--- a/src/Elastic.Markdown/Diagnostics/DiagnosticsChannel.cs
+++ b/src/Elastic.Markdown/Diagnostics/DiagnosticsChannel.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Collections.Concurrent;
 using System.Threading.Channels;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -86,6 +87,8 @@ public class DiagnosticsCollector(ILoggerFactory loggerFactory, IReadOnlyCollect
 
 	public HashSet<string> OffendingFiles { get; } = new();
 
+	public ConcurrentDictionary<string, bool> ExternalLinks { get; } = new();
+
 	public Task StartAsync(Cancel ctx)
 	{
 		if (_started is not null)
@@ -140,6 +143,7 @@ public class DiagnosticsCollector(ILoggerFactory loggerFactory, IReadOnlyCollect
 		await Channel.Reader.Completion;
 	}
 
+	public void EmitExternalLink(string link) => ExternalLinks.TryAdd(link, true);
 
 	public void EmitError(string file, string message, Exception? e = null)
 	{

--- a/src/Elastic.Markdown/IO/LinkReference.cs
+++ b/src/Elastic.Markdown/IO/LinkReference.cs
@@ -17,12 +17,12 @@ public record LinkReference
 	[JsonPropertyName("links")]
 	public required string[] Links { get; init; } = [];
 
-	[JsonPropertyName("external_links")]
-	public required string[] ExternalLinks { get; init; } = [];
+	[JsonPropertyName("cross_links")]
+	public required string[] CrossLinks { get; init; } = [];
 
 	public static LinkReference Create(DocumentationSet set)
 	{
-		var externalLinks = set.Context.Collector.ExternalLinks.Select(i => i.Key).ToArray();
+		var crossLinks = set.Context.Collector.CrossLinks.Select(i => i.Key).ToArray();
 
 		var links = set.FlatMappedFiles.Values
 			.OfType<MarkdownFile>()
@@ -32,7 +32,7 @@ public record LinkReference
 			UrlPathPrefix = set.Context.UrlPathPrefix,
 			Origin = set.Context.Git,
 			Links = links,
-			ExternalLinks = externalLinks
+			CrossLinks = crossLinks
 		};
 	}
 }

--- a/src/Elastic.Markdown/IO/LinkReference.cs
+++ b/src/Elastic.Markdown/IO/LinkReference.cs
@@ -17,8 +17,13 @@ public record LinkReference
 	[JsonPropertyName("links")]
 	public required string[] Links { get; init; } = [];
 
+	[JsonPropertyName("external_links")]
+	public required string[] ExternalLinks { get; init; } = [];
+
 	public static LinkReference Create(DocumentationSet set)
 	{
+		var externalLinks = set.Context.Collector.ExternalLinks.Select(i => i.Key).ToArray();
+
 		var links = set.FlatMappedFiles.Values
 			.OfType<MarkdownFile>()
 			.Select(m => m.RelativePath).ToArray();
@@ -26,7 +31,8 @@ public record LinkReference
 		{
 			UrlPathPrefix = set.Context.UrlPathPrefix,
 			Origin = set.Context.Git,
-			Links = links
+			Links = links,
+			ExternalLinks = externalLinks
 		};
 	}
 }

--- a/src/Elastic.Markdown/IO/LinkReference.cs
+++ b/src/Elastic.Markdown/IO/LinkReference.cs
@@ -22,8 +22,7 @@ public record LinkReference
 
 	public static LinkReference Create(DocumentationSet set)
 	{
-		var crossLinks = set.Context.Collector.CrossLinks.Select(i => i.Key).ToArray();
-
+		var crossLinks = set.Context.Collector.CrossLinks.ToHashSet().ToArray();
 		var links = set.FlatMappedFiles.Values
 			.OfType<MarkdownFile>()
 			.Select(m => m.RelativePath).ToArray();

--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -33,8 +33,9 @@ public class DiagnosticLinkInlineExtensions : IMarkdownExtension
 
 public class DiagnosticLinkInlineParser : LinkInlineParser
 {
-
-	private static readonly ImmutableHashSet<string> ExcludedSchemes = new[] { "http", "https", "tel", "jdbc" }.ToImmutableHashSet();
+	// See https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml for a list of URI schemes
+	// We can add more schemes as needed
+	private static readonly ImmutableHashSet<string> ExcludedSchemes = ["http", "https", "tel", "jdbc"];
 
 	public override bool Match(InlineProcessor processor, ref StringSlice slice)
 	{

--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -52,8 +52,8 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 		var column = link.Column;
 		var length = url?.Length ?? 1;
 
-		if (IsExternalLink(uri))
-			processor.GetContext().Build.Collector.EmitExternalLink(url!);
+		if (IsCrossLink(uri))
+			processor.GetContext().Build.Collector.EmitCrossLink(url!);
 
 		var context = processor.GetContext();
 		if (processor.GetContext().SkipValidation)
@@ -133,7 +133,7 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 		return match;
 	}
 
-	private static bool IsExternalLink(Uri? uri) =>
+	private static bool IsCrossLink(Uri? uri) =>
 		uri != null
 		&& !ExcludedSchemes.Contains(uri.Scheme)
 		&& !uri.IsFile

--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -2,15 +2,14 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Collections.Immutable;
 using Elastic.Markdown.Diagnostics;
 using Elastic.Markdown.IO;
-using Elastic.Markdown.Myst.Directives;
 using Markdig;
 using Markdig.Helpers;
 using Markdig.Parsers;
 using Markdig.Parsers.Inlines;
 using Markdig.Renderers;
-using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
 
 namespace Elastic.Markdown.Myst.InlineParsers;
@@ -34,6 +33,9 @@ public class DiagnosticLinkInlineExtensions : IMarkdownExtension
 
 public class DiagnosticLinkInlineParser : LinkInlineParser
 {
+
+	private static readonly ImmutableHashSet<string> ExcludedSchemes = new[] { "http", "https", "tel", "jdbc" }.ToImmutableHashSet();
+
 	public override bool Match(InlineProcessor processor, ref StringSlice slice)
 	{
 		var match = base.Match(processor, ref slice);
@@ -44,9 +46,13 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 			return match;
 
 		var url = link.Url;
+		var uri = Uri.TryCreate(url, UriKind.Absolute, out var u) ? u : null;
 		var line = link.Line + 1;
 		var column = link.Column;
 		var length = url?.Length ?? 1;
+
+		if (IsExternalLink(uri))
+			processor.GetContext().Build.Collector.EmitExternalLink(url!);
 
 		var context = processor.GetContext();
 		if (processor.GetContext().SkipValidation)
@@ -58,7 +64,7 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 			return match;
 		}
 
-		if (Uri.TryCreate(url, UriKind.Absolute, out var uri) && uri.Scheme.StartsWith("http"))
+		if (uri != null && uri.Scheme.StartsWith("http"))
 		{
 			var baseDomain = uri.Host == "localhost" ? "localhost" : string.Join('.', uri.Host.Split('.')[^2..]);
 			if (!context.Configuration.ExternalLinkHosts.Contains(baseDomain))
@@ -82,15 +88,11 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 		var anchor = anchors.Length > 1 ? anchors[1].Trim() : null;
 		url = anchors[0];
 
-		if (!string.IsNullOrWhiteSpace(url))
+		if (!string.IsNullOrWhiteSpace(url) && uri != null)
 		{
 			var pathOnDisk = Path.Combine(includeFrom, url.TrimStart('/'));
-			if (!context.Build.ReadFileSystem.File.Exists(pathOnDisk))
+			if (uri.IsFile && !context.Build.ReadFileSystem.File.Exists(pathOnDisk))
 				processor.EmitError(line, column, length, $"`{url}` does not exist. resolved to `{pathOnDisk}");
-			else
-			{
-
-			}
 		}
 		else
 			link.Url = "";
@@ -128,8 +130,11 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 			link.Url += $"#{anchor}";
 
 		return match;
-
-
-
 	}
+
+	private static bool IsExternalLink(Uri? uri) =>
+		uri != null
+		&& !ExcludedSchemes.Contains(uri.Scheme)
+		&& !uri.IsFile
+		&& Path.GetExtension(uri.OriginalString) == ".md";
 }

--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -47,13 +47,10 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 			return match;
 
 		var url = link.Url;
-		var uri = Uri.TryCreate(url, UriKind.Absolute, out var u) ? u : null;
 		var line = link.Line + 1;
 		var column = link.Column;
 		var length = url?.Length ?? 1;
 
-		if (IsCrossLink(uri))
-			processor.GetContext().Build.Collector.EmitCrossLink(url!);
 
 		var context = processor.GetContext();
 		if (processor.GetContext().SkipValidation)
@@ -64,6 +61,11 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 			processor.EmitWarning(line, column, length, $"Found empty url");
 			return match;
 		}
+
+		var uri = Uri.TryCreate(url, UriKind.Absolute, out var u) ? u : null;
+
+		if (IsCrossLink(uri))
+			processor.GetContext().Build.Collector.EmitCrossLink(url!);
 
 		if (uri != null && uri.Scheme.StartsWith("http"))
 		{

--- a/tests/Elastic.Markdown.Tests/Inline/InlineLinkTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/InlineLinkTests.cs
@@ -103,7 +103,7 @@ public class LinkReferenceTest(ITestOutputHelper output) : LinkTestBase(output,
 	public void HasNoErrors() => Collector.Diagnostics.Should().HaveCount(0);
 }
 
-public class ExternalLinkReferenceTest(ITestOutputHelper output) : LinkTestBase(output,
+public class CrossLinkReferenceTest(ITestOutputHelper output) : LinkTestBase(output,
 	"""
 	[test][test]
 
@@ -123,14 +123,14 @@ public class ExternalLinkReferenceTest(ITestOutputHelper output) : LinkTestBase(
 	public void HasNoErrors() => Collector.Diagnostics.Should().HaveCount(0);
 
 	[Fact]
-	public void EmitsExternalLink()
+	public void EmitsCrossLink()
 	{
-		Collector.ExternalLinks.Should().HaveCount(1);
-		Collector.ExternalLinks.Should().ContainKey("kibana://index.md");
+		Collector.CrossLinks.Should().HaveCount(1);
+		Collector.CrossLinks.Should().ContainKey("kibana://index.md");
 	}
 }
 
-public class ExternalLinkTest(ITestOutputHelper output) : LinkTestBase(output,
+public class CrossLinkTest(ITestOutputHelper output) : LinkTestBase(output,
 	"""
 	[test](kibana://index.md)
 	"""
@@ -148,14 +148,14 @@ public class ExternalLinkTest(ITestOutputHelper output) : LinkTestBase(output,
 	public void HasNoErrors() => Collector.Diagnostics.Should().HaveCount(0);
 
 	[Fact]
-	public void EmitsExternalLink()
+	public void EmitsCrossLink()
 	{
-		Collector.ExternalLinks.Should().HaveCount(1);
-		Collector.ExternalLinks.Should().ContainKey("kibana://index.md");
+		Collector.CrossLinks.Should().HaveCount(1);
+		Collector.CrossLinks.Should().ContainKey("kibana://index.md");
 	}
 }
 
-public class DuplicateExternalLinkTest(ITestOutputHelper output) : LinkTestBase(output,
+public class DuplicateCrossLinkTest(ITestOutputHelper output) : LinkTestBase(output,
 	"""
 	[a](kibana://index.md)
 	[b](kibana://index.md)
@@ -179,11 +179,11 @@ public class DuplicateExternalLinkTest(ITestOutputHelper output) : LinkTestBase(
 	public void HasNoErrors() => Collector.Diagnostics.Should().HaveCount(0);
 
 	[Fact]
-	public void EmitsExternalLink()
+	public void EmitsCrossLink()
 	{
-		Collector.ExternalLinks.Should().HaveCount(2);
-		Collector.ExternalLinks.Should().ContainKey("kibana://index.md");
-		Collector.ExternalLinks.Should().ContainKey("elasticsearch://index.md");
+		Collector.CrossLinks.Should().HaveCount(2);
+		Collector.CrossLinks.Should().ContainKey("kibana://index.md");
+		Collector.CrossLinks.Should().ContainKey("elasticsearch://index.md");
 	}
 }
 

--- a/tests/Elastic.Markdown.Tests/Inline/InlineLinkTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/InlineLinkTests.cs
@@ -115,6 +115,7 @@ public class ExternalLinkReferenceTest(ITestOutputHelper output) : LinkTestBase(
 	public void GeneratesHtml() =>
 		// language=html
 		Html.Should().Contain(
+			// TODO: The link is not rendered correctly yet, will be fixed in a follow-up
 			"""<p><a href="kibana://index.html">test</a></p>"""
 		);
 
@@ -139,6 +140,7 @@ public class ExternalLinkTest(ITestOutputHelper output) : LinkTestBase(output,
 	public void GeneratesHtml() =>
 		// language=html
 		Html.Should().Contain(
+			// TODO: The link is not rendered correctly yet, will be fixed in a follow-up
 			"""<p><a href="kibana://index.html">test</a></p>"""
 		);
 
@@ -153,4 +155,35 @@ public class ExternalLinkTest(ITestOutputHelper output) : LinkTestBase(output,
 	}
 }
 
+public class DuplicateExternalLinkTest(ITestOutputHelper output) : LinkTestBase(output,
+	"""
+	[a](kibana://index.md)
+	[b](kibana://index.md)
+	[c](elasticsearch://index.md)
+	"""
+)
+{
+	[Fact]
+	public void GeneratesHtml() =>
+		// language=html
+		Html.Should().Contain(
+			// TODO: The link is not rendered correctly yet, will be fixed in a follow-up
+			"""
+			<p><a href="kibana://index.html">a</a><br />
+			<a href="kibana://index.html">b</a><br />
+			<a href="elasticsearch://index.html">c</a></p>
+			"""
+		);
+
+    [Fact]
+    public void HasNoErrors() => Collector.Diagnostics.Should().HaveCount(0);
+
+    [Fact]
+    public void EmitsExternalLink()
+    {
+        Collector.ExternalLinks.Should().HaveCount(2);
+        Collector.ExternalLinks.Should().ContainKey("kibana://index.md");
+        Collector.ExternalLinks.Should().ContainKey("elasticsearch://index.md");
+    }
+}
 

--- a/tests/Elastic.Markdown.Tests/Inline/InlineLinkTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/InlineLinkTests.cs
@@ -83,3 +83,74 @@ public class InsertPageTitleTests(ITestOutputHelper output) : LinkTestBase(outpu
 	[Fact]
 	public void HasNoErrors() => Collector.Diagnostics.Should().HaveCount(0);
 }
+
+public class LinkReferenceTest(ITestOutputHelper output) : LinkTestBase(output,
+	"""
+	[test][test]
+
+	[test]: testing/req.md
+	"""
+)
+{
+	[Fact]
+	public void GeneratesHtml() =>
+		// language=html
+		Html.Should().Contain(
+			"""<p><a href="testing/req.html">test</a></p>"""
+		);
+
+	[Fact]
+	public void HasNoErrors() => Collector.Diagnostics.Should().HaveCount(0);
+}
+
+public class ExternalLinkReferenceTest(ITestOutputHelper output) : LinkTestBase(output,
+	"""
+	[test][test]
+
+	[test]: kibana://index.md
+	"""
+)
+{
+	[Fact]
+	public void GeneratesHtml() =>
+		// language=html
+		Html.Should().Contain(
+			"""<p><a href="kibana://index.html">test</a></p>"""
+		);
+
+	[Fact]
+	public void HasNoErrors() => Collector.Diagnostics.Should().HaveCount(0);
+
+	[Fact]
+	public void EmitsExternalLink()
+	{
+		Collector.ExternalLinks.Should().HaveCount(1);
+		Collector.ExternalLinks.Should().ContainKey("kibana://index.md");
+	}
+}
+
+public class ExternalLinkTest(ITestOutputHelper output) : LinkTestBase(output,
+	"""
+	[test](kibana://index.md)
+	"""
+)
+{
+	[Fact]
+	public void GeneratesHtml() =>
+		// language=html
+		Html.Should().Contain(
+			"""<p><a href="kibana://index.html">test</a></p>"""
+		);
+
+	[Fact]
+	public void HasNoErrors() => Collector.Diagnostics.Should().HaveCount(0);
+
+	[Fact]
+	public void EmitsExternalLink()
+	{
+		Collector.ExternalLinks.Should().HaveCount(1);
+		Collector.ExternalLinks.Should().ContainKey("kibana://index.md");
+	}
+}
+
+

--- a/tests/Elastic.Markdown.Tests/Inline/InlineLinkTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/InlineLinkTests.cs
@@ -175,15 +175,15 @@ public class DuplicateExternalLinkTest(ITestOutputHelper output) : LinkTestBase(
 			"""
 		);
 
-    [Fact]
-    public void HasNoErrors() => Collector.Diagnostics.Should().HaveCount(0);
+	[Fact]
+	public void HasNoErrors() => Collector.Diagnostics.Should().HaveCount(0);
 
-    [Fact]
-    public void EmitsExternalLink()
-    {
-        Collector.ExternalLinks.Should().HaveCount(2);
-        Collector.ExternalLinks.Should().ContainKey("kibana://index.md");
-        Collector.ExternalLinks.Should().ContainKey("elasticsearch://index.md");
-    }
+	[Fact]
+	public void EmitsExternalLink()
+	{
+		Collector.ExternalLinks.Should().HaveCount(2);
+		Collector.ExternalLinks.Should().ContainKey("kibana://index.md");
+		Collector.ExternalLinks.Should().ContainKey("elasticsearch://index.md");
+	}
 }
 

--- a/tests/Elastic.Markdown.Tests/Inline/InlineLinkTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/InlineLinkTests.cs
@@ -65,6 +65,12 @@ public class LinkToPageTests(ITestOutputHelper output) : LinkTestBase(output,
 
 	[Fact]
 	public void HasNoErrors() => Collector.Diagnostics.Should().HaveCount(0);
+
+	[Fact]
+	public void EmitsCrossLink()
+	{
+		Collector.CrossLinks.Should().HaveCount(0);
+	}
 }
 
 public class InsertPageTitleTests(ITestOutputHelper output) : LinkTestBase(output,
@@ -82,6 +88,12 @@ public class InsertPageTitleTests(ITestOutputHelper output) : LinkTestBase(outpu
 
 	[Fact]
 	public void HasNoErrors() => Collector.Diagnostics.Should().HaveCount(0);
+
+	[Fact]
+	public void EmitsCrossLink()
+	{
+		Collector.CrossLinks.Should().HaveCount(0);
+	}
 }
 
 public class LinkReferenceTest(ITestOutputHelper output) : LinkTestBase(output,
@@ -101,6 +113,12 @@ public class LinkReferenceTest(ITestOutputHelper output) : LinkTestBase(output,
 
 	[Fact]
 	public void HasNoErrors() => Collector.Diagnostics.Should().HaveCount(0);
+
+	[Fact]
+	public void EmitsCrossLink()
+	{
+		Collector.CrossLinks.Should().HaveCount(0);
+	}
 }
 
 public class CrossLinkReferenceTest(ITestOutputHelper output) : LinkTestBase(output,
@@ -126,13 +144,14 @@ public class CrossLinkReferenceTest(ITestOutputHelper output) : LinkTestBase(out
 	public void EmitsCrossLink()
 	{
 		Collector.CrossLinks.Should().HaveCount(1);
-		Collector.CrossLinks.Should().ContainKey("kibana://index.md");
+		Collector.CrossLinks.Should().Contain("kibana://index.md");
 	}
 }
 
 public class CrossLinkTest(ITestOutputHelper output) : LinkTestBase(output,
 	"""
-	[test](kibana://index.md)
+
+	Go to [test](kibana://index.md)
 	"""
 )
 {
@@ -141,7 +160,7 @@ public class CrossLinkTest(ITestOutputHelper output) : LinkTestBase(output,
 		// language=html
 		Html.Should().Contain(
 			// TODO: The link is not rendered correctly yet, will be fixed in a follow-up
-			"""<p><a href="kibana://index.html">test</a></p>"""
+			"""<p>Go to <a href="kibana://index.html">test</a></p>"""
 		);
 
 	[Fact]
@@ -151,39 +170,6 @@ public class CrossLinkTest(ITestOutputHelper output) : LinkTestBase(output,
 	public void EmitsCrossLink()
 	{
 		Collector.CrossLinks.Should().HaveCount(1);
-		Collector.CrossLinks.Should().ContainKey("kibana://index.md");
+		Collector.CrossLinks.Should().Contain("kibana://index.md");
 	}
 }
-
-public class DuplicateCrossLinkTest(ITestOutputHelper output) : LinkTestBase(output,
-	"""
-	[a](kibana://index.md)
-	[b](kibana://index.md)
-	[c](elasticsearch://index.md)
-	"""
-)
-{
-	[Fact]
-	public void GeneratesHtml() =>
-		// language=html
-		Html.Should().Contain(
-			// TODO: The link is not rendered correctly yet, will be fixed in a follow-up
-			"""
-			<p><a href="kibana://index.html">a</a><br />
-			<a href="kibana://index.html">b</a><br />
-			<a href="elasticsearch://index.html">c</a></p>
-			"""
-		);
-
-	[Fact]
-	public void HasNoErrors() => Collector.Diagnostics.Should().HaveCount(0);
-
-	[Fact]
-	public void EmitsCrossLink()
-	{
-		Collector.CrossLinks.Should().HaveCount(2);
-		Collector.CrossLinks.Should().ContainKey("kibana://index.md");
-		Collector.CrossLinks.Should().ContainKey("elasticsearch://index.md");
-	}
-}
-


### PR DESCRIPTION
Closes https://github.com/elastic/docs-builder/issues/162

## Context

For our Links Validation Service, we need to generate a list of cross-links (links pointing to external documentation in our system) that will be uploaded to the Link Index.

## Changes

Add external links  to the links.json

Resulting JSON file:

```json
{
  "origin": {
    "branch": "feature/add-external-links",
    "remote": "elastic/docs-builder-unknown",
    "ref": "03c22a29e6585b72f64a0aa64f087dd5664c939f"
  },
  "url_path_prefix": "",
  "internal_links": [
    "index.md",
    "configure/index.md",
    "configure/page.md",
    "testing/external-links.md",
    "...",
  ],
  "cross_links": [
    "kibana://index.md",
    "elasticsearch://index.md"
  ]
}
```

## Notes

Changed the naming to Cross-Links, so it won't get confused with external hosts.