### PR TITLE
Fix csharp code analysis warnings

### DIFF
--- a/src/Elastic.Markdown.Refactor/Move.cs
+++ b/src/Elastic.Markdown.Refactor/Move.cs
@@ -2,11 +2,9 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-using System.Collections.ObjectModel;
 using System.IO.Abstractions;
 using System.Text.RegularExpressions;
 using Elastic.Markdown.IO;
-using Elastic.Markdown.Slices;
 using Microsoft.Extensions.Logging;
 
 namespace Elastic.Markdown.Refactor;
@@ -291,9 +289,7 @@ public class Move(IFileSystem readFileSystem, IFileSystem writeFileSystem, Docum
 
 				string newLink;
 				if (originalPath.StartsWith('/'))
-				{
 					newLink = $"[{match.Groups[1].Value}]({absoluteStyleTarget}{anchor})";
-				}
 				else
 				{
 					var relativeTarget = Path.GetRelativePath(Path.GetDirectoryName(value.FilePath)!, target);

--- a/src/Elastic.Markdown/Diagnostics/DiagnosticsChannel.cs
+++ b/src/Elastic.Markdown/Diagnostics/DiagnosticsChannel.cs
@@ -5,7 +5,6 @@
 using System.Collections.Concurrent;
 using System.Threading.Channels;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 
 namespace Elastic.Markdown.Diagnostics;
 

--- a/src/Elastic.Markdown/Diagnostics/ProcessorDiagnosticExtensions.cs
+++ b/src/Elastic.Markdown/Diagnostics/ProcessorDiagnosticExtensions.cs
@@ -5,7 +5,6 @@
 using System.IO.Abstractions;
 using Elastic.Markdown.Myst;
 using Elastic.Markdown.Myst.Directives;
-using Markdig.Helpers;
 using Markdig.Parsers;
 using Markdig.Syntax.Inlines;
 

--- a/src/Elastic.Markdown/IO/Configuration/ConfigurationFile.cs
+++ b/src/Elastic.Markdown/IO/Configuration/ConfigurationFile.cs
@@ -146,12 +146,12 @@ public record ConfigurationFile : DocumentationFile
 			switch (key)
 			{
 				case "toc":
-					toc = ReadNestedToc(entry, parentPath, out fileFound);
+					toc = ReadNestedToc(entry, out fileFound);
 					break;
 				case "hidden":
 				case "file":
 					hiddenFile = key == "hidden";
-					file = ReadFile(entry, parentPath, key, out fileFound);
+					file = ReadFile(entry, parentPath, out fileFound);
 					break;
 				case "folder":
 					folder = ReadFolder(entry, parentPath, out folderFound);
@@ -230,7 +230,7 @@ public record ConfigurationFile : DocumentationFile
 		return folder;
 	}
 
-	private string? ReadFile(KeyValuePair<YamlNode, YamlNode> entry, string parentPath, string key, out bool found)
+	private string? ReadFile(KeyValuePair<YamlNode, YamlNode> entry, string parentPath, out bool found)
 	{
 		found = false;
 		var file = ReadString(entry);
@@ -247,7 +247,7 @@ public record ConfigurationFile : DocumentationFile
 		return file;
 	}
 
-	private ConfigurationFile? ReadNestedToc(KeyValuePair<YamlNode, YamlNode> entry, string parentPath, out bool found)
+	private ConfigurationFile? ReadNestedToc(KeyValuePair<YamlNode, YamlNode> entry, out bool found)
 	{
 		found = false;
 		var tocPath = ReadString(entry);

--- a/src/Elastic.Markdown/IO/MarkdownFile.cs
+++ b/src/Elastic.Markdown/IO/MarkdownFile.cs
@@ -13,7 +13,6 @@ using Elastic.Markdown.Slices;
 using Markdig;
 using Markdig.Extensions.Yaml;
 using Markdig.Syntax;
-using YamlDotNet.Serialization;
 
 namespace Elastic.Markdown.IO;
 
@@ -156,7 +155,7 @@ public record MarkdownFile : DocumentationFile
 				var header = h.Item1!.StripMarkdown();
 				if (header.AsSpan().ReplaceSubstitutions(subs, out var replacement))
 					header = replacement;
-				return new PageTocItem { Heading = header!, Slug = (h.Item2 ?? header).Slugify(), Level = h.Level };
+				return new PageTocItem { Heading = header, Slug = (h.Item2 ?? header).Slugify(), Level = h.Level };
 			})
 			.ToList();
 

--- a/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlock.cs
+++ b/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlock.cs
@@ -29,7 +29,7 @@ public class EnhancedCodeBlock(BlockParser parser, ParserContext context)
 
 	public List<CallOut> CallOuts { get; set; } = [];
 
-	public IReadOnlyCollection<CallOut> UniqueCallOuts => CallOuts?.DistinctBy(c => c.Index).ToList() ?? [];
+	public IReadOnlyCollection<CallOut> UniqueCallOuts => [.. CallOuts.DistinctBy(c => c.Index)];
 
 	public bool InlineAnnotations { get; set; }
 

--- a/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockHtmlRenderer.cs
+++ b/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockHtmlRenderer.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information
 
 using Elastic.Markdown.Diagnostics;
-using Elastic.Markdown.Myst.Directives;
 using Elastic.Markdown.Slices.Directives;
 using Markdig.Helpers;
 using Markdig.Renderers;
@@ -65,7 +64,7 @@ public class EnhancedCodeBlockHtmlRenderer : HtmlObjectRenderer<EnhancedCodeBloc
 
 	private static void RenderCallouts(HtmlRenderer renderer, EnhancedCodeBlock block, int lineNumber)
 	{
-		var callOuts = FindCallouts(block.CallOuts ?? [], lineNumber + 1);
+		var callOuts = FindCallouts(block.CallOuts, lineNumber + 1);
 		foreach (var callOut in callOuts)
 			renderer.Write($"<span class=\"code-callout\" data-index=\"{callOut.Index}\">{callOut.Index}</span>");
 	}

--- a/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockParser.cs
+++ b/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockParser.cs
@@ -103,12 +103,12 @@ public class EnhancedCodeBlockParser : FencedBlockParserBase<EnhancedCodeBlock>
 		if (codeBlock is not AppliesToDirective appliesToDirective)
 			ProcessCallOuts(lines, language, codeBlock, context);
 		else
-			ProcessAppliesToDirective(appliesToDirective, lines, context);
+			ProcessAppliesToDirective(appliesToDirective, lines);
 
 		return base.Close(processor, block);
 	}
 
