### PR TITLE
Add logging to git remote resolving

### DIFF
--- a/src/docs-assembler/Cli/InboundLinkCommands.cs
+++ b/src/docs-assembler/Cli/InboundLinkCommands.cs
@@ -50,7 +50,7 @@ internal sealed class InboundLinkCommands(ILoggerFactory logger, ICoreService gi
 		var root = fs.DirectoryInfo.New(Paths.Root.FullName);
 		if (from == null && to == null)
 		{
-			from ??= GitCheckoutInformation.Create(root, new FileSystem()).RepositoryName;
+			from ??= GitCheckoutInformation.Create(root, new FileSystem(), logger.CreateLogger(nameof(GitCheckoutInformation))).RepositoryName;
 			if (from == null)
 				throw new Exception("Unable to determine repository name");
 		}
@@ -69,7 +69,7 @@ internal sealed class InboundLinkCommands(ILoggerFactory logger, ICoreService gi
 		file ??= ".artifacts/docs/html/links.json";
 		var fs = new FileSystem();
 		var root = fs.DirectoryInfo.New(Paths.Root.FullName);
-		var repository = GitCheckoutInformation.Create(root, new FileSystem()).RepositoryName
+		var repository = GitCheckoutInformation.Create(root, new FileSystem(), logger.CreateLogger(nameof(GitCheckoutInformation))).RepositoryName
 						?? throw new Exception("Unable to determine repository name");
 
 		return await _linkIndexLinkChecker.CheckWithLocalLinksJson(repository, file, ctx);

--- a/tests/Elastic.Markdown.Tests/DocSet/LinkReferenceTests.cs
+++ b/tests/Elastic.Markdown.Tests/DocSet/LinkReferenceTests.cs
@@ -6,6 +6,7 @@ using Elastic.Markdown.IO;
 using Elastic.Markdown.IO.Discovery;
 using Elastic.Markdown.IO.State;
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
 
 namespace Elastic.Markdown.Tests.DocSet;
 
@@ -34,7 +35,7 @@ public class GitCheckoutInformationTests(ITestOutputHelper output) : NavigationT
 	public void Create()
 	{
 		var root = ReadFileSystem.DirectoryInfo.New(Paths.Root.FullName);
-		var git = GitCheckoutInformation.Create(root, ReadFileSystem);
+		var git = GitCheckoutInformation.Create(root, ReadFileSystem, LoggerFactory.CreateLogger(nameof(GitCheckoutInformation)));
 
 		git.Should().NotBeNull();
 		git.Branch.Should().NotBeNullOrWhiteSpace();


### PR DESCRIPTION
https://github.com/elastic/apm-agent-dotnet/actions/runs/13589578004/job/37992159615?pr=2558#step:13:37

Somehow we are eating the last character of the repository name on github actions, need to get to the bottom of this. 

This logging is temporary.