### PR TITLE
AOT compile assembler

### DIFF
--- a/build/Targets.fs
+++ b/build/Targets.fs
@@ -77,10 +77,6 @@ let private publishContainers _ =
         let imageTag =
             match project with
             | "docs-builder" -> "jammy-chiseled-aot"
-            // When .NET 10 releases we can create a chiseled image with git more easily
-            // https://github.com/dotnet/dotnet-docker/blob/main/documentation/ubuntu-chiseled.md#how-do-i-install-additional-packages-on-chiseled-images
-            // For now we run with base jammy
-            | "docs-assembler" -> "jammy"
             | _ -> "jammy-chiseled-aot"
         let labels =
             let exitCode = exec {

--- a/src/docs-assembler/docs-assembler.csproj
+++ b/src/docs-assembler/docs-assembler.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>Documentation.Assembler</RootNamespace>
     <InvariantGlobalization>true</InvariantGlobalization>
 
-    <PublishAot>false</PublishAot>
+    <PublishAot>true</PublishAot>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
 


### PR DESCRIPTION
Will use this to `docker cp` the binary on the github actions runner.

Don't want to waste time creating a custom base image with `git` installed.
