### PR TITLE
Allow multiple classic callouts in one line

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,3 +9,32 @@ Elastic Docs V3 is our next-generation documentation platform designed to improv
 * [Configure content sets in V3](./configure/index.md)
 * [Learn about V3 syntax](./syntax/index.md)
 * [Contribute to V3 (developer guide)](./development/index.md)
+
+
+:::{dropdown} Markdown
+:open:
+
+````markdown
+```csharp
+var x = 1; <1>
+var y = x - 2;
+var z = y - 2; <1> <2>
+```
+
+1. Foo
+2. Bar
+````
+
+:::
+
+:::{dropdown} Output
+:open:
+```csharp
+var x = 1; <1>
+var y = x - 2;
+var z = y - 2; <1> <2>
+```
+
+1. Foo
+2. Bar
+:::

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,32 +9,3 @@ Elastic Docs V3 is our next-generation documentation platform designed to improv
 * [Configure content sets in V3](./configure/index.md)
 * [Learn about V3 syntax](./syntax/index.md)
 * [Contribute to V3 (developer guide)](./development/index.md)
-
-
-:::{dropdown} Markdown
-:open:
-
-````markdown
-```csharp
-var x = 1; <1>
-var y = x - 2;
-var z = y - 2; <1> <2>
-```
-
-1. Foo
-2. Bar
-````
-
-:::
-
-:::{dropdown} Output
-:open:
-```csharp
-var x = 1; <1>
-var y = x - 2;
-var z = y - 2; <1> <2>
-```
-
-1. Foo
-2. Bar
-:::

--- a/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlock.cs
+++ b/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlock.cs
@@ -20,7 +20,7 @@ public class EnhancedCodeBlock(BlockParser parser, ParserContext context)
 
 	public int OpeningLength => Info?.Length ?? 0 + 3;
 
-	public List<CallOut>? CallOuts { get; set; }
+	public List<CallOut> CallOuts { get; set; } = [];
 
 	public IReadOnlyCollection<CallOut> UniqueCallOuts => CallOuts?.DistinctBy(c => c.Index).ToList() ?? [];
 

--- a/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockHtmlRenderer.cs
+++ b/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockHtmlRenderer.cs
@@ -55,7 +55,7 @@ public class EnhancedCodeBlockHtmlRenderer : HtmlObjectRenderer<EnhancedCodeBloc
 	{
 		var callOuts = FindCallouts(block.CallOuts ?? [], lineNumber + 1);
 		foreach (var callOut in callOuts)
-			renderer.Write($"<span class=\"code-callout\">{callOut.Index}</span>");
+			renderer.Write($"<span class=\"code-callout\" data-index=\"{callOut.Index}\">{callOut.Index}</span>");
 	}
 
 	private static IEnumerable<CallOut> FindCallouts(

--- a/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockParser.cs
+++ b/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockParser.cs
@@ -99,7 +99,6 @@ public class EnhancedCodeBlockParser : FencedBlockParserBase<EnhancedCodeBlock>
 				continue;
 
 			List<CallOut> callOuts = [];
-
 			var hasClassicCallout = span.IndexOf("<") > 0;
 			if (hasClassicCallout)
 			{
@@ -108,7 +107,6 @@ public class EnhancedCodeBlockParser : FencedBlockParserBase<EnhancedCodeBlock>
 					EnumerateAnnotations(matchClassicCallout, ref span, ref callOutIndex, originatingLine, false)
 				);
 			}
-
 			// only support magic callouts for smaller line lengths
 			if (callOuts.Count == 0 && span.Length < 200)
 			{
@@ -117,11 +115,6 @@ public class EnhancedCodeBlockParser : FencedBlockParserBase<EnhancedCodeBlock>
 					EnumerateAnnotations(matchInline, ref span, ref callOutIndex, originatingLine, true)
 				);
 			}
-
-			if (callOuts.Count == 0)
-				continue;
-
-			codeBlock.CallOuts ??= [];
 			codeBlock.CallOuts.AddRange(callOuts);
 		}
 

