### PR TITLE
Add support for diagnostic hints and track unused substitution keys

### DIFF
--- a/src/Elastic.Documentation.Tooling/Diagnostics/Console/ConsoleDiagnosticsCollector.cs
+++ b/src/Elastic.Documentation.Tooling/Diagnostics/Console/ConsoleDiagnosticsCollector.cs
@@ -16,13 +16,16 @@ public class ConsoleDiagnosticsCollector(ILoggerFactory loggerFactory, ICoreServ
 {
 	private readonly List<Diagnostic> _errors = [];
 	private readonly List<Diagnostic> _warnings = [];
+	private readonly List<Diagnostic> _hints = [];
 
 	protected override void HandleItem(Diagnostic diagnostic)
 	{
-		if (diagnostic.Severity == Severity.Warning)
+		if (diagnostic.Severity == Severity.Error)
+			_errors.Add(diagnostic);
+		else if (diagnostic.Severity == Severity.Warning)
 			_warnings.Add(diagnostic);
 		else
-			_errors.Add(diagnostic);
+			_hints.Add(diagnostic);
 	}
 
 	private bool _stopped;
@@ -32,10 +35,10 @@ public class ConsoleDiagnosticsCollector(ILoggerFactory loggerFactory, ICoreServ
 			return;
 		_stopped = true;
 		var repository = new ErrataFileSourceRepository();
-		repository.WriteDiagnosticsToConsole(_errors, _warnings);
+		repository.WriteDiagnosticsToConsole(_errors, _warnings, _hints);
 
 		AnsiConsole.WriteLine();
-		AnsiConsole.Write(new Markup($"	[bold red]{Errors} Errors[/] / [bold blue]{Warnings} Warnings[/]"));
+		AnsiConsole.Write(new Markup($"	[bold red]{Errors} Errors[/] / [bold blue]{Warnings} Warnings[/] / [bold yellow]{Hints} Hints[/]"));
 		AnsiConsole.WriteLine();
 		AnsiConsole.WriteLine();
 

--- a/src/Elastic.Documentation.Tooling/Diagnostics/Console/ErrataFileSourceRepository.cs
+++ b/src/Elastic.Documentation.Tooling/Diagnostics/Console/ErrataFileSourceRepository.cs
@@ -62,6 +62,9 @@ public class ErrataFileSourceRepository : ISourceRepository
 			else
 				d = d.WithNote(item.File);
 
+			if (item.Severity == Severity.Hint)
+				d = d.WithColor(Color.Yellow).WithCategory("Hint");
+
 			_ = report.AddDiagnostic(d);
 		}
 

--- a/src/Elastic.Documentation.Tooling/Diagnostics/Console/ErrataFileSourceRepository.cs
+++ b/src/Elastic.Documentation.Tooling/Diagnostics/Console/ErrataFileSourceRepository.cs
@@ -23,12 +23,18 @@ public class ErrataFileSourceRepository : ISourceRepository
 		return true;
 	}
 
-	public void WriteDiagnosticsToConsole(IReadOnlyCollection<Diagnostic> errors, IReadOnlyCollection<Diagnostic> warnings)
+	public void WriteDiagnosticsToConsole(IReadOnlyCollection<Diagnostic> errors, IReadOnlyCollection<Diagnostic> warnings, List<Diagnostic> hints)
 	{
 		var report = new Report(this);
-		var limitedErrors = errors.Take(100).ToArray();
-		var limitedWarnings = warnings.Take(100 - limitedErrors.Length);
-		var limited = limitedWarnings.Concat(limitedErrors).ToArray();
+		var limited = errors
+			.Concat(warnings)
+			.OrderBy(d => d.Severity switch { Severity.Error => 0, Severity.Warning => 1, Severity.Hint => 2, _ => 3 })
+			.Take(100)
+			.ToArray();
+
+		// show hints if we don't have plenty of errors/warnings to show
+		if (limited.Length < 100)
+			limited = limited.Concat(hints).Take(100).ToArray();
 
 		foreach (var item in limited)
 		{
@@ -36,6 +42,7 @@ public class ErrataFileSourceRepository : ISourceRepository
 			{
 				Severity.Error => Errata.Diagnostic.Error(item.Message),
 				Severity.Warning => Errata.Diagnostic.Warning(item.Message),
+				Severity.Hint => Errata.Diagnostic.Info(item.Message),
 				_ => Errata.Diagnostic.Info(item.Message)
 			};
 			if (item is { Line: not null, Column: not null })
@@ -44,7 +51,13 @@ public class ErrataFileSourceRepository : ISourceRepository
 				d = d.WithLabel(new Label(item.File, location, "")
 					.WithLength(item.Length == null ? 1 : Math.Clamp(item.Length.Value, 1, item.Length.Value + 3))
 					.WithPriority(1)
-					.WithColor(item.Severity == Severity.Error ? Color.Red : Color.Blue));
+					.WithColor(item.Severity switch
+					{
+						Severity.Error => Color.Red,
+						Severity.Warning => Color.Blue,
+						Severity.Hint => Color.Yellow,
+						_ => Color.Blue
+					}));
 			}
 			else
 				d = d.WithNote(item.File);
@@ -56,7 +69,33 @@ public class ErrataFileSourceRepository : ISourceRepository
 
 		AnsiConsole.WriteLine();
 		if (totalErrorCount <= 0)
+		{
+			if (hints.Count > 0)
+				DisplayHintsOnly(report, hints);
 			return;
+		}
+		DisplayErrorAndWarningSummary(report, totalErrorCount, limited);
+	}
+
+	private static void DisplayHintsOnly(Report report, List<Diagnostic> hints)
+	{
+		AnsiConsole.Write(new Markup($"	[bold]The following improvement hints found in the documentation[/]"));
+		AnsiConsole.WriteLine();
+		AnsiConsole.WriteLine();
+		// Render the report
+		report.Render(AnsiConsole.Console);
+
+		AnsiConsole.WriteLine();
+		AnsiConsole.WriteLine();
+
+		if (hints.Count >= 100)
+			AnsiConsole.Write(new Markup($"	[bold]Only shown the first [yellow]{100}[/] hints out of [yellow]{hints.Count}[/][/]"));
+
+		AnsiConsole.WriteLine();
+	}
+
+	private static void DisplayErrorAndWarningSummary(Report report, int totalErrorCount, Diagnostic[] limited)
+	{
 		AnsiConsole.Write(new Markup($"	[bold]The following errors and warnings were found in the documentation[/]"));
 		AnsiConsole.WriteLine();
 		AnsiConsole.WriteLine();

--- a/src/Elastic.Documentation.Tooling/Diagnostics/Console/GithubAnnotationOutput.cs
+++ b/src/Elastic.Documentation.Tooling/Diagnostics/Console/GithubAnnotationOutput.cs
@@ -27,5 +27,7 @@ public class GithubAnnotationOutput(ICoreService? githubActions) : IDiagnosticsO
 			githubActions.WriteError(diagnostic.Message, properties);
 		if (diagnostic.Severity == Severity.Warning)
 			githubActions.WriteWarning(diagnostic.Message, properties);
+		if (diagnostic.Severity == Severity.Hint)
+			githubActions.WriteNotice(diagnostic.Message, properties);
 	}
 }

