### PR TITLE
Add auto text link generation for markdown files

### DIFF
--- a/docs/source/syntax/applies.md
+++ b/docs/source/syntax/applies.md
@@ -48,7 +48,7 @@ applies:
 Are equivalent, note `all` just means we won't be rendering the version portion in the html.
 
 
-## This section has its own applies annotations
+## This section has its own applies annotations [#sections]
 
 :::{applies}
 :stack: unavailable

--- a/docs/source/syntax/links.md
+++ b/docs/source/syntax/links.md
@@ -42,6 +42,32 @@ Cross links are links that point to a different docset.
 
 The syntax is `<scheme>://<path>`, where <scheme> is the repository name and <path> is the path to the file.
 
+## Auto Text Links
+
+If you link to a local markdown file but omit any link text `docs-builder` will use the target's [title](titles.md).
+
+```markdown
+[](applies.md)
+```
+will output: [](applies.md)
+
+You can go one step further to auto generate link text for headings within files:
+
+```markdown
+[](applies.md#sections)
+```
+
+will output: [](applies.md#sections)
+
+This also applies to local anchors
+
+
+```markdown
+[](#anchor-link)
+```
+
+will output: [](#anchor-link)
+
 ## Heading anchors
 
 Headings will automatically create anchor links in the resulting html. 

--- a/docs/source/testing/index.md
+++ b/docs/source/testing/index.md
@@ -3,3 +3,6 @@ title: Testing
 ---
 
 The files in this directory are used for testing purposes. Do not edit these files unless you are working on tests.
+
+
+###### [#synthetics-config-file]

--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -119,7 +119,7 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 				processor.EmitWarning(line,
 					column,
 					length,
-					$"Can not create an auto title link to '{file.FullName}' however this file can not be resolved.");
+					$"'{url}' could not be resolved to a markdown file while creating an auto text link, '{file.FullName}' does not exist.");
 			}
 
 			var title = markdown?.Title;

--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -108,9 +108,20 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 
 		if (link.FirstChild == null || !string.IsNullOrEmpty(anchor))
 		{
-			var file = string.IsNullOrWhiteSpace(url) ? context.Path
-				: context.Build.ReadFileSystem.FileInfo.New(Path.Combine(context.Build.SourcePath.FullName, url.TrimStart('/')));
+			var file = string.IsNullOrWhiteSpace(url)
+				? context.Path
+				: url.StartsWith('/')
+					? context.Build.ReadFileSystem.FileInfo.New(Path.Combine(context.Build.SourcePath.FullName, url.TrimStart('/')))
+					: context.Build.ReadFileSystem.FileInfo.New(Path.Combine(context.Path.Directory!.FullName, url));
 			var markdown = context.GetDocumentationFile?.Invoke(file) as MarkdownFile;
+			if (markdown == null)
+			{
+				processor.EmitWarning(line,
+					column,
+					length,
+					$"Can not create an auto title link to '{file.FullName}' however this file can not be resolved.");
+			}
+
 			var title = markdown?.Title;
 
 			if (!string.IsNullOrEmpty(anchor))


### PR DESCRIPTION
Enhanced link handling to auto-generate text for markdown file links and headings when no link text is provided. Updated documentation with examples and fixed heading anchors to support new functionality.

This feature existed already but was missing documentation.
