### PR TITLE
Add unpoly for dynamic content loading

### DIFF
--- a/src/Elastic.Markdown/Assets/copybutton.ts
+++ b/src/Elastic.Markdown/Assets/copybutton.ts
@@ -95,19 +95,6 @@ if (!iconCopy) {
 /**
  * Set up copy/paste for code blocks
  */
-
-const runWhenDOMLoaded = cb => {
-  if (document.readyState != 'loading') {
-    cb()
-  } else if (document.addEventListener) {
-    document.addEventListener('DOMContentLoaded', cb)
-  } else {
-    document.attachEvent('onreadystatechange', function() {
-      if (document.readyState == 'complete') cb()
-    })
-  }
-}
-
 const codeCellId = index => `codecell${index}`
 
 // Clears selected text since ClipboardJS will select the text when copying
@@ -145,9 +132,14 @@ const addCopyButtonToCodeCells = () => {
   // happens because we load ClipboardJS asynchronously.
 	
   // Add copybuttons to all of our code cells
-  const COPYBUTTON_SELECTOR = 'div.highlight pre';
+  const COPYBUTTON_SELECTOR = '.markdown-content div.highlight pre';
   const codeCells = document.querySelectorAll(COPYBUTTON_SELECTOR)
   codeCells.forEach((codeCell, index) => {
+	  
+	if (codeCell.id != "") {
+	  return
+	}
+	  
     const id = codeCellId(index)
     codeCell.setAttribute('id', id)
 
@@ -256,6 +248,5 @@ var copyTargetText = (trigger) => {
 }
 
 export function initCopyButton() {
-	console.log("initCopyButton");
-	runWhenDOMLoaded(addCopyButtonToCodeCells)
+	addCopyButtonToCodeCells()
 }

--- a/src/Elastic.Markdown/Assets/hljs.ts
+++ b/src/Elastic.Markdown/Assets/hljs.ts
@@ -164,6 +164,6 @@ hljs.registerLanguage('esql', function() {
 
 hljs.addPlugin(mergeHTMLPlugin);
 export function initHighlight() {
-
-	hljs.highlightAll();
+	document.querySelectorAll('.markdown-content pre code:not(.hljs)')
+		.forEach((block) => { hljs.highlightElement(block as HTMLElement); });
 }

--- a/src/Elastic.Markdown/Assets/main.ts
+++ b/src/Elastic.Markdown/Assets/main.ts
@@ -1,9 +1,23 @@
 import {initTocNav} from "./toc-nav";
-import {initHighlight} from "./hljs";
 import {initTabs} from "./tabs";
 import {initCopyButton} from "./copybutton";
+import {initNav} from "./pages-nav";
+import {initHighlight} from "./hljs";
 
-initTocNav();
-initHighlight();
-initCopyButton();
-initTabs();
+
+
+up.link.config.followSelectors.push('a[href]')
+up.link.config.preloadSelectors.push('a[href]')
+
+
+up.compiler('.markdown-content, #toc-nav', () => {
+	window.scrollTo(0, 0);
+	const destroyTocNav = initTocNav();
+	initNav();
+	initHighlight();
+	initCopyButton();
+	initTabs();
+	return () => {
+		destroyTocNav();
+	}
+})

--- a/src/Elastic.Markdown/Assets/pages-nav.ts
+++ b/src/Elastic.Markdown/Assets/pages-nav.ts
@@ -1,87 +1,21 @@
-import {$, $$} from "select-dom";
+import {$} from "select-dom";
 
-type NavExpandState = {
-	current:string,
-	selected: Record<string, boolean>
-};
-const PAGE_NAV_EXPAND_STATE_KEY = 'pagesNavState';
-
-// Initialize the nav state from the session storage
-// Return a function to keep the nav state in the session storage that should be called before the page is unloaded
-function keepNavState(nav: HTMLElement): () => void {
-
-	const currentNavigation = nav.dataset.currentNavigation;
-	const currentPageId = nav.dataset.currentPageId;
-
-	let navState = JSON.parse(sessionStorage.getItem(PAGE_NAV_EXPAND_STATE_KEY) ?? "{}") as NavExpandState
-	if (navState.current !== currentNavigation)
-	{
-		sessionStorage.removeItem(PAGE_NAV_EXPAND_STATE_KEY);
-		navState = { current: currentNavigation } as NavExpandState;
-	}
-	if (currentPageId)
-	{
-		const currentPageLink = $('a[id="page-' + currentPageId + '"]', nav);
-		currentPageLink.classList.add('current');
-		currentPageLink.classList.add('pointer-events-none');
-		currentPageLink.classList.add('text-blue-elastic!');
-		currentPageLink.classList.add('font-semibold');
-
-		const parentIds = nav.dataset.currentPageParentIds?.split(',') ?? [];
-		for (const parentId of parentIds)
-		{
-			const input = $('input[type="checkbox"][id=\"'+parentId+'\"]', nav) as HTMLInputElement;
-			if (input) {
-				input.checked = true;
-				const link = input.nextElementSibling as HTMLAnchorElement;
-				link.classList.add('font-semibold');
-			}
+function expandAllParents(navItem: HTMLElement) {
+	let parent = navItem.closest('li');
+	while (parent) {
+		const input = parent.querySelector('input');
+		if (input) {
+			(input as HTMLInputElement).checked = true;
 		}
-	}
-
-	// expand items previously selected
-	for (const groupId in navState.selected)
-	{
-		const input = $('input[type="checkbox"][id=\"'+groupId+'\"]', nav) as HTMLInputElement;
-		input.checked = navState.selected[groupId];
-	}
-
-	return () => {
-		// store all expanded groups
-		const inputs = $$('input[type="checkbox"]:checked', nav);
-		const selectedMap: Record<string, boolean> = inputs
-			.filter(input => input.checked)
-			.reduce((state: Record<string, boolean>, input) => {
-			const key = input.id;
-			const value = input.checked;
-			return { ...state, [key]: value};
-		}, {});
-		const state = { current: currentNavigation, selected: selectedMap };
-		sessionStorage.setItem(PAGE_NAV_EXPAND_STATE_KEY, JSON.stringify(state));
-	}
-}
-
-type NavScrollPosition = number;
-const PAGE_NAV_SCROLL_POSITION_KEY = 'pagesNavScrollPosition';
-const pagesNavScrollPosition: NavScrollPosition = parseInt(
-	sessionStorage.getItem(PAGE_NAV_SCROLL_POSITION_KEY) ?? '0'
-);
-
-
-// Initialize the nav scroll position from the session storage
-// Return a function to keep the nav scroll position in the session storage that should be called before the page is unloaded
-function keepNavPosition(nav: HTMLElement): () => void {
-	if (pagesNavScrollPosition) {
-		nav.scrollTop = pagesNavScrollPosition;
-	}
-	return () => {
-		sessionStorage.setItem(PAGE_NAV_SCROLL_POSITION_KEY, nav.scrollTop.toString());
+		parent = parent.parentElement?.closest('li');
 	}
 }
 
 function scrollCurrentNaviItemIntoView(nav: HTMLElement, delay: number) {
+	const currentNavItem = $('.up-current', nav);
+	expandAllParents(currentNavItem);
 	setTimeout(() => {
-		const currentNavItem = $('.current', nav);
+		
 		if (currentNavItem && !isElementInViewport(currentNavItem)) {
 			currentNavItem.scrollIntoView({ behavior: 'smooth', block: 'center' });
 		}
@@ -102,13 +36,5 @@ export function initNav() {
 	if (!pagesNav) {
 		return;
 	}
-	const keepNavStateCallback = keepNavState(pagesNav);
-	const keepNavPositionCallback = keepNavPosition(pagesNav);
 	scrollCurrentNaviItemIntoView(pagesNav, 100);
-	window.addEventListener('beforeunload', () => {
-		keepNavStateCallback();
-		keepNavPositionCallback();
-	}, true);
 }
-
-initNav();

--- a/src/Elastic.Markdown/Assets/styles.css
+++ b/src/Elastic.Markdown/Assets/styles.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+/*@import "unpoly/unpoly.css";*/
 @import "./fonts.css";
 @import "./theme.css";
 @import "./markdown/typography.css";
@@ -85,7 +86,7 @@
 	}
 	
 	.content-container {
-		@apply w-full max-w-[80ch] lg:w-[80ch];
+		@apply w-full max-w-[80ch];
 	}
 
 	.applies {
@@ -119,9 +120,9 @@
 
 :root {
 	--outline-size: max(2px, 0.08em);
-	--outline-style: auto;
+	--outline-style: solid;
 	--outline-color: var(--color-blue-elastic);
-	--outline-offset: 5;
+	--outline-offset: 10;
 }
 
 :is(a, button, input, textarea, summary):focus {
@@ -136,4 +137,29 @@
 
 :is(a, button, input, textarea, summary):focus:not(:focus-visible) {
 	outline: none;
+}
+
+up-progress-bar {
+	@apply bg-pink-90!;
+}
+
+.left-right {
+	transform-origin: 0% 50%;
+}
+@keyframes progress {
+	0% {
+		transform:  translateX(0) scaleX(0);
+	}
+	40% {
+		transform:  translateX(0) scaleX(0.4);
+	}
+	100% {
+		transform:  translateX(100%) scaleX(0.5);
+	}
+}
+
+#pages-nav {
+	.up-current {
+		@apply text-blue-elastic!;
+	}
 }

--- a/src/Elastic.Markdown/Assets/styles.css
+++ b/src/Elastic.Markdown/Assets/styles.css
@@ -143,21 +143,6 @@ up-progress-bar {
 	@apply bg-pink-90!;
 }
 
-.left-right {
-	transform-origin: 0% 50%;
-}
-@keyframes progress {
-	0% {
-		transform:  translateX(0) scaleX(0);
-	}
-	40% {
-		transform:  translateX(0) scaleX(0.4);
-	}
-	100% {
-		transform:  translateX(100%) scaleX(0.5);
-	}
-}
-
 #pages-nav {
 	.up-current {
 		@apply text-blue-elastic!;

--- a/src/Elastic.Markdown/Assets/tabs.ts
+++ b/src/Elastic.Markdown/Assets/tabs.ts
@@ -34,7 +34,7 @@ function ready() {
   /** @type {string[]} */
   let groups = [];
 
-  document.querySelectorAll(".tabs-label").forEach((label) => {
+  document.querySelectorAll(".markdown-content .tabs-label").forEach((label) => {
     if (label instanceof HTMLElement) {
       let data = create_key(label);
       if (data) {
@@ -57,12 +57,6 @@ function ready() {
             group
           );
           if (tabParam) {
-            console.log(
-              "sphinx-design: Selecting tab id for group '" +
-                group +
-                "' from URL parameter: " +
-                tabParam
-            );
             window.sessionStorage.setItem(storageKeyPrefix + group, tabParam);
           }
         }
@@ -72,10 +66,6 @@ function ready() {
           storageKeyPrefix + group
         );
         if (previousId === id) {
-          // console.log(
-          //   "sphinx-design: Selecting tab from session storage: " + id
-          // );
-          // @ts-ignore
           label.previousElementSibling.checked = true;
         }
       }
@@ -101,6 +91,5 @@ function onSDLabelClick() {
 }
 
 export function initTabs() {
-	console.log("inittabs");
-  document.addEventListener("DOMContentLoaded", ready, false);
+	ready();
 }

--- a/src/Elastic.Markdown/Assets/toc-nav.ts
+++ b/src/Elastic.Markdown/Assets/toc-nav.ts
@@ -110,20 +110,29 @@ function updateIndicator(elements: TocElements) {
 	}
 }
 
-function setupSmoothScrolling(elements: TocElements) {
-	elements.tocLinks.forEach(link => {
-		link.addEventListener('click', (e) => {
-			const href = link.getAttribute('href');
-			if (href?.charAt(0) === '#') {
-				e.preventDefault();
-				const target = document.getElementById(href.slice(1));
-				if (target) {
-					target.scrollIntoView({ behavior: 'smooth' });
-					history.pushState(null, '', href);
-				}
+function setupSmoothScrolling(elements: TocElements): () => void {
+	const clickHandler = (e: Event) => {
+		const link = e.currentTarget as HTMLAnchorElement;
+		const href = link.getAttribute('href');
+		if (href?.charAt(0) === '#') {
+			e.preventDefault();
+			const target = document.getElementById(href.slice(1));
+			if (target) {
+				target.scrollIntoView({ behavior: 'smooth' });
+				history.pushState(null, '', href);
 			}
-		});
+		}
+	};
+
+	elements.tocLinks.forEach(link => {
+		link.addEventListener('click', clickHandler);
 	});
+
+	return () => {
+		elements.tocLinks.forEach(link => {
+			link.removeEventListener('click', clickHandler);
+		});
+	};
 }
 
 export function initTocNav(): () => void {
@@ -132,13 +141,14 @@ export function initTocNav(): () => void {
 		elements.progressIndicator.style.height = '0';
 		elements.progressIndicator.style.top = '0';
 	}
-	const update = () => updateIndicator(elements)
+	const update = () => updateIndicator(elements);
 	update();
 	window.addEventListener('scroll', update);
 	window.addEventListener('resize', update);
-	setupSmoothScrolling(elements);
+	const removeSmoothScrolling = setupSmoothScrolling(elements);
 	return () => {
 		window.removeEventListener('scroll', update);
 		window.removeEventListener('resize', update);
-	}
+		removeSmoothScrolling();
+	};
 }

--- a/src/Elastic.Markdown/Assets/toc-nav.ts
+++ b/src/Elastic.Markdown/Assets/toc-nav.ts
@@ -126,7 +126,7 @@ function setupSmoothScrolling(elements: TocElements) {
 	});
 }
 
-export function initTocNav() {
+export function initTocNav(): () => void {
 	const elements = initializeTocElements();
 	if (elements.progressIndicator != null) {
 		elements.progressIndicator.style.height = '0';
@@ -137,4 +137,8 @@ export function initTocNav() {
 	window.addEventListener('scroll', update);
 	window.addEventListener('resize', update);
 	setupSmoothScrolling(elements);
+	return () => {
+		window.removeEventListener('scroll', update);
+		window.removeEventListener('resize', update);
+	}
 }

--- a/src/Elastic.Markdown/Slices/Layout/_PagesNav.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_PagesNav.cshtml
@@ -1,8 +1,8 @@
 @inherits RazorSlice<LayoutViewModel>
-<aside class="sidebar hidden lg:block order-1 w-100 border-r-1 border-r-gray-200">
+<aside class="sidebar hidden lg:block order-1 border-r-1 border-r-gray-200">
 	<nav id="pages-nav" class="sidebar-nav pr-6"
 	     data-current-page-id="@Model.CurrentDocument.Id"
-	     data-current-page-parent-ids="@(string.Join(",",Model.ParentIds))"
+	     data-current-page-parent-ids="@(string.Join(",", Model.ParentIds))"
 	     @* used to invalidate session storage *@
 	     data-current-navigation="@LayoutViewModel.CurrentNavigationId">
 

--- a/src/Elastic.Markdown/Slices/Layout/_TableOfContents.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_TableOfContents.cshtml
@@ -1,6 +1,6 @@
 @inherits RazorSlice<LayoutViewModel>
 <aside class="sidebar hidden lg:block order-3 border-l-1 border-l-gray-200 w-80">
-	<nav id="toc-nav" class="sidebar-nav pl-6">
+	<nav id="toc-nav" class="sidebar-nav pl-6" up-hungry>
 		<div class="pt-6 pb-20">
 			@if (Model.PageTocItems.Count > 0)
 			{

--- a/src/Elastic.Markdown/Slices/Layout/_TocTree.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_TocTree.cshtml
@@ -1,7 +1,7 @@
 @inherits RazorSlice<NavigationViewModel>
-<div class="pt-6 pb-20">
+<div class="pt-6 pb-20 w-60">
 	<div class="font-bold">Elastic Docs</div>
-	<ul class="block w-full">
+	<ul class="block">
 		@await RenderPartialAsync(_TocTreeNav.Create(new NavigationTreeItem
 		{
 			Level = Model.Tree.Depth,

--- a/src/Elastic.Markdown/Slices/Layout/_TocTreeNav.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_TocTreeNav.cshtml
@@ -1,3 +1,4 @@
+@using Elastic.Markdown.Helpers
 @using Elastic.Markdown.IO.Navigation
 @inherits RazorSlice<NavigationTreeItem>
 @foreach (var item in Model.SubTree.NavigationItems)
@@ -9,7 +10,11 @@
 		<li class="block ml-2 pl-2 border-l-1 border-l-gray-200 group/li">
 			<div class="flex">
 				<a class="sidebar-link my-1 ml-5 group-[.current]/li:text-blue-elastic!"
-					id="page-@id" href="@f.Url">@f.NavigationTitle</a>
+				   id="page-@id"
+				   href="@f.Url"
+				>
+					@f.NavigationTitle
+				</a>
 			</div>
 		</li>
 	}
@@ -19,7 +24,7 @@
 		const int initialExpandLevel = 1;
 		var shouldInitiallyExpand = g.Depth <= initialExpandLevel;
 		<li class="flex flex-wrap group-navigation @(g.Depth > 1 ? "ml-2 pl-2 border-l-1 border-l-gray-200" : string.Empty)">
-			<label for="@id" class="peer group/label flex items-center overflow-hidden @(g.Depth == 1 ? "mt-2" : "")">
+			<label for="@id" class="peer flex group/label overflow-hidden @(g.Depth == 1 ? "mt-2" : "")">
 				<svg
 					xmlns="http://www.w3.org/2000/svg"
 					fill="none"
@@ -45,7 +50,7 @@
 			</label>
 			@if (g.NavigationItems.Count > 0)
 			{
-				<ul class="h-0 w-full overflow-y-hidden peer-has-checked:h-auto peer-has-[:focus]:h-auto has-[:focus]:h-auto peer-has-checked:my-1">
+				<ul class="h-0 w-full overflow-y-hidden peer-has-checked:h-auto peer-has-[:focus]:h-auto has-[:focus]:h-auto">
 					@await RenderPartialAsync(_TocTreeNav.Create(new NavigationTreeItem
 					{
 						Level = g.Depth,

--- a/src/Elastic.Markdown/Slices/_Layout.cshtml
+++ b/src/Elastic.Markdown/Slices/_Layout.cshtml
@@ -5,8 +5,13 @@
 	<title>@Model.Title</title>
 	<link rel="stylesheet" type="text/css" href="@Model.Static("styles.css")"/>
 	<meta charset="utf-8">
-	@* <meta name="viewport" content="width=device-width, initial-scale=1.0"> *@
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta name="robots" content="@(Model.AllowIndexing ? "index, follow" : "noindex, nofollow")">
+	<meta name="pages-nav-current-page-id" content="@Model.CurrentDocument.Id">
+	<meta name="pages-nav-current-page-parent-ids" content="@(string.Join(",", Model.ParentIds))">
+	<meta name="pages-nav-current-navigation" content="@LayoutViewModel.CurrentNavigationId">
+	<script src="https://cdn.jsdelivr.net/npm/unpoly@3.10.2/unpoly.min.js"></script>
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/unpoly@3.10.2/unpoly.min.css">
 </head>
 <body class="text-ink">
 @(await RenderPartialAsync(_Header.Create(Model)))
@@ -14,19 +19,21 @@
 <div class="container flex">
 	@await RenderPartialAsync(_PagesNav.Create(Model))
 	@await RenderPartialAsync(_TableOfContents.Create(Model))
-	<main class="w-full pt-6 pb-30 px-6 order-2">
+	<main class="w-full pt-6 pb-30 px-6 order-2" up-main>
 		<div class="content-container">
 			@await RenderPartialAsync(_Breadcrumbs.Create(Model))
 		</div>
-		<article class="content-container markdown-content">
+		<article id="markdown-content" class="content-container markdown-content">
 			@await RenderBodyAsync()
 		</article>
-		<footer class="content-container mt-20">
+		<footer class="content-container mt-20" id="prev-next-nav">
 			<div class="flex flex-wrap lg:flex-nowrap gap-2 mt-2">
 				<div class="w-full">
 					@if (Model.Previous != null)
 					{
-						<a href="@Model.Previous.Url" class="flex h-full items-center text-ink-light hover:black border-1 border-gray-300 hover:border-gray-500 rounded-lg p-6 shadow-md">
+						<a href="@Model.Previous.Url"
+						   class="flex h-full items-center text-ink-light hover:black border-1 border-gray-300 hover:border-gray-500 rounded-lg p-6 shadow-md"
+						>
 							<svg class="size-6 mr-2" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
 								<path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5"/>
 							</svg>
@@ -40,7 +47,8 @@
 				<div class="w-full">
 					@if (Model.Next != null)
 					{
-						<a href="@Model.Next.Url" class="flex h-full items-center justify-end text-ink-light hover:black border-1 border-gray-300 hover:border-gray-500 rounded-lg p-6 shadow-md text-right">
+						<a href="@Model.Next.Url"
+						   class="flex h-full items-center justify-end text-ink-light hover:black border-1 border-gray-300 hover:border-gray-500 rounded-lg p-6 shadow-md text-right">
 							<div>
 								<div class="text-xs lg:text-sm">Next</div>
 								<div class="text-base lg:text-xl text-black">@Model.Next.NavigationTitle</div>


### PR DESCRIPTION
## Changes
- Adds [unpoly](https://unpoly.com/) to dynamically load content in "progressive enhancement"-way.

## Notes

- I also evaluated htmx at https://github.com/elastic/docs-builder/pull/545
- 👍 However, unpoly feels more natural and straight forward to use and fits our use case well
- 👍 In the future we can also conditionally load content (e.g. the pages navigation)
- 👎 Unpoly creates a global variable `window.up` and it has no typescript support.
- 👎 When unpoly is initialized it messes up existing smooth scroll links. (e.g in ToC nav)

## Result


https://github.com/user-attachments/assets/6a20acf6-d7d6-48f0-92e0-7a4bdb306dea

