### PR TITLE
Add `landing-page-path` output and use it in preview workflow

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -133,6 +133,7 @@ jobs:
       # we run our artifact directly please use the prebuild
       # elastic/docs-builder@main GitHub Action for all other repositories!
       - name: Build documentation
+        id: docs-build
         if: github.repository == 'elastic/docs-builder' && steps.deployment.outputs.result
         run: |
           dotnet run --project src/docs-builder -- --strict --path-prefix "${PATH_PREFIX}"
@@ -176,6 +177,7 @@ jobs:
         if: always() && steps.deployment.outputs.result
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          FIRST_PAGE_PATH: ${{ steps.docs-build.outputs.first-page-path }}
         with:
           script: |
             await github.rest.repos.createDeploymentStatus({
@@ -183,6 +185,6 @@ jobs:
               repo: context.repo.repo,
               deployment_id: ${{ steps.deployment.outputs.result }},
               state: "${{ steps.docs-build.outputs.skip == 'true' && 'inactive' || (steps.s3-upload.outcome == 'success' && 'success' || 'failure') }}",
-              environment_url: `https://docs-v3-preview.elastic.dev${process.env.PATH_PREFIX}`,
+              environment_url: `https://docs-v3-preview.elastic.dev${process.env.FIRST_PAGE_PATH ?? process.env.PATH_PREFIX}`,
               log_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
             })

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -177,7 +177,7 @@ jobs:
         if: always() && steps.deployment.outputs.result
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          FIRST_PAGE_PATH: ${{ steps.docs-build.outputs.first-page-path }}
+          LANDING_PAGE_PATH: ${{ steps.docs-build.outputs.landing-page-path }}
         with:
           script: |
             await github.rest.repos.createDeploymentStatus({
@@ -185,6 +185,6 @@ jobs:
               repo: context.repo.repo,
               deployment_id: ${{ steps.deployment.outputs.result }},
               state: "${{ steps.docs-build.outputs.skip == 'true' && 'inactive' || (steps.s3-upload.outcome == 'success' && 'success' || 'failure') }}",
-              environment_url: `https://docs-v3-preview.elastic.dev${process.env.FIRST_PAGE_PATH ?? process.env.PATH_PREFIX}`,
+              environment_url: `https://docs-v3-preview.elastic.dev${process.env.LANDING_PAGE_PATH ?? process.env.PATH_PREFIX}`,
               log_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
             })

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -3,9 +3,6 @@ name: smoke-tests
 on:
   pull_request: ~
   
-env:
-  PATH_PREFIX: /docs
-  
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -14,9 +11,9 @@ jobs:
       matrix: 
         include:
           - repository: elastic/docs-content
-            landing-page-path-output: ${{ env.PATH_PREFIX }}/
+            landing-page-path-output: /docs/
           - repository: elastic/apm-agent-android
-            landing-page-path-output: ${{ env.PATH_PREFIX }}/reference/
+            landing-page-path-output: /docs/reference/
             
             # This is a random repository that should not have a docset.yml
           - repository: elastic/oblt-actions
@@ -35,7 +32,7 @@ jobs:
       - name: Build documentation
         id: docs-build
         run: |
-          dotnet run --project src/docs-builder -- --strict --path-prefix "${PATH_PREFIX}" -p test-repo
+          dotnet run --project src/docs-builder -- --strict --path-prefix "/docs" -p test-repo
       
       - name: Verify landing-page-path output
         run: test ${{ steps.docs-build.outputs.landing-page-path }} == ${{ matrix.landing-page-path-output }}

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -16,7 +16,7 @@ jobs:
           - repository: elastic/docs-content
             landing-page-path-output: ${{ env.PATH_PREFIX }}/
           - repository: elastic/apm-agent-android
