### PR TITLE
Fix root links

### DIFF
--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -149,9 +149,9 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 		if (url.EndsWith(".md"))
 			link.Url = Path.ChangeExtension(url, ".html");
 		// rooted links might need the configured path prefix to properly link
-		var prefix = processor.GetBuildContext().UrlPathPrefix.TrimEnd('/');
+		var prefix = processor.GetBuildContext().UrlPathPrefix;
 		if (url.StartsWith("/") && !string.IsNullOrWhiteSpace(prefix))
-			link.Url = $"{prefix}/{link.Url}";
+			link.Url = $"{prefix}{link.Url}";
 
 		if (!string.IsNullOrEmpty(anchor))
 			link.Url += $"#{anchor}";

--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -151,7 +151,7 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 		// rooted links might need the configured path prefix to properly link
 		var prefix = processor.GetBuildContext().UrlPathPrefix;
 		if (url.StartsWith("/") && !string.IsNullOrWhiteSpace(prefix))
-			link.Url = $"{prefix.TrimEnd('/')}{link.Url}";
+			link.Url = $"{prefix.TrimEnd('/')}/{link.Url}";
 
 		if (!string.IsNullOrEmpty(anchor))
 			link.Url += $"#{anchor}";

--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -149,7 +149,7 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 		if (url.EndsWith(".md"))
 			link.Url = Path.ChangeExtension(url, ".html");
 		// rooted links might need the configured path prefix to properly link
-		var prefix = processor.GetBuildContext().UrlPathPrefix;
+		var prefix = processor.GetBuildContext().UrlPathPrefix.TrimEnd('/');
 		if (url.StartsWith("/") && !string.IsNullOrWhiteSpace(prefix))
 			link.Url = $"{prefix}/{link.Url}";
 

--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -151,7 +151,7 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 		// rooted links might need the configured path prefix to properly link
 		var prefix = processor.GetBuildContext().UrlPathPrefix;
 		if (url.StartsWith("/") && !string.IsNullOrWhiteSpace(prefix))
-			link.Url = $"{prefix}{link.Url}";
+			link.Url = $"{prefix.TrimEnd('/')}{link.Url}";
 
 		if (!string.IsNullOrEmpty(anchor))
 			link.Url += $"#{anchor}";


### PR DESCRIPTION
## Context

Absolute links (Rooted links?) to markdown files e.g. `/path/to/markdown.md` are broken (double slash `//` between path and prefix)  on deployed documentation if the `--path-prefix` option is set. 

Currently, 

## Changes

Remove the extra `/`