### PR TITLE
Remove erroneous warning for link text generation on missing page

### DIFF
--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -202,19 +202,20 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 
 		var markdown = context.GetDocumentationFile?.Invoke(file) as MarkdownFile;
 
-		if (markdown == null)
+		if (markdown == null && link.FirstChild == null)
 		{
 			processor.EmitWarning(link,
 				$"'{url}' could not be resolved to a markdown file while creating an auto text link, '{file.FullName}' does not exist.");
 			return;
 		}
 
-		var title = markdown.Title;
+		var title = markdown?.Title;
 
 		if (!string.IsNullOrEmpty(anchor))
 		{
-			ValidateAnchor(processor, markdown, anchor, link);
-			if (link.FirstChild == null && markdown.TableOfContents.TryGetValue(anchor, out var heading))
+			if (markdown is not null)
+				ValidateAnchor(processor, markdown, anchor, link);
+			if (link.FirstChild == null && (markdown?.TableOfContents.TryGetValue(anchor, out var heading) ?? false))
 				title += " > " + heading.Heading;
 		}
 

--- a/tests/Elastic.Markdown.Tests/Inline/InlineLinkTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/InlineLinkTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System.IO.Abstractions.TestingHelpers;
+using Elastic.Markdown.Diagnostics;
 using FluentAssertions;
 using JetBrains.Annotations;
 using Markdig.Syntax.Inlines;
@@ -180,6 +181,23 @@ public class LinksWithInterpolationWarning(ITestOutputHelper output) : LinkTestB
 		Collector.Diagnostics.First().Severity.Should().Be(Diagnostics.Severity.Warning);
 		Collector.Diagnostics.First().Message.Should().Contain("The url contains a template expression. Please do not use template expressions in links. See https://github.com/elastic/docs-builder/issues/182 for further information.");
 	}
+}
+
+public class NonExistingLinks(ITestOutputHelper output) : LinkTestBase(output,
+	"""
+	[Non Existing Link](/non-existing.md)
+	"""
+)
+{
+	[Fact]
+	public void HasErrors() => Collector.Diagnostics
+		.Where(d => d.Severity == Severity.Error)
+		.Should().HaveCount(1);
+
+	[Fact]
+	public void HasNoWarning() => Collector.Diagnostics
+		.Where(d => d.Severity == Severity.Warning)
+		.Should().HaveCount(0);
 }
 
 public class CommentedNonExistingLinks(ITestOutputHelper output) : LinkTestBase(output,

--- a/tests/Elastic.Markdown.Tests/Inline/InlineLinkTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/InlineLinkTests.cs
@@ -178,7 +178,7 @@ public class LinksWithInterpolationWarning(ITestOutputHelper output) : LinkTestB
 	public void HasWarnings()
 	{
 		Collector.Diagnostics.Should().HaveCount(1);
-		Collector.Diagnostics.First().Severity.Should().Be(Diagnostics.Severity.Warning);
+		Collector.Diagnostics.First().Severity.Should().Be(Severity.Warning);
 		Collector.Diagnostics.First().Message.Should().Contain("The url contains a template expression. Please do not use template expressions in links. See https://github.com/elastic/docs-builder/issues/182 for further information.");
 	}
 }


### PR DESCRIPTION
Spotted here: https://github.com/elastic/asciidocalypse/actions/runs/13500318560/job/37716879330?pr=109#step:10:128