### PR TITLE
Exclude navigation elements from browser search if collapsed

### DIFF
--- a/src/Elastic.Markdown/Slices/Layout/_TocTreeNav.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_TocTreeNav.cshtml
@@ -62,7 +62,7 @@
 			</label>
 			@if (g.NavigationItems.Count > 0)
 			{
-				<ul class="h-0 w-full overflow-y-hidden peer-has-checked:h-auto peer-has-[:focus]:h-auto has-[:focus]:h-auto">
+				<ul class="w-full overflow-y-hidden hidden peer-has-checked:block peer-has-[:focus]:block has-[:focus]:block">
 					@await RenderPartialAsync(_TocTreeNav.Create(new NavigationTreeItem
 					{
 						Level = g.Depth,


### PR DESCRIPTION
Closes https://github.com/elastic/docs-builder/issues/580

## Context

The sub lists of the navigation items had `height: 0` and were expanded based on the height. This was done because the initial idea was to expand with an animation.

## Change

Instead of hiding with `height: 0` use `display: hidden`, this way it's excluded from the browser search.