### PR TITLE
Fix local file serving

### DIFF
--- a/src/docs-builder/Http/DocumentationWebHost.cs
+++ b/src/docs-builder/Http/DocumentationWebHost.cs
@@ -148,13 +148,17 @@ public class DocumentationWebHost
 	{
 		var generator = holder.Generator;
 
-		var s = Path.GetExtension(slug) == string.Empty ? slug + ".md" : slug;
+		var s = Path.GetExtension(slug) == string.Empty ? Path.Combine(slug, "index.md") : slug;
 		if (!generator.DocumentationSet.FlatMappedFiles.TryGetValue(s, out var documentationFile))
 		{
-			foreach (var extension in generator.Context.Configuration.EnabledExtensions)
+			s = Path.GetExtension(slug) == string.Empty ? slug + ".md" : s.Replace("/index.md", ".md");
+			if (!generator.DocumentationSet.FlatMappedFiles.TryGetValue(s, out documentationFile))
 			{
-				if (extension.TryGetDocumentationFileBySlug(generator.DocumentationSet, slug, out documentationFile))
-					break;
+				foreach (var extension in generator.Context.Configuration.EnabledExtensions)
+				{
+					if (extension.TryGetDocumentationFileBySlug(generator.DocumentationSet, slug, out documentationFile))
+						break;
+				}
 			}
 		}
 


### PR DESCRIPTION
## Context 

https://github.com/elastic/docs-builder/pull/666 introduced a bug where the index.md file of a directory was not found anymore.

## Changes

After trying to search for a markdown file, try to find the `/index.md`.