### PR TITLE
Fix HTMX head changes

### DIFF
--- a/src/Elastic.Markdown/Slices/Layout/_Head.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_Head.cshtml
@@ -1,6 +1,6 @@
 @inherits RazorSlice<LayoutViewModel>
 @using Elastic.Markdown.Helpers
-<head>
+<head hx-head="merge">
 	<meta charset="utf-8">
 	<title>@Model.Title</title>
 	<meta name="description" content="@Model.Description">


### PR DESCRIPTION
## Changes

Add the missing `hx-head="merge"` attribute on the head tag. This will make sure the head tags are updated when navigating while using htmx links.

## Result

https://github.com/user-attachments/assets/afdf6c52-3e59-4bdf-842a-0d26f1680beb


