### PR TITLE
Support `merge_group` event for preview builds

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -40,6 +40,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
+
       - name: Get changed files
         if: startsWith(github.event_name, 'pull_request') || github.event_name == 'merge_group'
         id: check-files

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -58,13 +58,6 @@ jobs:
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: false
-
-      - name: Checkout
-        if: github.event_name == 'push' || steps.check-files.outputs.any_changed == 'true'
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
-          persist-credentials: false
           
       - name: Create Deployment
         if: github.event_name == 'push' || (steps.check-files.outputs.any_changed == 'true' && startsWith(github.event_name, 'pull_request'))

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -133,7 +133,7 @@ jobs:
           dotnet run --project src/docs-builder -- --strict --path-prefix "${PATH_PREFIX}"
 
       - name: Build documentation
-        if: github.repository != 'elastic/docs-builder' && steps.deployment.outputs.result || github.event_name == 'merge_group'
+        if: github.repository != 'elastic/docs-builder' && (steps.deployment.outputs.result || (steps.check-files.outputs.any_changed == 'true' && github.event_name == 'merge_group'))
         uses: elastic/docs-builder@main
         continue-on-error: ${{ fromJSON(inputs.continue-on-error != '' && inputs.continue-on-error || 'false') }}
         with:
@@ -141,7 +141,7 @@ jobs:
           strict: ${{ fromJSON(inputs.strict != '' && inputs.strict || 'true') }}
 
       - uses: elastic/docs-builder/actions/validate-inbound-local@main
-        if: ${{ !cancelled() && (steps.deployment.outputs.result || github.event_name == 'merge_group') }}
+        if: ${{ !cancelled() && (steps.deployment.outputs.result || (steps.check-files.outputs.any_changed == 'true' && github.event_name == 'merge_group')) }}
 
       - uses: elastic/docs-builder/.github/actions/aws-auth@main
         if: ${{ !cancelled() && steps.deployment.outputs.result }}

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -66,7 +66,7 @@ jobs:
         id: deployment
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref_name }}
+          REF: ${{ startsWith(github.event_name, 'pull_request') && github.event.pull_request.head.sha || github.ref_name }}
         with:
           result-encoding: string
           script: |
@@ -100,7 +100,13 @@ jobs:
           GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
           case "${GITHUB_EVENT_NAME}" in
+            "merge_group")
+              echo "PATH_PREFIX=/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}" >> $GITHUB_ENV
+              ;;
             "pull_request_target")
+              echo "PATH_PREFIX=/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}" >> $GITHUB_ENV
+              ;;
+            "pull_request")
               echo "PATH_PREFIX=/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}" >> $GITHUB_ENV
               ;;
             "push")

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -99,13 +99,7 @@ jobs:
           GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
           case "${GITHUB_EVENT_NAME}" in
-            "merge_group")
-              echo "PATH_PREFIX=/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}" >> $GITHUB_ENV
-              ;;
-            "pull_request_target")
-              echo "PATH_PREFIX=/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}" >> $GITHUB_ENV
-              ;;
-            "pull_request")
+            "merge_group" | "pull_request" | "pull_request_target")
               echo "PATH_PREFIX=/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}" >> $GITHUB_ENV
               ;;
             "push")

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -36,18 +36,19 @@ jobs:
   build:
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref }}
-      cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+      cancel-in-progress: ${{ startsWith(github.event_name, 'pull_request') }}
     runs-on: ubuntu-latest
     steps:
 
       - name: Get changed files
-        if: github.event_name == 'pull_request_target'
+        if: startsWith(github.event_name, 'pull_request') || github.event_name == 'merge_group'
         id: check-files
         uses: tj-actions/changed-files@d6e91a2266cdb9d62096cebf1e8546899c6aa18f # v45.0.6
         with:
           files: ${{ inputs.path-pattern != '' && inputs.path-pattern || '**' }}
 
       - name: Free Disk Space
+        if: github.event_name != 'merge_group'
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: false
@@ -58,9 +59,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
-
+          
       - name: Create Deployment
-        if: github.event_name == 'push' || steps.check-files.outputs.any_changed == 'true'
+        if: github.event_name == 'push' || (steps.check-files.outputs.any_changed == 'true' && startsWith(github.event_name, 'pull_request'))
         uses: actions/github-script@v7
         id: deployment
         env:
@@ -127,7 +128,7 @@ jobs:
           dotnet run --project src/docs-builder -- --strict --path-prefix "${PATH_PREFIX}"
 
       - name: Build documentation
-        if: github.repository != 'elastic/docs-builder' && steps.deployment.outputs.result
+        if: github.repository != 'elastic/docs-builder' && steps.deployment.outputs.result || github.event_name == 'merge_group'
         uses: elastic/docs-builder@main
         continue-on-error: ${{ fromJSON(inputs.continue-on-error != '' && inputs.continue-on-error || 'false') }}
         with:
@@ -135,7 +136,7 @@ jobs:
           strict: ${{ fromJSON(inputs.strict != '' && inputs.strict || 'true') }}
 
       - uses: elastic/docs-builder/actions/validate-inbound-local@main
-        if: ${{ !cancelled() && steps.deployment.outputs.result }}
+        if: ${{ !cancelled() && (steps.deployment.outputs.result || github.event_name == 'merge_group') }}
 
       - uses: elastic/docs-builder/.github/actions/aws-auth@main
         if: ${{ !cancelled() && steps.deployment.outputs.result }}


### PR DESCRIPTION
## Context

Some repositories are using GitHub's merge queue feature.

## Changes

When the `merge_group` event is triggered only build the documentation and run link validation.
The deployment to s3 is skipped.

## Result

You can see that only the relevant steps are executed here:

<img width="544" alt="image" src="https://github.com/user-attachments/assets/8d16df76-718b-4875-86f3-170197c97400" />
