### PR TITLE
Fix relative links

### DIFF
--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -241,15 +241,20 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 		if (url.EndsWith(".md"))
 			url = Path.ChangeExtension(url, ".html");
 
-		if (url.StartsWith("/") && !string.IsNullOrWhiteSpace(urlPathPrefix))
+
+		if (!url.StartsWith('/'))
+			url = GetRootRelativePath(context, file);
+
+		if (!string.IsNullOrWhiteSpace(urlPathPrefix))
 			url = $"{urlPathPrefix.TrimEnd('/')}{url}";
-		else
-		{
-			var docsetDirectory = context.Configuration.SourceFile.Directory;
-			url = file.FullName.Replace(docsetDirectory!.FullName, string.Empty);
-		}
 
 		link.Url = !string.IsNullOrEmpty(anchor) ? $"{url}#{anchor}" : url;
+	}
+
+	private static string GetRootRelativePath(ParserContext context, IFileInfo file)
+	{
+		var docsetDirectory = context.Configuration.SourceFile.Directory;
+		return file.FullName.Replace(docsetDirectory!.FullName, string.Empty);
 	}
 
 	private static bool IsCrossLink(Uri? uri) =>

--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -239,11 +239,14 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 	{
 		var newUrl = url;
 		var urlPathPrefix = context.Build.UrlPathPrefix ?? string.Empty;
+
+		if (!url.StartsWith('/') && !string.IsNullOrEmpty(url))
+		{
+			newUrl = GetRootRelativePath(context, file);
+		}
+
 		if (url.EndsWith(".md"))
 			newUrl = Path.ChangeExtension(newUrl, ".html");
-
-		if (!url.StartsWith('/'))
-			newUrl = GetRootRelativePath(context, file);
 
 		if (!string.IsNullOrWhiteSpace(urlPathPrefix))
 			newUrl = $"{urlPathPrefix.TrimEnd('/')}{newUrl}";

--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -237,21 +237,18 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 
 	private static void UpdateLinkUrl(LinkInline link, string url, ParserContext context, string? anchor, IFileInfo file)
 	{
-		var newUrl = url;
 		var urlPathPrefix = context.Build.UrlPathPrefix ?? string.Empty;
 
 		if (!url.StartsWith('/') && !string.IsNullOrEmpty(url))
-		{
-			newUrl = GetRootRelativePath(context, file);
-		}
+			url = GetRootRelativePath(context, file);
 
 		if (url.EndsWith(".md"))
-			newUrl = Path.ChangeExtension(newUrl, ".html");
+			url = Path.ChangeExtension(url, ".html");
 
-		if (!string.IsNullOrWhiteSpace(newUrl) && !string.IsNullOrWhiteSpace(urlPathPrefix))
-			newUrl = $"{urlPathPrefix.TrimEnd('/')}{newUrl}";
+		if (!string.IsNullOrWhiteSpace(url) && !string.IsNullOrWhiteSpace(urlPathPrefix))
+			url = $"{urlPathPrefix.TrimEnd('/')}{url}";
 
-		link.Url = !string.IsNullOrEmpty(anchor) ? $"{newUrl}#{anchor}" : newUrl;
+		link.Url = string.IsNullOrEmpty(anchor) ? url : $"{url}#{anchor}";
 	}
 
 	private static string GetRootRelativePath(ParserContext context, IFileInfo file)

--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -237,18 +237,18 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 
 	private static void UpdateLinkUrl(LinkInline link, string url, ParserContext context, string? anchor, IFileInfo file)
 	{
+		var newUrl = url;
 		var urlPathPrefix = context.Build.UrlPathPrefix ?? string.Empty;
 		if (url.EndsWith(".md"))
-			url = Path.ChangeExtension(url, ".html");
-
+			newUrl = Path.ChangeExtension(newUrl, ".html");
 
 		if (!url.StartsWith('/'))
-			url = GetRootRelativePath(context, file);
+			newUrl = GetRootRelativePath(context, file);
 
 		if (!string.IsNullOrWhiteSpace(urlPathPrefix))
-			url = $"{urlPathPrefix.TrimEnd('/')}{url}";
+			newUrl = $"{urlPathPrefix.TrimEnd('/')}{newUrl}";
 
-		link.Url = !string.IsNullOrEmpty(anchor) ? $"{url}#{anchor}" : url;
+		link.Url = !string.IsNullOrEmpty(anchor) ? $"{newUrl}#{anchor}" : newUrl;
 	}
 
 	private static string GetRootRelativePath(ParserContext context, IFileInfo file)

--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -248,7 +248,7 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 		if (url.EndsWith(".md"))
 			newUrl = Path.ChangeExtension(newUrl, ".html");
 
-		if (!string.IsNullOrWhiteSpace(urlPathPrefix))
+		if (!string.IsNullOrWhiteSpace(newUrl) && !string.IsNullOrWhiteSpace(urlPathPrefix))
 			newUrl = $"{urlPathPrefix.TrimEnd('/')}{newUrl}";
 
 		link.Url = !string.IsNullOrEmpty(anchor) ? $"{newUrl}#{anchor}" : newUrl;

--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -168,10 +168,10 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 	{
 		var (url, anchor) = SplitUrlAndAnchor(link.Url ?? string.Empty);
 		var includeFrom = GetIncludeFromPath(url, context);
-
+		var file = ResolveFile(context, url);
 		ValidateInternalUrl(processor, url, includeFrom, line, column, length, context);
-		ProcessLinkText(processor, link, context, url, anchor, line, column, length);
-		UpdateLinkUrl(link, url, anchor, context.Build.UrlPathPrefix ?? string.Empty);
+		ProcessLinkText(processor, link, context, url, anchor, line, column, length, file);
+		UpdateLinkUrl(link, url, context, anchor, file);
 	}
 
 	private static (string url, string? anchor) SplitUrlAndAnchor(string fullUrl)
@@ -195,12 +195,11 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 			processor.EmitError(line, column, length, $"`{url}` does not exist. resolved to `{pathOnDisk}");
 	}
 
