### PR TITLE
Rename assembler environment from `production` to `prod`

### DIFF
--- a/src/docs-assembler/assembler.yml
+++ b/src/docs-assembler/assembler.yml
@@ -1,5 +1,5 @@
 environments:
-  production:
+  prod:
     uri: https://www.elastic.co
     path_prefix: docs
     allow_indexing: false

--- a/tests/docs-assembler.Tests/src/docs-assembler.Tests/GlobalNavigationTests.cs
+++ b/tests/docs-assembler.Tests/src/docs-assembler.Tests/GlobalNavigationTests.cs
@@ -51,7 +51,7 @@ public class GlobalNavigationTests
 		var checkouts = repos.Select(r => CreateCheckout(fs, r)).ToArray();
 		var globalNavigation = new GlobalNavigation(assembleContext, globalNavigationFile, checkouts);
 
-		var env = assembleContext.Configuration.Environments["production"];
+		var env = assembleContext.Configuration.Environments["prod"];
 		var uriResolver = new PublishEnvironmentUriResolver(globalNavigation, env);
 
 		// docs-content://reference/apm/something.md - url hasn't changed


### PR DESCRIPTION
To align with infra naming.
