### PR TITLE
Fix rendering of code blocks with callouts and a block in between

### DIFF
--- a/docs/syntax/code.md
+++ b/docs/syntax/code.md
@@ -101,6 +101,7 @@ render(input2);
 
 1. `Hello, World!`
 2. `Hello, Elastic!`
+
 :::
 
 
@@ -121,11 +122,13 @@ render(input2);
 
 **Inputs:**
 
-1. Hello
+1. `World`
+2. `Elastic`
 
 **Outputs**:
 
-1. Hello, World!
+1. `Hello, World!`
+2. `Hello, Elastic!`
 ````
 
 :::

--- a/docs/syntax/code.md
+++ b/docs/syntax/code.md
@@ -58,7 +58,6 @@ project:
 
 :::
 
-
 :::{tab-item} Markdown
 
 ````markdown
@@ -74,6 +73,66 @@ project:
 :::
 
 ::::
+
+You can also have one block element in between the code block and the callout list:
+
+::::{tab-set}
+
+:::{tab-item} Output
+
+```javascript
+var input1 = "World"; // <1>
+var input2 = "Elastic"; // <2>
+
+function render(input) {
+    return `Hello, ${input}!`;
+}
+
+render(input1);
+render(input2);
+```
+
+**Inputs:**
+
+1. `World`
+2. `Elastic`
+
+**Outputs**:
+
+1. `Hello, World!`
+2. `Hello, Elastic!`
+:::
+
+
+:::{tab-item} Markdown
+
+````markdown
+```javascript
+var input1 = "World"; // <1>
+var input2 = "Elastic"; // <2>
+
+function render(input) {
+    return `Hello, ${input}!`;
+}
+
+render(input1);
+render(input2);
+```
+
+**Inputs:**
+
+1. Hello
+
+**Outputs**:
+
+1. Hello, World!
+````
+
+:::
+
+::::
+
+
 
 
 #### Magic Callouts

--- a/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockHtmlRenderer.cs
+++ b/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockHtmlRenderer.cs
@@ -126,7 +126,6 @@ public class EnhancedCodeBlockHtmlRenderer : HtmlObjectRenderer<EnhancedCodeBloc
 		});
 
 		RenderRazorSlice(slice, renderer, block);
-
 		if (!block.InlineAnnotations && callOuts.Count > 0)
 		{
 			var index = block.Parent!.IndexOf(block);
@@ -137,11 +136,18 @@ public class EnhancedCodeBlockHtmlRenderer : HtmlObjectRenderer<EnhancedCodeBloc
 				var siblingBlock = block.Parent[index + 1];
 				if (siblingBlock is not ListBlock)
 				{
-					//allow one block of content in between
-					if (index + 2 <= (block.Parent!.Count - 1))
-						siblingBlock = block.Parent[index + 2];
+					// allow one block of content in between
+					// render it immediately and remove it, so it's not rendered twice
+					if (index + 2 <= block.Parent.Count - 1)
+					{
+						_ = renderer.Render(block.Parent[index + 1]);
+						_ = block.Parent.Remove(block.Parent[index + 1]);
+						siblingBlock = block.Parent[index + 1];
+					}
 					if (siblingBlock is not ListBlock)
+					{
 						block.EmitError("Code block with annotations is not followed by a list");
+					}
 				}
 				if (siblingBlock is ListBlock l && l.Count < callOuts.Count)
 				{

--- a/tests/Elastic.Markdown.Tests/CodeBlocks/CallOutTests.cs
+++ b/tests/Elastic.Markdown.Tests/CodeBlocks/CallOutTests.cs
@@ -117,6 +117,25 @@ var z = y - 2; <2>
 		.And.OnlyContain(c => c.Text.StartsWith('<'));
 
 	[Fact]
+	public void RendersExpectedHtml() =>
+		Html.Should().Contain("""
+		                      <div class="highlight-csharp notranslate">
+		                      	<div class="highlight">
+		                      		<pre><code class="language-csharp">var x = 1; <span class="code-callout" data-index="1">1</span>
+		                      var y = x - 2;
+		                      var z = y - 2; <span class="code-callout" data-index="2">2</span>
+		                      </code></pre>
+		                      	</div>
+		                      </div>
+		                      <p><strong>OUTPUT:</strong></p>
+		                      <ol class="code-callouts">
+		                      <li>Marking the first callout</li>
+		                      <li>Marking the second callout</li>
+		                      </ol>
+		                      """);
+
+
+	[Fact]
 	public void AllowsAParagraphInBetween() => Collector.Diagnostics.Should().BeEmpty();
 }
 


### PR DESCRIPTION
Closes https://github.com/elastic/docs-builder/issues/562

## Changes

Fix rendering of elements in between code block and callout lists.

## Result

<img width="49%" alt="image" src="https://github.com/user-attachments/assets/0984c5fc-2a84-4c9d-b25a-58be8c359918" />

<img width="49%" alt="image" src="https://github.com/user-attachments/assets/eaa946a5-2e67-4e89-a977-ca9ceb599486" />