-	private static void ProcessLinkText(InlineProcessor processor, LinkInline link, ParserContext context, string url, string? anchor, int line, int column, int length)
+	private static void ProcessLinkText(InlineProcessor processor, LinkInline link, ParserContext context, string url, string? anchor, int line, int column, int length, IFileInfo file)
 	{
 		if (link.FirstChild != null && string.IsNullOrEmpty(anchor))
 			return;
 
-		var file = ResolveFile(context, url);
 		var markdown = context.GetDocumentationFile?.Invoke(file) as MarkdownFile;
 
 		if (markdown == null)
@@ -236,13 +235,19 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 			processor.EmitError(line, column, length, $"`{anchor}` does not exist in {markdown.FileName}.");
 	}
 
-	private static void UpdateLinkUrl(LinkInline link, string url, string? anchor, string urlPathPrefix)
+	private static void UpdateLinkUrl(LinkInline link, string url, ParserContext context, string? anchor, IFileInfo file)
 	{
+		var urlPathPrefix = context.Build.UrlPathPrefix ?? string.Empty;
 		if (url.EndsWith(".md"))
 			url = Path.ChangeExtension(url, ".html");
 
 		if (url.StartsWith("/") && !string.IsNullOrWhiteSpace(urlPathPrefix))
 			url = $"{urlPathPrefix.TrimEnd('/')}{url}";
+		else
+		{
+			var docsetDirectory = context.Configuration.SourceFile.Directory;
+			url = file.FullName.Replace(docsetDirectory!.FullName, string.Empty);
+		}
 
 		link.Url = !string.IsNullOrEmpty(anchor) ? $"{url}#{anchor}" : url;
 	}

