### PR TITLE
Allow substitutions in code blocks from global docset variables.

### DIFF
--- a/docs/syntax/substitutions.md
+++ b/docs/syntax/substitutions.md
@@ -46,5 +46,9 @@ tar -xzf elasticsearch-{{version}}-linux-x86_64.tar.gz
 cd elasticsearch-{{version}}/
 ```
 
+```bash 
+echo "{{a-global-variable}}"
+```
+
 
 Here is a variable with dashes: {{a-key-with-dashes}}

--- a/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockParser.cs
+++ b/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockParser.cs
@@ -147,16 +147,16 @@ public class EnhancedCodeBlockParser : FencedBlockParserBase<EnhancedCodeBlock>
 
 			var span = line.Slice.AsSpan();
 
-			if (span.ReplaceSubstitutions(context.YamlFrontMatter?.Properties, out var frontMatterreplacement))
+			if (span.ReplaceSubstitutions(context.YamlFrontMatter?.Properties, out var frontMatterReplacement))
 			{
-				var s = new StringSlice(frontMatterreplacement);
+				var s = new StringSlice(frontMatterReplacement);
 				lines.Lines[index] = new StringLine(ref s);
 				span = lines.Lines[index].Slice.AsSpan();
 			}
 
-			if (span.ReplaceSubstitutions(context.Substitutions, out var replacement))
+			if (span.ReplaceSubstitutions(context.Substitutions, out var globalReplacement))
 			{
-				var s = new StringSlice(replacement);
+				var s = new StringSlice(globalReplacement);
 				lines.Lines[index] = new StringLine(ref s);
 				span = lines.Lines[index].Slice.AsSpan();
 			}

--- a/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockParser.cs
+++ b/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockParser.cs
@@ -147,12 +147,20 @@ public class EnhancedCodeBlockParser : FencedBlockParserBase<EnhancedCodeBlock>
 
 			var span = line.Slice.AsSpan();
 
-			if (span.ReplaceSubstitutions(context.YamlFrontMatter?.Properties, out var replacement))
+			if (span.ReplaceSubstitutions(context.YamlFrontMatter?.Properties, out var frontMatterreplacement))
+			{
+				var s = new StringSlice(frontMatterreplacement);
+				lines.Lines[index] = new StringLine(ref s);
+				span = lines.Lines[index].Slice.AsSpan();
+			}
+
+			if (span.ReplaceSubstitutions(context.Substitutions, out var replacement))
 			{
 				var s = new StringSlice(replacement);
 				lines.Lines[index] = new StringLine(ref s);
 				span = lines.Lines[index].Slice.AsSpan();
 			}
+
 
 			if (codeBlock.OpeningFencedCharCount > 3)
 				continue;


### PR DESCRIPTION
## Changes

Also run substitutions from global docset variables.

## Result

See the result at https://docs-v3-preview.elastic.dev/elastic/docs-builder/pull/685/syntax/substitutions#example