### PR TITLE
BREAKING CHANGE: Allow explicit code callout only after a comment

### DIFF
--- a/docs/_docset.yml
+++ b/docs/_docset.yml
@@ -102,6 +102,7 @@ toc:
       - folder: nested
       - file: cross-links.md
       - file: custom-highlighters.md
+      - file: code-callouts.md
       - folder: mover
         children:
           - file: first-page.md

--- a/docs/syntax/code.md
+++ b/docs/syntax/code.md
@@ -39,10 +39,9 @@ There are two ways to add callouts to a code block. When using callouts, you mus
 
 #### Explicit callouts
 
-Add `<\d+>` to the end of a line to explicitly create a code callout.
+Add one or more callouts to a code block by adding a comment (`#`  or `//` ) with a callout label at the end of the line. The callout label must be a number enclosed in angle brackets `<>`. 
 
 An ordered list with the same number of items as callouts must follow the code block. If the number of list items doesn’t match the callouts, docs-builder will throw an error.
-
 
 ::::{tab-set}
 
@@ -51,7 +50,7 @@ An ordered list with the same number of items as callouts must follow the code b
 ```yaml
 project:
   license:
-    content: CC-BY-4.0 <1>
+    content: CC-BY-4.0 # <1>
 ```
 
 1. The license
@@ -65,7 +64,7 @@ project:
 ```yaml
 project:
   license:
-    content: CC-BY-4.0 <1>
+    content: CC-BY-4.0 # <1>
 ```
 
 1. The license

--- a/docs/testing/code-callouts.md
+++ b/docs/testing/code-callouts.md
@@ -1,5 +1,12 @@
 # Code Callout testing
 
