### PR TITLE
Remove custom dataLayer push

### DIFF
--- a/src/Elastic.Markdown/Assets/main.ts
+++ b/src/Elastic.Markdown/Assets/main.ts
@@ -14,14 +14,6 @@ import {$, $$} from "select-dom"
 import { UAParser } from 'ua-parser-js';
 const { getOS } = new UAParser();
 
-document.addEventListener('htmx:pushedIntoHistory', function(event) {
-	window.dataLayer = window.dataLayer || [];
-	window.dataLayer.push({
-		event: "virtualPageview",
-		page_path: event.detail.path,
-	});
-});
-
 // Don't remove style tags because they are used by the elastic global nav.
 document.addEventListener('htmx:removingHeadElement', function(event) {
 	if (event.detail.headElement.tagName === 'STYLE') {


### PR DESCRIPTION
@christianweinke did some testing and it seems this is not needed. GA recognizes page swaps.