### PR TITLE
Path prefix duplication detection in navigation.yml

### DIFF
--- a/src/docs-assembler/Cli/PathPrefixCollisionCommand.cs
+++ b/src/docs-assembler/Cli/PathPrefixCollisionCommand.cs
@@ -1,0 +1,41 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Diagnostics.CodeAnalysis;
+using System.IO.Abstractions;
+using Actions.Core.Services;
+using ConsoleAppFramework;
+using Elastic.Documentation.Tooling.Diagnostics.Console;
+using Elastic.Markdown.InboundLinks;
+using Elastic.Markdown.IO;
+using Elastic.Markdown.IO.Discovery;
+using Microsoft.Extensions.Logging;
+
+namespace Documentation.Assembler.Cli;
+
+internal sealed class PathPrefixCollisionCommand(ILoggerFactory logger, ICoreService githubActionsService)
+{
+	private readonly LinkIndexLinkChecker _linkIndexLinkChecker = new(logger);
+
+	[SuppressMessage("Usage", "CA2254:Template should be a static expression")]
+	private void AssignOutputLogger()
+	{
+		var log = logger.CreateLogger<Program>();
+		ConsoleApp.Log = msg => log.LogInformation(msg);
+		ConsoleApp.LogError = msg => log.LogError(msg);
+	}
+
+	/// <summary> Validate all published cross_links in all published links.json files. </summary>
+	/// <param name="ctx"></param>
+	[Command("")]
+	public async Task<int> DetectCollisions(Cancel ctx = default)
+	{
+		AssignOutputLogger();
+		await using var collector = new ConsoleDiagnosticsCollector(logger, githubActionsService);
+
+		var assembleContext = new AssembleContext("dev", collector, new FileSystem(), new FileSystem(), null, null);
+		return await _linkIndexLinkChecker.CheckAll(collector, ctx);
+	}
+
+}

--- a/src/docs-assembler/Cli/RepositoryCommands.cs
+++ b/src/docs-assembler/Cli/RepositoryCommands.cs
@@ -75,6 +75,15 @@ internal sealed class RepositoryCommands(ICoreService githubActionsService, ILog
 			Force = force ?? false,
 			AllowIndexing = allowIndexing ?? false,
 		};
+
+		// this validates all path prefixes are unique, early exit if duplicates are detected
+		if (!GlobalNavigationFile.ValidatePathPrefixes(assembleContext) || assembleContext.Collector.Errors > 0)
+		{
+			assembleContext.Collector.Channel.TryComplete();
+			await assembleContext.Collector.StopAsync(ctx);
+			return 1;
+		}
+
 		var cloner = new AssemblerRepositorySourcer(logger, assembleContext);
 		var checkouts = cloner.GetAll().ToArray();
 		if (checkouts.Length == 0)

--- a/src/docs-assembler/Navigation/GlobalNavigationFile.cs
+++ b/src/docs-assembler/Navigation/GlobalNavigationFile.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Collections.Immutable;
 using System.IO.Abstractions;
 using Documentation.Assembler.Configuration;
 using Elastic.Markdown.IO.Configuration;
@@ -28,6 +29,80 @@ public record GlobalNavigationFile : ITableOfContentsScope
 		ScopeDirectory = _context.NavigationPath.Directory!;
 	}
 
