### PR TITLE
Allow _docset.yml and _toc.yml as configuration filenames

### DIFF
--- a/src/Elastic.Markdown/BuildContext.cs
+++ b/src/Elastic.Markdown/BuildContext.cs
@@ -75,8 +75,7 @@ public record BuildContext
 			return (rootPath, configurationPath);
 
 		configurationPath = rootPath
-			.EnumerateFiles("docset.yml", SearchOption.AllDirectories)
-			.OrderByDescending(f => f.Name switch { "docset.yml" => 2, "_docset.yml" => 1, _ => 0 })
+			.EnumerateFiles("*docset.yml", SearchOption.AllDirectories)
 			.FirstOrDefault()
 			?? throw new Exception($"Can not locate docset.yml file in '{rootPath}'");
 

--- a/src/Elastic.Markdown/IO/Configuration/ConfigurationFile.cs
+++ b/src/Elastic.Markdown/IO/Configuration/ConfigurationFile.cs
@@ -257,8 +257,17 @@ public record ConfigurationFile : DocumentationFile
 		var rootPath = _context.ReadFileSystem.DirectoryInfo.New(Path.Combine(_rootPath.FullName, tocPath));
 		var path = Path.Combine(rootPath.FullName, "toc.yml");
 		var source = _context.ReadFileSystem.FileInfo.New(path);
+
+		var errorMessage = $"Nested toc: '{source.Directory}' directory has no toc.yml or _toc.yml file";
+
 		if (!source.Exists)
-			EmitError($"Nested toc: '{source.FullName}' does not exist", entry.Key);
+		{
+			path = Path.Combine(rootPath.FullName, "_toc.yml");
+			source = _context.ReadFileSystem.FileInfo.New(path);
+		}
+
+		if (!source.Exists)
+			EmitError(errorMessage, entry.Key);
 		else
 			found = true;
 

--- a/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockParser.cs
+++ b/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockParser.cs
@@ -88,10 +88,6 @@ public class EnhancedCodeBlockParser : FencedBlockParserBase<EnhancedCodeBlock>
 			var line = lines.Lines[index];
 			var span = line.Slice.AsSpan();
 
-			var startIndex = Math.Max(span.IndexOf("//"), span.IndexOf('#'));
-			if (startIndex <= 0)
-				continue;
-
 			if (span.ReplaceSubstitutions(context.FrontMatter?.Properties, out var replacement))
 			{
 				var s = new StringSlice(replacement);

--- a/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockParser.cs
+++ b/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockParser.cs
@@ -88,6 +88,10 @@ public class EnhancedCodeBlockParser : FencedBlockParserBase<EnhancedCodeBlock>
 			var line = lines.Lines[index];
 			var span = line.Slice.AsSpan();
 
+			var startIndex = Math.Max(span.IndexOf("//"), span.IndexOf('#'));
+			if (startIndex <= 0)
+				continue;
+
 			if (span.ReplaceSubstitutions(context.FrontMatter?.Properties, out var replacement))
 			{
 				var s = new StringSlice(replacement);

--- a/tests/authoring/Framework/Setup.fs
+++ b/tests/authoring/Framework/Setup.fs
@@ -5,6 +5,7 @@
 namespace authoring
 
 
+open System
 open System.Collections.Generic
 open System.IO
 open System.IO.Abstractions.TestingHelpers
@@ -53,7 +54,8 @@ type Setup =
             )
         | _ -> ()
 
-        fileSystem.AddFile(Path.Combine(root.FullName, "docset.yml"), MockFileData(yaml.ToString()));
+        let name = if Random().Next(0, 10) % 2 = 0 then "_docset.yml" else "docset.yml"
+        fileSystem.AddFile(Path.Combine(root.FullName, name), MockFileData(yaml.ToString()));
 
     static member Generator (files: TestFile seq) : Task<GeneratorResults> =
 


### PR DESCRIPTION
This allows docsets to use underscore variants of the configuration files.

* `docset.yml`, `_docset.yml` in order of precedence
* `toc.yml`, `_toc.yml` in order of precedence

This will aid with content sets that hold a lot of content at the root.