### PR TITLE
[docs] Update custom anchor links section in heading syntax docs

### DIFF
--- a/docs/syntax/headings.md
+++ b/docs/syntax/headings.md
@@ -85,7 +85,7 @@ You can also specify a custom anchor link using the following syntax.
 
 ```markdown
 
-#### Heading [#custom-anchor]
+#### Heading [custom-anchor]
 
 ```
 
@@ -93,7 +93,7 @@ You can also specify a custom anchor link using the following syntax.
 
 :::{tab-item} Output
 
-#### Heading [#custom-anchor]
+#### Heading [custom-anchor]
 
 :::
 


### PR DESCRIPTION
Update custom anchor links section in heading syntax docs to use an example that is consistent with how the migration tool handled custom anchor IDs. 

Note: I think using `[#some-id]` is also valid, but since the migration tool didn't include the `#` I don't think it should be the primary example. If anyone feels strongly about communicating in the docs that both `[#some-id]` and `[some-id]` are valid, I can also add a note. 