-	private static void ProcessAppliesToDirective(AppliesToDirective appliesToDirective, StringLineGroup lines, ParserContext context)
+	private static void ProcessAppliesToDirective(AppliesToDirective appliesToDirective, StringLineGroup lines)
 	{
 		var yaml = lines.ToSlice().AsSpan().ToString();
 
@@ -195,8 +195,8 @@ public class EnhancedCodeBlockParser : FencedBlockParserBase<EnhancedCodeBlock>
 			}
 		}
 
-		var inlineAnnotations = codeBlock.CallOuts?.Where(c => c.InlineCodeAnnotation).Count() ?? 0;
-		var classicAnnotations = codeBlock.CallOuts?.Count - inlineAnnotations ?? 0;
+		var inlineAnnotations = codeBlock.CallOuts.Count(c => c.InlineCodeAnnotation);
+		var classicAnnotations = codeBlock.CallOuts.Count - inlineAnnotations;
 		if (inlineAnnotations > 0 && classicAnnotations > 0)
 			codeBlock.EmitError("Both inline and classic callouts are not supported");
 

--- a/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeMarkdownExtensions.cs
+++ b/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeMarkdownExtensions.cs
@@ -2,7 +2,6 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-using Elastic.Markdown.Myst.Directives;
 using Markdig;
 using Markdig.Parsers;
 using Markdig.Renderers;

