### PR TITLE
Optimize comment-on-asciidoc-changes.yml

### DIFF
--- a/.github/workflows/comment-on-asciidoc-changes.yml
+++ b/.github/workflows/comment-on-asciidoc-changes.yml
@@ -38,6 +38,7 @@ jobs:
               issue_number: context.payload.pull_request.number,
               body: 'It looks like this PR modifies one or more `.asciidoc` files. These files are being migrated to Markdown, and any changes merged now will be lost. See the [migration guide](https://elastic.github.io/docs-builder/migration/freeze/index.html) for details.'
             })
+
       - name: Error if .asciidoc files changed
-        if: steps.check-files.outputs.asciidoc_changed == 'true'
+        if: steps.check-files.outputs.any_changed == 'true'
         run: exit 1

--- a/.github/workflows/comment-on-asciidoc-changes.yml
+++ b/.github/workflows/comment-on-asciidoc-changes.yml
@@ -3,6 +3,10 @@ name: Comment on PR for .asciidoc changes
 on:
   workflow_call: ~
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   comment-on-asciidoc-change:
     runs-on: ubuntu-latest
@@ -10,20 +14,16 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # This is important to fetch all history
 
-      - name: Check for changes in .asciidoc files
+      - name: Get changed files
         id: check-files
-        run: |
-          git fetch origin ${{ github.base_ref }}
-          if git diff --name-only origin/${{ github.base_ref }}..HEAD | grep -E '\.asciidoc$'; then
-            echo "asciidoc_changed=true" >> $GITHUB_OUTPUT
-          else
-            echo "asciidoc_changed=false" >> $GITHUB_OUTPUT
-          fi
+        uses: tj-actions/changed-files@d6e91a2266cdb9d62096cebf1e8546899c6aa18f # v45.0.6
+        with:
+          files: |
+            **/*.asciidoc
+
       - name: Add a comment if .asciidoc files changed
-        if: steps.check-files.outputs.asciidoc_changed == 'true'
+        if: steps.check-files.outputs.any_changed == 'true'
         uses: actions/github-script@v6
         with:
           script: |

--- a/.github/workflows/comment-on-asciidoc-changes.yml
+++ b/.github/workflows/comment-on-asciidoc-changes.yml
@@ -38,3 +38,6 @@ jobs:
               issue_number: context.payload.pull_request.number,
               body: 'It looks like this PR modifies one or more `.asciidoc` files. These files are being migrated to Markdown, and any changes merged now will be lost. See the [migration guide](https://elastic.github.io/docs-builder/migration/freeze/index.html) for details.'
             })
+      - name: Error if .asciidoc files changed
+        if: steps.check-files.outputs.asciidoc_changed == 'true'
+        run: exit 1

--- a/.github/workflows/comment-on-asciidoc-changes.yml
+++ b/.github/workflows/comment-on-asciidoc-changes.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
+        with:
+          # This is considered a security risk when used in conjunction with pull_request_target
+          # However, we are not running any code from the PR, so it's safe
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Get changed files
         id: check-files

--- a/.github/workflows/comment-on-asciidoc-changes.yml
+++ b/.github/workflows/comment-on-asciidoc-changes.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           # This is considered a security risk when used in conjunction with pull_request_target
           # However, we are not running any code from the PR, so it's safe
+          # https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Get changed files


### PR DESCRIPTION
## Context

The current script relies on `fetch-depth: 0`. This causes a checkout time of ~5 minutes on kibana PRs.

## Changes

- Use https://github.com/tj-actions/changed-files instead of a custom script.
  - According to https://github.com/tj-actions/changed-files?tab=readme-ov-file#usage-, `fetch-depth: 0` is only needed for the `push` event and thus not needed for the `pull_request_event`
- Explicitly checkout the PR commit