### PR TITLE
Empty url in markdown links should result in an error not warning

### DIFF
--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -119,7 +119,7 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 	{
 		if (string.IsNullOrEmpty(url))
 		{
-			processor.EmitWarning(link, "Found empty url");
+			processor.EmitError(link, "Found empty url");
 			return false;
 		}
 

--- a/tests/authoring/Inline/InlineLinks.fs
+++ b/tests/authoring/Inline/InlineLinks.fs
@@ -45,7 +45,7 @@ type ``inline link with mailto not allowed external host`` () =
     let ``has no errors`` () = markdown |> hasNoErrors
 
     [<Fact>]
-    let ``has warning`` () = markdown |> hasWarning "mailto links should be to elastic.co domains."
+    let ``has error`` () = markdown |> hasWarning "External URI 'mailto:fake-email@somehost.co' is not allowed."
 
 type ``empty link should result in an error`` () =
 
@@ -54,7 +54,7 @@ type ``empty link should result in an error`` () =
 """
 
     [<Fact>]
-    let ``should warn`` () = markdown |> hasWarning "Found empty url"
+    let ``has error`` () = markdown |> hasError "Found empty url"
 
     [<Fact>]
-    let ``has no erros`` () = markdown |> hasNoErrors
+    let ``has no warnings`` () = markdown |> hasNoWarnings

--- a/tests/authoring/Inline/InlineLinks.fs
+++ b/tests/authoring/Inline/InlineLinks.fs
@@ -45,7 +45,7 @@ type ``inline link with mailto not allowed external host`` () =
     let ``has no errors`` () = markdown |> hasNoErrors
 
     [<Fact>]
-    let ``has error`` () = markdown |> hasWarning "External URI 'mailto:fake-email@somehost.co' is not allowed."
+    let ``has error`` () = markdown |> hasWarning "mailto links should be to elastic.co domains."
 
 type ``empty link should result in an error`` () =
 


### PR DESCRIPTION
Cherry-pick from: https://github.com/elastic/docs-builder/pull/515

This time only merge it when these errors have been addressed in `docs-content` and `asciidocalypse