--- a/src/Elastic.Markdown/Myst/Comments/CommentBlockParser.cs
+++ b/src/Elastic.Markdown/Myst/Comments/CommentBlockParser.cs
@@ -107,7 +107,6 @@ public class CommentBlockParser : BlockParser
 			// The optional closing sequence of #s must be preceded by a space and may be followed by spaces only.
 			var endState = 0;
 			var countClosingTags = 0;
-			var sourceEnd = processor.Line.End;
 			for (var i = processor.Line.End;
 				 i >= processor.Line.Start - 1;
 				 i--) // Go up to Start - 1 in order to match the space after the first ###

--- a/src/Elastic.Markdown/Myst/Directives/AppliesBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/AppliesBlock.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information
 
 using Elastic.Markdown.Diagnostics;
-using Elastic.Markdown.Myst.FrontMatter;
-using Markdig.Syntax;
 
 namespace Elastic.Markdown.Myst.Directives;
 

--- a/src/Elastic.Markdown/Myst/Directives/DirectiveBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/DirectiveBlock.cs
@@ -6,7 +6,6 @@
 // See the license.txt file in the project root for more information.
 
 using System.IO.Abstractions;
-using Elastic.Markdown.Diagnostics;
 using Markdig.Helpers;
 using Markdig.Syntax;
 

--- a/src/Elastic.Markdown/Myst/Directives/DirectiveHtmlRenderer.cs
+++ b/src/Elastic.Markdown/Myst/Directives/DirectiveHtmlRenderer.cs
@@ -6,7 +6,6 @@
 // See the license.txt file in the project root for more information.
 
 using Elastic.Markdown.Diagnostics;
-using Elastic.Markdown.Myst.FrontMatter;
 using Elastic.Markdown.Myst.Settings;
 using Elastic.Markdown.Myst.Substitution;
 using Elastic.Markdown.Slices.Directives;
@@ -121,7 +120,7 @@ public class DirectiveHtmlRenderer : HtmlObjectRenderer<DirectiveBlock>
 					   (block.ImageUrl.StartsWith("/_static") || block.ImageUrl.StartsWith("_static"))
 			? $"{block.Build.UrlPathPrefix}/{block.ImageUrl.TrimStart('/')}"
 			: block.ImageUrl;