--- a/src/Elastic.Documentation.Tooling/Diagnostics/Log.cs
+++ b/src/Elastic.Documentation.Tooling/Diagnostics/Log.cs
@@ -16,15 +16,19 @@ public class Log(ILogger logger) : IDiagnosticsOutput
 		{
 			if (diagnostic.Severity == Severity.Error)
 				logger.LogError("{Message}", diagnostic.Message);
-			else
+			else if (diagnostic.Severity == Severity.Warning)
 				logger.LogWarning("{Message}", diagnostic.Message);
+			else
+				logger.LogInformation("{Message}", diagnostic.Message);
 		}
 		else
 		{
 			if (diagnostic.Severity == Severity.Error)
 				logger.LogError("{Message} ({File}:{Line})", diagnostic.Message, diagnostic.File, diagnostic.Line ?? 0);
+			else if (diagnostic.Severity == Severity.Warning)
+				logger.LogWarning("{Message}", diagnostic.Message);
 			else
-				logger.LogWarning("{Message} ({File}:{Line})", diagnostic.Message, diagnostic.File, diagnostic.Line ?? 0);
+				logger.LogInformation("{Message} ({File}:{Line})", diagnostic.Message, diagnostic.File, diagnostic.Line ?? 0);
 		}
 	}
 }

--- a/src/Elastic.Markdown/Diagnostics/DiagnosticsChannel.cs
+++ b/src/Elastic.Markdown/Diagnostics/DiagnosticsChannel.cs
@@ -8,6 +8,23 @@ using Microsoft.Extensions.Hosting;
 
 namespace Elastic.Markdown.Diagnostics;
 
