### PR TITLE
Add macos-latest-large runner to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-latest, windows-latest, macos-latest, macos-latest-large ]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write


### PR DESCRIPTION
According to https://github.com/actions/runner-images?tab=readme-ov-file#available-images, `maco-latest-large` should be the non-ARM macOS version.