### PR TITLE
Includes GITHUB_PR_REF_NAME as a job-level environment variable.

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -50,6 +50,8 @@ jobs:
       group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref }}
       cancel-in-progress: ${{ startsWith(github.event_name, 'pull_request') }}
     runs-on: ubuntu-latest
+    env:
+      GITHUB_PR_REF_NAME: ${{ github.event.pull_request.head.ref }}
     steps:
 
       - name: Checkout

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -117,7 +117,6 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
-          GITHUB_PR_REF_NAME: ${{ github.event.pull_request.head.ref }}
         run: |
           case "${GITHUB_EVENT_NAME}" in
             "merge_group" | "pull_request" | "pull_request_target")


### PR DESCRIPTION
This variable was not being propagated in the workflow, causing the branch reference to fallback to main.