### PR TITLE
feature/htmx poc main pages cherry pick

### DIFF
--- a/src/Elastic.Markdown/DocumentationGenerator.cs
+++ b/src/Elastic.Markdown/DocumentationGenerator.cs
@@ -255,4 +255,11 @@ public class DocumentationGenerator
 		var pageHtml = await HtmlWriter.RenderPageHtml(markdown, ctx);
 		return await HtmlWriter.RenderLayout(markdown, pageHtml, ctx);
 	}
+
+	public async Task<string?> RenderPage(MarkdownFile markdown, Cancel ctx)
+	{
+		await DocumentationSet.Tree.Resolve(ctx);
+		var pageHtml = await HtmlWriter.RenderPageHtml(markdown, ctx);
+		return await HtmlWriter.RenderPage(markdown, pageHtml, ctx);
+	}
 }

--- a/src/Elastic.Markdown/DocumentationGenerator.cs
+++ b/src/Elastic.Markdown/DocumentationGenerator.cs
@@ -252,6 +252,7 @@ public class DocumentationGenerator
 	public async Task<string?> RenderLayout(MarkdownFile markdown, Cancel ctx)
 	{
 		await DocumentationSet.Tree.Resolve(ctx);
-		return await HtmlWriter.RenderLayout(markdown, ctx);
+		var pageHtml = await HtmlWriter.RenderPageHtml(markdown, ctx);
+		return await HtmlWriter.RenderLayout(markdown, pageHtml, ctx);
 	}
 }

--- a/src/Elastic.Markdown/IO/MarkdownFile.cs
+++ b/src/Elastic.Markdown/IO/MarkdownFile.cs
@@ -74,9 +74,31 @@ public record MarkdownFile : DocumentationFile
 	public string FilePath { get; }
 	public string FileName { get; }
 
-	public string Url => Path.GetFileName(RelativePath) == "index.md"
-		? $"{UrlPathPrefix}/{RelativePath.Remove(RelativePath.LastIndexOf("index.md", StringComparison.Ordinal), "index.md".Length)}"
-		: $"{UrlPathPrefix}/{RelativePath.Remove(RelativePath.LastIndexOf(".md", StringComparison.Ordinal), 3)}";
+	private string? _url;
+	public string Url
+	{
+		get
+		{
+			if (_url is not null)
+				return _url;
+			_url = Path.GetFileName(RelativePath) == "index.md"
+				? $"{UrlPathPrefix}/{RelativePath.Remove(RelativePath.LastIndexOf("index.md", StringComparison.Ordinal), "index.md".Length)}"
+				: $"{UrlPathPrefix}/{RelativePath.Remove(RelativePath.LastIndexOf(".md", StringComparison.Ordinal), 3)}";
+			return _url;
+		}
+	}
+
+	private string? _urlFetch;
+	public string UrlFetch
+	{
+		get
+		{
+			if (_urlFetch is not null)
+				return _urlFetch;
+			_urlFetch = Url.TrimEnd('/') + "/index.main.html";
+			return _urlFetch;
+		}
+	}
 
 	public int NavigationIndex { get; internal set; } = -1;
 

--- a/src/Elastic.Markdown/IO/MarkdownFile.cs
+++ b/src/Elastic.Markdown/IO/MarkdownFile.cs
@@ -95,7 +95,7 @@ public record MarkdownFile : DocumentationFile
 		{
 			if (_urlFetch is not null)
 				return _urlFetch;
-			_urlFetch = Url.TrimEnd('/') + "/index.main.html";
+			_urlFetch = Url.TrimEnd('/') + "/index.page.html";
 			return _urlFetch;
 		}
 	}

