### PR TITLE
Add support for single paragraph between code and list

### DIFF
--- a/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockHtmlRenderer.cs
+++ b/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockHtmlRenderer.cs
@@ -129,7 +129,13 @@ public class EnhancedCodeBlockHtmlRenderer : HtmlObjectRenderer<EnhancedCodeBloc
 			{
 				var siblingBlock = block.Parent[index + 1];
 				if (siblingBlock is not ListBlock)
-					block.EmitError("Code block with annotations is not followed by a list");
+				{
+					//allow one block of content in between
+					if (index + 2 <= (block.Parent!.Count - 1))
+						siblingBlock = block.Parent[index + 2];
+					if (siblingBlock is not ListBlock)
+						block.EmitError("Code block with annotations is not followed by a list");
+				}
 				if (siblingBlock is ListBlock l && l.Count < callOuts.Count)
 				{
 					block.EmitError(

--- a/tests/Elastic.Markdown.Tests/CodeBlocks/CallOutTests.cs
+++ b/tests/Elastic.Markdown.Tests/CodeBlocks/CallOutTests.cs
@@ -94,6 +94,64 @@ var z = y - 2; <2>
 		.And.OnlyContain(c => c.Message.StartsWith("Code block with annotations is not followed by a list"));
 }
 
+
+public class ClassicCallOutsFollowedByAListWithOneParagraph(ITestOutputHelper output) : CodeBlockCallOutTests(output, "csharp",
+"""
+var x = 1; <1>
+var y = x - 2;
+var z = y - 2; <2>
+""",
+"""
+
+**OUTPUT:**
+
+1. Marking the first callout
+2. Marking the second callout
+"""
+
+	)
+{
+	[Fact]
+	public void ParsesMagicCallOuts() => Block!.CallOuts
+		.Should().NotBeNullOrEmpty()
+		.And.HaveCount(2)
+		.And.OnlyContain(c => c.Text.StartsWith("<"));
+
+	[Fact]
+	public void AllowsAParagraphInBetween() => Collector.Diagnostics.Should().BeEmpty();
+}
+
+public class ClassicCallOutsFollowedByListButWithTwoParagraphs(ITestOutputHelper output) : CodeBlockCallOutTests(output, "csharp",
+"""
+var x = 1; <1>
+var y = x - 2;
+var z = y - 2; <2>
+""",
+"""
+
+**OUTPUT:**
+
+BLOCK TWO
+
+1. Marking the first callout
+2. Marking the second callout
+"""
+
+	)
+{
+	[Fact]
+	public void ParsesMagicCallOuts() => Block!.CallOuts
+		.Should().NotBeNullOrEmpty()
+		.And.HaveCount(2)
+		.And.OnlyContain(c => c.Text.StartsWith("<"));
+
+	[Fact]
+	public void RequiresContentToFollow() => Collector.Diagnostics.Should().HaveCount(1)
+		.And.OnlyContain(c => c.Message.StartsWith("Code block with annotations is not followed by a list"));
+}
+
+
+
 public class ClassicCallOutsFollowedByListWithWrongCoung(ITestOutputHelper output) : CodeBlockCallOutTests(output, "csharp",
 """
 var x = 1; <1>


### PR DESCRIPTION
Enhanced the logic to allow a single paragraph between annotated code blocks and a follow-up list. Added new test cases to confirm this behavior and ensure proper error handling for invalid cases.
