### PR TITLE
Remove tj-actions usage, eventhough we had it pinned as gitref

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -57,15 +57,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
-      - name: Get changed files
-        if: contains(fromJSON('["merge_group", "pull_request", "pull_request_target"]'), github.event_name)
-        id: check-files
-        uses: tj-actions/changed-files@d6e91a2266cdb9d62096cebf1e8546899c6aa18f # v45.0.6
-        with:
-          files: ${{ inputs.path-pattern != '' && inputs.path-pattern || '**' }}
-          
       - name: Checkout
-        if: startsWith(github.event_name, 'pull_request') && steps.check-files.outputs.any_modified == 'true'
+        if: startsWith(github.event_name, 'pull_request')
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
@@ -77,7 +70,7 @@ jobs:
           tool-cache: false
           
       - name: Create Deployment
-        if: github.event_name == 'push' || (steps.check-files.outputs.any_modified == 'true' && startsWith(github.event_name, 'pull_request'))
+        if: github.event_name == 'push' || startsWith(github.event_name, 'pull_request')
         uses: actions/github-script@v7
         id: deployment
         env:
@@ -144,7 +137,7 @@ jobs:
           dotnet run --project src/docs-builder -- --strict --path-prefix "${PATH_PREFIX}"
 
       - name: Build documentation
-        if: github.repository != 'elastic/docs-builder' && (steps.deployment.outputs.result || (steps.check-files.outputs.any_modified == 'true' && github.event_name == 'merge_group'))
+        if: github.repository != 'elastic/docs-builder' && (steps.deployment.outputs.result || github.event_name == 'merge_group')
         uses: elastic/docs-builder@main
         id: docs-build
         continue-on-error: ${{ fromJSON(inputs.continue-on-error != '' && inputs.continue-on-error || 'false') }}
@@ -154,7 +147,7 @@ jobs:
           metadata-only: ${{ fromJSON(inputs.metadata-only != '' && inputs.metadata-only || 'true') }}
 
       - name: 'Validate Inbound Links'
-        if: ${{ !cancelled() && steps.docs-build.outputs.skip != 'true' && (steps.deployment.outputs.result || (steps.check-files.outputs.any_modified == 'true' && github.event_name == 'merge_group')) }}
+        if: ${{ !cancelled() && steps.docs-build.outputs.skip != 'true' && (steps.deployment.outputs.result || github.event_name == 'merge_group') }}
         uses: elastic/docs-builder/actions/validate-inbound-local@main
 
       - uses: elastic/docs-builder/.github/actions/aws-auth@main


### PR DESCRIPTION
This will do a full docs build even for PR's that do not change docs. However because we run reasonably fast the impact is limited. 

We do want to restore some checks so we don't always upload to S3 for the preview environment which might take a bit longer.

NOTE: the actions repo itself now 404's (maybe as a precaution by github)