### PR TITLE
New "safe" preview deployment workflows

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,7 +42,3 @@ jobs:
           path: .artifacts/publish/docs-builder/release/docs-builder
           if-no-files-found: error
           retention-days: 1
-
-  preview:
-    needs: build
-    uses: ./.github/workflows/preview.yml

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -1,0 +1,57 @@
+name: preview-build
+
+on:
+  pull_request: ~
+  workflow_call:
+    inputs:
+      strict:
+        description: 'Treat warnings as errors'
+        type: boolean
+        default: true
+      continue-on-error:
+        description: 'Do not fail to publish if build fails'
+        type: boolean
+        required: false
+        default: true
+
+permissions: 
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Bootstrap Action Workspace
+        if: github.repository == 'elastic/docs-builder'
+        uses: ./.github/actions/bootstrap
+
+      # we run our artifact directly please use the prebuild
+      # elastic/docs-builder@main GitHub Action for all other repositories!
+      - name: Build documentation
+        if: github.repository == 'elastic/docs-builder'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          dotnet run --project src/docs-builder -- --strict --path-prefix "/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}"
+
+      - name: Build documentation
+        if: github.repository != 'elastic/docs-builder'
+        uses: elastic/docs-builder@main
+        continue-on-error: true
+        with:
+          prefix: "/${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
+          strict: true
+      - name: Add pull request number to build
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_REF: ${{ github.event.pull_request.head.sha }}
+        run: |
+          echo "${PR_NUMBER}" >> .artifacts/docs/html/pull_request_number.txt
+          echo "${PR_REF}" >> .artifacts/docs/html/pull_request_ref.txt
+      - uses: actions/upload-artifact@v4
+        with:
+          name: docs
+          path: .artifacts/docs/html/

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -6,15 +6,14 @@ on:
     types: [closed]
 
 permissions:
+  contents: none
   deployments: write
   id-token: write
-  contents: read
 
 jobs:
   destroy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
       - uses: elastic/docs-builder/.github/actions/aws-auth@main
       - name: Delete s3 objects
         env:
@@ -46,6 +45,3 @@ jobs:
                 deployment_id: deployment.id
               });
             }
-
-    
-            

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,0 +1,79 @@
+name: preview-deploy
+
+on:
+  workflow_call: ~
+  workflow_run:
+    workflows: [preview-build]
+    types:
+      - completed
+
+permissions:
+  contents: none
+  id-token: write
+  deployments: write
+  actions: read
+
+jobs:
+  docs-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download docs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh run download ${{ github.event.workflow_run.id }} --name docs --repo "${GITHUB_REPOSITORY}"
+      - name: Get PR data
+        id: pull_request
+        run: |
+          echo "number=$(cat pull_request_number.txt)" >> "${GITHUB_OUTPUT}"
+          echo "ref=$(cat pull_request_ref.txt)" >> "${GITHUB_OUTPUT}"
+
+      - name: Create Deployment
+        uses: actions/github-script@v7
+        id: deployment
+        env:
+          PR_NUMBER: ${{ steps.pull_request.outputs.number }}
+          PR_REF: ${{ steps.pull_request.outputs.ref }}
+        with:
+          result-encoding: string
+          script: |
+            const { owner, repo } = context.repo;
+            const deployment = await github.rest.repos.createDeployment({
+                owner,
+                repo,
+                ref: process.env.PR_REF,
+                environment: `docs-preview-${process.env.PR_NUMBER}`,
+                auto_merge: false,
+                required_contexts: [],
+            })
+            await github.rest.repos.createDeploymentStatus({
+                deployment_id: deployment.data.id,
+                owner,
+                repo,
+                state: "in_progress",
+                log_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            })
+            return deployment.data.id
+
+      - uses: elastic/docs-builder/.github/actions/aws-auth@main
+
+      - name: Upload to S3
+        env:
+          PR_NUMBER: ${{ steps.pull_request.outputs.number }}
+        run: |
+          aws s3 sync . "s3://elastic-docs-v3-website-preview/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}" --delete --exclude "pull_request_number.txt"
+          aws cloudfront create-invalidation --distribution-id EKT7LT5PM8RKS --paths "/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}/*"
+
+      - name: Update deployment status
+        uses: actions/github-script@v7
+        if: always() && steps.deployment.outputs.result
+        with:
+          script: |
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: ${{ steps.deployment.outputs.result }},
+              state: "${{ job.status == 'success' && 'success' || 'failure' }}",
+              environment_url: `https://docs-v3-preview.elastic.dev/${context.repo.owner}/${context.repo.repo}/pull/${{ steps.pull_request.outputs.number}}`,
+              log_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            })


### PR DESCRIPTION
## Context

The current preview deployment workflow required `pull_request_target` to be able to deploy PRs from forks.

Using `pull_request_target` in conjunction with checking out the fork is considered a security risk.

## Changes

This introduces a workflow setup that requires three workflows. 
1. A workflow that builds the docs using the `pull_request` event and uploads it as artifacts
2. A workflow that downloads the artifacts and deploys the docs to the preview environment using the `workflow_run` event
3. A workflow that destroys the destroys the preview environment using the `pull_request_target` event (but without a **checkout** step)

This way untrusted code will never be checked out.

