### PR TITLE
Better error messages for cross_link errors (From `docs-builder` and `docs-assembler`)

### DIFF
--- a/src/Elastic.Markdown/CrossLinks/ConfigurationCrossLinkFetcher.cs
+++ b/src/Elastic.Markdown/CrossLinks/ConfigurationCrossLinkFetcher.cs
@@ -36,7 +36,8 @@ public class ConfigurationCrossLinkFetcher(ConfigurationFile configuration, ILog
 		return new FetchedCrossLinks
 		{
 			DeclaredRepositories = declaredRepositories,
-			LinkReferences = dictionary.ToFrozenDictionary()
+			LinkReferences = dictionary.ToFrozenDictionary(),
+			FromConfiguration = true
 		};
 	}
 

--- a/src/Elastic.Markdown/CrossLinks/CrossLinkFetcher.cs
+++ b/src/Elastic.Markdown/CrossLinks/CrossLinkFetcher.cs
@@ -13,12 +13,16 @@ namespace Elastic.Markdown.CrossLinks;
 public record FetchedCrossLinks
 {
 	public required FrozenDictionary<string, LinkReference> LinkReferences { get; init; }
+
 	public required HashSet<string> DeclaredRepositories { get; init; }
+
+	public required bool FromConfiguration { get; init; }
 
 	public static FetchedCrossLinks Empty { get; } = new()
 	{
 		DeclaredRepositories = [],
-		LinkReferences = new Dictionary<string, LinkReference>().ToFrozenDictionary()
+		LinkReferences = new Dictionary<string, LinkReference>().ToFrozenDictionary(),
+		FromConfiguration = false
 	};
 }
 

--- a/src/Elastic.Markdown/CrossLinks/CrossLinkResolver.cs
+++ b/src/Elastic.Markdown/CrossLinks/CrossLinkResolver.cs
@@ -167,7 +167,8 @@ public class CrossLinkResolver(CrossLinkFetcher fetcher) : ICrossLinkResolver
 			return true;
 		}
 
-		errorEmitter($"'{lookupPath}' is not a valid link in the '{crossLinkUri.Scheme}' cross link repository.");
+		var linksJson = $"https://elastic-docs-link-index.s3.us-east-2.amazonaws.com/elastic/{crossLinkUri.Scheme}/main/links.json";
+		errorEmitter($"'{lookupPath}' is not a valid link in the '{crossLinkUri.Scheme}' cross link index: {linksJson}.");
 		return false;
 	}
 

--- a/src/Elastic.Markdown/CrossLinks/CrossLinkResolver.cs
+++ b/src/Elastic.Markdown/CrossLinks/CrossLinkResolver.cs
@@ -82,7 +82,8 @@ public class CrossLinkResolver(CrossLinkFetcher fetcher) : ICrossLinkResolver
 		var declaredRepositories = fetchedCrossLinks.DeclaredRepositories;
 		if (!declaredRepositories.Contains(crossLinkUri.Scheme))
 		{
-			errorEmitter($"'{crossLinkUri.Scheme}' is not declared as valid cross link repository in docset.yml under cross_links");
+			if (fetchedCrossLinks.FromConfiguration)
+				errorEmitter($"'{crossLinkUri.Scheme}' is not declared as valid cross link repository in docset.yml under cross_links: '{crossLinkUri}'");
 			return false;
 		}
 

--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -162,7 +162,11 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 		if (url != null)
 			context.Build.Collector.EmitCrossLink(url);
 
-		if (context.CrossLinkResolver.TryResolve(s => processor.EmitError(link, s), uri, out var resolvedUri))
+		if (context.CrossLinkResolver.TryResolve(
+				s => processor.EmitError(link, s),
+				s => processor.EmitWarning(link, s),
+				uri, out var resolvedUri)
+		   )
 			link.Url = resolvedUri.ToString();
 	}
 

--- a/src/docs-assembler/Links/LinkIndexCrossLinkFetcher.cs
+++ b/src/docs-assembler/Links/LinkIndexCrossLinkFetcher.cs
@@ -27,7 +27,8 @@ public class LinksIndexCrossLinkFetcher(ILoggerFactory logger) : CrossLinkFetche
 		return new FetchedCrossLinks
 		{
 			DeclaredRepositories = declaredRepositories,
-			LinkReferences = dictionary.ToFrozenDictionary()
+			LinkReferences = dictionary.ToFrozenDictionary(),
+			FromConfiguration = false
 		};
 	}
 }

--- a/src/docs-assembler/Links/LinkIndexLinkChecker.cs
+++ b/src/docs-assembler/Links/LinkIndexLinkChecker.cs
@@ -11,32 +11,44 @@ using Microsoft.Extensions.Logging;
 
 namespace Documentation.Assembler.Links;
 
