### PR TITLE
Refactor TOC processing to handle excluded and unreachable files

### DIFF
--- a/src/Elastic.Markdown/IO/DocumentationSet.cs
+++ b/src/Elastic.Markdown/IO/DocumentationSet.cs
@@ -64,12 +64,18 @@ public class DocumentationSet
 			.ToDictionary(g => g.Key, g => g.ToArray());
 
 		var fileIndex = 0;
-		Tree = new DocumentationGroup(Configuration.TableOfContents, FlatMappedFiles, folderFiles, ref fileIndex)
+		Tree = new DocumentationGroup(Context, Configuration.TableOfContents, FlatMappedFiles, folderFiles, ref fileIndex)
 		{
 			Parent = null
 		};
 
-		MarkdownFiles = Files.OfType<MarkdownFile>().ToDictionary(i => i.NavigationIndex, i => i).ToFrozenDictionary();
+		var markdownFiles = Files.OfType<MarkdownFile>().ToArray();
+
+		var excludedChildren = markdownFiles.Where(f => f.NavigationIndex == -1).ToArray();
+		foreach (var excludedChild in excludedChildren)
+			Context.EmitError(Context.ConfigurationPath, $"{excludedChild.RelativePath} is unreachable in the TOC because one of its parents matches exclusion glob");
+
+		MarkdownFiles = markdownFiles.Where(f => f.NavigationIndex > -1).ToDictionary(i => i.NavigationIndex, i => i).ToFrozenDictionary();
 
 	}
 

--- a/src/Elastic.Markdown/IO/MarkdownFile.cs
+++ b/src/Elastic.Markdown/IO/MarkdownFile.cs
@@ -61,7 +61,7 @@ public record MarkdownFile : DocumentationFile
 	public string FileName { get; }
 	public string Url => $"{UrlPathPrefix}/{RelativePath.Replace(".md", ".html")}";
 
-	public int NavigationIndex { get; set; }
+	public int NavigationIndex { get; internal set; } = -1;
 
 	private bool _instructionsParsed;
 	private DocumentationGroup? _parent;

--- a/src/docs-assembler/conf.yml
+++ b/src/docs-assembler/conf.yml
@@ -1,4 +1,14 @@
+
 repos:
+  docs-content:
+    repo: "git@github.com:elastic/apm-aws-lambda.git"
+  docs-builder:
+    repo: "git@github.com:elastic/apm-aws-lambda.git"
+  docs-builder:
+    repo: "git@github.com:elastic/apm-aws-lambda.git"
+
+
+repos-old:
   apm-aws-lambda:
     repo: "git@github.com:elastic/apm-aws-lambda.git"
   apm-k8s-attacher:

--- a/src/docs-assembler/conf.yml
+++ b/src/docs-assembler/conf.yml
@@ -1,14 +1,4 @@
-
 repos:
-  docs-content:
-    repo: "git@github.com:elastic/apm-aws-lambda.git"
-  docs-builder:
-    repo: "git@github.com:elastic/apm-aws-lambda.git"
-  docs-builder:
-    repo: "git@github.com:elastic/apm-aws-lambda.git"
-
-
-repos-old:
   apm-aws-lambda:
     repo: "git@github.com:elastic/apm-aws-lambda.git"
   apm-k8s-attacher:


### PR DESCRIPTION
Updated the TOC processing logic to emit errors for excluded or unreachable files and ensure valid navigation indexes. These changes improve diagnostics during documentation builds and prevent invalid entries in the output structure.

Markdown files who's parent matches an exclusion glob never receive a `NavigationIndex` since they are effectively unreachable. 

This caused issues in https://github.com/elastic/elasticsearch.md as can be seen by this [workflow run](https://github.com/elastic/elasticsearch.md/actions/runs/12857035309/job/35844425339)

Since several migrated files now start with an underscore but `docset.yml` includes the following:

```
exclude:
  - '_*.md'
```

Yet the TOC still references files that start with an underscore. We now emit a better error message for this:

<img width="1367" alt="image" src="https://github.com/user-attachments/assets/04c2551b-743a-4d0d-b5cf-6f061ca6ca6f" />

Another issue is that children of these excluded files never receive a `NavigationIndex` and thus defaulted to `0`. This blew up later when we create an index by `NavigationIndex`.

```yaml
  - file: _data_store_architecture.md
    children:
      - file: nodes-shards.md
      - file: node-roles-overview.md
      - file: docs-replication.md
      - file: shard-allocation-relocation-recovery.md
        children:
          - file: shard-allocation-awareness.md
```

These are now also emitted as configuration errors properly:

<img width="1367" alt="image" src="https://github.com/user-attachments/assets/562d8cf0-5c59-4b35-847f-e3f9237bb844" />

And we no longer crash the build, we recover and build all files again if this does occur.


