### PR TITLE
Add Free Disk Space to preview build workflow

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -1,7 +1,7 @@
 name: preview-build
 
 on:
-  pull_request_target: 
+  pull_request_target:
     types:
       - opened
       - synchronize
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   build:
-    concurrency: 
+    concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref }}
       cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
     runs-on: ubuntu-latest
@@ -46,14 +46,19 @@ jobs:
         uses: tj-actions/changed-files@d6e91a2266cdb9d62096cebf1e8546899c6aa18f # v45.0.6
         with:
           files: ${{ inputs.path-pattern != '' && inputs.path-pattern || '**' }}
-            
+
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+
       - name: Checkout
         if: github.event_name == 'push' || steps.check-files.outputs.any_changed == 'true'
         uses: actions/checkout@v4
-        with: 
+        with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
-        
+
       - name: Create Deployment
         if: github.event_name == 'push' || steps.check-files.outputs.any_changed == 'true'
         uses: actions/github-script@v7
@@ -86,7 +91,7 @@ jobs:
                 log_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
             })
             return deployment.data.id
-            
+
       - name: Generate env.PATH_PREFIX
         if: steps.deployment.outputs.result
         env:
@@ -113,7 +118,7 @@ jobs:
       - name: Bootstrap Action Workspace
         if: github.repository == 'elastic/docs-builder' && steps.deployment.outputs.result
         uses: ./.github/actions/bootstrap
-        
+
       # we run our artifact directly please use the prebuild
       # elastic/docs-builder@main GitHub Action for all other repositories!
       - name: Build documentation
@@ -142,7 +147,7 @@ jobs:
             --paths "${PATH_PREFIX}" "${PATH_PREFIX}/*"
 
       - name: Update Link Index
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.s3-upload.outcome == 'success' 
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.s3-upload.outcome == 'success'
         uses: elastic/docs-builder/actions/update-link-index@main
 
       - name: Update deployment status


### PR DESCRIPTION
Attempt to add [Free Disk Space (Ubuntu)](https://github.com/marketplace/actions/free-disk-space-ubuntu) to prevent running out of space in PR previews.