### PR TITLE
Add support for "previous" and "next" document navigation

### DIFF
--- a/src/Elastic.Markdown/IO/MarkdownFile.cs
+++ b/src/Elastic.Markdown/IO/MarkdownFile.cs
@@ -61,8 +61,15 @@ public record MarkdownFile : DocumentationFile
 	public string FileName { get; }
 	public string Url => $"{UrlPathPrefix}/{RelativePath.Replace(".md", ".html")}";
 
+	public int NavigationIndex
+	{
+		get { return _navigationIndex; }
+		set { _navigationIndex = value; }
+	}
+
 	private bool _instructionsParsed;
 	private DocumentationGroup? _parent;
+	private int _navigationIndex;
 
 	public MarkdownFile[] YieldParents()
 	{

--- a/src/Elastic.Markdown/IO/MarkdownFile.cs
+++ b/src/Elastic.Markdown/IO/MarkdownFile.cs
@@ -61,15 +61,10 @@ public record MarkdownFile : DocumentationFile
 	public string FileName { get; }
 	public string Url => $"{UrlPathPrefix}/{RelativePath.Replace(".md", ".html")}";
 
-	public int NavigationIndex
-	{
-		get { return _navigationIndex; }
-		set { _navigationIndex = value; }
-	}
+	public int NavigationIndex { get; set; }
 
 	private bool _instructionsParsed;
 	private DocumentationGroup? _parent;
-	private int _navigationIndex;
 
 	public MarkdownFile[] YieldParents()
 	{

--- a/src/Elastic.Markdown/IO/Navigation/DocumentationGroup.cs
+++ b/src/Elastic.Markdown/IO/Navigation/DocumentationGroup.cs
@@ -36,12 +36,13 @@ public class DocumentationGroup
 		IReadOnlyCollection<ITocItem> toc,
 		IDictionary<string, DocumentationFile> lookup,
 		IDictionary<string, DocumentationFile[]> folderLookup,
+		ref int fileIndex,
 		int depth = 0,
 		MarkdownFile? index = null
 	)
 	{
 		Depth = depth;
-		Index = ProcessTocItems(index, toc, lookup, folderLookup, depth, out var groups, out var files, out var navigationItems);
+		Index = ProcessTocItems(index, toc, lookup, folderLookup, depth, ref fileIndex, out var groups, out var files, out var navigationItems);
 
 		GroupsInOrder = groups;
 		FilesInOrder = files;
@@ -59,6 +60,7 @@ public class DocumentationGroup
 		IDictionary<string, DocumentationFile> lookup,
 		IDictionary<string, DocumentationFile[]> folderLookup,
 		int depth,
+		ref int fileIndex,
 		out List<DocumentationGroup> groups,
 		out List<MarkdownFile> files,
 		out List<INavigationItem> navigationItems)
@@ -75,10 +77,11 @@ public class DocumentationGroup
 					continue;
 
 				md.Parent = this;
+				md.NavigationIndex = ++fileIndex;
 
 				if (file.Children.Count > 0 && d is MarkdownFile virtualIndex)
 				{
-					var group = new DocumentationGroup(file.Children, lookup, folderLookup, depth + 1, virtualIndex)
+					var group = new DocumentationGroup(file.Children, lookup, folderLookup, ref fileIndex, depth + 1, virtualIndex)
 					{
 						Parent = this
 					};
@@ -108,7 +111,7 @@ public class DocumentationGroup
 						.ToArray();
 				}
 
-				var group = new DocumentationGroup(children, lookup, folderLookup, depth + 1)
+				var group = new DocumentationGroup(children, lookup, folderLookup, ref fileIndex, depth + 1)
 				{
 					Parent = this
 				};

--- a/src/Elastic.Markdown/IO/State/LinkReference.cs
+++ b/src/Elastic.Markdown/IO/State/LinkReference.cs
@@ -24,8 +24,7 @@ public record LinkReference
 	public static LinkReference Create(DocumentationSet set)
 	{
 		var crossLinks = set.Context.Collector.CrossLinks.ToHashSet().ToArray();
-		var links = set.FlatMappedFiles.Values
-			.OfType<MarkdownFile>()
+		var links = set.MarkdownFiles.Values
 			.Select(m => m.RelativePath).ToArray();
 		return new LinkReference
 		{

--- a/src/Elastic.Markdown/Slices/HtmlWriter.cs
+++ b/src/Elastic.Markdown/Slices/HtmlWriter.cs
@@ -45,7 +45,8 @@ public class HtmlWriter
 		await DocumentationSet.Tree.Resolve(ctx);
 		var navigationHtml = await RenderNavigation(markdown, ctx);
 
-		var previous = DocumentationSet;
+		var previous = DocumentationSet.MarkdownFiles.GetValueOrDefault(markdown.NavigationIndex -1);
+		var next = DocumentationSet.MarkdownFiles.GetValueOrDefault(markdown.NavigationIndex +1);
 
 		var remote = DocumentationSet.Context.Git.RepositoryName;
 		var branch = DocumentationSet.Context.Git.Branch;
@@ -59,6 +60,8 @@ public class HtmlWriter
 			PageTocItems = markdown.TableOfContents.Values.ToList(),
 			Tree = DocumentationSet.Tree,
 			CurrentDocument = markdown,
+			PreviousDocument = previous,
+			NextDocument = next,
 			NavigationHtml = navigationHtml,
 			UrlPathPrefix = markdown.UrlPathPrefix,
 			Applies = markdown.YamlFrontMatter?.AppliesTo,

--- a/src/Elastic.Markdown/Slices/HtmlWriter.cs
+++ b/src/Elastic.Markdown/Slices/HtmlWriter.cs
@@ -45,8 +45,8 @@ public class HtmlWriter
 		await DocumentationSet.Tree.Resolve(ctx);
 		var navigationHtml = await RenderNavigation(markdown, ctx);
 
-		var previous = DocumentationSet.MarkdownFiles.GetValueOrDefault(markdown.NavigationIndex -1);
-		var next = DocumentationSet.MarkdownFiles.GetValueOrDefault(markdown.NavigationIndex +1);
+		var previous = DocumentationSet.MarkdownFiles.GetValueOrDefault(markdown.NavigationIndex - 1);
+		var next = DocumentationSet.MarkdownFiles.GetValueOrDefault(markdown.NavigationIndex + 1);
 
 		var remote = DocumentationSet.Context.Git.RepositoryName;
 		var branch = DocumentationSet.Context.Git.Branch;

--- a/src/Elastic.Markdown/Slices/Index.cshtml
+++ b/src/Elastic.Markdown/Slices/Index.cshtml
@@ -7,6 +7,8 @@
 		PageTocItems = Model.PageTocItems,
 		Tree = Model.Tree,
 		CurrentDocument = Model.CurrentDocument,
+		Previous = Model.PreviousDocument,
+		Next = Model.NextDocument,
 		NavigationHtml = Model.NavigationHtml,
 		UrlPathPrefix = Model.UrlPathPrefix,
 		GithubEditUrl = Model.GithubEditUrl

--- a/src/Elastic.Markdown/Slices/_Layout.cshtml
+++ b/src/Elastic.Markdown/Slices/_Layout.cshtml
@@ -64,15 +64,30 @@
 					<span>Back to top</span>
 				</button>
 				<div class="navigation flex print:hidden">
+					@if (Model.Previous != null)
+					{
+					<div class="navigation-previous">
+						<i class="i-lucide chevron-left"></i>
+						<a href="@Model.Previous.Url">
+							<div class="page-info">
+								<span>Previous</span>
+								<div class="title">@Model.Previous.NavigationTitle</div>
+							</div>
+						</a>
+					</div>
+					}
+					@if (Model.Next != null)
+					{
 					<div class="navigation-next">
-						<a href="elastic/index.html">
+						<a href="@Model.Next.Url">
 							<div class="page-info">
 								<span>Next</span>
-								<div class="title">Elastic content</div>
+								<div class="title">@Model.Next.NavigationTitle</div>
 							</div>
 							<i class="i-lucide chevron-right"></i>
 						</a>
 					</div>
+					}
 				</div>
 			</div>
 		</div>

--- a/src/Elastic.Markdown/Slices/_ViewModels.cs
+++ b/src/Elastic.Markdown/Slices/_ViewModels.cs
@@ -14,6 +14,8 @@ public class IndexViewModel
 	public required DocumentationGroup Tree { get; init; }
 	public required IReadOnlyCollection<PageTocItem> PageTocItems { get; init; }
 	public required MarkdownFile CurrentDocument { get; init; }
+	public required MarkdownFile? PreviousDocument { get; init; }
+	public required MarkdownFile? NextDocument { get; init; }
 	public required string NavigationHtml { get; init; }
 	public required string? UrlPathPrefix { get; init; }
 	public required string? GithubEditUrl { get; init; }
@@ -26,6 +28,8 @@ public class LayoutViewModel
 	public required IReadOnlyCollection<PageTocItem> PageTocItems { get; init; }
 	public required DocumentationGroup Tree { get; init; }
 	public required MarkdownFile CurrentDocument { get; init; }
+	public required MarkdownFile? Previous { get; init; }
+	public required MarkdownFile? Next { get; init; }
 	public required string NavigationHtml { get; set; }
 	public required string? UrlPathPrefix { get; set; }
 	public required string? GithubEditUrl { get; set; }


### PR DESCRIPTION
Introduced navigation indices for Markdown files, enabling seamless transitions between "previous" and "next" documents. Updated views and models to reflect these changes, improving navigation usability.

https://github.com/user-attachments/assets/dda58a4e-5684-4c18-a409-3fca5f74f782


Video inspired by @reakaleek's PR's :)