### PR TITLE
Refactor to use `WorkingDirectoryRoot` over `Root`.

### DIFF
--- a/src/Elastic.Markdown/BuildContext.cs
+++ b/src/Elastic.Markdown/BuildContext.cs
@@ -16,10 +16,11 @@ public record BuildContext
 	public IFileSystem ReadFileSystem { get; }
 	public IFileSystem WriteFileSystem { get; }
 
+	public IDirectoryInfo? DocumentationCheckoutDirectory { get; }
 	public IDirectoryInfo DocumentationSourceDirectory { get; }
 	public IDirectoryInfo DocumentationOutputDirectory { get; }
 
-	public ConfigurationFile Configuration { get; set; }
+	public ConfigurationFile Configuration { get; }
 
 	public IFileInfo ConfigurationPath { get; }
 
@@ -61,19 +62,21 @@ public record BuildContext
 
 		var rootFolder = !string.IsNullOrWhiteSpace(source)
 			? ReadFileSystem.DirectoryInfo.New(source)
-			: ReadFileSystem.DirectoryInfo.New(Path.Combine(Paths.Root.FullName));
+			: ReadFileSystem.DirectoryInfo.New(Path.Combine(Paths.WorkingDirectoryRoot.FullName));
 
 		(DocumentationSourceDirectory, ConfigurationPath) = FindDocsFolderFromRoot(rootFolder);
 
+		DocumentationCheckoutDirectory = Paths.DetermineSourceDirectoryRoot(DocumentationSourceDirectory);
+
 		DocumentationOutputDirectory = !string.IsNullOrWhiteSpace(output)
 			? WriteFileSystem.DirectoryInfo.New(output)
-			: WriteFileSystem.DirectoryInfo.New(Path.Combine(Paths.Root.FullName, Path.Combine(".artifacts", "docs", "html")));
+			: WriteFileSystem.DirectoryInfo.New(Path.Combine(Paths.WorkingDirectoryRoot.FullName, Path.Combine(".artifacts", "docs", "html")));
 
 		if (ConfigurationPath.FullName != DocumentationSourceDirectory.FullName)
 			DocumentationSourceDirectory = ConfigurationPath.Directory!;
 
 
-		Git = GitCheckoutInformation.Create(DocumentationSourceDirectory, ReadFileSystem);
+		Git = GitCheckoutInformation.Create(DocumentationCheckoutDirectory, ReadFileSystem);
 		Configuration = new ConfigurationFile(this);
 	}
 