-public class LinkIndexLinkChecker(ILoggerFactory logger)
+public class LinkIndexLinkChecker(ILoggerFactory logger, ICoreService githubActionsService)
 {
 	private readonly ILogger _logger = logger.CreateLogger<LinkIndexLinkChecker>();
 
-	public async Task<int> CheckAll(ICoreService githubActionsService, Cancel ctx)
+	private sealed record RepositoryFilter
 	{
-		var fetcher = new LinksIndexCrossLinkFetcher(logger);
-		var resolver = new CrossLinkResolver(fetcher);
-		//todo add ctx
-		var crossLinks = await resolver.FetchLinks();
+		public string? LinksTo { get; set; }
+		public string? LinksFrom { get; set; }
 
-		return await ValidateCrossLinks(githubActionsService, crossLinks, resolver, null, ctx);
+		public static RepositoryFilter None => new();
 	}
 
-	public async Task<int> CheckRepository(ICoreService githubActionsService, string repository, Cancel ctx)
+	public async Task<int> CheckAll(Cancel ctx)
 	{
 		var fetcher = new LinksIndexCrossLinkFetcher(logger);
 		var resolver = new CrossLinkResolver(fetcher);
 		//todo add ctx
 		var crossLinks = await resolver.FetchLinks();
 
-		return await ValidateCrossLinks(githubActionsService, crossLinks, resolver, repository, ctx);
+		return await ValidateCrossLinks(crossLinks, resolver, RepositoryFilter.None, ctx);
+	}
+
+	public async Task<int> CheckRepository(string? toRepository, string? fromRepository, Cancel ctx)
+	{
+		var fetcher = new LinksIndexCrossLinkFetcher(logger);
+		var resolver = new CrossLinkResolver(fetcher);
+		//todo add ctx
+		var crossLinks = await resolver.FetchLinks();
+		var filter = new RepositoryFilter
+		{
+			LinksTo = toRepository,
+			LinksFrom = fromRepository
+		};
+
+		return await ValidateCrossLinks(crossLinks, resolver, filter, ctx);
 	}
 
 	public async Task<int> CheckWithLocalLinksJson(
-		ICoreService githubActionsService,
 		string repository,
 		string localLinksJson,
 		Cancel ctx
@@ -70,23 +82,32 @@ public class LinkIndexLinkChecker(ILoggerFactory logger)
 		}
 
 		_logger.LogInformation("Validating all cross links to {Repository}:// from all repositories published to link-index.json", repository);
+		var filter = new RepositoryFilter
+		{
+			LinksTo = repository
+		};
 
-		return await ValidateCrossLinks(githubActionsService, crossLinks, resolver, repository, ctx);
+		return await ValidateCrossLinks(crossLinks, resolver, filter, ctx);
 	}
 
 	private async Task<int> ValidateCrossLinks(
-		ICoreService githubActionsService,
 		FetchedCrossLinks crossLinks,
 		CrossLinkResolver resolver,
-		string? currentRepository,
+		RepositoryFilter filter,
 		Cancel ctx)
 	{
 		var collector = new ConsoleDiagnosticsCollector(logger, githubActionsService);
 		_ = collector.StartAsync(ctx);
 		foreach (var (repository, linkReference) in crossLinks.LinkReferences)
 		{
-			if (!string.IsNullOrEmpty(currentRepository))
-				_logger.LogInformation("Validating '{CurrentRepository}://' links in {TargetRepository}", currentRepository, repository);
+			if (!string.IsNullOrEmpty(filter.LinksTo))
+				_logger.LogInformation("Validating '{CurrentRepository}://' links in {TargetRepository}", filter.LinksTo, repository);
+			else if (!string.IsNullOrEmpty(filter.LinksFrom))
+			{
+				if (repository != filter.LinksFrom)
+					continue;
+				_logger.LogInformation("Validating cross_links from {TargetRepository}", filter.LinksFrom);
+			}
 			else
 				_logger.LogInformation("Validating all cross_links in {Repository}", repository);
 			foreach (var crossLink in linkReference.CrossLinks)
@@ -94,7 +115,7 @@ public class LinkIndexLinkChecker(ILoggerFactory logger)
 				// if we are filtering we only want errors from inbound links to a certain
 				// repository
 				var uri = new Uri(crossLink);
-				if (currentRepository != null && uri.Scheme != currentRepository)
+				if (filter.LinksTo != null && uri.Scheme != filter.LinksTo)
 					continue;
 
 				_ = resolver.TryResolve(s =>

--- a/tests/Elastic.Markdown.Tests/TestCrossLinkResolver.cs
+++ b/tests/Elastic.Markdown.Tests/TestCrossLinkResolver.cs
@@ -49,7 +49,8 @@ public class TestCrossLinkResolver : ICrossLinkResolver
 		_crossLinks = new FetchedCrossLinks
 		{
 			DeclaredRepositories = DeclaredRepositories,
-			LinkReferences = LinkReferences.ToFrozenDictionary()
+			LinkReferences = LinkReferences.ToFrozenDictionary(),
+			FromConfiguration = true
 		};
 		return Task.FromResult(_crossLinks);
 	}

--- a/tests/Elastic.Markdown.Tests/TestCrossLinkResolver.cs
+++ b/tests/Elastic.Markdown.Tests/TestCrossLinkResolver.cs
@@ -55,6 +55,6 @@ public class TestCrossLinkResolver : ICrossLinkResolver
 		return Task.FromResult(_crossLinks);
 	}
 
-	public bool TryResolve(Action<string> errorEmitter, Uri crossLinkUri, [NotNullWhen(true)] out Uri? resolvedUri) =>
-		CrossLinkResolver.TryResolve(errorEmitter, _crossLinks, crossLinkUri, out resolvedUri);
+	public bool TryResolve(Action<string> errorEmitter, Action<string> warningEmitter, Uri crossLinkUri, [NotNullWhen(true)] out Uri? resolvedUri) =>
+		CrossLinkResolver.TryResolve(errorEmitter, warningEmitter, _crossLinks, crossLinkUri, out resolvedUri);
 }

