### PR TITLE
Preload fonts in use as per CSS definitions

### DIFF
--- a/src/Elastic.Markdown/Helpers/Preloader.cs
+++ b/src/Elastic.Markdown/Helpers/Preloader.cs
@@ -1,0 +1,37 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Diagnostics;
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+namespace Elastic.Markdown.Helpers;
+
+public static partial class FontPreloader
+{
+	private static List<string>? FontUriCache = null!;
+
+	public static async Task<IEnumerable<string>> GetFontUrisAsync() => FontUriCache ??= await LoadFontUrisAsync();
+	public static async Task<List<string>> LoadFontUrisAsync()
+	{
+		FontUriCache = [];
+		var assembly = Assembly.GetExecutingAssembly();
+		var stylesResourceName = assembly.GetManifestResourceNames().First(n => n.EndsWith("styles.css"));
+
+		using var cssFileStream = new StreamReader(assembly.GetManifestResourceStream(stylesResourceName)!);
+
+		var cssFile = await cssFileStream.ReadToEndAsync();
+		var matches = FontUriRegex().Matches(cssFile);
+
+		foreach (Match match in matches)
+		{
+			if (match.Success)
+				FontUriCache.Add($"/_static/{match.Groups[1].Value}");
+		}
+		return FontUriCache;
+	}
+
+	[GeneratedRegex(@"url\([""']?([^""'\)]+)[""']?\)", RegexOptions.Multiline | RegexOptions.Compiled)]
+	private static partial Regex FontUriRegex();
+}

--- a/src/Elastic.Markdown/Helpers/Preloader.cs
+++ b/src/Elastic.Markdown/Helpers/Preloader.cs
@@ -14,7 +14,7 @@ public static partial class FontPreloader
 	private static IReadOnlyCollection<string>? FontUriCache = null!;
 
 	public static async Task<IReadOnlyCollection<string>> GetFontUrisAsync() => FontUriCache ??= await LoadFontUrisAsync();
-	public static async Task<IReadOnlyCollection<string>> LoadFontUrisAsync()
+	private static async Task<IReadOnlyCollection<string>> LoadFontUrisAsync()
 	{
 		var cachedFontUris = new List<string>();
 		var assembly = Assembly.GetExecutingAssembly();

--- a/src/Elastic.Markdown/Helpers/Preloader.cs
+++ b/src/Elastic.Markdown/Helpers/Preloader.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -10,12 +11,12 @@ namespace Elastic.Markdown.Helpers;
 
 public static partial class FontPreloader
 {
-	private static List<string>? FontUriCache = null!;
+	private static IReadOnlyCollection<string>? FontUriCache = null!;
 
-	public static async Task<IEnumerable<string>> GetFontUrisAsync() => FontUriCache ??= await LoadFontUrisAsync();
-	public static async Task<List<string>> LoadFontUrisAsync()
+	public static async Task<IReadOnlyCollection<string>> GetFontUrisAsync() => FontUriCache ??= await LoadFontUrisAsync();
+	public static async Task<IReadOnlyCollection<string>> LoadFontUrisAsync()
 	{
-		FontUriCache = [];
+		var cachedFontUris = new List<string>();
 		var assembly = Assembly.GetExecutingAssembly();
 		var stylesResourceName = assembly.GetManifestResourceNames().First(n => n.EndsWith("styles.css"));
 
@@ -27,11 +28,12 @@ public static partial class FontPreloader
 		foreach (Match match in matches)
 		{
 			if (match.Success)
-				FontUriCache.Add($"/_static/{match.Groups[1].Value}");
+				cachedFontUris.Add($"/_static/{match.Groups[1].Value}");
 		}
+		FontUriCache = cachedFontUris;
 		return FontUriCache;
 	}
 
-	[GeneratedRegex(@"url\([""']?([^""'\)]+)[""']?\)", RegexOptions.Multiline | RegexOptions.Compiled)]
+	[GeneratedRegex(@"url\([""']?([^""'\)]+?\.(woff2|ttf|otf))[""']?\)", RegexOptions.Multiline | RegexOptions.Compiled)]
 	private static partial Regex FontUriRegex();
 }

--- a/src/Elastic.Markdown/Slices/Layout/_Head.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_Head.cshtml
@@ -1,7 +1,12 @@
 @inherits RazorSlice<LayoutViewModel>
+@using Elastic.Markdown.Helpers
 <head>
 	<title>@Model.Title</title>
-	<link rel="stylesheet" type="text/css" href="@Model.Static("styles.css")"/>
+	<link rel="stylesheet preload" as="style" type="text/css" href="@Model.Static("styles.css")" crossorigin/>
+	@foreach (var fontFile in await FontPreloader.GetFontUrisAsync())
+	{
+		<link rel="preload" href="@fontFile" as="font" type="font/woff2" crossorigin>
+	}
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	@await RenderPartialAsync(_Favicon.Create())

--- a/src/Elastic.Markdown/Slices/Layout/_Head.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_Head.cshtml
@@ -2,11 +2,11 @@
 @using Elastic.Markdown.Helpers
 <head>
 	<title>@Model.Title</title>
-	<link rel="stylesheet preload" as="style" type="text/css" href="@Model.Static("styles.css")" crossorigin/>
 	@foreach (var fontFile in await FontPreloader.GetFontUrisAsync())
 	{
 		<link rel="preload" href="@fontFile" as="font" type="font/woff2" crossorigin>
 	}
+	<link rel="stylesheet preload" as="style" type="text/css" href="@Model.Static("styles.css")" crossorigin/>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	@await RenderPartialAsync(_Favicon.Create())


### PR DESCRIPTION
In order to preload fonts, a hint must be given to the browser in the form of a <link> tag:

`<link rel="preload" href="/path/to/font.woff2" as="font" type="font/woff2" crossorigin>`

This PR includes a cached repository for the font definitions in .css files so we don't need to worry about adding these if fonts change.

Handles https://github.com/elastic/docs-builder/issues/704