+public enum Severity
+{
+	Error,
+	Warning,
+	Hint
+}
+
+public readonly record struct Diagnostic
+{
+	public Severity Severity { get; init; }
+	public int? Line { get; init; }
+	public int? Column { get; init; }
+	public int? Length { get; init; }
+	public string File { get; init; }
+	public string Message { get; init; }
+}
+
 public sealed class DiagnosticsChannel : IDisposable
 {
 	private readonly Channel<Diagnostic> _channel;
@@ -18,7 +35,11 @@ public sealed class DiagnosticsChannel : IDisposable
 
 	public DiagnosticsChannel()
 	{
-		var options = new UnboundedChannelOptions { SingleReader = true, SingleWriter = false };
+		var options = new UnboundedChannelOptions
+		{
+			SingleReader = true,
+			SingleWriter = false
+		};
 		_ctxSource = new CancellationTokenSource();
 		_channel = Channel.CreateUnbounded<Diagnostic>(options);
 	}
@@ -43,18 +64,6 @@ public sealed class DiagnosticsChannel : IDisposable
 	public void Dispose() => _ctxSource.Dispose();
 }
 
-public enum Severity { Error, Warning }
-
-public readonly record struct Diagnostic
-{
-	public Severity Severity { get; init; }
-	public int? Line { get; init; }
-	public int? Column { get; init; }
-	public int? Length { get; init; }
-	public string File { get; init; }
-	public string Message { get; init; }
-}
-
 public interface IDiagnosticsOutput
 {
 	void Write(Diagnostic diagnostic);
@@ -67,12 +76,16 @@ public class DiagnosticsCollector(IReadOnlyCollection<IDiagnosticsOutput> output
 
 	private int _errors;
 	private int _warnings;
+	private int _hints;
 	public int Warnings => _warnings;
 	public int Errors => _errors;
+	public int Hints => _hints;
 
 	private Task? _started;
 
 	public HashSet<string> OffendingFiles { get; } = [];
+
+	public HashSet<string> InUseSubstitutionKeys { get; } = [];
 
 	public ConcurrentBag<string> CrossLinks { get; } = [];
 
@@ -119,6 +132,8 @@ public class DiagnosticsCollector(IReadOnlyCollection<IDiagnosticsOutput> output
 			_ = Interlocked.Increment(ref _errors);
 		else if (item.Severity == Severity.Warning)
 			_ = Interlocked.Increment(ref _warnings);
+		else if (item.Severity == Severity.Hint)
+			_ = Interlocked.Increment(ref _hints);
 	}
 
 	protected virtual void HandleItem(Diagnostic diagnostic) { }
@@ -132,30 +147,25 @@ public class DiagnosticsCollector(IReadOnlyCollection<IDiagnosticsOutput> output
 
 	public void EmitCrossLink(string link) => CrossLinks.Add(link);
 
-	public void EmitError(string file, string message, Exception? e = null)
-	{
-		var d = new Diagnostic
+	private void Emit(Severity severity, string file, string message) =>
+		Channel.Write(new Diagnostic
 		{
-			Severity = Severity.Error,
+			Severity = severity,
 			File = file,
 			Message = message
-					  + (e != null ? Environment.NewLine + e : string.Empty)
-					  + (e?.InnerException != null ? Environment.NewLine + e.InnerException : string.Empty),
+		});
 
-		};
-		Channel.Write(d);
-	}
-
-	public void EmitWarning(string file, string message)
+	public void EmitError(string file, string message, Exception? e = null)
 	{
-		var d = new Diagnostic
-		{
-			Severity = Severity.Warning,
-			File = file,
-			Message = message,
-		};
-		Channel.Write(d);
+		message = message
+				+ (e != null ? Environment.NewLine + e : string.Empty)
+				+ (e?.InnerException != null ? Environment.NewLine + e.InnerException : string.Empty);
+		Emit(Severity.Error, file, message);
 	}
+
+	public void EmitWarning(string file, string message) => Emit(Severity.Warning, file, message);
+
+	public void EmitHint(string file, string message) => Emit(Severity.Hint, file, message);
 
 	public async ValueTask DisposeAsync()
 	{
@@ -163,4 +173,7 @@ public class DiagnosticsCollector(IReadOnlyCollection<IDiagnosticsOutput> output
 		await StopAsync(CancellationToken.None);
 		GC.SuppressFinalize(this);
 	}
+
+	public void CollectUsedSubstitutionKey(ReadOnlySpan<char> key) =>
+		_ = InUseSubstitutionKeys.Add(key.ToString());
 }

--- a/src/Elastic.Markdown/IO/MarkdownFile.cs
+++ b/src/Elastic.Markdown/IO/MarkdownFile.cs
@@ -210,7 +210,7 @@ public record MarkdownFile : DocumentationFile
 
 		if (!string.IsNullOrEmpty(NavigationTitle))
 		{
-			if (NavigationTitle.AsSpan().ReplaceSubstitutions(subs, out var replacement))
+			if (NavigationTitle.AsSpan().ReplaceSubstitutions(subs, Collector, out var replacement))
 				NavigationTitle = replacement;
 		}
 
@@ -219,7 +219,7 @@ public record MarkdownFile : DocumentationFile
 			Title = RelativePath;
 			Collector.EmitWarning(FilePath, "Document has no title, using file name as title.");
 		}
-		else if (Title.AsSpan().ReplaceSubstitutions(subs, out var replacement))
+		else if (Title.AsSpan().ReplaceSubstitutions(subs, Collector, out var replacement))
 			Title = replacement;
 
 		var toc = GetAnchors(_set, MarkdownParser, YamlFrontMatter, document, subs, out var anchors);
@@ -272,7 +272,7 @@ public record MarkdownFile : DocumentationFile
 			.Concat(includedTocs)
 			.Select(toc => subs.Count == 0
 				? toc
-				: toc.Heading.AsSpan().ReplaceSubstitutions(subs, out var r)
+				: toc.Heading.AsSpan().ReplaceSubstitutions(subs, set.Build.Collector, out var r)
 					? toc with { Heading = r }
 					: toc)
 			.ToList();

--- a/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockParser.cs
+++ b/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockParser.cs
@@ -177,14 +177,14 @@ public class EnhancedCodeBlockParser : FencedBlockParserBase<EnhancedCodeBlock>
 			var span = line.Slice.AsSpan();
 			if (codeBlockArgs.UseSubstitutions)
 			{
-				if (span.ReplaceSubstitutions(context.YamlFrontMatter?.Properties, out var frontMatterReplacement))
+				if (span.ReplaceSubstitutions(context.YamlFrontMatter?.Properties, context.Build.Collector, out var frontMatterReplacement))
 				{
 					var s = new StringSlice(frontMatterReplacement);
 					lines.Lines[index] = new StringLine(ref s);
 					span = lines.Lines[index].Slice.AsSpan();
 				}
 
-				if (span.ReplaceSubstitutions(context.Substitutions, out var globalReplacement))
+				if (span.ReplaceSubstitutions(context.Substitutions, context.Build.Collector, out var globalReplacement))
 				{
 					var s = new StringSlice(globalReplacement);
 					lines.Lines[index] = new StringLine(ref s);

--- a/tests/Elastic.Markdown.Tests/Interpolation/InterpolationTests.cs
+++ b/tests/Elastic.Markdown.Tests/Interpolation/InterpolationTests.cs
@@ -14,7 +14,7 @@ public class InterpolationTests
 	{
 		var span = "My text {{with-variables}} {{not-defined}}".AsSpan();
 		var replacements = new Dictionary<string, string> { { "with-variables", "With Variables" } };
-		var replaced = span.ReplaceSubstitutions(replacements, out var replacement);
+		var replaced = span.ReplaceSubstitutions(replacements, null, out var replacement);
 
 		replaced.Should().BeTrue();
 		replacement.Should().Be("My text With Variables {{not-defined}}");
@@ -25,7 +25,7 @@ public class InterpolationTests
 	{
 		var span = "My text {{not-defined}}".AsSpan();
 		var replacements = new Dictionary<string, string> { { "with-variables", "With Variables" } };
-		var replaced = span.ReplaceSubstitutions(replacements, out var replacement);
+		var replaced = span.ReplaceSubstitutions(replacements, null, out var replacement);
 
 		replaced.Should().BeFalse();
 		// no need to allocate replacement we can continue with span


### PR DESCRIPTION
Introduced a "Hint" severity level to diagnostics for improvement suggestions. Enhanced substitution tracking to collect unused keys and provide hints, optimizing substitution usage. Updated console and GitHub outputs to display diagnostic hints alongside errors and warnings for better feedback.

<img width="1196" alt="image" src="https://github.com/user-attachments/assets/ea56d673-bf4a-4388-8c15-7b0f7a6ff2ae" />

Hints have no bearing on the exit code of `docs-builder`.


If there are too many variables it will be emitted as a single hint.


Built to aid with the work ongoing at: https://github.com/elastic/docs-content/issues/811