### PR TITLE
Remove hardcoded links to link references, use advertised path from the registry

### DIFF
--- a/docs/_docset.yml
+++ b/docs/_docset.yml
@@ -1,6 +1,7 @@
 project: 'doc-builder'
 cross_links:
   - docs-content
+  - cloud
 exclude:
   - '_*.md'
 subs:

--- a/docs/_docset.yml
+++ b/docs/_docset.yml
@@ -1,7 +1,6 @@
 project: 'doc-builder'
 cross_links:
   - docs-content
-  - cloud
 exclude:
   - '_*.md'
 subs:

--- a/docs/testing/cross-links.md
+++ b/docs/testing/cross-links.md
@@ -2,8 +2,6 @@
 
 [Elasticsearch](docs-content://index.md)
 
-[Cloud](cloud://reference/cloud-enterprise/index.md)
-
 [Kibana][1]
 
 [1]: docs-content://index.md

--- a/docs/testing/cross-links.md
+++ b/docs/testing/cross-links.md
@@ -2,6 +2,8 @@
 
 [Elasticsearch](docs-content://index.md)
 
+[Cloud](cloud://reference/cloud-enterprise/index.md)
+
 [Kibana][1]
 
 [1]: docs-content://index.md

--- a/src/Elastic.Markdown/CrossLinks/ConfigurationCrossLinkFetcher.cs
+++ b/src/Elastic.Markdown/CrossLinks/ConfigurationCrossLinkFetcher.cs
@@ -13,7 +13,8 @@ public class ConfigurationCrossLinkFetcher(ConfigurationFile configuration, ILog
 {
 	public override async Task<FetchedCrossLinks> Fetch()
 	{
-		var dictionary = new Dictionary<string, LinkReference>();
+		var linkReferences = new Dictionary<string, LinkReference>();
+		var linkIndexEntries = new Dictionary<string, LinkIndexEntry>();
 		var declaredRepositories = new HashSet<string>();
 		foreach (var repository in configuration.CrossLinkRepositories)
 		{
@@ -21,7 +22,9 @@ public class ConfigurationCrossLinkFetcher(ConfigurationFile configuration, ILog
 			try
 			{
 				var linkReference = await Fetch(repository);
-				dictionary.Add(repository, linkReference);
+				linkReferences.Add(repository, linkReference);
+				var linkIndexReference = await GetLinkIndexEntry(repository);
+				linkIndexEntries.Add(repository, linkIndexReference);
 			}
 			catch when (repository == "docs-content")
 			{
@@ -36,7 +39,8 @@ public class ConfigurationCrossLinkFetcher(ConfigurationFile configuration, ILog
 		return new FetchedCrossLinks
 		{
 			DeclaredRepositories = declaredRepositories,
-			LinkReferences = dictionary.ToFrozenDictionary(),
+			LinkReferences = linkReferences.ToFrozenDictionary(),
+			LinkIndexEntries = linkIndexEntries.ToFrozenDictionary(),
 			FromConfiguration = true
 		};
 	}

--- a/src/Elastic.Markdown/CrossLinks/CrossLinkFetcher.cs
+++ b/src/Elastic.Markdown/CrossLinks/CrossLinkFetcher.cs
@@ -92,7 +92,7 @@ public abstract class CrossLinkFetcher(ILoggerFactory logger) : IDisposable
 
 	private void WriteLinksJsonCachedFile(string repository, LinkIndexEntry linkIndexEntry, string json)
 	{
-		var cachedFileName = $"links-elastic-{repository}-main-{linkIndexEntry.ETag}.json";
+		var cachedFileName = $"links-elastic-{repository}-{linkIndexEntry.Branch}-{linkIndexEntry.ETag}.json";
 		var cachedPath = Path.Combine(Paths.ApplicationData.FullName, "links", cachedFileName);
 		if (File.Exists(cachedPath))
 			return;

--- a/src/Elastic.Markdown/CrossLinks/CrossLinkFetcher.cs
+++ b/src/Elastic.Markdown/CrossLinks/CrossLinkFetcher.cs
@@ -18,11 +18,14 @@ public record FetchedCrossLinks
 
 	public required bool FromConfiguration { get; init; }
 
+	public required FrozenDictionary<string, LinkIndexEntry> LinkIndexEntries { get; init; }
+
 	public static FetchedCrossLinks Empty { get; } = new()
 	{
 		DeclaredRepositories = [],
 		LinkReferences = new Dictionary<string, LinkReference>().ToFrozenDictionary(),
-		FromConfiguration = false
+		FromConfiguration = false,
+		LinkIndexEntries = new Dictionary<string, LinkIndexEntry>().ToFrozenDictionary()
 	};
 }
 
@@ -41,7 +44,7 @@ public abstract class CrossLinkFetcher(ILoggerFactory logger) : IDisposable
 	{
 		if (_linkIndex is not null)
 		{
-			_logger.LogInformation("Using cached link index");
+			_logger.LogTrace("Using cached link index");
 			return _linkIndex;
 		}
 		var url = $"https://elastic-docs-link-index.s3.us-east-2.amazonaws.com/link-index.json";
@@ -51,16 +54,26 @@ public abstract class CrossLinkFetcher(ILoggerFactory logger) : IDisposable
 		return _linkIndex;
 	}
 
+	protected async Task<LinkIndexEntry> GetLinkIndexEntry(string repository)
+	{
+		var linkIndex = await FetchLinkIndex();
+		if (linkIndex.Repositories.TryGetValue(repository, out var repositoryLinks))
+			return repositoryLinks.First().Value;
+		throw new Exception($"Repository {repository} not found in link index");
+	}
+
 	protected async Task<LinkReference> Fetch(string repository)
 	{
 		var linkIndex = await FetchLinkIndex();
 		if (!linkIndex.Repositories.TryGetValue(repository, out var repositoryLinks))
 			throw new Exception($"Repository {repository} not found in link index");
 
-		if (!repositoryLinks.TryGetValue("main", out var linkIndexEntry))
-			throw new Exception($"Repository {repository} not found in link index");
+		if (repositoryLinks.TryGetValue("main", out var linkIndexEntry))
+			return await FetchLinkIndexEntry(repository, linkIndexEntry);
+		if (repositoryLinks.TryGetValue("master", out linkIndexEntry))
+			return await FetchLinkIndexEntry(repository, linkIndexEntry);
+		throw new Exception($"Repository {repository} not found in link index");
 
-		return await FetchLinkIndexEntry(repository, linkIndexEntry);
 	}
 
 	protected async Task<LinkReference> FetchLinkIndexEntry(string repository, LinkIndexEntry linkIndexEntry)
@@ -69,7 +82,7 @@ public abstract class CrossLinkFetcher(ILoggerFactory logger) : IDisposable
 		if (linkReference is not null)
 			return linkReference;
 
-		var url = $"https://elastic-docs-link-index.s3.us-east-2.amazonaws.com/elastic/{repository}/main/links.json";
+		var url = $"https://elastic-docs-link-index.s3.us-east-2.amazonaws.com/{linkIndexEntry.Path}";
 		_logger.LogInformation("Fetching links.json for '{Repository}': {Url}", repository, url);
 		var json = await _client.GetStringAsync(url);
 		linkReference = Deserialize(json);

--- a/src/Elastic.Markdown/CrossLinks/IUriEnvironmentResolver.cs
+++ b/src/Elastic.Markdown/CrossLinks/IUriEnvironmentResolver.cs
@@ -21,11 +21,12 @@ public class PreviewEnvironmentUriResolver : IUriEnvironmentResolver
 
 	/// Hardcoding these for now, we'll have an index.json pointing to all links.json files
 	/// at some point from which we can query the branch soon.
-	private static string GetBranch(Uri crossLinkUri)
+	public static string GetBranch(Uri crossLinkUri)
 	{
 		var branch = crossLinkUri.Scheme switch
 		{
 			"docs-content" => "main",
+			"cloud" => "master",
 			_ => "main"
 		};
 		return branch;

--- a/src/Elastic.Markdown/InboundLinks/LinkIndexCrossLinkFetcher.cs
+++ b/src/Elastic.Markdown/InboundLinks/LinkIndexCrossLinkFetcher.cs
@@ -13,21 +13,24 @@ public class LinksIndexCrossLinkFetcher(ILoggerFactory logger) : CrossLinkFetche
 {
 	public override async Task<FetchedCrossLinks> Fetch()
 	{
-		var dictionary = new Dictionary<string, LinkReference>();
+		var linkReferences = new Dictionary<string, LinkReference>();
+		var linkEntries = new Dictionary<string, LinkIndexEntry>();
 		var declaredRepositories = new HashSet<string>();
 		var linkIndex = await FetchLinkIndex();
 		foreach (var (repository, value) in linkIndex.Repositories)
 		{
 			var linkIndexEntry = value.First().Value;
+			linkEntries.Add(repository, linkIndexEntry);
 			var linkReference = await FetchLinkIndexEntry(repository, linkIndexEntry);
-			dictionary.Add(repository, linkReference);
+			linkReferences.Add(repository, linkReference);
 			_ = declaredRepositories.Add(repository);
 		}
 
 		return new FetchedCrossLinks
 		{
 			DeclaredRepositories = declaredRepositories,
-			LinkReferences = dictionary.ToFrozenDictionary(),
+			LinkReferences = linkReferences.ToFrozenDictionary(),
+			LinkIndexEntries = linkEntries.ToFrozenDictionary(),
 			FromConfiguration = false
 		};
 	}

--- a/src/Elastic.Markdown/InboundLinks/LinkIndexLinkChecker.cs
+++ b/src/Elastic.Markdown/InboundLinks/LinkIndexLinkChecker.cs
@@ -55,7 +55,6 @@ public class LinkIndexLinkChecker(ILoggerFactory logger)
 		var resolver = new CrossLinkResolver(fetcher);
 		// ReSharper disable once RedundantAssignment
 		var crossLinks = await resolver.FetchLinks();
-
 		if (string.IsNullOrEmpty(repository))
 			throw new ArgumentNullException(nameof(repository));
 		if (string.IsNullOrEmpty(localLinksJson))
@@ -117,6 +116,8 @@ public class LinkIndexLinkChecker(ILoggerFactory logger)
 					continue;
 
 				var linksJson = $"https://elastic-docs-link-index.s3.us-east-2.amazonaws.com/elastic/{uri.Scheme}/main/links.json";
+				if (crossLinks.LinkIndexEntries.TryGetValue(uri.Scheme, out var linkIndexEntry))
+					linksJson = $"https://elastic-docs-link-index.s3.us-east-2.amazonaws.com/{linkIndexEntry.Path}";
 				_ = resolver.TryResolve(s =>
 				{
 					if (s.Contains("is not a valid link in the"))

--- a/src/docs-assembler/Building/AssemblerCrossLinkFetcher.cs
+++ b/src/docs-assembler/Building/AssemblerCrossLinkFetcher.cs
@@ -14,7 +14,8 @@ public class AssemblerCrossLinkFetcher(ILoggerFactory logger, AssemblyConfigurat
 {
 	public override async Task<FetchedCrossLinks> Fetch()
 	{
-		var dictionary = new Dictionary<string, LinkReference>();
+		var linkReferences = new Dictionary<string, LinkReference>();
+		var linkIndexEntries = new Dictionary<string, LinkIndexEntry>();
 		var declaredRepositories = new HashSet<string>();
 		var repositories = configuration.ReferenceRepositories.Values.Concat<Repository>([configuration.Narrative]);
 
@@ -25,13 +26,16 @@ public class AssemblerCrossLinkFetcher(ILoggerFactory logger, AssemblyConfigurat
 			var repositoryName = repository.Name;
 			_ = declaredRepositories.Add(repositoryName);
 			var linkReference = await Fetch(repositoryName);
-			dictionary.Add(repositoryName, linkReference);
+			linkReferences.Add(repositoryName, linkReference);
+			var linkIndexReference = await GetLinkIndexEntry(repositoryName);
+			linkIndexEntries.Add(repositoryName, linkIndexReference);
 		}
 
 		return new FetchedCrossLinks
 		{
 			DeclaredRepositories = declaredRepositories,
-			LinkReferences = dictionary.ToFrozenDictionary(),
+			LinkIndexEntries = linkIndexEntries.ToFrozenDictionary(),
+			LinkReferences = linkReferences.ToFrozenDictionary(),
 			FromConfiguration = true
 		};
 	}

--- a/tests/Elastic.Markdown.Tests/TestCrossLinkResolver.cs
+++ b/tests/Elastic.Markdown.Tests/TestCrossLinkResolver.cs
@@ -47,11 +47,20 @@ public class TestCrossLinkResolver : ICrossLinkResolver
 		LinkReferences.Add("docs-content", reference);
 		LinkReferences.Add("kibana", reference);
 		DeclaredRepositories.AddRange(["docs-content", "kibana", "elasticsearch"]);
+
+		var indexEntries = LinkReferences.ToDictionary(e => e.Key, e => new LinkIndexEntry
+		{
+			Repository = e.Key,
+			Path = $"elastic/asciidocalypse/{e.Key}/links.json",
+			Branch = "main",
+			ETag = Guid.NewGuid().ToString()
+		});
 		_crossLinks = new FetchedCrossLinks
 		{
 			DeclaredRepositories = DeclaredRepositories,
 			LinkReferences = LinkReferences.ToFrozenDictionary(),
-			FromConfiguration = true
+			FromConfiguration = true,
+			LinkIndexEntries = indexEntries.ToFrozenDictionary()
 		};
 		return Task.FromResult(_crossLinks);
 	}


### PR DESCRIPTION
After https://github.com/elastic/docs-builder/pull/732 landed we now publish `links.json` files for `cloud` but on `master`.

https://elastic-docs-link-index.s3.us-east-2.amazonaws.com/elastic/cloud/master/links.json

This PR removes hardcoded paths to `/main/links.json` and uses paths as advertised by the links registry.

https://elastic-docs-link-index.s3.us-east-2.amazonaws.com/link-index.json

```json
"cloud": {
      "master": {
        "repository": "cloud",
        "path": "elastic/cloud/master/links.json",
        "branch": "master",
        "etag": "64f49248eb9d421065125c346b4d0ce4"
      }
    },
```