--- a/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockParser.cs
+++ b/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockParser.cs
@@ -131,7 +131,8 @@ public class EnhancedCodeBlockParser : FencedBlockParserBase<EnhancedCodeBlock>
 
 			var callouts = codeBlock.CallOuts.Aggregate(new Dictionary<int, CallOut>(), (acc, curr) =>
 			{
-				if (acc.TryAdd(curr.Line, curr)) return acc;
+				if (acc.TryAdd(curr.Line, curr))
+					return acc;
 				if (acc[curr.Line].SliceStart > curr.SliceStart)
 					acc[curr.Line] = curr;
 				return acc;

--- a/src/Elastic.Markdown/_static/copybutton.js
+++ b/src/Elastic.Markdown/_static/copybutton.js
@@ -153,15 +153,14 @@ function escapeRegExp(string) {
  * Removes excluded text from a Node.
  *
  * @param {Node} target Node to filter.
- * @param {string} exclude CSS selector of nodes to exclude.
+ * @param {string[]} excludes CSS selector of nodes to exclude.
  * @returns {DOMString} Text from `target` with text removed.
  */
-function filterText(target, exclude) {
+function filterText(target, excludes) {
     const clone = target.cloneNode(true);  // clone as to not modify the live DOM
-    if (exclude) {
-        // remove excluded nodes
-        clone.querySelectorAll(exclude).forEach(node => node.remove());
-    }
+    excludes.forEach(exclude => {
+      clone.querySelectorAll(excludes).forEach(node => node.remove());
+    })
     return clone.innerText;
 }
 
@@ -222,11 +221,9 @@ function formatCopyText(textContent, copybuttonPromptText, isRegexp = false, onl
 
 var copyTargetText = (trigger) => {
   var target = document.querySelector(trigger.attributes['data-clipboard-target'].value);
-
   // get filtered text
-  let exclude = '.linenos';
-
-  let text = filterText(target, exclude);
+  let excludes = ['.code-callout', '.linenos'];
+  let text = filterText(target, excludes);
   return formatCopyText(text, '', false, true, true, true, '', '')
 }
 

--- a/src/Elastic.Markdown/_static/custom.css
+++ b/src/Elastic.Markdown/_static/custom.css
@@ -150,6 +150,15 @@ See https://github.com/elastic/docs-builder/issues/219 for further details
 	justify-content: center;
 	margin: 0;
 	transform: translateY(-2px);
+	user-select: none; /* Standard */
+	-webkit-user-select: none; /* Safari */
+	-moz-user-select: none; /* Firefox */
+	-ms-user-select: none; /* IE10+/Edge */
+	user-select: none; /* Standard */
+}
+
+.yue code span.code-callout:not(:last-child) {
+	margin-right: 5px;
 }
 
 .yue code span.code-callout > span {

--- a/tests/Elastic.Markdown.Tests/CodeBlocks/CallOutTests.cs
+++ b/tests/Elastic.Markdown.Tests/CodeBlocks/CallOutTests.cs
@@ -148,21 +148,92 @@ var z = y - 2; <2>
 
 public class ClassicCallOutWithTheRightListItems(ITestOutputHelper output) : CodeBlockCallOutTests(output, "csharp",
 """
-var x = 1; <1>
-var y = x - 2;
-var z = y - 2; <2>
+receivers: <1>
+  # ...
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+processors: <2>
+  # ...
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 2000
+  batch:
+
+exporters:
+  debug:
+    verbosity: detailed <3>
+  otlp: <4>
+    # Elastic APM server https endpoint without the "https://" prefix
+    endpoint: "${env:ELASTIC_APM_SERVER_ENDPOINT}" <5> <7>
+    headers:
+      # Elastic APM Server secret token
+      Authorization: "Bearer ${env:ELASTIC_APM_SECRET_TOKEN}" <6> <7>
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [..., memory_limiter, batch]
+      exporters: [debug, otlp]
+    metrics:
+      receivers: [otlp]
+      processors: [..., memory_limiter, batch]
+      exporters: [debug, otlp]
+    logs: <8>
+      receivers: [otlp]
+      processors: [..., memory_limiter, batch]
+      exporters: [debug, otlp]
 """,
 """
-1. First callout
-2. Second callout
+1. The receivers, like the OTLP receiver, that forward data emitted by APM agents, or the host metrics receiver.
+2. We recommend using the Batch processor and the memory limiter processor. For more information, see recommended processors.
+3. The debug exporter is helpful for troubleshooting, and supports configurable verbosity levels: basic (default), normal, and detailed.
+4. Elastic {observability} endpoint configuration. APM Server supports a ProtoBuf payload via both the OTLP protocol over gRPC transport (OTLP/gRPC) and the OTLP protocol over HTTP transport (OTLP/HTTP). To learn more about these exporters, see the OpenTelemetry Collector documentation: OTLP/HTTP Exporter or OTLP/gRPC exporter. When adding an endpoint to an existing configuration an optional name component can be added, like otlp/elastic, to distinguish endpoints as described in the OpenTelemetry Collector Configuration Basics.
+5. Hostname and port of the APM Server endpoint. For example, elastic-apm-server:8200.
+6. Credential for Elastic APM secret token authorization (Authorization: "Bearer a_secret_token") or API key authorization (Authorization: "ApiKey an_api_key").
+7. Environment-specific configuration parameters can be conveniently passed in as environment variables documented here (e.g. ELASTIC_APM_SERVER_ENDPOINT and ELASTIC_APM_SECRET_TOKEN).
+8. [preview] To send OpenTelemetry logs to {stack} version 8.0+, declare a logs pipeline.
 """
 
 	)
 {
 	[Fact]
+	public void ParsesClassicCallouts()
+	{
+		Block!.CallOuts
+			.Should().NotBeNullOrEmpty()
+			.And.HaveCount(9)
+			.And.OnlyContain(c => c.Text.StartsWith("<"));
+
+		Block!.UniqueCallOuts
+			.Should().NotBeNullOrEmpty()
+			.And.HaveCount(8);
+	}
+
+	[Fact]
+	public void HasNoErrors() => Collector.Diagnostics.Should().HaveCount(0);
+}
+
+public class MultipleCalloutsInOneLine(ITestOutputHelper output) : CodeBlockCallOutTests(output, "csharp",
+	"""
+	var x = 1; // <1>
+	var y = x - 2;
+	var z = y - 2; // <1> <2>
+	""",
+	"""
+	1. First callout
+	2. Second callout
+	"""
+)
+{
+	[Fact]
 	public void ParsesMagicCallOuts() => Block!.CallOuts
 		.Should().NotBeNullOrEmpty()
-		.And.HaveCount(2)
+		.And.HaveCount(3)
 		.And.OnlyContain(c => c.Text.StartsWith("<"));
 
 	[Fact]

--- a/tests/Elastic.Markdown.Tests/CodeBlocks/CallOutTests.cs
+++ b/tests/Elastic.Markdown.Tests/CodeBlocks/CallOutTests.cs
@@ -239,3 +239,28 @@ public class MultipleCalloutsInOneLine(ITestOutputHelper output) : CodeBlockCall
 	[Fact]
 	public void HasNoErrors() => Collector.Diagnostics.Should().HaveCount(0);
 }
+
+public class CodeBlockWithChevronInsideCode(ITestOutputHelper output) : CodeBlockCallOutTests(output, "csharp",
+	"""
+	app.UseFilter<StopwatchFilter>(); <1>
+	app.UseFilter<CatchExceptionFilter>(); <2>
+
+	var x = 1; <1>
+	var y = x - 2;
+	var z = y - 2; <1> <2>
+	""",
+	"""
+	1. First callout
+	2. Second callout
+	"""
+)
+{
+	[Fact]
+	public void ParsesMagicCallOuts() => Block!.CallOuts
+		.Should().NotBeNullOrEmpty()
+		.And.HaveCount(5)
+		.And.OnlyContain(c => c.Text.StartsWith("<"));
+
+	[Fact]
+	public void HasNoErrors() => Collector.Diagnostics.Should().HaveCount(0);
+}


### PR DESCRIPTION
Closes https://github.com/elastic/docs-builder/issues/175

## Changes

Allow multiple classic callouts in a single line.

<img width="831" alt="image" src="https://github.com/user-attachments/assets/0490c1a8-5d7c-46b4-8bf6-93b77d289da4" />