### PR TITLE
Skip preview jobs on fork repositories

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -45,7 +45,7 @@ permissions:
 
 jobs:
   build:
-    if: github.event.repository.fork == false
+    if: github.event.repository.fork == false # Skip running the job on the fork itself (It still runs on PRs on the upstream from forks)
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref }}
       cancel-in-progress: ${{ startsWith(github.event_name, 'pull_request') }}

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -45,6 +45,7 @@ permissions:
 
 jobs:
   build:
+    if: github.event.repository.fork == false
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref }}
       cancel-in-progress: ${{ startsWith(github.event_name, 'pull_request') }}

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   destroy:
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - name: Delete GitHub environment

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   destroy:
-    if: github.event.repository.fork == false
+    if: github.event.repository.fork == false # Skip running the job on the fork itself (It still runs on PRs on the upstream from forks)
     runs-on: ubuntu-latest
     steps:
       - name: Delete GitHub environment


### PR DESCRIPTION
## Changes

This change will make the jobs skip on forks.
But they will still run on the upstream repo, even on PRs from forks.

## Context

This workflow does not work on workflows running on the fork itself because of the aws auth step.


## Related
- https://github.com/elastic/kibana/pull/214886