### PR TITLE
Fix extra whitespace in code block

### DIFF
--- a/src/Elastic.Markdown/Slices/Directives/Code.cshtml
+++ b/src/Elastic.Markdown/Slices/Directives/Code.cshtml
@@ -8,12 +8,6 @@
 				<a class="headerlink" href="@Model.CrossReferenceName" title="Link to this code">¶</a>
 			</div>
 		}
-		<pre>
-		@if (!string.IsNullOrEmpty(Model.ApiCallHeader))
-		{
-			<code class="language-apiheader">@Model.ApiCallHeader</code>
-		}
-			[CONTENT]
-		</pre>
+		<pre>@if (!string.IsNullOrEmpty(Model.ApiCallHeader)) { <code class="language-apiheader">@Model.ApiCallHeader</code> }[CONTENT]</pre>
 	</div>
 </div>


### PR DESCRIPTION
## Context

To reproduce, go to https://elastic.github.io/docs-builder/syntax/code.html#asciidoc-syntax
and copy the code using the copy button on the top-right corner.

If you paste the code somewhere, it will show like this (first line has extra whitespaces)

```
			[source,sh]
--------------------------------------------------
GET _tasks
GET _tasks?nodes=nodeId1,nodeId2
GET _tasks?nodes=nodeId1,nodeId2&actions=cluster:*
--------------------------------------------------
```

## Changes

Fix the template to not add extra white space to the code block.

## How to test

Open https://docs-v3-preview.elastic.dev/elastic/docs-builder/pull/410/syntax/code.html and copy any code block and paste it somewhere.
