### PR TITLE
Inbound link checking, fully validate if found in links-index

### DIFF
--- a/src/Elastic.Documentation.Tooling/Diagnostics/Log.cs
+++ b/src/Elastic.Documentation.Tooling/Diagnostics/Log.cs
@@ -12,10 +12,19 @@ public class Log(ILogger logger) : IDiagnosticsOutput
 {
 	public void Write(Diagnostic diagnostic)
 	{
-		if (diagnostic.Severity == Severity.Error)
-			logger.LogError("{Message} ({File}:{Line})", diagnostic.Message, diagnostic.File, diagnostic.Line);
+		if (diagnostic.File.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+		{
+			if (diagnostic.Severity == Severity.Error)
+				logger.LogError("{Message}", diagnostic.Message);
+			else
+				logger.LogWarning("{Message}", diagnostic.Message);
+		}
 		else
-			logger.LogWarning("{Message} ({File}:{Line})", diagnostic.Message, diagnostic.File, diagnostic.Line);
+		{
+			if (diagnostic.Severity == Severity.Error)
+				logger.LogError("{Message} ({File}:{Line})", diagnostic.Message, diagnostic.File, diagnostic.Line ?? 0);
+			else
+				logger.LogWarning("{Message} ({File}:{Line})", diagnostic.Message, diagnostic.File, diagnostic.Line ?? 0);
+		}
 	}
 }
-

--- a/src/Elastic.Markdown/CrossLinks/CrossLinkResolver.cs
+++ b/src/Elastic.Markdown/CrossLinks/CrossLinkResolver.cs
@@ -57,7 +57,10 @@ public class CrossLinkResolver(CrossLinkFetcher fetcher) : ICrossLinkResolver
 	{
 		var dictionary = _crossLinks.LinkReferences.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 		dictionary[repository] = linkReference;
-		_crossLinks = _crossLinks with { LinkReferences = dictionary.ToFrozenDictionary() };
+		_crossLinks = _crossLinks with
+		{
+			LinkReferences = dictionary.ToFrozenDictionary()
+		};
 		return _crossLinks;
 	}
 
@@ -68,21 +71,15 @@ public class CrossLinkResolver(CrossLinkFetcher fetcher) : ICrossLinkResolver
 		[NotNullWhen(true)] out Uri? resolvedUri
 	)
 	{
-		var lookup = fetchedCrossLinks.LinkReferences;
-		var declaredRepositories = fetchedCrossLinks.DeclaredRepositories;
 		resolvedUri = null;
-		if (crossLinkUri.Scheme == "docs-content")
-		{
-			if (!lookup.TryGetValue(crossLinkUri.Scheme, out var linkReference))
-			{
-				errorEmitter($"'{crossLinkUri.Scheme}' is not declared as valid cross link repository in docset.yml under cross_links");
-				return false;
-			}
-
+		var lookup = fetchedCrossLinks.LinkReferences;
+		if (crossLinkUri.Scheme != "asciidocalypse" && lookup.TryGetValue(crossLinkUri.Scheme, out var linkReference))
 			return TryFullyValidate(errorEmitter, linkReference, crossLinkUri, out resolvedUri);
-		}
 
-		// TODO this is temporary while we wait for all links.json files to be published
+		// TODO this is temporary while we wait for all links.json to be published
+		// Here we just silently rewrite the cross_link to the url
+
+		var declaredRepositories = fetchedCrossLinks.DeclaredRepositories;
 		if (!declaredRepositories.Contains(crossLinkUri.Scheme))
 		{
 			errorEmitter($"'{crossLinkUri.Scheme}' is not declared as valid cross link repository in docset.yml under cross_links");

--- a/src/docs-assembler/Links/LinkIndexLinkChecker.cs
+++ b/src/docs-assembler/Links/LinkIndexLinkChecker.cs
@@ -88,9 +88,10 @@ public class LinkIndexLinkChecker(ILoggerFactory logger)
 				{
 					if (s.Contains("is not a valid link in the"))
 					{
+						//
 						var error = $"'elastic/{repository}' links to unknown file: " + s;
 						error = error.Replace("is not a valid link in the", "in the");
-						collector.EmitError(repository, error);
+						collector.EmitError($"https://elastic-docs-link-index.s3.us-east-2.amazonaws.com/elastic/{uri.Scheme}/main/links.json", error);
 						return;
 					}
 


### PR DESCRIPTION
Improves error messages so you can quickly go to to the links.json file:

<img width="1071" alt="image" src="https://github.com/user-attachments/assets/4aa25ca5-5158-4b02-9b24-4967f8191f29" />

We skip validating links to `asciidocalypse` for now. 

Will make links to asciidocalypse an error soon while docs are being updated.