### PR TITLE
Upload links.json to s3

### DIFF
--- a/src/docs-builder/Cli/Commands.cs
+++ b/src/docs-builder/Cli/Commands.cs
@@ -6,10 +6,10 @@ using Actions.Core.Services;
 using ConsoleAppFramework;
 using Documentation.Builder.Diagnostics.Console;
 using Documentation.Builder.Http;
+using Documentation.Builder.LinkIndex;
 using Elastic.Markdown;
 using Elastic.Markdown.IO;
 using Microsoft.Extensions.Logging;
-using Documentation.Builder.LinkIndex;
 
 namespace Documentation.Builder.Cli;
 

--- a/src/docs-builder/LinkIndex/ILinkIndex.cs
+++ b/src/docs-builder/LinkIndex/ILinkIndex.cs
@@ -1,3 +1,6 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
 namespace Documentation.Builder.LinkIndex;
 
 public interface ILinkIndex

--- a/src/docs-builder/LinkIndex/ILinkIndex.cs
+++ b/src/docs-builder/LinkIndex/ILinkIndex.cs
@@ -5,5 +5,5 @@ namespace Documentation.Builder.LinkIndex;
 
 public interface ILinkIndex
 {
-    Task UploadFileAsync(string filePath, bool shouldUpload);
-} 
+	Task UploadFileAsync(string filePath, bool shouldUpload);
+}

--- a/src/docs-builder/LinkIndex/ILinkIndex.cs
+++ b/src/docs-builder/LinkIndex/ILinkIndex.cs
@@ -1,0 +1,6 @@
+namespace Documentation.Builder.LinkIndex;
+
+public interface ILinkIndex
+{
+    Task UploadFileAsync(string filePath, bool shouldUpload);
+} 

--- a/src/docs-builder/LinkIndex/S3LinkIndex.cs
+++ b/src/docs-builder/LinkIndex/S3LinkIndex.cs
@@ -9,58 +9,58 @@ namespace Documentation.Builder.LinkIndex;
 
 public class S3LinkIndex : ILinkIndex
 {
-    private readonly string _bucketName;
-    private readonly ILogger<S3LinkIndex> _logger;
+	private readonly string _bucketName;
+	private readonly ILogger<S3LinkIndex> _logger;
 
-    public S3LinkIndex(string bucketName, ILoggerFactory loggerFactory)
-    {
-        _bucketName = bucketName;
-        _logger = loggerFactory.CreateLogger<S3LinkIndex>();
-    }
+	public S3LinkIndex(string bucketName, ILoggerFactory loggerFactory)
+	{
+		_bucketName = bucketName;
+		_logger = loggerFactory.CreateLogger<S3LinkIndex>();
+	}
 
-    public async Task UploadFileAsync(string filePath, bool shouldUpload)
-    {
-        if (!shouldUpload)
-        {
-            _logger.LogInformation("Not uploading link index: skip flag is set");
-            return;
-        }
+	public async Task UploadFileAsync(string filePath, bool shouldUpload)
+	{
+		if (!shouldUpload)
+		{
+			_logger.LogInformation("Not uploading link index: skip flag is set");
+			return;
+		}
 
-        var githubRef = Environment.GetEnvironmentVariable("GITHUB_REF");
-        if (string.IsNullOrEmpty(githubRef) || githubRef != "refs/heads/main")
-        {
-            _logger.LogWarning("Not uploading link index: GITHUB_REF '{GitHubRef}' is not main branch", githubRef);
-            return;
-        }
-    
-        var s3DestinationPath = DeriveDestinationPath();
-        if (string.IsNullOrEmpty(s3DestinationPath))
-        {
-            _logger.LogWarning("Failed to derive destination path - cannot upload to link index");
-            return;
-        }
-        _logger.LogInformation("Uploading link index {FilePath} to S3://{Bucket}/{DestinationPath}", filePath, _bucketName, s3DestinationPath);
-        using var client = new AmazonS3Client();
-        var fileTransferUtility = new TransferUtility(client);
-        try
-        {
-            await fileTransferUtility.UploadAsync(filePath, _bucketName, s3DestinationPath);
-            _logger.LogInformation("Successfully uploaded link reference {FilePath} to S3://{Bucket}/{DestinationPath}", 
-                filePath, _bucketName, s3DestinationPath);
-        }
-        catch (Exception e)
-        {
-            _logger.LogError(e, "Failed to upload link index {FilePath} to S3://{Bucket}/{DestinationPath}", 
-                filePath, _bucketName, s3DestinationPath);
-            throw;
-        }
-    }
+		var githubRef = Environment.GetEnvironmentVariable("GITHUB_REF");
+		if (string.IsNullOrEmpty(githubRef) || githubRef != "refs/heads/main")
+		{
+			_logger.LogWarning("Not uploading link index: GITHUB_REF '{GitHubRef}' is not main branch", githubRef);
+			return;
+		}
 
-    private static string DeriveDestinationPath()
-    {
-        var repositoryName = Environment.GetEnvironmentVariable("GITHUB_REPOSITORY")?.Split('/').Last();
-        return string.IsNullOrEmpty(repositoryName) 
-            ? string.Empty 
-            : $"{repositoryName}.json";
-    }
+		var s3DestinationPath = DeriveDestinationPath();
+		if (string.IsNullOrEmpty(s3DestinationPath))
+		{
+			_logger.LogWarning("Failed to derive destination path - cannot upload to link index");
+			return;
+		}
+		_logger.LogInformation("Uploading link index {FilePath} to S3://{Bucket}/{DestinationPath}", filePath, _bucketName, s3DestinationPath);
+		using var client = new AmazonS3Client();
+		var fileTransferUtility = new TransferUtility(client);
+		try
+		{
+			await fileTransferUtility.UploadAsync(filePath, _bucketName, s3DestinationPath);
+			_logger.LogInformation("Successfully uploaded link reference {FilePath} to S3://{Bucket}/{DestinationPath}",
+				filePath, _bucketName, s3DestinationPath);
+		}
+		catch (Exception e)
+		{
+			_logger.LogError(e, "Failed to upload link index {FilePath} to S3://{Bucket}/{DestinationPath}",
+				filePath, _bucketName, s3DestinationPath);
+			throw;
+		}
+	}
+
+	private static string DeriveDestinationPath()
+	{
+		var repositoryName = Environment.GetEnvironmentVariable("GITHUB_REPOSITORY")?.Split('/').Last();
+		return string.IsNullOrEmpty(repositoryName)
+			? string.Empty
+			: $"{repositoryName}.json";
+	}
 }

