### PR TITLE
Update code block parser to handle YAML key warnings

### DIFF
--- a/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockParser.cs
+++ b/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockParser.cs
@@ -116,6 +116,11 @@ public class EnhancedCodeBlockParser : FencedBlockParserBase<EnhancedCodeBlock>
 		{
 			var applicableTo = YamlSerialization.Deserialize<ApplicableTo>(yaml);
 			appliesToDirective.AppliesTo = applicableTo;
+			if (appliesToDirective.AppliesTo.Warnings is null)
+				return;
+			foreach (var warning in appliesToDirective.AppliesTo.Warnings)
+				appliesToDirective.EmitWarning(warning);
+			applicableTo.Warnings = null;
 		}
 		catch (Exception e)
 		{

--- a/tests/authoring/Applicability/AppliesToDirective.fs
+++ b/tests/authoring/Applicability/AppliesToDirective.fs
@@ -56,3 +56,29 @@ serverless:
                 Observability=ApplicabilityOverTime.op_Explicit "discontinued 9.2.0"
             )
         ))
+
+type ``warns on old syntax`` () =
+    static let markdown = Setup.Markdown """
+```{applies_to}
+:hosted: all
+```
+"""
+    [<Fact>]
+    let ``has no errors`` () = markdown |> hasNoErrors
+
+    [<Fact>]
+    let ``warns on bad syntax`` () =
+        markdown |> hasWarning "Applies block does not use valid yaml keys: :hosted"
+
+type ``warns on invalid keys`` () =
+    static let markdown = Setup.Markdown """
+```{applies_to}
+hosted: all
+```
+"""
+    [<Fact>]
+    let ``has no errors`` () = markdown |> hasNoErrors
+
+    [<Fact>]
+    let ``warns on bad syntax`` () =
+        markdown |> hasWarning "Applies block does not support the following keys: hosted"


### PR DESCRIPTION
Enhanced the `ApplicableTo` deserialization to detect and warn about invalid or outdated YAML keys. Added corresponding unit tests to ensure proper warning messages are generated for unsupported or old syntax in `applies_to` blocks.
