### PR TITLE
Share inbound-links commands with `docs-builder`

### DIFF
--- a/src/Elastic.Documentation.Tooling/Diagnostics/Console/ConsoleDiagnosticsCollector.cs
+++ b/src/Elastic.Documentation.Tooling/Diagnostics/Console/ConsoleDiagnosticsCollector.cs
@@ -25,8 +25,12 @@ public class ConsoleDiagnosticsCollector(ILoggerFactory loggerFactory, ICoreServ
 			_errors.Add(diagnostic);
 	}
 
+	private bool _stopped;
 	public override async Task StopAsync(Cancel cancellationToken)
 	{
+		if (_stopped)
+			return;
+		_stopped = true;
 		var repository = new ErrataFileSourceRepository();
 		repository.WriteDiagnosticsToConsole(_errors, _warnings);
 

--- a/src/Elastic.Documentation.Tooling/Diagnostics/Console/ErrataFileSourceRepository.cs
+++ b/src/Elastic.Documentation.Tooling/Diagnostics/Console/ErrataFileSourceRepository.cs
@@ -26,11 +26,11 @@ public class ErrataFileSourceRepository : ISourceRepository
 	public void WriteDiagnosticsToConsole(IReadOnlyCollection<Diagnostic> errors, IReadOnlyCollection<Diagnostic> warnings)
 	{
 		var report = new Report(this);
-		var limttedErrors = errors.Take(100).ToArray();
-		var limittedWarnings = warnings.Take(100 - limttedErrors.Length);
-		var limitted = limittedWarnings.Concat(limttedErrors).ToArray();
+		var limitedErrors = errors.Take(100).ToArray();
+		var limitedWarnings = warnings.Take(100 - limitedErrors.Length);
+		var limited = limitedWarnings.Concat(limitedErrors).ToArray();
 
-		foreach (var item in limitted)
+		foreach (var item in limited)
 		{
 			var d = item.Severity switch
 			{
@@ -55,22 +55,20 @@ public class ErrataFileSourceRepository : ISourceRepository
 		var totalErrorCount = errors.Count + warnings.Count;
 
 		AnsiConsole.WriteLine();
-		if (totalErrorCount > 0)
-		{
-			AnsiConsole.Write(new Markup($"	[bold]The following errors and warnings were found in the documentation[/]"));
-			AnsiConsole.WriteLine();
-			AnsiConsole.WriteLine();
-			// Render the report
-			report.Render(AnsiConsole.Console);
+		if (totalErrorCount <= 0)
+			return;
+		AnsiConsole.Write(new Markup($"	[bold]The following errors and warnings were found in the documentation[/]"));
+		AnsiConsole.WriteLine();
+		AnsiConsole.WriteLine();
+		// Render the report
+		report.Render(AnsiConsole.Console);
 
-			AnsiConsole.WriteLine();
-			AnsiConsole.WriteLine();
+		AnsiConsole.WriteLine();
+		AnsiConsole.WriteLine();
 
-			if (limitted.Length <= totalErrorCount)
-				AnsiConsole.Write(new Markup($"	[bold]Only shown the first [yellow]{limitted.Length}[/] diagnostics out of [yellow]{totalErrorCount}[/][/]"));
+		if (totalErrorCount > limited.Length)
+			AnsiConsole.Write(new Markup($"	[bold]Only shown the first [yellow]{limited.Length}[/] diagnostics out of [yellow]{totalErrorCount}[/][/]"));
 
-			AnsiConsole.WriteLine();
-
-		}
+		AnsiConsole.WriteLine();
 	}
 }

--- a/src/Elastic.Markdown/Diagnostics/DiagnosticsChannel.cs
+++ b/src/Elastic.Markdown/Diagnostics/DiagnosticsChannel.cs
@@ -61,7 +61,7 @@ public interface IDiagnosticsOutput
 }
 
 public class DiagnosticsCollector(IReadOnlyCollection<IDiagnosticsOutput> outputs)
-	: IHostedService
+	: IHostedService, IAsyncDisposable
 {
 	public DiagnosticsChannel Channel { get; } = new();
 
@@ -155,5 +155,12 @@ public class DiagnosticsCollector(IReadOnlyCollection<IDiagnosticsOutput> output
 			Message = message,
 		};
 		Channel.Write(d);
+	}
+
+	public async ValueTask DisposeAsync()
+	{
+		Channel.TryComplete();
+		await StopAsync(CancellationToken.None);
+		GC.SuppressFinalize(this);
 	}
 }