--- a/src/docs-builder/LinkIndex/S3LinkIndex.cs
+++ b/src/docs-builder/LinkIndex/S3LinkIndex.cs
@@ -1,0 +1,64 @@
+using Amazon.S3;
+using Amazon.S3.Transfer;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Configuration;
+
+namespace Documentation.Builder.LinkIndex;
+
+public class S3LinkIndex : ILinkIndex
+{
+    private readonly string _bucketName;
+    private readonly ILogger<S3LinkIndex> _logger;
+
+    public S3LinkIndex(string bucketName, ILoggerFactory loggerFactory)
+    {
+        _bucketName = bucketName;
+        _logger = loggerFactory.CreateLogger<S3LinkIndex>();
+    }
+
+    public async Task UploadFileAsync(string filePath, bool shouldUpload)
+    {
+        if (!shouldUpload)
+        {
+            _logger.LogInformation("Not uploading link index: skip flag is set");
+            return;
+        }
+
+        var githubRef = Environment.GetEnvironmentVariable("GITHUB_REF");
+        if (string.IsNullOrEmpty(githubRef) || githubRef != "refs/heads/main")
+        {
+            _logger.LogWarning("Not uploading link index: GITHUB_REF '{GitHubRef}' is not main branch", githubRef);
+            return;
+        }
+    
+        var s3DestinationPath = DeriveDestinationPath();
+        if (string.IsNullOrEmpty(s3DestinationPath))
+        {
+            _logger.LogWarning("Failed to derive destination path - cannot upload to link index");
+            return;
+        }
+        _logger.LogInformation("Uploading link index {FilePath} to S3://{Bucket}/{DestinationPath}", filePath, _bucketName, s3DestinationPath);
+        using var client = new AmazonS3Client();
+        var fileTransferUtility = new TransferUtility(client);
+        try
+        {
+            await fileTransferUtility.UploadAsync(filePath, _bucketName, s3DestinationPath);
+            _logger.LogInformation("Successfully uploaded link reference {FilePath} to S3://{Bucket}/{DestinationPath}", 
+                filePath, _bucketName, s3DestinationPath);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Failed to upload link index {FilePath} to S3://{Bucket}/{DestinationPath}", 
+                filePath, _bucketName, s3DestinationPath);
+            throw;
+        }
+    }
+
+    private static string DeriveDestinationPath()
+    {
+        var repositoryName = Environment.GetEnvironmentVariable("GITHUB_REPOSITORY")?.Split('/').Last();
+        return string.IsNullOrEmpty(repositoryName) 
+            ? string.Empty 
+            : $"{repositoryName}.json";
+    }
+}

--- a/src/docs-builder/LinkIndex/S3LinkIndex.cs
+++ b/src/docs-builder/LinkIndex/S3LinkIndex.cs
@@ -1,7 +1,9 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
 using Amazon.S3;
 using Amazon.S3.Transfer;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Configuration;
 
 namespace Documentation.Builder.LinkIndex;
 

--- a/src/docs-builder/Program.cs
+++ b/src/docs-builder/Program.cs
@@ -6,10 +6,10 @@ using Actions.Core.Extensions;
 using ConsoleAppFramework;
 using Documentation.Builder;
 using Documentation.Builder.Cli;
+using Documentation.Builder.LinkIndex;
 using Elastic.Markdown.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Documentation.Builder.LinkIndex;
 
 var services = new ServiceCollection();
 services.AddGitHubActionsCore();

--- a/src/docs-builder/Program.cs
+++ b/src/docs-builder/Program.cs
@@ -9,6 +9,7 @@ using Documentation.Builder.Cli;
 using Elastic.Markdown.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Documentation.Builder.LinkIndex;
 
 var services = new ServiceCollection();
 services.AddGitHubActionsCore();
@@ -26,7 +27,8 @@ services.AddLogging(x =>
 });
 services.AddSingleton<DiagnosticsChannel>();
 services.AddSingleton<DiagnosticsCollector>();
-
+services.AddSingleton<S3LinkIndex>(sp => new S3LinkIndex("elastic-docs-link-index", sp.GetRequiredService<ILoggerFactory>()));
+services.AddSingleton<ILinkIndex>(sp => sp.GetRequiredService<S3LinkIndex>());
 
 await using var serviceProvider = services.BuildServiceProvider();
 var logger = serviceProvider.GetRequiredService<ILogger<Program>>();

--- a/src/docs-builder/docs-builder.csproj
+++ b/src/docs-builder/docs-builder.csproj
@@ -19,6 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AWSSDK.S3" Version="3.7.411.5" />
     <PackageReference Include="ConsoleAppFramework" Version="5.3.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Context

We want to upload the links.json file to the Link Index (s3 bucket) for later validation.

## Changes

This adds the `--upload-to-link-index` option, which uploads the links.json file to the s3 bucket.

It only happens under certain conditions, e.g.:

- when it's running on main
- if it's can derive the repository name from the `GITHUB_REPOSITORY` environment variable