### PR TITLE
Add support for hidden files in documentation TOC

### DIFF
--- a/docs/configure/content-set/navigation.md
+++ b/docs/configure/content-set/navigation.md
@@ -73,15 +73,18 @@ toc:
   - file: index.md
 ```
 
-The table of contents can be created independent of the directory structure of the files it defines. You can use directories to define nesting in the TOC, but you don't have to. For example, both of the following create the same nav structure:
+The TOC in principle follows the directory structure on disk.
+
+#### `folder:`
 
 ```yaml
   ...
-  - file: subsection/index.md
-    children:
-      - file: subsection/page-one.md
-      - file: subsection/page-two.md
+  - folder: subsection
 ```
+
+If a folder does not explicitly define `children` all markdown files within that folder are included automatically 
+
+If a folder does define `children` all markdown files within that folder have to be included. `docs-builder` will error if it detects dangling documentation files.
 
 ```yaml
   ...
@@ -92,7 +95,33 @@ The table of contents can be created independent of the directory structure of t
       - file: page-two.md
 ```
 
-#### Nest `toc`
+#### Virtual grouping
+
+A `file` element may include children to create a virtual grouping that 
+does not match the directory structure. 
+
+```yaml
+  ...
+  - file: subsection/index.md
+    children:
+      - file: subsection/page-one.md
+      - file: subsection/page-two.md
+```
+
+A `file` may only select siblings and more deeply nested files as its children. It may not select files outside its own subtree on disk.
+
+#### Hidden files
+
+A hidden file can be declared in the TOC. 
+```yaml
+  - hidden: developer-pages.md
+```
+
+It may not have any children and won't show up in the navigation.
+
+It [may be linked to locally however](../../developer-notes.md)
+
+#### Nesting `toc`
 
 The `toc` key can include nested `toc.yml` files.
 
@@ -122,4 +151,6 @@ See [Attributes](./attributes.md) to learn more.
 
 As a rule, each `docset.yml` file can only be included once in the assembler. This prevents us from accidentally duplicating pages in the docs. However, there are times when you want to split content sets and include them partially in different areas of the TOC. That's what `toc.yml` files are for. These files split one documentation set into multiple “sub-TOCs,” each mapped to a different navigation node.
 
-All configuration options that `docset.yml` supports are supported by `toc.yml`.
+A `toc.yml` file may only declare a nested [TOC](#toc), other options are ignored. 
+
+A `toc.yml` may not link to further nested `toc.yml` files. Doing so will result in an error

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -1,0 +1,18 @@
+# These are developer notes
+
+Because this page is included as hidden:
+
+
+```yaml
+toc:
+  - file: index.md
+  - hidden: developer-notes.md
+```
+
+This page 
+
+- will not appear in the TOC navigation
+- will always include a `noindexed` meta header.
+
+
+This page **can** be linked to using [a regular link](developer-notes.md)

--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -24,6 +24,7 @@ subs:
   a-global-variable: "This was defined in docset.yml"
 toc:
   - file: index.md
+  - hidden: developer-notes.md
   - folder: contribute
     children:
       - file: index.md

--- a/src/Elastic.Markdown/IO/Configuration/ITocItem.cs
+++ b/src/Elastic.Markdown/IO/Configuration/ITocItem.cs
@@ -6,6 +6,6 @@ namespace Elastic.Markdown.IO.Configuration;
 
 public interface ITocItem;
 
-public record FileReference(string Path, bool Found, IReadOnlyCollection<ITocItem> Children) : ITocItem;
+public record FileReference(string Path, bool Found, bool Hidden, IReadOnlyCollection<ITocItem> Children) : ITocItem;
 
 public record FolderReference(string Path, bool Found, IReadOnlyCollection<ITocItem> Children) : ITocItem;

--- a/src/Elastic.Markdown/IO/DocumentationSet.cs
+++ b/src/Elastic.Markdown/IO/DocumentationSet.cs
@@ -92,6 +92,39 @@ public class DocumentationSet
 		return null;
 	}
 
+	public MarkdownFile? GetPrevious(MarkdownFile current)
+	{
+		var index = current.NavigationIndex;
+		do
+		{
+			var previous = MarkdownFiles.GetValueOrDefault(index - 1);
+			if (previous is null)
+				return null;
+			if (!previous.Hidden)
+				return previous;
+			index--;
+		} while (index > 0);
+
+		return null;
+	}
+
+	public MarkdownFile? GetNext(MarkdownFile current)
+	{
+		var index = current.NavigationIndex;
+		do
+		{
+			var previous = MarkdownFiles.GetValueOrDefault(index + 1);
+			if (previous is null)
+				return null;
+			if (!previous.Hidden)
+				return previous;
+			index++;
+		} while (index <= MarkdownFiles.Count - 1);
+
+		return null;
+	}
+
+
 	public async Task ResolveDirectoryTree(Cancel ctx) =>
 		await Tree.Resolve(ctx);
 

--- a/src/Elastic.Markdown/IO/MarkdownFile.cs
+++ b/src/Elastic.Markdown/IO/MarkdownFile.cs
@@ -39,6 +39,7 @@ public record MarkdownFile : DocumentationFile
 		set => _parent = value;
 	}
 
+	public bool Hidden { get; internal set; }
 	public string? UrlPathPrefix { get; }
 	private MarkdownParser MarkdownParser { get; }
 	public YamlFrontMatter? YamlFrontMatter { get; private set; }

--- a/src/Elastic.Markdown/IO/State/LinkReference.cs
+++ b/src/Elastic.Markdown/IO/State/LinkReference.cs
@@ -12,6 +12,10 @@ public record LinkMetadata
 	[JsonPropertyName("anchors")]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public required string[]? Anchors { get; init; } = [];
+
+	[JsonPropertyName("hidden")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+	public required bool Hidden { get; init; }
 }
 
 public record LinkReference
@@ -33,11 +37,11 @@ public record LinkReference
 	{
 		var crossLinks = set.Context.Collector.CrossLinks.ToHashSet().ToArray();
 		var links = set.MarkdownFiles.Values
-			.Select(m => (m.RelativePath, m.Anchors))
+			.Select(m => (m.RelativePath, File: m))
 			.ToDictionary(k => k.RelativePath, v =>
 			{
-				var anchors = v.Anchors.Count == 0 ? null : v.Anchors.ToArray();
-				return new LinkMetadata { Anchors = anchors };
+				var anchors = v.File.Anchors.Count == 0 ? null : v.File.Anchors.ToArray();
+				return new LinkMetadata { Anchors = anchors, Hidden = v.File.Hidden };
 			});
 		return new LinkReference
 		{

--- a/src/Elastic.Markdown/Slices/HtmlWriter.cs
+++ b/src/Elastic.Markdown/Slices/HtmlWriter.cs
@@ -45,8 +45,8 @@ public class HtmlWriter
 		await DocumentationSet.Tree.Resolve(ctx);
 		var navigationHtml = await RenderNavigation(markdown, ctx);
 
-		var previous = DocumentationSet.MarkdownFiles.GetValueOrDefault(markdown.NavigationIndex - 1);
-		var next = DocumentationSet.MarkdownFiles.GetValueOrDefault(markdown.NavigationIndex + 1);
+		var previous = DocumentationSet.GetPrevious(markdown);
+		var next = DocumentationSet.GetNext(markdown);
 
 		var remote = DocumentationSet.Context.Git.RepositoryName;
 		var branch = DocumentationSet.Context.Git.Branch;
@@ -67,7 +67,7 @@ public class HtmlWriter
 			UrlPathPrefix = markdown.UrlPathPrefix,
 			Applies = markdown.YamlFrontMatter?.AppliesTo,
 			GithubEditUrl = editUrl,
-			AllowIndexing = DocumentationSet.Context.AllowIndexing
+			AllowIndexing = DocumentationSet.Context.AllowIndexing && !markdown.Hidden
 		});
 		return await slice.RenderAsync(cancellationToken: ctx);
 	}

--- a/src/Elastic.Markdown/Slices/Layout/_TocTree.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_TocTree.cshtml
@@ -6,7 +6,7 @@
 				<p class="caption" role="heading" aria-level="3">
 					<span class="caption-text">Elastic Docs Guide</span>
 				</p>
-				<ul class="current">@await RenderPartialAsync(Elastic.Markdown.Slices.Layout._TocTreeNav.Create(new NavigationTreeItem
+				<ul class="current">@await RenderPartialAsync(_TocTreeNav.Create(new NavigationTreeItem
 					{
 						Level = Model.Tree.Depth,
 						SubTree = Model.Tree,


### PR DESCRIPTION
Hidden files can now be excluded from navigation and indexing but still linked directly if needed. Adjustments include handling hidden attributes in TOC parsing and ensuring related navigation logic respects these exclusions.

Hidden pages can be included just as you would any `file` in the TOC. 

```
   hidden: my-page.md
```

* Still only one place to configure files. 
* Participates in dangling documentation detection
* Is picked up as a `MarkdownFile` in our codebase like any other.
* Includes a hidden flag so that we:
  * Never render it in any navigation item.
  * Always include a noindex header.
  * Advertise it as hidden in links.json artifact.



https://github.com/user-attachments/assets/f6d0f4ed-0d60-4ac8-8718-0867437e9359


