### PR TITLE
Load navigation javascript earlier

### DIFF
--- a/src/Elastic.Markdown/.gitignore
+++ b/src/Elastic.Markdown/.gitignore
@@ -2,6 +2,8 @@
 node_modules/
 _static/main.js
 _static/main.js.map
+_static/pages-nav.js
+_static/pages-nav.js.map
 _static/styles.css
 _static/styles.css.map
 _static/*.woff2

--- a/src/Elastic.Markdown/Assets/main.ts
+++ b/src/Elastic.Markdown/Assets/main.ts
@@ -1,10 +1,8 @@
-import {initNav} from "./pages-nav";
 import {initTocNav} from "./toc-nav";
 import {initHighlight} from "./hljs";
 import {initTabs} from "./tabs";
 import {initCopyButton} from "./copybutton";
 
-initNav();
 initTocNav();
 initHighlight();
 initCopyButton();

--- a/src/Elastic.Markdown/Assets/pages-nav.ts
+++ b/src/Elastic.Markdown/Assets/pages-nav.ts
@@ -81,3 +81,5 @@ export function initNav() {
 		keepNavPositionCallback();
 	}, true);
 }
+
+initNav();

--- a/src/Elastic.Markdown/Slices/Layout/_PagesNav.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_PagesNav.cshtml
@@ -3,4 +3,5 @@
 	<nav id="pages-nav" class="sidebar-nav pr-6">
 		@(new HtmlString(Model.NavigationHtml))
 	</nav>
+	<script src="@Model.Static("pages-nav.js")"></script>
 </aside>

--- a/src/Elastic.Markdown/package.json
+++ b/src/Elastic.Markdown/package.json
@@ -13,6 +13,10 @@
       "distDir": "_static",
       "source": "Assets/main.ts"
     },
+    "navigation": {
+      "distDir": "_static",
+      "source": "Assets/pages-nav.ts"
+    },
     "css": {
       "distDir": "_static",
       "source": "Assets/styles.css"


### PR DESCRIPTION
## Changes

Put the script for the navigation directly under it's DOM element. Hence, it should be loaded and executed before the rest of the content is loaded.

## Notes

Not sure if there is an actual performance gain. But I would like to see the effect in elastic/docs-content