-            landing-page-path-output: ${{ env.PATH_PREFIX }/reference/
+            landing-page-path-output: ${{ env.PATH_PREFIX }}/reference/
             
             # This is a random repository that should not have a docset.yml
           - repository: elastic/oblt-actions

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -3,6 +3,9 @@ name: smoke-tests
 on:
   pull_request: ~
   
+env:
+  PATH_PREFIX: /docs
+  
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -11,10 +14,12 @@ jobs:
       matrix: 
         include:
           - repository: elastic/docs-content
-            first-page-path-output: /docs
+            first-page-path-output: /docs/
           - repository: elastic/apm-agent-android
-            first-page-path-output: /docs/reference
-          - repository: elastic/cloud-on-k8s
+            first-page-path-output: /docs/reference/
+            
+            # This is a random repository that should not have a docset.yml
+          - repository: elastic/oblt-actions
             first-page-path-output: ""
 
     steps:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -11,8 +11,11 @@ jobs:
       matrix: 
         include:
           - repository: elastic/docs-content
+            first-page-path-output: /docs
           - repository: elastic/apm-agent-android
+            first-page-path-output: /docs/reference
           - repository: elastic/cloud-on-k8s
+            first-page-path-output: ""
 
     steps:
       - uses: actions/checkout@v4
@@ -25,5 +28,9 @@ jobs:
           path: test-repo
 
       - name: Build documentation
+        id: docs-build
         run: |
           dotnet run --project src/docs-builder -- --strict --path-prefix "/docs" -p test-repo
+      
+      - name: Verify first page path
+        run: test ${{ steps.docs-build.outputs.first-page-path }} == ${{ matrix.first-page-path-output }}

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -14,13 +14,13 @@ jobs:
       matrix: 
         include:
           - repository: elastic/docs-content
-            first-page-path-output: /docs/
+            landing-page-path-output: ${{ env.PATH_PREFIX }}/
           - repository: elastic/apm-agent-android
-            first-page-path-output: /docs/reference/
+            landing-page-path-output: ${{ env.PATH_PREFIX }/reference/
             
             # This is a random repository that should not have a docset.yml
           - repository: elastic/oblt-actions
-            first-page-path-output: ""
+            landing-page-path-output: ""
 
     steps:
       - uses: actions/checkout@v4
@@ -35,7 +35,7 @@ jobs:
       - name: Build documentation
         id: docs-build
         run: |
-          dotnet run --project src/docs-builder -- --strict --path-prefix "/docs" -p test-repo
+          dotnet run --project src/docs-builder -- --strict --path-prefix "${PATH_PREFIX}" -p test-repo
       
-      - name: Verify first page path
-        run: test ${{ steps.docs-build.outputs.first-page-path }} == ${{ matrix.first-page-path-output }}
+      - name: Verify landing-page-path output
+        run: test ${{ steps.docs-build.outputs.landing-page-path }} == ${{ matrix.landing-page-path-output }}

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    name: build (${{ matrix.repository }})
     strategy:
       fail-fast: false
       matrix: 

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,8 @@ inputs:
     description: 'Treat warnings as errors'
     required: false
 outputs:
+  landing-page-path:
+    description: 'Path to the landing page of the documentation'
   skip:
     description: "hint from the documentation tool to skip the docs build for this PR"
 

--- a/src/Elastic.Markdown/Slices/HtmlWriter.cs
+++ b/src/Elastic.Markdown/Slices/HtmlWriter.cs
@@ -1,6 +1,8 @@
 // Licensed to Elasticsearch B.V under one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
+
+using System.Collections.Concurrent;
 using System.IO.Abstractions;
 using Elastic.Markdown.IO;
 using Elastic.Markdown.IO.Configuration;
@@ -32,7 +34,7 @@ public class HtmlWriter(DocumentationSet documentationSet, IFileSystem writeFile
 		return await slice.RenderAsync(cancellationToken: ctx);
 	}
 
-	private readonly Dictionary<string, string> _renderedNavigationCache = [];
+	private readonly ConcurrentDictionary<string, string> _renderedNavigationCache = [];
 
 	public async Task<string> RenderLayout(MarkdownFile markdown, Cancel ctx = default)
 	{

--- a/src/docs-builder/Cli/Commands.cs
+++ b/src/docs-builder/Cli/Commands.cs
@@ -109,23 +109,7 @@ internal sealed class Commands(ILoggerFactory logger, ICoreService githubActions
 		var generator = new DocumentationGenerator(set, logger);
 		await generator.GenerateAll(ctx);
 		if (runningOnCi)
-		{
-			var firstIndex = (set.Tree.Index ?? set.Tree.NavigationItems
-				.OfType<GroupNavigation>()
-				.SelectMany(i =>
-				{
-					return GetAllIndexes(i.Group);
-					static IEnumerable<MarkdownFile?> GetAllIndexes(DocumentationGroup group)
-					{
-						yield return group.Index;
-						foreach (var child in group.NavigationItems.OfType<GroupNavigation>())
-							foreach (var index in GetAllIndexes(child.Group))
-								yield return index;
-					}
-				})
-				.FirstOrDefault(i => i != null)) ?? throw new InvalidOperationException("No index found");
-			await githubActionsService.SetOutputAsync("first-page-path", firstIndex.Url);
-		}
+			await githubActionsService.SetOutputAsync("landing-page-path", set.MarkdownFiles.First().Value.Url);
 		if (bool.TryParse(githubActionsService.GetInput("strict"), out var strictValue) && strictValue)
 			strict ??= strictValue;
 


### PR DESCRIPTION
## Changes

- Add `landing-page-path` output to docs-builder "main" action.
- Also fix concurrent access to `_renderedNavigationCache` in `HtmlWrite.cs`