### PR TITLE
Fix lists continuations.

### DIFF
--- a/docs/syntax/applies.md
+++ b/docs/syntax/applies.md
@@ -52,9 +52,7 @@ Are equivalent, note `all` just means we won't be rendering the version portion 
 ## This section has its own applies annotations [#sections]
 
 :::{applies}
-:stack: unavailable
-:serverless: tech-preview
-:cloud: ga
+:serverless: unavailable
 :::
 
 :::{note}

--- a/src/Elastic.Markdown/Myst/Comments/CommentBlockParser.cs
+++ b/src/Elastic.Markdown/Myst/Comments/CommentBlockParser.cs
@@ -155,7 +155,7 @@ public class CommentBlockParser : BlockParser
 	{
 		if (!processor.TrackTrivia)
 		{
-			var heading = (HeadingBlock)block;
+			var heading = (CommentBlock)block;
 			heading.Lines.Trim();
 		}
 

--- a/src/Elastic.Markdown/Myst/MarkdownParser.cs
+++ b/src/Elastic.Markdown/Myst/MarkdownParser.cs
@@ -60,7 +60,6 @@ public class MarkdownParser(
 				return _pipeline;
 
 			var builder = new MarkdownPipelineBuilder()
-				.EnableTrackTrivia()
 				.UseInlineAnchors()
 				.UsePreciseSourceLocation()
 				.UseDiagnosticLinks()

--- a/tests/Elastic.Markdown.Tests/Directives/AdmonitionTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/AdmonitionTests.cs
@@ -203,10 +203,10 @@ public class DirectiveInList(ITestOutputHelper output) : DirectiveTest<Admonitio
 
 	[Fact]
 	public void Render() => Html.Should().Contain("""
-	                                              <li> List Item 1
+	                                              <li>List Item 1
 	                                              <div class="admonition note">
 	                                              	<p class="admonition-title">Note</p>
-	                                              	  Hello, World!
+	                                              	Hello, World!
 	                                              </div>
 	                                              </li>
 	                                              """);

--- a/tests/Elastic.Markdown.Tests/Directives/AdmonitionTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/AdmonitionTests.cs
@@ -120,7 +120,7 @@ public class NestedDirectiveWithListTests(ITestOutputHelper output) : DirectiveT
 {
 	[Fact]
 	public void Render() => Html.Should().Contain("""
-	                                              <li> List Item 1
+	                                              <li>List Item 1
 	                                              <div class="admonition note">
 	                                              	<p class="admonition-title">Note</p>
 	                                              	Hello, World!

--- a/tests/Elastic.Markdown.Tests/Directives/AdmonitionTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/AdmonitionTests.cs
@@ -123,7 +123,7 @@ public class NestedDirectiveWithListTests(ITestOutputHelper output) : DirectiveT
 	                                              <li> List Item 1
 	                                              <div class="admonition note">
 	                                              	<p class="admonition-title">Note</p>
-	                                              	  Hello, World!
+	                                              	Hello, World!
 	                                              </div>
 	                                              </li>
 	                                              """);
@@ -152,7 +152,7 @@ public class NestedDirectiveWithListTests2(ITestOutputHelper output) : Directive
 	                                              <li> List Item 1
 	                                              <div class="admonition note">
 	                                              	<p class="admonition-title">Note</p>
-	                                              	  Hello, World!
+	                                              	Hello, World!
 	                                              </div>
 	                                              </li>
 	                                              """);
@@ -180,7 +180,7 @@ public class NestedDirectiveWithListTests3(ITestOutputHelper output) : Directive
 	                                              <li> List Item 1
 	                                              <div class="admonition note">
 	                                              	<p class="admonition-title">Note</p>
-	                                              	  Hello, World!
+	                                              	Hello, World!
 	                                              </div>
 	                                              </li>
 	                                              """);

--- a/tests/Elastic.Markdown.Tests/Directives/AdmonitionTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/AdmonitionTests.cs
@@ -149,7 +149,7 @@ public class NestedDirectiveWithListTests2(ITestOutputHelper output) : Directive
 {
 	[Fact]
 	public void Render() => Html.Should().Contain("""
-	                                              <li> List Item 1
+	                                              <li>List Item 1
 	                                              <div class="admonition note">
 	                                              	<p class="admonition-title">Note</p>
 	                                              	Hello, World!
@@ -177,7 +177,7 @@ public class NestedDirectiveWithListTests3(ITestOutputHelper output) : Directive
 {
 	[Fact]
 	public void Render() => Html.Should().Contain("""
-	                                              <li> List Item 1
+	                                              <li>List Item 1
 	                                              <div class="admonition note">
 	                                              	<p class="admonition-title">Note</p>
 	                                              	Hello, World!

--- a/tests/Elastic.Markdown.Tests/Inline/InlineAnchorTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/InlineAnchorTests.cs
@@ -132,7 +132,7 @@ public class ExplicitSlugInHeader(ITestOutputHelper output) : BlockTest<HeadingB
 		// language=html
 		Html.Should().Be(
 			"""
-			<section id="my-anchor"><h2>Hello world <a class="headerlink" href="#my-anchor" title="Link to this heading">¶</a>
+			<section id="my-anchor"><h2>Hello world<a class="headerlink" href="#my-anchor" title="Link to this heading">¶</a>
 			</h2>
 			</section>
 			""".TrimEnd()

--- a/tests/Elastic.Markdown.Tests/Inline/InlineLinkTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/InlineLinkTests.cs
@@ -225,10 +225,10 @@ public class CommentedNonExistingLinks2(ITestOutputHelper output) : LinkTestBase
 		Html.TrimEnd().Should().Be("""
 		<p>Links:</p>
 		<ul>
-		<li> <a href="/testing/req.html">Special Requirements</a></li>
+		<li><a href="/testing/req.html">Special Requirements</a></li>
 		</ul>
 		<ul>
-		<li> <a href="/testing/req.html">Special Requirements</a></li>
+		<li><a href="/testing/req.html">Special Requirements</a></li>
 		</ul>
 		""");
 

--- a/tests/authoring/Blocks/Lists.fs
+++ b/tests/authoring/Blocks/Lists.fs
@@ -1,4 +1,7 @@
-module ``block elements``.``lists``
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+module ``block elements``.``list elements``
 
 open Xunit
 open authoring

--- a/tests/authoring/Blocks/Lists.fs
+++ b/tests/authoring/Blocks/Lists.fs
@@ -1,0 +1,27 @@
+module ``block elements``.``lists``
+
+open Xunit
+open authoring
+
+type ``supports loose lists`` () =
+    static let markdown = Setup.Markdown """
+* **Consumption-based billing**:
+
+   You pay for the actual product used, regardless of the application or use case. This is different from subscription-based billing models where customers pay a flat fee restricted by usage quotas, or one-time upfront payment billing models such as those used for on-prem software licenses.
+
+   You can purchase credits for a single or multi-year contract. Consumption is on demand, and every month we deduct from your balance based on your usage and contract terms. This allows you to seamlessly expand your usage to the full extent of your requirements and available budget, without any quotas or restrictions.
+"""
+
+    [<Fact>]
+    let ``validate HTML: adds paragraphs`` () =
+        markdown |> convertsToHtml """
+        <ul>
+            <li>
+                <p>
+                    <strong>Consumption-based billing</strong>:</p>
+                <p>You pay for the actual product used, regardless of the application or use case. This is different from subscription-based billing models where customers pay a flat fee restricted by usage quotas, or one-time upfront payment billing models such as those used for on-prem software licenses.</p>
+                <p>You can purchase credits for a single or multi-year contract. Consumption is on demand, and every month we deduct from your balance based on your usage and contract terms. This allows you to seamlessly expand your usage to the full extent of your requirements and available budget, without any quotas or restrictions.</p>
+            </li>
+        </ul>
+        """
+

--- a/tests/authoring/Container/DefinitionLists.fs
+++ b/tests/authoring/Container/DefinitionLists.fs
@@ -57,3 +57,34 @@ This is my `definition`
             """
     [<Fact>]
     let ``has no errors 2`` () = markdown |> hasNoErrors
+
+
+
+type ``preserves paragraphs`` () =
+
+    static let markdown = Setup.Markdown """
+Elastic Consumption Unit (ECU)
+:   An ECU is a unit of aggregate consumption across multiple resources over time.
+
+    Each type of computing resource (capacity, data transfer, and snapshot) that you consume has its own unit of measure.
+
+    In order to aggregate consumption across different resource types, all resources are priced in ECU.
+
+    Check Using Elastic Consumption Units for billing for more details.
+"""
+
+    [<Fact>]
+    let ``validate HTML 2`` () =
+        markdown |> convertsToHtml """
+        <dl>
+            <dt>Elastic Consumption Unit (ECU)</dt>
+            <dd>
+                <p>An ECU is a unit of aggregate consumption across multiple resources over time.</p>
+                <p>Each type of computing resource (capacity, data transfer, and snapshot) that you consume has its own unit of measure.</p>
+                <p>In order to aggregate consumption across different resource types, all resources are priced in ECU.</p>
+                <p>Check Using Elastic Consumption Units for billing for more details.</p>
+            </dd>
+        </dl>
+        """
+    [<Fact>]
+    let ``has no errors`` () = markdown |> hasNoErrors

--- a/tests/authoring/authoring.fsproj
+++ b/tests/authoring/authoring.fsproj
@@ -46,6 +46,7 @@
 
   <ItemGroup>
     <Compile Include="Blocks\CodeBlocks\CodeBlocks.fs" />
+    <Compile Include="Blocks\Lists.fs" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
List continuations that have blank lines are considered loose. As per commonmark spec these should render as paragraphs.

`EnableTrackTrivia()` was breaking this behaviour.

Validated we don't need triva for error message highlighting.

Closes https://github.com/elastic/docs-builder/issues/347
