### PR TITLE
Fix image styling

### DIFF
--- a/src/Elastic.Markdown/Assets/markdown/images.css
+++ b/src/Elastic.Markdown/Assets/markdown/images.css
@@ -2,17 +2,17 @@
 	.markdown-content {
 		a.image-reference {
 			@apply block mt-4 align-middle;
+			&>img {
+				@apply block;
+			}
 		}
-	}
-}
-
-@layer base {
-	/* 
-	 * tailwind reset makes all images `display: block`
-	 * this resets it to `display: initial`
-	 */
-	img {
-		display: initial;
-		vertical-align: initial;
+		/* 
+		 * tailwind reset makes all images `display: block`
+		 * this resets it to `display: initial`
+		 */
+		img {
+			display: initial;
+			vertical-align: initial;
+		}
 	}
 }

--- a/src/Elastic.Markdown/Assets/markdown/images.css
+++ b/src/Elastic.Markdown/Assets/markdown/images.css
@@ -1,0 +1,18 @@
+@layer components {
+	.markdown-content {
+		a.image-reference {
+			@apply block mt-4 align-middle;
+		}
+	}
+}
+
+@layer base {
+	/* 
+	 * tailwind reset makes all images `display: block`
+	 * this resets it to `display: initial`
+	 */
+	img {
+		display: initial;
+		vertical-align: initial;
+	}
+}

--- a/src/Elastic.Markdown/Assets/styles.css
+++ b/src/Elastic.Markdown/Assets/styles.css
@@ -10,6 +10,7 @@
 @import "./markdown/dropdown.css";
 @import "./markdown/table.css";
 @import "./markdown/definition-list.css";
+@import "./markdown/images.css";
 
 
 :root {


### PR DESCRIPTION
## Context

tailwindcss resets the img to use `display: block` and `vertical-align` middle. Hence, inline images were broken.

In the case of the image directive, which should be `display: block`, the surrounding `a` tag was `display: inline`

## Changes

- This resets the tailwind css reset 
- And set the a tag that surrounds the an image to `display: block`
- Add the default top margin to the `a` tag.

## Related Issues
- https://github.com/elastic/docs-builder/issues/664
- https://github.com/elastic/docs-builder/issues/439