-		var slice = Slices.Directives.Figure.Create(new ImageViewModel
+		var slice = Figure.Create(new ImageViewModel
 		{
 			Label = block.Label,
 			Align = block.Align,

--- a/src/Elastic.Markdown/Myst/Directives/DirectiveParagraphParser.cs
+++ b/src/Elastic.Markdown/Myst/Directives/DirectiveParagraphParser.cs
@@ -13,9 +13,9 @@ public class DirectiveParagraphParser : ParagraphBlockParser
 		var line = processor.Line.AsSpan();
 
 		// TODO Validate properties on directive.
-		if (line.StartsWith(":") && processor.CurrentBlock is DirectiveBlock directive)
+		if (line.StartsWith(":") && processor.CurrentBlock is DirectiveBlock)
 			return BlockState.None;
-		else if (line.StartsWith(":"))
+		if (line.StartsWith(":"))
 			return BlockState.None;
 
 		return base.TryOpen(processor);

--- a/src/Elastic.Markdown/Myst/Directives/TabSetBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/TabSetBlock.cs
@@ -4,7 +4,6 @@
 
 using Elastic.Markdown.Diagnostics;
 using Elastic.Markdown.Helpers;
-using Elastic.Markdown.Slices.Directives;
 
 namespace Elastic.Markdown.Myst.Directives;
 

--- a/src/Elastic.Markdown/Myst/FrontMatter/AllVersions.cs
+++ b/src/Elastic.Markdown/Myst/FrontMatter/AllVersions.cs
@@ -18,7 +18,7 @@ public class SemVersionConverter : IYamlTypeConverter
 {
 	public bool Accepts(Type type) => type == typeof(SemVersion);
 
-	public object? ReadYaml(IParser parser, Type type, ObjectDeserializer rootDeserializer)
+	public object ReadYaml(IParser parser, Type type, ObjectDeserializer rootDeserializer)
 	{
 		var value = parser.Consume<Scalar>();
 		if (string.IsNullOrWhiteSpace(value.Value))

--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -109,7 +109,7 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 			return;
 		}
 
-		if (ValidateExternalUri(link, processor, context, uri))
+		if (ValidateExternalUri(link, processor, uri))
 			return;
 
 		ProcessInternalLink(link, processor, context);
@@ -134,7 +134,7 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 		return true;
 	}
 
-	private bool ValidateExternalUri(LinkInline link, InlineProcessor processor, ParserContext context, Uri? uri)
+	private bool ValidateExternalUri(LinkInline link, InlineProcessor processor, Uri? uri)
 	{
 		if (uri == null)
 			return false;

--- a/src/Elastic.Markdown/Myst/InlineParsers/HeadingBlockWithSlugParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/HeadingBlockWithSlugParser.cs
@@ -6,7 +6,6 @@ using System.Text.RegularExpressions;
 using Markdig;
 using Markdig.Helpers;
 using Markdig.Parsers;
-using Markdig.Parsers.Inlines;
 using Markdig.Renderers;
 using Markdig.Syntax;
 

--- a/src/Elastic.Markdown/Myst/InlineParsers/InlineAnchorParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/InlineAnchorParser.cs
@@ -4,7 +4,6 @@
 
 using Elastic.Markdown.Helpers;
 using Markdig;
-using Markdig.Extensions.SmartyPants;
 using Markdig.Helpers;
 using Markdig.Parsers;
 using Markdig.Parsers.Inlines;
@@ -35,16 +34,10 @@ public class InlineAnchorBuilderExtension : IMarkdownExtension
 
 public class InlineAnchorParser : InlineParser
 {
-	public InlineAnchorParser()
-	{
-		OpeningCharacters = ['$'];
-	}
+	public InlineAnchorParser() => OpeningCharacters = ['$'];
 
 	public override bool Match(InlineProcessor processor, ref StringSlice slice)
 	{
-		var startPosition = processor.GetSourcePosition(slice.Start, out var line, out var column);
-		var c = slice.CurrentChar;
-
 		var span = slice.AsSpan();
 		if (!span.StartsWith("$$$"))
 			return false;

--- a/src/Elastic.Markdown/Myst/MarkdownParser.cs
+++ b/src/Elastic.Markdown/Myst/MarkdownParser.cs
@@ -7,7 +7,6 @@ using Cysharp.IO;
 using Elastic.Markdown.CrossLinks;
 using Elastic.Markdown.IO;
 using Elastic.Markdown.IO.Configuration;
-using Elastic.Markdown.IO.State;
 using Elastic.Markdown.Myst.CodeBlocks;
 using Elastic.Markdown.Myst.Comments;
 using Elastic.Markdown.Myst.Directives;

--- a/src/Elastic.Markdown/Myst/Substitution/SubstitutionParser.cs
+++ b/src/Elastic.Markdown/Myst/Substitution/SubstitutionParser.cs
@@ -3,10 +3,8 @@
 // See the LICENSE file in the project root for more information
 using System.Buffers;
 using System.Diagnostics;
-using System.Net.Mime;
 using System.Runtime.CompilerServices;
 using Elastic.Markdown.Diagnostics;
-using Markdig;
 using Markdig.Helpers;
 using Markdig.Parsers;
 using Markdig.Renderers;
@@ -69,7 +67,7 @@ internal struct LazySubstring
 	}
 }
 
-[DebuggerDisplay("{GetType().Name} Line: {Line}, {Lines} Level: {Level}")]
+[DebuggerDisplay("{GetType().Name} Line: {Line}, Found: {Found}, Replacement: {Replacement}")]
 public class SubstitutionLeaf(string content, bool found, string replacement) : CodeInline(content)
 {
 	public bool Found { get; } = found;
@@ -78,13 +76,8 @@ public class SubstitutionLeaf(string content, bool found, string replacement) : 
 
 public class SubstitutionRenderer : HtmlObjectRenderer<SubstitutionLeaf>
 {
-	protected override void Write(HtmlRenderer renderer, SubstitutionLeaf obj)
-	{
-		if (obj.Found)
-			renderer.Write(obj.Replacement);
-		else
-			renderer.Write(obj.Content);
-	}
+	protected override void Write(HtmlRenderer renderer, SubstitutionLeaf obj) =>
+		renderer.Write(obj.Found ? obj.Replacement : obj.Content);
 }
 
 public class SubstitutionParser : InlineParser

--- a/src/Elastic.Markdown/Slices/Directives/ApplicableTo.cshtml
+++ b/src/Elastic.Markdown/Slices/Directives/ApplicableTo.cshtml
@@ -57,25 +57,7 @@
 
 @functions {
 
-	private string GetLifeCycleClass(ProductLifecycle cycle)
-	{
-		switch (cycle)
-		{
-			case ProductLifecycle.Deprecated:
-			case ProductLifecycle.Coming:
-			case ProductLifecycle.Discontinued:
-			case ProductLifecycle.Unavailable:
-				return "muted";
-			case ProductLifecycle.GenerallyAvailable:
-			case ProductLifecycle.TechnicalPreview:
-			case ProductLifecycle.Beta:
-			case ProductLifecycle.Development:
-				return "primary";
-			default:
-				throw new ArgumentOutOfRangeException(nameof(cycle), cycle, null);
-		}
-	}
-	private string GetLifeCycleName(ProductLifecycle cycle)
+	private static string GetLifeCycleName(ProductLifecycle cycle)
 	{
 		switch (cycle)
 		{
@@ -104,7 +86,6 @@
 	{
 		foreach (var applicability in applications)
 		{
-			var c = GetLifeCycleClass(applicability.Lifecycle);
 			<span class="applicable-info">
 				@name
 				@if (applicability.Lifecycle != ProductLifecycle.GenerallyAvailable)

--- a/src/Elastic.Markdown/Slices/Directives/Settings.cshtml
+++ b/src/Elastic.Markdown/Slices/Directives/Settings.cshtml
@@ -1,4 +1,3 @@
-@using Elastic.Markdown.Myst.FrontMatter
 @using Elastic.Markdown.Myst.Settings
 @inherits RazorSlice<SettingsViewModel>
 

--- a/src/Elastic.Markdown/Slices/Directives/_ViewModels.cs
+++ b/src/Elastic.Markdown/Slices/Directives/_ViewModels.cs
@@ -2,7 +2,6 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 using System.Text;
-using Elastic.Markdown.Myst.Directives;
 using Elastic.Markdown.Myst.Settings;
 
 namespace Elastic.Markdown.Slices.Directives;

--- a/src/Elastic.Markdown/Slices/HtmlWriter.cs
+++ b/src/Elastic.Markdown/Slices/HtmlWriter.cs
@@ -28,9 +28,6 @@ public class HtmlWriter
 	public ILoggerFactory LoggerFactory { get; }
 	public ServiceProvider ServiceProvider { get; }
 
-	private Task<string> RenderEmptyString(MarkdownFile markdown, Cancel ctx = default) =>
-		Task.FromResult(string.Empty);
-
 	private async Task<string> RenderNavigation(MarkdownFile markdown, Cancel ctx = default)
 	{
 		var slice = Layout._TocTree.Create(new NavigationViewModel

--- a/src/Elastic.Markdown/Slices/Layout/_Announcement.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_Announcement.cshtml
@@ -1,8 +1,0 @@
-<div class="announcement">
-	<div class="announcement-inner">
-		<p></p><center>👋 Thanks for checking out our Elastic Docs v3 POC. Have feedback? Reach out <a href="https://elastic.slack.com/archives/C07APH4RCDT">here</a>. Thanks!</center><p></p>
-		<button class="announcement-close" aria-label="Close announcement">
-			<i class="i-lucide close"></i>
-		</button>
-	</div>
-</div>

--- a/src/Elastic.Markdown/Slices/Layout/_Head.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_Head.cshtml
@@ -6,7 +6,6 @@
 	<title>@Model.Title</title>
 	<link rel="index" title="Index" href="@Model.Link("genindex.html")"/>
 	<link rel="search" title="Search" href="@Model.Link("search.html")"/>
-	<link rel="next" title="Elastic content" href="elastic/index.html"/>
 	<link rel="stylesheet" type="text/css" href="@Model.Static("pygments.css")"/>
 	<link rel="stylesheet" type="text/css" href="@Model.Static("shibuya.css")"/>
 	<link rel="stylesheet" type="text/css" href="@Model.Static("mystnb.css")"/>

--- a/src/Elastic.Markdown/Slices/Layout/_HeadNav.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_HeadNav.cshtml
@@ -48,6 +48,7 @@
 									<small>Description.</small>
 								</a></li></ul>
 					</li><li class="link"><a href="#">What's New</a></li></ul></nav>
+			@* ReSharper disable once Html.PathError *@
 			<div class="sy-head-extra flex items-center print:hidden"><form class="searchbox flex items-center" action="search.html" method="get">
 					<input type="text" name="q" placeholder="Search">
 					<kbd>/</kbd>

--- a/src/Elastic.Markdown/SourceGenerationContext.cs
+++ b/src/Elastic.Markdown/SourceGenerationContext.cs
@@ -4,7 +4,6 @@
 
 using System.Text.Json.Serialization;
 using Elastic.Markdown.CrossLinks;
-using Elastic.Markdown.IO;
 using Elastic.Markdown.IO.Discovery;
 using Elastic.Markdown.IO.State;
 

--- a/src/docs-assembler/Cli/LinkCommands.cs
+++ b/src/docs-assembler/Cli/LinkCommands.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information
 
 using System.Text;
-using Actions.Core.Services;
 using Amazon.S3;
 using Amazon.S3.Model;
 using ConsoleAppFramework;

--- a/src/docs-assembler/Cli/RepositoryCommands.cs
+++ b/src/docs-assembler/Cli/RepositoryCommands.cs
@@ -37,6 +37,7 @@ internal class RepositoryCommands(ILoggerFactory logger)
 	[Command("clone-all")]
 	public async Task CloneAll(Cancel ctx = default)
 	{
+		AssignOutputLogger();
 		var configFile = Path.Combine(Paths.Root.FullName, "src/docs-assembler/conf.yml");
 		var config = AssemblyConfiguration.Deserialize(File.ReadAllText(configFile));
 
@@ -73,6 +74,7 @@ internal class RepositoryCommands(ILoggerFactory logger)
 	[Command("list")]
 	public async Task ListRepositories(Cancel ctx = default)
 	{
+		AssignOutputLogger();
 		var assemblyPath = Path.Combine(Paths.Root.FullName, $".artifacts/assembly");
 		var dir = new DirectoryInfo(assemblyPath);
 		var dictionary = new Dictionary<string, string>();

--- a/src/docs-assembler/Program.cs
+++ b/src/docs-assembler/Program.cs
@@ -2,19 +2,13 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-using System.Collections.Concurrent;
-using System.Diagnostics;
 using Actions.Core.Extensions;
 using Actions.Core.Services;
 using ConsoleAppFramework;
-using Documentation.Assembler;
 using Documentation.Assembler.Cli;
 using Elastic.Markdown.Diagnostics;
-using Elastic.Markdown.IO;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using ProcNet;
-using ProcNet.Std;
 
 var services = new ServiceCollection();
 services.AddGitHubActionsCore();

--- a/src/docs-builder/Http/DocumentationWebHost.cs
+++ b/src/docs-builder/Http/DocumentationWebHost.cs
@@ -1,21 +1,16 @@
 // Licensed to Elasticsearch B.V under one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
-using System.Diagnostics.CodeAnalysis;
+
 using System.IO.Abstractions;
-using System.Reflection;
-using Documentation.Builder.Diagnostics;
-using Documentation.Builder.Diagnostics.Console;
 using Documentation.Builder.Diagnostics.LiveMode;
 using Elastic.Markdown;
-using Elastic.Markdown.Diagnostics;
 using Elastic.Markdown.IO;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
-using Microsoft.Extensions.FileProviders.Physical;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
@@ -29,11 +24,9 @@ public class DocumentationWebHost
 	private readonly WebApplication _webApplication;
 
 	private readonly BuildContext _context;
-	private readonly ILogger<DocumentationWebHost> _logger;
 
 	public DocumentationWebHost(string? path, int port, ILoggerFactory logger, IFileSystem fileSystem)
 	{
-		_logger = logger.CreateLogger<DocumentationWebHost>();
 		var builder = WebApplication.CreateSlimBuilder();
 
 		builder.Logging.ClearProviders();
@@ -134,7 +127,7 @@ public class EmbeddedOrPhysicalFileProvider : IFileProvider
 	private readonly EmbeddedFileProvider _embeddedProvider = new(typeof(BuildContext).Assembly, "Elastic.Markdown._static");
 	private readonly PhysicalFileProvider? _staticFilesInDocsFolder;
 
-	private readonly PhysicalFileProvider? _staticWebFilesDuringDebug = null;
+	private readonly PhysicalFileProvider? _staticWebFilesDuringDebug;
 
 	public EmbeddedOrPhysicalFileProvider(BuildContext context)
 	{

--- a/src/docs-builder/Http/DocumentationWebHost.cs
+++ b/src/docs-builder/Http/DocumentationWebHost.cs
@@ -142,6 +142,8 @@ public class EmbeddedOrPhysicalFileProvider : IFileProvider
 			var debugWebFiles = Path.Combine(solutionRoot.FullName, "src", "Elastic.Markdown", "_static");
 			_staticWebFilesDuringDebug = new PhysicalFileProvider(debugWebFiles);
 		}
+#else
+		_staticWebFilesDuringDebug = null;
 #endif
 		if (context.ReadFileSystem.Directory.Exists(documentationStaticFiles))
 			_staticFilesInDocsFolder = new PhysicalFileProvider(documentationStaticFiles);

--- a/src/docs-builder/Program.cs
+++ b/src/docs-builder/Program.cs
@@ -4,7 +4,6 @@
 
 using Actions.Core.Extensions;
 using ConsoleAppFramework;
-using Documentation.Builder;
 using Documentation.Builder.Cli;
 using Elastic.Markdown.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;

--- a/tests/Elastic.Markdown.Tests/Directives/DirectiveBaseTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/DirectiveBaseTests.cs
@@ -3,12 +3,10 @@
 // See the LICENSE file in the project root for more information
 using System.IO.Abstractions.TestingHelpers;
 using Elastic.Markdown.IO;
-using Elastic.Markdown.Myst;
 using Elastic.Markdown.Myst.Directives;
 using FluentAssertions;
 using JetBrains.Annotations;
 using Markdig.Syntax;
-using Microsoft.Extensions.Logging;
 
 namespace Elastic.Markdown.Tests.Directives;
 

--- a/tests/Elastic.Markdown.Tests/Directives/MermaidTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/MermaidTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information
 using Elastic.Markdown.Myst.Directives;
 using FluentAssertions;
-using Xunit;
 
 namespace Elastic.Markdown.Tests.Directives;
 

--- a/tests/Elastic.Markdown.Tests/Directives/TabTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/TabTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information
 using Elastic.Markdown.Myst.Directives;
 using FluentAssertions;
-using Markdig;
 
 namespace Elastic.Markdown.Tests.Directives;
 
@@ -161,9 +160,7 @@ Content for C# tab
 		sets.Length.Should().Be(2);
 
 		foreach (var t in sets)
-		{
 			t.GetGroupKey().Should().Be("languages");
-		}
 	}
 
 	[Fact]

--- a/tests/Elastic.Markdown.Tests/Directives/VersionTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/VersionTests.cs
@@ -5,7 +5,6 @@
 using Elastic.Markdown.Helpers;
 using Elastic.Markdown.Myst.Directives;
 using FluentAssertions;
-using Markdig.Syntax;
 
 namespace Elastic.Markdown.Tests.Directives;
 

--- a/tests/Elastic.Markdown.Tests/DocSet/LinkReferenceTests.cs
+++ b/tests/Elastic.Markdown.Tests/DocSet/LinkReferenceTests.cs
@@ -2,7 +2,6 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-using Elastic.Markdown.IO;
 using Elastic.Markdown.IO.Discovery;
 using Elastic.Markdown.IO.State;
 using FluentAssertions;
@@ -36,7 +35,7 @@ public class GitCheckoutInformationTests(ITestOutputHelper output) : NavigationT
 		var git = GitCheckoutInformation.Create(ReadFileSystem);
 
 		git.Should().NotBeNull();
-		git!.Branch.Should().NotBeNullOrWhiteSpace();
+		git.Branch.Should().NotBeNullOrWhiteSpace();
 		// this validates we are not returning the test instance as were doing a real read
 		git.Branch.Should().NotContain(git.Ref);
 		git.Ref.Should().NotBeNullOrWhiteSpace();

--- a/tests/Elastic.Markdown.Tests/DocSet/NavigationTestsBase.cs
+++ b/tests/Elastic.Markdown.Tests/DocSet/NavigationTestsBase.cs
@@ -4,7 +4,6 @@
 
 using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
-using Elastic.Markdown.Diagnostics;
 using Elastic.Markdown.IO;
 using Elastic.Markdown.IO.Configuration;
 using FluentAssertions;

--- a/tests/Elastic.Markdown.Tests/Inline/InlneBaseTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/InlneBaseTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information
 using System.IO.Abstractions.TestingHelpers;
 using Elastic.Markdown.IO;
-using Elastic.Markdown.Tests.Directives;
 using FluentAssertions;
 using JetBrains.Annotations;
 using Markdig.Syntax;

--- a/tests/Elastic.Markdown.Tests/OutputDirectoryTests.cs
+++ b/tests/Elastic.Markdown.Tests/OutputDirectoryTests.cs
@@ -5,7 +5,6 @@ using System.IO.Abstractions.TestingHelpers;
 using Elastic.Markdown.Diagnostics;
 using Elastic.Markdown.IO;
 using FluentAssertions;
-using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Elastic.Markdown.Tests;
 

--- a/tests/Elastic.Markdown.Tests/TestLogger.cs
+++ b/tests/Elastic.Markdown.Tests/TestLogger.cs
@@ -13,7 +13,7 @@ public class TestLogger(ITestOutputHelper output) : ILogger
 		public void Dispose() { }
 	}
 
-	public IDisposable? BeginScope<TState>(TState state) where TState : notnull => new NullScope();
+	public IDisposable BeginScope<TState>(TState state) where TState : notnull => new NullScope();
 
 	public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Trace;
 


### PR DESCRIPTION
Just a little cleanup to get us back to zero warnings.

At some point we want to be more strict and make warnings errors as well as have better linting on CI.