### PR TITLE
Set up release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -3,8 +3,8 @@ template: |
   $CHANGES
 
   **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
-name-template: 'docs-builder v$RESOLVED_VERSION'
-tag-template: 'v$RESOLVED_VERSION'
+name-template: 'docs-builder $RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
 change-template: '- $TITLE by @$AUTHOR in #$NUMBER'
 categories:
   - title: '💥 Breaking Changes'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -9,29 +9,31 @@ change-template: '- $TITLE by @$AUTHOR in #$NUMBER'
 categories:
   - title: '💥 Breaking Changes'
     labels:
-      - 'changelog:breaking' # When a breaking change is introduced
+      - 'breaking' # When a breaking change is introduced
   - title: '✨ Features'
     labels:
-      - 'changelog:feature' # When a new feature is introduced
-      - 'changelog:enhancement' # When an existing feature is improved
+      - 'feature' # When a new feature is introduced
+      - 'enhancement' # When an existing feature is improved
   - title: '🐛 Bug Fixes'
     labels:
-      - 'changelog:fix' # When a bug is fixed
+      - 'bug' # When a bug is fixed
+      - 'fix' # When a bug is fixed
   - title: '📝 Documentation'
     labels:
-      - 'changelog:docs' # When documentation is updated
+      - 'documentation' # When documentation is updated
   - title: '🧰 Maintenance'
     labels:
-      - 'changelog:chore' # When a chore is done
-      - 'changelog:ci' # When CI is updated
-      - 'changelog:dependencies' # When dependencies are updated
+      - 'chore' # When a chore is done
+      - 'ci' # When CI is updated
+      - 'dependencies' # When dependencies are updated
 exclude-labels:
   - 'changelog:skip' # When a PR should be excluded from the changelog
 version-resolver:
   major:
     labels:
-      - 'changelog:breaking'
+      - 'breaking'
   minor:
     labels:
-      - 'changelog:feature'
+      - 'feature'
+      - 'enhancement'
   default: patch

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,37 @@
+# https://github.com/release-drafter/release-drafter?tab=readme-ov-file#configuration-options
+template: |
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+name-template: 'docs-builder v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+change-template: '- $TITLE by @$AUTHOR in #$NUMBER'
+categories:
+  - title: '💥 Breaking Changes'
+    labels:
+      - 'changelog:breaking' # When a breaking change is introduced
+  - title: '✨ Features'
+    labels:
+      - 'changelog:feature' # When a new feature is introduced
+      - 'changelog:enhancement' # When an existing feature is improved
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'changelog:fix' # When a bug is fixed
+  - title: '📝 Documentation'
+    labels:
+      - 'changelog:docs' # When documentation is updated
+  - title: '🧰 Maintenance'
+    labels:
+      - 'changelog:chore' # When a chore is done
+      - 'changelog:ci' # When CI is updated
+      - 'changelog:dependencies' # When dependencies are updated
+exclude-labels:
+  - 'changelog:skip' # When a PR should be excluded from the changelog
+version-resolver:
+  major:
+    labels:
+      - 'changelog:breaking'
+  minor:
+    labels:
+      - 'changelog:feature'
+  default: patch

--- a/.github/workflows/create-major-tag.yml
+++ b/.github/workflows/create-major-tag.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Get major version
         run: |
-          MAJOR_VERSION=$(echo "${GITHUB_REF#refs/tags/v}" | awk -F. '{print $1}')
+          MAJOR_VERSION=$(echo "${GITHUB_REF#refs/tags/}" | awk -F. '{print $1}')
           echo "MAJOR_VERSION=${MAJOR_VERSION}" >> "${GITHUB_ENV}"
       - name: Create major tag
         run: |

