### PR TITLE
Add extension hook points to all special usecases to inject themselves into docs build process

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -231,6 +231,8 @@ dotnet_diagnostic.IDE0059.severity = suggestion
 
 dotnet_diagnostic.CA1859.severity = none
 
+dotnet_diagnostic.IDE0305.severity = none
+
 
 [DocumentationWebHost.cs]
 dotnet_diagnostic.IL3050.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -229,12 +229,12 @@ dotnet_diagnostic.IDE0057.severity = none
 dotnet_diagnostic.IDE0051.severity = suggestion
 dotnet_diagnostic.IDE0059.severity = suggestion
 
+dotnet_diagnostic.CA1859.severity = none
+
 
 [DocumentationWebHost.cs]
 dotnet_diagnostic.IL3050.severity = none
 dotnet_diagnostic.IL2026.severity = none
-
-
 
 [tests/**/*.cs]
 dotnet_diagnostic.IDE0058.severity = none

--- a/docs/_docset.yml
+++ b/docs/_docset.yml
@@ -58,6 +58,7 @@ toc:
           - file: file-structure.md
           - file: attributes.md
           - file: navigation.md
+          - file: extensions.md
       - file: page.md
   - folder: syntax
     children:

--- a/docs/configure/content-set/extensions.md
+++ b/docs/configure/content-set/extensions.md
@@ -22,10 +22,11 @@ extensions:
 ```
 
 This now allows you to use the special `detection_rules` instruction in the [Table of Contents](navigation.md)
+As a means to pick up `toml` files as `children`
 
 ```yaml
 toc:
   - file: index.md
