### PR TITLE
Fix new compilation errors introduced in 9.0.200

### DIFF
--- a/build/CommandLine.fs
+++ b/build/CommandLine.fs
@@ -74,7 +74,9 @@ with
         seq {
              for c in cases do
                  if c.GetFields().Length = 0 then
-                     FSharpValue.MakeUnion(c, [| |]) :?> Build
+                     match FSharpValue.MakeUnion(c, [| |]) with
+                     | NonNull u -> u :?> Build
+                     | _ -> failwithf $"%s{c.Name} can not be cast to Build enum"
         }
         
     static member Ignore (_: Build) _ = ()

--- a/build/build.fsproj
+++ b/build/build.fsproj
@@ -12,8 +12,6 @@
     <PackageReference Include="Proc.Fs" Version="0.9.1" />
     <PackageReference Include="Fake.Tools.Git" Version="6.1.3" />
     <PackageReference Include="Fake.IO.Zip" Version="6.1.3" />
-    <PackageReference Remove="FSharp.Core"/>
-    <PackageReference Include="FSharp.Core" Version="9.0.100" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Elastic.Markdown/Diagnostics/DiagnosticsChannel.cs
+++ b/src/Elastic.Markdown/Diagnostics/DiagnosticsChannel.cs
@@ -56,7 +56,7 @@ public readonly record struct Diagnostic
 
 public interface IDiagnosticsOutput
 {
-	public void Write(Diagnostic diagnostic);
+	void Write(Diagnostic diagnostic);
 }
 
 public class DiagnosticsCollector(IReadOnlyCollection<IDiagnosticsOutput> outputs)

--- a/tests/authoring/Framework/ErrorCollectorAssertions.fs
+++ b/tests/authoring/Framework/ErrorCollectorAssertions.fs
@@ -27,8 +27,14 @@ module DiagnosticsCollectorAssertions =
                                    .Where(fun d -> d.Severity = Severity.Error)
                                    .ToArray()
                                    |> List.ofArray
-        let message = errorDiagnostics.FirstOrDefault().Message
-        test <@ message.Contains(expected) @>
+                                   |> List.tryHead
+
+        match errorDiagnostics with
+        | Some e ->
+            let message = e.Message
+            test <@ message.Contains(expected) @>
+        | None -> failwithf "Expected errors but no errors were logged"
+
         
     let hasNoWarnings (actual: Lazy<GeneratorResults>) =
         let actual = actual.Value
@@ -43,5 +49,9 @@ module DiagnosticsCollectorAssertions =
                                    .Where(fun d -> d.Severity = Severity.Warning)
                                    .ToArray()
                                    |> List.ofArray
-        let message = errorDiagnostics.FirstOrDefault().Message
-        test <@ message.Contains(expected) @>
+                                   |> List.tryHead
+        match errorDiagnostics with
+        | Some e ->
+            let message = e.Message
+            test <@ message.Contains(expected) @>
+        | None -> failwithf "Expected errors but no errors were logged"


### PR DESCRIPTION
This addresses new compilation errors that were introduced with .NET SDK 9.0.200
