### PR TITLE
SEO optimized title

### DIFF
--- a/src/Elastic.Markdown/Slices/HtmlWriter.cs
+++ b/src/Elastic.Markdown/Slices/HtmlWriter.cs
@@ -98,8 +98,11 @@ public class HtmlWriter(
 			editUrl = $"https://github.com/elastic/{remote}/edit/{branch}/{path}";
 		}
 
+		var siteName = DocumentationSet.Tree.Index?.Title ?? "Elastic Documentation";
+
 		var slice = Index.Create(new IndexViewModel
 		{
+			SiteName = siteName,
 			DocSetName = DocumentationSet.Name,
 			Title = markdown.Title ?? "[TITLE NOT SET]",
 			Description = markdown.YamlFrontMatter?.Description ?? descriptionGenerator.GenerateDescription(document),

--- a/src/Elastic.Markdown/Slices/Index.cshtml
+++ b/src/Elastic.Markdown/Slices/Index.cshtml
@@ -5,7 +5,7 @@
 	public LayoutViewModel LayoutModel => new()
 	{
 		DocSetName = Model.DocSetName,
-		Title = $"Elastic Documentation: {Model.Title}",
+		Title =  Model.CurrentDocument.Url.AsSpan().TrimStart(Model.UrlPathPrefix) is "/" ?  Model.Title : $"{Model.Title} | Elastic documentation",
 		Description = Model.Description,
 		PageTocItems = Model.PageTocItems.Where(i => i is { Level: 2 or 3 }).ToList(),
 		CurrentDocument = Model.CurrentDocument,

--- a/src/Elastic.Markdown/Slices/Index.cshtml
+++ b/src/Elastic.Markdown/Slices/Index.cshtml
@@ -5,7 +5,7 @@
 	public LayoutViewModel LayoutModel => new()
 	{
 		DocSetName = Model.DocSetName,
-		Title =  Model.CurrentDocument.Url.AsSpan().TrimStart(Model.UrlPathPrefix) is "/" ?  Model.Title : $"{Model.Title} | Elastic documentation",
+		Title = Model.CurrentDocument.Parent == null ? Model.Title : $"{Model.Title} | {Model.SiteName}",
 		Description = Model.Description,
 		PageTocItems = Model.PageTocItems.Where(i => i is { Level: 2 or 3 }).ToList(),
 		CurrentDocument = Model.CurrentDocument,

--- a/src/Elastic.Markdown/Slices/_ViewModels.cs
+++ b/src/Elastic.Markdown/Slices/_ViewModels.cs
@@ -10,6 +10,7 @@ namespace Elastic.Markdown.Slices;
 
 public class IndexViewModel
 {
+	public required string SiteName { get; init; }
 	public required string DocSetName { get; init; }
 	public required string Title { get; init; }
 	public required string Description { get; init; }


### PR DESCRIPTION
## Changes

Get the title of the root index.md page and use it as site name that is appended to the title.

E.g. if the site name is `Elastic documentation` and the current page is `Get started` the title will be `Get started | Elastic documentation`