+	public static bool ValidatePathPrefixes(AssembleContext context)
+	{
+		var sourcePathPrefixes = GetAllPathPrefixes(context);
+		var pathPrefixSet = new HashSet<string>();
+		var valid = true;
+		foreach (var pathPrefix in sourcePathPrefixes)
+		{
+			var prefix = $"{pathPrefix.Host}/{pathPrefix.AbsolutePath.TrimStart('/')}/";
+			if (pathPrefixSet.Add(prefix))
+				continue;
+			var duplicateOf = sourcePathPrefixes.First(p => p.Host == pathPrefix.Host && p.AbsolutePath == pathPrefix.AbsolutePath);
+			context.Collector.EmitError(context.NavigationPath.FullName,
+				$"Duplicate path prefix: {pathPrefix} duplicate: {duplicateOf}"
+			);
+			valid = false;
+		}
+		return valid;
+	}
+
+
+	public static ImmutableHashSet<Uri> GetAllPathPrefixes(AssembleContext context)
+	{
+		var reader = new YamlStreamReader(context.NavigationPath, context.Collector);
+		var set = new HashSet<Uri>();
+		foreach (var entry in reader.Read())
+		{
+			if (entry.Key == "toc")
+				ReadPathPrefixes(reader, entry.Entry, set);
+		}
+		return set.ToImmutableHashSet();
+
+		static void ReadPathPrefixes(YamlStreamReader reader, KeyValuePair<YamlNode, YamlNode> entry, HashSet<Uri> hashSet, string? parent = null)
+		{
+			if (entry.Key is not YamlScalarNode { Value: not null } scalarKey)
+			{
+				reader.EmitWarning($"key '{entry.Key}' is not string");
+				return;
+			}
+
+			if (entry.Value is not YamlSequenceNode sequence)
+			{
+				reader.EmitWarning($"'{scalarKey.Value}' is not an array");
+				return;
+			}
+
+			foreach (var tocEntry in sequence.Children.OfType<YamlMappingNode>())
+			{
+				var source = ReadToc(reader, tocEntry, ref parent, out var pathPrefix, out var sourceUri);
+				if (sourceUri is not null && pathPrefix is not null)
+				{
+					var pathUri = new Uri($"{sourceUri.Scheme}://{pathPrefix.TrimEnd('/')}/");
+					if (!hashSet.Add(pathUri))
+						reader.EmitError($"Duplicate path prefix in the same repository: {pathUri}", tocEntry);
+				}
+
+				foreach (var child in tocEntry.Children)
+				{
+					var key = ((YamlScalarNode)child.Key).Value;
+					switch (key)
+					{
+						case "children":
+							if (source is null && pathPrefix is null)
+							{
+								reader.EmitWarning("toc entry has no toc or path_prefix defined");
+								continue;
+							}
+
+							ReadPathPrefixes(reader, child, hashSet);
+							break;
+					}
+				}
+			}
+		}
+	}
 	public void EmitWarning(string message) =>
 		_context.Collector.EmitWarning(_context.NavigationPath.FullName, message);
 
