### PR TITLE
Add support for image sizing via titles in markdown

### DIFF
--- a/docs/syntax/images.md
+++ b/docs/syntax/images.md
@@ -39,10 +39,49 @@ Or, use the `image` directive.
 ## Inline images
 
 ```markdown
-Here is the same image used inline ![Elasticsearch](img/observability.png)
+Here is the same image used inline ![Elasticsearch](img/observability.png "elasticsearch =50%x50%")
 ```
 
-Here is the same image used inline ![Elasticsearch](img/observability.png)
+Here is the same image used inline ![Elasticsearch](img/observability.png "elasticsearch =50%x50%")
+
+
+### Inline image titles
+
+Titles are optional making this the minimal syntax required
+
+```markdown
+![Elasticsearch](img/observability.png)
+```
+
+Including a title can be done by supplying it as an optional argument.
+
+```markdown
+![Elasticsearch](img/observability.png "elasticsearch")
+```
+
+### Inline image sizing
+
+Inline images are supplied at the end through the title argument.
+
+This is done to maintain maximum compatibility with markdown parsers
+and previewers. 
+
+```markdown
+![alt](img.png "title =WxH")
+![alt](img.png "title =W")
+```
+
+`W` and `H` can be either an absolute number in pixels or a number followed by `%` to indicate relative sizing.
+
+If `H` is omitted `W` is used as the height as well.
+
+```markdown
+![alt](img.png "title =250x330")
+![alt](img.png "title =50%x40%")
+![alt](img.png "title =50%")
+```
+
+
 
 ### SVG 
 

--- a/tests/authoring/Inline/InlineImages.fs
+++ b/tests/authoring/Inline/InlineImages.fs
@@ -28,3 +28,46 @@ type ``relative path to image`` () =
         markdown |> convertsToHtml """
             <p><img src="_static/img/observability.png" alt="Elasticsearch" /></p>
         """
+
+type ``supplying a tittle`` () =
+    static let markdown = Setup.Markdown """
+![Elasticsearch](_static/img/observability.png "Hello world")
+"""
+
+    [<Fact>]
+    let ``validate HTML: includes title`` () =
+        markdown |> convertsToHtml """
+            <p><img src="_static/img/observability.png" alt="Elasticsearch" title="Hello world" /></p>
+        """
+
+type ``supplying a tittle with width and height`` () =
+    static let markdown = Setup.Markdown """
+![o](obs.png "Title =250x400")
+"""
+
+    [<Fact>]
+    let ``validate HTML: does not include width and height in title`` () =
+        markdown |> convertsToHtml """
+            <p><img src="obs.png" width="250px" height="400px" alt="o" title="Title"/></p>
+        """
+
+type ``supplying a tittle with width and height in percentage`` () =
+    static let markdown = Setup.Markdown """
+![o](obs.png "Title =50%x40%")
+"""
+
+    [<Fact>]
+    let ``validate HTML: does not include width and height in title`` () =
+        markdown |> convertsToHtml """
+            <p><img src="obs.png" width="50%" height="40%" alt="o" title="Title"/></p>
+        """
+type ``supplying a tittle with width only`` () =
+    static let markdown = Setup.Markdown """
+![o](obs.png "Title =30%")
+"""
+
+    [<Fact>]
+    let ``validate HTML: sets height to width if not supplied`` () =
+        markdown |> convertsToHtml """
+            <p><img src="obs.png" width="30%" height="30%" alt="o" title="Title"/></p>
+        """


### PR DESCRIPTION
Introduced a feature to parse width and height from image titles using a regex pattern. Updated the markdown parser, tests, and docs to support and demonstrate inline image resizing with syntax like `=WxH` or `=W`. If height is omitted, it defaults to the width value.


See also the updated docs: https://docs-v3-preview.elastic.dev/elastic/docs-builder/pull/398/syntax/images.html#inline-images