--- a/tests/Elastic.Markdown.Tests/Inline/AnchorLinkTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/AnchorLinkTests.cs
@@ -166,9 +166,8 @@ public class NestedHeadingTest(ITestOutputHelper output) : AnchorLinkTestBase(ou
 	public void GeneratesHtml() =>
 		// language=html
 		Html.Should().Contain(
-			"""<a href="testing/req.html#heading-inside-dropdown">Heading inside dropdown</a>"""
+			"""<a href="/testing/req#heading-inside-dropdown">Heading inside dropdown</a>"""
 		);
-
 	[Fact]
 	public void HasError() => Collector.Diagnostics.Should().HaveCount(0);
 }

--- a/tests/Elastic.Markdown.Tests/Inline/AnchorLinkTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/AnchorLinkTests.cs
@@ -76,7 +76,7 @@ public class ExternalPageAnchorTests(ITestOutputHelper output) : AnchorLinkTestB
 	public void GeneratesHtml() =>
 		// language=html
 		Html.Should().Contain(
-			"""<p><a href="/testing/req.html#sub-requirements">Sub Requirements</a></p>"""
+			"""<p><a href="/docs/testing/req.html#sub-requirements">Sub Requirements</a></p>"""
 		);
 
 	[Fact]
@@ -94,7 +94,7 @@ public class ExternalPageCustomAnchorTests(ITestOutputHelper output) : AnchorLin
 	public void GeneratesHtml() =>
 		// language=html
 		Html.Should().Contain(
-			"""<p><a href="/testing/req.html#new-reqs">Sub Requirements</a></p>"""
+			"""<p><a href="/docs/testing/req.html#new-reqs">Sub Requirements</a></p>"""
 		);
 
 	[Fact]
@@ -111,7 +111,7 @@ public class ExternalPageAnchorAutoTitleTests(ITestOutputHelper output) : Anchor
 	public void GeneratesHtml() =>
 		// language=html
 		Html.Should().Contain(
-			"""<p><a href="/testing/req.html#sub-requirements">Special Requirements &gt; Sub Requirements</a></p>"""
+			"""<p><a href="/docs/testing/req.html#sub-requirements">Special Requirements &gt; Sub Requirements</a></p>"""
 		);
 
 	[Fact]
@@ -147,7 +147,7 @@ public class ExternalPageBadAnchorTests(ITestOutputHelper output) : AnchorLinkTe
 	public void GeneratesHtml() =>
 		// language=html
 		Html.Should().Contain(
-			"""<p><a href="/testing/req.html#sub-requirements2">Sub Requirements</a></p>"""
+			"""<p><a href="/docs/testing/req.html#sub-requirements2">Sub Requirements</a></p>"""
 		);
 
 	[Fact]