--- a/tests/authoring/Framework/TestCrossLinkResolver.fs
+++ b/tests/authoring/Framework/TestCrossLinkResolver.fs
@@ -65,7 +65,8 @@ type TestCrossLinkResolver (config: ConfigurationFile) =
             let crossLinks =
                 FetchedCrossLinks(
                     DeclaredRepositories=this.DeclaredRepositories,
-                    LinkReferences=this.LinkReferences.ToFrozenDictionary()
+                    LinkReferences=this.LinkReferences.ToFrozenDictionary(),
+                    FromConfiguration=true
                 )
             Task.FromResult crossLinks
 
@@ -73,7 +74,8 @@ type TestCrossLinkResolver (config: ConfigurationFile) =
             let crossLinks =
                 FetchedCrossLinks(
                     DeclaredRepositories=this.DeclaredRepositories,
-                    LinkReferences=this.LinkReferences.ToFrozenDictionary()
+                    LinkReferences=this.LinkReferences.ToFrozenDictionary(),
+                    FromConfiguration=true
                 )
             CrossLinkResolver.TryResolve(errorEmitter, crossLinks, crossLinkUri, &resolvedUri);
 

--- a/tests/authoring/Framework/TestCrossLinkResolver.fs
+++ b/tests/authoring/Framework/TestCrossLinkResolver.fs
@@ -70,13 +70,13 @@ type TestCrossLinkResolver (config: ConfigurationFile) =
                 )
             Task.FromResult crossLinks
 
-        member this.TryResolve(errorEmitter, crossLinkUri, [<Out>]resolvedUri : byref<Uri|null>) =
+        member this.TryResolve(errorEmitter, warningEmitter, crossLinkUri, [<Out>]resolvedUri : byref<Uri|null>) =
             let crossLinks =
                 FetchedCrossLinks(
                     DeclaredRepositories=this.DeclaredRepositories,
                     LinkReferences=this.LinkReferences.ToFrozenDictionary(),
                     FromConfiguration=true
                 )
-            CrossLinkResolver.TryResolve(errorEmitter, crossLinks, crossLinkUri, &resolvedUri);
+            CrossLinkResolver.TryResolve(errorEmitter, warningEmitter, crossLinks, crossLinkUri, &resolvedUri);
 
 


### PR DESCRIPTION
Better `docs-builder` error message when a cross link is not found in the published index:

<img width="1331" alt="image" src="https://github.com/user-attachments/assets/3b01699b-8dbc-4682-80b4-cc0ed5634858" />

Better `docs-assembler inbound-links <COMMAND>` error messages:

<img width="1333" alt="image" src="https://github.com/user-attachments/assets/e3d58f32-dd96-428b-b65d-343f7bbf588e" />

* Remove `is not declared as valid cross link repository in docset.yml under cross_links:` error message when called from `docs-assembler inbound-link` which made no sense in this context. (Since the `CrossLinksFetcher` is not `ConfigurationCrossLinksFetcher`)
* **Insteead** we now warn that the cross_link to repository not yet in the registry.
* Better error message with more context if a link to a repository in the registry is not found


