### PR TITLE
Fix deployment cache invaldation

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -96,7 +96,7 @@ jobs:
           aws s3 sync ./html "s3://elastic-docs-v3-website-preview${PATH_PREFIX}" --delete
           aws cloudfront create-invalidation \
             --distribution-id EKT7LT5PM8RKS \
-            --paths "${PATH_PREFIX}" "/${PATH_PREFIX}/*"
+            --paths "${PATH_PREFIX}" "${PATH_PREFIX}/*"
 
       - name: Update deployment status
         uses: actions/github-script@v7


### PR DESCRIPTION
## Context

The deploy workflow invalidates the wrong path (See double slash `//`):

```
{
    "Location": "https://cloudfront.amazonaws.com/2020-05-31/distribution/EKT7LT5PM8RKS/invalidation/I1X25INZRFOX3XG00NT7HHAEES",
    "Invalidation": {
        "Id": "I1X25INZRFOX3XG00NT7HHAEES",
        "Status": "InProgress",
        "CreateTime": "2025-02-11T09:57:40.926000+00:00",
        "InvalidationBatch": {
            "Paths": {
                "Quantity": 2,
                "Items": [
                    "/elastic/docs-content/tree/main",
                    "//elastic/docs-content/tree/main/*"
                ]
            },
            "CallerReference": "cli-1739267860-138763"
        }
    }
}
```

Source: https://github.com/elastic/docs-content/actions/runs/13260176152/job/37014759944#step:5:24989