--- a/src/Elastic.Markdown/InboundLinks/LinkIndexCrossLinkFetcher.cs
+++ b/src/Elastic.Markdown/InboundLinks/LinkIndexCrossLinkFetcher.cs
@@ -7,7 +7,7 @@ using Elastic.Markdown.CrossLinks;
 using Elastic.Markdown.IO.State;
 using Microsoft.Extensions.Logging;
 
-namespace Documentation.Assembler.Links;
+namespace Elastic.Markdown.InboundLinks;
 
 public class LinksIndexCrossLinkFetcher(ILoggerFactory logger) : CrossLinkFetcher(logger)
 {

--- a/src/docs-assembler/Cli/LinkRegistryCommands.cs
+++ b/src/docs-assembler/Cli/LinkRegistryCommands.cs
@@ -2,29 +2,24 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-using System.IO.Abstractions;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
-using Actions.Core.Services;
 using Amazon.S3;
 using Amazon.S3.Model;
 using ConsoleAppFramework;
-using Documentation.Assembler.Links;
 using Elastic.Markdown.CrossLinks;
-using Elastic.Markdown.IO;
-using Elastic.Markdown.IO.Discovery;
 using Microsoft.Extensions.Logging;
 
 namespace Documentation.Assembler.Cli;
 
 internal sealed class LinkRegistryCommands(ILoggerFactory logger)
 {
+	[SuppressMessage("Usage", "CA2254:Template should be a static expression")]
 	private void AssignOutputLogger()
 	{
 		var log = logger.CreateLogger<Program>();
-#pragma warning disable CA2254
 		ConsoleApp.Log = msg => log.LogInformation(msg);
 		ConsoleApp.LogError = msg => log.LogError(msg);
-#pragma warning restore CA2254
 	}
 
 	/// <summary>

--- a/src/docs-assembler/Cli/RepositoryCommands.cs
+++ b/src/docs-assembler/Cli/RepositoryCommands.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using ConsoleAppFramework;
 using Elastic.Markdown.IO;
 using Microsoft.Extensions.Logging;
@@ -23,13 +24,12 @@ public class ConsoleLineHandler(string prefix) : IConsoleLineHandler
 
 internal sealed class RepositoryCommands(ILoggerFactory logger)
 {
+	[SuppressMessage("Usage", "CA2254:Template should be a static expression")]
 	private void AssignOutputLogger()
 	{
 		var log = logger.CreateLogger<Program>();
-#pragma warning disable CA2254
 		ConsoleApp.Log = msg => log.LogInformation(msg);
 		ConsoleApp.LogError = msg => log.LogError(msg);
-#pragma warning restore CA2254
 	}
 
 	// would love to use libgit2 so there is no git dependency but

--- a/src/docs-builder/Cli/InboundLinkCommands.cs
+++ b/src/docs-builder/Cli/InboundLinkCommands.cs
@@ -7,12 +7,13 @@ using System.IO.Abstractions;
 using Actions.Core.Services;
 using ConsoleAppFramework;
 using Elastic.Documentation.Tooling.Diagnostics.Console;
+using Elastic.Documentation.Tooling.Filters;
 using Elastic.Markdown.InboundLinks;
 using Elastic.Markdown.IO;
 using Elastic.Markdown.IO.Discovery;
 using Microsoft.Extensions.Logging;
 
-namespace Documentation.Assembler.Cli;
+namespace Documentation.Builder.Cli;
 
 internal sealed class InboundLinkCommands(ILoggerFactory logger, ICoreService githubActionsService)
 {
@@ -29,6 +30,8 @@ internal sealed class InboundLinkCommands(ILoggerFactory logger, ICoreService gi
 	/// <summary> Validate all published cross_links in all published links.json files. </summary>
 	/// <param name="ctx"></param>
 	[Command("validate-all")]
+	[ConsoleAppFilter<StopwatchFilter>]
+	[ConsoleAppFilter<CatchExceptionFilter>]
 	public async Task<int> ValidateAllInboundLinks(Cancel ctx = default)
 	{
 		AssignOutputLogger();
@@ -36,11 +39,13 @@ internal sealed class InboundLinkCommands(ILoggerFactory logger, ICoreService gi
 		return await _linkIndexLinkChecker.CheckAll(collector, ctx);
 	}
 
-	/// <summary> Validate all published cross_links in all published links.json files. </summary>
-	/// <param name="from"></param>
-	/// <param name="to"></param>
+	/// <summary> Validate a single repository against the published cross_links in all published links.json files. </summary>
+	/// <param name="from">Outbound links 'from' repository to others, defaults to {pwd}/.git </param>
+	/// <param name="to">Outbound links 'to' repository form others</param>
 	/// <param name="ctx"></param>
 	[Command("validate")]
+	[ConsoleAppFilter<StopwatchFilter>]
+	[ConsoleAppFilter<CatchExceptionFilter>]
 	public async Task<int> ValidateRepoInboundLinks(string? from = null, string? to = null, Cancel ctx = default)
 	{
 		AssignOutputLogger();
@@ -62,6 +67,8 @@ internal sealed class InboundLinkCommands(ILoggerFactory logger, ICoreService gi
 	/// <param name="file">Path to `links.json` defaults to '.artifacts/docs/html/links.json'</param>
 	/// <param name="ctx"></param>
 	[Command("validate-link-reference")]
+	[ConsoleAppFilter<StopwatchFilter>]
+	[ConsoleAppFilter<CatchExceptionFilter>]
 	public async Task<int> ValidateLocalLinkReference([Argument] string? file = null, Cancel ctx = default)
 	{
 		AssignOutputLogger();

--- a/src/docs-builder/Program.cs
+++ b/src/docs-builder/Program.cs
@@ -16,5 +16,6 @@ ConsoleApp.ServiceProvider = serviceProvider;
 
 var app = ConsoleApp.Create();
 app.Add<Commands>();
+app.Add<InboundLinkCommands>("inbound-links");
 
 await app.RunAsync(args).ConfigureAwait(false);


### PR DESCRIPTION
```bash
docs-builder inbound-links --help
Usage: [command] [options...] [-h|--help] [--version]

Converts a source markdown folder or file to an output folder

Options:
  -p|--path <string?>         Defaults to the`{pwd}/docs` folder (Default: null)
  -o|--output <string?>       Defaults to `.artifacts/html` (Default: null)
  --path-prefix <string?>     Specifies the path prefix for urls (Default: null)
  --force <bool?>             Force a full rebuild of the destination folder (Default: null)
  --strict <bool?>            Treat warnings as errors and fail the build on warnings (Default: null)
  --allow-indexing <bool?>    Allow indexing and following of html files (Default: null)

Commands:
  generate                                 Converts a source markdown folder or file to an output folder
         <para>global options:</para>
         --log-level level
  inbound-links validate                   Validate a single repository against the published cross_links in all published links.json files.
  inbound-links validate-all               Validate all published cross_links in all published links.json files.
  inbound-links validate-link-reference    Validate a locally published links.json file against all published links.json files in the registry
  mv                                       Move a file from one location to another and update all links in the documentation
  serve                                    Continuously serve a documentation folder at http://localhost:3000.
         File systems changes will be reflected without having to restart the server.
```


Allows writers to check the local links.json file after building e.g:

```
$ docs-builder
$ docs-builder inbound-links validate-link-reference
```

The latter command will check the local `.artifacts/docs/html/links.json`'s outbound links against the link registry. 

Allowing writers to shorten their feedback loop. 