### PR TITLE
GlobalNavigationPathProvider: change definition for the newRelativePath

### DIFF
--- a/src/docs-assembler/Navigation/GlobalNavigationPathProvider.cs
+++ b/src/docs-assembler/Navigation/GlobalNavigationPathProvider.cs
@@ -98,7 +98,11 @@ public record GlobalNavigationPathProvider : IDocumentationFileOutputProvider
 		}
 
 		var originalPath = Path.Combine(match.Host, match.AbsolutePath.Trim('/')).TrimStart('/');
-		var newRelativePath = relativePath.AsSpan().TrimStart(originalPath).TrimStart('/').ToString();
+		var relativePathSpan = relativePath.AsSpan();
+		var newRelativePath = relativePathSpan.StartsWith(originalPath, StringComparison.Ordinal)
+			? relativePathSpan.Slice(originalPath.Length).TrimStart('/').ToString()
+			: relativePathSpan.TrimStart(originalPath).TrimStart('/').ToString();
+
 		var path = fs.Path.Combine(outputDirectory.FullName, toc.SourcePathPrefix, newRelativePath);
 
 		return fs.FileInfo.New(path);


### PR DESCRIPTION
Fixes #830 

The issue is a subtle behavior detail on `TrimStart()` (and `TrimEnd()`). Rather than acting akin to `Substring()`, it continues to try and remove more of the input being manipulated as long as a character belongs in the trim set, until it finds a character not belonging to it.

Anyhow, the default behavior has been changed to verify if it starts with the originalPath, and if it does, perform a `Slice()` instead.