### PR TITLE
Add support for custom GitCheckoutInformation in BuildContext

### DIFF
--- a/src/Elastic.Markdown/BuildContext.cs
+++ b/src/Elastic.Markdown/BuildContext.cs
@@ -51,10 +51,14 @@ public record BuildContext
 	public BuildContext(DiagnosticsCollector collector, IFileSystem fileSystem)
 		: this(collector, fileSystem, fileSystem, null, null) { }
 
-	public BuildContext(DiagnosticsCollector collector, IFileSystem readFileSystem, IFileSystem writeFileSystem)
-		: this(collector, readFileSystem, writeFileSystem, null, null) { }
-
-	public BuildContext(DiagnosticsCollector collector, IFileSystem readFileSystem, IFileSystem writeFileSystem, string? source, string? output)
+	public BuildContext(
+		DiagnosticsCollector collector,
+		IFileSystem readFileSystem,
+		IFileSystem writeFileSystem,
+		string? source = null,
+		string? output = null,
+		GitCheckoutInformation? gitCheckoutInformation = null
+	)
 	{
 		Collector = collector;
 		ReadFileSystem = readFileSystem;
@@ -75,8 +79,7 @@ public record BuildContext
 		if (ConfigurationPath.FullName != DocumentationSourceDirectory.FullName)
 			DocumentationSourceDirectory = ConfigurationPath.Directory!;
 
-
-		Git = GitCheckoutInformation.Create(DocumentationCheckoutDirectory, ReadFileSystem);
+		Git = gitCheckoutInformation ?? GitCheckoutInformation.Create(DocumentationCheckoutDirectory, ReadFileSystem);
 		Configuration = new ConfigurationFile(this);
 	}
 

--- a/src/Elastic.Markdown/IO/Discovery/GitCheckoutInformation.cs
+++ b/src/Elastic.Markdown/IO/Discovery/GitCheckoutInformation.cs
@@ -29,7 +29,7 @@ public record GitCheckoutInformation
 	public required string Ref { get; init; }
 
 	[JsonPropertyName("name")]
-	public string? RepositoryName { get; init; }
+	public string RepositoryName { get; init; } = "unavailable";
 
 	// manual read because libgit2sharp is not yet AOT ready
 	public static GitCheckoutInformation Create(IDirectoryInfo? source, IFileSystem fileSystem, ILogger? logger = null)
@@ -52,12 +52,8 @@ public record GitCheckoutInformation
 		var gitConfig = Git(source, Path.Combine(".git", "config"));
 		if (!gitConfig.Exists)
 		{
-			gitConfig = Git(source, Path.Combine("..", ".git", "config"));
-			if (!gitConfig.Exists)
-			{
-				logger?.LogInformation("Git checkout information not available.");
-				return Unavailable;
-			}
+			logger?.LogInformation("Git checkout information not available.");
+			return Unavailable;
 		}
 
 		var head = Read(source, Path.Combine(".git", "HEAD")) ?? fakeRef;

--- a/src/Elastic.Markdown/IO/DocumentationSet.cs
+++ b/src/Elastic.Markdown/IO/DocumentationSet.cs
@@ -77,7 +77,7 @@ public class DocumentationSet : INavigationLookups
 		};
 		MarkdownParser = new MarkdownParser(build, resolver);
 
-		Name = Build.Git.RepositoryName ?? "unavailable";
+		Name = Build.Git.RepositoryName ?? Build.DocumentationCheckoutDirectory?.Name ?? "unavailable";
 		OutputStateFile = OutputDirectory.FileSystem.FileInfo.New(Path.Combine(OutputDirectory.FullName, ".doc.state"));
 		LinkReferenceFile = OutputDirectory.FileSystem.FileInfo.New(Path.Combine(OutputDirectory.FullName, "links.json"));
 

--- a/src/Elastic.Markdown/IO/DocumentationSet.cs
+++ b/src/Elastic.Markdown/IO/DocumentationSet.cs
@@ -77,7 +77,7 @@ public class DocumentationSet : INavigationLookups
 		};
 		MarkdownParser = new MarkdownParser(build, resolver);
 
-		Name = Build.Git.RepositoryName ?? Build.DocumentationCheckoutDirectory?.Name ?? "unavailable";
+		Name = Build.Git.RepositoryName;
 		OutputStateFile = OutputDirectory.FileSystem.FileInfo.New(Path.Combine(OutputDirectory.FullName, ".doc.state"));
 		LinkReferenceFile = OutputDirectory.FileSystem.FileInfo.New(Path.Combine(OutputDirectory.FullName, "links.json"));
 

