### PR TITLE
Add support for 'continue-on-error' input in publish action

### DIFF
--- a/actions/publish/action.yml
+++ b/actions/publish/action.yml
@@ -14,6 +14,10 @@ inputs:
   strict:
     description: 'Treat warnings as errors'
     required: false
+  continue-on-error:
+    description: 'Treat warnings as errors'
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -23,6 +27,7 @@ runs:
       run: 'echo "value=`basename ${{ github.repository }}`" >> $GITHUB_OUTPUT'
     - name: Build documentation
       uses: elastic/docs-builder@main
+      continue-on-error: ${{ inputs.continue-on-error == 'true' }}
       with:
         prefix: '${{ steps.repo-basename.outputs.value }}'
         strict: ${{ inputs.strict }}


### PR DESCRIPTION
This adds an optional 'continue-on-error' input to the publish action. It allows the workflow to proceed even if documentation building fails, based on the provided value. Defaults to 'false' to maintain the current behavior.
