### PR TITLE
Fix layout shift on page load

### DIFF
--- a/src/Elastic.Markdown/Assets/styles.css
+++ b/src/Elastic.Markdown/Assets/styles.css
@@ -85,7 +85,7 @@
 	}
 	
 	.content-container {
-		@apply w-full max-w-[80ch];
+		@apply w-full max-w-[80ch] lg:w-[80ch];
 	}
 
 	.applies {


### PR DESCRIPTION
## Context

On https://docs-v3-preview.elastic.dev/elastic/docs-content/tree/main you can see the layout shifting when navigating through pages.

## Changes

This sets the min width of the content container so the layout doesn't shift.