### PR TITLE
Move base image for assembly over to jammy to ensure git is available

### DIFF
--- a/build/Targets.fs
+++ b/build/Targets.fs
@@ -74,7 +74,14 @@ let private publishZip _ =
 let private publishContainers _ =
 
     let createImage project =
-        let imageTag = match project with | "docs-builder" -> "jammy-chiseled-aot" | _ -> "jammy-chiseled"
+        let imageTag =
+            match project with
+            | "docs-builder" -> "jammy-chiseled-aot"
+            // When .NET 10 releases we can create a chiseled image with git more easily
+            // https://github.com/dotnet/dotnet-docker/blob/main/documentation/ubuntu-chiseled.md#how-do-i-install-additional-packages-on-chiseled-images
+            // For now we run with base jammy
+            | "docs-assembler" -> "jammy"
+            | _ -> "jammy-chiseled-aot"
         let labels =
             let exitCode = exec {
                 validExitCode (fun _ -> true)


### PR DESCRIPTION
With .NET 10 it'll easier for us to create custom chisseled images (e.g one with git available):

https://github.com/dotnet/dotnet-docker/blob/main/documentation/ubuntu-chiseled.md#how-do-i-install-additional-packages-on-chiseled-images


Jammy is bigger https://github.com/dotnet/dotnet-docker/blob/main/documentation/sample-image-size-report.md#self-contained--trimming-deployment but since `assembler` will only run for us this is good enough for now.