### PR TITLE
Support substitutions in directive titles (admonitions, tabs)

### DIFF
--- a/docs/syntax/_snippets/reusable-snippet.md
+++ b/docs/syntax/_snippets/reusable-snippet.md
@@ -1,4 +1,4 @@
-This is a snippet included on "{{page_title}}".
+This is a snippet included on "{{context.page_title}}".
 
 :::{tip}
 This is a snippet

--- a/docs/testing/nested/index.md
+++ b/docs/testing/nested/index.md
@@ -1,8 +1,9 @@
 ---
 sub:
   x: "Variable"
+navigation_title: "Testing nesting and {{x}}"
 ---
-# Testing Nesting
+# Testing Nesting and {{x}}
 
 The files in this directory are used for testing purposes. Do not edit these files unless you are working on tests.
 

--- a/src/Elastic.Markdown/Helpers/Interpolation.cs
+++ b/src/Elastic.Markdown/Helpers/Interpolation.cs
@@ -54,7 +54,7 @@ public static class Interpolation
 	public static bool ReplaceSubstitutions(
 		this ReadOnlySpan<char> span,
 		IReadOnlyDictionary<string, string>[] properties,
-		[NotNullWhen(true)]out string? replacement
+		[NotNullWhen(true)] out string? replacement
 	)
 	{
 		replacement = null;

--- a/src/Elastic.Markdown/Helpers/Interpolation.cs
+++ b/src/Elastic.Markdown/Helpers/Interpolation.cs
@@ -2,7 +2,9 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
+using Elastic.Markdown.Myst;
 
 namespace Elastic.Markdown.Helpers;
 
@@ -14,22 +16,60 @@ internal static partial class InterpolationRegex
 
 public static class Interpolation
 {
-	public static bool ReplaceSubstitutions(this ReadOnlySpan<char> span, IReadOnlyDictionary<string, string>? properties, out string? replacement)
+	public static string ReplaceSubstitutions(
+		this string input,
+		ParserContext context
+	)
+	{
+		var span = input.AsSpan();
+		if (span.ReplaceSubstitutions([context.Substitutions, context.ContextSubstitutions], out var replacement))
+			return replacement;
+		return input;
+	}
+
+
+	public static bool ReplaceSubstitutions(
+		this ReadOnlySpan<char> span,
+		ParserContext context,
+		[NotNullWhen(true)] out string? replacement
+	) =>
+		span.ReplaceSubstitutions([context.Substitutions, context.ContextSubstitutions], out replacement);
+
+	public static bool ReplaceSubstitutions(
+		this ReadOnlySpan<char> span,
+		IReadOnlyDictionary<string, string>? properties,
+		[NotNullWhen(true)] out string? replacement
+	)
+	{
+		replacement = null;
+		if (properties is null || properties.Count == 0)
+			return false;
+
+		if (span.IndexOf("}}") < 0)
+			return false;
+
+		return span.ReplaceSubstitutions([properties], out replacement);
+	}
+
+	public static bool ReplaceSubstitutions(
+		this ReadOnlySpan<char> span,
+		IReadOnlyDictionary<string, string>[] properties,
+		[NotNullWhen(true)]out string? replacement
+	)
 	{
 		replacement = null;
 		if (span.IndexOf("}}") < 0)
 			return false;
 
-		if (properties is null || properties.Count == 0)
+		if (properties.Length == 0 || properties.Sum(p => p.Count) == 0)
 			return false;
 
-		var substitutions = properties as Dictionary<string, string>
-							?? new Dictionary<string, string>(properties, StringComparer.OrdinalIgnoreCase);
-		if (substitutions.Count == 0)
-			return false;
+		var lookups = properties
+			.Select(p => p as Dictionary<string, string> ?? new Dictionary<string, string>(p, StringComparer.OrdinalIgnoreCase))
+			.Select(d => d.GetAlternateLookup<ReadOnlySpan<char>>())
+			.ToArray();
 
 		var matchSubs = InterpolationRegex.MatchSubstitutions().EnumerateMatches(span);
-		var lookup = substitutions.GetAlternateLookup<ReadOnlySpan<char>>();
 
 		var replaced = false;
 		foreach (var match in matchSubs)
@@ -39,14 +79,15 @@ public static class Interpolation
 
 			var spanMatch = span.Slice(match.Index, match.Length);
 			var key = spanMatch.Trim(['{', '}']);
+			foreach (var lookup in lookups)
+			{
+				if (!lookup.TryGetValue(key, out var value))
+					continue;
 
-			if (!lookup.TryGetValue(key, out var value))
-				continue;
-
-			replacement ??= span.ToString();
-			replacement = replacement.Replace(spanMatch.ToString(), value);
-			replaced = true;
-
+				replacement ??= span.ToString();
+				replacement = replacement.Replace(spanMatch.ToString(), value);
+				replaced = true;
+			}
 		}
 
 		return replaced;

--- a/src/Elastic.Markdown/Myst/Directives/AdmonitionBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/AdmonitionBlock.cs
@@ -20,10 +20,6 @@ public class AdmonitionBlock : DirectiveBlock
 
 		var t = Admonition;
 		var title = Thread.CurrentThread.CurrentCulture.TextInfo.ToTitleCase(t);
-		if (_admonition is "admonition" or "dropdown" && !string.IsNullOrEmpty(Arguments))
-			title = Arguments;
-		else if (!string.IsNullOrEmpty(Arguments))
-			title += $" {Arguments}";
 		Title = title;
 
 	}
@@ -44,6 +40,10 @@ public class AdmonitionBlock : DirectiveBlock
 		if (DropdownOpen.HasValue)
 			Classes = "dropdown";
 
+		if (_admonition is "admonition" or "dropdown" && !string.IsNullOrEmpty(Arguments))
+			Title = Arguments;
+		else if (!string.IsNullOrEmpty(Arguments))
+			Title += $" {Arguments}";
 		Title = Title.ReplaceSubstitutions(context);
 	}
 }

