### PR TITLE
Adjust path resolution to enable Windows support.

### DIFF
--- a/src/Elastic.Markdown/BuildContext.cs
+++ b/src/Elastic.Markdown/BuildContext.cs
@@ -62,7 +62,7 @@ public record BuildContext
 
 		DocumentationOutputDirectory = !string.IsNullOrWhiteSpace(output)
 			? WriteFileSystem.DirectoryInfo.New(output)
-			: WriteFileSystem.DirectoryInfo.New(Path.Combine(Paths.Root.FullName, ".artifacts/docs/html"));
+			: WriteFileSystem.DirectoryInfo.New(Path.Combine(Paths.Root.FullName, Path.Combine(".artifacts", "docs", "html")));
 
 		if (ConfigurationPath.FullName != DocumentationSourceDirectory.FullName)
 			DocumentationSourceDirectory = ConfigurationPath.Directory!;

--- a/src/Elastic.Markdown/DocumentationGenerator.cs
+++ b/src/Elastic.Markdown/DocumentationGenerator.cs
@@ -146,7 +146,7 @@ public class DocumentationGenerator
 			if (resourceStream == null)
 				continue;
 
-			var path = a.Replace("Elastic.Markdown.", "").Replace("_static.", "_static/");
+			var path = a.Replace("Elastic.Markdown.", "").Replace("_static.", $"_static{Path.DirectorySeparatorChar}");
 
 			var outputFile = OutputFile(path);
 			if (outputFile.Directory is { Exists: false })

--- a/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRulesDocsBuilderExtension.cs
+++ b/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRulesDocsBuilderExtension.cs
@@ -80,7 +80,7 @@ public class DetectionRulesDocsBuilderExtension(BuildContext build) : IDocsBuild
 		HashSet<string> files
 	)
 	{
-		var detectionRulesFolder = $"{Path.Combine(parentPath, detectionRules)}".TrimStart('/');
+		var detectionRulesFolder = Path.Combine(parentPath, detectionRules).TrimStart(Path.DirectorySeparatorChar);
 		var fs = Build.ReadFileSystem;
 		var sourceDirectory = Build.DocumentationSourceDirectory;
 		var path = fs.DirectoryInfo.New(fs.Path.GetFullPath(fs.Path.Combine(sourceDirectory.FullName, detectionRulesFolder)));

--- a/src/Elastic.Markdown/IO/Configuration/ConfigurationFile.cs
+++ b/src/Elastic.Markdown/IO/Configuration/ConfigurationFile.cs
@@ -114,7 +114,7 @@ public record ConfigurationFile : DocumentationFile
 			throw;
 		}
 
-		Globs = [.. ImplicitFolders.Select(f => Glob.Parse($"{f}/*.md"))];
+		Globs = [.. ImplicitFolders.Select(f => Glob.Parse($"{f}{Path.DirectorySeparatorChar}*.md"))];
 	}
 
 	private IReadOnlyCollection<IDocsBuilderExtension> InstantiateExtensions()
@@ -184,13 +184,13 @@ public record ConfigurationFile : DocumentationFile
 					break;
 				case "folder":
 					folder = ReadFolder(reader, entry, parentPath, out folderFound);
-					parentPath += $"/{folder}";
+					parentPath += $"{Path.DirectorySeparatorChar}{folder}";
 					break;
 				case "detection_rules":
 					if (Extensions.IsDetectionRulesEnabled)
 					{
 						detectionRules = ReadDetectionRules(reader, entry, parentPath, out detectionRulesFound);
-						parentPath += $"/{folder}";
+						parentPath += $"{Path.DirectorySeparatorChar}{folder}";
 					}
 					break;
 				case "children":
@@ -204,7 +204,7 @@ public record ConfigurationFile : DocumentationFile
 			foreach (var f in toc.Files)
 				_ = Files.Add(f);
 
-			return [new FolderReference($"{parentPath}".TrimStart('/'), folderFound, toc.TableOfContents)];
+			return [new FolderReference($"{parentPath}".TrimStart(Path.DirectorySeparatorChar), folderFound, toc.TableOfContents)];
 		}
 
 		if (file is not null)
