### PR TITLE
Fix preview build workflow

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -147,7 +147,7 @@ jobs:
             --paths "${PATH_PREFIX}" "${PATH_PREFIX}/*"
 
       - name: Update Link Index
-        if: steps.s3-upload.outcome == 'success'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.s3-upload.outcome == 'success' 
         uses: elastic/docs-builder/actions/update-link-index@main
 
       - name: Update deployment status

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -53,7 +53,6 @@ jobs:
         if: github.event_name == 'push' || steps.check-files.outputs.any_changed == 'true'
         uses: actions/checkout@v4
         with: 
-          repository: '${{ github.event.pull_request.head.repo.full_name || github.repository }}'
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
         


### PR DESCRIPTION
## Context

- The preview build workflow fails to checkout the code if it's coming from a private fork.
- The link index is in a wrong state

## Changes

- **Remove repository input from checkout step** (This will allow the workflow to checkout the fork)
- **Fix update-link-index condition**