--- a/.github/workflows/create-major-tag.yml
+++ b/.github/workflows/create-major-tag.yml
@@ -1,0 +1,26 @@
+---
+# This workflow creates a major tag in the format of vX when a release is published.
+# E.g. if a release is published with the tag v1.1.0, this workflow will create a tag v1.
+name: create-major-tag
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: write
+
+jobs:
+  create-major-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get major version
+        run: |
+          MAJOR_VERSION=$(echo "${GITHUB_REF#refs/tags/v}" | awk -F. '{print $1}')
+          echo "MAJOR_VERSION=${MAJOR_VERSION}" >> "${GITHUB_ENV}"
+      - name: Create major tag
+        run: |
+          git tag "v${MAJOR_VERSION}"
+          git push -f origin "refs/tags/v${MAJOR_VERSION}"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,20 @@
+name: release-drafter
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  update-release-draft:
+    permissions:
+      contents: write
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@3f0f87098bd6b5c5b9a36d49c41d998ea58f9348 # v6.0.0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/required-labels.yml
+++ b/.github/workflows/required-labels.yml
@@ -1,0 +1,33 @@
+name: required-labels
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - labeled
+      - unlabeled
+      - synchronize
+
+permissions:
+  contents: read
+
+jobs:
+  check-labels:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - id: get-labels
+        run: |
+          labels=$(yq '[.categories[].labels] + .exclude-labels | flatten | unique | sort | @tsv' .github/release-drafter.yml | tr '\t' ',')
+          echo "labels=$labels" >> "${GITHUB_OUTPUT}"
+      - id: check-labels
+        uses: mheap/github-action-required-labels@5847eef68201219cf0a4643ea7be61e77837bbce # v5.4.1
+        with:
+          mode: exactly
+          count: 1
+          use_regex: false
+          add_comment: true
+          labels: ${{ steps.get-labels.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -162,4 +162,4 @@ To create a new release you need to publish the existing draft release created b
 > [!NOTE]
 > When a release is published, the [create-major-tag workflow](../.github/workflows/create-major-tag.yml)
 > will force push a new major tag in the format `vX` where `X` is the major version of the release.
-> For example, if the release is `v1.2.3` was published, the workflow will force push a new tag `v1` on the same commit.
+> For example, if the release is `1.2.3` was published, the workflow will force push a new tag `v1` on the same commit.

--- a/README.md
+++ b/README.md
@@ -136,3 +136,30 @@ To test performance it's best to build the binary and run outside of docker:
 
 For reference here's the `markitpy-doc` docset (50k markdown files) currently takes `14s` vs `several minutes` compared to
 existing surveyed tools
+
+# Release Process
+
+This section outlines the process for releasing a new version of this project.
+
+## Versioning
+
+This project uses [Semantic Versioning](https://semver.org/) and its version is
+automatically determined by [release-drafter](https://github.com/release-drafter/release-drafter)
+based on the labels of the pull requests merged into the `main` branch.
+
+See the [release-drafter configuration](../.github/release-drafter.yml) for more details.
+
+## Creating a New Release
+
+Every time a pull request is merged into the `main` branch, release-drafter will
+create a draft release or update the existing draft release in the [Releases](https://github.com/elastic/docs-builder/releases) page.
+
+To create a new release you need to publish the existing draft release created by release-drafter.
+
+> [!IMPORTANT]
+> Make sure the [release-drafter workflow](../.github/workflows/release-drafter.yml) is finished before publishing the release.
+
+> [!NOTE]
+> When a release is published, the [create-major-tag workflow](../.github/workflows/create-major-tag.yml)
+> will force push a new major tag in the format `vX` where `X` is the major version of the release.
+> For example, if the release is `v1.2.3` was published, the workflow will force push a new tag `v1` on the same commit.


### PR DESCRIPTION
The following information was also added to the README.md

# Release Process

This section outlines the process for releasing a new version of this project.

## Versioning

This project uses [Semantic Versioning](https://semver.org/) and its version is automatically determined by [release-drafter](https://github.com/release-drafter/release-drafter) based on the labels of the pull requests merged into the `main` branch.

See the [release-drafter configuration](../.github/release-drafter.yml) for more details.

## Creating a New Release

Every time a pull request is merged into the `main` branch, release-drafter will
create a draft release or update the existing draft release in the [Releases](https://github.com/elastic/docs-builder/releases) page.

To create a new release you need to publish the existing draft release created by release-drafter.

> [!IMPORTANT]
> Make sure the [release-drafter workflow](../.github/workflows/release-drafter.yml) is finished before publishing the release.

> [!NOTE]
> When a release is published, the [create-major-tag workflow](../.github/workflows/create-major-tag.yml)
> will force push a new major tag in the format `vX` where `X` is the major version of the release.
> For example, if the release is `v1.2.3` was published, the workflow will force push a new tag `v1` on the same commit.