--- a/src/Elastic.Markdown/IO/Discovery/GitCheckoutInformation.cs
+++ b/src/Elastic.Markdown/IO/Discovery/GitCheckoutInformation.cs
@@ -11,7 +11,7 @@ namespace Elastic.Markdown.IO.Discovery;
 
 public record GitCheckoutInformation
 {
-	private static GitCheckoutInformation Unavailable { get; } = new()
+	public static GitCheckoutInformation Unavailable { get; } = new()
 	{
 		Branch = "unavailable",
 		Remote = "unavailable",
@@ -32,8 +32,11 @@ public record GitCheckoutInformation
 	public string? RepositoryName { get; init; }
 
 	// manual read because libgit2sharp is not yet AOT ready
-	public static GitCheckoutInformation Create(IDirectoryInfo source, IFileSystem fileSystem, ILogger? logger = null)
+	public static GitCheckoutInformation Create(IDirectoryInfo? source, IFileSystem fileSystem, ILogger? logger = null)
 	{
+		if (source is null)
+			return Unavailable;
+
 		if (fileSystem is not FileSystem)
 		{
 			return new GitCheckoutInformation

--- a/src/Elastic.Markdown/IO/DocumentationSet.cs
+++ b/src/Elastic.Markdown/IO/DocumentationSet.cs
@@ -41,8 +41,6 @@ public class DocumentationSet : INavigationLookups
 	public IDirectoryInfo SourceDirectory { get; }
 	public IDirectoryInfo OutputDirectory { get; }
 
-	public string RelativeSourcePath { get; }
-
 	public DateTimeOffset LastWrite { get; }
 
 	public ConfigurationFile Configuration { get; }
@@ -68,7 +66,6 @@ public class DocumentationSet : INavigationLookups
 		Build = build;
 		SourceDirectory = build.DocumentationSourceDirectory;
 		OutputDirectory = build.DocumentationOutputDirectory;
-		RelativeSourcePath = Path.GetRelativePath(Paths.Root.FullName, SourceDirectory.FullName);
 		LinkResolver =
 			linkResolver ?? new CrossLinkResolver(new ConfigurationCrossLinkFetcher(build.Configuration, logger));
 		Configuration = build.Configuration;

--- a/src/Elastic.Markdown/IO/Paths.cs
+++ b/src/Elastic.Markdown/IO/Paths.cs
@@ -1,21 +1,34 @@
 // Licensed to Elasticsearch B.V under one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions;
+
 namespace Elastic.Markdown.IO;
 
 public static class Paths
 {
-	public static readonly DirectoryInfo Root = RootDirectoryInfo();
+	public static readonly DirectoryInfo WorkingDirectoryRoot = DetermineWorkingDirectoryRoot();
 
 	public static readonly DirectoryInfo ApplicationData = GetApplicationFolder();
 
-	private static DirectoryInfo RootDirectoryInfo()
+	private static DirectoryInfo DetermineWorkingDirectoryRoot()
 	{
 		var directory = new DirectoryInfo(Directory.GetCurrentDirectory());
 		while (directory != null &&
 			   (directory.GetFiles("*.sln").Length == 0 || directory.GetDirectories(".git").Length == 0))
 			directory = directory.Parent;
 		return directory ?? new DirectoryInfo(Directory.GetCurrentDirectory());
+	}
+
+	public static IDirectoryInfo? DetermineSourceDirectoryRoot(IDirectoryInfo sourceDirectory)
+	{
+		IDirectoryInfo? sourceRoot = null;
+		var directory = sourceDirectory;
+		while (directory != null && directory.GetDirectories(".git").Length == 0)
+			directory = directory.Parent;
+		sourceRoot ??= directory;
+		return sourceRoot;
 	}
 
 	/// Used in debug to locate static folder so we can change js/css files while the server is running

--- a/src/Elastic.Markdown/InboundLinks/LinkIndexLinkChecker.cs
+++ b/src/Elastic.Markdown/InboundLinks/LinkIndexLinkChecker.cs
@@ -63,7 +63,7 @@ public class LinkIndexLinkChecker(ILoggerFactory logger)
 		_logger.LogInformation("Checking '{Repository}' with local '{LocalLinksJson}'", repository, localLinksJson);
 
 		if (!Path.IsPathRooted(localLinksJson))
-			localLinksJson = Path.Combine(Paths.Root.FullName, localLinksJson);
+			localLinksJson = Path.Combine(Paths.WorkingDirectoryRoot.FullName, localLinksJson);
 
 		try
 		{

--- a/src/Elastic.Markdown/Slices/HtmlWriter.cs
+++ b/src/Elastic.Markdown/Slices/HtmlWriter.cs
@@ -5,6 +5,7 @@
 using System.Collections.Concurrent;
 using System.IO.Abstractions;
 using Elastic.Markdown.IO;
+using Elastic.Markdown.IO.Discovery;
 using Elastic.Markdown.IO.Navigation;
 using Markdig.Syntax;
 using RazorSlices;
@@ -63,7 +64,11 @@ public class IsolatedBuildNavigationHtmlWriter(DocumentationSet set) : INavigati
 	}
 }
 
-public class HtmlWriter(DocumentationSet documentationSet, IFileSystem writeFileSystem, IDescriptionGenerator descriptionGenerator, INavigationHtmlWriter? navigationHtmlWriter = null)
+public class HtmlWriter(
+	DocumentationSet documentationSet,
+	IFileSystem writeFileSystem,
+	IDescriptionGenerator descriptionGenerator,
+	INavigationHtmlWriter? navigationHtmlWriter = null)
 {
 	private DocumentationSet DocumentationSet { get; } = documentationSet;
 	public INavigationHtmlWriter NavigationHtmlWriter { get; } = navigationHtmlWriter ?? new IsolatedBuildNavigationHtmlWriter(documentationSet);
@@ -88,8 +93,14 @@ public class HtmlWriter(DocumentationSet documentationSet, IFileSystem writeFile
 
 		var remote = DocumentationSet.Build.Git.RepositoryName;
 		var branch = DocumentationSet.Build.Git.Branch;
-		var path = Path.Combine(DocumentationSet.RelativeSourcePath, markdown.RelativePath);
-		var editUrl = $"https://github.com/elastic/{remote}/edit/{branch}/{path}";
+		string? editUrl = null;
+		if (DocumentationSet.Build.Git != GitCheckoutInformation.Unavailable && DocumentationSet.Build.DocumentationCheckoutDirectory is { } checkoutDirectory)
+		{
+			var relativeSourcePath = Path.GetRelativePath(checkoutDirectory.FullName, DocumentationSet.Build.DocumentationSourceDirectory.FullName);
+			var path = Path.Combine(relativeSourcePath, markdown.RelativePath);
+			editUrl = $"https://github.com/elastic/{remote}/edit/{branch}/{path}";
+		}
+
 		var slice = Index.Create(new IndexViewModel
 		{
 			Title = markdown.Title ?? "[TITLE NOT SET]",

--- a/src/docs-assembler/AssembleContext.cs
+++ b/src/docs-assembler/AssembleContext.cs
@@ -44,7 +44,7 @@ public class AssembleContext
 		ReadFileSystem = readFileSystem;
 		WriteFileSystem = writeFileSystem;
 
-		var configPath = Path.Combine(Paths.Root.FullName, "src", "docs-assembler", "assembler.yml");
+		var configPath = Path.Combine(Paths.WorkingDirectoryRoot.FullName, "src", "docs-assembler", "assembler.yml");
 		// temporarily fallback to embedded assembler.yml
 		// This will live in docs-content soon
 		if (!ReadFileSystem.File.Exists(configPath))
@@ -52,7 +52,7 @@ public class AssembleContext
 		ConfigurationPath = ReadFileSystem.FileInfo.New(configPath);
 		Configuration = AssemblyConfiguration.Deserialize(ReadFileSystem.File.ReadAllText(ConfigurationPath.FullName));
 
-		var navigationPath = Path.Combine(Paths.Root.FullName, "src", "docs-assembler", "navigation.yml");
+		var navigationPath = Path.Combine(Paths.WorkingDirectoryRoot.FullName, "src", "docs-assembler", "navigation.yml");
 		if (!ReadFileSystem.File.Exists(navigationPath))
 			ExtractAssemblerConfiguration(navigationPath);
 		NavigationPath = ReadFileSystem.FileInfo.New(navigationPath);

--- a/src/docs-assembler/Cli/InboundLinkCommands.cs
+++ b/src/docs-assembler/Cli/InboundLinkCommands.cs
@@ -45,7 +45,7 @@ internal sealed class InboundLinkCommands(ILoggerFactory logger, ICoreService gi
 	{
 		AssignOutputLogger();
 		var fs = new FileSystem();
-		var root = fs.DirectoryInfo.New(Paths.Root.FullName);
+		var root = fs.DirectoryInfo.New(Paths.WorkingDirectoryRoot.FullName);
 		if (from == null && to == null)
 		{
 			from ??= GitCheckoutInformation.Create(root, new FileSystem(), logger.CreateLogger(nameof(GitCheckoutInformation))).RepositoryName;
@@ -67,7 +67,7 @@ internal sealed class InboundLinkCommands(ILoggerFactory logger, ICoreService gi
 		AssignOutputLogger();
 		file ??= ".artifacts/docs/html/links.json";
 		var fs = new FileSystem();
-		var root = fs.DirectoryInfo.New(Paths.Root.FullName);
+		var root = fs.DirectoryInfo.New(Paths.WorkingDirectoryRoot.FullName);
 		var repository = GitCheckoutInformation.Create(root, new FileSystem(), logger.CreateLogger(nameof(GitCheckoutInformation))).RepositoryName
 						?? throw new Exception("Unable to determine repository name");
 

--- a/src/docs-assembler/Sourcing/RepositorySourcesFetcher.cs
+++ b/src/docs-assembler/Sourcing/RepositorySourcesFetcher.cs
@@ -74,7 +74,7 @@ public class RepositoryCheckoutProvider(ILoggerFactory logger, AssembleContext c
 	{
 		var fs = context.ReadFileSystem;
 		var checkoutFolder = fs.DirectoryInfo.New(Path.Combine(context.CheckoutDirectory.FullName, name));
-		var relativePath = Path.GetRelativePath(Paths.Root.FullName, checkoutFolder.FullName);
+		var relativePath = Path.GetRelativePath(Paths.WorkingDirectoryRoot.FullName, checkoutFolder.FullName);
 		var sw = Stopwatch.StartNew();
 		_ = dict.AddOrUpdate(name, sw, (_, _) => sw);
 		var head = string.Empty;

--- a/src/docs-builder/Cli/Commands.cs
+++ b/src/docs-builder/Cli/Commands.cs
@@ -124,7 +124,7 @@ internal sealed class Commands(ILoggerFactory logger, ICoreService githubActions
 		{
 			var outputDirectory = !string.IsNullOrWhiteSpace(output)
 				? fileSystem.DirectoryInfo.New(output)
-				: fileSystem.DirectoryInfo.New(Path.Combine(Paths.Root.FullName, ".artifacts/docs/html"));
+				: fileSystem.DirectoryInfo.New(Path.Combine(Paths.WorkingDirectoryRoot.FullName, ".artifacts/docs/html"));
 			// we temporarily do not error when pointed to a non documentation folder.
 			_ = fileSystem.Directory.CreateDirectory(outputDirectory.FullName);
 

--- a/src/docs-builder/Cli/InboundLinkCommands.cs
+++ b/src/docs-builder/Cli/InboundLinkCommands.cs
@@ -50,7 +50,7 @@ internal sealed class InboundLinkCommands(ILoggerFactory logger, ICoreService gi
 	{
 		AssignOutputLogger();
 		var fs = new FileSystem();
-		var root = fs.DirectoryInfo.New(Paths.Root.FullName);
+		var root = fs.DirectoryInfo.New(Paths.WorkingDirectoryRoot.FullName);
 		if (from == null && to == null)
 		{
 			from ??= GitCheckoutInformation.Create(root, new FileSystem(), logger.CreateLogger(nameof(GitCheckoutInformation))).RepositoryName;
@@ -74,7 +74,7 @@ internal sealed class InboundLinkCommands(ILoggerFactory logger, ICoreService gi
 		AssignOutputLogger();
 		file ??= ".artifacts/docs/html/links.json";
 		var fs = new FileSystem();
-		var root = fs.DirectoryInfo.New(Paths.Root.FullName);
+		var root = fs.DirectoryInfo.New(Paths.WorkingDirectoryRoot.FullName);
 		var repository = GitCheckoutInformation.Create(root, new FileSystem(), logger.CreateLogger(nameof(GitCheckoutInformation))).RepositoryName
 						?? throw new Exception("Unable to determine repository name");
 

--- a/src/docs-builder/Http/ParcelWatchService.cs
+++ b/src/docs-builder/Http/ParcelWatchService.cs
@@ -22,7 +22,7 @@ public class ParcelWatchService : IHostedService
 			RedirectStandardError = true,
 			UseShellExecute = false,
 			CreateNoWindow = true,
-			WorkingDirectory = Path.Combine(Paths.Root.FullName, "src", "Elastic.Markdown")
+			WorkingDirectory = Path.Combine(Paths.WorkingDirectoryRoot.FullName, "src", "Elastic.Markdown")
 		})!;
 
 		_process.EnableRaisingEvents = true;

--- a/src/docs-builder/Http/StaticWebHost.cs
+++ b/src/docs-builder/Http/StaticWebHost.cs
@@ -60,7 +60,7 @@ public class StaticWebHost
 			return Results.NotFound();
 
 		await Task.CompletedTask;
-		var path = Path.Combine(Paths.Root.FullName, ".artifacts", "assembly");
+		var path = Path.Combine(Paths.WorkingDirectoryRoot.FullName, ".artifacts", "assembly");
 		var localPath = Path.Combine(path, slug.Replace('/', Path.DirectorySeparatorChar));
 		var fileInfo = new FileInfo(localPath);
 		var directoryInfo = new DirectoryInfo(localPath);

--- a/tests/Elastic.Markdown.Tests/Directives/DirectiveBaseTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/DirectiveBaseTests.cs
@@ -57,13 +57,13 @@ $"""
 			{ "docs/index.md", new MockFileData(documentContents) }
 		}, new MockFileSystemOptions
 		{
-			CurrentDirectory = Paths.Root.FullName
+			CurrentDirectory = Paths.WorkingDirectoryRoot.FullName
 		});
 		// ReSharper disable once VirtualMemberCallInConstructor
 		// nasty but sub implementations won't use class state.
 		AddToFileSystem(FileSystem);
 
-		var root = FileSystem.DirectoryInfo.New(Path.Combine(Paths.Root.FullName, "docs/"));
+		var root = FileSystem.DirectoryInfo.New(Path.Combine(Paths.WorkingDirectoryRoot.FullName, "docs/"));
 		FileSystem.GenerateDocSetYaml(root);
 
 		Collector = new TestDiagnosticsCollector(output);

--- a/tests/Elastic.Markdown.Tests/DocSet/LinkReferenceTests.cs
+++ b/tests/Elastic.Markdown.Tests/DocSet/LinkReferenceTests.cs
@@ -34,7 +34,7 @@ public class GitCheckoutInformationTests(ITestOutputHelper output) : NavigationT
 	[Fact]
 	public void Create()
 	{
-		var root = ReadFileSystem.DirectoryInfo.New(Paths.Root.FullName);
+		var root = ReadFileSystem.DirectoryInfo.New(Paths.WorkingDirectoryRoot.FullName);
 		var git = GitCheckoutInformation.Create(root, ReadFileSystem, LoggerFactory.CreateLogger(nameof(GitCheckoutInformation)));
 
 		git.Should().NotBeNull();

--- a/tests/Elastic.Markdown.Tests/DocSet/NavigationTestsBase.cs
+++ b/tests/Elastic.Markdown.Tests/DocSet/NavigationTestsBase.cs
@@ -19,7 +19,7 @@ public class NavigationTestsBase : IAsyncLifetime
 		ReadFileSystem = new FileSystem(); //use real IO to read docs.
 		WriteFileSystem = new MockFileSystem(new MockFileSystemOptions //use in memory mock fs to test generation
 		{
-			CurrentDirectory = Paths.Root.FullName
+			CurrentDirectory = Paths.WorkingDirectoryRoot.FullName
 		});
 		var collector = new TestDiagnosticsCollector(output);
 		var context = new BuildContext(collector, ReadFileSystem, WriteFileSystem)

--- a/tests/Elastic.Markdown.Tests/Inline/InlneBaseTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/InlneBaseTests.cs
@@ -99,14 +99,14 @@ $"""
 			{ "docs/index.md", new MockFileData(documentContents) }
 		}, new MockFileSystemOptions
 		{
-			CurrentDirectory = Paths.Root.FullName,
+			CurrentDirectory = Paths.WorkingDirectoryRoot.FullName,
 		});
 		// ReSharper disable once VirtualMemberCallInConstructor
 		// nasty but sub implementations won't use class state.
 		AddToFileSystem(FileSystem);
 		var baseRootPath = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-		 ? Paths.Root.FullName.Replace('\\', '/')
-		 : Paths.Root.FullName;
+		 ? Paths.WorkingDirectoryRoot.FullName.Replace('\\', '/')
+		 : Paths.WorkingDirectoryRoot.FullName;
 		var root = FileSystem.DirectoryInfo.New($"{baseRootPath}/docs/");
 		FileSystem.GenerateDocSetYaml(root, globalVariables);
 

--- a/tests/Elastic.Markdown.Tests/OutputDirectoryTests.cs
+++ b/tests/Elastic.Markdown.Tests/OutputDirectoryTests.cs
@@ -25,7 +25,7 @@ toc:
 			{ "docs/index.md", new MockFileData("test") }
 		}, new MockFileSystemOptions
 		{
-			CurrentDirectory = Paths.Root.FullName
+			CurrentDirectory = Paths.WorkingDirectoryRoot.FullName
 		});
 		var context = new BuildContext(fileSystem);
 		var linkResolver = new TestCrossLinkResolver();

--- a/tests/Elastic.Markdown.Tests/SettingsInclusion/IncludeTests.cs
+++ b/tests/Elastic.Markdown.Tests/SettingsInclusion/IncludeTests.cs
@@ -23,7 +23,7 @@ $$"""
 
 	protected override void AddToFileSystem(MockFileSystem fileSystem)
 	{
-		var realSettingsPath = Path.Combine(Paths.Root.FullName, SettingsPath);
+		var realSettingsPath = Path.Combine(Paths.WorkingDirectoryRoot.FullName, SettingsPath);
 		// language=markdown
 		var inclusion = System.IO.File.ReadAllText(realSettingsPath);
 		fileSystem.AddFile(SettingsPath, inclusion);

--- a/tests/authoring/Framework/Setup.fs
+++ b/tests/authoring/Framework/Setup.fs
@@ -42,7 +42,7 @@ type Setup =
         fileSystem: MockFileSystem,
         globalVariables: Dictionary<string, string> option
     ) =
-        let root = fileSystem.DirectoryInfo.New(Path.Combine(Paths.Root.FullName, "docs/"));
+        let root = fileSystem.DirectoryInfo.New(Path.Combine(Paths.WorkingDirectoryRoot.FullName, "docs/"));
         let yaml = new StringWriter();
         yaml.WriteLine("cross_links:");
         yaml.WriteLine("  - docs-content");
@@ -91,7 +91,7 @@ type Setup =
                 )
                 |> Map.ofSeq
 
-        let opts = MockFileSystemOptions(CurrentDirectory=Paths.Root.FullName)
+        let opts = MockFileSystemOptions(CurrentDirectory=Paths.WorkingDirectoryRoot.FullName)
         let fileSystem = MockFileSystem(d, opts)
 
         GenerateDocSetYaml (fileSystem, None)

--- a/tests/authoring/Generator/LinkReferenceFile.fs
+++ b/tests/authoring/Generator/LinkReferenceFile.fs
@@ -56,10 +56,10 @@ Through various means $$$including-this-inline-syntax$$$
     let ``validate links.json`` () =
         generator |> convertsToJson ".artifacts/docs/html/links.json" """{
          "origin": {
-           "branch": "test-e35fcb27-5f60-4e",
-           "remote": "elastic/docs-builder",
-           "ref": "e35fcb27-5f60-4e",
-           "name": "docs-builder"
+           "branch": "unavailable",
+           "remote": "unavailable",
+           "ref": "unavailable",
+           "name": "unavailable"
          },
          "url_path_prefix": "",
          "links": {


### PR DESCRIPTION
Replaced references to `Paths.Root` with `Paths.WorkingDirectoryRoot` across the project to improve clarity and alignment with current working directory semantics. Adjusted related logic to handle directory determination and path relations more effectively.

Introduced `BuildContext.DocumentationCheckoutDirectory?` to centrally determine the checkout folder.
