### PR TITLE
Re-enable inbound links validation on publish

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -149,7 +149,6 @@ jobs:
       - name: 'Validate Inbound Links'
         if: ${{ !cancelled() && steps.docs-build.outputs.skip != 'true' && (steps.deployment.outputs.result || (steps.check-files.outputs.any_modified == 'true' && github.event_name == 'merge_group')) }}
         uses: elastic/docs-builder/actions/validate-inbound-local@main
-        continue-on-error: true
 
       - uses: elastic/docs-builder/.github/actions/aws-auth@main
         if: ${{ !cancelled() && steps.docs-build.outputs.skip != 'true' && steps.deployment.outputs.result }}


### PR DESCRIPTION
Checking all locally is now as easy as: 

```bash
docs-builder inbound-links validate-all
```

There are a lot of warnings currently in the form of:

```
Warning: 'logstash-docs' is not yet publishing to the links registry: 'logstash-docs://reference/codec-line-index.md'
NOTE: https://elastic-docs-link-index.s3.us-east-2.amazonaws.com/elastic/logstash-docs/main/links.json
```

Warnings will for now however not result in a failure exit code. 

There is one error in asciidocalypse:

```
Error: 'deploy-manage/users-roles/cluster-or-deployment-auth/defining-roles.md' is set a redirect but none of redirect 'deploy-manage/users-roles/cluster-or-deployment-auth/defining-roles.md' match or exist in links.json.
NOTE: asciidocalypse
```

We can fix that in due time.


To check a local `links.json` after a documentation build use the following:

```
docs-builder --force
docs-builder inbound-links validate-link-reference
```