-```
+```plaintext
 This should not be registered as explicit callout <1>
 ```
+
+```plaintext
+This should not be registered as explicit callout <1> but the following should // <1> <2>
+```
+
+1. But this is a code callout
+2. This also

--- a/docs/testing/code-callouts.md
+++ b/docs/testing/code-callouts.md
@@ -1,0 +1,5 @@
+# Code Callout testing
+
+```
+This should not be registered as explicit callout <1>
+```

--- a/src/Elastic.Markdown/Assets/markdown/code.css
+++ b/src/Elastic.Markdown/Assets/markdown/code.css
@@ -28,7 +28,7 @@
 	}
 	
 	pre code .code-callout {
-		@apply ml-1;
+		@apply ml-[1ch];
 		transform: translateY(-1px);
 		user-select: none;
 	}
@@ -48,8 +48,9 @@
 		}
 	}
 	
-	pre code .code-callout .hljs-number {
-		@apply text-white!;
+	pre code .code-callout,
+	pre code .code-callout>*{
+		@apply text-white! text-xs;
 	}
 
 	pre code .code-callout,

--- a/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockParser.cs
+++ b/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockParser.cs
@@ -258,12 +258,16 @@ public class EnhancedCodeBlockParser : FencedBlockParserBase<EnhancedCodeBlock>
 	private static List<CallOut> ParseClassicCallOuts(ValueMatch match, ref ReadOnlySpan<char> span, ref int callOutIndex, int originatingLine)
 	{
 		var indexOfLastComment = Math.Max(span.LastIndexOf(" # "), span.LastIndexOf(" // "));
+
+		if (indexOfLastComment == -1)
+			return [];
+
 		var startIndex = span.LastIndexOf('<');
 		if (startIndex <= 0)
 			return [];
 
 		var allStartIndices = new List<int>();
-		for (var i = 0; i < span.Length; i++)
+		for (var i = indexOfLastComment; i < span.Length; i++)
 		{
 			if (span[i] == '<')
 				allStartIndices.Add(i);

--- a/tests/Elastic.Markdown.Tests/CodeBlocks/CallOutTests.cs
+++ b/tests/Elastic.Markdown.Tests/CodeBlocks/CallOutTests.cs
@@ -53,9 +53,9 @@ var z = y - 2; // another callout
 
 public class ClassicCallOutsRequiresContent(ITestOutputHelper output) : CodeBlockCallOutTests(output, "csharp",
 """
-var x = 1; <1>
+var x = 1; # <1>
 var y = x - 2;
-var z = y - 2; <2>
+var z = y - 2; # <2>
 """
 	)
 {
@@ -72,9 +72,9 @@ var z = y - 2; <2>
 
 public class ClassicCallOutsNotFollowedByList(ITestOutputHelper output) : CodeBlockCallOutTests(output, "csharp",
 """
-var x = 1; <1>
+var x = 1; # <1>
 var y = x - 2;
-var z = y - 2; <2>
+var z = y - 2; # <2>
 """,
 """
 ## hello world
@@ -96,9 +96,9 @@ var z = y - 2; <2>
 
 public class ClassicCallOutsFollowedByAListWithOneParagraph(ITestOutputHelper output) : CodeBlockCallOutTests(output, "csharp",
 """
-var x = 1; <1>
+var x = 1; // <1>
 var y = x - 2;
-var z = y - 2; <2>
+var z = y - 2; // <2>
 """,
 """
 
@@ -122,9 +122,9 @@ var z = y - 2; <2>
 
 public class ClassicCallOutsFollowedByListButWithTwoParagraphs(ITestOutputHelper output) : CodeBlockCallOutTests(output, "csharp",
 """
-var x = 1; <1>
+var x = 1; // <1>
 var y = x - 2;
-var z = y - 2; <2>
+var z = y - 2; // <2>
 """,
 """
 
@@ -153,9 +153,9 @@ BLOCK TWO
 
 public class ClassicCallOutsFollowedByListWithWrongCoung(ITestOutputHelper output) : CodeBlockCallOutTests(output, "csharp",
 """
-var x = 1; <1>
+var x = 1; // <1>
 var y = x - 2;
-var z = y - 2; <2>
+var z = y - 2; // <2>
 """,
 """
 1. Only marking the first callout
@@ -176,9 +176,9 @@ var z = y - 2; <2>
 
 public class ClassicCallOutsReuseHighlights(ITestOutputHelper output) : CodeBlockCallOutTests(output, "csharp",
 """
-var x = 1; <1>
-var y = x - 2; <2>
-var z = y - 2; <2>
+var x = 1; // <1>
+var y = x - 2; // <2>
+var z = y - 2; // <2>
 """,
 """
 1. The first
@@ -205,7 +205,7 @@ var z = y - 2; <2>
 
 public class ClassicCallOutWithTheRightListItems(ITestOutputHelper output) : CodeBlockCallOutTests(output, "csharp",
 """
-receivers: <1>
+receivers: # <1>
   # ...
   otlp:
     protocols:
@@ -213,7 +213,7 @@ receivers: <1>
         endpoint: 0.0.0.0:4317
       http:
         endpoint: 0.0.0.0:4318
-processors: <2>
+processors: # <2>
   # ...
   memory_limiter:
     check_interval: 1s
@@ -222,13 +222,13 @@ processors: <2>
 
 exporters:
   debug:
-    verbosity: detailed <3>
-  otlp: <4>
+    verbosity: detailed # <3>
+  otlp: # <4>
     # Elastic APM server https endpoint without the "https://" prefix
-    endpoint: "${env:ELASTIC_APM_SERVER_ENDPOINT}" <5> <7>
+    endpoint: "${env:ELASTIC_APM_SERVER_ENDPOINT}" # <5> <7>
     headers:
       # Elastic APM Server secret token
-      Authorization: "Bearer ${env:ELASTIC_APM_SECRET_TOKEN}" <6> <7>
+      Authorization: "Bearer ${env:ELASTIC_APM_SECRET_TOKEN}" # <6> <7>
 
 service:
   pipelines:
@@ -240,7 +240,7 @@ service:
       receivers: [otlp]
       processors: [..., memory_limiter, batch]
       exporters: [debug, otlp]
-    logs: <8>
+    logs: # <8>
       receivers: [otlp]
       processors: [..., memory_limiter, batch]
       exporters: [debug, otlp]
@@ -299,12 +299,12 @@ public class MultipleCalloutsInOneLine(ITestOutputHelper output) : CodeBlockCall
 
 public class CodeBlockWithChevronInsideCode(ITestOutputHelper output) : CodeBlockCallOutTests(output, "csharp",
 	"""
-	app.UseFilter<StopwatchFilter>(); <1>
-	app.UseFilter<CatchExceptionFilter>(); <2>
+	app.UseFilter<StopwatchFilter>(); # <1>
+	app.UseFilter<CatchExceptionFilter>(); # <2>
 
-	var x = 1; <1>
+	var x = 1; # <1>
 	var y = x - 2;
-	var z = y - 2; <1> <2>
+	var z = y - 2; # <1> <2>
 	""",
 	"""
 	1. First callout


### PR DESCRIPTION
## Changes

Only allow explicit code callouts after a comment `#` or `//`.

This way we avoid cases where there are valid angle brackets in the code.

## Related Issues
- https://github.com/elastic/docs-builder/issues/431