### PR TITLE
[DOCS] Update file_inclusion.md for linking to snippets with custom anchors

### DIFF
--- a/docs/syntax/file_inclusion.md
+++ b/docs/syntax/file_inclusion.md
@@ -22,7 +22,9 @@ Files to be included must live in a `_snippets` folder to be considered a snippe
 
 #### Linking to snippets with custom anchors
 
-To link to a heading with a [custom anchor (ID)](headings/#custom-anchor-links) defined in a snippet, target the parent file + anchor:
+To link to a heading with a [custom anchor (ID)](./headings/#custom-anchor-links) defined in a snippet, target the parent file + anchor. 
+
+For example:
 
 ```markdown
 [my favorite esql function](parent-file.md#id-from-included-snippet)

--- a/docs/syntax/file_inclusion.md
+++ b/docs/syntax/file_inclusion.md
@@ -22,7 +22,7 @@ Files to be included must live in a `_snippets` folder to be considered a snippe
 
 #### Linking to snippets with custom anchors
 
-To link to a heading with a [custom anchor (ID)](./headings.md/#custom-anchor-links) defined in a snippet, target the parent file + anchor. 
+To link to a heading with a [custom anchor (ID)](./headings.md#custom-anchor-links) defined in a snippet, target the parent file + anchor. 
 
 For example:
 

--- a/docs/syntax/file_inclusion.md
+++ b/docs/syntax/file_inclusion.md
@@ -20,6 +20,14 @@ Files to be included must live in a `_snippets` folder to be considered a snippe
 :::{include} _snippets/reusable-snippet.md
 :::
 
+#### Linking to snippets with custom anchors
+
+To link to a heading with a [custom anchor (ID)](headings/#custom-anchor-links) defined in a snippet, target the parent file + anchor:
+
+```markdown
+[my favorite esql function](parent-file.md#id-from-included-snippet)
+```
+
 ### Asciidoc syntax
 
 ```asciidoc

--- a/docs/syntax/file_inclusion.md
+++ b/docs/syntax/file_inclusion.md
@@ -22,7 +22,7 @@ Files to be included must live in a `_snippets` folder to be considered a snippe
 
 #### Linking to snippets with custom anchors
 
-To link to a heading with a [custom anchor (ID)](./headings/#custom-anchor-links) defined in a snippet, target the parent file + anchor. 
+To link to a heading with a [custom anchor (ID)](./headings.md/#custom-anchor-links) defined in a snippet, target the parent file + anchor. 
 
 For example:
 


### PR DESCRIPTION
working with esql folks they have lots of custom anchors/IDs within snippets and wiring up links wasn't immediately obvious


[PREVIEW](https://docs-v3-preview.elastic.dev/elastic/docs-builder/pull/564/syntax/file_inclusion#linking-to-snippets-with-custom-anchors)