--- a/src/Elastic.Markdown/Slices/HtmlWriter.cs
+++ b/src/Elastic.Markdown/Slices/HtmlWriter.cs
@@ -49,7 +49,6 @@ public class HtmlWriter(DocumentationSet documentationSet, IFileSystem writeFile
 			TitleRaw = markdown.TitleRaw ?? "[TITLE NOT SET]",
 			MarkdownHtml = markdownHtml,
 			PageTocItems = [.. markdown.TableOfContents.Values],
-			Tree = DocumentationSet.Tree,
 			CurrentDocument = markdown,
 			PreviousDocument = previous,
 			NextDocument = next,
@@ -73,7 +72,7 @@ public class HtmlWriter(DocumentationSet documentationSet, IFileSystem writeFile
 		var path = Path.Combine(DocumentationSet.RelativeSourcePath, markdown.RelativePath);
 		var editUrl = $"https://github.com/elastic/{remote}/edit/{branch}/{path}";
 
-		var slice = Page.Create(new MainViewModel
+		var slice = Page.Create(new IndexViewModel
 		{
 			Title = markdown.Title ?? "[TITLE NOT SET]",
 			TitleRaw = markdown.TitleRaw ?? "[TITLE NOT SET]",
@@ -81,6 +80,7 @@ public class HtmlWriter(DocumentationSet documentationSet, IFileSystem writeFile
 			PageTocItems = [.. markdown.TableOfContents.Values],
 			CurrentDocument = markdown,
 			PreviousDocument = previous,
+			NavigationHtml = string.Empty,
 			NextDocument = next,
 			UrlPathPrefix = markdown.UrlPathPrefix,
 			Applies = markdown.YamlFrontMatter?.AppliesTo,

--- a/src/Elastic.Markdown/Slices/HtmlWriter.cs
+++ b/src/Elastic.Markdown/Slices/HtmlWriter.cs
@@ -111,7 +111,7 @@ public class HtmlWriter(DocumentationSet documentationSet, IFileSystem writeFile
 				? Path.GetFileNameWithoutExtension(outputFile.Name) + ".html"
 				: Path.Combine(dir, "index.html");
 		}
-		var mainPath = Path.ChangeExtension(path, ".main.html");
+		var mainPath = Path.ChangeExtension(path, ".page.html");
 
 		var pageHtml = await RenderPageHtml(markdown, ctx);
 

--- a/src/Elastic.Markdown/Slices/Index.cshtml
+++ b/src/Elastic.Markdown/Slices/Index.cshtml
@@ -6,7 +6,6 @@
 	{
 		Title = $"Elastic Documentation: {Model.Title}",
 		PageTocItems = Model.PageTocItems.Where(i => i is { Level: 2 or 3 }).ToList(),
-		Tree = Model.Tree,
 		CurrentDocument = Model.CurrentDocument,
 		Previous = Model.PreviousDocument,
 		Next = Model.NextDocument,

--- a/src/Elastic.Markdown/Slices/Layout/_Breadcrumbs.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_Breadcrumbs.cshtml
@@ -5,10 +5,10 @@
 		<a
 			itemprop="item"
 			href="@Model.UrlPathPrefix/"
-			hx-get="@Model.UrlPathPrefix/"
+			hx-get="@Model.UrlPathPrefix/index.page.html"
+			hx-push-url="@Model.UrlPathPrefix/"
 			hx-select-oob="@Htmx.GetHxSelectOob()"
 			hx-swap="none"
-			hx-push-url="true"
 			hx-indicator="#htmx-indicator"
 			preload="mouseover"
 	>

--- a/src/Elastic.Markdown/Slices/Layout/_Breadcrumbs.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_Breadcrumbs.cshtml
@@ -1,5 +1,5 @@
 @using Elastic.Markdown.Helpers
-@inherits RazorSlice<IBreadCrumbModel>
+@inherits RazorSlice<LayoutViewModel>
 <ol id="breadcrumbs" class="block w-full" itemscope="" itemtype="https://schema.org/BreadcrumbList">
 	<li class="inline text-ink text-sm hover:text-ink leading-[1.2em] tracking-[-0.02em]" itemprop="itemListElement" itemscope="" itemtype="https://schema.org/ListItem">
 		<a
@@ -23,10 +23,10 @@
 			<a
 				itemprop="item"
 				href="@item.Url"
-				hx-get="@item.Url"
+				hx-get="@(item.UrlFetch)"
+				hx-push-url="@item.Url"
 				hx-select-oob="@Htmx.GetHxSelectOob()"
 				hx-swap="none"
-				hx-push-url="true"
 				hx-indicator="#htmx-indicator"
 				preload="mouseover"
 			>

--- a/src/Elastic.Markdown/Slices/Layout/_Breadcrumbs.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_Breadcrumbs.cshtml
@@ -1,8 +1,8 @@
 @using Elastic.Markdown.Helpers
-@inherits RazorSlice<LayoutViewModel>
+@inherits RazorSlice<IBreadCrumbModel>
 <ol id="breadcrumbs" class="block w-full" itemscope="" itemtype="https://schema.org/BreadcrumbList">
 	<li class="inline text-ink text-sm hover:text-ink leading-[1.2em] tracking-[-0.02em]" itemprop="itemListElement" itemscope="" itemtype="https://schema.org/ListItem">
-		<a 
+		<a
 			itemprop="item"
 			href="@Model.UrlPathPrefix/"
 			hx-get="@Model.UrlPathPrefix/"
@@ -21,7 +21,7 @@
 		<li class="inline text-gray-500 text-sm leading-[1.2em] tracking-[-0.02em]" itemprop="itemListElement" itemscope="" itemtype="https://schema.org/ListItem">
 			<span class="px-1">/</span>
 			<a
-				itemprop="item" 
+				itemprop="item"
 				href="@item.Url"
 				hx-get="@item.Url"
 				hx-select-oob="@Htmx.GetHxSelectOob()"

--- a/src/Elastic.Markdown/Slices/Layout/_TableOfContents.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_TableOfContents.cshtml
@@ -1,4 +1,4 @@
-@inherits RazorSlice<ITableOfContentsModel>
+@inherits RazorSlice<LayoutViewModel>
 <aside class="sidebar hidden lg:block order-3 border-l-1 border-l-gray-200 w-80">
 	<nav id="toc-nav" class="sidebar-nav pl-6">
 		<div class="pt-6 pb-20">

--- a/src/Elastic.Markdown/Slices/Layout/_TableOfContents.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_TableOfContents.cshtml
@@ -1,4 +1,4 @@
-@inherits RazorSlice<LayoutViewModel>
+@inherits RazorSlice<ITableOfContentsModel>
 <aside class="sidebar hidden lg:block order-3 border-l-1 border-l-gray-200 w-80">
 	<nav id="toc-nav" class="sidebar-nav pl-6">
 		<div class="pt-6 pb-20">

--- a/src/Elastic.Markdown/Slices/Layout/_TocTreeNav.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_TocTreeNav.cshtml
@@ -10,15 +10,16 @@
 		<li class="block ml-2 pl-2 border-l-1 border-l-gray-200 group/li">
 			<div class="flex">
 				<a
-					hx-get="@f.Url"
+					href="@f.Url"
+					hx-get="@(f.UrlFetch)"
+					hx-push-url="@f.Url"
 					hx-select-oob="@Htmx.GetHxSelectOob()"
 					hx-swap="none"
-					hx-push-url="true"
 					hx-indicator="#htmx-indicator"
 					preload="mouseover"
 					class="sidebar-link my-1 ml-5 group-[.current]/li:text-blue-elastic!"
 					id="page-@id"
-					href="@f.Url">
+					>
 					@f.NavigationTitle
 				</a>
 			</div>
@@ -49,7 +50,8 @@
 				>
 				<a
 					href="@g.Index?.Url"
-					hx-get="@g.Index?.Url"
+					hx-get="@(g.Index?.UrlFetch)"
+					hx-push-url="@g.Index?.Url"
 					hx-select-oob="@Htmx.GetHxSelectOob()"
 					hx-swap="none"
 					hx-push-url="true"

--- a/src/Elastic.Markdown/Slices/Page.cshtml
+++ b/src/Elastic.Markdown/Slices/Page.cshtml
@@ -1,79 +1,26 @@
-@using Elastic.Markdown.Helpers
 @using Markdig
-@inherits RazorSliceHttpResult<MainViewModel>
-<div class="flex flex-col items-center px-6">
-	<div class="container flex">
-		@await RenderPartialAsync(_PagesNav.Create(Model))
-		@await RenderPartialAsync(_TableOfContents.Create<ITableOfContentsModel>(Model))
-		<main class="w-full pt-6 pb-30 px-6 order-2 relative">
-			<div class="w-full absolute top-0 left-0 right-0 htmx-indicator" id="htmx-indicator" role="status">
-				<div class="h-[2px] w-full overflow-hidden">
-					<div class="progress w-full h-full bg-pink-70 left-right"></div>
-				</div>
-				<div class="sr-only">Loading</div>
-			</div>
-			<div class="content-container">
-				@await RenderPartialAsync(_Breadcrumbs.Create<IBreadCrumbModel>(Model))
-			</div>
-			<article id="markdown-content" class="content-container markdown-content">
-				@* This way it's correctly rendered as <h1>text</h1> instead of <h1><p>text</p></h1> *@
-				@(new HtmlString(Markdown.ToHtml("# " + Model.TitleRaw)))
-				@if (Model.Applies is not null)
-				{
-					await RenderPartialAsync(ApplicableTo.Create(Model.Applies));
-				}
-				@(new HtmlString(Model.MarkdownHtml))
-			</article>
-			<footer id="prev-next-nav" class="content-container mt-20">
-				<div class="flex flex-wrap lg:flex-nowrap gap-2 mt-2">
-					<div class="w-full">
-						@if (Model.PreviousDocument != null)
-						{
-							<a
-								href="@Model.PreviousDocument.Url"
-								hx-get="@Model.PreviousDocument.Url"
-								hx-select-oob="@Htmx.GetHxSelectOob()"
-								hx-swap="none"
-								hx-push-url="true"
-								hx-indicator="#htmx-indicator"
-								preload="mouseover"
-								class="flex h-full items-center text-ink-light hover:black border-1 border-gray-300 hover:border-gray-500 rounded-lg p-6 shadow-md"
-							>
-								<svg class="size-6 mr-2" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-									<path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5"/>
-								</svg>
-								<div>
-									<div class="text-xs lg:text-sm">Previous</div>
-									<div class="text-base lg:text-xl text-black">@Model.PreviousDocument.NavigationTitle</div>
-								</div>
-							</a>
-						}
-					</div>
-					<div class="w-full">
-						@if (Model.NextDocument != null)
-						{
-							<a
-								href="@Model.NextDocument.Url"
-								hx-get="@Model.NextDocument.Url"
-								hx-select-oob="@Htmx.GetHxSelectOob()"
-								hx-swap="none"
-								hx-push-url="true"
-								hx-indicator="#htmx-indicator"
-								preload="mouseover"
-								class="flex h-full items-center justify-end text-ink-light hover:black border-1 border-gray-300 hover:border-gray-500 rounded-lg p-6 shadow-md text-right"
-							>
-								<div>
-									<div class="text-xs lg:text-sm">Next</div>
-									<div class="text-base lg:text-xl text-black">@Model.NextDocument.NavigationTitle</div>
-								</div>
-								<svg class="size-6 ml-2" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-									<path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5"/>
-								</svg>
-							</a>
-						}
-					</div>
-				</div>
-			</footer>
-		</main>
-	</div>
-</div>
+@inherits RazorSliceHttpResult<IndexViewModel>
+@implements IUsesLayout<Elastic.Markdown.Slices._Layout, LayoutViewModel>
+@functions {
+	public LayoutViewModel LayoutModel => new()
+	{
+		Title = $"Elastic Documentation: {Model.Title}",
+		PageTocItems = Model.PageTocItems.Where(i => i is { Level: 2 or 3 }).ToList(),
+		CurrentDocument = Model.CurrentDocument,
+		Previous = Model.PreviousDocument,
+		Next = Model.NextDocument,
+		NavigationHtml = string.Empty,
+		UrlPathPrefix = Model.UrlPathPrefix,
+		GithubEditUrl = Model.GithubEditUrl,
+		AllowIndexing = Model.AllowIndexing,
+	};
+}
+<section id="elastic-docs-v3">
+	@* This way it's correctly rendered as <h1>text</h1> instead of <h1><p>text</p></h1> *@
+	@(new HtmlString(Markdown.ToHtml("# " + Model.TitleRaw)))
+	@if (Model.Applies is not null)
+	{
+		await RenderPartialAsync(ApplicableTo.Create(Model.Applies));
+	}
+	@(new HtmlString(Model.MarkdownHtml))
+</section>

--- a/src/Elastic.Markdown/Slices/Page.cshtml
+++ b/src/Elastic.Markdown/Slices/Page.cshtml
@@ -1,17 +1,6 @@
 @using Elastic.Markdown.Helpers
-@inherits RazorLayoutSlice<LayoutViewModel>
-<!DOCTYPE html>
-<html lang="en" class="h-screen">
-<head>
-	<title>@Model.Title</title>
-	<link rel="stylesheet" type="text/css" href="@Model.Static("styles.css")"/>
-	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta name="robots" content="@(Model.AllowIndexing ? "index, follow" : "noindex, nofollow")">
-	<meta name="htmx-config" content='{"scrollIntoViewOnBoost": false, "selfRequestsOnly": true}'>
-</head>
-<body class="text-ink" hx-ext="preload,head-support">
-@(await RenderPartialAsync(_Header.Create(Model)))
+@using Markdig
+@inherits RazorSliceHttpResult<MainViewModel>
 <div class="flex flex-col items-center px-6">
 	<div class="container flex">
 		@await RenderPartialAsync(_PagesNav.Create(Model))
@@ -27,16 +16,22 @@
 				@await RenderPartialAsync(_Breadcrumbs.Create<IBreadCrumbModel>(Model))
 			</div>
 			<article id="markdown-content" class="content-container markdown-content">
-				@await RenderBodyAsync()
+				@* This way it's correctly rendered as <h1>text</h1> instead of <h1><p>text</p></h1> *@
+				@(new HtmlString(Markdown.ToHtml("# " + Model.TitleRaw)))
+				@if (Model.Applies is not null)
+				{
+					await RenderPartialAsync(ApplicableTo.Create(Model.Applies));
+				}
+				@(new HtmlString(Model.MarkdownHtml))
 			</article>
 			<footer id="prev-next-nav" class="content-container mt-20">
 				<div class="flex flex-wrap lg:flex-nowrap gap-2 mt-2">
 					<div class="w-full">
-						@if (Model.Previous != null)
+						@if (Model.PreviousDocument != null)
 						{
 							<a
-								href="@Model.Previous.Url"
-								hx-get="@Model.Previous.Url"
+								href="@Model.PreviousDocument.Url"
+								hx-get="@Model.PreviousDocument.Url"
 								hx-select-oob="@Htmx.GetHxSelectOob()"
 								hx-swap="none"
 								hx-push-url="true"
@@ -49,17 +44,17 @@
 								</svg>
 								<div>
 									<div class="text-xs lg:text-sm">Previous</div>
-									<div class="text-base lg:text-xl text-black">@Model.Previous.NavigationTitle</div>
+									<div class="text-base lg:text-xl text-black">@Model.PreviousDocument.NavigationTitle</div>
 								</div>
 							</a>
 						}
 					</div>
 					<div class="w-full">
-						@if (Model.Next != null)
+						@if (Model.NextDocument != null)
 						{
 							<a
-								href="@Model.Next.Url"
-								hx-get="@Model.Next.Url"
+								href="@Model.NextDocument.Url"
+								hx-get="@Model.NextDocument.Url"
 								hx-select-oob="@Htmx.GetHxSelectOob()"
 								hx-swap="none"
 								hx-push-url="true"
@@ -69,7 +64,7 @@
 							>
 								<div>
 									<div class="text-xs lg:text-sm">Next</div>
-									<div class="text-base lg:text-xl text-black">@Model.Next.NavigationTitle</div>
+									<div class="text-base lg:text-xl text-black">@Model.NextDocument.NavigationTitle</div>
 								</div>
 								<svg class="size-6 ml-2" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
 									<path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5"/>
@@ -82,7 +77,3 @@
 		</main>
 	</div>
 </div>
-@(await RenderPartialAsync(_Footer.Create(Model)))
-<script src="@Model.Static("main.js")"></script>
-</body>
-</html>

--- a/src/Elastic.Markdown/Slices/_Layout.cshtml
+++ b/src/Elastic.Markdown/Slices/_Layout.cshtml
@@ -14,8 +14,11 @@
 @(await RenderPartialAsync(_Header.Create(Model)))
 <div class="flex flex-col items-center px-6">
 	<div class="container flex">
-		@await RenderPartialAsync(_PagesNav.Create(Model))
-		@await RenderPartialAsync(_TableOfContents.Create<ITableOfContentsModel>(Model))
+		@if (!string.IsNullOrWhiteSpace(Model.NavigationHtml))
+		{
+			await RenderPartialAsync(_PagesNav.Create(Model));
+		}
+		@await RenderPartialAsync(_TableOfContents.Create(Model))
 		<main class="w-full pt-6 pb-30 px-6 order-2 relative">
 			<div class="w-full absolute top-0 left-0 right-0 htmx-indicator" id="htmx-indicator" role="status">
 				<div class="h-[2px] w-full overflow-hidden">
@@ -24,7 +27,7 @@
 				<div class="sr-only">Loading</div>
 			</div>
 			<div class="content-container">
-				@await RenderPartialAsync(_Breadcrumbs.Create<IBreadCrumbModel>(Model))
+				@await RenderPartialAsync(_Breadcrumbs.Create(Model))
 			</div>
 			<article id="markdown-content" class="content-container markdown-content">
 				@await RenderBodyAsync()
@@ -36,10 +39,10 @@
 						{
 							<a
 								href="@Model.Previous.Url"
-								hx-get="@Model.Previous.Url"
+								hx-get="@Model.Previous.UrlFetch"
+								hx-push-url="@Model.Previous.Url"
 								hx-select-oob="@Htmx.GetHxSelectOob()"
 								hx-swap="none"
-								hx-push-url="true"
 								hx-indicator="#htmx-indicator"
 								preload="mouseover"
 								class="flex h-full items-center text-ink-light hover:black border-1 border-gray-300 hover:border-gray-500 rounded-lg p-6 shadow-md"
@@ -59,10 +62,10 @@
 						{
 							<a
 								href="@Model.Next.Url"
-								hx-get="@Model.Next.Url"
+								hx-get="@Model.Next.UrlFetch"
+								hx-push-url="@Model.Next.Url"
 								hx-select-oob="@Htmx.GetHxSelectOob()"
 								hx-swap="none"
-								hx-push-url="true"
 								hx-indicator="#htmx-indicator"
 								preload="mouseover"
 								class="flex h-full items-center justify-end text-ink-light hover:black border-1 border-gray-300 hover:border-gray-500 rounded-lg p-6 shadow-md text-right"

--- a/src/Elastic.Markdown/Slices/_ViewModels.cs
+++ b/src/Elastic.Markdown/Slices/_ViewModels.cs
@@ -7,6 +7,47 @@ using Elastic.Markdown.Myst.FrontMatter;
 
 namespace Elastic.Markdown.Slices;
 
+public interface IBreadCrumbModel
+{
+	MarkdownFile[] Parents { get; }
+	string? UrlPathPrefix { get; }
+}
+
+public interface ITableOfContentsModel
+{
+	IReadOnlyCollection<PageTocItem> PageTocItems { get; }
+	string? GithubEditUrl { get; }
+}
+
+public class MainViewModel : IBreadCrumbModel, ITableOfContentsModel
+{
+	public required string Title { get; init; }
+	public required string TitleRaw { get; init; }
+	public required string MarkdownHtml { get; init; }
+	public required IReadOnlyCollection<PageTocItem> PageTocItems { get; init; }
+	public required MarkdownFile CurrentDocument { get; init; }
+	public required MarkdownFile? PreviousDocument { get; init; }
+	public required MarkdownFile? NextDocument { get; init; }
+	public required string? UrlPathPrefix { get; init; }
+	public required string? GithubEditUrl { get; init; }
+	public required ApplicableTo? Applies { get; init; }
+	public required bool AllowIndexing { get; init; }
+
+	private MarkdownFile[]? _parents;
+	public MarkdownFile[] Parents
+	{
+		get
+		{
+			if (_parents is not null)
+				return _parents;
+
+			_parents = [.. CurrentDocument.YieldParents()];
+			return _parents;
+		}
+	}
+
+}
+
 public class IndexViewModel
 {
 	public required string Title { get; init; }
@@ -24,7 +65,7 @@ public class IndexViewModel
 	public required bool AllowIndexing { get; init; }
 }
 
-public class LayoutViewModel
+public class LayoutViewModel : IBreadCrumbModel, ITableOfContentsModel
 {
 	/// Used to identify the navigation for the current compilation
 	/// We want to reset users sessionStorage every time this changes to invalidate

--- a/src/Elastic.Markdown/Slices/_ViewModels.cs
+++ b/src/Elastic.Markdown/Slices/_ViewModels.cs
@@ -7,53 +7,11 @@ using Elastic.Markdown.Myst.FrontMatter;
 
 namespace Elastic.Markdown.Slices;
 
-public interface IBreadCrumbModel
-{
-	MarkdownFile[] Parents { get; }
-	string? UrlPathPrefix { get; }
-}
-
-public interface ITableOfContentsModel
-{
-	IReadOnlyCollection<PageTocItem> PageTocItems { get; }
-	string? GithubEditUrl { get; }
-}
-
-public class MainViewModel : IBreadCrumbModel, ITableOfContentsModel
-{
-	public required string Title { get; init; }
-	public required string TitleRaw { get; init; }
-	public required string MarkdownHtml { get; init; }
-	public required IReadOnlyCollection<PageTocItem> PageTocItems { get; init; }
-	public required MarkdownFile CurrentDocument { get; init; }
-	public required MarkdownFile? PreviousDocument { get; init; }
-	public required MarkdownFile? NextDocument { get; init; }
-	public required string? UrlPathPrefix { get; init; }
-	public required string? GithubEditUrl { get; init; }
-	public required ApplicableTo? Applies { get; init; }
-	public required bool AllowIndexing { get; init; }
-
-	private MarkdownFile[]? _parents;
-	public MarkdownFile[] Parents
-	{
-		get
-		{
-			if (_parents is not null)
-				return _parents;
-
-			_parents = [.. CurrentDocument.YieldParents()];
-			return _parents;
-		}
-	}
-
-}
-
 public class IndexViewModel
 {
 	public required string Title { get; init; }
 	public required string TitleRaw { get; init; }
 	public required string MarkdownHtml { get; init; }
-	public required DocumentationGroup Tree { get; init; }
 	public required IReadOnlyCollection<PageTocItem> PageTocItems { get; init; }
 	public required MarkdownFile CurrentDocument { get; init; }
 	public required MarkdownFile? PreviousDocument { get; init; }
@@ -65,16 +23,14 @@ public class IndexViewModel
 	public required bool AllowIndexing { get; init; }
 }
 
-public class LayoutViewModel : IBreadCrumbModel, ITableOfContentsModel
+public class LayoutViewModel
 {
 	/// Used to identify the navigation for the current compilation
 	/// We want to reset users sessionStorage every time this changes to invalidate
 	/// the guids that no longer exist
 	public static string CurrentNavigationId { get; } = Guid.NewGuid().ToString("N")[..8];
 	public string Title { get; set; } = "Elastic Documentation";
-	public string RawTitle { get; set; } = "Elastic Documentation";
 	public required IReadOnlyCollection<PageTocItem> PageTocItems { get; init; }
-	public required DocumentationGroup Tree { get; init; }
 	public string[] ParentIds => [.. CurrentDocument.YieldParentGroups()];
 	public required MarkdownFile CurrentDocument { get; init; }
 	public required MarkdownFile? Previous { get; init; }
@@ -85,6 +41,7 @@ public class LayoutViewModel : IBreadCrumbModel, ITableOfContentsModel
 	public required bool AllowIndexing { get; init; }
 
 	private MarkdownFile[]? _parents;
+
 	public MarkdownFile[] Parents
 	{
 		get

--- a/src/docs-builder/Http/DocumentationWebHost.cs
+++ b/src/docs-builder/Http/DocumentationWebHost.cs
@@ -98,10 +98,10 @@ public class DocumentationWebHost
 
 
 		var renderPage = false;
-		if (slug.EndsWith(".main.html"))
+		if (slug.EndsWith(".page.html"))
 		{
 			renderPage = true;
-			slug = slug.Replace(".main.html", ".html");
+			slug = slug.Replace(".page.html", ".html");
 		}
 
 		var markdownPath = Path.GetExtension(slug) == string.Empty ? Path.Combine(slug, "index.md") : slug.Replace(".html", ".md");


### PR DESCRIPTION
This adds seperate `.page.html` output adjacent to the regular HTML output. 

On e.g asciidocalypse a single html page is `5mb` due to the massive navigation thats included on each page. 

This PR creates a `.page.html` that HTMX will get and prefetch instead which is typically only in the `4-80kb` range. Which should aid with latency while navigating through the docs.

The `serve` command has also been updated to render pages instead when receiving `.page.html` requests.