### PR TITLE
Add the notion of documentation file exporters.

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -16,6 +16,10 @@ on:
         description: 'Treat warnings as errors'
         type: string
         default: 'true'
+      metadata-only:
+        description: 'Only generate documentation metadata files'
+        required: false
+        default: 'false'
       continue-on-error:
         description: 'Do not fail to publish if build fails'
         type: string

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,9 @@ inputs:
   strict:
     description: 'Treat warnings as errors'
     required: false
+  metadata-only:
+    description: 'Only generate documentation metadata files'
+    required: false
 outputs:
   landing-page-path:
     description: 'Path to the landing page of the documentation'

--- a/src/Elastic.Markdown/Exporters/DocumentationFileExporter.cs
+++ b/src/Elastic.Markdown/Exporters/DocumentationFileExporter.cs
@@ -1,0 +1,68 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions;
+using Elastic.Markdown.IO;
+using Elastic.Markdown.Slices;
+
+namespace Elastic.Markdown.Exporters;
+
+public interface IDocumentationFileExporter
+{
+	/// Used in documentation state to ensure we break the build cache if a different exporter is chosen
+	string Name { get; }
+
+	Task ProcessFile(DocumentationFile file, IFileInfo outputFile, Cancel token);
+
+	Task CopyEmbeddedResource(IFileInfo outputFile, Stream resourceStream, Cancel ctx);
+}
+
+public abstract class DocumentationFileExporterBase(IFileSystem readFileSystem, IFileSystem writeFileSystem) : IDocumentationFileExporter
+{
+	public abstract string Name { get; }
+	public abstract Task ProcessFile(DocumentationFile file, IFileInfo outputFile, Cancel token);
+
+	protected async Task CopyFileFsAware(DocumentationFile file, IFileInfo outputFile, Cancel ctx)
+	{
+		// fast path, normal case.
+		if (readFileSystem == writeFileSystem)
+			readFileSystem.File.Copy(file.SourceFile.FullName, outputFile.FullName, true);
+		//slower when we are mocking the write filesystem
+		else
+		{
+			var bytes = await file.SourceFile.FileSystem.File.ReadAllBytesAsync(file.SourceFile.FullName, ctx);
+			await outputFile.FileSystem.File.WriteAllBytesAsync(outputFile.FullName, bytes, ctx);
+		}
+	}
+
+	public async Task CopyEmbeddedResource(IFileInfo outputFile, Stream resourceStream, Cancel ctx)
+	{
+		if (outputFile.Directory is { Exists: false })
+			outputFile.Directory.Create();
+		await using var stream = outputFile.OpenWrite();
+		await resourceStream.CopyToAsync(stream, ctx);
+	}
+}
+
+public class DocumentationFileExporter(
+	IFileSystem readFileSystem,
+	IFileSystem writeFileSystem,
+	HtmlWriter htmlWriter,
+	IConversionCollector? conversionCollector
+) : DocumentationFileExporterBase(readFileSystem, writeFileSystem)
+{
+	public override string Name { get; } = nameof(DocumentationFileExporter);
+
+	public override async Task ProcessFile(DocumentationFile file, IFileInfo outputFile, Cancel token)
+	{
+		if (file is MarkdownFile markdown)
+			await htmlWriter.WriteAsync(outputFile, markdown, conversionCollector, token);
+		else
+		{
+			if (outputFile.Directory is { Exists: false })
+				outputFile.Directory.Create();
+			await CopyFileFsAware(file, outputFile, token);
+		}
+	}
+}

--- a/src/Elastic.Markdown/Exporters/NoopDocumentationFileExporter.cs
+++ b/src/Elastic.Markdown/Exporters/NoopDocumentationFileExporter.cs
@@ -1,0 +1,15 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions;
+using Elastic.Markdown.IO;
+
+namespace Elastic.Markdown.Exporters;
+
+public class NoopDocumentationFileExporter : IDocumentationFileExporter
+{
+	public string Name { get; } = nameof(NoopDocumentationFileExporter);
+	public Task ProcessFile(DocumentationFile file, IFileInfo outputFile, Cancel token) => Task.CompletedTask;
+	public Task CopyEmbeddedResource(IFileInfo outputFile, Stream resourceStream, Cancel ctx) => Task.CompletedTask;
+}

--- a/src/Elastic.Markdown/IO/State/GenerationState.cs
+++ b/src/Elastic.Markdown/IO/State/GenerationState.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System.Text.Json.Serialization;
+using Elastic.Markdown.Exporters;
 using Elastic.Markdown.IO.Discovery;
 
 namespace Elastic.Markdown.IO.State;
@@ -14,6 +15,9 @@ public record GenerationState
 
 	[JsonPropertyName("invalid_files")]
 	public required string[] InvalidFiles { get; init; } = [];
+
+	[JsonPropertyName("exporter")]
+	public string Exporter { get; init; } = nameof(DocumentationFileExporter);
 
 	[JsonPropertyName("git")]
 	public required GitCheckoutInformation Git { get; init; }

