### PR TITLE
Support unique callouts for enhanced code blocks

### DIFF
--- a/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlock.cs
+++ b/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlock.cs
@@ -22,6 +22,8 @@ public class EnhancedCodeBlock(BlockParser parser, ParserContext context)
 
 	public List<CallOut>? CallOuts { get; set; }
 
+	public IReadOnlyCollection<CallOut> UniqueCallOuts => CallOuts?.DistinctBy(c => c.Index).ToList() ?? [];
+
 	public bool InlineAnnotations { get; set; }
 
 	public string Language { get; set; } = "unknown";

--- a/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockHtmlRenderer.cs
+++ b/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockHtmlRenderer.cs
@@ -25,7 +25,7 @@ public class EnhancedCodeBlockHtmlRenderer : HtmlObjectRenderer<EnhancedCodeBloc
 	}
 	protected override void Write(HtmlRenderer renderer, EnhancedCodeBlock block)
 	{
-		var callOuts = block.CallOuts ?? [];
+		var callOuts = block.UniqueCallOuts;
 
 		var slice = Code.Create(new CodeViewModel
 		{
@@ -46,7 +46,7 @@ public class EnhancedCodeBlockHtmlRenderer : HtmlObjectRenderer<EnhancedCodeBloc
 				var siblingBlock = block.Parent[index + 1];
 				if (siblingBlock is not ListBlock)
 					block.EmitError("Code block with annotations is not followed by a list");
-				if (siblingBlock is ListBlock l && l.Count != callOuts.Count)
+				if (siblingBlock is ListBlock l && l.Count < callOuts.Count)
 				{
 					block.EmitError(
 						$"Code block has {callOuts.Count} callouts but the following list only has {l.Count}");
@@ -84,7 +84,7 @@ public class EnhancedCodeBlockHtmlRenderer : HtmlObjectRenderer<EnhancedCodeBloc
 		else if (block.InlineAnnotations)
 		{
 			renderer.WriteLine("<ol class=\"code-callouts\">");
-			foreach (var c in block.CallOuts ?? [])
+			foreach (var c in block.UniqueCallOuts)
 			{
 				renderer.WriteLine("<li>");
 				renderer.WriteLine(c.Text);

--- a/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockParser.cs
+++ b/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockParser.cs
@@ -172,9 +172,14 @@ public class EnhancedCodeBlockParser : FencedBlockParserBase<EnhancedCodeBlock>
 
 			callOutIndex++;
 			var callout = span.Slice(match.Index + startIndex, match.Length - startIndex);
+			var index = callOutIndex;
+			if (!inlineCodeAnnotation && int.TryParse(callout.Trim(['<', '>']), out index))
+			{
+
+			}
 			return new CallOut
 			{
-				Index = callOutIndex,
+				Index = index,
 				Text = callout.TrimStart('/').TrimStart('#').TrimStart().ToString(),
 				InlineCodeAnnotation = inlineCodeAnnotation,
 				SliceStart = startIndex,

--- a/tests/Elastic.Markdown.Tests/CodeBlocks/CallOutTests.cs
+++ b/tests/Elastic.Markdown.Tests/CodeBlocks/CallOutTests.cs
@@ -117,6 +117,35 @@ var z = y - 2; <2>
 		.And.OnlyContain(c => c.Message.StartsWith("Code block has 2 callouts but the following list only has 1"));
 }
 
+public class ClassicCallOutsReuseHighlights(ITestOutputHelper output) : CodeBlockCallOutTests(output, "csharp",
+"""
+var x = 1; <1>
+var y = x - 2; <2>
+var z = y - 2; <2>
+""",
+"""
+1. The first
+2. The second appears twice
+"""
+
+	)
+{
+	[Fact]
+	public void SeesTwoUniqueCallouts() => Block!.UniqueCallOuts
+		.Should().NotBeNullOrEmpty()
+		.And.HaveCount(2)
+		.And.OnlyContain(c => c.Text.StartsWith("<"));
+
+	[Fact]
+	public void ParsesAllForLineInformation() => Block!.CallOuts
+		.Should().NotBeNullOrEmpty()
+		.And.HaveCount(3)
+		.And.OnlyContain(c => c.Text.StartsWith("<"));
+
+	[Fact]
+	public void RequiresContentToFollow() => Collector.Diagnostics.Should().BeEmpty();
+}
+
 public class ClassicCallOutWithTheRightListItems(ITestOutputHelper output) : CodeBlockCallOutTests(output, "csharp",
 """
 var x = 1; <1>


### PR DESCRIPTION
Updated logic to handle unique callouts by index and ensure proper rendering in HTML. Adjusted tests to validate the new behavior and improved error handling for mismatched annotations and lists.

This now also support reusing callouts e.g

````markdown
```js
var x = 1; <1>
var y = x - 2; <2>
var z = y - 2; <2>
```
1. a
2. b
````