-  - detection_rules: '../rules'
+    detection_rules: '../rules'
 ```
 

--- a/docs/configure/content-set/extensions.md
+++ b/docs/configure/content-set/extensions.md
@@ -1,0 +1,31 @@
+---
+navigation_title: Extensions
+---
+
+# Content set extensions. 
+
+The documentation engineering team will on occasion built extensions for specific use-cases.
+
+These extension needs to be explicitly opted into since they typically only apply to a few content sets.
+
+
+## Detection Rules Extensions
+
+For the TRADE team the team built in support to picking up detection rule files from the source and emitting 
+documentation and navigation for them.
+
+To enable:
+
+```yaml
+extensions:
+  - detection-rules
+```
+
+This now allows you to use the special `detection_rules` instruction in the [Table of Contents](navigation.md)
+
+```yaml
+toc:
+  - file: index.md
+  - detection_rules: '../rules'
+```
+

--- a/src/Elastic.Markdown/BuildContext.cs
+++ b/src/Elastic.Markdown/BuildContext.cs
@@ -4,6 +4,7 @@
 
 using System.IO.Abstractions;
 using Elastic.Markdown.Diagnostics;
+using Elastic.Markdown.Extensions;
 using Elastic.Markdown.IO;
 using Elastic.Markdown.IO.Configuration;
 using Elastic.Markdown.IO.Discovery;
@@ -67,6 +68,7 @@ public record BuildContext
 
 		Git = GitCheckoutInformation.Create(DocumentationSourceDirectory, ReadFileSystem);
 		Configuration = new ConfigurationFile(ConfigurationPath, DocumentationSourceDirectory, this);
+
 	}
 
 	public ConfigurationFile Configuration { get; set; }

--- a/src/Elastic.Markdown/BuildContext.cs
+++ b/src/Elastic.Markdown/BuildContext.cs
@@ -19,6 +19,8 @@ public record BuildContext
 	public IDirectoryInfo DocumentationSourceDirectory { get; }
 	public IDirectoryInfo DocumentationOutputDirectory { get; }
 
+	public ConfigurationFile Configuration { get; set; }
+
 	public IFileInfo ConfigurationPath { get; }
 
 	public GitCheckoutInformation Git { get; }
@@ -71,8 +73,6 @@ public record BuildContext
 
 	}
 
-	public ConfigurationFile Configuration { get; set; }
-
 	private (IDirectoryInfo, IFileInfo) FindDocsFolderFromRoot(IDirectoryInfo rootPath)
 	{
 		string[] files = ["docset.yml", "_docset.yml"];
@@ -97,4 +97,5 @@ public record BuildContext
 
 		return (docsFolder, configurationPath);
 	}
+
 }

--- a/src/Elastic.Markdown/Elastic.Markdown.csproj
+++ b/src/Elastic.Markdown/Elastic.Markdown.csproj
@@ -51,6 +51,7 @@
 
   <ItemGroup>
     <PackageReference Include="DotNet.Glob" Version="3.1.3" />
+    <PackageReference Include="Samboy063.Tomlet" Version="6.0.0" />
     <PackageReference Include="SoftCircuits.IniFileParser" Version="2.6.0" />
     <PackageReference Include="Markdig" Version="0.39.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />

--- a/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRule.cs
+++ b/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRule.cs
@@ -1,0 +1,97 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Diagnostics.CodeAnalysis;
+using System.IO.Abstractions;
+using Tomlet;
+using Tomlet.Models;
+
+namespace Elastic.Markdown.Extensions.DetectionRules;
+
+public record DetectionRule
+{
+	public required string Name { get; init; }
+
+	public required string[]? Authors { get; init; }
+
+	public required string? Note { get; init; }
+
+	public required string? Query { get; init; }
+
+	public required string[]? Tags { get; init; }
+
+	public required string Severity { get; init; }
+
+	public required string RuleId { get; init; }
+
+	public required int RiskScore { get; init; }
+
+	public required string License { get; init; }
+
+	public required string Description { get; init; }
+	public required string Type { get; init; }
+	public required string? Language { get; init; }
+	public required string[]? Indices { get; init; }
+	public required string RunsEvery { get; init; }
+	public required string? IndicesFromDateMath { get; init; }
+	public required string MaximumAlertsPerExecution { get; init; }
+	public required string[]? References { get; init; }
+	public required string Version { get; init; }
+
+	//[UnconditionalSuppressMessage("AssemblyLoadTrimming", "IL2075", Justification = "Manually verified")]
+	//[UnconditionalSuppressMessage("AssemblyLoadTrimming", "IL3050", Justification = "Manually verified")]
+	public static DetectionRule From(IFileInfo source)
+	{
+		TomlDocument model;
+		try
+		{
+			var sourceText = File.ReadAllText(source.FullName);
+			model = new TomlParser().Parse(sourceText);
+		}
+		catch (Exception e)
+		{
+			throw new Exception($"Could not parse toml in: {source.FullName}", e);
+		}
+		if (!model.TryGetValue("metadata", out var node) || node is not TomlTable metadata)
+			throw new Exception($"Could not find metadata section in {source.FullName}");
+
+		if (!model.TryGetValue("rule", out node) || node is not TomlTable rule)
+			throw new Exception($"Could not find rule section in {source.FullName}");
+
+		return new DetectionRule
+		{
+			Authors = TryGetStringArray(rule, "author"),
+			Description = rule.GetString("description"),
+			Type = rule.GetString("type"),
+			Language = TryGetString(rule, "language"),
+			License = rule.GetString("license"),
+			RiskScore = TryRead<int>(rule, "risk_score"),
+			RuleId = rule.GetString("rule_id"),
+			Severity = rule.GetString("severity"),
+			Tags = TryGetStringArray(rule, "tags"),
+			Indices = TryGetStringArray(rule, "index"),
+			References = TryGetStringArray(rule, "references"),
+			IndicesFromDateMath = TryGetString(rule, "from"),
+			Query = TryGetString(rule, "query"),
+			Note = TryGetString(rule, "note"),
+			Name = rule.GetString("name"),
+			RunsEvery = "?",
+			MaximumAlertsPerExecution = "?",
+			Version = "?",
+		};
+	}
+
+	private static string[]? TryGetStringArray(TomlTable table, string key) =>
+		table.TryGetValue(key, out var node) && node is TomlArray t ? t.ArrayValues.Select(value => value.StringValue).ToArray() : null;
+
+	private static string? TryGetString(TomlTable table, string key) =>
+		table.TryGetValue(key, out var node) && node is TomlString t ? t.Value : null;
+
+	private static TTarget? TryRead<TTarget>(TomlTable table, string key) =>
+		table.TryGetValue(key, out var node) && node is TTarget t ? t : default;
+
+	private static TTarget Read<TTarget>(TomlTable table, string key) =>
+		TryRead<TTarget>(table, key) ?? throw new Exception($"Could not find {key} in {table}");
+
+}

--- a/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRule.cs
+++ b/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRule.cs
@@ -39,8 +39,6 @@ public record DetectionRule
 	public required string[]? References { get; init; }
 	public required string Version { get; init; }
 
-	//[UnconditionalSuppressMessage("AssemblyLoadTrimming", "IL2075", Justification = "Manually verified")]
-	//[UnconditionalSuppressMessage("AssemblyLoadTrimming", "IL3050", Justification = "Manually verified")]
 	public static DetectionRule From(IFileInfo source)
 	{
 		TomlDocument model;

--- a/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRuleFile.cs
+++ b/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRuleFile.cs
@@ -23,6 +23,8 @@ public record DetectionRuleFile : MarkdownFile
 	{
 	}
 
+	protected override string RelativePathUrl => RelativePath.AsSpan().TrimStart("../").ToString();
+
 	protected override Task<MarkdownDocument> GetMinimalParseDocumentAsync(Cancel ctx)
 	{
 		var document = MarkdownParser.MinimalParseStringAsync(Rule?.Note ?? string.Empty, SourceFile, null);

--- a/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRuleFile.cs
+++ b/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRuleFile.cs
@@ -1,0 +1,75 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions;
+using Elastic.Markdown.IO;
+using Elastic.Markdown.Myst;
+using Markdig.Syntax;
+
+namespace Elastic.Markdown.Extensions.DetectionRules;
+
+public record DetectionRuleFile : MarkdownFile
+{
+	public DetectionRule? Rule { get; set; }
+
+	public DetectionRuleFile(
+		IFileInfo sourceFile,
+		IDirectoryInfo rootPath,
+		MarkdownParser parser,
+		BuildContext build,
+		DocumentationSet set
+	) : base(sourceFile, rootPath, parser, build, set)
+	{
+	}
+
+	protected override Task<MarkdownDocument> GetMinimalParseDocumentAsync(Cancel ctx)
+	{
+		var document = MarkdownParser.MinimalParseStringAsync(Rule?.Note ?? string.Empty, SourceFile, null);
+		Title = Rule?.Name;
+		return Task.FromResult(document);
+	}
+
+	protected override Task<MarkdownDocument> GetParseDocumentAsync(Cancel ctx)
+	{
+		if (Rule == null)
+			return Task.FromResult(MarkdownParser.ParseStringAsync($"# {Title}", SourceFile, null));
+
+		// language=markdown
+		var markdown = $"""
+# {Rule.Name}
+
+**Rule type**: {Rule.Type}
+**Rule indices**: {RenderArray(Rule.Indices)}
+**Rule Severity**: {Rule.Severity}
+**Risk Score**: {Rule.RiskScore}
+**Runs every**: {Rule.RunsEvery}
+**Searches indices from**: `{Rule.IndicesFromDateMath}`
+**Maximum alerts per execution**: {Rule.MaximumAlertsPerExecution}
+**References**: {RenderArray(Rule.References)}
+**Tags**: {RenderArray(Rule.Tags)}
+**Version**: {Rule.Version}
+**Rule authors**: {RenderArray(Rule.Authors)}
+**Rule license**: {Rule.License}
+
+## Investigation guide
+
+{Rule.Note}
+
+## Rule Query
+
+```{Rule.Language ?? Rule.Type}
+{Rule.Query}
+```
+""";
+		var document = MarkdownParser.ParseStringAsync(markdown, SourceFile, null);
+		return Task.FromResult(document);
+	}
+
+	private static string RenderArray(string[]? values)
+	{
+		if (values == null || values.Length == 0)
+			return string.Empty;
+		return "\n - " + string.Join("\n - ", values) + "\n";
+	}
+}

--- a/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRulesDocsBuilderExtension.cs
+++ b/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRulesDocsBuilderExtension.cs
@@ -1,0 +1,81 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions;
+using Elastic.Markdown.IO;
+using Elastic.Markdown.IO.Configuration;
+using Elastic.Markdown.IO.Navigation;
+
+namespace Elastic.Markdown.Extensions.DetectionRules;
+
+public class DetectionRulesDocsBuilderExtension(BuildContext build) : IDocsBuilderExtension
+{
+	private BuildContext Build { get; } = build;
+	public bool Processes(ITocItem tocItem) => tocItem is RulesFolderReference;
+
+	public void CreateNavigationItem(
+		DocumentationGroup? parent,
+		ITocItem tocItem,
+		NavigationLookups lookups,
+		List<DocumentationGroup> groups,
+		List<INavigationItem> navigationItems,
+		int depth,
+		ref int fileIndex,
+		int index)
+	{
+		var detectionRulesFolder = (RulesFolderReference)tocItem;
+		var children = detectionRulesFolder.Children;
+		var group = new DocumentationGroup(Build, lookups with { TableOfContents = children }, ref fileIndex, depth + 1)
+		{
+			Parent = parent
+		};
+		groups.Add(group);
+		navigationItems.Add(new GroupNavigation(index, depth, group));
+	}
+
+	public DocumentationFile? CreateDocumentationFile(IFileInfo file, IDirectoryInfo sourceDirectory, DocumentationSet documentationSet)
+	{
+		if (file.Extension != ".toml")
+			return null;
+
+		return new DetectionRuleFile(file, Build.DocumentationSourceDirectory, documentationSet.MarkdownParser, Build, documentationSet);
+	}
+
+	public IEnumerable<ITocItem> CreateTableOfContentItems(
+		string parentPath,
+		bool detectionRulesFound,
+		string detectionRules,
+		HashSet<string> files
+	)
+	{
+		var detectionRulesFolder = $"{Path.Combine(parentPath, detectionRules)}".TrimStart('/');
+		var fs = Build.ReadFileSystem;
+		var sourceDirectory = Build.DocumentationSourceDirectory;
+		var path = fs.DirectoryInfo.New(fs.Path.GetFullPath(fs.Path.Combine(sourceDirectory.FullName, detectionRulesFolder)));
+		IReadOnlyCollection<ITocItem> children =
+		[
+			.. path
+				.EnumerateFiles("*.*", SearchOption.AllDirectories)
+				.Where(f => !f.Attributes.HasFlag(FileAttributes.Hidden) && !f.Attributes.HasFlag(FileAttributes.System))
+				.Where(f => !f.Directory!.Attributes.HasFlag(FileAttributes.Hidden) && !f.Directory!.Attributes.HasFlag(FileAttributes.System))
+				.Where(f => f.Extension is ".md" or ".toml")
+				.Select(f =>
+				{
+					var relativePath = Path.GetRelativePath(sourceDirectory.FullName, f.FullName);
+					if (f.Extension == ".toml")
+					{
+						var rule = DetectionRule.From(f);
+						return new RuleReference(relativePath, true, [], rule);
+					}
+
+					_ = files.Add(relativePath);
+					return new FileReference(relativePath, true, false, []);
+				})
+				.OrderBy(d => d is RuleReference r ? r.Rule.Name : null, StringComparer.OrdinalIgnoreCase)
+		];
+
+
+		return [new RulesFolderReference(detectionRulesFolder, detectionRulesFound, children)];
+	}
+}

--- a/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRulesDocsBuilderExtension.cs
+++ b/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRulesDocsBuilderExtension.cs
@@ -12,7 +12,7 @@ namespace Elastic.Markdown.Extensions.DetectionRules;
 public class DetectionRulesDocsBuilderExtension(BuildContext build) : IDocsBuilderExtension
 {
 	private BuildContext Build { get; } = build;
-	public bool Processes(ITocItem tocItem) => tocItem is RulesFolderReference;
+	public bool InjectsIntoNavigation(ITocItem tocItem) => tocItem is RulesFolderReference;
 
 	public void CreateNavigationItem(
 		DocumentationGroup? parent,
@@ -32,6 +32,13 @@ public class DetectionRulesDocsBuilderExtension(BuildContext build) : IDocsBuild
 		};
 		groups.Add(group);
 		navigationItems.Add(new GroupNavigation(index, depth, group));
+	}
+
+	public void Visit(DocumentationFile file, ITocItem tocItem)
+	{
+		// ensure the file has an instance of the rule the reference parsed.
+		if (file is DetectionRuleFile df && tocItem is RuleReference r)
+			df.Rule = r.Rule;
 	}
 
 	public DocumentationFile? CreateDocumentationFile(IFileInfo file, IDirectoryInfo sourceDirectory, DocumentationSet documentationSet)

--- a/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRulesDocsBuilderExtension.cs
+++ b/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRulesDocsBuilderExtension.cs
@@ -49,6 +49,12 @@ public class DetectionRulesDocsBuilderExtension(BuildContext build) : IDocsBuild
 		return new DetectionRuleFile(file, Build.DocumentationSourceDirectory, documentationSet.MarkdownParser, Build, documentationSet);
 	}
 
+	public bool TryGetDocumentationFileBySlug(DocumentationSet documentationSet, string slug, out DocumentationFile? documentationFile)
+	{
+		var tomlFile = $"../{slug}.toml";
+		return documentationSet.FlatMappedFiles.TryGetValue(tomlFile, out documentationFile);
+	}
+
 	public IEnumerable<ITocItem> CreateTableOfContentItems(
 		string parentPath,
 		bool detectionRulesFound,

--- a/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRulesReference.cs
+++ b/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRulesReference.cs
@@ -2,11 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-using System.Diagnostics.CodeAnalysis;
-using System.IO.Abstractions;
 using Elastic.Markdown.IO.Configuration;
-using Tomlet;
-using Tomlet.Models;
 
 namespace Elastic.Markdown.Extensions.DetectionRules;
 
@@ -14,91 +10,3 @@ public record RulesFolderReference(string Path, bool Found, IReadOnlyCollection<
 
 public record RuleReference(string Path, bool Found, IReadOnlyCollection<ITocItem> Children, DetectionRule Rule)
 	: FileReference(Path, Found, false, Children);
-
-
-public record DetectionRule
-{
-	public required string Name { get; init; }
-
-	public required string[]? Authors { get; init; }
-
-	public required string? Note { get; init; }
-
-	public required string? Query { get; init; }
-
-	public required string[]? Tags { get; init; }
-
-	public required string Severity { get; init; }
-
-	public required string RuleId { get; init; }
-
-	public required int RiskScore { get; init; }
-
-	public required string License { get; init; }
-
-	public required string Description { get; init; }
-	public required string Type { get; init; }
-	public required string? Language { get; init; }
-	public required string[]? Indices { get; init; }
-	public required string RunsEvery { get; init; }
-	public required string? IndicesFromDateMath { get; init; }
-	public required string MaximumAlertsPerExecution { get; init; }
-	public required string[]? References { get; init; }
-	public required string Version { get; init; }
-
-	[UnconditionalSuppressMessage("AssemblyLoadTrimming", "IL2075", Justification = "Manually verified")]
-	[UnconditionalSuppressMessage("AssemblyLoadTrimming", "IL3050", Justification = "Manually verified")]
-	public static DetectionRule From(IFileInfo source)
-	{
-		TomlDocument model;
-		try
-		{
-			var sourceText = File.ReadAllText(source.FullName);
-			model = new TomlParser().Parse(sourceText);
-		}
-		catch (Exception e)
-		{
-			throw new Exception($"Could not parse toml in: {source.FullName}", e);
-		}
-		if (!model.TryGetValue("metadata", out var node) || node is not TomlTable metadata)
-			throw new Exception($"Could not find metadata section in {source.FullName}");
-
-		if (!model.TryGetValue("rule", out node) || node is not TomlTable rule)
-			throw new Exception($"Could not find rule section in {source.FullName}");
-
-		return new DetectionRule
-		{
-			Authors = TryGetStringArray(rule, "author"),
-			Description = rule.GetString("description"),
-			Type = rule.GetString("type"),
-			Language = TryGetString(rule, "language"),
-			License = rule.GetString("license"),
-			RiskScore = TryRead<int>(rule, "risk_score"),
-			RuleId = rule.GetString("rule_id"),
-			Severity = rule.GetString("severity"),
-			Tags = TryGetStringArray(rule, "tags"),
-			Indices = TryGetStringArray(rule, "index"),
-			References = TryGetStringArray(rule, "references"),
-			IndicesFromDateMath = TryGetString(rule, "from"),
-			Query = TryGetString(rule, "query"),
-			Note = TryGetString(rule, "note"),
-			Name = rule.GetString("name"),
-			RunsEvery = "?",
-			MaximumAlertsPerExecution = "?",
-			Version = "?",
-		};
-	}
-
-	private static string[]? TryGetStringArray(TomlTable table, string key) =>
-		table.TryGetValue(key, out var node) && node is TomlArray t ? t.ArrayValues.Select(value => value.StringValue).ToArray() : null;
-
-	private static string? TryGetString(TomlTable table, string key) =>
-		table.TryGetValue(key, out var node) && node is TomlString t ? t.Value : null;
-
-	private static TTarget? TryRead<TTarget>(TomlTable table, string key) =>
-		table.TryGetValue(key, out var node) && node is TTarget t ? t : default;
-
-	private static TTarget Read<TTarget>(TomlTable table, string key) =>
-		TryRead<TTarget>(table, key) ?? throw new Exception($"Could not find {key} in {table}");
-
-}

--- a/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRulesReference.cs
+++ b/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRulesReference.cs
@@ -1,0 +1,104 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Diagnostics.CodeAnalysis;
+using System.IO.Abstractions;
+using Elastic.Markdown.IO.Configuration;
+using Tomlet;
+using Tomlet.Models;
+
+namespace Elastic.Markdown.Extensions.DetectionRules;
+
+public record RulesFolderReference(string Path, bool Found, IReadOnlyCollection<ITocItem> Children) : ITocItem;
+
+public record RuleReference(string Path, bool Found, IReadOnlyCollection<ITocItem> Children, DetectionRule Rule)
+	: FileReference(Path, Found, false, Children);
+
+
+public record DetectionRule
+{
+	public required string Name { get; init; }
+
+	public required string[]? Authors { get; init; }
+
+	public required string? Note { get; init; }
+
+	public required string? Query { get; init; }
+
+	public required string[]? Tags { get; init; }
+
+	public required string Severity { get; init; }
+
+	public required string RuleId { get; init; }
+
+	public required int RiskScore { get; init; }
+
+	public required string License { get; init; }
+
+	public required string Description { get; init; }
+	public required string Type { get; init; }
+	public required string? Language { get; init; }
+	public required string[]? Indices { get; init; }
+	public required string RunsEvery { get; init; }
+	public required string? IndicesFromDateMath { get; init; }
+	public required string MaximumAlertsPerExecution { get; init; }
+	public required string[]? References { get; init; }
+	public required string Version { get; init; }
+
+	[UnconditionalSuppressMessage("AssemblyLoadTrimming", "IL2075", Justification = "Manually verified")]
+	[UnconditionalSuppressMessage("AssemblyLoadTrimming", "IL3050", Justification = "Manually verified")]
+	public static DetectionRule From(IFileInfo source)
+	{
+		TomlDocument model;
+		try
+		{
+			var sourceText = File.ReadAllText(source.FullName);
+			model = new TomlParser().Parse(sourceText);
+		}
+		catch (Exception e)
+		{
+			throw new Exception($"Could not parse toml in: {source.FullName}", e);
+		}
+		if (!model.TryGetValue("metadata", out var node) || node is not TomlTable metadata)
+			throw new Exception($"Could not find metadata section in {source.FullName}");
+
+		if (!model.TryGetValue("rule", out node) || node is not TomlTable rule)
+			throw new Exception($"Could not find rule section in {source.FullName}");
+
+		return new DetectionRule
+		{
+			Authors = TryGetStringArray(rule, "author"),
+			Description = rule.GetString("description"),
+			Type = rule.GetString("type"),
+			Language = TryGetString(rule, "language"),
+			License = rule.GetString("license"),
+			RiskScore = TryRead<int>(rule, "risk_score"),
+			RuleId = rule.GetString("rule_id"),
+			Severity = rule.GetString("severity"),
+			Tags = TryGetStringArray(rule, "tags"),
+			Indices = TryGetStringArray(rule, "index"),
+			References = TryGetStringArray(rule, "references"),
+			IndicesFromDateMath = TryGetString(rule, "from"),
+			Query = TryGetString(rule, "query"),
+			Note = TryGetString(rule, "note"),
+			Name = rule.GetString("name"),
+			RunsEvery = "?",
+			MaximumAlertsPerExecution = "?",
+			Version = "?",
+		};
+	}
+
+	private static string[]? TryGetStringArray(TomlTable table, string key) =>
+		table.TryGetValue(key, out var node) && node is TomlArray t ? t.ArrayValues.Select(value => value.StringValue).ToArray() : null;
+
+	private static string? TryGetString(TomlTable table, string key) =>
+		table.TryGetValue(key, out var node) && node is TomlString t ? t.Value : null;
+
+	private static TTarget? TryRead<TTarget>(TomlTable table, string key) =>
+		table.TryGetValue(key, out var node) && node is TTarget t ? t : default;
+
+	private static TTarget Read<TTarget>(TomlTable table, string key) =>
+		TryRead<TTarget>(table, key) ?? throw new Exception($"Could not find {key} in {table}");
+
+}

--- a/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRulesReference.cs
+++ b/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRulesReference.cs
@@ -8,5 +8,5 @@ namespace Elastic.Markdown.Extensions.DetectionRules;
 
 public record RulesFolderReference(string Path, bool Found, IReadOnlyCollection<ITocItem> Children) : ITocItem;
 
-public record RuleReference(string Path, bool Found, IReadOnlyCollection<ITocItem> Children, DetectionRule Rule)
+public record RuleReference(string Path, string SourceDirectory, bool Found, IReadOnlyCollection<ITocItem> Children, DetectionRule Rule)
 	: FileReference(Path, Found, false, Children);

--- a/src/Elastic.Markdown/Extensions/IDocsBuilderExtension.cs
+++ b/src/Elastic.Markdown/Extensions/IDocsBuilderExtension.cs
@@ -1,0 +1,64 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions;
+using Elastic.Markdown.Extensions.DetectionRules;
+using Elastic.Markdown.IO;
+using Elastic.Markdown.IO.Configuration;
+using Elastic.Markdown.IO.Navigation;
+
+namespace Elastic.Markdown.Extensions;
+
+public interface IDocsBuilderExtension
+{
+	bool Processes(ITocItem tocItem);
+
+	void CreateNavigationItem(
+		DocumentationGroup? parent,
+		ITocItem tocItem,
+		NavigationLookups lookups,
+		List<DocumentationGroup> groups,
+		List<INavigationItem> navigationItems,
+		int depth,
+		ref int fileIndex,
+		int index
+	);
+
+	DocumentationFile? CreateDocumentationFile(IFileInfo file, IDirectoryInfo sourceDirectory);
+}
+
+public class DetectionRulesDocsBuilderExtension(BuildContext build, DocumentationSet set) : IDocsBuilderExtension
+{
+	public string Name { get; } = "detection-rules";
+	public BuildContext Build { get; } = build;
+	public bool Processes(ITocItem tocItem) => tocItem is RulesFolderReference;
+
+	public void CreateNavigationItem(
+		DocumentationGroup? parent,
+		ITocItem tocItem,
+		NavigationLookups lookups,
+		List<DocumentationGroup> groups,
+		List<INavigationItem> navigationItems,
+		int depth,
+		ref int fileIndex,
+		int index)
+	{
+		var detectionRulesFolder = (RulesFolderReference)tocItem;
+		var children = detectionRulesFolder.Children;
+		var group = new DocumentationGroup(Build, lookups with { TableOfContents = children }, ref fileIndex, depth + 1)
+		{
+			Parent = parent
+		};
+		groups.Add(group);
+		navigationItems.Add(new GroupNavigation(index, depth, group));
+	}
+
+	public DocumentationFile? CreateDocumentationFile(IFileInfo file, IDirectoryInfo sourceDirectory)
+	{
+		if (file.Extension != ".toml")
+			return null;
+
+		return new DetectionRuleFile(file, Build.DocumentationSourceDirectory, set.MarkdownParser, Build, set);
+	}
+}

--- a/src/Elastic.Markdown/Extensions/IDocsBuilderExtension.cs
+++ b/src/Elastic.Markdown/Extensions/IDocsBuilderExtension.cs
@@ -11,8 +11,10 @@ namespace Elastic.Markdown.Extensions;
 
 public interface IDocsBuilderExtension
 {
-	bool Processes(ITocItem tocItem);
+	/// Return true if this extension handles Navigation injection
+	bool InjectsIntoNavigation(ITocItem tocItem);
 
+	///  Inject items into the current navigation
 	void CreateNavigationItem(
 		DocumentationGroup? parent,
 		ITocItem tocItem,
@@ -24,5 +26,11 @@ public interface IDocsBuilderExtension
 		int index
 	);
 
+	/// Visit the <paramref name="tocItem"/> and its equivalent <see cref="DocumentationFile"/>
+	void Visit(DocumentationFile file, ITocItem tocItem);
+
+	/// Create an instance of <see cref="DocumentationFile"/> if it matches the <paramref name="file"/>.
+	/// Return `null` to let another extension handle this.
 	DocumentationFile? CreateDocumentationFile(IFileInfo file, IDirectoryInfo sourceDirectory, DocumentationSet documentationSet);
+
 }

--- a/src/Elastic.Markdown/Extensions/IDocsBuilderExtension.cs
+++ b/src/Elastic.Markdown/Extensions/IDocsBuilderExtension.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information
 
 using System.IO.Abstractions;
-using Elastic.Markdown.Extensions.DetectionRules;
 using Elastic.Markdown.IO;
 using Elastic.Markdown.IO.Configuration;
 using Elastic.Markdown.IO.Navigation;
@@ -25,40 +24,5 @@ public interface IDocsBuilderExtension
 		int index
 	);
 
-	DocumentationFile? CreateDocumentationFile(IFileInfo file, IDirectoryInfo sourceDirectory);
-}
-
-public class DetectionRulesDocsBuilderExtension(BuildContext build, DocumentationSet set) : IDocsBuilderExtension
-{
-	public string Name { get; } = "detection-rules";
-	public BuildContext Build { get; } = build;
-	public bool Processes(ITocItem tocItem) => tocItem is RulesFolderReference;
-
-	public void CreateNavigationItem(
-		DocumentationGroup? parent,
-		ITocItem tocItem,
-		NavigationLookups lookups,
-		List<DocumentationGroup> groups,
-		List<INavigationItem> navigationItems,
-		int depth,
-		ref int fileIndex,
-		int index)
-	{
-		var detectionRulesFolder = (RulesFolderReference)tocItem;
-		var children = detectionRulesFolder.Children;
-		var group = new DocumentationGroup(Build, lookups with { TableOfContents = children }, ref fileIndex, depth + 1)
-		{
-			Parent = parent
-		};
-		groups.Add(group);
-		navigationItems.Add(new GroupNavigation(index, depth, group));
-	}
-
-	public DocumentationFile? CreateDocumentationFile(IFileInfo file, IDirectoryInfo sourceDirectory)
-	{
-		if (file.Extension != ".toml")
-			return null;
-
-		return new DetectionRuleFile(file, Build.DocumentationSourceDirectory, set.MarkdownParser, Build, set);
-	}
+	DocumentationFile? CreateDocumentationFile(IFileInfo file, IDirectoryInfo sourceDirectory, DocumentationSet documentationSet);
 }

--- a/src/Elastic.Markdown/Extensions/IDocsBuilderExtension.cs
+++ b/src/Elastic.Markdown/Extensions/IDocsBuilderExtension.cs
@@ -33,4 +33,6 @@ public interface IDocsBuilderExtension
 	/// Return `null` to let another extension handle this.
 	DocumentationFile? CreateDocumentationFile(IFileInfo file, IDirectoryInfo sourceDirectory, DocumentationSet documentationSet);
 
+	/// Attempts to locate a documentation file by slug, used to locate the document for `docs-builder serve` command
+	bool TryGetDocumentationFileBySlug(DocumentationSet documentationSet, string slug, out DocumentationFile? documentationFile);
 }

--- a/src/Elastic.Markdown/Extensions/IDocsBuilderExtension.cs
+++ b/src/Elastic.Markdown/Extensions/IDocsBuilderExtension.cs
@@ -35,4 +35,10 @@ public interface IDocsBuilderExtension
 
 	/// Attempts to locate a documentation file by slug, used to locate the document for `docs-builder serve` command
 	bool TryGetDocumentationFileBySlug(DocumentationSet documentationSet, string slug, out DocumentationFile? documentationFile);
+
+	/// Allows the extension to discover more documentation files for <see cref="DocumentationSet"/>
+	IReadOnlyCollection<DocumentationFile> ScanDocumentationFiles(
+		Func<BuildContext, IDirectoryInfo, DocumentationFile[]> scanDocumentationFiles,
+		Func<IFileInfo, IDirectoryInfo, DocumentationFile> defaultFileHandling
+	);
 }

--- a/src/Elastic.Markdown/IO/Configuration/EnabledExtensions.cs
+++ b/src/Elastic.Markdown/IO/Configuration/EnabledExtensions.cs
@@ -1,0 +1,18 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic.Markdown.IO.Configuration;
+
+public class EnabledExtensions(IReadOnlyCollection<string> extensions)
+{
+	private readonly HashSet<string> _extensionsSet = [
+		..extensions
+	];
+
+	private bool IsEnabled(string key) => _extensionsSet.Contains(key);
+
+	public bool IsDetectionRulesEnabled => IsEnabled("detection-rules");
+
+	public IEnumerable<string> Enabled => _extensionsSet;
+}

--- a/src/Elastic.Markdown/IO/Configuration/FeatureFlags.cs
+++ b/src/Elastic.Markdown/IO/Configuration/FeatureFlags.cs
@@ -6,6 +6,7 @@ namespace Elastic.Markdown.IO.Configuration;
 
 public class FeatureFlags(Dictionary<string, bool> featureFlags)
 {
-	public bool IsPrimaryNavEnabled => IsEnabled("primary-nav");
 	private bool IsEnabled(string key) => featureFlags.TryGetValue(key, out var value) && value;
+
+	public bool IsPrimaryNavEnabled => IsEnabled("primary-nav");
 }

--- a/src/Elastic.Markdown/IO/DocumentationSet.cs
+++ b/src/Elastic.Markdown/IO/DocumentationSet.cs
@@ -6,6 +6,8 @@ using System.Collections.Frozen;
 using System.IO.Abstractions;
 using Elastic.Markdown.CrossLinks;
 using Elastic.Markdown.Diagnostics;
+using Elastic.Markdown.Extensions;
+using Elastic.Markdown.Extensions.DetectionRules;
 using Elastic.Markdown.IO.Configuration;
 using Elastic.Markdown.IO.Navigation;
 using Elastic.Markdown.Myst;
@@ -13,7 +15,23 @@ using Microsoft.Extensions.Logging;
 
 namespace Elastic.Markdown.IO;
 
-public class DocumentationSet
+public interface INavigationLookups
+{
+	FrozenDictionary<string, DocumentationFile> FlatMappedFiles { get; }
+	IReadOnlyCollection<ITocItem> TableOfContents { get; }
+	IReadOnlyCollection<IDocsBuilderExtension> EnabledExtensions { get; }
+	FrozenDictionary<string, DocumentationFile[]> FilesGroupedByFolder { get; }
+}
+
+public record NavigationLookups : INavigationLookups
+{
+	public required FrozenDictionary<string, DocumentationFile> FlatMappedFiles { get; init; }
+	public required IReadOnlyCollection<ITocItem> TableOfContents { get; init; }
+	public required IReadOnlyCollection<IDocsBuilderExtension> EnabledExtensions { get; init; }
+	public required FrozenDictionary<string, DocumentationFile[]> FilesGroupedByFolder { get; init; }
+}
+
+public class DocumentationSet : INavigationLookups
 {
 	public BuildContext Build { get; }
 	public string Name { get; }
@@ -29,9 +47,21 @@ public class DocumentationSet
 
 	public ConfigurationFile Configuration { get; }
 
-	private MarkdownParser MarkdownParser { get; }
+	public MarkdownParser MarkdownParser { get; }
 
 	public ICrossLinkResolver LinkResolver { get; }
+
+	public IReadOnlyCollection<IDocsBuilderExtension> EnabledExtensions { get; }
+
+	public DocumentationGroup Tree { get; }
+
+	public IReadOnlyCollection<DocumentationFile> Files { get; }
+
+	public FrozenDictionary<string, DocumentationFile[]> FilesGroupedByFolder { get; }
+
+	public FrozenDictionary<string, DocumentationFile> FlatMappedFiles { get; }
+
+	IReadOnlyCollection<ITocItem> INavigationLookups.TableOfContents => Configuration.TableOfContents;
 
 	public DocumentationSet(BuildContext build, ILoggerFactory logger, ICrossLinkResolver? linkResolver = null)
 	{
@@ -54,34 +84,40 @@ public class DocumentationSet
 		OutputStateFile = OutputDirectory.FileSystem.FileInfo.New(Path.Combine(OutputDirectory.FullName, ".doc.state"));
 		LinkReferenceFile = OutputDirectory.FileSystem.FileInfo.New(Path.Combine(OutputDirectory.FullName, "links.json"));
 
-		Files = [.. build.ReadFileSystem.Directory
-			.EnumerateFiles(SourceDirectory.FullName, "*.*", SearchOption.AllDirectories)
-			.Select(f => build.ReadFileSystem.FileInfo.New(f))
-			.Where(f => !f.Attributes.HasFlag(FileAttributes.Hidden) && !f.Attributes.HasFlag(FileAttributes.System))
-			.Where(f => !f.Directory!.Attributes.HasFlag(FileAttributes.Hidden) && !f.Directory!.Attributes.HasFlag(FileAttributes.System))
-			// skip hidden folders
-			.Where(f => !Path.GetRelativePath(SourceDirectory.FullName, f.FullName).StartsWith('.'))
-			.Select<IFileInfo, DocumentationFile>(file => file.Extension switch
-			{
-				".jpg" => new ImageFile(file, SourceDirectory, "image/jpeg"),
-				".jpeg" => new ImageFile(file, SourceDirectory, "image/jpeg"),
-				".gif" => new ImageFile(file, SourceDirectory, "image/gif"),
-				".svg" => new ImageFile(file, SourceDirectory, "image/svg+xml"),
-				".png" => new ImageFile(file, SourceDirectory),
-				".md" => CreateMarkDownFile(file, build),
-				_ => new StaticFile(file, SourceDirectory)
-			})];
+		EnabledExtensions = InstantiateExtensions();
+
+
+		var files = ScanDocumentationFiles(build, SourceDirectory);
+		var ruleSetSources = Configuration.TableOfContents.OfType<RulesFolderReference>();
+		Files =
+		[
+			..files
+				.Concat(ruleSetSources.SelectMany(rules =>
+				{
+					var directory = build.ReadFileSystem.DirectoryInfo.New(Path.GetFullPath(Path.Combine(SourceDirectory.FullName, rules.Path)));
+					return ScanDocumentationFiles(build, directory);
+				}))
+		];
 
 		LastWrite = Files.Max(f => f.SourceFile.LastWriteTimeUtc);
 
 		FlatMappedFiles = Files.ToDictionary(file => file.RelativePath, file => file).ToFrozenDictionary();
 
-		var folderFiles = Files
+		FilesGroupedByFolder = Files
 			.GroupBy(file => file.RelativeFolder)
-			.ToDictionary(g => g.Key, g => g.ToArray());
+			.ToDictionary(g => g.Key, g => g.ToArray())
+			.ToFrozenDictionary();
 
 		var fileIndex = 0;
-		Tree = new DocumentationGroup(Build, Configuration.TableOfContents, FlatMappedFiles, folderFiles, ref fileIndex)
+		var lookups = new NavigationLookups
+		{
+			FlatMappedFiles = FlatMappedFiles,
+			TableOfContents = Configuration.TableOfContents,
+			EnabledExtensions = EnabledExtensions,
+			FilesGroupedByFolder = FilesGroupedByFolder
+		};
+
+		Tree = new DocumentationGroup(Build, lookups, ref fileIndex)
 		{
 			Parent = null
 		};
@@ -93,7 +129,54 @@ public class DocumentationSet
 			Build.EmitError(Build.ConfigurationPath, $"{excludedChild.RelativePath} is unreachable in the TOC because one of its parents matches exclusion glob");
 
 		MarkdownFiles = markdownFiles.Where(f => f.NavigationIndex > -1).ToDictionary(i => i.NavigationIndex, i => i).ToFrozenDictionary();
+
 		ValidateRedirectsExists();
+	}
+
+	private IReadOnlyCollection<IDocsBuilderExtension> InstantiateExtensions()
+	{
+		var list = new List<IDocsBuilderExtension>();
+		foreach (var extension in Configuration.Extensions.Enabled)
+		{
+			switch (extension.ToLowerInvariant())
+			{
+				case "detection-rules":
+					list.Add(new DetectionRulesDocsBuilderExtension(Build, this));
+					continue;
+			}
+		}
+
+		return list.AsReadOnly();
+	}
+
+	private DocumentationFile[] ScanDocumentationFiles(BuildContext build, IDirectoryInfo sourceDirectory) =>
+		[.. build.ReadFileSystem.Directory
+			.EnumerateFiles(sourceDirectory.FullName, "*.*", SearchOption.AllDirectories)
+			.Select(f => build.ReadFileSystem.FileInfo.New(f))
+			.Where(f => !f.Attributes.HasFlag(FileAttributes.Hidden) && !f.Attributes.HasFlag(FileAttributes.System))
+			.Where(f => !f.Directory!.Attributes.HasFlag(FileAttributes.Hidden) && !f.Directory!.Attributes.HasFlag(FileAttributes.System))
+			// skip hidden folders
+			.Where(f => !Path.GetRelativePath(sourceDirectory.FullName, f.FullName).StartsWith('.'))
+			.Select<IFileInfo, DocumentationFile>(file => file.Extension switch
+			{
+				".jpg" => new ImageFile(file, SourceDirectory, "image/jpeg"),
+				".jpeg" => new ImageFile(file, SourceDirectory, "image/jpeg"),
+				".gif" => new ImageFile(file, SourceDirectory, "image/gif"),
+				".svg" => new ImageFile(file, SourceDirectory, "image/svg+xml"),
+				".png" => new ImageFile(file, SourceDirectory),
+				".md" => CreateMarkDownFile(file, build),
+				_ => DefaultFileHandling(file, sourceDirectory)
+		})];
+
+	private DocumentationFile DefaultFileHandling(IFileInfo file, IDirectoryInfo sourceDirectory)
+	{
+		foreach (var extension in EnabledExtensions)
+		{
+			var documentationFile = extension.CreateDocumentationFile(file, sourceDirectory);
+			if (documentationFile is not null)
+				return documentationFile;
+		}
+		return new StaticFile(file, sourceDirectory);
 	}
 
 	private void ValidateRedirectsExists()
@@ -209,13 +292,6 @@ public class DocumentationSet
 		context.EmitError(Configuration.SourceFile, $"Not linked in toc: {relativePath}");
 		return new ExcludedFile(file, SourceDirectory);
 	}
-
-	public DocumentationGroup Tree { get; }
-
-	public IReadOnlyCollection<DocumentationFile> Files { get; }
-
-	public FrozenDictionary<string, DocumentationFile> FlatMappedFiles { get; }
-
 	public void ClearOutputDirectory()
 	{
 		if (OutputDirectory.Exists)

--- a/src/Elastic.Markdown/IO/MarkdownFile.cs
+++ b/src/Elastic.Markdown/IO/MarkdownFile.cs
@@ -162,7 +162,7 @@ public record MarkdownFile : DocumentationFile
 		await MarkdownParser.MinimalParseAsync(SourceFile, ctx);
 
 	protected virtual async Task<MarkdownDocument> GetParseDocumentAsync(Cancel ctx) =>
-		await MarkdownParser.MinimalParseAsync(SourceFile, ctx);
+		await MarkdownParser.ParseAsync(SourceFile, YamlFrontMatter, ctx);
 
 	public async Task<MarkdownDocument> MinimalParseAsync(Cancel ctx)
 	{

--- a/src/Elastic.Markdown/IO/MarkdownFile.cs
+++ b/src/Elastic.Markdown/IO/MarkdownFile.cs
@@ -58,14 +58,14 @@ public record MarkdownFile : DocumentationFile
 
 	public bool Hidden { get; internal set; }
 	public string? UrlPathPrefix { get; }
-	private MarkdownParser MarkdownParser { get; }
+	protected MarkdownParser MarkdownParser { get; }
 	public YamlFrontMatter? YamlFrontMatter { get; private set; }
-	public string? TitleRaw { get; private set; }
+	public string? TitleRaw { get; protected set; }
 
 	public string? Title
 	{
 		get => _title;
-		private set
+		protected set
 		{
 			_title = value?.StripMarkdown();
 			TitleRaw = value;
@@ -88,9 +88,16 @@ public record MarkdownFile : DocumentationFile
 	public string FilePath { get; }
 	public string FileName { get; }
 
-	public string Url => Path.GetFileName(RelativePath) == "index.md"
-		? $"{UrlPathPrefix}/{RelativePath.Remove(RelativePath.LastIndexOf("index.md", StringComparison.Ordinal), "index.md".Length)}"
-		: $"{UrlPathPrefix}/{RelativePath.Remove(RelativePath.LastIndexOf(".md", StringComparison.Ordinal), 3)}";
+	public string Url
+	{
+		get
+		{
+			var relativePath = RelativePath.AsSpan().TrimStart("../").ToString();
+			return Path.GetFileName(relativePath) == "index.md"
+				? $"{UrlPathPrefix}/{relativePath.Remove(relativePath.LastIndexOf("index.md", StringComparison.Ordinal), "index.md".Length)}"
+				: $"{UrlPathPrefix}/{relativePath.Remove(relativePath.LastIndexOf(SourceFile.Extension, StringComparison.Ordinal), SourceFile.Extension.Length)}";
+		}
+	}
 
 	public int NavigationIndex { get; internal set; } = -1;
 
@@ -149,9 +156,15 @@ public record MarkdownFile : DocumentationFile
 		}
 	}
 
+	protected virtual async Task<MarkdownDocument> GetMinimalParseDocumentAsync(Cancel ctx) =>
+		await MarkdownParser.MinimalParseAsync(SourceFile, ctx);
+
+	protected virtual async Task<MarkdownDocument> GetParseDocumentAsync(Cancel ctx) =>
+		await MarkdownParser.MinimalParseAsync(SourceFile, ctx);
+
 	public async Task<MarkdownDocument> MinimalParseAsync(Cancel ctx)
 	{
-		var document = await MarkdownParser.MinimalParseAsync(SourceFile, ctx);
+		var document = await GetMinimalParseDocumentAsync(ctx);
 		ReadDocumentInstructions(document);
 		ValidateAnchorRemapping();
 		return document;
@@ -162,7 +175,7 @@ public record MarkdownFile : DocumentationFile
 		if (!_instructionsParsed)
 			_ = await MinimalParseAsync(ctx);
 
-		var document = await MarkdownParser.ParseAsync(SourceFile, YamlFrontMatter, ctx);
+		var document = await GetParseDocumentAsync(ctx);
 		return document;
 	}
 
@@ -179,9 +192,9 @@ public record MarkdownFile : DocumentationFile
 		return allProperties;
 	}
 
-	private void ReadDocumentInstructions(MarkdownDocument document)
+	protected void ReadDocumentInstructions(MarkdownDocument document)
 	{
-		Title = document
+		Title ??= document
 			.FirstOrDefault(block => block is HeadingBlock { Level: 1 })?
 			.GetData("header") as string;
 
@@ -204,10 +217,6 @@ public record MarkdownFile : DocumentationFile
 		else if (Title.AsSpan().ReplaceSubstitutions(subs, out var replacement))
 			Title = replacement;
 
-		if (RelativePath.Contains("esql-functions-operators"))
-		{
-
-		}
 		var toc = GetAnchors(_set, MarkdownParser, YamlFrontMatter, document, subs, out var anchors);
 
 		_tableOfContent.Clear();
@@ -315,7 +324,6 @@ public record MarkdownFile : DocumentationFile
 		}
 	}
 
-
 	public string CreateHtml(MarkdownDocument document)
 	{
 		//we manually render title and optionally append an applies block embedded in yaml front matter.
@@ -323,14 +331,5 @@ public record MarkdownFile : DocumentationFile
 		if (h1 is not null)
 			_ = document.Remove(h1);
 		return document.ToHtml(MarkdownParser.Pipeline);
-	}
-
-	public static string CreateHtml(MarkdownDocument document, MarkdownParser parser)
-	{
-		//we manually render title and optionally append an applies block embedded in yaml front matter.
-		var h1 = document.Descendants<HeadingBlock>().FirstOrDefault(h => h.Level == 1);
-		if (h1 is not null)
-			_ = document.Remove(h1);
-		return document.ToHtml(parser.Pipeline);
 	}
 }

--- a/src/Elastic.Markdown/IO/MarkdownFile.cs
+++ b/src/Elastic.Markdown/IO/MarkdownFile.cs
@@ -88,11 +88,13 @@ public record MarkdownFile : DocumentationFile
 	public string FilePath { get; }
 	public string FileName { get; }
 
+	protected virtual string RelativePathUrl => RelativePath;
+
 	public string Url
 	{
 		get
 		{
-			var relativePath = RelativePath.AsSpan().TrimStart("../").ToString();
+			var relativePath = RelativePathUrl;
 			return Path.GetFileName(relativePath) == "index.md"
 				? $"{UrlPathPrefix}/{relativePath.Remove(relativePath.LastIndexOf("index.md", StringComparison.Ordinal), "index.md".Length)}"
 				: $"{UrlPathPrefix}/{relativePath.Remove(relativePath.LastIndexOf(SourceFile.Extension, StringComparison.Ordinal), SourceFile.Extension.Length)}";

--- a/src/Elastic.Markdown/IO/Navigation/DocumentationGroup.cs
+++ b/src/Elastic.Markdown/IO/Navigation/DocumentationGroup.cs
@@ -2,7 +2,10 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.IO.Abstractions;
 using Elastic.Markdown.Diagnostics;
+using Elastic.Markdown.Extensions;
+using Elastic.Markdown.Extensions.DetectionRules;
 using Elastic.Markdown.IO.Configuration;
 
 namespace Elastic.Markdown.IO.Navigation;
@@ -24,7 +27,6 @@ public record FileNavigation(int Order, int Depth, MarkdownFile File) : INavigat
 	public string Id { get; } = File.Id;
 }
 
-
 public class DocumentationGroup
 {
 	public string Id { get; } = Guid.NewGuid().ToString("N")[..8];
@@ -39,28 +41,25 @@ public class DocumentationGroup
 
 	public required DocumentationGroup? Parent { get; init; }
 
-	private HashSet<MarkdownFile> OwnFiles { get; }
-
 	public int Depth { get; }
-
-	public bool ContainsCurrentPage(MarkdownFile current) => NavigationItems.Any(n => n switch
-		{
-			FileNavigation f => f.File == current,
-			GroupNavigation g => g.Group.ContainsCurrentPage(current),
-			_ => false
-		});
 
 	public DocumentationGroup(
 		BuildContext context,
-		IReadOnlyCollection<ITocItem> toc,
-		IDictionary<string, DocumentationFile> lookup,
-		IDictionary<string, DocumentationFile[]> folderLookup,
+		NavigationLookups lookups,
+		ref int fileIndex)
+		: this(context, lookups, ref fileIndex, depth: 0)
+	{
+	}
+
+	internal DocumentationGroup(
+		BuildContext context,
+		NavigationLookups lookups,
 		ref int fileIndex,
-		int depth = 0,
+		int depth,
 		MarkdownFile? index = null)
 	{
 		Depth = depth;
-		Index = ProcessTocItems(context, index, toc, lookup, folderLookup, depth, ref fileIndex, out var groups, out var files, out var navigationItems);
+		Index = ProcessTocItems(context, index, lookups, depth, ref fileIndex, out var groups, out var files, out var navigationItems);
 		if (Index is not null)
 			Index.GroupId = Id;
 
@@ -71,16 +70,12 @@ public class DocumentationGroup
 
 		if (Index is not null)
 			FilesInOrder = [.. FilesInOrder.Except([Index])];
-
-		OwnFiles = [.. FilesInOrder];
 	}
 
 	private MarkdownFile? ProcessTocItems(
 		BuildContext context,
 		MarkdownFile? configuredIndex,
-		IReadOnlyCollection<ITocItem> toc,
-		IDictionary<string, DocumentationFile> lookup,
-		IDictionary<string, DocumentationFile[]> folderLookup,
+		NavigationLookups lookups,
 		int depth,
 		ref int fileIndex,
 		out List<DocumentationGroup> groups,
@@ -91,22 +86,28 @@ public class DocumentationGroup
 		navigationItems = [];
 		files = [];
 		var indexFile = configuredIndex;
-		foreach (var (tocItem, index) in toc.Select((t, i) => (t, i)))
+		foreach (var (tocItem, index) in lookups.TableOfContents.Select((t, i) => (t, i)))
 		{
 			if (tocItem is FileReference file)
 			{
-				if (!lookup.TryGetValue(file.Path, out var d))
+				if (!lookups.FlatMappedFiles.TryGetValue(file.Path, out var d))
 				{
-					context.EmitError(context.ConfigurationPath, $"The following file could not be located: {file.Path} it may be excluded from the build in docset.yml");
+					context.EmitError(context.ConfigurationPath,
+						$"The following file could not be located: {file.Path} it may be excluded from the build in docset.yml");
 					continue;
 				}
+
 				if (d is ExcludedFile excluded && excluded.RelativePath.EndsWith(".md"))
 				{
 					context.EmitError(context.ConfigurationPath, $"{excluded.RelativePath} matches exclusion glob from docset.yml yet appears in TOC");
 					continue;
 				}
+
 				if (d is not MarkdownFile md)
 					continue;
+
+				if (d is DetectionRuleFile df && tocItem is RuleReference r)
+					df.Rule = r.Rule;
 
 				md.Parent = this;
 				md.Hidden = file.Hidden;
@@ -118,7 +119,8 @@ public class DocumentationGroup
 					if (file.Hidden)
 						context.EmitError(context.ConfigurationPath, $"The following file is hidden but has children: {file.Path}");
 
-					var group = new DocumentationGroup(context, file.Children, lookup, folderLookup, ref fileIndex, depth + 1, virtualIndex)
+					var group = new DocumentationGroup(
+						context, lookups with { TableOfContents = file.Children }, ref fileIndex, depth + 1, virtualIndex)
 					{
 						Parent = this
 					};
@@ -141,27 +143,34 @@ public class DocumentationGroup
 			else if (tocItem is FolderReference folder)
 			{
 				var children = folder.Children;
-				if (children.Count == 0 && folderLookup.TryGetValue(folder.Path, out var documentationFiles))
+				if (children.Count == 0 && lookups.FilesGroupedByFolder.TryGetValue(folder.Path, out var documentationFiles))
 				{
-					children = [.. documentationFiles
-						.Select(d => new FileReference(d.RelativePath, true, false, []))
+					children =
+					[
+						.. documentationFiles
+							.Select(d => new FileReference(d.RelativePath, true, false, []))
 					];
 				}
 
-				var group = new DocumentationGroup(context, children, lookup, folderLookup, ref fileIndex, depth + 1)
+				var group = new DocumentationGroup(context, lookups with { TableOfContents = children }, ref fileIndex, depth + 1)
 				{
 					Parent = this
 				};
 				groups.Add(group);
 				navigationItems.Add(new GroupNavigation(index, depth, group));
 			}
+			else
+			{
+				foreach (var extension in lookups.EnabledExtensions)
+				{
+					if (extension.Processes(tocItem))
+						extension.CreateNavigationItem(this, tocItem, lookups, groups, navigationItems, depth, ref fileIndex, index);
+				}
+			}
 		}
 
 		return indexFile ?? files.FirstOrDefault();
 	}
-
-	public bool HoldsCurrent(MarkdownFile current) =>
-		Index == current || OwnFiles.Contains(current) || GroupsInOrder.Any(n => n.HoldsCurrent(current));
 
 	private bool _resolved;
 

--- a/src/Elastic.Markdown/IO/Navigation/DocumentationGroup.cs
+++ b/src/Elastic.Markdown/IO/Navigation/DocumentationGroup.cs
@@ -106,8 +106,12 @@ public class DocumentationGroup
 				if (d is not MarkdownFile md)
 					continue;
 
-				if (d is DetectionRuleFile df && tocItem is RuleReference r)
-					df.Rule = r.Rule;
+
+				foreach (var extension in context.Configuration.EnabledExtensions)
+				{
+					if (extension.InjectsIntoNavigation(tocItem))
+						extension.Visit(d, tocItem);
+				}
 
 				md.Parent = this;
 				md.Hidden = file.Hidden;
@@ -163,7 +167,7 @@ public class DocumentationGroup
 			{
 				foreach (var extension in lookups.EnabledExtensions)
 				{
-					if (extension.Processes(tocItem))
+					if (extension.InjectsIntoNavigation(tocItem))
 						extension.CreateNavigationItem(this, tocItem, lookups, groups, navigationItems, depth, ref fileIndex, index);
 				}
 			}

--- a/src/Elastic.Markdown/IO/Navigation/DocumentationGroup.cs
+++ b/src/Elastic.Markdown/IO/Navigation/DocumentationGroup.cs
@@ -108,10 +108,7 @@ public class DocumentationGroup
 
 
 				foreach (var extension in context.Configuration.EnabledExtensions)
-				{
-					if (extension.InjectsIntoNavigation(tocItem))
-						extension.Visit(d, tocItem);
-				}
+					extension.Visit(d, tocItem);
 
 				md.Parent = this;
 				md.Hidden = file.Hidden;

--- a/src/Elastic.Markdown/Myst/Directives/DirectiveHtmlRenderer.cs
+++ b/src/Elastic.Markdown/Myst/Directives/DirectiveHtmlRenderer.cs
@@ -259,7 +259,7 @@ public class DirectiveHtmlRenderer(MarkdownParser markdownParser) : HtmlObjectRe
 			SettingsCollection = settings,
 			RenderMarkdown = s =>
 			{
-				var document = parser.ParseEmbeddedMarkdown(s, block.IncludeFrom, block.Context.YamlFrontMatter);
+				var document = parser.ParseStringAsync(s, block.IncludeFrom, block.Context.YamlFrontMatter);
 				var html = document.ToHtml(parser.Pipeline);
 				return html;
 			}

--- a/src/Elastic.Markdown/Myst/MarkdownParser.cs
+++ b/src/Elastic.Markdown/Myst/MarkdownParser.cs
@@ -65,7 +65,13 @@ public class MarkdownParser(BuildContext build, IParserResolvers resolvers)
 		return ParseAsync(path, context, Pipeline, ctx);
 	}
 
-	public MarkdownDocument ParseEmbeddedMarkdown(string markdown, IFileInfo path, YamlFrontMatter? matter)
+	public MarkdownDocument ParseStringAsync(string markdown, IFileInfo path, YamlFrontMatter? matter) =>
+		ParseMarkdownStringAsync(markdown, path, matter, Pipeline);
+
+	public MarkdownDocument MinimalParseStringAsync(string markdown, IFileInfo path, YamlFrontMatter? matter) =>
+		ParseMarkdownStringAsync(markdown, path, matter, MinimalPipeline);
+
+	private MarkdownDocument ParseMarkdownStringAsync(string markdown, IFileInfo path, YamlFrontMatter? matter, MarkdownPipeline pipeline)
 	{
 		var state = new ParserState(Build)
 		{
@@ -75,7 +81,7 @@ public class MarkdownParser(BuildContext build, IParserResolvers resolvers)
 			CrossLinkResolver = Resolvers.CrossLinkResolver
 		};
 		var context = new ParserContext(state);
-		var markdownDocument = Markdig.Markdown.Parse(markdown, Pipeline, context);
+		var markdownDocument = Markdig.Markdown.Parse(markdown, pipeline, context);
 		return markdownDocument;
 	}
 
@@ -103,6 +109,7 @@ public class MarkdownParser(BuildContext build, IParserResolvers resolvers)
 
 	// ReSharper disable once InconsistentNaming
 	private MarkdownPipeline? _minimalPipelineCached;
+
 	private MarkdownPipeline MinimalPipeline
 	{
 		get
@@ -123,6 +130,7 @@ public class MarkdownParser(BuildContext build, IParserResolvers resolvers)
 
 	// ReSharper disable once InconsistentNaming
 	private MarkdownPipeline? _pipelineCached;
+
 	public MarkdownPipeline Pipeline
 	{
 		get
@@ -153,5 +161,4 @@ public class MarkdownParser(BuildContext build, IParserResolvers resolvers)
 			return _pipelineCached;
 		}
 	}
-
 }

--- a/src/Elastic.Markdown/Slices/_ViewModels.cs
+++ b/src/Elastic.Markdown/Slices/_ViewModels.cs
@@ -72,7 +72,7 @@ public class LayoutViewModel
 
 	public string Link(string path)
 	{
-		path = path.AsSpan().TrimStart('/').TrimStart("../").ToString();
+		path = path.AsSpan().TrimStart('/').ToString();
 		return $"{UrlPathPrefix}/{path}";
 	}
 }

--- a/src/Elastic.Markdown/Slices/_ViewModels.cs
+++ b/src/Elastic.Markdown/Slices/_ViewModels.cs
@@ -72,7 +72,7 @@ public class LayoutViewModel
 
 	public string Link(string path)
 	{
-		path = path.TrimStart('/');
+		path = path.AsSpan().TrimStart('/').TrimStart("../").ToString();
 		return $"{UrlPathPrefix}/{path}";
 	}
 }

--- a/src/docs-builder/Http/DocumentationWebHost.cs
+++ b/src/docs-builder/Http/DocumentationWebHost.cs
@@ -6,7 +6,6 @@ using System.IO.Abstractions;
 using Documentation.Builder.Diagnostics.LiveMode;
 using Elastic.Documentation.Tooling;
 using Elastic.Markdown;
-using Elastic.Markdown.Extensions.DetectionRules;
 using Elastic.Markdown.IO;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -152,8 +151,11 @@ public class DocumentationWebHost
 		var s = Path.GetExtension(slug) == string.Empty ? slug + ".md" : slug;
 		if (!generator.DocumentationSet.FlatMappedFiles.TryGetValue(s, out var documentationFile))
 		{
-			if (!generator.DocumentationSet.FlatMappedFiles.TryGetValue("../" + slug + ".toml", out documentationFile))
-				return Results.NotFound();
+			foreach (var extension in generator.Context.Configuration.EnabledExtensions)
+			{
+				if (extension.TryGetDocumentationFileBySlug(generator.DocumentationSet, slug, out documentationFile))
+					break;
+			}
 		}
 
 		switch (documentationFile)


### PR DESCRIPTION
Implements `detection-rules` as an extension. 

Extensions implement `IDocsBuilderExtension` and allows us to build specific use case extensions for teams by hooking into various places (TOC building/File scanning/rendering) while not injecting too much bespoke logic in our common building blocks.

Extensions are opt-in and can be enabled in docset.yml e.g:

```yaml
extensions:
  - detection-rules
```

This particular one allows you to use a special `detection_rules` instruction to discover TOML detection rule set definition files as `children`.

```yaml
toc:
  - file: index.md
    detection_rules: '../rules'
```




