### PR TITLE
Fix tabs in list

### DIFF
--- a/src/Elastic.Markdown/Assets/markdown/list.css
+++ b/src/Elastic.Markdown/Assets/markdown/list.css
@@ -37,10 +37,13 @@
 	ol>li>ol>li>ol>li>ol>li>ol>li>ol { list-style-type: lower-roman; }
 	
 	/* Special handling of elements within a list item */
-	li>p:nth-child(2),
-	li>div>.highlight,
-	li>.admonition
+	li>*:first-child,
+	li>p:nth-child(2)
 	{
 		@apply mt-1;
+	}
+	li>p:first-child
+	{
+		@apply mt-4;
 	}
 }

--- a/src/Elastic.Markdown/Myst/Directives/TabSetBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/TabSetBlock.cs
@@ -2,11 +2,8 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-using System.Linq;
-using System.Reflection.Metadata;
 using Elastic.Markdown.Diagnostics;
 using Elastic.Markdown.Helpers;
-using Markdig.Syntax;
 
 namespace Elastic.Markdown.Myst.Directives;
 

--- a/src/Elastic.Markdown/Myst/Directives/TabSetBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/TabSetBlock.cs
@@ -10,8 +10,6 @@ namespace Elastic.Markdown.Myst.Directives;
 public class TabSetBlock(DirectiveBlockParser parser, ParserContext context)
 	: DirectiveBlock(parser, context)
 {
-	public string Id { get; private set; } = Guid.NewGuid().ToString();
-
 	public override string Directive => "tab-set";
 
 	public int Index { get; set; }

--- a/src/Elastic.Markdown/Myst/Directives/TabSetBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/TabSetBlock.cs
@@ -2,14 +2,19 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Reflection.Metadata;
 using Elastic.Markdown.Diagnostics;
 using Elastic.Markdown.Helpers;
+using Markdig.Syntax;
+using System.Linq;
 
 namespace Elastic.Markdown.Myst.Directives;
 
 public class TabSetBlock(DirectiveBlockParser parser, ParserContext context)
 	: DirectiveBlock(parser, context)
 {
+	public string Id { get; private set; } = Guid.NewGuid().ToString();
+
 	public override string Directive => "tab-set";
 
 	public int Index { get; set; }
@@ -18,15 +23,20 @@ public class TabSetBlock(DirectiveBlockParser parser, ParserContext context)
 	public override void FinalizeAndValidate(ParserContext context) => Index = FindIndex();
 
 	private int _index = -1;
+
+	// For simplicity, we use the line number as the index.
+	// It's not ideal, but it's unique.
+	// This is more efficient than finding the root block and then finding the index.
 	public int FindIndex()
 	{
 		if (_index > -1)
 			return _index;
-		var siblings = Parent!.OfType<TabSetBlock>().ToList();
-		_index = siblings.IndexOf(this);
+
+		_index = Line;
 		return _index;
 	}
 }
+
 public class TabItemBlock(DirectiveBlockParser parser, ParserContext context)
 	: DirectiveBlock(parser, context)
 {

--- a/src/Elastic.Markdown/Myst/Directives/TabSetBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/TabSetBlock.cs
@@ -2,11 +2,11 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Linq;
 using System.Reflection.Metadata;
 using Elastic.Markdown.Diagnostics;
 using Elastic.Markdown.Helpers;
 using Markdig.Syntax;
-using System.Linq;
 
 namespace Elastic.Markdown.Myst.Directives;
 

--- a/src/Elastic.Markdown/Slices/Directives/TabItem.cshtml
+++ b/src/Elastic.Markdown/Slices/Directives/TabItem.cshtml
@@ -1,6 +1,11 @@
 @inherits RazorSlice<TabItemViewModel>
-<input class="tabs-input" checked="@(Model.Index == 0 ? "checked" : "")" id="tabs-item-@Model.TabSetIndex-@Model.Index" name="tabs-set-@Model.TabSetIndex" type="radio" tabindex="0">
-<label class="tabs-label" data-sync-id="@Model.SyncKey" data-sync-group="@Model.TabSetGroupKey" for="tabs-item-@Model.TabSetIndex-@Model.Index">@Model.Title</label>
+
+@{
+	var id = $"tabs-item-{Model.TabSetIndex}-{Model.Index}";
+}
+
+<input class="tabs-input" checked="@(Model.Index == 0 ? "checked" : "")" id="@id" name="tabs-set-@Model.TabSetIndex" type="radio" tabindex="0">
+<label class="tabs-label" data-sync-id="@Model.SyncKey" data-sync-group="@Model.TabSetGroupKey" for="@id">@Model.Title</label>
 <div class="tabs-content" tabindex="0">
 	[CONTENT]
 </div>

--- a/tests/Elastic.Markdown.Tests/Directives/TabTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/TabTests.cs
@@ -49,7 +49,6 @@ Frank Herbert  |Dune           |604            |1965-06-01T00:00:00.000Z
 		for (var i = 0; i < items.Length; i++)
 		{
 			items[i].Index.Should().Be(i);
-			items[i].TabSetIndex.Should().Be(0);
 		}
 	}
 }
@@ -88,7 +87,7 @@ Tabs are easy. You can even embed other directives like the admonition you see h
 			for (var i = 0; i < items.Length; i++)
 			{
 				items[i].Index.Should().Be(i);
-				items[i].TabSetIndex.Should().Be(s);
+				items[i].TabSetIndex.Should().Be(sets[s].Line);
 			}
 		}
 	}
@@ -148,7 +147,7 @@ Content for C# tab
 			for (var i = 0; i < items.Length; i++)
 			{
 				items[i].Index.Should().Be(i);
-				items[i].TabSetIndex.Should().Be(s);
+				items[i].TabSetIndex.Should().Be(sets[s].Line);
 			}
 		}
 	}


### PR DESCRIPTION
Closes https://github.com/elastic/docs-builder/issues/568

## Context

When tabs are in a list or is a child of any block, then the index, which is used as ID is is wrong because it only searches for siblings.

## Changes

This change uses the line number as ID for simplicity. It doesn't represent the actual number of the tab set but it's unique and effecient.

## Result

https://github.com/user-attachments/assets/87600b8c-164a-482c-a751-7ac75342d279


