### PR TITLE
Improve safety of callout handling in EnhancedCodeBlockParser.

### DIFF
--- a/src/Elastic.Markdown/DocumentationGenerator.cs
+++ b/src/Elastic.Markdown/DocumentationGenerator.cs
@@ -72,7 +72,6 @@ public class DocumentationGenerator
 
 		await ExtractEmbeddedStaticResources(ctx);
 
-
 		_logger.LogInformation($"Completing diagnostics channel");
 		Context.Collector.Channel.TryComplete();
 
@@ -92,6 +91,7 @@ public class DocumentationGenerator
 	{
 		var processedFileCount = 0;
 		var exceptionCount = 0;
+		var totalFileCount = DocumentationSet.Files.Count;
 		_ = Context.Collector.StartAsync(ctx);
 		await Parallel.ForEachAsync(DocumentationSet.Files, ctx, async (file, token) =>
 		{
@@ -112,8 +112,9 @@ public class DocumentationGenerator
 			}
 
 			if (processedFiles % 100 == 0)
-				_logger.LogInformation($"-> Handled {processedFiles} files");
+				_logger.LogInformation($"-> Processed {processedFiles}/{totalFileCount} files");
 		});
+		_logger.LogInformation($"-> Processed {processedFileCount}/{totalFileCount} files");
 	}
 
 	private async Task ExtractEmbeddedStaticResources(Cancel ctx)
@@ -149,7 +150,7 @@ public class DocumentationGenerator
 				return;
 		}
 
-		_logger.LogTrace($"{file.SourceFile.FullName}");
+		_logger.LogTrace($"--> {file.SourceFile.FullName}");
 		var outputFile = OutputFile(file.RelativePath);
 		if (file is MarkdownFile markdown)
 			await HtmlWriter.WriteAsync(outputFile, markdown, token);

--- a/src/Elastic.Markdown/Myst/CodeBlocks/CallOutParser.cs
+++ b/src/Elastic.Markdown/Myst/CodeBlocks/CallOutParser.cs
@@ -8,9 +8,9 @@ namespace Elastic.Markdown.Myst.CodeBlocks;
 
 public static partial class CallOutParser
 {
-	[GeneratedRegex(@"^.+\S+.*?\s<\d+>$", RegexOptions.IgnoreCase, "en-US")]
+	[GeneratedRegex(@"^.+\S+.*?\s<\d+>$", RegexOptions.IgnoreCase, 2000, "en-US")]
 	public static partial Regex CallOutNumber();
 
-	[GeneratedRegex(@"^.+\S+.*?\s(?:\/\/|#)\s[^""\/#]+$", RegexOptions.IgnoreCase, "en-US")]
+	[GeneratedRegex(@"^.+\S+.*?\s(?:\/\/|#)\s[^""\/#]+$", RegexOptions.IgnoreCase, 2000, "en-US")]
 	public static partial Regex MathInlineAnnotation();
 }

--- a/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockParser.cs
+++ b/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockParser.cs
@@ -119,7 +119,7 @@ public class EnhancedCodeBlockParser : FencedBlockParserBase<EnhancedCodeBlock>
 				continue;
 
 			List<CallOut> callOuts = [];
-			var hasClassicCallout = span.IndexOf("<") > 0;
+			var hasClassicCallout = span.IndexOf("<") > 0 && span.LastIndexOf(">") == span.Length - 1;
 			if (hasClassicCallout)
 			{
 				var matchClassicCallout = CallOutParser.CallOutNumber().EnumerateMatches(span);

--- a/src/Elastic.Markdown/Slices/HtmlWriter.cs
+++ b/src/Elastic.Markdown/Slices/HtmlWriter.cs
@@ -28,6 +28,9 @@ public class HtmlWriter
 	public ILoggerFactory LoggerFactory { get; }
 	public ServiceProvider ServiceProvider { get; }
 
+	private Task<string> RenderEmptyString(MarkdownFile markdown, Cancel ctx = default) =>
+		Task.FromResult(string.Empty);
+
 	private async Task<string> RenderNavigation(MarkdownFile markdown, Cancel ctx = default)
 	{
 		var slice = Layout._TocTree.Create(new NavigationViewModel


### PR DESCRIPTION
Adjusted logic to ensure stricter detection of classic callouts by checking for a closing angle bracket at the end of the span. Also updated regex generation in CallOutParser to use a timeout for better performance and stability.

This brings the full build of the [reference branch in asciidocalypse](https://github.com/elastic/asciidocalypse/tree/reference/docs) back down to ~45s on my local laptop again (from 4 minutes prior).

Most of the remaining time is in the unoptomized `RenderNavivation()` subbing that out for something that is cached brings the total build further down to ~10s. Will save that work for another PR once the redesign kicks in!

