### PR TITLE
Protect against asciidoc headers

### DIFF
--- a/src/Elastic.Markdown/IO/MarkdownFile.cs
+++ b/src/Elastic.Markdown/IO/MarkdownFile.cs
@@ -281,6 +281,7 @@ public record MarkdownFile : DocumentationFile, INavigationScope, ITableOfConten
 			.Descendants<HeadingBlock>()
 			.Where(block => block is { Level: >= 2 })
 			.Select(h => (h.GetData("header") as string, h.GetData("anchor") as string, h.Level))
+			.Where(h => h.Item1 is not null)
 			.Select(h =>
 			{
 				var header = h.Item1!.StripMarkdown();


### PR DESCRIPTION
```
[source,esql]
----
```

This failed the build here: https://github.com/elastic/docs-content/pull/912/commits/d29ee5dfe6ffd8220f2429bf4d3d990bc733ee75
