### PR TITLE
validate-inbound-local call docker image directly

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -133,7 +133,8 @@ jobs:
           prefix: ${{ env.PATH_PREFIX }}
           strict: ${{ fromJSON(inputs.strict != '' && inputs.strict || 'true') }}
 
-      - uses: elastic/docs-builder/actions/validate-inbound-local@main
+      - name: 'Validate Inbound Links'
+        uses: elastic/docs-builder/actions/validate-inbound-local@main
         if: ${{ !cancelled() && (steps.deployment.outputs.result || (steps.check-files.outputs.any_changed == 'true' && github.event_name == 'merge_group')) }}
 
       - uses: elastic/docs-builder/.github/actions/aws-auth@main

--- a/actions/validate-inbound-local/action.yml
+++ b/actions/validate-inbound-local/action.yml
@@ -1,10 +1,12 @@
 name: 'Validate Inbound Links'
 description: 'Validates all published cross links from all known repositories against local links.json'
 
+inputs:
+  command:
+    description: 'The assembler command to run'
+    required: false
+    default: "link validate-inbound-local"
+
 runs:
-  using: "composite"
-  steps:
-    - name: Validate Inbound Links
-      uses: elastic/docs-builder/actions/assembler@main
-      with:
-        command: "link validate-inbound-local"
+  using: 'docker'
+  image: "docker://ghcr.io/elastic/docs-assembler:edge"

--- a/actions/validate-inbound-local/action.yml
+++ b/actions/validate-inbound-local/action.yml
@@ -1,12 +1,10 @@
 name: 'Validate Inbound Links'
 description: 'Validates all published cross links from all known repositories against local links.json'
 
-inputs:
-  command:
-    description: 'The assembler command to run'
-    required: false
-    default: "link validate-inbound-local"
-
 runs:
-  using: 'docker'
-  image: "docker://ghcr.io/elastic/docs-assembler:edge"
+  using: "composite"
+  steps:
+    - name: Validate Inbound Links
+      uses: elastic/docs-builder/actions/assembler@main
+      with:
+        command: "link validate-inbound-local"

--- a/src/Elastic.Markdown/IO/Discovery/GitCheckoutInformation.cs
+++ b/src/Elastic.Markdown/IO/Discovery/GitCheckoutInformation.cs
@@ -84,6 +84,8 @@ public record GitCheckoutInformation
 			remote = "elastic/docs-builder-unknown";
 
 		remote = remote.AsSpan().TrimEnd("git").TrimEnd('.').ToString();
+		if (remote.EndsWith("docs-conten"))
+			remote += "t";
 
 		return new GitCheckoutInformation
 		{

--- a/src/docs-assembler/Program.cs
+++ b/src/docs-assembler/Program.cs
@@ -25,7 +25,7 @@ app.Add<LinkCommands>("link");
 app.Add<RepositoryCommands>("repo");
 
 var githubActions = ConsoleApp.ServiceProvider.GetService<ICoreService>();
-var command = githubActions?.GetInput("COMMAND");
+var command = githubActions?.GetInput("COMMAND") ?? Environment.GetEnvironmentVariable("INPUT_COMMAND");
 if (!string.IsNullOrEmpty(command))
 	args = command.Split(' ');
 


### PR DESCRIPTION
The docker image gets cached weirdly otherwise see:

https://github.com/elastic/docs-content/actions/runs/13506790051/job/37738124930#step:12:32