### PR TITLE
Fix "Edit this page" links to docs-content repo

### DIFF
--- a/tests/Elastic.Markdown.Tests/TestCrossLinkResolver.cs
+++ b/tests/Elastic.Markdown.Tests/TestCrossLinkResolver.cs
@@ -23,7 +23,7 @@ public class TestCrossLinkResolver : ICrossLinkResolver
 		           {
 		           	  "origin": {
 		           		"branch": "main",
-		           		"remote": " https://github.com/elastic/docs-conten",
+		           		"remote": " https://github.com/elastic/docs-content",
 		           		"ref": "76aac68d066e2af935c38bca8ce04d3ee67a8dd9"
 		           	  },
 		           	  "url_path_prefix": "/elastic/docs-content/tree/main",

--- a/tests/authoring/Framework/TestCrossLinkResolver.fs
+++ b/tests/authoring/Framework/TestCrossLinkResolver.fs
@@ -28,7 +28,7 @@ type TestCrossLinkResolver (config: ConfigurationFile) =
             let json = $$"""{
   "origin": {
     "branch": "main",
-    "remote": " https://github.com/elastic/docs-conten",
+    "remote": " https://github.com/elastic/docs-content",
     "ref": "76aac68d066e2af935c38bca8ce04d3ee67a8dd9"
   },
   "url_path_prefix": "/elastic/docs-content/tree/main",


### PR DESCRIPTION
Spotted on the docs preview site, the "Edit this page" link has a typo in the URL:
<img width="635" alt="image" src="https://github.com/user-attachments/assets/85232f24-e55d-44c6-b61a-d47fc2e00b9c" />

This hopefully fixes it. Those seem to be test files but they're the only ones where I found this typo. 
