### PR TITLE
Add support for vertical definition lists

### DIFF
--- a/src/Elastic.Markdown/Myst/MarkdownParser.cs
+++ b/src/Elastic.Markdown/Myst/MarkdownParser.cs
@@ -51,6 +51,7 @@ public class MarkdownParser(
 			.UseGridTables()
 			.UsePipeTables()
 			.UseDirectives()
+			.UseDefinitionLists()
 			.UseEnhancedCodeBlocks()
 			.DisableHtml()
 			.UseHardBreaks()

--- a/tests/authoring/Container/DefinitionLists.fs
+++ b/tests/authoring/Container/DefinitionLists.fs
@@ -1,0 +1,59 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+module ``container elements``.``vertical definition lists``
+
+open Xunit
+open authoring
+
+type ``simple multiline definition with markup`` () =
+
+    static let markdown = Setup.Markdown """
+This is my `definition`
+:   And this is the definition **body**
+    Which may contain multiple lines
+"""
+
+    [<Fact>]
+    let ``validate HTML`` () =
+        markdown |> convertsToHtml """
+             <dl>
+                <dt>This is my <code>definition</code> </dt>
+                <dd>
+                    <p> And this is the definition <strong>body</strong> <br>
+                        Which may contain multiple lines</p>
+                </dd>
+             </dl>
+            """
+    [<Fact>]
+    let ``has no errors`` () = markdown |> hasNoErrors
+
+type ``with embedded directives`` () =
+
+    static let markdown = Setup.Markdown """
+This is my `definition`
+:   And this is the definition **body**
+    Which may contain multiple lines
+    :::{note}
+    My note
+    :::
+"""
+
+    [<Fact>]
+    let ``validate HTML`` () =
+        markdown |> convertsToHtml """
+             <dl>
+                <dt>This is my <code>definition</code> </dt>
+                <dd>
+                    <p> And this is the definition <strong>body</strong> <br>
+                        Which may contain multiple lines</p>
+                        <div class="admonition note">
+ 			                <p class="admonition-title">Note</p>
+                        <p>My note</p>
+                    </div>
+                </dd>
+             </dl>
+            """
+    [<Fact>]
+    let ``has no errors`` () = markdown |> hasNoErrors

--- a/tests/authoring/authoring.fsproj
+++ b/tests/authoring/authoring.fsproj
@@ -37,4 +37,8 @@
     <Compile Include="Inline\InlineAnchors.fs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="Container\DefinitionLists.fs" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
<img width="807" alt="image" src="https://github.com/user-attachments/assets/93fcbbc7-89be-4e6e-a660-f0add1573b6f" />

### Syntax 

Note these lists are close to the asciidoc syntax with one distinction namely content will need to be indented. 

```
TITLE
:<THREE SPACES> <CONTENT>
[FOUR SPACES] [CONTENT CONTINUATION]
```

Note the additional three spaces after the semicolon.

### Horizontal definition lists

Not supported we need to discuss if we **really** want this.