### PR TITLE
Add path-pattern input to preview-build.yml workflow

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -32,7 +32,6 @@ jobs:
         id: check-files
         uses: tj-actions/changed-files@d6e91a2266cdb9d62096cebf1e8546899c6aa18f # v45.0.6
         with:
-          since_last_remote_commit: true
           files: ${{ inputs.path-pattern != '' && inputs.path-pattern || '**' }}
             
       - name: Checkout

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -32,6 +32,7 @@ jobs:
         id: check-files
         uses: tj-actions/changed-files@d6e91a2266cdb9d62096cebf1e8546899c6aa18f # v45.0.6
         with:
+          since_last_remote_commit: true
           files: ${{ inputs.path-pattern != '' && inputs.path-pattern || '**' }}
             
       - name: Checkout

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -13,6 +13,11 @@ on:
         type: string
         required: false
         default: 'true'
+      path-pattern:
+        description: 'Path pattern to filter files. Only if changed files match the pattern, the workflow will continue.'
+        type: string
+        default: '**'
+        required: false
 
 permissions: 
   contents: read
@@ -21,7 +26,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+
+      - name: Get changed files
+        id: check-files
+        uses: tj-actions/changed-files@d6e91a2266cdb9d62096cebf1e8546899c6aa18f # v45.0.6
+        with:
+          files: ${{ inputs.path-pattern != '' && inputs.path-pattern || '**' }}
+            
       - name: Checkout
+        if: steps.check-files.outputs.any_changed == 'true'
         uses: actions/checkout@v4
         with: 
           persist-credentials: false
@@ -30,11 +43,13 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_REF: ${{ github.event.pull_request.head.sha }}
+          ANY_CHANGED: ${{ steps.check-files.outputs.any_changed }}
         run: |
           cat << EOF > pull_request.json
           {
             "number": ${PR_NUMBER},
-            "ref": "${PR_REF}"
+            "ref": "${PR_REF}",
+            "any_changed": ${ANY_CHANGED}"
           }
           EOF
       
@@ -48,26 +63,28 @@ jobs:
           compression-level: 1
 
       - name: Bootstrap Action Workspace
-        if: github.repository == 'elastic/docs-builder'
+        if: github.repository == 'elastic/docs-builder' && steps.check-files.outputs.any_changed == 'true'
         uses: ./.github/actions/bootstrap
 
       # we run our artifact directly please use the prebuild
       # elastic/docs-builder@main GitHub Action for all other repositories!
       - name: Build documentation
-        if: github.repository == 'elastic/docs-builder'
+        if: github.repository == 'elastic/docs-builder' && steps.check-files.outputs.any_changed == 'true'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           dotnet run --project src/docs-builder -- --strict --path-prefix "/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}"
 
       - name: Build documentation
-        if: github.repository != 'elastic/docs-builder'
+        if: github.repository != 'elastic/docs-builder' && steps.check-files.outputs.any_changed == 'true'
         uses: elastic/docs-builder@main
         continue-on-error: ${{ fromJSON(inputs.continue-on-error != '' && inputs.continue-on-error || 'false') }}
         with:
           prefix: "/${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
           strict: ${{ fromJSON(inputs.strict != '' && inputs.strict || 'true') }}
+
       - uses: actions/upload-artifact@v4
+        if: steps.check-files.outputs.any_changed == 'true'
         with:
           name: docs
           path: .artifacts/docs/html/

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -21,6 +21,7 @@ on:
 
 permissions: 
   contents: read
+  pull-requests: read
 
 jobs:
   build:

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -49,7 +49,7 @@ jobs:
           {
             "number": ${PR_NUMBER},
             "ref": "${PR_REF}",
-            "any_changed": ${ANY_CHANGED}"
+            "any_changed": ${ANY_CHANGED}
           }
           EOF
       

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -14,15 +14,9 @@ jobs:
   destroy:
     runs-on: ubuntu-latest
     steps:
