### PR TITLE
Fix scroll position when opening a link with an anchor

### DIFF
--- a/src/Elastic.Markdown/Assets/main.ts
+++ b/src/Elastic.Markdown/Assets/main.ts
@@ -19,6 +19,7 @@ document.addEventListener('htmx:load', function() {
 document.body.addEventListener('htmx:oobBeforeSwap', function(event) {
 	// This is needed to scroll to the top of the page when the content is swapped
 	if (event.target.id === 'markdown-content' || event.target.id === 'content-container') {
+		console.log("Scrolling to top");
 		window.scrollTo(0, 0);
 	}
 });

--- a/src/Elastic.Markdown/Assets/main.ts
+++ b/src/Elastic.Markdown/Assets/main.ts
@@ -19,7 +19,6 @@ document.addEventListener('htmx:load', function() {
 document.body.addEventListener('htmx:oobBeforeSwap', function(event) {
 	// This is needed to scroll to the top of the page when the content is swapped
 	if (event.target.id === 'markdown-content' || event.target.id === 'content-container') {
-		console.log("Scrolling to top");
 		window.scrollTo(0, 0);
 	}
 });

--- a/src/Elastic.Markdown/Assets/pages-nav.ts
+++ b/src/Elastic.Markdown/Assets/pages-nav.ts
@@ -17,7 +17,12 @@ function scrollCurrentNaviItemIntoView(nav: HTMLElement) {
 	if (currentNavItem && !isElementInViewport(nav, currentNavItem)) {
 		const navRect = nav.getBoundingClientRect();
 		const currentNavItemRect = currentNavItem.getBoundingClientRect();
+		// Calculate the offset needed to scroll the current navigation item into view.
+		// The offset is determined by the difference between the top of the current navigation item and the top of the navigation container,
+		// adjusted by one-third of the height of the navigation container and half the height of the current navigation item.
 		const offset = currentNavItemRect.top - navRect.top - navRect.height / 3 + currentNavItemRect.height / 2;
+		
+		// Scroll the navigation container by the calculated offset to bring the current navigation item into view.
 		nav.scrollTop = nav.scrollTop + offset;
 	}
 }

--- a/src/Elastic.Markdown/Assets/pages-nav.ts
+++ b/src/Elastic.Markdown/Assets/pages-nav.ts
@@ -11,17 +11,15 @@ function expandAllParents(navItem: HTMLElement) {
 	}
 }
 
-function scrollCurrentNaviItemIntoView(nav: HTMLElement, delay: number) {
+function scrollCurrentNaviItemIntoView(nav: HTMLElement) {
 	const currentNavItem = $('.current', nav);
 	expandAllParents(currentNavItem);
-	setTimeout(() => {
-		if (currentNavItem && !isElementInViewport(nav, currentNavItem)) {
-			const navRect = nav.getBoundingClientRect();
-			const currentNavItemRect = currentNavItem.getBoundingClientRect();
-			const offset = currentNavItemRect.top - navRect.top - navRect.height / 3 + currentNavItemRect.height / 2;
-			nav.scrollTop = nav.scrollTop + offset;
-		}
-	}, delay);
+	if (currentNavItem && !isElementInViewport(nav, currentNavItem)) {
+		const navRect = nav.getBoundingClientRect();
+		const currentNavItemRect = currentNavItem.getBoundingClientRect();
+		const offset = currentNavItemRect.top - navRect.top - navRect.height / 3 + currentNavItemRect.height / 2;
+		nav.scrollTop = nav.scrollTop + offset;
+	}
 }
 
 function isElementInViewport(parent: HTMLElement, child: HTMLElement, ): boolean {
@@ -44,5 +42,5 @@ export function initNav() {
 	navItems.forEach(el => {
 		el.classList.add('current');
 	});
-	scrollCurrentNaviItemIntoView(pagesNav, 100);
+	scrollCurrentNaviItemIntoView(pagesNav);
 }

--- a/src/Elastic.Markdown/Assets/pages-nav.ts
+++ b/src/Elastic.Markdown/Assets/pages-nav.ts
@@ -16,11 +16,14 @@ function scrollCurrentNaviItemIntoView(nav: HTMLElement, delay: number) {
 	expandAllParents(currentNavItem);
 	setTimeout(() => {
 		if (currentNavItem && !isElementInViewport(nav, currentNavItem)) {
-			currentNavItem.scrollIntoView({ behavior: 'smooth', block: 'center' });
-			window.scrollTo(0, 0);
+			const navRect = nav.getBoundingClientRect();
+			const currentNavItemRect = currentNavItem.getBoundingClientRect();
+			const offset = currentNavItemRect.top - navRect.top - navRect.height / 3 + currentNavItemRect.height / 2;
+			nav.scrollTop = nav.scrollTop + offset;
 		}
 	}, delay);
 }
+
 function isElementInViewport(parent: HTMLElement, child: HTMLElement, ): boolean {
 	const childRect = child.getBoundingClientRect();
 	const parentRect = parent.getBoundingClientRect();
@@ -38,11 +41,11 @@ export function initNav() {
 		return;
 	}
 	const navItems = $$('a[href="' + window.location.pathname + '"], a[href="' + window.location.pathname + '/"]', pagesNav);
+	
+	console.log(navItems)
+	
 	navItems.forEach(el => {
 		el.classList.add('current');
 	});
 	scrollCurrentNaviItemIntoView(pagesNav, 100);
 }
-
-
-// initNav();

--- a/src/Elastic.Markdown/Assets/pages-nav.ts
+++ b/src/Elastic.Markdown/Assets/pages-nav.ts
@@ -41,9 +41,6 @@ export function initNav() {
 		return;
 	}
 	const navItems = $$('a[href="' + window.location.pathname + '"], a[href="' + window.location.pathname + '/"]', pagesNav);
-	
-	console.log(navItems)
-	
 	navItems.forEach(el => {
 		el.classList.add('current');
 	});

--- a/src/Elastic.Markdown/Assets/styles.css
+++ b/src/Elastic.Markdown/Assets/styles.css
@@ -34,6 +34,7 @@
 /*	background-repeat: no-repeat;*/
 /*}*/
 
+
 #pages-nav li.current {
 	position: relative;
 	&::before {
@@ -87,6 +88,7 @@
 			@apply sticky top-(--offset-top) z-30 overflow-y-auto;
 			max-height: calc(100vh - var(--offset-top));
 			scrollbar-gutter: stable;
+			scroll-behavior: smooth;
 		}
 		
 		.sidebar-link {


### PR DESCRIPTION
## Context

When you open a link that contains a fragment (`https://url.com#anchor`), the scroll position is forced to the top.

You can see this behaviour when opening: https://docs-v3-preview.elastic.dev/elastic/docs-builder/tree/main/syntax/code#inline-code

This PR fixes this behaviour, which you can see when opening: https://docs-v3-preview.elastic.dev/elastic/docs-builder/pull/702/syntax/code#inline-code