@@ -166,7 +166,7 @@ public class NestedHeadingTest(ITestOutputHelper output) : AnchorLinkTestBase(ou
 	public void GeneratesHtml() =>
 		// language=html
 		Html.Should().Contain(
-			"""<a href="/testing/req.html#heading-inside-dropdown">Heading inside dropdown</a>"""
+			"""<a href="/docs/testing/req.html#heading-inside-dropdown">Heading inside dropdown</a>"""
 		);
 	[Fact]
 	public void HasError() => Collector.Diagnostics.Should().HaveCount(0);

--- a/tests/Elastic.Markdown.Tests/Inline/AnchorLinkTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/AnchorLinkTests.cs
@@ -76,7 +76,7 @@ public class ExternalPageAnchorTests(ITestOutputHelper output) : AnchorLinkTestB
 	public void GeneratesHtml() =>
 		// language=html
 		Html.Should().Contain(
-			"""<p><a href="testing/req.html#sub-requirements">Sub Requirements</a></p>"""
+			"""<p><a href="/testing/req.html#sub-requirements">Sub Requirements</a></p>"""
 		);
 
 	[Fact]
@@ -94,7 +94,7 @@ public class ExternalPageCustomAnchorTests(ITestOutputHelper output) : AnchorLin
 	public void GeneratesHtml() =>
 		// language=html
 		Html.Should().Contain(
-			"""<p><a href="testing/req.html#new-reqs">Sub Requirements</a></p>"""
+			"""<p><a href="/testing/req.html#new-reqs">Sub Requirements</a></p>"""
 		);
 
 	[Fact]
@@ -111,7 +111,7 @@ public class ExternalPageAnchorAutoTitleTests(ITestOutputHelper output) : Anchor
 	public void GeneratesHtml() =>
 		// language=html
 		Html.Should().Contain(
-			"""<p><a href="testing/req.html#sub-requirements">Special Requirements &gt; Sub Requirements</a></p>"""
+			"""<p><a href="/testing/req.html#sub-requirements">Special Requirements &gt; Sub Requirements</a></p>"""
 		);
 
 	[Fact]
@@ -147,7 +147,7 @@ public class ExternalPageBadAnchorTests(ITestOutputHelper output) : AnchorLinkTe
 	public void GeneratesHtml() =>
 		// language=html
 		Html.Should().Contain(
-			"""<p><a href="testing/req.html#sub-requirements2">Sub Requirements</a></p>"""
+			"""<p><a href="/testing/req.html#sub-requirements2">Sub Requirements</a></p>"""
 		);
 
 	[Fact]
@@ -166,7 +166,7 @@ public class NestedHeadingTest(ITestOutputHelper output) : AnchorLinkTestBase(ou
 	public void GeneratesHtml() =>
 		// language=html
 		Html.Should().Contain(
-			"""<a href="/testing/req#heading-inside-dropdown">Heading inside dropdown</a>"""
+			"""<a href="/testing/req.html#heading-inside-dropdown">Heading inside dropdown</a>"""
 		);
 	[Fact]
 	public void HasError() => Collector.Diagnostics.Should().HaveCount(0);

--- a/tests/Elastic.Markdown.Tests/Inline/DirectiveBlockLinkTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/DirectiveBlockLinkTests.cs
@@ -67,7 +67,7 @@ public class ExternalDirectiveLinkTests(ITestOutputHelper output) : DirectiveBlo
 	public void GeneratesHtml() =>
 		// language=html
 		Html.Should().Contain(
-			"""<p><a href="/testing/req.html#hint_ref">Sub Requirements</a></p>"""
+			"""<p><a href="/docs/testing/req.html#hint_ref">Sub Requirements</a></p>"""
 		);
 
 	[Fact]

--- a/tests/Elastic.Markdown.Tests/Inline/DirectiveBlockLinkTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/DirectiveBlockLinkTests.cs
@@ -67,7 +67,7 @@ public class ExternalDirectiveLinkTests(ITestOutputHelper output) : DirectiveBlo
 	public void GeneratesHtml() =>
 		// language=html
 		Html.Should().Contain(
-			"""<p><a href="testing/req.html#hint_ref">Sub Requirements</a></p>"""
+			"""<p><a href="/testing/req.html#hint_ref">Sub Requirements</a></p>"""
 		);
 
 	[Fact]

--- a/tests/Elastic.Markdown.Tests/Inline/InlineAnchorTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/InlineAnchorTests.cs
@@ -203,7 +203,7 @@ public class ExternalPageInlineAnchorCanBeLinkedToo(ITestOutputHelper output) : 
 	public void GeneratesHtml() =>
 		// language=html
 		Html.Should().Contain(
-			"""<p><a href="/testing/req.html#custom-anchor">Sub Requirements</a></p>"""
+			"""<p><a href="/docs/testing/req.html#custom-anchor">Sub Requirements</a></p>"""
 		);
 
 	[Fact]

--- a/tests/Elastic.Markdown.Tests/Inline/InlineAnchorTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/InlineAnchorTests.cs
@@ -203,7 +203,7 @@ public class ExternalPageInlineAnchorCanBeLinkedToo(ITestOutputHelper output) : 
 	public void GeneratesHtml() =>
 		// language=html
 		Html.Should().Contain(
-			"""<p><a href="testing/req.html#custom-anchor">Sub Requirements</a></p>"""
+			"""<p><a href="/testing/req.html#custom-anchor">Sub Requirements</a></p>"""
 		);
 
 	[Fact]

--- a/tests/Elastic.Markdown.Tests/Inline/InlineImageTest.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/InlineImageTest.cs
@@ -37,6 +37,6 @@ public class RelativeInlineImageTest(ITestOutputHelper output) : InlineTest<Link
 	public void GeneratesAttributesInHtml() =>
 		// language=html
 		Html.Should().Contain(
-			"""<p><img src="_static/img/observability.png" alt="Elasticsearch" /></p>"""
+			"""<p><img src="/_static/img/observability.png" alt="Elasticsearch" /></p>"""
 		);
 }

--- a/tests/Elastic.Markdown.Tests/Inline/InlineImageTest.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/InlineImageTest.cs
@@ -20,7 +20,7 @@ public class InlineImageTest(ITestOutputHelper output) : InlineTest<LinkInline>(
 	public void GeneratesAttributesInHtml() =>
 		// language=html
 		Html.Should().Contain(
-			"""<p><img src="/_static/img/observability.png" alt="Elasticsearch" /></p>"""
+			"""<p><img src="/docs/_static/img/observability.png" alt="Elasticsearch" /></p>"""
 		);
 }
 
@@ -37,6 +37,6 @@ public class RelativeInlineImageTest(ITestOutputHelper output) : InlineTest<Link
 	public void GeneratesAttributesInHtml() =>
 		// language=html
 		Html.Should().Contain(
-			"""<p><img src="/_static/img/observability.png" alt="Elasticsearch" /></p>"""
+			"""<p><img src="/docs/_static/img/observability.png" alt="Elasticsearch" /></p>"""
 		);
 }

