### PR TITLE
Only validate `docs-content` cross links for now

### DIFF
--- a/tests/Elastic.Markdown.Tests/TestCrossLinkResolver.cs
+++ b/tests/Elastic.Markdown.Tests/TestCrossLinkResolver.cs
@@ -5,12 +5,14 @@
 using System.Diagnostics.CodeAnalysis;
 using Elastic.Markdown.CrossLinks;
 using Elastic.Markdown.IO.State;
+using Xunit.Internal;
 
 namespace Elastic.Markdown.Tests;
 
 public class TestCrossLinkResolver : ICrossLinkResolver
 {
 	public Dictionary<string, LinkReference> LinkReferences { get; } = new();
+	public HashSet<string> DeclaredRepositories { get; } = new();
 
 	public Task FetchLinks()
 	{
@@ -40,9 +42,10 @@ public class TestCrossLinkResolver : ICrossLinkResolver
 		var reference = CrossLinkResolver.Deserialize(json);
 		LinkReferences.Add("docs-content", reference);
 		LinkReferences.Add("kibana", reference);
+		DeclaredRepositories.AddRange(["docs-content", "kibana", "elasticsearch"]);
 		return Task.CompletedTask;
 	}
 
 	public bool TryResolve(Action<string> errorEmitter, Uri crossLinkUri, [NotNullWhen(true)] out Uri? resolvedUri) =>
-		CrossLinkResolver.TryResolve(errorEmitter, LinkReferences, crossLinkUri, out resolvedUri);
+		CrossLinkResolver.TryResolve(errorEmitter, DeclaredRepositories, LinkReferences, crossLinkUri, out resolvedUri);
 }

--- a/tests/authoring/Framework/Setup.fs
+++ b/tests/authoring/Framework/Setup.fs
@@ -42,6 +42,8 @@ type Setup =
         let yaml = new StringWriter();
         yaml.WriteLine("cross_links:");
         yaml.WriteLine("  - docs-content");
+        yaml.WriteLine("  - elasticsearch");
+        yaml.WriteLine("  - kibana");
         yaml.WriteLine("toc:");
         let markdownFiles = fileSystem.Directory.EnumerateFiles(root.FullName, "*.md", SearchOption.AllDirectories)
         markdownFiles

--- a/tests/authoring/Framework/TestCrossLinkResolver.fs
+++ b/tests/authoring/Framework/TestCrossLinkResolver.fs
@@ -14,7 +14,10 @@ open Elastic.Markdown.IO.State
 type TestCrossLinkResolver () =
 
     let references = Dictionary<string, LinkReference>()
+    let declared = HashSet<string>()
+
     member this.LinkReferences = references
+    member this.DeclaredRepositories = declared
 
     interface ICrossLinkResolver with
         member this.FetchLinks() =
@@ -44,9 +47,12 @@ type TestCrossLinkResolver () =
             let reference = CrossLinkResolver.Deserialize json
             this.LinkReferences.Add("docs-content", reference)
             this.LinkReferences.Add("kibana", reference)
+            this.DeclaredRepositories.Add("docs-content") |> ignore;
+            this.DeclaredRepositories.Add("kibana") |> ignore;
+            this.DeclaredRepositories.Add("elasticsearch") |> ignore;
             Task.CompletedTask
 
         member this.TryResolve(errorEmitter, crossLinkUri, [<Out>]resolvedUri : byref<Uri|null>) =
-            CrossLinkResolver.TryResolve(errorEmitter, this.LinkReferences, crossLinkUri, &resolvedUri);
+            CrossLinkResolver.TryResolve(errorEmitter, this.DeclaredRepositories, this.LinkReferences, crossLinkUri, &resolvedUri);
 
 

--- a/tests/authoring/Inline/CrossLinks.fs
+++ b/tests/authoring/Inline/CrossLinks.fs
@@ -78,3 +78,25 @@ type ``link to valid anchor`` () =
 
     [<Fact>]
     let ``has no warning`` () = markdown |> hasNoWarnings
+
+type ``link to repository that does not resolve yet`` () =
+
+    static let markdown = Setup.Markdown """
+[Elasticsearch Documentation](elasticsearch:/index.md)
+"""
+
+    [<Fact>]
+    let ``validate HTML`` () =
+        markdown |> convertsToHtml """
+            <p><a
+                href="https://docs-v3-preview.elastic.dev/elastic/elasticsearch/tree/main/">
+                Elasticsearch Documentation
+                </a>
+            </p>
+        """
+
+    [<Fact>]
+    let ``has no errors`` () = markdown |> hasNoErrors
+
+    [<Fact>]
+    let ``has no warning`` () = markdown |> hasNoWarnings


### PR DESCRIPTION
Introduced a `_declaredRepositories` field in `CrossLinkResolver` to track valid repositories explicitly. Updated logic to validate cross-links against declared repositories and handle errors or missing links more gracefully. Extended tests to ensure correctness and consistency with declared repository functionality.

This allows us to temporarily allow cross links to repositories that do not publish a links.json file.

With this PR we only validate:

- docs-content links completely

For all other repositories we only validate that they are declared in docset.yml
