### PR TITLE
github-action: Add AsciiDoc freeze warning

### DIFF
--- a/.github/workflows/comment-on-asciidoc-changes.yml
+++ b/.github/workflows/comment-on-asciidoc-changes.yml
@@ -1,35 +1,20 @@
+---
 name: Comment on PR for .asciidoc changes
 
 on:
-  workflow_call: ~
+  pull_request:
+    types:
+      - synchronize
+      - opened
+      - reopened
+    branches:
+      - main
+      - master
+      - "9.0"
 
 jobs:
   comment-on-asciidoc-change:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout the repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # This is important to fetch all history
-
-      - name: Check for changes in .asciidoc files
-        id: check-files
-        run: |
-          git fetch origin ${{ github.base_ref }}
-          if git diff --name-only origin/${{ github.base_ref }}..HEAD | grep -E '\.asciidoc$'; then
-            echo "asciidoc_changed=true" >> $GITHUB_OUTPUT
-          else
-            echo "asciidoc_changed=false" >> $GITHUB_OUTPUT
-          fi
-      - name: Add a comment if .asciidoc files changed
-        if: steps.check-files.outputs.asciidoc_changed == 'true'
-        uses: actions/github-script@v6
-        with:
-          script: |
-            github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              body: 'It looks like this PR modifies one or more `.asciidoc` files. The documentation is currently under a documentation freeze. Please do not merge this PR. See the [migration guide](https://elastic.github.io/docs-builder/migration/index.html) to learn more.'
-            })
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: elastic/docs-builder/.github/workflows/comment-on-asciidoc-changes.yml@main


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

Add a workflow that will comment on PRs with AsciiDoc changes.

## Why

During the migration to Elastic Docs v3, the Docs team will focus exclusively on migrating content.
To maintain consistency, prevent conflicts, and ensure a smoother transition we will freeze all AsciiDoc changes.

This means you will get a warning when you create AsciiDoc changes in your PRs.

   See https://github.com/elastic/docs-builder/issues/281 for details

If there are any questions, please reach out to the @elastic/docs-engineering
