### PR TITLE
Fix preview-cleanup pt3

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -11,7 +11,6 @@ permissions:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
-    environment: preview-${{ github.event.pull_request.number }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/aws-auth
@@ -45,12 +44,6 @@ jobs:
                 deployment_id: deployment.id
               });
             }
-
-            await github.rest.repos.deleteAnEnvironment({
-              owner,
-              repo,
-              environment_name: `preview-${context.issue.number}`,
-            });
 
     
             


### PR DESCRIPTION
We can delete all deployments to clean-up the UI, but we cannot delete the environment.

We need a GH PAT for that with permissions to delete environments.

This is okay for now.