--- a/src/Elastic.Markdown/Myst/Directives/AdmonitionBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/AdmonitionBlock.cs
@@ -1,6 +1,9 @@
 // Licensed to Elasticsearch B.V under one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
+
+using Elastic.Markdown.Helpers;
+
 namespace Elastic.Markdown.Myst.Directives;
 
 public class DropdownBlock(DirectiveBlockParser parser, ParserContext context) : AdmonitionBlock(parser, "dropdown", context);
@@ -14,6 +17,15 @@ public class AdmonitionBlock : DirectiveBlock
 		_admonition = admonition;
 		if (_admonition is "admonition")
 			Classes = "plain";
+
+		var t = Admonition;
+		var title = Thread.CurrentThread.CurrentCulture.TextInfo.ToTitleCase(t);
+		if (_admonition is "admonition" or "dropdown" && !string.IsNullOrEmpty(Arguments))
+			title = Arguments;
+		else if (!string.IsNullOrEmpty(Arguments))
+			title += $" {Arguments}";
+		Title = title;
+
 	}
 
 	public string Admonition => _admonition;
@@ -23,19 +35,7 @@ public class AdmonitionBlock : DirectiveBlock
 	public string? Classes { get; protected set; }
 	public bool? DropdownOpen { get; private set; }
 
-	public string Title
-	{
-		get
-		{
-			var t = Admonition;
-			var title = Thread.CurrentThread.CurrentCulture.TextInfo.ToTitleCase(t);
-			if (_admonition is "admonition" or "dropdown" && !string.IsNullOrEmpty(Arguments))
-				title = Arguments;
-			else if (!string.IsNullOrEmpty(Arguments))
-				title += $" {Arguments}";
-			return title;
-		}
-	}
+	public string Title { get; private set; }
 
 	public override void FinalizeAndValidate(ParserContext context)
 	{
@@ -43,6 +43,8 @@ public class AdmonitionBlock : DirectiveBlock
 		DropdownOpen = TryPropBool("open");
 		if (DropdownOpen.HasValue)
 			Classes = "dropdown";
+
+		Title = Title.ReplaceSubstitutions(context);
 	}
 }
 

--- a/src/Elastic.Markdown/Myst/Directives/TabSetBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/TabSetBlock.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using Elastic.Markdown.Diagnostics;
+using Elastic.Markdown.Helpers;
 using Elastic.Markdown.Slices.Directives;
 
 namespace Elastic.Markdown.Myst.Directives;
@@ -44,7 +45,7 @@ public class TabItemBlock(DirectiveBlockParser parser, ParserContext context)
 		if (string.IsNullOrWhiteSpace(Arguments))
 			this.EmitError("{tab-item} requires an argument to name the tab.");
 
-		Title = Arguments ?? "{undefined}";
+		Title = (Arguments ?? "{undefined}").ReplaceSubstitutions(context);
 		Index = Parent!.IndexOf(this);
 
 		var tabSet = Parent as TabSetBlock;


### PR DESCRIPTION
This also introcudes `context.*` variables as its own separate mechanism to inject machine variables.


Today we only support `context.page_title`

closes: https://github.com/elastic/docs-builder/issues/151 too.