### PR TITLE
Disable `primary-nav` and `landing-page` feature in docs-builder

### DIFF
--- a/docs/_docset.yml
+++ b/docs/_docset.yml
@@ -11,8 +11,8 @@ subs:
   eck:   "Elastic Cloud on Kubernetes"
   
 features:
-  primary-nav: true
-  landing-page: true
+  primary-nav: false
+  landing-page: false
 
 toc:
   - file: index.md


### PR DESCRIPTION
# Context

I forgot to revert it in #663 