### PR TITLE
Add tests for nested and indented inline anchors

### DIFF
--- a/src/Elastic.Markdown/IO/MarkdownFile.cs
+++ b/src/Elastic.Markdown/IO/MarkdownFile.cs
@@ -176,8 +176,6 @@ public record MarkdownFile : DocumentationFile
 		foreach (var t in contents)
 			_tableOfContent[t.Slug] = t;
 
-		var inlineAnchros = document.Descendants<InlineAnchor>().ToList();
-
 		var anchors = document.Descendants<DirectiveBlock>()
 			.Select(b => b.CrossReferenceName)
 			.Where(l => !string.IsNullOrWhiteSpace(l))

--- a/src/Elastic.Markdown/IO/MarkdownFile.cs
+++ b/src/Elastic.Markdown/IO/MarkdownFile.cs
@@ -89,7 +89,7 @@ public record MarkdownFile : DocumentationFile
 		return parents.ToArray();
 	}
 
-	public async Task<MarkdownDocument> MinimalParse(Cancel ctx)
+	public async Task<MarkdownDocument> MinimalParseAsync(Cancel ctx)
 	{
 		var document = await MarkdownParser.MinimalParseAsync(SourceFile, ctx);
 		ReadDocumentInstructions(document);
@@ -99,7 +99,7 @@ public record MarkdownFile : DocumentationFile
 	public async Task<MarkdownDocument> ParseFullAsync(Cancel ctx)
 	{
 		if (!_instructionsParsed)
-			await MinimalParse(ctx);
+			await MinimalParseAsync(ctx);
 
 		var document = await MarkdownParser.ParseAsync(SourceFile, YamlFrontMatter, ctx);
 		return document;
@@ -175,6 +175,8 @@ public record MarkdownFile : DocumentationFile
 		_tableOfContent.Clear();
 		foreach (var t in contents)
 			_tableOfContent[t.Slug] = t;
+
+		var inlineAnchros = document.Descendants<InlineAnchor>().ToList();
 
 		var anchors = document.Descendants<DirectiveBlock>()
 			.Select(b => b.CrossReferenceName)

--- a/src/Elastic.Markdown/IO/Navigation/DocumentationGroup.cs
+++ b/src/Elastic.Markdown/IO/Navigation/DocumentationGroup.cs
@@ -146,10 +146,10 @@ public class DocumentationGroup
 		if (_resolved)
 			return;
 
-		await Parallel.ForEachAsync(FilesInOrder, ctx, async (file, token) => await file.MinimalParse(token));
+		await Parallel.ForEachAsync(FilesInOrder, ctx, async (file, token) => await file.MinimalParseAsync(token));
 		await Parallel.ForEachAsync(GroupsInOrder, ctx, async (group, token) => await group.Resolve(token));
 
-		await (Index?.MinimalParse(ctx) ?? Task.CompletedTask);
+		await (Index?.MinimalParseAsync(ctx) ?? Task.CompletedTask);
 
 		_resolved = true;
 	}

--- a/src/Elastic.Markdown/Myst/MarkdownParser.cs
+++ b/src/Elastic.Markdown/Myst/MarkdownParser.cs
@@ -35,7 +35,8 @@ public class MarkdownParser(
 	{
 		get
 		{
-			if (_minimalPipeline is not null) return _minimalPipeline;
+			if (_minimalPipeline is not null)
+				return _minimalPipeline;
 			var builder = new MarkdownPipelineBuilder()
 				.UseYamlFrontMatter()
 				.UseInlineAnchors()
@@ -51,10 +52,12 @@ public class MarkdownParser(
 
 	// ReSharper disable once InconsistentNaming
 	private static MarkdownPipeline? _pipeline;
-	public static MarkdownPipeline Pipeline {
+	public static MarkdownPipeline Pipeline
+	{
 		get
 		{
-			if (_pipeline is not null) return _pipeline;
+			if (_pipeline is not null)
+				return _pipeline;
 
 			var builder = new MarkdownPipelineBuilder()
 				.EnableTrackTrivia()

--- a/src/Elastic.Markdown/Myst/MarkdownParser.cs
+++ b/src/Elastic.Markdown/Myst/MarkdownParser.cs
@@ -14,6 +14,7 @@ using Elastic.Markdown.Myst.InlineParsers;
 using Elastic.Markdown.Myst.Substitution;
 using Markdig;
 using Markdig.Extensions.EmphasisExtras;
+using Markdig.Parsers;
 using Markdig.Syntax;
 
 namespace Elastic.Markdown.Myst;
@@ -28,34 +29,56 @@ public class MarkdownParser(
 
 	private BuildContext Context { get; } = context;
 
-	public static MarkdownPipeline MinimalPipeline { get; } =
-		new MarkdownPipelineBuilder()
-			.UseYamlFrontMatter()
-			.UseInlineAnchors()
-			.UseHeadingsWithSlugs()
-			.UseDirectives()
-			.Build();
+	// ReSharper disable once InconsistentNaming
+	private static MarkdownPipeline? _minimalPipeline;
+	public static MarkdownPipeline MinimalPipeline
+	{
+		get
+		{
+			if (_minimalPipeline is not null) return _minimalPipeline;
+			var builder = new MarkdownPipelineBuilder()
+				.UseYamlFrontMatter()
+				.UseInlineAnchors()
+				.UseHeadingsWithSlugs()
+				.UseDirectives();
 
-	public static MarkdownPipeline Pipeline { get; } =
-		new MarkdownPipelineBuilder()
-			.EnableTrackTrivia()
-			.UseInlineAnchors()
-			.UsePreciseSourceLocation()
-			.UseDiagnosticLinks()
-			.UseHeadingsWithSlugs()
-			.UseEmphasisExtras(EmphasisExtraOptions.Default)
-			.UseSoftlineBreakAsHardlineBreak()
-			.UseSubstitution()
-			.UseComments()
-			.UseYamlFrontMatter()
-			.UseGridTables()
-			.UsePipeTables()
-			.UseDirectives()
-			.UseDefinitionLists()
-			.UseEnhancedCodeBlocks()
-			.DisableHtml()
-			.UseHardBreaks()
-			.Build();
+			builder.BlockParsers.TryRemove<IndentedCodeBlockParser>();
+			_minimalPipeline = builder.Build();
+			return _minimalPipeline;
+
+		}
+	}
+
+	// ReSharper disable once InconsistentNaming
+	private static MarkdownPipeline? _pipeline;
+	public static MarkdownPipeline Pipeline {
+		get
+		{
+			if (_pipeline is not null) return _pipeline;
+
+			var builder = new MarkdownPipelineBuilder()
+				.EnableTrackTrivia()
+				.UseInlineAnchors()
+				.UsePreciseSourceLocation()
+				.UseDiagnosticLinks()
+				.UseHeadingsWithSlugs()
+				.UseEmphasisExtras(EmphasisExtraOptions.Default)
+				.UseSoftlineBreakAsHardlineBreak()
+				.UseSubstitution()
+				.UseComments()
+				.UseYamlFrontMatter()
+				.UseGridTables()
+				.UsePipeTables()
+				.UseDirectives()
+				.UseDefinitionLists()
+				.UseEnhancedCodeBlocks()
+				.DisableHtml()
+				.UseHardBreaks();
+			builder.BlockParsers.TryRemove<IndentedCodeBlockParser>();
+			_pipeline = builder.Build();
+			return _pipeline;
+		}
+	}
 
 	public ConfigurationFile Configuration { get; } = configuration;
 

--- a/tests/authoring/Framework/ErrorCollectorAssertions.fs
+++ b/tests/authoring/Framework/ErrorCollectorAssertions.fs
@@ -16,7 +16,8 @@ module DiagnosticsCollectorAssertions =
     [<DebuggerStepThrough>]
     let hasNoErrors (actual: Lazy<GeneratorResults>) =
         let actual = actual.Value
-        test <@ actual.Context.Collector.Errors = 0 @>
+        let errors = actual.Context.Collector.Errors
+        test <@ errors = 0 @>
 
     [<DebuggerStepThrough>]
     let hasError (expected: string) (actual: Lazy<GeneratorResults>) =

--- a/tests/authoring/Framework/MarkdownDocumentAssertions.fs
+++ b/tests/authoring/Framework/MarkdownDocumentAssertions.fs
@@ -1,0 +1,25 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace authoring
+
+open System.Diagnostics
+open Markdig.Syntax
+open Xunit.Sdk
+
+module MarkdownDocumentAssertions =
+
+    [<DebuggerStepThrough>]
+    let parses<'element when 'element :> MarkdownObject> (actual: MarkdownResult) =
+        let unsupportedBlocks = actual.Document.Descendants<'element>() |> Array.ofSeq
+        if unsupportedBlocks.Length = 0 then
+            raise (XunitException($"Could not find {typedefof<'element>.Name} in fully parsed document"))
+        unsupportedBlocks;
+
+    [<DebuggerStepThrough>]
+    let parsesMinimal<'element when 'element :> MarkdownObject> (actual: MarkdownResult) =
+        let unsupportedBlocks = actual.MinimalParse.Descendants<'element>() |> Array.ofSeq
+        if unsupportedBlocks.Length = 0 then
+            raise (XunitException($"Could not find {typedefof<'element>.Name} in minimally parsed document"))
+        unsupportedBlocks;

--- a/tests/authoring/Framework/TestValues.fs
+++ b/tests/authoring/Framework/TestValues.fs
@@ -61,6 +61,7 @@ type TestLoggerFactory () =
 
 type MarkdownResult = {
     File: MarkdownFile
+    MinimalParse: MarkdownDocument
     Document: MarkdownDocument
     Html: string
     Context: MarkdownTestContext
@@ -89,8 +90,9 @@ and MarkdownTestContext =
             |> Seq.map (fun (f: MarkdownFile) -> task {
                 // technically we do this work twice since generate all also does it
                 let! document = f.ParseFullAsync(ctx)
+                let! minimal = f.MinimalParseAsync(ctx)
                 let html = f.CreateHtml(document)
-                return { File = f; Document = document; Html = html; Context = this  }
+                return { File = f; Document = document; MinimalParse = minimal; Html = html; Context = this  }
             })
             // this is not great code, refactor or depend on FSharp.Control.TaskSeq
             // for now this runs without issue

--- a/tests/authoring/Inline/InlineAnchors.fs
+++ b/tests/authoring/Inline/InlineAnchors.fs
@@ -4,8 +4,13 @@
 
 module ``inline elements``.``anchors DEPRECATED``
 
+open Elastic.Markdown.Myst.InlineParsers
+open Markdig.Syntax
+open Swensen.Unquote
+open System.Linq
 open Xunit
 open authoring
+open authoring.MarkdownDocumentAssertions
 
 type ``inline anchor in the middle`` () =
 
@@ -22,3 +27,83 @@ this is *regular* text and this $$$is-an-inline-anchor$$$ and this continues to 
             """
     [<Fact>]
     let ``has no errors`` () = markdown |> hasNoErrors
+
+type ``inline anchors embedded in definition lists`` () =
+
+    static let markdown = Setup.Generate [
+        Index """# Testing nested inline anchors
+
+$$$search-type$$$
+
+`search_type`
+:   (Optional, string) How distributed term frequencies are calculated for relevance scoring.
+
+    ::::{dropdown} Valid values for `search_type`
+    `query_then_fetch`
+    :   (Default) Distributed term frequencies are calculated locally for each shard running the search. We recommend this option for faster searches with potentially less accurate scoring.
+
+    $$$dfs-query-then-fetch$$$
+
+    `dfs_query_then_fetch`
+    :   Distributed term frequencies are calculated globally, using information gathered from all shards running the search.
+
+    ::::
+"""
+        Markdown "file.md" """
+ [Link to first](index.md#search-type)
+ [Link to second](index.md#dfs-query-then-fetch)
+        """
+    ]
+
+    [<Fact>]
+    let ``emits nested inline anchor`` () =
+        markdown |> convertsToContainingHtml """<a id="dfs-query-then-fetch"></a>"""
+
+    [<Fact>]
+    let ``emits definition list block anchor`` () =
+        markdown |> convertsToContainingHtml """<a id="search-type"></a>"""
+
+    [<Fact>]
+    let ``has no errors`` () = markdown |> hasNoErrors
+
+    [<Fact>]
+    let ``minimal parse sees two inline anchors`` () =
+        let inlineAnchors = markdown |> converts "index.md" |> parsesMinimal<InlineAnchor>
+        test <@ inlineAnchors.Length = 2 @>
+
+
+
+type ``inline anchors embedded in indented code`` () =
+
+    static let markdown = Setup.Generate [
+        Index """# Testing nested inline anchors
+
+$$$search-type$$$
+
+    indented codeblock
+
+    $$$dfs-query-then-fetch$$$
+
+    block
+"""
+        Markdown "file.md" """
+ [Link to first](index.md#search-type)
+ [Link to second](index.md#dfs-query-then-fetch)
+        """
+    ]
+
+    [<Fact>]
+    let ``emits nested inline anchor`` () =
+        markdown |> convertsToContainingHtml """<a id="dfs-query-then-fetch"></a>"""
+
+    [<Fact>]
+    let ``emits definition list block anchor`` () =
+        markdown |> convertsToContainingHtml """<a id="search-type"></a>"""
+
+    [<Fact>]
+    let ``has no errors`` () = markdown |> hasNoErrors
+
+    [<Fact>]
+    let ``minimal parse sees two inline anchors`` () =
+        let inlineAnchors = markdown |> converts "index.md" |> parsesMinimal<InlineAnchor>
+        test <@ inlineAnchors.Length = 2 @>

--- a/tests/authoring/authoring.fsproj
+++ b/tests/authoring/authoring.fsproj
@@ -29,6 +29,7 @@
     <Compile Include="Framework\MarkdownResultsAssertions.fs" />
     <Compile Include="Framework\HtmlAssertions.fs" />
     <Compile Include="Framework\ErrorCollectorAssertions.fs" />
+    <Compile Include="Framework\MarkdownDocumentAssertions.fs" />
     <Compile Include="Inline\Substitutions.fs" />
   </ItemGroup>
 


### PR DESCRIPTION
Introduced new tests to verify inline anchor generation within definition lists and indented code blocks. Ensures proper HTML output and validates parsing behavior to prevent future regressions.

This removes indented code support from our parsers.

The problem was that during our minimal parse phase anchors that lived in indented code (lists/definition lists) was not discovered because they were marked as part of an indented code block.

Removing support for indented code blocks since all code should be included through fenced blocks.


```markdown
### Connection modes [sniff-proxy-modes] 

$$$sniff-mode$$$

term
:   def
    Sniff mode is the default connection mode.

    $$$gateway-nodes-selection$$$
```

We parse documents twice, once minimally with only the parsers needed to extract metadata and once fully when we actually convert the markdown to HTML. 

Our minimal parse was not picking up on the inline anchors in defininition lists because during minimal parsing these are considered indented code blocks. While our full parser did. 
This meant that we were emitting the anchors in HTML but the builder model did not resulting in resolve issues. 


I fixed this by removing support for indented code blocks alltogether. We want all our code to be marked with fenced blocks.
