### PR TITLE
Ensure `authoring` test project reports properly on Github Actions

### DIFF
--- a/tests/Elastic.Markdown.Tests/CodeBlocks/CallOutTests.cs
+++ b/tests/Elastic.Markdown.Tests/CodeBlocks/CallOutTests.cs
@@ -6,7 +6,6 @@ using Elastic.Markdown.Myst.CodeBlocks;
 using Elastic.Markdown.Tests.Inline;
 using FluentAssertions;
 using JetBrains.Annotations;
-using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests.CodeBlocks;
 

--- a/tests/Elastic.Markdown.Tests/CodeBlocks/CodeTests.cs
+++ b/tests/Elastic.Markdown.Tests/CodeBlocks/CodeTests.cs
@@ -5,7 +5,6 @@
 using Elastic.Markdown.Myst.CodeBlocks;
 using Elastic.Markdown.Tests.Inline;
 using FluentAssertions;
-using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests.CodeBlocks;
 

--- a/tests/Elastic.Markdown.Tests/Directives/AdmonitionTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/AdmonitionTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information
 using Elastic.Markdown.Myst.Directives;
 using FluentAssertions;
-using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests.Directives;
 

--- a/tests/Elastic.Markdown.Tests/Directives/AdmonitionUnsupportedTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/AdmonitionUnsupportedTests.cs
@@ -4,7 +4,6 @@
 
 using Elastic.Markdown.Myst.Directives;
 using FluentAssertions;
-using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests.Directives;
 

--- a/tests/Elastic.Markdown.Tests/Directives/AppliesBlockTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/AppliesBlockTests.cs
@@ -5,7 +5,6 @@
 using Elastic.Markdown.Diagnostics;
 using Elastic.Markdown.Myst.Directives;
 using FluentAssertions;
-using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests.Directives;
 

--- a/tests/Elastic.Markdown.Tests/Directives/DirectiveBaseTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/DirectiveBaseTests.cs
@@ -9,7 +9,6 @@ using FluentAssertions;
 using JetBrains.Annotations;
 using Markdig.Syntax;
 using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests.Directives;
 
