### PR TITLE
Add files_separator input to changed-files action

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -64,6 +64,7 @@ jobs:
         uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46.0.1
         with:
           files: ${{ inputs.path-pattern != '' && inputs.path-pattern || '**' }}
+          files_separator: ','
           
       - name: Checkout
         if: startsWith(github.event_name, 'pull_request') && steps.check-files.outputs.any_modified == 'true'


### PR DESCRIPTION
The `files_separator` parameter has been added to the `changed-files` action in the preview-build workflow. This update allows for specifying a custom separator for file paths, ensuring better handling of complex path patterns.

This allows people to listen to more then one folder.

Detection rules need this because they need to listen to `docs` as well as the source directories `rules` and `rules_building_block`
