### PR TITLE
Add GitHub edit link generation for documentation pages

### DIFF
--- a/docs/source/contribute/on-the-web.md
+++ b/docs/source/contribute/on-the-web.md
@@ -2,10 +2,6 @@
 title: Contribute on the web
 ---
 
-:::{warning}
-This feature is not supported yet. See [#171](https://github.com/elastic/docs-builder/issues/171) for more information.
-:::
-
 1. On the right side of the page you want to edit, select **Edit this page**.
 1. Do something on GitHub.
 1. Take the dog for a walk.

--- a/src/Elastic.Markdown/IO/Discovery/GitCheckoutInformation.cs
+++ b/src/Elastic.Markdown/IO/Discovery/GitCheckoutInformation.cs
@@ -86,7 +86,10 @@ public record GitCheckoutInformation
 
 		return new GitCheckoutInformation
 		{
-			Ref = gitRef, Branch = branch, Remote = remote, RepositoryName = remote.Split('/').Last()
+			Ref = gitRef,
+			Branch = branch,
+			Remote = remote,
+			RepositoryName = remote.Split('/').Last()
 		};
 
 		IFileInfo Git(string path) => fileSystem.FileInfo.New(Path.Combine(Paths.Root.FullName, path));

--- a/src/Elastic.Markdown/IO/Discovery/GitCheckoutInformation.cs
+++ b/src/Elastic.Markdown/IO/Discovery/GitCheckoutInformation.cs
@@ -10,11 +10,14 @@ namespace Elastic.Markdown.IO.Discovery;
 
 public record GitCheckoutInformation
 {
+	private string? _repositoryName;
+
 	private static GitCheckoutInformation Unavailable { get; } = new()
 	{
 		Branch = "unavailable",
 		Remote = "unavailable",
-		Ref = "unavailable"
+		Ref = "unavailable",
+		RepositoryName = "unavailable"
 	};
 
 	[JsonPropertyName("branch")]
@@ -26,6 +29,13 @@ public record GitCheckoutInformation
 	[JsonPropertyName("ref")]
 	public required string Ref { get; init; }
 
+	[JsonIgnore]
+	public string? RepositoryName
+	{
+		get => _repositoryName ??= Remote.Split('/').Last();
+		set => _repositoryName = value;
+	}
+
 	// manual read because libgit2sharp is not yet AOT ready
 	public static GitCheckoutInformation Create(IFileSystem fileSystem)
 	{
@@ -33,7 +43,13 @@ public record GitCheckoutInformation
 		if (fileSystem is not FileSystem)
 		{
 			var fakeRef = Guid.NewGuid().ToString().Substring(0, 16);
-			return new GitCheckoutInformation { Branch = $"test-{fakeRef}", Remote = "elastic/docs-builder", Ref = fakeRef, };
+			return new GitCheckoutInformation
+			{
+				Branch = $"test-{fakeRef}",
+				Remote = "elastic/docs-builder",
+				Ref = fakeRef,
+				RepositoryName = "docs-builder"
+			};
 		}
 
 		var gitConfig = Git(".git/config");
@@ -66,7 +82,12 @@ public record GitCheckoutInformation
 		if (string.IsNullOrEmpty(remote))
 			remote = Environment.GetEnvironmentVariable("GITHUB_REPOSITORY") ?? "elastic/docs-builder-unknown";
 
-		return new GitCheckoutInformation { Ref = gitRef, Branch = branch, Remote = remote };
+		remote = remote.AsSpan().TrimEnd(".git").ToString();
+
+		return new GitCheckoutInformation
+		{
+			Ref = gitRef, Branch = branch, Remote = remote, RepositoryName = remote.Split('/').Last()
+		};
 
 		IFileInfo Git(string path) => fileSystem.FileInfo.New(Path.Combine(Paths.Root.FullName, path));
 
@@ -80,7 +101,7 @@ public record GitCheckoutInformation
 			if (!sections.Contains(branchSection))
 				return string.Empty;
 
-			var remoteName = ini.GetSetting(branchSection, "remote");
+			var remoteName = ini.GetSetting(branchSection, "remote")?.Trim();
 
 			var remoteSection = $"remote \"{remoteName}\"";
 

--- a/src/Elastic.Markdown/IO/DocumentationSet.cs
+++ b/src/Elastic.Markdown/IO/DocumentationSet.cs
@@ -20,6 +20,8 @@ public class DocumentationSet
 	public IDirectoryInfo SourcePath { get; }
 	public IDirectoryInfo OutputPath { get; }
 
+	public string RelativeSourcePath { get; }
+
 	public DateTimeOffset LastWrite { get; }
 
 	public ConfigurationFile Configuration { get; }
@@ -31,6 +33,7 @@ public class DocumentationSet
 		Context = context;
 		SourcePath = context.SourcePath;
 		OutputPath = context.OutputPath;
+		RelativeSourcePath = Path.GetRelativePath(Paths.Root.FullName, SourcePath.FullName);
 		Configuration = new ConfigurationFile(context.ConfigurationPath, SourcePath, context);
 
 		MarkdownParser = new MarkdownParser(SourcePath, context, GetMarkdownFile, Configuration);

--- a/src/Elastic.Markdown/Slices/HtmlWriter.cs
+++ b/src/Elastic.Markdown/Slices/HtmlWriter.cs
@@ -47,6 +47,11 @@ public class HtmlWriter
 
 		var previous = DocumentationSet;
 
+		var remote = DocumentationSet.Context.Git.RepositoryName;
+		var branch = DocumentationSet.Context.Git.Branch;
+		var path = Path.Combine(DocumentationSet.RelativeSourcePath, markdown.RelativePath);
+		var editUrl = $"https://github.com/elastic/{remote}/edit/{branch}/{path}";
+
 		var slice = Index.Create(new IndexViewModel
 		{
 			Title = markdown.Title ?? "[TITLE NOT SET]",
@@ -56,7 +61,8 @@ public class HtmlWriter
 			CurrentDocument = markdown,
 			NavigationHtml = navigationHtml,
 			UrlPathPrefix = markdown.UrlPathPrefix,
-			Applies = markdown.YamlFrontMatter?.AppliesTo
+			Applies = markdown.YamlFrontMatter?.AppliesTo,
+			GithubEditUrl = editUrl
 		});
 		return await slice.RenderAsync(cancellationToken: ctx);
 	}

--- a/src/Elastic.Markdown/Slices/Index.cshtml
+++ b/src/Elastic.Markdown/Slices/Index.cshtml
@@ -9,6 +9,7 @@
 		CurrentDocument = Model.CurrentDocument,
 		NavigationHtml = Model.NavigationHtml,
 		UrlPathPrefix = Model.UrlPathPrefix,
+		GithubEditUrl = Model.GithubEditUrl
 	};
 }
 <section id="elastic-docs-v3">