@@ -19,7 +18,7 @@ public abstract class DirectiveTest<TDirective>(ITestOutputHelper output, [Langu
 {
 	protected TDirective? Block { get; private set; }
 
-	public override async Task InitializeAsync()
+	public override async ValueTask InitializeAsync()
 	{
 		await base.InitializeAsync();
 		Block = Document
@@ -82,7 +81,7 @@ $"""
 
 	protected virtual void AddToFileSystem(MockFileSystem fileSystem) { }
 
-	public virtual async Task InitializeAsync()
+	public virtual async ValueTask InitializeAsync()
 	{
 		_ = Collector.StartAsync(default);
 
@@ -98,6 +97,6 @@ $"""
 		await Collector.StopAsync(default);
 	}
 
-	public Task DisposeAsync() => Task.CompletedTask;
+	public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
 }

--- a/tests/Elastic.Markdown.Tests/Directives/ImageTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/ImageTests.cs
@@ -6,7 +6,6 @@ using System.IO.Abstractions.TestingHelpers;
 using Elastic.Markdown.Diagnostics;
 using Elastic.Markdown.Myst.Directives;
 using FluentAssertions;
-using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests.Directives;
 

--- a/tests/Elastic.Markdown.Tests/Directives/MermaidTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/MermaidTests.cs
@@ -4,7 +4,6 @@
 using Elastic.Markdown.Myst.Directives;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests.Directives;
 

--- a/tests/Elastic.Markdown.Tests/Directives/TabTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/TabTests.cs
@@ -4,7 +4,6 @@
 using Elastic.Markdown.Myst.Directives;
 using FluentAssertions;
 using Markdig;
-using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests.Directives;
 

--- a/tests/Elastic.Markdown.Tests/Directives/UnsupportedTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/UnsupportedTests.cs
@@ -5,7 +5,6 @@
 using Elastic.Markdown.Diagnostics;
 using Elastic.Markdown.Myst.Directives;
 using FluentAssertions;
-using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests.Directives;
 

--- a/tests/Elastic.Markdown.Tests/Directives/VersionTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/VersionTests.cs
@@ -6,7 +6,6 @@ using Elastic.Markdown.Helpers;
 using Elastic.Markdown.Myst.Directives;
 using FluentAssertions;
 using Markdig.Syntax;
-using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests.Directives;
 

--- a/tests/Elastic.Markdown.Tests/DocSet/BreadCrumbTests.cs
+++ b/tests/Elastic.Markdown.Tests/DocSet/BreadCrumbTests.cs
@@ -4,7 +4,6 @@
 
 using Elastic.Markdown.IO;
 using FluentAssertions;
-using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests.DocSet;
 

--- a/tests/Elastic.Markdown.Tests/DocSet/LinkReferenceTests.cs
+++ b/tests/Elastic.Markdown.Tests/DocSet/LinkReferenceTests.cs
@@ -6,7 +6,6 @@ using Elastic.Markdown.IO;
 using Elastic.Markdown.IO.Discovery;
 using Elastic.Markdown.IO.State;
 using FluentAssertions;
-using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests.DocSet;
 

--- a/tests/Elastic.Markdown.Tests/DocSet/NavigationTests.cs
+++ b/tests/Elastic.Markdown.Tests/DocSet/NavigationTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information
 
 using FluentAssertions;
-using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests.DocSet;
 

--- a/tests/Elastic.Markdown.Tests/DocSet/NavigationTestsBase.cs
+++ b/tests/Elastic.Markdown.Tests/DocSet/NavigationTestsBase.cs
@@ -9,7 +9,6 @@ using Elastic.Markdown.IO;
 using Elastic.Markdown.IO.Configuration;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests.DocSet;
 
@@ -45,11 +44,11 @@ public class NavigationTestsBase : IAsyncLifetime
 	protected DocumentationGenerator Generator { get; }
 	protected ConfigurationFile Configuration { get; set; } = default!;
 
-	public async Task InitializeAsync()
+	public async ValueTask InitializeAsync()
 	{
 		await Generator.ResolveDirectoryTree(default);
 		Configuration = Generator.DocumentationSet.Configuration;
 	}
 
-	public Task DisposeAsync() => Task.CompletedTask;
+	public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 }

--- a/tests/Elastic.Markdown.Tests/DocSet/NestedTocTests.cs
+++ b/tests/Elastic.Markdown.Tests/DocSet/NestedTocTests.cs
@@ -4,7 +4,6 @@
 
 using Elastic.Markdown.IO;
 using FluentAssertions;
-using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests.DocSet;
 

--- a/tests/Elastic.Markdown.Tests/Elastic.Markdown.Tests.csproj
+++ b/tests/Elastic.Markdown.Tests/Elastic.Markdown.Tests.csproj
@@ -7,17 +7,22 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <OutputType>Exe</OutputType>
+
+    <UseMicrosoftTestingPlatformRunner>false</UseMicrosoftTestingPlatformRunner>
+    <DisableTestingPlatformServerCapability>true</DisableTestingPlatformServerCapability>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0"/>
+    <PackageReference Include="xunit.v3" Version="1.1.0"/>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2"/>
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
+
     <PackageReference Include="coverlet.collector" Version="6.0.0"/>
     <PackageReference Include="FluentAssertions" Version="6.12.1"/>
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="21.0.29"/>
-    <PackageReference Include="xunit" Version="2.9.2"/>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2"/>
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Elastic.Markdown.Tests/FileInclusion/IncludeTests.cs
+++ b/tests/Elastic.Markdown.Tests/FileInclusion/IncludeTests.cs
@@ -7,7 +7,6 @@ using Elastic.Markdown.Diagnostics;
 using Elastic.Markdown.Myst.Directives;
 using Elastic.Markdown.Tests.Directives;
 using FluentAssertions;
-using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests.FileInclusion;
 

--- a/tests/Elastic.Markdown.Tests/FileInclusion/LiteralIncludeTests.cs
+++ b/tests/Elastic.Markdown.Tests/FileInclusion/LiteralIncludeTests.cs
@@ -6,7 +6,6 @@ using System.IO.Abstractions.TestingHelpers;
 using Elastic.Markdown.Myst.Directives;
 using Elastic.Markdown.Tests.Directives;
 using FluentAssertions;
-using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests.FileInclusion;
 

--- a/tests/Elastic.Markdown.Tests/FrontMatter/ProductConstraintTests.cs
+++ b/tests/Elastic.Markdown.Tests/FrontMatter/ProductConstraintTests.cs
@@ -5,7 +5,6 @@
 using Elastic.Markdown.Myst.FrontMatter;
 using Elastic.Markdown.Tests.Directives;
 using FluentAssertions;
-using Xunit.Abstractions;
 using static Elastic.Markdown.Myst.FrontMatter.ProductLifecycle;
 
 namespace Elastic.Markdown.Tests.FrontMatter;

--- a/tests/Elastic.Markdown.Tests/FrontMatter/YamlFrontMatterTests.cs
+++ b/tests/Elastic.Markdown.Tests/FrontMatter/YamlFrontMatterTests.cs
@@ -4,7 +4,6 @@
 
 using Elastic.Markdown.Tests.Directives;
 using FluentAssertions;
-using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests.FrontMatter;
 

--- a/tests/Elastic.Markdown.Tests/Inline/AnchorLinkTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/AnchorLinkTests.cs
@@ -6,7 +6,6 @@ using System.IO.Abstractions.TestingHelpers;
 using FluentAssertions;
 using JetBrains.Annotations;
 using Markdig.Syntax.Inlines;
-using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests.Inline;
 

--- a/tests/Elastic.Markdown.Tests/Inline/CommentTest.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/CommentTest.cs
@@ -2,7 +2,6 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 using FluentAssertions;
-using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests.Inline;
 

--- a/tests/Elastic.Markdown.Tests/Inline/DirectiveBlockLinkTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/DirectiveBlockLinkTests.cs
@@ -6,7 +6,6 @@ using System.IO.Abstractions.TestingHelpers;
 using FluentAssertions;
 using JetBrains.Annotations;
 using Markdig.Syntax.Inlines;
-using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests.Inline;
 

--- a/tests/Elastic.Markdown.Tests/Inline/HardBreakTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/HardBreakTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information
 
 using FluentAssertions;
-using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests.Inline;
 

--- a/tests/Elastic.Markdown.Tests/Inline/InlineAnchorTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/InlineAnchorTests.cs
@@ -8,7 +8,6 @@ using FluentAssertions;
 using JetBrains.Annotations;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
-using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests.Inline;
 

--- a/tests/Elastic.Markdown.Tests/Inline/InlineImageTest.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/InlineImageTest.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information
 using FluentAssertions;
 using Markdig.Syntax.Inlines;
-using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests.Inline;
 

--- a/tests/Elastic.Markdown.Tests/Inline/InlineLinkTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/InlineLinkTests.cs
@@ -6,7 +6,6 @@ using System.IO.Abstractions.TestingHelpers;
 using FluentAssertions;
 using JetBrains.Annotations;
 using Markdig.Syntax.Inlines;
-using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests.Inline;
 

--- a/tests/Elastic.Markdown.Tests/Inline/InlneBaseTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/InlneBaseTests.cs
@@ -8,7 +8,6 @@ using FluentAssertions;
 using JetBrains.Annotations;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
-using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests.Inline;
 
@@ -18,7 +17,7 @@ public abstract class LeafTest<TDirective>(ITestOutputHelper output, [LanguageIn
 {
 	protected TDirective? Block { get; private set; }
 
-	public override async Task InitializeAsync()
+	public override async ValueTask InitializeAsync()
 	{
 		await base.InitializeAsync();
 		Block = Document
@@ -37,7 +36,7 @@ public abstract class BlockTest<TDirective>(ITestOutputHelper output, [LanguageI
 {
 	protected TDirective? Block { get; private set; }
 
-	public override async Task InitializeAsync()
+	public override async ValueTask InitializeAsync()
 	{
 		await base.InitializeAsync();
 		Block = Document
@@ -56,7 +55,7 @@ public abstract class InlineTest<TDirective>(ITestOutputHelper output, [Language
 {
 	protected TDirective? Block { get; private set; }
 
-	public override async Task InitializeAsync()
+	public override async ValueTask InitializeAsync()
 	{
 		await base.InitializeAsync();
 		Block = Document
@@ -123,7 +122,7 @@ $"""
 
 	protected virtual void AddToFileSystem(MockFileSystem fileSystem) { }
 
-	public virtual async Task InitializeAsync()
+	public virtual async ValueTask InitializeAsync()
 	{
 		_ = Collector.StartAsync(default);
 
@@ -140,6 +139,6 @@ $"""
 		await Collector.StopAsync(default);
 	}
 
-	public Task DisposeAsync() => Task.CompletedTask;
+	public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
 }

--- a/tests/Elastic.Markdown.Tests/Inline/SubstitutionTest.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/SubstitutionTest.cs
@@ -5,7 +5,6 @@
 using Elastic.Markdown.Myst.CodeBlocks;
 using Elastic.Markdown.Myst.Substitution;
 using FluentAssertions;
-using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests.Inline;
 

--- a/tests/Elastic.Markdown.Tests/Mover/MoverTests.cs
+++ b/tests/Elastic.Markdown.Tests/Mover/MoverTests.cs
@@ -6,7 +6,6 @@ using Documentation.Mover;
 using Elastic.Markdown.Tests.DocSet;
 using FluentAssertions;
 
-using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests.Mover;
 
@@ -20,7 +19,7 @@ public class MoverTests(ITestOutputHelper output) : NavigationTestsBase(output)
 		Directory.SetCurrentDirectory(workingDirectory!);
 
 		var mover = new Move(ReadFileSystem, WriteFileSystem, Set, LoggerFactory);
-		await mover.Execute("testing/mover/first-page.md", "new-folder/hello-world.md", true);
+		await mover.Execute("testing/mover/first-page.md", "new-folder/hello-world.md", true, TestContext.Current.CancellationToken);
 
 		mover.Changes.Should().HaveCount(1);
 		var changeSet = mover.Changes.First();
@@ -49,7 +48,7 @@ public class MoverTests(ITestOutputHelper output) : NavigationTestsBase(output)
 		Directory.SetCurrentDirectory(workingDirectory!);
 
 		var mover = new Move(ReadFileSystem, WriteFileSystem, Set, LoggerFactory);
-		await mover.Execute("testing/mover/first-page.md", "new-folder", true);
+		await mover.Execute("testing/mover/first-page.md", "new-folder", true, TestContext.Current.CancellationToken);
 
 		mover.Changes.Should().HaveCount(1);
 		var changeSet = mover.Changes.First();
@@ -77,7 +76,7 @@ public class MoverTests(ITestOutputHelper output) : NavigationTestsBase(output)
 		Directory.SetCurrentDirectory(workingDirectory!);
 
 		var mover = new Move(ReadFileSystem, WriteFileSystem, Set, LoggerFactory);
-		await mover.Execute("testing/mover", "new-folder", true);
+		await mover.Execute("testing/mover", "new-folder", true, TestContext.Current.CancellationToken);
 
 		mover.Changes.Should().HaveCount(2);
 		var changeSet = mover.LinkModifications.FirstOrDefault(k => k.Key.From.Name == "first-page.md").Key;

--- a/tests/Elastic.Markdown.Tests/OutputDirectoryTests.cs
+++ b/tests/Elastic.Markdown.Tests/OutputDirectoryTests.cs
@@ -6,7 +6,6 @@ using Elastic.Markdown.Diagnostics;
 using Elastic.Markdown.IO;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
-using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests;
 
@@ -31,7 +30,7 @@ public class OutputDirectoryTests(ITestOutputHelper output)
 		var set = new DocumentationSet(context);
 		var generator = new DocumentationGenerator(set, logger);
 
-		await generator.GenerateAll(default);
+		await generator.GenerateAll(TestContext.Current.CancellationToken);
 
 		fileSystem.Directory.Exists(".artifacts").Should().BeTrue();
 

--- a/tests/Elastic.Markdown.Tests/SettingsInclusion/IncludeTests.cs
+++ b/tests/Elastic.Markdown.Tests/SettingsInclusion/IncludeTests.cs
@@ -8,7 +8,6 @@ using Elastic.Markdown.IO;
 using Elastic.Markdown.Myst.Directives;
 using Elastic.Markdown.Tests.Directives;
 using FluentAssertions;
-using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests.SettingsInclusion;
 

--- a/tests/Elastic.Markdown.Tests/TestDiagnosticsCollector.cs
+++ b/tests/Elastic.Markdown.Tests/TestDiagnosticsCollector.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information
 
 using Elastic.Markdown.Diagnostics;
-using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests;
 

--- a/tests/Elastic.Markdown.Tests/TestLogger.cs
+++ b/tests/Elastic.Markdown.Tests/TestLogger.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information
 
 using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
 
 namespace Elastic.Markdown.Tests;
 

--- a/tests/authoring/Blocks/Lists.fs
+++ b/tests/authoring/Blocks/Lists.fs
@@ -21,7 +21,7 @@ type ``supports loose lists`` () =
         <ul>
             <li>
                 <p>
-                    <strong>onsumption-based billing</strong>:</p>
+                    <strong>Consumption-based billing</strong>:</p>
                 <p>You pay for the actual product used, regardless of the application or use case. This is different from subscription-based billing models where customers pay a flat fee restricted by usage quotas, or one-time upfront payment billing models such as those used for on-prem software licenses.</p>
                 <p>You can purchase credits for a single or multi-year contract. Consumption is on demand, and every month we deduct from your balance based on your usage and contract terms. This allows you to seamlessly expand your usage to the full extent of your requirements and available budget, without any quotas or restrictions.</p>
             </li>

--- a/tests/authoring/Blocks/Lists.fs
+++ b/tests/authoring/Blocks/Lists.fs
@@ -21,7 +21,7 @@ type ``supports loose lists`` () =
         <ul>
             <li>
                 <p>
-                    <strong>Consumption-based billing</strong>:</p>
+                    <strong>onsumption-based billing</strong>:</p>
                 <p>You pay for the actual product used, regardless of the application or use case. This is different from subscription-based billing models where customers pay a flat fee restricted by usage quotas, or one-time upfront payment billing models such as those used for on-prem software licenses.</p>
                 <p>You can purchase credits for a single or multi-year contract. Consumption is on demand, and every month we deduct from your balance based on your usage and contract terms. This allows you to seamlessly expand your usage to the full extent of your requirements and available budget, without any quotas or restrictions.</p>
             </li>

--- a/tests/authoring/authoring.fsproj
+++ b/tests/authoring/authoring.fsproj
@@ -2,24 +2,28 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
+
     <IsPackable>false</IsPackable>
-    <GenerateProgramFile>false</GenerateProgramFile>
-    <!-- Add this to your project file. -->
-    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
-    <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
+    <IsTestProject>true</IsTestProject>
+    <OutputType>Exe</OutputType>
+
+    <UseMicrosoftTestingPlatformRunner>false</UseMicrosoftTestingPlatformRunner>
+    <DisableTestingPlatformServerCapability>true</DisableTestingPlatformServerCapability>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0"/>
+    <PackageReference Include="xunit.v3" Version="1.1.0"/>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2"/>
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1"/>
+
     <PackageReference Include="coverlet.collector" Version="6.0.2"/>
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
-    <PackageReference Include="xunit.v3" Version="1.0.1"/>
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="21.0.29"/>
     <PackageReference Include="FsUnit.xUnit" Version="7.0.1"/>
     <PackageReference Include="AngleSharp.Diffing" Version="1.0.0"/>
     <PackageReference Include="DiffPlex" Version="1.7.2"/>
-    <PackageReference Include="Unquote" Version="7.0.1" />
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
+    <PackageReference Include="Unquote" Version="7.0.1"/>
   </ItemGroup>
 
   <ItemGroup>
@@ -27,29 +31,29 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="Framework\TestValues.fs" />
-    <Compile Include="Framework\Setup.fs" />
-    <Compile Include="Framework\MarkdownResultsAssertions.fs" />
-    <Compile Include="Framework\HtmlAssertions.fs" />
-    <Compile Include="Framework\ErrorCollectorAssertions.fs" />
-    <Compile Include="Framework\MarkdownDocumentAssertions.fs" />
-    <Compile Include="Inline\Substitutions.fs" />
+    <Compile Include="Framework\TestValues.fs"/>
+    <Compile Include="Framework\Setup.fs"/>
+    <Compile Include="Framework\MarkdownResultsAssertions.fs"/>
+    <Compile Include="Framework\HtmlAssertions.fs"/>
+    <Compile Include="Framework\ErrorCollectorAssertions.fs"/>
+    <Compile Include="Framework\MarkdownDocumentAssertions.fs"/>
+    <Compile Include="Inline\Substitutions.fs"/>
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="Inline\Comments.fs" />
-    <Compile Include="Inline\InlineImages.fs" />
-    <Compile Include="Inline\InlineAnchors.fs" />
+    <Compile Include="Inline\Comments.fs"/>
+    <Compile Include="Inline\InlineImages.fs"/>
+    <Compile Include="Inline\InlineAnchors.fs"/>
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="Container\DefinitionLists.fs" />
-    <Compile Include="Generator\LinkReferenceFile.fs" />
+    <Compile Include="Container\DefinitionLists.fs"/>
+    <Compile Include="Generator\LinkReferenceFile.fs"/>
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="Blocks\CodeBlocks\CodeBlocks.fs" />
-    <Compile Include="Blocks\Lists.fs" />
+    <Compile Include="Blocks\CodeBlocks\CodeBlocks.fs"/>
+    <Compile Include="Blocks\Lists.fs"/>
   </ItemGroup>
 
 </Project>

--- a/tests/authoring/authoring.fsproj
+++ b/tests/authoring/authoring.fsproj
@@ -4,6 +4,9 @@
     <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
+    <!-- Add this to your project file. -->
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION


There are two test engines in .NET core. 

* `VSTest`, the old engine.
* `TestPlatform`, the brandspanking new platform. [Read more here why there is a new one](https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-platform-intro?tabs=dotnetcli)

By default xunit3 will run under `TestPlatform` however that engine is not allowing `--logger` arguments so we can not see the github annotations for failed tests.

See: https://github.com/microsoft/testfx/issues/4365 for more background about this missing feature. The author for TSUnit still has a few issues open to properly write extensions to support this.


So here we now run `xunit3` under the old `VSTest` platform so we can run `dotnet test` as per default with the `--logger` argument.

---

<img width="928" alt="image" src="https://github.com/user-attachments/assets/09fd1cc2-c97a-4448-a210-5bb3d9fba638" />

---

This now also moves both projects over to xunit v3 so both test projects behave the same.


cc @elastic/dotnet 