@@ -107,56 +182,11 @@ public record GlobalNavigationFile : ITableOfContentsScope
 
 	private TocReference? ReadTocDefinition(YamlStreamReader reader, YamlMappingNode tocEntry, string? parent, int depth)
 	{
-		string? repository = null;
-		string? source = null;
-		string? pathPrefix = null;
-		foreach (var entry in tocEntry.Children)
-		{
-			var key = ((YamlScalarNode)entry.Key).Value;
-			switch (key)
-			{
-				case "toc":
-					source = reader.ReadString(entry);
-					if (source != null && !source.Contains("://"))
-					{
-						parent = source;
-						pathPrefix = source;
-						source = ContentSourceMoniker.CreateString(NarrativeRepository.RepositoryName, source);
-					}
+		var source = ReadToc(reader, tocEntry, ref parent, out var pathPrefix, out var sourceUri);
 
-					break;
-				case "repo":
-					repository = reader.ReadString(entry);
-					break;
-				case "path_prefix":
-					pathPrefix = reader.ReadString(entry);
-					break;
-			}
-		}
-
-		if (repository is not null)
-		{
-			if (source is not null)
-				reader.EmitError($"toc config defines 'repo' can not be combined with 'toc': {source}", tocEntry);
-			pathPrefix = string.Join("/", [parent, repository]);
-			source = ContentSourceMoniker.CreateString(repository, parent);
-		}
-
-		if (source is null)
+		if (sourceUri is null)
 			return null;
 
-		if (!Uri.TryCreate(source.TrimEnd('/') + "/", UriKind.Absolute, out var sourceUri))
-		{
-			reader.EmitError($"Source toc entry is not a valid uri: {source}", tocEntry);
-			return null;
-		}
-
-
-		var sourcePrefix = $"{sourceUri.Host}/{sourceUri.AbsolutePath.TrimStart('/')}";
-		if (string.IsNullOrEmpty(pathPrefix))
-			reader.EmitError($"Path prefix is not defined for: {source}, falling back to {sourcePrefix} which may be incorrect", tocEntry);
-
-		pathPrefix ??= sourcePrefix;
 
 		if (!_assembleSources.TocConfigurationMapping.TryGetValue(sourceUri, out var mapping))
 		{
@@ -190,4 +220,71 @@ public record GlobalNavigationFile : ITableOfContentsScope
 		return tocReference;
 	}
 
+	private static string? ReadTocSourcePathPrefix(YamlStreamReader reader, YamlMappingNode tocEntry, string? source, out Uri? sourceUri, string? pathPrefix)
+	{
+		sourceUri = null;
+		if (source is null)
+			return pathPrefix;
+
+		if (!Uri.TryCreate(source.TrimEnd('/') + "/", UriKind.Absolute, out sourceUri))
+		{
+			reader.EmitError($"Source toc entry is not a valid uri: {source}", tocEntry);
+			return pathPrefix;
+		}
+
+		var sourcePrefix = $"{sourceUri.Host}/{sourceUri.AbsolutePath.TrimStart('/')}";
+		if (string.IsNullOrEmpty(pathPrefix))
+			reader.EmitError($"Path prefix is not defined for: {source}, falling back to {sourcePrefix} which may be incorrect", tocEntry);
+
+		pathPrefix ??= sourcePrefix;
+		return pathPrefix;
+	}
+
+	private static string? ReadToc(
+		YamlStreamReader reader,
+		YamlMappingNode tocEntry,
+		ref string? parent,
+		out string? pathPrefix,
+		out Uri? sourceUri
+	)
+	{
+		string? repository = null;
+		string? source = null;
+		pathPrefix = null;
+		foreach (var entry in tocEntry.Children)
+		{
+			var key = ((YamlScalarNode)entry.Key).Value;
+			switch (key)
+			{
+				case "toc":
+					source = reader.ReadString(entry);
+					if (source != null && !source.Contains("://"))
+					{
+						parent = source;
+						pathPrefix = source;
+						source = ContentSourceMoniker.CreateString(NarrativeRepository.RepositoryName, source);
+					}
+
+					break;
+				case "repo":
+					repository = reader.ReadString(entry);
+					break;
+				case "path_prefix":
+					pathPrefix = reader.ReadString(entry);
+					break;
+			}
+		}
+
+		if (repository is not null)
+		{
+			if (source is not null)
+				reader.EmitError($"toc config defines 'repo' can not be combined with 'toc': {source}", tocEntry);
+			pathPrefix = string.Join("/", [parent, repository]);
+			source = ContentSourceMoniker.CreateString(repository, parent);
+		}
+
+		pathPrefix = ReadTocSourcePathPrefix(reader, tocEntry, source, out sourceUri, pathPrefix);
+
+		return source;
+	}
 }

--- a/tests/docs-assembler.Tests/src/docs-assembler.Tests/GlobalNavigationTests.cs
+++ b/tests/docs-assembler.Tests/src/docs-assembler.Tests/GlobalNavigationTests.cs
@@ -61,6 +61,19 @@ public class GlobalNavigationPathProviderTests
 	}
 
 	[Fact]
+	public async Task ReadAllPathPrefixes()
+	{
+		await using var collector = new DiagnosticsCollector([]);
+
+		var assembleContext = new AssembleContext("dev", collector, new FileSystem(), new FileSystem(), null, null);
+
+		var pathPrefixes = GlobalNavigationFile.GetAllPathPrefixes(assembleContext);
+
+		pathPrefixes.Should().NotBeEmpty();
+		pathPrefixes.Should().Contain(new Uri("eland://reference/elasticsearch/clients/eland/"));
+	}
+
+	[Fact]
 	public async Task ParsesReferences()
 	{
 		Assert.SkipUnless(HasCheckouts(), $"Requires local checkout folder: {CheckoutDirectory.FullName}");


### PR DESCRIPTION
Add build diagnostic error when `navigation.yml` contains duplicate `path_prefix` definitions.

Detects same prefix in different repositories:

<img width="962" alt="image" src="https://github.com/user-attachments/assets/6e9006d6-0e15-45d9-a6d9-bb45a54000af" />


And within the same repository:

<img width="962" alt="image" src="https://github.com/user-attachments/assets/5462ab2b-10a9-49b1-af34-4b088b536238" />

