### PR TITLE
Fix pages navigation appearance

### DIFF
--- a/src/Elastic.Markdown/Slices/Layout/_TocTree.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_TocTree.cshtml
@@ -60,7 +60,6 @@
 			Level = Model.Tree.Depth,
 			SubTree = Model.Tree,
 			RootNavigationId = Model.Tree.Id,
-			IsRoot = Model.IsRoot
 		}))
 	</ul>
 </div>

--- a/src/Elastic.Markdown/Slices/Layout/_TocTreeNav.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_TocTreeNav.cshtml
@@ -2,8 +2,8 @@
 @using Elastic.Markdown.IO.Navigation
 @inherits RazorSlice<NavigationTreeItem>
 @{
-	var topLevelGroup = Model.IsRoot ? 1 : 2;
-	var topLevelFile = Model.IsRoot ? 0 : 1;
+	var topLevelGroup = Model.IsPrimaryNavEnabled ? 2 : 1;
+	var topLevelFile = Model.IsPrimaryNavEnabled ? 1 : 0;
 }
 @foreach (var item in Model.SubTree.NavigationItems)
 {
@@ -66,7 +66,6 @@
 						IsPrimaryNavEnabled = Model.IsPrimaryNavEnabled,
 						Level = g.Depth,
 						SubTree = g,
-						IsRoot = Model.IsRoot,
 						RootNavigationId = Model.RootNavigationId
 					}))
 				</ul>

--- a/src/Elastic.Markdown/Slices/_ViewModels.cs
+++ b/src/Elastic.Markdown/Slices/_ViewModels.cs
@@ -96,9 +96,7 @@ public class NavigationViewModel
 	public required string TitleUrl { get; init; }
 	public required INavigation Tree { get; init; }
 	//public required MarkdownFile CurrentDocument { get; init; }
-	public required bool IsRoot { get; init; }
 	public required bool IsPrimaryNavEnabled { get; init; }
-
 	public required IEnumerable<GroupNavigation> TopLevelItems { get; init; }
 }
 
@@ -107,7 +105,6 @@ public class NavigationTreeItem
 	public required int Level { get; init; }
 	//public required MarkdownFile CurrentDocument { get; init; }
 	public required INavigation SubTree { get; init; }
-	public required bool IsRoot { get; init; }
 	public required bool IsPrimaryNavEnabled { get; init; }
 	public required string RootNavigationId { get; set; }
 }


### PR DESCRIPTION
## Context

The appearance of the pages navigation is broken.

<img width="720" alt="image" src="https://github.com/user-attachments/assets/4f3dbef3-9250-4d77-8567-f92575f60da9" />

## Changes

This determines correctly if the navigation is the overall root navigation, which is needed to determine the styling based on the depth of a `FileNavigation` or `GroupNavigation`.