-      - uses: elastic/docs-builder/.github/actions/aws-auth@main
-      - name: Delete s3 objects
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-            aws s3 rm "s3://elastic-docs-v3-website-preview/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}" --recursive
-
       - name: Delete GitHub environment
         uses: actions/github-script@v7
+        id: delete-deployment
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -31,6 +25,7 @@ jobs:
               repo,
               environment: `docs-preview-${context.issue.number}`
             });
+            core.setOutput('is-empty', deployments.data.length === 0)
             for (const deployment of deployments.data) {
               await github.rest.repos.createDeploymentStatus({
                 owner,
@@ -45,3 +40,13 @@ jobs:
                 deployment_id: deployment.id
               });
             }
+
+      - uses: elastic/docs-builder/.github/actions/aws-auth@main
+        if: steps.delete-deployment.outputs.is-empty == 'false'
+
+      - name: Delete s3 objects
+        if: steps.delete-deployment.outputs.is-empty == 'false'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          aws s3 rm "s3://elastic-docs-v3-website-preview/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}" --recursive

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -14,7 +14,7 @@ permissions:
   actions: read
 
 jobs:
-  docs-deploy:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Download PR data
@@ -30,9 +30,11 @@ jobs:
           {
             echo "number=$(jq -r '.number' pull_request.json)"
             echo "ref=$(jq -r '.ref' pull_request.json)"
+            echo "any_changed=$(jq -r '.any_changed' pull_request.json)"
           } >> "${GITHUB_OUTPUT}"
 
       - name: Create Deployment
+        if: steps.pull_request.outputs.any_changed == 'true'
         uses: actions/github-script@v7
         id: deployment
         env:
@@ -60,6 +62,7 @@ jobs:
             return deployment.data.id
             
       - name: Download docs
+        if: steps.pull_request.outputs.any_changed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -69,8 +72,10 @@ jobs:
             --dir html
 
       - uses: elastic/docs-builder/.github/actions/aws-auth@main
+        if: steps.pull_request.outputs.any_changed == 'true'
 
       - name: Upload to S3
+        if: steps.pull_request.outputs.any_changed == 'true'
         env:
           PR_NUMBER: ${{ steps.pull_request.outputs.number }}
         run: |

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -14,9 +14,13 @@ permissions:
   actions: read
 
 jobs:
-  deploy:
+  pull-request-data:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
+    outputs: 
+      number: ${{ steps.pull_request.outputs.number }}
+      ref: ${{ steps.pull_request.outputs.ref }}
+      any_changed: ${{ steps.pull_request.outputs.any_changed }}
     steps:
       - name: Download PR data
         env:
@@ -33,14 +37,21 @@ jobs:
             echo "ref=$(jq -r '.ref' pull_request.json)"
             echo "any_changed=$(jq -r '.any_changed' pull_request.json)"
           } >> "${GITHUB_OUTPUT}"
-
+    
+  deploy:
+    needs: pull-request-data
+    runs-on: ubuntu-latest
+    concurrency: 
+      group: ${{ github.workflow }}-${{ needs.pull-request-data.outputs.number }}
+      cancel-in-progress: true
+    steps:
       - name: Create Deployment
-        if: steps.pull_request.outputs.any_changed == 'true'
+        if: needs.pull-request-data.outputs.any_changed == 'true'
         uses: actions/github-script@v7
         id: deployment
         env:
-          PR_NUMBER: ${{ steps.pull_request.outputs.number }}
-          PR_REF: ${{ steps.pull_request.outputs.ref }}
+          PR_NUMBER: ${{ needs.pull-request-data.outputs.number }}
+          PR_REF: ${{ needs.pull-request-data.outputs.ref }}
         with:
           result-encoding: string
           script: |
@@ -63,7 +74,7 @@ jobs:
             return deployment.data.id
             
       - name: Download docs
