### PR TITLE
Limit diagnostics output and enhance logging clarity

### DIFF
--- a/src/Elastic.Markdown/Diagnostics/DiagnosticsChannel.cs
+++ b/src/Elastic.Markdown/Diagnostics/DiagnosticsChannel.cs
@@ -124,6 +124,7 @@ public class DiagnosticsCollector(IReadOnlyCollection<IDiagnosticsOutput> output
 
 	public virtual async Task StopAsync(CancellationToken cancellationToken)
 	{
+		Console.WriteLine("Stopping diagnostics");
 		if (_started is not null)
 			await _started;
 		await Channel.Reader.Completion;

--- a/src/Elastic.Markdown/DocumentationGenerator.cs
+++ b/src/Elastic.Markdown/DocumentationGenerator.cs
@@ -88,10 +88,11 @@ public class DocumentationGenerator
 					throw;
 			}
 
-			if (processedFiles % 1_000 == 0)
-				_logger.LogInformation($"Handled {processedFiles} files");
+			if (processedFiles % 100 == 0)
+				_logger.LogInformation($"-> Handled {processedFiles} files");
 		});
 
+		_logger.LogInformation($"Copying static files to output directory");
 		var embeddedStaticFiles = Assembly.GetExecutingAssembly()
 			.GetManifestResourceNames()
 			.ToList();
@@ -112,12 +113,19 @@ public class DocumentationGenerator
 		}
 
 
+		_logger.LogInformation($"Completing diagnostics channel");
 		Context.Collector.Channel.TryComplete();
 
+		_logger.LogInformation($"Generating documentation compilation state");
 		await GenerateDocumentationState(ctx);
+		_logger.LogInformation($"Generating links.json");
 		await GenerateLinkReference(ctx);
 
+		_logger.LogInformation($"Completing diagnostics channel");
+
 		await Context.Collector.StopAsync(ctx);
+
+		_logger.LogInformation($"Completed diagnostics channel");
 	}
 
 	private async Task ProcessFile(HashSet<string> offendingFiles, DocumentationFile file, DateTimeOffset outputSeenChanges, CancellationToken token)

--- a/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockParser.cs
+++ b/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockParser.cs
@@ -87,6 +87,8 @@ public class EnhancedCodeBlockParser : FencedBlockParserBase<EnhancedCodeBlock>
 			originatingLine++;
 			var line = lines.Lines[index];
 			var span = line.Slice.AsSpan();
+			if (span.IndexOf("{{") < 0)
+				continue;
 
 			if (span.ReplaceSubstitutions(context.FrontMatter?.Properties, out var replacement))
 			{

--- a/src/docs-builder/Diagnostics/Console/ErrataFileSourceRepository.cs
+++ b/src/docs-builder/Diagnostics/Console/ErrataFileSourceRepository.cs
@@ -22,10 +22,14 @@ public class ErrataFileSourceRepository : ISourceRepository
 		return true;
 	}
 
-	public void WriteDiagnosticsToConsole(IReadOnlyCollection<Diagnostic> items)
+	public void WriteDiagnosticsToConsole(IReadOnlyCollection<Diagnostic> errors, IReadOnlyCollection<Diagnostic> warnings)
 	{
 		var report = new Report(this);
-		foreach (var item in items)
+		var limttedErrors = errors.Take(100).ToArray();
+		var limittedWarnings = warnings.Take(100 - limttedErrors.Length);
+		var limitted = limittedWarnings.Concat(limttedErrors).ToArray();
+
+		foreach (var item in limitted)
 		{
 			var d = item.Severity switch
 			{
@@ -49,5 +53,15 @@ public class ErrataFileSourceRepository : ISourceRepository
 
 		// Render the report
 		report.Render(AnsiConsole.Console);
+
+		var totalErrorCount = errors.Count + warnings.Count;
+		if (limitted.Length >= totalErrorCount)
+			return;
+
+		AnsiConsole.WriteLine();
+		AnsiConsole.WriteLine();
+		AnsiConsole.Write(new Markup($"Displayed first [bold]{limitted.Length}[/] error/warnings out of [bold]{totalErrorCount}[/]"));
+
+		AnsiConsole.WriteLine();
 	}
 }


### PR DESCRIPTION
Introduced pagination for diagnostics console output to handle only the first 100 errors/warnings and added clear messages for truncated results. Improved logging consistency in various components and added null safety when reading Git-related data.

This PR also caught a performance regression in the handling of codeblocks. It was too eagerly trying to attempt substitutions on each line.
