### PR TITLE
Cache Navigation

### DIFF
--- a/src/Elastic.Markdown/IO/Navigation/DocumentationGroup.cs
+++ b/src/Elastic.Markdown/IO/Navigation/DocumentationGroup.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using Elastic.Markdown.Diagnostics;
+using Elastic.Markdown.Helpers;
 using Elastic.Markdown.IO.Configuration;
 
 namespace Elastic.Markdown.IO.Navigation;
@@ -11,14 +12,24 @@ public interface INavigationItem
 {
 	int Order { get; }
 	int Depth { get; }
+	string Id { get; }
 }
 
-public record GroupNavigation(int Order, int Depth, DocumentationGroup Group) : INavigationItem;
-public record FileNavigation(int Order, int Depth, MarkdownFile File) : INavigationItem;
+public record GroupNavigation(int Order, int Depth, DocumentationGroup Group) : INavigationItem
+{
+	public string Id { get; } = Group.Id;
+}
+
+public record FileNavigation(int Order, int Depth, MarkdownFile File) : INavigationItem
+{
+	public string Id { get; } = File.Id;
+}
 
 
 public class DocumentationGroup
 {
+	public string Id { get; } = Guid.NewGuid().ToString("N")[..8];
+
 	public MarkdownFile? Index { get; set; }
 
 	private IReadOnlyCollection<MarkdownFile> FilesInOrder { get; }
@@ -51,6 +62,9 @@ public class DocumentationGroup
 	{
 		Depth = depth;
 		Index = ProcessTocItems(context, index, toc, lookup, folderLookup, depth, ref fileIndex, out var groups, out var files, out var navigationItems);
+		if (Index is not null)
+			Index.GroupId = Id;
+
 
 		GroupsInOrder = groups;
 		FilesInOrder = files;

--- a/src/Elastic.Markdown/Slices/HtmlWriter.cs
+++ b/src/Elastic.Markdown/Slices/HtmlWriter.cs
@@ -41,12 +41,14 @@ public class HtmlWriter
 		return await slice.RenderAsync(cancellationToken: ctx);
 	}
 
+	private string? _renderedNavigation;
+
 	public async Task<string> RenderLayout(MarkdownFile markdown, Cancel ctx = default)
 	{
 		var document = await markdown.ParseFullAsync(ctx);
 		var html = markdown.CreateHtml(document);
 		await DocumentationSet.Tree.Resolve(ctx);
-		var navigationHtml = await RenderNavigation(markdown, ctx);
+		_renderedNavigation ??= await RenderNavigation(markdown, ctx);
 
 		var previous = DocumentationSet.GetPrevious(markdown);
 		var next = DocumentationSet.GetNext(markdown);
@@ -66,7 +68,7 @@ public class HtmlWriter
 			CurrentDocument = markdown,
 			PreviousDocument = previous,
 			NextDocument = next,
-			NavigationHtml = navigationHtml,
+			NavigationHtml = _renderedNavigation,
 			UrlPathPrefix = markdown.UrlPathPrefix,
 			Applies = markdown.YamlFrontMatter?.AppliesTo,
 			GithubEditUrl = editUrl,

--- a/src/Elastic.Markdown/Slices/Layout/_PagesNav.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_PagesNav.cshtml
@@ -1,6 +1,11 @@
 @inherits RazorSlice<LayoutViewModel>
 <aside class="sidebar hidden lg:block order-1 w-100 border-r-1 border-r-gray-200">
-	<nav id="pages-nav" class="sidebar-nav pr-6">
+	<nav id="pages-nav" class="sidebar-nav pr-6"
+	     data-current-page-id="@Model.CurrentDocument.Id"
+	     data-current-page-parent-ids="@(string.Join(",",Model.ParentIds))"
+	     @* used to invalidate session storage *@
+	     data-current-navigation="@LayoutViewModel.CurrentNavigationId">
+
 		@(new HtmlString(Model.NavigationHtml))
 	</nav>
 	<script src="@Model.Static("pages-nav.js")"></script>

--- a/src/Elastic.Markdown/Slices/Layout/_TocTreeNav.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_TocTreeNav.cshtml
@@ -3,16 +3,16 @@
 @inherits RazorSlice<NavigationTreeItem>
 @foreach (var item in Model.SubTree.NavigationItems)
 {
+	var id = item.Id;
 	if (item is FileNavigation file)
 	{
 		var f = file.File;
-		var isCurrent = f == Model.CurrentDocument;
-		<li class="block ml-2 pl-2 border-l-1 border-l-gray-200 group/li @(isCurrent ? "current" : string.Empty)">
+		<li class="block ml-2 pl-2 border-l-1 border-l-gray-200 group/li">
 			<div class="flex">
 				<a
-					class="sidebar-link my-1 ml-5 group-[.current]/li:text-blue-elastic! @(isCurrent ? "pointer-events-none" : string.Empty)"
-					href="@f.Url"
-					@(isCurrent ? "aria-current=page" : string.Empty)>
+					class="sidebar-link my-1 ml-5 group-[.current]/li:text-blue-elastic!"
+					id="page-@id"
+					href="@f.Url">
 					@f.NavigationTitle
 				</a>
 			</div>
@@ -21,13 +21,10 @@
 	else if (item is GroupNavigation folder)
 	{
 		var g = folder.Group;
-		var isCurrent = g.Index == Model.CurrentDocument;
 		const int initialExpandLevel = 1;
-		var containsCurrent = g.HoldsCurrent(Model.CurrentDocument) || g.ContainsCurrentPage(Model.CurrentDocument);
-		var shouldInitiallyExpand = containsCurrent || g.Depth <= initialExpandLevel;
-		var uuid = Guid.NewGuid().ToString();
-		<li class="flex flex-wrap @(g.Depth > 1 ? "ml-2 pl-2 border-l-1 border-l-gray-200" : string.Empty)">
-			<label for="@uuid" class="peer group/label flex items-center overflow-hidden @(g.Depth == 1 ? "mt-2" : "")">
+		var shouldInitiallyExpand = g.Depth <= initialExpandLevel;
+		<li class="flex flex-wrap group-navigation @(g.Depth > 1 ? "ml-2 pl-2 border-l-1 border-l-gray-200" : string.Empty)">
+			<label for="@id" class="peer group/label flex items-center overflow-hidden @(g.Depth == 1 ? "mt-2" : "")">
 				<svg
 					xmlns="http://www.w3.org/2000/svg"
 					fill="none"
@@ -38,16 +35,16 @@
 					<path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/>
 				</svg>
 				<input
-					id="@uuid"
+					id="@id"
 					type="checkbox"
 					class="hidden"
 					aria-hidden="true"
-					data-should-expand="@((containsCurrent).ToLowerString())"
 					@(shouldInitiallyExpand ? "checked" : string.Empty)
 				>
 				<a
 					href="@g.Index?.Url"
-					class="sidebar-link inline-block my-1 @(g.Depth == 1 ? "uppercase tracking-[0.05em] text-ink-light font-semibold" : string.Empty) @(containsCurrent ? "font-semibold" : string.Empty) @(isCurrent ? "current pointer-events-none text-blue-elastic!" : string.Empty)">
+					id="page-@g.Index?.Id"
+					class="sidebar-link inline-block my-1 @(g.Depth == 1 ? "uppercase tracking-[0.05em] text-ink-light font-semibold" : string.Empty)">
 					@g.Index?.NavigationTitle
 				</a>
 			</label>

--- a/src/Elastic.Markdown/Slices/Layout/_TocTreeNav.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_TocTreeNav.cshtml
@@ -53,7 +53,7 @@
 			</label>
 			@if (g.NavigationItems.Count > 0)
 			{
-				<ul class="h-0 w-full overflow-y-hidden peer-has-checked:h-auto peer-has-[:focus]:h-auto has-[:focus]:h-auto peer-has-checked:my-1" data-has-current="@g.ContainsCurrentPage(Model.CurrentDocument)">
+				<ul class="h-0 w-full overflow-y-hidden peer-has-checked:h-auto peer-has-[:focus]:h-auto has-[:focus]:h-auto peer-has-checked:my-1">
 					@await RenderPartialAsync(_TocTreeNav.Create(new NavigationTreeItem
 					{
 						Level = g.Depth,

--- a/src/Elastic.Markdown/Slices/_ViewModels.cs
+++ b/src/Elastic.Markdown/Slices/_ViewModels.cs
@@ -26,10 +26,15 @@ public class IndexViewModel
 
 public class LayoutViewModel
 {
+	/// Used to identify the navigation for the current compilation
+	/// We want to reset users sessionStorage every time this changes to invalidate
+	/// the guids that no longer exist
+	public static string CurrentNavigationId { get; } = Guid.NewGuid().ToString("N")[..8];
 	public string Title { get; set; } = "Elastic Documentation";
 	public string RawTitle { get; set; } = "Elastic Documentation";
 	public required IReadOnlyCollection<PageTocItem> PageTocItems { get; init; }
 	public required DocumentationGroup Tree { get; init; }
+	public string[] ParentIds => [.. CurrentDocument.YieldParentGroups()];
 	public required MarkdownFile CurrentDocument { get; init; }
 	public required MarkdownFile? Previous { get; init; }
 	public required MarkdownFile? Next { get; init; }


### PR DESCRIPTION
https://github.com/user-attachments/assets/fcdd8e19-2dae-46a7-9695-8a0403f4a3b8

Caches navigation for significantly faster build times.

Uses javascript to set the current page selected and expand its parent. Something we already do as we keep track of which nodes the user expanded.

Includes a few javascript speedups too.

- don't iterate over all inputs to set the previously selected, instead loop over selected state.
- when saving we only iterate over the checked inputs


We burn an overall navigation uuid into nav, if the users state does not match this we reset the users state. This prevents needlessly growing the users sessionStorage with UUID's that won't be valid anymore since the HTML is regenerated.

 