### PR TITLE
Allow extensions to inject IDocumentationFileExporter and control the relative path published in links.json

### DIFF
--- a/src/Elastic.Markdown/DocumentationGenerator.cs
+++ b/src/Elastic.Markdown/DocumentationGenerator.cs
@@ -28,6 +28,7 @@ public interface IDocumentationFileOutputProvider
 public class DocumentationGenerator
 {
 	private readonly IDocumentationFileOutputProvider? _documentationFileOutputProvider;
+	private readonly IConversionCollector? _conversionCollector;
 	private readonly ILogger _logger;
 	private readonly IFileSystem _writeFileSystem;
 	private readonly IDocumentationFileExporter _documentationFileExporter;
@@ -46,6 +47,7 @@ public class DocumentationGenerator
 	)
 	{
 		_documentationFileOutputProvider = documentationFileOutputProvider;
+		_conversionCollector = conversionCollector;
 		_writeFileSystem = docSet.Build.WriteFileSystem;
 		_logger = logger.CreateLogger(nameof(DocumentationGenerator));
 
@@ -55,7 +57,8 @@ public class DocumentationGenerator
 		HtmlWriter = new HtmlWriter(DocumentationSet, _writeFileSystem, new DescriptionGenerator());
 		_documentationFileExporter =
 			documentationExporter
-			?? new DocumentationFileExporter(docSet.Build.ReadFileSystem, _writeFileSystem, HtmlWriter, conversionCollector);
+			?? docSet.Build.Configuration.EnabledExtensions.FirstOrDefault(e => e.FileExporter != null)?.FileExporter
+			?? new DocumentationFileExporter(docSet.Build.ReadFileSystem, _writeFileSystem);
 
 		_logger.LogInformation("Created documentation set for: {DocumentationSetName}", DocumentationSet.Name);
 		_logger.LogInformation("Source directory: {SourcePath} Exists: {SourcePathExists}", docSet.SourceDirectory, docSet.SourceDirectory.Exists);
@@ -205,7 +208,7 @@ public class DocumentationGenerator
 		//TODO send file to OutputFile() so we can validate its scope is defined in navigation.yml
 		var outputFile = OutputFile(file.RelativePath);
 		if (outputFile is not null)
-			await _documentationFileExporter.ProcessFile(file, outputFile, token);
+			await _documentationFileExporter.ProcessFile(Context, file, outputFile, HtmlWriter, _conversionCollector, token);
 	}
 
 	private IFileInfo? OutputFile(string relativePath)

--- a/src/Elastic.Markdown/Exporters/DocumentationFileExporter.cs
+++ b/src/Elastic.Markdown/Exporters/DocumentationFileExporter.cs
@@ -13,7 +13,8 @@ public interface IDocumentationFileExporter
 	/// Used in documentation state to ensure we break the build cache if a different exporter is chosen
 	string Name { get; }
 
-	Task ProcessFile(DocumentationFile file, IFileInfo outputFile, Cancel token);
+	Task ProcessFile(BuildContext context, DocumentationFile file, IFileInfo outputFile, HtmlWriter htmlWriter, IConversionCollector? conversionCollector,
+		Cancel token);
 
 	Task CopyEmbeddedResource(IFileInfo outputFile, Stream resourceStream, Cancel ctx);
 }
