### PR TITLE
Fix inline code wrapping

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,3 +9,31 @@ Elastic Docs V3 is our next-generation documentation platform designed to improv
 * [Configure content sets in V3](./configure/index.md)
 * [Learn about V3 syntax](./syntax/index.md)
 * [Contribute to V3 (developer guide)](./development/index.md)
+
+
+## What the `code`?
+
+
+
+`super long inline code that should wrap super long inline code that should wrap super long inline code that should wrap`
+
+
+:::{important}
+
+Test `code` inline within admonition.
+
+`super long inline code that should wrap super long inline code that should wrap super long inline code that should wrap`
+:::
+
+:::{warning}
+
+Test `code` inline within admonition.
+
+`super long inline code that should wrap super long inline code that should wrap super long inline code that should wrap`
+:::
+
+
+- list item 1
+    - sub list item 1 
+
+        `with super long inline code that should wrap super long inline code that should wrap super long inline code that should wrap`

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,31 +9,3 @@ Elastic Docs V3 is our next-generation documentation platform designed to improv
 * [Configure content sets in V3](./configure/index.md)
 * [Learn about V3 syntax](./syntax/index.md)
 * [Contribute to V3 (developer guide)](./development/index.md)
-
-
-## What the `code`?
-
-
-
-`super long inline code that should wrap super long inline code that should wrap super long inline code that should wrap`
-
-
-:::{important}
-
-Test `code` inline within admonition.
-
-`super long inline code that should wrap super long inline code that should wrap super long inline code that should wrap`
-:::
-
-:::{warning}
-
-Test `code` inline within admonition.
-
-`super long inline code that should wrap super long inline code that should wrap super long inline code that should wrap`
-:::
-
-
-- list item 1
-    - sub list item 1 
-
-        `with super long inline code that should wrap super long inline code that should wrap super long inline code that should wrap`

--- a/src/Elastic.Markdown/Assets/markdown/code.css
+++ b/src/Elastic.Markdown/Assets/markdown/code.css
@@ -15,6 +15,7 @@
 					p-6!
 				;
 				background-color: #22272e;
+				mix-blend-mode: unset;
 			}
 			code:first-child {
 				@apply rounded-t-sm;

--- a/src/Elastic.Markdown/Assets/markdown/code.css
+++ b/src/Elastic.Markdown/Assets/markdown/code.css
@@ -68,8 +68,6 @@
 		rounded-xs
 		border-1
 		border-gray-300
-		inline-block
-		text-nowrap
 		;
 		font-size: 0.875em;
 		line-height: 1.4em;
@@ -78,6 +76,7 @@
 		letter-spacing: 0.02em;
 		text-decoration: inherit;
 		font-weight: inherit;
+		mix-blend-mode: multiply;
 	}
 
 


### PR DESCRIPTION
Closes https://github.com/elastic/docs-builder/issues/530

## Changes

- Fix inline code to wrap when it's long
- Additionally: use `mix-blend-mode: multiply`, so the color adapts to it's background.

## Result
<img width="837" alt="image" src="https://github.com/user-attachments/assets/4e1eefd3-5575-4742-909c-51a54acc0cf1" />