--- a/src/Elastic.Markdown/Slices/Layout/_TableOfContents.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_TableOfContents.cshtml
@@ -14,7 +14,7 @@
 			</ul>
 		</div>
 		<div class="edit-this-page">
-			<a href="https://github.com/elastic/markitpy-samples/blob/master/docs/source/index.md">Edit this page</a>
+			<a href="@Model.GithubEditUrl">Edit this page</a>
 		</div>
 	</div>
 </aside>

--- a/src/Elastic.Markdown/Slices/_ViewModels.cs
+++ b/src/Elastic.Markdown/Slices/_ViewModels.cs
@@ -16,6 +16,7 @@ public class IndexViewModel
 	public required MarkdownFile CurrentDocument { get; init; }
 	public required string NavigationHtml { get; init; }
 	public required string? UrlPathPrefix { get; init; }
+	public required string? GithubEditUrl { get; init; }
 	public required Deployment? Applies { get; init; }
 }
 
@@ -27,6 +28,7 @@ public class LayoutViewModel
 	public required MarkdownFile CurrentDocument { get; init; }
 	public required string NavigationHtml { get; set; }
 	public required string? UrlPathPrefix { get; set; }
+	public required string? GithubEditUrl { get; set; }
 
 	private MarkdownFile[]? _parents;
 	public MarkdownFile[] Parents

--- a/tests/Elastic.Markdown.Tests/DocSet/LinkReferenceTests.cs
+++ b/tests/Elastic.Markdown.Tests/DocSet/LinkReferenceTests.cs
@@ -34,5 +34,8 @@ public class GitCheckoutInformationTests(ITestOutputHelper output) : NavigationT
 		git.Branch.Should().NotContain(git.Ref);
 		git.Ref.Should().NotBeNullOrWhiteSpace();
 		git.Remote.Should().NotBeNullOrWhiteSpace();
+		git.Remote.Should().NotContain("unknown");
+		git.RepositoryName.Should().NotContain(".git");
+		git.Remote.Should().NotContain(".git");
 	}
 }


### PR DESCRIPTION
Generate and include GitHub edit URLs for documentation pages based on the repository, branch, and source path. Update the relevant models, views, and tests to support and display this functionality. This enhances the ability for users to easily contribute edits directly from the rendered documentation pages.