@@ -21,7 +22,10 @@ public interface IDocumentationFileExporter
 public abstract class DocumentationFileExporterBase(IFileSystem readFileSystem, IFileSystem writeFileSystem) : IDocumentationFileExporter
 {
 	public abstract string Name { get; }
-	public abstract Task ProcessFile(DocumentationFile file, IFileInfo outputFile, Cancel token);
+
+	public abstract Task ProcessFile(BuildContext context, DocumentationFile file, IFileInfo outputFile, HtmlWriter htmlWriter,
+		IConversionCollector? conversionCollector,
+		Cancel token);
 
 	protected async Task CopyFileFsAware(DocumentationFile file, IFileInfo outputFile, Cancel ctx)
 	{
@@ -47,14 +51,16 @@ public abstract class DocumentationFileExporterBase(IFileSystem readFileSystem, 
 
 public class DocumentationFileExporter(
 	IFileSystem readFileSystem,
-	IFileSystem writeFileSystem,
-	HtmlWriter htmlWriter,
-	IConversionCollector? conversionCollector
+	IFileSystem writeFileSystem
 ) : DocumentationFileExporterBase(readFileSystem, writeFileSystem)
 {
 	public override string Name { get; } = nameof(DocumentationFileExporter);
 
-	public override async Task ProcessFile(DocumentationFile file, IFileInfo outputFile, Cancel token)
+	public override async Task ProcessFile(BuildContext context, DocumentationFile file,
+		IFileInfo outputFile,
+		HtmlWriter htmlWriter,
+		IConversionCollector? conversionCollector,
+		Cancel token)
 	{
 		if (file is MarkdownFile markdown)
 			await htmlWriter.WriteAsync(outputFile, markdown, conversionCollector, token);

--- a/src/Elastic.Markdown/Exporters/NoopDocumentationFileExporter.cs
+++ b/src/Elastic.Markdown/Exporters/NoopDocumentationFileExporter.cs
@@ -4,12 +4,17 @@
 
 using System.IO.Abstractions;
 using Elastic.Markdown.IO;
+using Elastic.Markdown.Slices;
 
 namespace Elastic.Markdown.Exporters;
 
 public class NoopDocumentationFileExporter : IDocumentationFileExporter
 {
 	public string Name { get; } = nameof(NoopDocumentationFileExporter);
-	public Task ProcessFile(DocumentationFile file, IFileInfo outputFile, Cancel token) => Task.CompletedTask;
+
+	public Task ProcessFile(BuildContext context, DocumentationFile file, IFileInfo outputFile, HtmlWriter htmlWriter,
+		IConversionCollector? conversionCollector, Cancel token) =>
+		Task.CompletedTask;
+
 	public Task CopyEmbeddedResource(IFileInfo outputFile, Stream resourceStream, Cancel ctx) => Task.CompletedTask;
 }

--- a/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRule.cs
+++ b/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRule.cs
@@ -61,7 +61,7 @@ public record DetectionRule
 	public required string Type { get; init; }
 	public required string? Language { get; init; }
 	public required string[]? Indices { get; init; }
-	public required string RunsEvery { get; init; }
+	public required string? RunsEvery { get; init; }
 	public required string? IndicesFromDateMath { get; init; }
 	public required string MaximumAlertsPerExecution { get; init; }
 	public required string[]? References { get; init; }
@@ -108,7 +108,7 @@ public record DetectionRule
 			Query = TryGetString(rule, "query"),
 			Note = TryGetString(rule, "note"),
 			Name = rule.GetString("name"),
-			RunsEvery = "?",
+			RunsEvery = TryGetString(rule, "interval"),
 			MaximumAlertsPerExecution = "?",
 			Version = "?",
 			Threats = threats

--- a/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRuleFile.cs
+++ b/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRuleFile.cs
@@ -69,85 +69,84 @@ public record DetectionRuleFile : MarkdownFile
 			return $"# {Title}";
 		// language=markdown
 		var markdown =
-			$"""
-			 # {Rule.Name}
+$"""
+# {Rule.Name}
 
-			 {Rule.Description}
+{Rule.Description}
 
-			 **Rule type**: {Rule.Type}
+**Rule type**: {Rule.Type}
 
-			 **Rule indices**: {RenderArray(Rule.Indices)}
+**Rule indices**: {RenderArray(Rule.Indices)}
 
-			 **Rule Severity**: {Rule.Severity}
+**Rule Severity**: {Rule.Severity}
 
-			 **Risk Score**: {Rule.RiskScore}
+**Risk Score**: {Rule.RiskScore}
 
-			 **Runs every**: {Rule.RunsEvery}
+**Runs every**: {Rule.RunsEvery}
 
-			 **Searches indices from**: `{Rule.IndicesFromDateMath}`
+**Searches indices from**: `{Rule.IndicesFromDateMath}`
 
-			 **Maximum alerts per execution**: {Rule.MaximumAlertsPerExecution}
+**Maximum alerts per execution**: {Rule.MaximumAlertsPerExecution}
 
-			 **References**: {RenderArray((Rule.References ?? []).Select(r => $"[{r}]({r})").ToArray())}
+**References**: {RenderArray((Rule.References ?? []).Select(r => $"[{r}]({r})").ToArray())}
 
-			 **Tags**: {RenderArray(Rule.Tags)}
+**Tags**: {RenderArray(Rule.Tags)}
 
-			 **Version**: {Rule.Version}
+**Version**: {Rule.Version}
 
-			 **Rule authors**: {RenderArray(Rule.Authors)}
+**Rule authors**: {RenderArray(Rule.Authors)}
 
-			 **Rule license**: {Rule.License}
-			 """;
+**Rule license**: {Rule.License}
+""";
 		// language=markdown
 		if (!string.IsNullOrWhiteSpace(Rule.Setup))
 		{
 			markdown +=
-				$"""
+$"""
 
-				  {Rule.Setup}
-				 """;
+ {Rule.Setup}
+""";
 		}
 
 		// language=markdown
 		if (!string.IsNullOrWhiteSpace(Rule.Note))
 		{
 			markdown +=
-				$"""
+$"""
 
-				  ## Investigation guide
+ ## Investigation guide
 
-				  {Rule.Note}
-				 """;
+ {Rule.Note}
+""";
 		}
-
 		// language=markdown
 		if (!string.IsNullOrWhiteSpace(Rule.Query))
 		{
 			markdown +=
-				$"""
+$"""
 
-				 ## Rule Query
+ ## Rule Query
 
-				 ```{Rule.Language ?? Rule.Type}
-				 {Rule.Query}
-				 ```
-				 """;
+ ```{Rule.Language ?? Rule.Type}
+ {Rule.Query}
+ ```
+ """;
 		}
 
 		foreach (var threat in Rule.Threats)
 		{
 			// language=markdown
 			markdown +=
-				$"""
+$"""
 
-				 **Framework:** {threat.Framework}
+**Framework:** {threat.Framework}
 
-				 * Tactic:
-				   * Name: {threat.Tactic.Name}
-				   * Id: {threat.Tactic.Id}
-				   * Reference URL: [{threat.Tactic.Reference}]({threat.Tactic.Reference})
+* Tactic:
+  * Name: {threat.Tactic.Name}
+  * Id: {threat.Tactic.Id}
+  * Reference URL: [{threat.Tactic.Reference}]({threat.Tactic.Reference})
 
-				 """;
+""";
 			foreach (var technique in threat.Techniques)
 			{
 				// language=markdown
@@ -156,19 +155,18 @@ public record DetectionRuleFile : MarkdownFile
 					markdown += TechniqueMarkdown(subTechnique, "Sub Technique");
 			}
 		}
-
 		return markdown;
 	}
 
 	private static string TechniqueMarkdown(DetectionRuleSubTechnique technique, string header) =>
-		$"""
+$"""
 
-		 * {header}:
-		   * Name: {technique.Name}
-		   * Id: {technique.Id}
-		   * Reference URL: [{technique.Reference}]({technique.Reference})
+* {header}:
+  * Name: {technique.Name}
+  * Id: {technique.Id}
+  * Reference URL: [{technique.Reference}]({technique.Reference})
 
-		 """;
+""";
 
 	private static string RenderArray(string[]? values)
 	{

--- a/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRulesDocsBuilderExtension.cs
+++ b/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRulesDocsBuilderExtension.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System.IO.Abstractions;
+using Elastic.Markdown.Exporters;
 using Elastic.Markdown.Helpers;
 using Elastic.Markdown.IO;
 using Elastic.Markdown.IO.Configuration;
@@ -15,6 +16,8 @@ public class DetectionRulesDocsBuilderExtension(BuildContext build) : IDocsBuild
 	private BuildContext Build { get; } = build;
 
 	public bool InjectsIntoNavigation(ITocItem tocItem) => false;
+
+	public IDocumentationFileExporter? FileExporter { get; } = new RuleDocumentationFileExporter(build.ReadFileSystem, build.WriteFileSystem);
 
 	public void CreateNavigationItem(
 		DocumentationGroup? parent,

--- a/src/Elastic.Markdown/Extensions/DetectionRules/RuleDocumentationFileExporter.cs
+++ b/src/Elastic.Markdown/Extensions/DetectionRules/RuleDocumentationFileExporter.cs
@@ -1,0 +1,31 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions;
+using Elastic.Markdown.Exporters;
+using Elastic.Markdown.IO;
+using Elastic.Markdown.Slices;
+
+namespace Elastic.Markdown.Extensions.DetectionRules;
+
+public class RuleDocumentationFileExporter(IFileSystem readFileSystem, IFileSystem writeFileSystem)
+	: DocumentationFileExporterBase(readFileSystem, writeFileSystem)
+{
+	public override string Name { get; } = nameof(RuleDocumentationFileExporter);
+
+	public override async Task ProcessFile(BuildContext context, DocumentationFile file, IFileInfo outputFile, HtmlWriter htmlWriter,
+		IConversionCollector? conversionCollector, Cancel token)
+	{
+		if (file is DetectionRuleFile df)
+			await htmlWriter.WriteAsync(DetectionRuleFile.OutputPath(outputFile, context), df, conversionCollector, token);
+		else if (file is MarkdownFile markdown)
+			await htmlWriter.WriteAsync(outputFile, markdown, conversionCollector, token);
+		else
+		{
+			if (outputFile.Directory is { Exists: false })
+				outputFile.Directory.Create();
+			await CopyFileFsAware(file, outputFile, token);
+		}
+	}
+}

--- a/src/Elastic.Markdown/Extensions/IDocsBuilderExtension.cs
+++ b/src/Elastic.Markdown/Extensions/IDocsBuilderExtension.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System.IO.Abstractions;
+using Elastic.Markdown.Exporters;
 using Elastic.Markdown.IO;
 using Elastic.Markdown.IO.Configuration;
 using Elastic.Markdown.IO.Navigation;
@@ -11,6 +12,8 @@ namespace Elastic.Markdown.Extensions;
 
 public interface IDocsBuilderExtension
 {
+	IDocumentationFileExporter? FileExporter { get; }
+
 	///  Inject items into the current navigation
 	void CreateNavigationItem(
 		DocumentationGroup? parent,

--- a/src/Elastic.Markdown/IO/DocumentationFile.cs
+++ b/src/Elastic.Markdown/IO/DocumentationFile.cs
@@ -13,6 +13,9 @@ public abstract record DocumentationFile(IFileInfo SourceFile, IDirectoryInfo Ro
 	public string RelativePath { get; } = Path.GetRelativePath(RootPath.FullName, SourceFile.FullName);
 	public string RelativeFolder { get; } = Path.GetRelativePath(RootPath.FullName, SourceFile.Directory!.FullName);
 
+	/// Allows documentation files of non markdown origins to advertise as their markdown equivalent in links.json
+	public virtual string LinkReferenceRelativePath => RelativePath;
+
 }
 
 public record ImageFile(IFileInfo SourceFile, IDirectoryInfo RootPath, string MimeType = "image/png")

--- a/src/Elastic.Markdown/IO/State/LinkReference.cs
+++ b/src/Elastic.Markdown/IO/State/LinkReference.cs
@@ -70,10 +70,10 @@ public record LinkReference
 		var redirects = set.Configuration.Redirects;
 		var crossLinks = set.Build.Collector.CrossLinks.ToHashSet().ToArray();
 		var links = set.MarkdownFiles.Values
-			.Select(m => (m.RelativePath, File: m))
+			.Select(m => (m.LinkReferenceRelativePath, File: m))
 			.ToDictionary(k => RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-			? k.RelativePath.Replace('\\', '/')
-			: k.RelativePath, v =>
+			? k.LinkReferenceRelativePath.Replace('\\', '/')
+			: k.LinkReferenceRelativePath, v =>
 			{
 				var anchors = v.File.Anchors.Count == 0 ? null : v.File.Anchors.ToArray();
 				return new LinkMetadata { Anchors = anchors, Hidden = v.File.Hidden };


### PR DESCRIPTION
Fixes: https://github.com/elastic/detection-rules/pull/4508

Ensures the detection rule extension emits to `.artifacts/docs/html` not `.artifacts/docs` because the rule references come from `../rules`. 


This also ensures links.json advertises the `virtual` markdown files not the toml files.

See bad links.json file here: https://docs-v3-preview.elastic.dev/elastic/detection-rules/pull/4508/links.json

Excerpt from local build:

```json
"rules/cross-platform/initial_access_zoom_meeting_with_no_passcode.md": {
      "anchors": [
        "setup",
        "investigation-guide",
        "triage-and-analysis",
        "investigating-zoom-meeting-with-no-passcode",
        "possible-investigation-steps",
        "false-positive-analysis",
        "response-and-remediation",
        "rule-query"
      ]
    }
```