--- a/src/Elastic.Markdown/IO/DocumentationSet.cs
+++ b/src/Elastic.Markdown/IO/DocumentationSet.cs
@@ -9,6 +9,7 @@ using Elastic.Markdown.CrossLinks;
 using Elastic.Markdown.Diagnostics;
 using Elastic.Markdown.Extensions;
 using Elastic.Markdown.IO.Configuration;
+using Elastic.Markdown.IO.Discovery;
 using Elastic.Markdown.IO.Navigation;
 using Elastic.Markdown.Myst;
 using Microsoft.Extensions.Logging;
@@ -77,7 +78,9 @@ public class DocumentationSet : INavigationLookups
 		};
 		MarkdownParser = new MarkdownParser(build, resolver);
 
-		Name = Build.Git.RepositoryName;
+		Name = Build.Git != GitCheckoutInformation.Unavailable
+			? Build.Git.RepositoryName
+			: Build.DocumentationCheckoutDirectory?.Name ?? $"unknown-{Build.DocumentationSourceDirectory.Name}";
 		OutputStateFile = OutputDirectory.FileSystem.FileInfo.New(Path.Combine(OutputDirectory.FullName, ".doc.state"));
 		LinkReferenceFile = OutputDirectory.FileSystem.FileInfo.New(Path.Combine(OutputDirectory.FullName, "links.json"));
 

--- a/src/docs-assembler/Building/AssemblerBuilder.cs
+++ b/src/docs-assembler/Building/AssemblerBuilder.cs
@@ -8,6 +8,7 @@ using Documentation.Assembler.Sourcing;
 using Elastic.Markdown;
 using Elastic.Markdown.CrossLinks;
 using Elastic.Markdown.IO;
+using Elastic.Markdown.IO.Discovery;
 using Microsoft.Extensions.Logging;
 
 namespace Documentation.Assembler.Building;
@@ -56,7 +57,15 @@ public class AssemblerBuilder(ILoggerFactory logger, AssembleContext context, Gl
 		var path = checkout.Directory.FullName;
 		var output = environment.PathPrefix != null ? Path.Combine(context.OutputDirectory.FullName, environment.PathPrefix) : context.OutputDirectory.FullName;
 
-		var buildContext = new BuildContext(context.Collector, context.ReadFileSystem, context.WriteFileSystem, path, output)
+		var gitConfiguration = new GitCheckoutInformation
+		{
+			RepositoryName = checkout.Repository.Name,
+			Ref = checkout.HeadReference,
+			Remote = $"elastic/${checkout.Repository.Name}",
+			Branch = checkout.Repository.CurrentBranch
+		};
+
+		var buildContext = new BuildContext(context.Collector, context.ReadFileSystem, context.WriteFileSystem, path, output, gitConfiguration)
 		{
 			UrlPathPrefix = environment.PathPrefix,
 			Force = false,

--- a/src/docs-assembler/Navigation/GlobalNavigation.cs
+++ b/src/docs-assembler/Navigation/GlobalNavigation.cs
@@ -97,7 +97,9 @@ public record GlobalNavigation : IDocumentationFileOutputProvider
 		var outputDirectory = documentationSet.OutputDirectory;
 		var fs = defaultOutputFile.FileSystem;
 
-		var l = $"{documentationSet.Name}://{relativePath.TrimStart('/')}";
+		var repositoryName = documentationSet.Build.Git.RepositoryName;
+
+		var l = $"{repositoryName}://{relativePath.TrimStart('/')}";
 		var lookup = l.AsSpan();
 		if (lookup.StartsWith("docs-content://serverless/", StringComparison.Ordinal))
 			return null;
@@ -136,7 +138,7 @@ public record GlobalNavigation : IDocumentationFileOutputProvider
 			if (relativePath.EndsWith(".asciidoc", StringComparison.Ordinal))
 				return null;
 
-			var fallBack = fs.Path.Combine(outputDirectory.FullName, "_failed", documentationSet.Name, relativePath);
+			var fallBack = fs.Path.Combine(outputDirectory.FullName, "_failed", repositoryName, relativePath);
 			_context.Collector.EmitError(_context.NavigationPath, $"No toc for output path: '{lookup}' falling back to: '{fallBack}'");
 			return fs.FileInfo.New(fallBack);
 		}


### PR DESCRIPTION
Introduced an optional parameter to pass a custom GitCheckoutInformation to BuildContext, reducing dependency on internal creation logic. Updated repository name handling and fallback mechanisms to ensure consistency and robustness. Simplified Git-related logging and error handling for better maintainability.
