### PR TITLE
Rename Elastic Cloud to Elastic Cloud Hosted for applies_to displayed values

### DIFF
--- a/src/Elastic.Markdown/Slices/Directives/ApplicableTo.cshtml
+++ b/src/Elastic.Markdown/Slices/Directives/ApplicableTo.cshtml
@@ -18,7 +18,7 @@
 		}
 		if (Model.Deployment.Ess is not null)
 		{
-			@RenderProduct("Elastic Cloud", Model.Deployment.Ess)
+			@RenderProduct("Elastic Cloud Hosted", Model.Deployment.Ess)
 		}
 		if (Model.Deployment.Self is not null)
 		{


### PR DESCRIPTION
Elastic Cloud includes both Elastic Cloud Hosted and Serverless, so we rather need "ess" to map to "Elastic Cloud Hosted" rather than "Elastic Cloud" to avoid ambiguity on our pages.

When something applies to "all Elastic Cloud", we can show both `Elastic Cloud Hosted` and `Serverless`, also to avoid any ambiguity.