-        if: steps.pull_request.outputs.any_changed == 'true'
+        if:  needs.pull-request-data.outputs.any_changed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -73,12 +84,12 @@ jobs:
             --dir html
 
       - uses: elastic/docs-builder/.github/actions/aws-auth@main
-        if: steps.pull_request.outputs.any_changed == 'true'
+        if: needs.pull-request-data.outputs.any_changed == 'true'
 
       - name: Upload to S3
-        if: steps.pull_request.outputs.any_changed == 'true'
+        if: needs.pull-request-data.outputs.any_changed == 'true'
         env:
-          PR_NUMBER: ${{ steps.pull_request.outputs.number }}
+          PR_NUMBER: ${{ needs.pull-request-data.outputs.number }}
         run: |
           aws s3 sync ./html "s3://elastic-docs-v3-website-preview/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}" --delete
           aws cloudfront create-invalidation --distribution-id EKT7LT5PM8RKS --paths "/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}/*"
@@ -93,6 +104,6 @@ jobs:
               repo: context.repo.repo,
               deployment_id: ${{ steps.deployment.outputs.result }},
               state: "${{ job.status == 'success' && 'success' || 'failure' }}",
-              environment_url: `https://docs-v3-preview.elastic.dev/${context.repo.owner}/${context.repo.repo}/pull/${{ steps.pull_request.outputs.number}}`,
+              environment_url: `https://docs-v3-preview.elastic.dev/${context.repo.owner}/${context.repo.repo}/pull/${{  needs.pull-request-data.outputs.number}}`,
               log_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
             })

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -94,6 +94,8 @@ jobs:
       - name: Update deployment status
         uses: actions/github-script@v7
         if: always() && steps.deployment.outputs.result
+        env:
+          PR_NUMBER: ${{ needs.pull-request-data.outputs.number }}
         with:
           script: |
             await github.rest.repos.createDeploymentStatus({
@@ -101,6 +103,6 @@ jobs:
               repo: context.repo.repo,
               deployment_id: ${{ steps.deployment.outputs.result }},
               state: "${{ job.status == 'success' && 'success' || 'failure' }}",
-              environment_url: `https://docs-v3-preview.elastic.dev/${context.repo.owner}/${context.repo.repo}/pull/${{  needs.pull-request-data.outputs.number}}`,
+              environment_url: `https://docs-v3-preview.elastic.dev/${context.repo.owner}/${context.repo.repo}/pull/${process.env.PR_NUMBER}`,
               log_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
             })

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -40,13 +40,13 @@ jobs:
     
   deploy:
     needs: pull-request-data
+    if: needs.pull-request-data.outputs.any_changed == 'true'
     runs-on: ubuntu-latest
     concurrency: 
       group: ${{ github.workflow }}-${{ needs.pull-request-data.outputs.number }}
       cancel-in-progress: true
     steps:
       - name: Create Deployment
-        if: needs.pull-request-data.outputs.any_changed == 'true'
         uses: actions/github-script@v7
         id: deployment
         env:
@@ -74,7 +74,6 @@ jobs:
             return deployment.data.id
             
       - name: Download docs
-        if:  needs.pull-request-data.outputs.any_changed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -84,10 +83,8 @@ jobs:
             --dir html
 
       - uses: elastic/docs-builder/.github/actions/aws-auth@main
-        if: needs.pull-request-data.outputs.any_changed == 'true'
 
       - name: Upload to S3
-        if: needs.pull-request-data.outputs.any_changed == 'true'
         env:
           PR_NUMBER: ${{ needs.pull-request-data.outputs.number }}
         run: |

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Download PR data


### PR DESCRIPTION
## Changes

- Add `path-pattern` input for the preview-build workflow
- Run build and deployment only if the path-pattern matches

## Details

This means a PR to the repository will only build and deploy the documentation if there are changes to the docs (assuming the pattern matches). But repo owners can still set the commit status as required status check, because it will still be green.