### PR TITLE
Separate static url prefix from path prefix

### DIFF
--- a/src/Elastic.Markdown/BuildContext.cs
+++ b/src/Elastic.Markdown/BuildContext.cs
@@ -39,6 +39,15 @@ public record BuildContext
 		init => _urlPathPrefix = value;
 	}
 
+	private readonly string? _staticUrlPathPrefix;
+	public string? StaticUrlPathPrefix
+	{
+		get => !string.IsNullOrWhiteSpace(_staticUrlPathPrefix)
+			? $"/{_staticUrlPathPrefix.Trim('/')}"
+			: UrlPathPrefix;
+		init => _staticUrlPathPrefix = value;
+	}
+
 	public BuildContext(IFileSystem fileSystem)
 		: this(new DiagnosticsCollector([]), fileSystem, fileSystem, null, null) { }
 

--- a/src/Elastic.Markdown/Slices/HtmlWriter.cs
+++ b/src/Elastic.Markdown/Slices/HtmlWriter.cs
@@ -98,6 +98,7 @@ public class HtmlWriter(DocumentationSet documentationSet, IFileSystem writeFile
 			TopLevelNavigationItems = [.. topLevelNavigationItems],
 			NavigationHtml = navigationHtml,
 			UrlPathPrefix = markdown.UrlPathPrefix,
+			StaticUrlPathPrefix = DocumentationSet.Build.StaticUrlPathPrefix,
 			Applies = markdown.YamlFrontMatter?.AppliesTo,
 			GithubEditUrl = editUrl,
 			AllowIndexing = DocumentationSet.Build.AllowIndexing && !markdown.Hidden,

--- a/src/Elastic.Markdown/Slices/Index.cshtml
+++ b/src/Elastic.Markdown/Slices/Index.cshtml
@@ -13,6 +13,7 @@
 		NavigationHtml = Model.NavigationHtml,
 		TopLevelNavigationItems = Model.TopLevelNavigationItems,
 		UrlPathPrefix = Model.UrlPathPrefix,
+		StaticUrlPathPrefix = Model.StaticUrlPathPrefix,
 		GithubEditUrl = Model.GithubEditUrl,
 		AllowIndexing = Model.AllowIndexing,
 		Features = Model.Features

--- a/src/Elastic.Markdown/Slices/_ViewModels.cs
+++ b/src/Elastic.Markdown/Slices/_ViewModels.cs
@@ -23,6 +23,7 @@ public class IndexViewModel
 
 	public required string NavigationHtml { get; init; }
 	public required string? UrlPathPrefix { get; init; }
+	public required string? StaticUrlPathPrefix { get; init; }
 	public required string? GithubEditUrl { get; init; }
 	public required ApplicableTo? Applies { get; init; }
 	public required bool AllowIndexing { get; init; }
@@ -43,9 +44,10 @@ public class LayoutViewModel
 	public required MarkdownFile CurrentDocument { get; init; }
 	public required MarkdownFile? Previous { get; init; }
 	public required MarkdownFile? Next { get; init; }
-	public required string NavigationHtml { get; set; }
-	public required string? UrlPathPrefix { get; set; }
-	public required string? GithubEditUrl { get; set; }
+	public required string NavigationHtml { get; init; }
+	public required string? StaticUrlPathPrefix { get; init; }
+	public required string? UrlPathPrefix { get; init; }
+	public required string? GithubEditUrl { get; init; }
 	public required bool AllowIndexing { get; init; }
 	public required FeatureFlags Features { get; init; }
 
@@ -67,7 +69,7 @@ public class LayoutViewModel
 	public string Static(string path)
 	{
 		path = $"_static/{path.TrimStart('/')}";
-		return $"{UrlPathPrefix}/{path}";
+		return $"{StaticUrlPathPrefix}/{path}";
 	}
 
 	public string Link(string path)

--- a/src/docs-assembler/AssembleContext.cs
+++ b/src/docs-assembler/AssembleContext.cs
@@ -30,13 +30,19 @@ public class AssembleContext
 	// This property is used to determine if the site should be indexed by search engines
 	public bool AllowIndexing { get; init; }
 
-	public AssembleContext(DiagnosticsCollector collector, IFileSystem readFileSystem, IFileSystem writeFileSystem, string? checkoutDirectory, string? output)
+	public AssembleContext(
+		DiagnosticsCollector collector,
+		IFileSystem readFileSystem,
+		IFileSystem writeFileSystem,
+		string? checkoutDirectory,
+		string? output
+	)
 	{
 		Collector = collector;
 		ReadFileSystem = readFileSystem;
 		WriteFileSystem = writeFileSystem;
 
-		var configPath = Path.Combine(Paths.Root.FullName, "src/docs-assembler/assembler.yml");
+		var configPath = Path.Combine(Paths.Root.FullName, "src", "docs-assembler", "assembler.yml");
 		// temporarily fallback to embedded assembler.yml
 		// This will live in docs-content soon
 		if (!ReadFileSystem.File.Exists(configPath))

--- a/src/docs-assembler/Building/PublishEnvironmentUriResolver.cs
+++ b/src/docs-assembler/Building/PublishEnvironmentUriResolver.cs
@@ -18,15 +18,13 @@ public class PublishEnvironmentUriResolver : IUriEnvironmentResolver
 
 	private FrozenDictionary<string, Repository> AllRepositories { get; }
 
-	public PublishEnvironmentUriResolver(AssemblyConfiguration configuration, string environment)
+	public PublishEnvironmentUriResolver(AssemblyConfiguration configuration, PublishEnvironment environment)
 	{
-		if (!configuration.Environments.TryGetValue(environment, out var e))
-			throw new Exception($"Could not find environment {environment}");
-		if (!Uri.TryCreate(e.Uri, UriKind.Absolute, out var uri))
-			throw new Exception($"Could not parse uri {e.Uri} in environment {environment}");
+		if (!Uri.TryCreate(environment.Uri, UriKind.Absolute, out var uri))
+			throw new Exception($"Could not parse uri {environment.Uri} in environment {environment}");
 
 		BaseUri = uri;
-		PublishEnvironment = e;
+		PublishEnvironment = environment;
 		PreviewResolver = new PreviewEnvironmentUriResolver();
 		AllRepositories = configuration.ReferenceRepositories.Values.Concat<Repository>([configuration.Narrative])
 			.ToFrozenDictionary(e => e.Name, e => e);

--- a/src/docs-assembler/Sourcing/RepositorySourcesFetcher.cs
+++ b/src/docs-assembler/Sourcing/RepositorySourcesFetcher.cs
@@ -143,7 +143,7 @@ public class RepositoryCheckoutProvider(ILoggerFactory logger, AssembleContext c
 		var arguments = new StartArguments(binary, args)
 		{
 			WorkingDirectory = workingDirectory?.FullName,
-			WaitForStreamReadersTimeout = TimeSpan.FromSeconds(3),
+			//WaitForStreamReadersTimeout = TimeSpan.FromSeconds(3),
 			Timeout = TimeSpan.FromSeconds(3),
 			WaitForExit = TimeSpan.FromSeconds(3),
 			ConsoleOutWriter = NoopConsoleWriter.Instance

--- a/src/docs-assembler/assembler.yml
+++ b/src/docs-assembler/assembler.yml
@@ -8,6 +8,9 @@ environments:
   preview:
     uri: https://docs-v3-preview.elastic.dev
     path_prefix:
+  dev:
+    uri: http://localhost:4000
+    path_prefix: docs
 narrative:
   checkout_strategy: full
 references:

--- a/src/docs-builder/Cli/Commands.cs
+++ b/src/docs-builder/Cli/Commands.cs
@@ -47,6 +47,24 @@ internal sealed class Commands(ILoggerFactory logger, ICoreService githubActions
 	}
 
 	/// <summary>
+	/// Serve html files directly
+	/// </summary>
+	/// <param name="path">-p, Path to serve the documentation.
+	/// Defaults to the`{pwd}/docs` folder
+	/// </param>
+	/// <param name="port">Port to serve the documentation.</param>
+	/// <param name="ctx"></param>
+	[Command("serve-static")]
+	[ConsoleAppFilter<CheckForUpdatesFilter>]
+	public async Task ServeStatic(string? path = null, int port = 4000, Cancel ctx = default)
+	{
+		AssignOutputLogger();
+		var host = new StaticWebHost(path, port, new FileSystem());
+		await host.RunAsync(ctx);
+		await host.StopAsync(ctx);
+	}
+
+	/// <summary>
 	/// Converts a source markdown folder or file to an output folder
 	/// <para>global options:</para>
 	/// --log-level level

--- a/src/docs-builder/Http/StaticWebHost.cs
+++ b/src/docs-builder/Http/StaticWebHost.cs
@@ -1,0 +1,105 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions;
+using System.Net;
+using Documentation.Builder.Diagnostics.LiveMode;
+using Elastic.Documentation.Tooling;
+using Elastic.Markdown;
+using Elastic.Markdown.Diagnostics;
+using Elastic.Markdown.IO;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
+using Westwind.AspNetCore.LiveReload;
+using IFileInfo = Microsoft.Extensions.FileProviders.IFileInfo;
+
+namespace Documentation.Builder.Http;
+
+public class StaticWebHost
+{
+	private readonly WebApplication _webApplication;
+
+	private readonly BuildContext _context;
+
+	public StaticWebHost(string? path, int port, IFileSystem fileSystem)
+	{
+		var builder = WebApplication.CreateSlimBuilder();
+		DocumentationTooling.CreateServiceCollection(builder.Services, LogLevel.Warning);
+
+		_ = builder.Logging
+			.AddFilter("Microsoft.AspNetCore.Hosting.Diagnostics", LogLevel.Error)
+			.AddFilter("Microsoft.AspNetCore.StaticFiles.StaticFileMiddleware", LogLevel.Error)
+			.AddFilter("Microsoft.Hosting.Lifetime", LogLevel.Information);
+		_ = builder.WebHost.UseUrls($"http://localhost:{port}");
+
+		_webApplication = builder.Build();
+		_context = new BuildContext(new DiagnosticsCollector([]), fileSystem, fileSystem, path, null);
+		SetUpRoutes();
+	}
+
+	public async Task RunAsync(Cancel ctx) => await _webApplication.RunAsync(ctx);
+
+	public async Task StopAsync(Cancel ctx) => await _context.Collector.StopAsync(ctx);
+
+	private void SetUpRoutes()
+	{
+		_ =
+			_webApplication
+				.UseRouting();
+
+		_ = _webApplication.MapGet("/", (Cancel _) => Results.Redirect("docs"));
+
+		_ = _webApplication.MapGet("docs/", (Cancel ctx) =>
+			ServeDocumentationFile("index.html", ctx));
+
+		_ = _webApplication.MapGet("docs/{**slug}", (string slug, Cancel ctx) =>
+			ServeDocumentationFile(slug, ctx));
+	}
+
+	private static async Task<IResult> ServeDocumentationFile(string slug, Cancel _)
+	{
+		// from the injected top level navigation which expects us to run on elastic.co
+		if (slug.StartsWith("static-res/"))
+			return Results.NotFound();
+
+		await Task.CompletedTask;
+		var path = Path.Combine(Paths.Root.FullName, ".artifacts", "assembly");
+		var localPath = Path.Combine(path, slug.Replace('/', Path.DirectorySeparatorChar));
+		var fileInfo = new FileInfo(localPath);
+		var directoryInfo = new DirectoryInfo(localPath);
+		if (directoryInfo.Exists)
+			fileInfo = new FileInfo(Path.Combine(directoryInfo.FullName, "index.html"));
+
+		if (fileInfo.Exists)
+		{
+			var mimetype = fileInfo.Extension switch
+			{
+				".js" => "text/javascript",
+				".css" => "text/css",
+				".png" => "image/png",
+				".jpg" => "image/jpeg",
+				".gif" => "image/gif",
+				".svg" => "image/svg+xml",
+				".ico" => "image/x-icon",
+				".json" => "application/json",
+				".map" => "application/json",
+				".txt" => "text/plain",
+				".xml" => "text/xml",
+				".yml" => "text/yaml",
+				".md" => "text/markdown",
+				_ => "text/html"
+			};
+			return Results.File(fileInfo.FullName, mimetype);
+		}
+
+
+		return Results.NotFound();
+	}
+}


### PR DESCRIPTION
It still defaults to UrlPathPrefix but with the assembler build we need a way to ensure static files can
be rooted seperately from the path prefix of the page.

To help with development we now have a 'dev' environment which defaults to http://localhost:4000/docs

We can now view the output of `docs-assembler repo build all` with `docs-builder serve-static`
which will host the combined docs under http://localhost:4000