--- a/src/docs-builder/Cli/Commands.cs
+++ b/src/docs-builder/Cli/Commands.cs
@@ -110,7 +110,11 @@ internal sealed class Commands(ILoggerFactory logger, ICoreService githubActions
 		if (runningOnCi)
 			await githubActionsService.SetOutputAsync("skip", "false");
 		var set = new DocumentationSet(context, logger);
+
+		if (bool.TryParse(githubActionsService.GetInput("metadata-only"), out var metaValue) && metaValue)
+			metadataOnly ??= metaValue;
 		var exporter = metadataOnly.HasValue && metadataOnly.Value ? new NoopDocumentationFileExporter() : null;
+
 		var generator = new DocumentationGenerator(set, logger, exporter);
 		await generator.GenerateAll(ctx);
 		if (runningOnCi)

--- a/src/docs-builder/Cli/Commands.cs
+++ b/src/docs-builder/Cli/Commands.cs
@@ -10,6 +10,7 @@ using Documentation.Builder.Http;
 using Elastic.Documentation.Tooling.Diagnostics.Console;
 using Elastic.Documentation.Tooling.Filters;
 using Elastic.Markdown;
+using Elastic.Markdown.Exporters;
 using Elastic.Markdown.IO;
 using Elastic.Markdown.Refactor;
 using Microsoft.Extensions.Logging;
@@ -56,6 +57,7 @@ internal sealed class Commands(ILoggerFactory logger, ICoreService githubActions
 	/// <param name="force"> Force a full rebuild of the destination folder</param>
 	/// <param name="strict"> Treat warnings as errors and fail the build on warnings</param>
 	/// <param name="allowIndexing"> Allow indexing and following of html files</param>
+	/// <param name="metadataOnly"> Only emit documentation metadata to output</param>
 	/// <param name="ctx"></param>
 	[Command("generate")]
 	[ConsoleAppFilter<StopwatchFilter>]
@@ -68,6 +70,7 @@ internal sealed class Commands(ILoggerFactory logger, ICoreService githubActions
 		bool? force = null,
 		bool? strict = null,
 		bool? allowIndexing = null,
+		bool? metadataOnly = null,
 		Cancel ctx = default
 	)
 	{
@@ -107,7 +110,8 @@ internal sealed class Commands(ILoggerFactory logger, ICoreService githubActions
 		if (runningOnCi)
 			await githubActionsService.SetOutputAsync("skip", "false");
 		var set = new DocumentationSet(context, logger);
-		var generator = new DocumentationGenerator(set, logger);
+		var exporter = metadataOnly.HasValue && metadataOnly.Value ? new NoopDocumentationFileExporter() : null;
+		var generator = new DocumentationGenerator(set, logger, exporter);
 		await generator.GenerateAll(ctx);
 		if (runningOnCi)
 			await githubActionsService.SetOutputAsync("landing-page-path", set.MarkdownFiles.First().Value.Url);
@@ -128,6 +132,7 @@ internal sealed class Commands(ILoggerFactory logger, ICoreService githubActions
 	/// <param name="force"> Force a full rebuild of the destination folder</param>
 	/// <param name="strict"> Treat warnings as errors and fail the build on warnings</param>
 	/// <param name="allowIndexing"> Allow indexing and following of html files</param>
+	/// <param name="metadataOnly"> Only emit documentation metadata to output</param>
 	/// <param name="ctx"></param>
 	[Command("")]
 	[ConsoleAppFilter<StopwatchFilter>]
@@ -140,9 +145,10 @@ internal sealed class Commands(ILoggerFactory logger, ICoreService githubActions
 		bool? force = null,
 		bool? strict = null,
 		bool? allowIndexing = null,
+		bool? metadataOnly = null,
 		Cancel ctx = default
 	) =>
-		await Generate(path, output, pathPrefix, force, strict, allowIndexing, ctx);
+		await Generate(path, output, pathPrefix, force, strict, allowIndexing, metadataOnly, ctx);
 
 
 	/// <summary>

--- a/tests/authoring/Framework/Setup.fs
+++ b/tests/authoring/Framework/Setup.fs
@@ -102,7 +102,7 @@ type Setup =
         let conversionCollector = TestConversionCollector()
         let linkResolver = TestCrossLinkResolver(context.Configuration)
         let set = DocumentationSet(context, logger, linkResolver);
-        let generator = DocumentationGenerator(set, logger, conversionCollector)
+        let generator = DocumentationGenerator(set, logger, null, conversionCollector)
 
         let context = {
             Collector = collector


### PR DESCRIPTION
This allows us to have different implementations of how a `DocumentationFile` gets exported to the output folder.

Right now we have two implementations:

- Default
- Noop

The noop exporter can be used by passing `--metadata-only` to `docs-builder`.

This will only emit our metadata files to the output folder.

This is primarely build for https://github.com/elastic/asciidocalypse/pull/140 to ensure it can build and publish links but we no longer care about the html output.
