### PR TITLE
Change one Security serverless "applies to" duplicate to missing Elasticsearch serverless

### DIFF
--- a/src/Elastic.Markdown/Slices/Directives/ApplicableTo.cshtml
+++ b/src/Elastic.Markdown/Slices/Directives/ApplicableTo.cshtml
@@ -33,9 +33,9 @@
 		}
 		else
 		{
-			if (Model.Serverless.Security is not null)
+			if (Model.Serverless.Elasticsearch is not null)
 			{
-				@RenderProduct("Serverless Security", Model.Serverless.Security)
+				@RenderProduct("Serverless Elasticsearch", Model.Serverless.Elasticsearch)
 			}
 			if (Model.Serverless.Observability is not null)
 			{


### PR DESCRIPTION
Seems like ES is missing and Security is duplicated. Hopefully this actually fixes it 😅 Otherwise we get this: 
<img width="689" alt="image" src="https://github.com/user-attachments/assets/cb521218-7445-4ad1-bd17-b96ea2ae0812" />
