### PR TITLE
Add "strict" mode to treat warnings as errors

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,9 @@ inputs:
   prefix:
     description: 'Path prefix for all urls'
     required: false
+  strict:
+    description: 'Treat warnings as errors'
+    required: false
 
 runs:
   using: 'docker'

--- a/actions/publish/action.yml
+++ b/actions/publish/action.yml
@@ -10,6 +10,11 @@ outputs:
     description: "The github actions url"
     value: ${{steps.deployment.outputs.page_url}}
 
+inputs:
+  strict:
+    description: 'Treat warnings as errors'
+    required: false
+
 runs:
   using: "composite"
   steps:
@@ -20,6 +25,7 @@ runs:
       uses: elastic/docs-builder@main
       with:
         prefix: '${{ steps.repo-basename.outputs.value }}'
+        strict: ${{ inputs.strict }}
     - name: Setup Pages
       id: pages
       uses: actions/configure-pages@v5.0.0

--- a/src/docs-builder/Cli/Commands.cs
+++ b/src/docs-builder/Cli/Commands.cs
@@ -39,6 +39,7 @@ internal class Commands(ILoggerFactory logger, ICoreService githubActionsService
 	/// <param name="output"> -o, Defaults to `.artifacts/html` </param>
 	/// <param name="pathPrefix"> Specifies the path prefix for urls </param>
 	/// <param name="force"> Force a full rebuild of the destination folder</param>
+	/// <param name="strict"> Treat warnings as errors and fail the build on warnings</param>
 	/// <param name="ctx"></param>
 	[Command("generate")]
 	[ConsoleAppFilter<StopwatchFilter>]
@@ -48,6 +49,7 @@ internal class Commands(ILoggerFactory logger, ICoreService githubActionsService
 		string? output = null,
 		string? pathPrefix = null,
 		bool? force = null,
+		bool? strict = null,
 		Cancel ctx = default
 	)
 	{
@@ -62,7 +64,13 @@ internal class Commands(ILoggerFactory logger, ICoreService githubActionsService
 		var set = new DocumentationSet(context);
 		var generator = new DocumentationGenerator(set, logger);
 		await generator.GenerateAll(ctx);
-		return context.Collector.Errors + context.Collector.Warnings;
+
+		if (bool.TryParse(githubActionsService.GetInput("strict"), out var strictValue) && strictValue)
+			strict ??= strictValue;
+
+		if (strict ?? false)
+			return context.Collector.Errors + context.Collector.Warnings;
+		return context.Collector.Errors;
 	}
 
 	/// <summary>
@@ -72,6 +80,7 @@ internal class Commands(ILoggerFactory logger, ICoreService githubActionsService
 	/// <param name="output"> -o, Defaults to `.artifacts/html` </param>
 	/// <param name="pathPrefix"> Specifies the path prefix for urls </param>
 	/// <param name="force"> Force a full rebuild of the destination folder</param>
+	/// <param name="strict"> Treat warnings as errors and fail the build on warnings</param>
 	/// <param name="ctx"></param>
 	[Command("")]
 	[ConsoleAppFilter<StopwatchFilter>]
@@ -81,7 +90,8 @@ internal class Commands(ILoggerFactory logger, ICoreService githubActionsService
 		string? output = null,
 		string? pathPrefix = null,
 		bool? force = null,
+		bool? strict = null,
 		Cancel ctx = default
 	) =>
-		await Generate(path, output, pathPrefix, force, ctx);
+		await Generate(path, output, pathPrefix, force, strict, ctx);
 }


### PR DESCRIPTION
This adds a "strict" input option to the publish action and CLI commands. When enabled, warnings are treated as errors, causing builds to fail on warnings. It's an optional setting for stricter validation during documentation generation.
