### PR TITLE
pages-nav: Fix spacing shift when clicking on a group

### DIFF
--- a/src/Elastic.Markdown/Slices/Layout/_TocTreeNav.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_TocTreeNav.cshtml
@@ -61,7 +61,7 @@
 			</label>
 			@if (g.NavigationItems.Count > 0)
 			{
-				<ul class="h-0 w-full overflow-y-hidden peer-has-checked:h-auto peer-has-[:focus]:h-auto has-[:focus]:h-auto peer-has-checked:my-1">
+				<ul class="h-0 w-full overflow-y-hidden peer-has-checked:h-auto peer-has-[:focus]:h-auto has-[:focus]:h-auto">
 					@await RenderPartialAsync(_TocTreeNav.Create(new NavigationTreeItem
 					{
 						Level = g.Depth,


### PR DESCRIPTION
## Context

When clicking on a group and the group expands, there is a visible layout shift

https://github.com/user-attachments/assets/e1ab1c4a-5acf-4e2d-9ca4-7c9374823f8d

## Result

https://github.com/user-attachments/assets/4b608988-1920-4736-b617-6fd59208815e



