### PR TITLE
Normalize substitution keys to be case-insensitive.

### DIFF
--- a/src/Elastic.Markdown/Myst/ParserContext.cs
+++ b/src/Elastic.Markdown/Myst/ParserContext.cs
@@ -45,18 +45,18 @@ public class ParserContext : MarkdownParserContext
 		Configuration = configuration;
 
 		foreach (var (key, value) in configuration.Substitutions)
-			Properties[key] = value;
+			Properties[key.ToLowerInvariant()] = value;
 
 		if (frontMatter?.Properties is { } props)
 		{
-			foreach (var (key, value) in props)
+			foreach (var (k, value) in props)
 			{
+				var key = k.ToLowerInvariant();
 				if (configuration.Substitutions.TryGetValue(key, out _))
 					this.EmitError($"{{{key}}} can not be redeclared in front matter as its a global substitution");
 				else
 					Properties[key] = value;
 			}
-
 		}
 
 		if (frontMatter?.Title is { } title)

--- a/src/Elastic.Markdown/Myst/Substitution/SubstitutionParser.cs
+++ b/src/Elastic.Markdown/Myst/Substitution/SubstitutionParser.cs
@@ -137,7 +137,7 @@ public class SubstitutionParser : InlineParser
 		startPosition -= openSticks;
 		startPosition = Math.Max(startPosition, 0);
 
-		var key = content.ToString().Trim(['{', '}']);
+		var key = content.ToString().Trim(['{', '}']).ToLowerInvariant();
 		var found = false;
 		var replacement = string.Empty;
 		if (processor.Context?.Properties.TryGetValue(key, out var value) ?? false)


### PR DESCRIPTION
Substitution keys are now consistently converted to lowercase to ensure case-insensitive matching. This avoids potential mismatches caused by differing key casing in configurations and front matter.
