### PR TITLE
Use default font for definition lists

### DIFF
--- a/src/Elastic.Markdown/Assets/markdown/definition-list.css
+++ b/src/Elastic.Markdown/Assets/markdown/definition-list.css
@@ -4,10 +4,10 @@
 			@apply mt-4;
 		}
 		dt {
-			@apply font-mono text-grey-100 mt-6;
+			@apply text-black mt-6;
 		}
 		dd {
-			@apply mt-2 ml-4;
+			@apply text-ink-light mt-2 ml-4;
 		}
 	}
 }

--- a/src/Elastic.Markdown/Assets/markdown/typography.css
+++ b/src/Elastic.Markdown/Assets/markdown/typography.css
@@ -1,6 +1,6 @@
 .markdown-content {
 	
-	@apply  text-ink text-base;
+	@apply text-ink text-base font-body;
 
 	h1 {
 		@apply text-4xl text-ink-dark font-semibold;
@@ -47,7 +47,7 @@
 	}
 	
 	p {
-		@apply font-body mt-4;
+		@apply mt-4;
 		letter-spacing: 0;
 		line-height: 1.5em;
 		/*text-wrap: pretty;*/

--- a/src/Elastic.Markdown/Assets/markdown/typography.css
+++ b/src/Elastic.Markdown/Assets/markdown/typography.css
@@ -1,6 +1,6 @@
 .markdown-content {
 	
-	font-size: 16px;
+	@apply  text-ink text-base;
 
 	h1 {
 		@apply text-4xl text-ink-dark font-semibold;
@@ -47,10 +47,10 @@
 	}
 	
 	p {
-		@apply font-body text-base text-ink mt-4;
+		@apply font-body mt-4;
 		letter-spacing: 0;
 		line-height: 1.5em;
-		text-wrap: pretty;
+		/*text-wrap: pretty;*/
 	}
 	
 	a {


### PR DESCRIPTION
Closes https://github.com/elastic/docs-builder/issues/595

## Result

<img width="785" alt="image" src="https://github.com/user-attachments/assets/65f42688-0601-438e-af35-3f76b3b5c99f" />