@@ -225,15 +225,15 @@ public record ConfigurationFile : DocumentationFile
 					children = extension.CreateTableOfContentItems(parentPath, detectionRules, Files);
 				}
 			}
-			return [new FileReference($"{parentPath}/{file}".TrimStart('/'), fileFound, hiddenFile, children ?? [])];
+			return [new FileReference($"{parentPath}{Path.DirectorySeparatorChar}{file}".TrimStart(Path.DirectorySeparatorChar), fileFound, hiddenFile, children ?? [])];
 		}
 
 		if (folder is not null)
 		{
 			if (children is null)
-				_ = ImplicitFolders.Add(parentPath.TrimStart('/'));
+				_ = ImplicitFolders.Add(parentPath.TrimStart(Path.DirectorySeparatorChar));
 
-			return [new FolderReference($"{parentPath}".TrimStart('/'), folderFound, children ?? [])];
+			return [new FolderReference($"{parentPath}".TrimStart(Path.DirectorySeparatorChar), folderFound, children ?? [])];
 		}
 
 		return null;
@@ -245,7 +245,7 @@ public record ConfigurationFile : DocumentationFile
 		var folder = reader.ReadString(entry);
 		if (folder is not null)
 		{
-			var path = Path.Combine(_rootPath.FullName, parentPath.TrimStart('/'), folder);
+			var path = Path.Combine(_rootPath.FullName, parentPath.TrimStart(Path.DirectorySeparatorChar), folder);
 			if (!_context.ReadFileSystem.DirectoryInfo.New(path).Exists)
 				reader.EmitError($"Directory '{path}' does not exist", entry.Key);
 			else
@@ -261,7 +261,7 @@ public record ConfigurationFile : DocumentationFile
 		var folder = reader.ReadString(entry);
 		if (folder is not null)
 		{
-			var path = Path.Combine(_rootPath.FullName, parentPath.TrimStart('/'), folder);
+			var path = Path.Combine(_rootPath.FullName, parentPath.TrimStart(Path.DirectorySeparatorChar), folder);
 			if (!_context.ReadFileSystem.DirectoryInfo.New(path).Exists)
 				reader.EmitError($"Directory '{path}' does not exist", entry.Key);
 			else
@@ -277,13 +277,15 @@ public record ConfigurationFile : DocumentationFile
 		var file = reader.ReadString(entry);
 		if (file is null)
 			return null;
+		if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+			file = file.Replace('/', Path.DirectorySeparatorChar);
 
-		var path = Path.Combine(_rootPath.FullName, parentPath.TrimStart('/'), file);
+		var path = Path.Combine(_rootPath.FullName, parentPath.TrimStart(Path.DirectorySeparatorChar), file);
 		if (!_context.ReadFileSystem.FileInfo.New(path).Exists)
 			reader.EmitError($"File '{path}' does not exist", entry.Key);
 		else
 			found = true;
-		_ = Files.Add((parentPath + "/" + file).TrimStart('/'));
+		_ = Files.Add((parentPath + Path.DirectorySeparatorChar + file).TrimStart(Path.DirectorySeparatorChar));
 
 		return file;
 	}

--- a/src/Elastic.Markdown/IO/Configuration/ConfigurationFile.cs
+++ b/src/Elastic.Markdown/IO/Configuration/ConfigurationFile.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System.IO.Abstractions;
+using System.Runtime.InteropServices;
 using DotNet.Globbing;
 using Elastic.Markdown.Diagnostics;
 using Elastic.Markdown.Extensions;
@@ -277,7 +278,7 @@ public record ConfigurationFile : DocumentationFile
 		var file = reader.ReadString(entry);
 		if (file is null)
 			return null;
-		if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+		if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 			file = file.Replace('/', Path.DirectorySeparatorChar);
 
 		var path = Path.Combine(_rootPath.FullName, parentPath.TrimStart(Path.DirectorySeparatorChar), file);

--- a/src/Elastic.Markdown/IO/DocumentationSet.cs
+++ b/src/Elastic.Markdown/IO/DocumentationSet.cs
@@ -175,6 +175,9 @@ public class DocumentationSet : INavigationLookups
 
 		void ValidateExists(string from, string to, IReadOnlyDictionary<string, string?>? valueAnchors)
 		{
+			if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+				to = to.Replace('/', Path.DirectorySeparatorChar);
+
 			if (!FlatMappedFiles.TryGetValue(to, out var file))
 			{
 				Build.EmitError(Configuration.SourceFile, $"Redirect {from} points to {to} which does not exist");
@@ -262,7 +265,7 @@ public class DocumentationSet : INavigationLookups
 			return new MarkdownFile(file, SourceDirectory, MarkdownParser, context, this);
 
 		// we ignore files in folders that start with an underscore
-		if (relativePath.IndexOf("/_", StringComparison.Ordinal) > 0 || relativePath.StartsWith('_'))
+		if (relativePath.IndexOf($"{Path.DirectorySeparatorChar}_", StringComparison.Ordinal) > 0 || relativePath.StartsWith('_'))
 			return new ExcludedFile(file, SourceDirectory);
 
 		context.EmitError(Configuration.SourceFile, $"Not linked in toc: {relativePath}");

--- a/src/Elastic.Markdown/IO/DocumentationSet.cs
+++ b/src/Elastic.Markdown/IO/DocumentationSet.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Frozen;
 using System.IO.Abstractions;
+using System.Runtime.InteropServices;
 using Elastic.Markdown.CrossLinks;
 using Elastic.Markdown.Diagnostics;
 using Elastic.Markdown.Extensions;
@@ -175,7 +176,7 @@ public class DocumentationSet : INavigationLookups
 
 		void ValidateExists(string from, string to, IReadOnlyDictionary<string, string?>? valueAnchors)
 		{
-			if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 				to = to.Replace('/', Path.DirectorySeparatorChar);
 
 			if (!FlatMappedFiles.TryGetValue(to, out var file))

--- a/src/docs-builder/Http/DocumentationWebHost.cs
+++ b/src/docs-builder/Http/DocumentationWebHost.cs
@@ -4,6 +4,7 @@
 
 using System.IO.Abstractions;
 using System.Net;
+using System.Runtime.InteropServices;
 using Documentation.Builder.Diagnostics.LiveMode;
 using Elastic.Documentation.Tooling;
 using Elastic.Markdown;
@@ -149,7 +150,7 @@ public class DocumentationWebHost
 	{
 		var generator = holder.Generator;
 
-		if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+		if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 			slug = slug.Replace('/', Path.DirectorySeparatorChar);
 
 		var s = Path.GetExtension(slug) == string.Empty ? Path.Combine(slug, "index.md") : slug;

--- a/src/docs-builder/Http/DocumentationWebHost.cs
+++ b/src/docs-builder/Http/DocumentationWebHost.cs
@@ -149,10 +149,13 @@ public class DocumentationWebHost
 	{
 		var generator = holder.Generator;
 
+		if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+			slug = slug.Replace('/', Path.DirectorySeparatorChar);
+
 		var s = Path.GetExtension(slug) == string.Empty ? Path.Combine(slug, "index.md") : slug;
 		if (!generator.DocumentationSet.FlatMappedFiles.TryGetValue(s, out var documentationFile))
 		{
-			s = Path.GetExtension(slug) == string.Empty ? slug + ".md" : s.Replace("/index.md", ".md");
+			s = Path.GetExtension(slug) == string.Empty ? slug + ".md" : s.Replace($"{Path.DirectorySeparatorChar}index.md", ".md");
 			if (!generator.DocumentationSet.FlatMappedFiles.TryGetValue(s, out documentationFile))
 			{
 				foreach (var extension in generator.Context.Configuration.EnabledExtensions)
@@ -230,7 +233,7 @@ public sealed class EmbeddedOrPhysicalFileProvider : IFileProvider, IDisposable
 
 	public IFileInfo GetFileInfo(string subpath)
 	{
-		var path = subpath.Replace("/_static", "");
+		var path = subpath.Replace($"{Path.DirectorySeparatorChar}_static", "");
 		var fileInfo = FirstYielding(path, static (a, p) => p.GetFileInfo(a));
 		if (fileInfo is null || !fileInfo.Exists)
 			fileInfo = _embeddedProvider.GetFileInfo(subpath);


### PR DESCRIPTION
On situations where we receive a prebuilt resource path string, an OS check is performed beforehand.