--- a/tests/Elastic.Markdown.Tests/Inline/InlineLinkTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/InlineLinkTests.cs
@@ -58,7 +58,7 @@ public class LinkToPageTests(ITestOutputHelper output) : LinkTestBase(output,
 	public void GeneratesHtml() =>
 		// language=html
 		Html.Should().Contain(
-			"""<p><a href="/testing/req">Requirements</a></p>"""
+			"""<p><a href="/testing/req.html">Requirements</a></p>"""
 		);
 
 	[Fact]
@@ -81,7 +81,7 @@ public class InsertPageTitleTests(ITestOutputHelper output) : LinkTestBase(outpu
 	public void GeneratesHtml() =>
 		// language=html
 		Html.Should().Contain(
-			"""<p><a href="/testing/req">Special Requirements</a></p>"""
+			"""<p><a href="/testing/req.html">Special Requirements</a></p>"""
 		);
 
 	[Fact]
@@ -106,7 +106,7 @@ public class LinkReferenceTest(ITestOutputHelper output) : LinkTestBase(output,
 	public void GeneratesHtml() =>
 		// language=html
 		Html.Should().Contain(
-			"""<p><a href="/testing/req">test</a></p>"""
+			"""<p><a href="/testing/req.html">test</a></p>"""
 		);
 
 	[Fact]

--- a/tests/Elastic.Markdown.Tests/Inline/InlineLinkTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/InlineLinkTests.cs
@@ -41,7 +41,7 @@ public class InlineLinkTests(ITestOutputHelper output) : LinkTestBase(output,
 	public void GeneratesHtml() =>
 		// language=html
 		Html.Should().Contain(
-			"""<p><a href="/_static/img/observability.png">Elasticsearch</a></p>"""
+			"""<p><a href="/docs/_static/img/observability.png">Elasticsearch</a></p>"""
 		);
 
 	[Fact]
@@ -58,7 +58,7 @@ public class LinkToPageTests(ITestOutputHelper output) : LinkTestBase(output,
 	public void GeneratesHtml() =>
 		// language=html
 		Html.Should().Contain(
-			"""<p><a href="/testing/req.html">Requirements</a></p>"""
+			"""<p><a href="/docs/testing/req.html">Requirements</a></p>"""
 		);
 
 	[Fact]
@@ -81,7 +81,7 @@ public class InsertPageTitleTests(ITestOutputHelper output) : LinkTestBase(outpu
 	public void GeneratesHtml() =>
 		// language=html
 		Html.Should().Contain(
-			"""<p><a href="/testing/req.html">Special Requirements</a></p>"""
+			"""<p><a href="/docs/testing/req.html">Special Requirements</a></p>"""
 		);
 
 	[Fact]
@@ -106,7 +106,7 @@ public class LinkReferenceTest(ITestOutputHelper output) : LinkTestBase(output,
 	public void GeneratesHtml() =>
 		// language=html
 		Html.Should().Contain(
-			"""<p><a href="/testing/req.html">test</a></p>"""
+			"""<p><a href="/docs/testing/req.html">test</a></p>"""
 		);
 
 	[Fact]
@@ -225,10 +225,10 @@ public class CommentedNonExistingLinks2(ITestOutputHelper output) : LinkTestBase
 		Html.TrimEnd().Should().Be("""
 		<p>Links:</p>
 		<ul>
-		<li> <a href="/testing/req.html">Special Requirements</a></li>
+		<li> <a href="/docs/testing/req.html">Special Requirements</a></li>
 		</ul>
 		<ul>
-		<li> <a href="/testing/req.html">Special Requirements</a></li>
+		<li> <a href="/docs/testing/req.html">Special Requirements</a></li>
 		</ul>
 		""");
 

--- a/tests/Elastic.Markdown.Tests/Inline/InlineLinkTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/InlineLinkTests.cs
@@ -58,11 +58,7 @@ public class LinkToPageTests(ITestOutputHelper output) : LinkTestBase(output,
 	public void GeneratesHtml() =>
 		// language=html
 		Html.Should().Contain(
-<<<<<<< Updated upstream
-			"""<p><a href="testing/req.html">Requirements</a></p>"""
-=======
 			"""<p><a href="/testing/req">Requirements</a></p>"""
->>>>>>> Stashed changes
 		);
 
 	[Fact]
@@ -110,11 +106,7 @@ public class LinkReferenceTest(ITestOutputHelper output) : LinkTestBase(output,
 	public void GeneratesHtml() =>
 		// language=html
 		Html.Should().Contain(
-<<<<<<< Updated upstream
-			"""<p><a href="testing/req.html">test</a></p>"""
-=======
 			"""<p><a href="/testing/req">test</a></p>"""
->>>>>>> Stashed changes
 		);
 
 	[Fact]

--- a/tests/Elastic.Markdown.Tests/Inline/InlineLinkTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/InlineLinkTests.cs
@@ -58,7 +58,11 @@ public class LinkToPageTests(ITestOutputHelper output) : LinkTestBase(output,
 	public void GeneratesHtml() =>
 		// language=html
 		Html.Should().Contain(
+<<<<<<< Updated upstream
 			"""<p><a href="testing/req.html">Requirements</a></p>"""
+=======
+			"""<p><a href="/testing/req">Requirements</a></p>"""
+>>>>>>> Stashed changes
 		);
 
 	[Fact]
@@ -81,7 +85,7 @@ public class InsertPageTitleTests(ITestOutputHelper output) : LinkTestBase(outpu
 	public void GeneratesHtml() =>
 		// language=html
 		Html.Should().Contain(
-			"""<p><a href="testing/req.html">Special Requirements</a></p>"""
+			"""<p><a href="/testing/req">Special Requirements</a></p>"""
 		);
 
 	[Fact]
@@ -106,7 +110,11 @@ public class LinkReferenceTest(ITestOutputHelper output) : LinkTestBase(output,
 	public void GeneratesHtml() =>
 		// language=html
 		Html.Should().Contain(
+<<<<<<< Updated upstream
 			"""<p><a href="testing/req.html">test</a></p>"""
+=======
+			"""<p><a href="/testing/req">test</a></p>"""
+>>>>>>> Stashed changes
 		);
 
 	[Fact]

--- a/tests/Elastic.Markdown.Tests/Inline/InlneBaseTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/InlneBaseTests.cs
@@ -100,7 +100,7 @@ $"""
 			{ "docs/index.md", new MockFileData(documentContents) }
 		}, new MockFileSystemOptions
 		{
-			CurrentDirectory = Paths.Root.FullName
+			CurrentDirectory = Paths.Root.FullName,
 		});
 		// ReSharper disable once VirtualMemberCallInConstructor
 		// nasty but sub implementations won't use class state.
@@ -112,7 +112,8 @@ $"""
 		Collector = new TestDiagnosticsCollector(output);
 		var context = new BuildContext(FileSystem)
 		{
-			Collector = Collector
+			Collector = Collector,
+			UrlPathPrefix = "/docs"
 		};
 		Set = new DocumentationSet(context);
 		File = Set.GetMarkdownFile(FileSystem.FileInfo.New("docs/index.md")) ?? throw new NullReferenceException();

--- a/tests/authoring/Inline/InlineImages.fs
+++ b/tests/authoring/Inline/InlineImages.fs
@@ -26,7 +26,7 @@ type ``relative path to image`` () =
     [<Fact>]
     let ``validate HTML: preserves relative path`` () =
         markdown |> convertsToHtml """
-            <p><img src="_static/img/observability.png" alt="Elasticsearch" /></p>
+            <p><img src="/_static/img/observability.png" alt="Elasticsearch" /></p>
         """
 
 type ``supplying a tittle`` () =
@@ -37,7 +37,7 @@ type ``supplying a tittle`` () =
     [<Fact>]
     let ``validate HTML: includes title`` () =
         markdown |> convertsToHtml """
-            <p><img src="_static/img/observability.png" alt="Elasticsearch" title="Hello world" /></p>
+            <p><img src="/_static/img/observability.png" alt="Elasticsearch" title="Hello world" /></p>
         """
 
 type ``supplying a tittle with width and height`` () =
@@ -48,7 +48,7 @@ type ``supplying a tittle with width and height`` () =
     [<Fact>]
     let ``validate HTML: does not include width and height in title`` () =
         markdown |> convertsToHtml """
-            <p><img src="obs.png" width="250px" height="400px" alt="o" title="Title"/></p>
+            <p><img src="/obs.png" width="250px" height="400px" alt="o" title="Title"/></p>
         """
 
 type ``supplying a tittle with width and height in percentage`` () =
@@ -59,7 +59,7 @@ type ``supplying a tittle with width and height in percentage`` () =
     [<Fact>]
     let ``validate HTML: does not include width and height in title`` () =
         markdown |> convertsToHtml """
-            <p><img src="obs.png" width="50%" height="40%" alt="o" title="Title"/></p>
+            <p><img src="/obs.png" width="50%" height="40%" alt="o" title="Title"/></p>
         """
 type ``supplying a tittle with width only`` () =
     static let markdown = Setup.Markdown """
@@ -69,5 +69,5 @@ type ``supplying a tittle with width only`` () =
     [<Fact>]
     let ``validate HTML: sets height to width if not supplied`` () =
         markdown |> convertsToHtml """
-            <p><img src="obs.png" width="30%" height="30%" alt="o" title="Title"/></p>
+            <p><img src="/obs.png" width="30%" height="30%" alt="o" title="Title"/></p>
         """


### PR DESCRIPTION
## Context

In https://github.com/elastic/docs-builder/pull/436#discussion_r1944762710 we discovered an unexpected behaviour of relative links. (unexpected but correct behaviour)

TL;DR

If you are on a page with relative links, your link resolves to something different depending if the current path has a trailing slash or not.

## Reproduce

1. Go to https://docs-v3-preview.elastic.dev/elastic/docs-builder/pull/436
2. Click on the first link "Contribute to Elastic documentation"
3. It leads to a non existing link.

-

1. Go to https://docs-v3-preview.elastic.dev/elastic/docs-builder/pull/436/ (trailing slash)
2. Click on the first link "Contribute to Elastic documentation"
3. It works

## Changes

- This transforms every relative path to a root-relative path (starting with `/`) to avoid the problem of relative links.
- Also, it's sets `/docs` as url path prefix in tests as this resembles production.

## How to test

1. Go to https://docs-v3-preview.elastic.dev/elastic/docs-builder/pull/442
2. Click on the first link "Contribute to Elastic documentation"