### PR TITLE
Make comment-on-asciidoc-changes.yml scarier

### DIFF
--- a/.github/workflows/comment-on-asciidoc-changes.yml
+++ b/.github/workflows/comment-on-asciidoc-changes.yml
@@ -36,7 +36,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              body: '> [!WARNING]\n> It looks like this PR modifies one or more `.asciidoc` files. These files are being migrated to Markdown, and any changes merged now will be lost. See the [migration guide](https://elastic.github.io/docs-builder/migration/freeze/index.html) for details.
+              body: '> [!WARNING]\n> It looks like this PR modifies one or more `.asciidoc` files. These files are being migrated to Markdown, and any changes merged now will be lost. See the [migration guide](https://elastic.github.io/docs-builder/migration/freeze/index.html) for details.'
             })
 
       - name: Error if .asciidoc files changed

--- a/.github/workflows/comment-on-asciidoc-changes.yml
+++ b/.github/workflows/comment-on-asciidoc-changes.yml
@@ -36,9 +36,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              body: | 
-              > [!WARNING]
-              > It looks like this PR modifies one or more `.asciidoc` files. These files are being migrated to Markdown, and any changes merged now will be lost. See the [migration guide](https://elastic.github.io/docs-builder/migration/freeze/index.html) for details.
+              body: '> [!WARNING]\n> It looks like this PR modifies one or more `.asciidoc` files. These files are being migrated to Markdown, and any changes merged now will be lost. See the [migration guide](https://elastic.github.io/docs-builder/migration/freeze/index.html) for details.
             })
 
       - name: Error if .asciidoc files changed

--- a/.github/workflows/comment-on-asciidoc-changes.yml
+++ b/.github/workflows/comment-on-asciidoc-changes.yml
@@ -36,7 +36,9 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              body: 'It looks like this PR modifies one or more `.asciidoc` files. These files are being migrated to Markdown, and any changes merged now will be lost. See the [migration guide](https://elastic.github.io/docs-builder/migration/freeze/index.html) for details.'
+              body: | 
+              > [!WARNING]
+              > It looks like this PR modifies one or more `.asciidoc` files. These files are being migrated to Markdown, and any changes merged now will be lost. See the [migration guide](https://elastic.github.io/docs-builder/migration/freeze/index.html) for details.
             })
 
       - name: Error if .asciidoc files changed


### PR DESCRIPTION
The comment is [currently](https://github.com/elastic/docs-content/pull/370#issuecomment-2642883221) a little understated :)

(I _think_ the syntax is correct in the yml)

> [!WARNING]
> It looks like this PR modifies one or more `.asciidoc` files. These files are being migrated to Markdown, and any changes merged now will be lost. See the [migration guide](https://elastic.github.io/docs-builder/migration/freeze/index.html) for details.