### PR TITLE
Fix ToC nav

### DIFF
--- a/src/Elastic.Markdown/Assets/toc-nav.ts
+++ b/src/Elastic.Markdown/Assets/toc-nav.ts
@@ -116,7 +116,7 @@ function setupSmoothScrolling(elements: TocElements) {
 			const href = link.getAttribute('href');
 			if (href?.charAt(0) === '#') {
 				e.preventDefault();
-				const target = $(href.replace('.', '\\.'));
+				const target = document.getElementById(href.slice(1));
 				if (target) {
 					target.scrollIntoView({ behavior: 'smooth' });
 					history.pushState(null, '', href);


### PR DESCRIPTION
## Context

Clicking on "What if I need to update both 8.x and 9.x docs?" in https://docs-v3-preview.elastic.dev/elastic/docs-builder/tree/main/contribute/on-the-web doesn't work as expected.

Seems like the id is too long for `document.querySelector`.

## Changes

Use `document.getElementById` instead.