### PR TITLE
Restrict docset.yml configs that define toc.yml sections to ONLY link to sub toc.yml files

### DIFF
--- a/docs/_docset.yml
+++ b/docs/_docset.yml
@@ -1,5 +1,8 @@
 project: 'doc-builder'
 max_toc_depth: 2
+# indicates this documentation set is not linkable by assembler.
+# relaxes a few restrictions around toc building and file placement
+dev_docs: true
 cross_links:
   - docs-content
 exclude:

--- a/src/Elastic.Markdown/IO/Configuration/ConfigurationFile.cs
+++ b/src/Elastic.Markdown/IO/Configuration/ConfigurationFile.cs
@@ -51,7 +51,7 @@ public record ConfigurationFile : DocumentationFile
 	// TODO ensure project key is `docs-content`
 	private bool IsNarrativeDocs =>
 		_context.Configuration.Project is not null
-	    && _context.Configuration.Project.Equals("Elastic documentation", StringComparison.OrdinalIgnoreCase);
+		&& _context.Configuration.Project.Equals("Elastic documentation", StringComparison.OrdinalIgnoreCase);
 
 	public ConfigurationFile(BuildContext context)
 		: base(context.ConfigurationPath, context.DocumentationSourceDirectory)
@@ -157,6 +157,4 @@ public record ConfigurationFile : DocumentationFile
 
 		return list.AsReadOnly();
 	}
-
-
 }

--- a/src/Elastic.Markdown/IO/Configuration/ConfigurationFile.cs
+++ b/src/Elastic.Markdown/IO/Configuration/ConfigurationFile.cs
@@ -48,6 +48,11 @@ public record ConfigurationFile : DocumentationFile
 	/// Setting this to true relaxes a few restrictions such as mixing toc references with file and folder reference
 	public bool DevelopmentDocs { get; }
 
+	// TODO ensure project key is `docs-content`
+	private bool IsNarrativeDocs =>
+		_context.Configuration.Project is not null
+	    && _context.Configuration.Project.Equals("Elastic documentation", StringComparison.OrdinalIgnoreCase);
+
 	public ConfigurationFile(BuildContext context)
 		: base(context.ConfigurationPath, context.DocumentationSourceDirectory)
 	{
@@ -120,7 +125,7 @@ public record ConfigurationFile : DocumentationFile
 						var toc = new TableOfContentsConfiguration(this, _context, 0, "");
 						var children = toc.ReadChildren(reader, entry.Entry);
 						var tocEntries = children.OfType<TocReference>().ToArray();
-						if (!DevelopmentDocs && tocEntries.Length > 0 && children.Count != tocEntries.Length)
+						if (!DevelopmentDocs && !IsNarrativeDocs && tocEntries.Length > 0 && children.Count != tocEntries.Length)
 							reader.EmitError("toc links to other toc sections it may only contain other toc references", entry.Key);
 						TableOfContents = children;
 						Files = toc.Files; //side-effect ripe for refactor

--- a/src/Elastic.Markdown/IO/Configuration/ConfigurationFile.cs
+++ b/src/Elastic.Markdown/IO/Configuration/ConfigurationFile.cs
@@ -50,8 +50,8 @@ public record ConfigurationFile : DocumentationFile
 
 	// TODO ensure project key is `docs-content`
 	private bool IsNarrativeDocs =>
-		_context.Configuration.Project is not null
-		&& _context.Configuration.Project.Equals("Elastic documentation", StringComparison.OrdinalIgnoreCase);
+		Project is not null
+		&& Project.Equals("Elastic documentation", StringComparison.OrdinalIgnoreCase);
 
 	public ConfigurationFile(BuildContext context)
 		: base(context.ConfigurationPath, context.DocumentationSourceDirectory)

--- a/src/Elastic.Markdown/IO/Configuration/ITocItem.cs
+++ b/src/Elastic.Markdown/IO/Configuration/ITocItem.cs
@@ -9,3 +9,5 @@ public interface ITocItem;
 public record FileReference(string Path, bool Found, bool Hidden, IReadOnlyCollection<ITocItem> Children) : ITocItem;
 
 public record FolderReference(string Path, bool Found, bool InNav, IReadOnlyCollection<ITocItem> Children) : ITocItem;
+
+public record TocReference(string Path, bool Found, bool InNav, IReadOnlyCollection<ITocItem> Children) : FolderReference(Path, Found, InNav, Children);

--- a/src/Elastic.Markdown/IO/Configuration/TableOfContentsConfiguration.cs
+++ b/src/Elastic.Markdown/IO/Configuration/TableOfContentsConfiguration.cs
@@ -112,7 +112,7 @@ public record TableOfContentsConfiguration
 			foreach (var f in toc.Files)
 				_ = Files.Add(f);
 
-			return [new FolderReference($"{parentPath}".TrimStart(Path.DirectorySeparatorChar), folderFound, inNav, toc.TableOfContents)];
+			return [new TocReference($"{parentPath}".TrimStart(Path.DirectorySeparatorChar), folderFound, inNav, toc.TableOfContents)];
 		}
 
 		if (file is not null)


### PR DESCRIPTION
This introduces a restriction so that if a `docset.yml` file links to a `toc.yml` file it may ONLY link to `toc.yml` files. 

This to ensure all folders can be `homed` by the assembler `navigation.yml`.

e.g [elasticsearch's `docset.yml`](https://github.com/elastic/elasticsearch/blob/main/docs/docset.yml#L24-L27) defines:

```yaml
toc:
  - toc: reference
  - toc: release-notes
  - toc: extend
```

and the `navigation.yml` injects them in various places using `elasticsearch://reference` 

There is no valid home for any files that might be placed at the root e.g: `elasticsearch://` 
this PR prevents people from adding such `file` and `folder` references.


This also introduces `dev_docs` configuration for documentation sets that never intend to publish through assembler like our `docs-builder` docs. 

Enabling this relaxes this new `toc` only restriction. 


cc @colleenmcginnis 


