### PR TITLE
Allow to manually trigger release-drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,6 +1,7 @@
 name: release-drafter
 
 on:
+  workflow_dispatch: ~
   push:
     branches:
       - main


### PR DESCRIPTION
This gives us the ability to update the draft release, in case we add or change a label to a PR post-merge.