### PR TITLE
Detect variables as they are parsed in the AST

### DIFF
--- a/src/Elastic.Markdown/Myst/Substitution/SubstitutionParser.cs
+++ b/src/Elastic.Markdown/Myst/Substitution/SubstitutionParser.cs
@@ -147,6 +147,8 @@ public class SubstitutionParser : InlineParser
 			found = true;
 			replacement = value;
 		}
+		if (found)
+			context.Build.Collector.CollectUsedSubstitutionKey(key);
 
 		var start = processor.GetSourcePosition(startPosition, out var line, out var column);
 		var end = processor.GetSourcePosition(slice.Start);


### PR DESCRIPTION
We added support for detecting variables being used an hinting on ones that are not in use.

This PR fixes a glaring omission of not emitting the keys as they are parsed in the markdown parser.

We were only emitting keys that we're used in random string replacements (code and a few other places).