### PR TITLE
Keep track of navigation source on markdown files for easier root navigation lookups in assembler

### DIFF
--- a/src/Elastic.Markdown/IO/MarkdownFile.cs
+++ b/src/Elastic.Markdown/IO/MarkdownFile.cs
@@ -51,11 +51,14 @@ public record MarkdownFile : DocumentationFile, INavigationScope, ITableOfConten
 		//todo refactor mutability of MarkdownFile as a whole
 		ScopeDirectory = build.Configuration.ScopeDirectory;
 		NavigationRoot = set.Tree;
+		NavigationSource = set.Source;
 	}
 
 	public IDirectoryInfo ScopeDirectory { get; set; }
 
 	public INavigation NavigationRoot { get; set; }
+
+	public Uri NavigationSource { get; set; }
 
 	public string Id { get; } = Guid.NewGuid().ToString("N")[..8];
 

--- a/src/Elastic.Markdown/IO/Navigation/DocumentationGroup.cs
+++ b/src/Elastic.Markdown/IO/Navigation/DocumentationGroup.cs
@@ -80,7 +80,7 @@ public class TableOfContentsTree : DocumentationGroup
 		NavigationLookups lookups,
 		TableOfContentsTreeCollector treeCollector,
 		ref int fileIndex)
-		: base(treeCollector, context, lookups, ref fileIndex)
+		: base(treeCollector, context, lookups, source, ref fileIndex)
 	{
 		TreeCollector = treeCollector;
 		NavigationRoot = this;
@@ -101,7 +101,7 @@ public class TableOfContentsTree : DocumentationGroup
 		DocumentationGroup? toplevelTree,
 		DocumentationGroup? parent,
 		MarkdownFile? index = null
-	) : base(folderName, treeCollector, context, lookups, ref fileIndex, depth, toplevelTree, parent, index)
+	) : base(folderName, treeCollector, context, lookups, source, ref fileIndex, depth, toplevelTree, parent, index)
 	{
 		Source = source;
 		TreeCollector = treeCollector;
@@ -123,6 +123,8 @@ public class DocumentationGroup : INavigation
 
 	public INavigation NavigationRoot { get; set; }
 
+	public Uri NavigationSource { get; set; }
+
 	public MarkdownFile? Index { get; set; }
 
 	private IReadOnlyCollection<MarkdownFile> FilesInOrder { get; }
@@ -141,20 +143,25 @@ public class DocumentationGroup : INavigation
 
 	protected virtual DocumentationGroup DefaultNavigation => this;
 
-	public DocumentationGroup(
+	protected DocumentationGroup(
 		TableOfContentsTreeCollector treeCollector,
 		BuildContext context,
 		NavigationLookups lookups,
+		Uri navigationSource,
 		ref int fileIndex
 	)
-		: this(".", treeCollector, context, lookups, ref fileIndex, depth: 0, null, null) =>
+		: this(".", treeCollector, context, lookups, navigationSource, ref fileIndex, depth: 0, null, null)
+	{
+		NavigationSource = navigationSource;
 		_treeCollector = treeCollector;
+	}
 
 	internal DocumentationGroup(
 		string folderName,
 		TableOfContentsTreeCollector treeCollector,
 		BuildContext context,
 		NavigationLookups lookups,
+		Uri navigationSource,
 		ref int fileIndex,
 		int depth,
 		DocumentationGroup? toplevelTree,
@@ -163,6 +170,7 @@ public class DocumentationGroup : INavigation
 	)
 	{
 		FolderName = folderName;
+		NavigationSource = navigationSource;
 		_treeCollector = treeCollector;
 		Depth = depth;
 		Parent = parent;
@@ -227,6 +235,7 @@ public class DocumentationGroup : INavigation
 				md.NavigationIndex = navigationIndex;
 				md.ScopeDirectory = file.TableOfContentsScope.ScopeDirectory;
 				md.NavigationRoot = topLevelGroup;
+				md.NavigationSource = NavigationSource;
 
 				foreach (var extension in context.Configuration.EnabledExtensions)
 					extension.Visit(d, tocItem);
@@ -239,7 +248,7 @@ public class DocumentationGroup : INavigation
 						_treeCollector, context, lookups with
 						{
 							TableOfContents = file.Children
-						}, ref fileIndex, depth + 1, topLevelGroup, this, virtualIndex);
+						}, NavigationSource, ref fileIndex, depth + 1, topLevelGroup, this, virtualIndex);
 					groups.Add(group);
 					navigationItems.Add(new GroupNavigationItem(index, depth, group));
 					continue;
@@ -267,6 +276,7 @@ public class DocumentationGroup : INavigation
 							.Select(d => new FileReference(folder.TableOfContentsScope, d.RelativePath, true, false, []))
 					];
 				}
+
 				DocumentationGroup group;
 				if (folder is TocReference tocReference)
 				{
@@ -275,8 +285,6 @@ public class DocumentationGroup : INavigation
 						TableOfContents = children
 					}, ref fileIndex, depth + 1, topLevelGroup, this);
 
-					//if (lookups.IndexedTableOfContents.TryGetValue(tocReference.Source, out var indexedToc))
-					//	toc.NavigationItems = toc.NavigationItems.Concat(indexedToc.Children).ToArray();
 					group = toc;
 					navigationItems.Add(new TocNavigationItem(index, depth, toc, tocReference.Source));
 				}
@@ -285,7 +293,7 @@ public class DocumentationGroup : INavigation
 					group = new DocumentationGroup(folder.Path, _treeCollector, context, lookups with
 					{
 						TableOfContents = children
-					}, ref fileIndex, depth + 1, topLevelGroup, this);
+					}, NavigationSource, ref fileIndex, depth + 1, topLevelGroup, this);
 					navigationItems.Add(new GroupNavigationItem(index, depth, group));
 				}
 

--- a/src/Elastic.Markdown/Slices/HtmlWriter.cs
+++ b/src/Elastic.Markdown/Slices/HtmlWriter.cs
@@ -15,7 +15,7 @@ namespace Elastic.Markdown.Slices;
 
 public interface INavigationHtmlWriter
 {
-	Task<string> RenderNavigation(INavigation currentRootNavigation, Cancel ctx = default);
+	Task<string> RenderNavigation(INavigation currentRootNavigation, Uri navigationSource, Cancel ctx = default);
 
 	async Task<string> Render(NavigationViewModel model, Cancel ctx)
 	{
@@ -30,7 +30,7 @@ public class IsolatedBuildNavigationHtmlWriter(DocumentationSet set) : INavigati
 
 	private readonly ConcurrentDictionary<string, string> _renderedNavigationCache = [];
 
-	public async Task<string> RenderNavigation(INavigation currentRootNavigation, Cancel ctx = default)
+	public async Task<string> RenderNavigation(INavigation currentRootNavigation, Uri navigationSource, Cancel ctx = default)
 	{
 		var navigation = Set.Configuration.Features.IsPrimaryNavEnabled
 			? currentRootNavigation
@@ -84,7 +84,7 @@ public class HtmlWriter(
 		var html = markdown.CreateHtml(document);
 		await DocumentationSet.Tree.Resolve(ctx);
 
-		var navigationHtml = await NavigationHtmlWriter.RenderNavigation(markdown.NavigationRoot, ctx);
+		var navigationHtml = await NavigationHtmlWriter.RenderNavigation(markdown.NavigationRoot, markdown.NavigationSource, ctx);
 
 		var previous = DocumentationSet.GetPrevious(markdown);
 		var next = DocumentationSet.GetNext(markdown);

--- a/src/docs-assembler/Navigation/GlobalNavigationHtmlWriter.cs
+++ b/src/docs-assembler/Navigation/GlobalNavigationHtmlWriter.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using Elastic.Markdown.IO.Navigation;
 using Elastic.Markdown.Slices;
 
@@ -19,46 +20,51 @@ public class GlobalNavigationHtmlWriter(
 
 	private ImmutableHashSet<Uri> Phantoms { get; } = [.. navigationFile.Phantoms.Select(p => p.Source)];
 
-	private (DocumentationGroup, Uri) GetRealNavigationRoot(TableOfContentsTree tree)
+	private bool TryGetNavigationRoot(
+		Uri navigationSource,
+		[NotNullWhen(true)] out TableOfContentsTree? navigationRoot,
+		[NotNullWhen(true)] out Uri? navigationRootSource
+	)
 	{
-		if (!assembleSources.TocTopLevelMappings.TryGetValue(tree.Source, out var topLevelUri))
+		navigationRoot = null;
+		navigationRootSource = null;
+		if (!assembleSources.TocTopLevelMappings.TryGetValue(navigationSource, out var topLevelMapping))
 		{
-			assembleContext.Collector.EmitWarning(assembleContext.NavigationPath.FullName, $"Could not find a top level mapping for {tree.Source}");
-			return (tree, tree.Source);
+			assembleContext.Collector.EmitWarning(assembleContext.NavigationPath.FullName, $"Could not find a top level mapping for {navigationSource}");
+			return false;
 		}
 
-		if (!assembleSources.TreeCollector.TryGetTableOfContentsTree(topLevelUri.TopLevelSource, out var topLevel))
+		if (!assembleSources.TreeCollector.TryGetTableOfContentsTree(topLevelMapping.TopLevelSource, out navigationRoot))
 		{
-			assembleContext.Collector.EmitWarning(assembleContext.NavigationPath.FullName, $"Could not find a toc tree for {topLevelUri.TopLevelSource}");
-			return (tree, tree.Source);
-
+			assembleContext.Collector.EmitWarning(assembleContext.NavigationPath.FullName, $"Could not find a toc tree for {topLevelMapping.TopLevelSource}");
+			return false;
 		}
-		return (topLevel, topLevelUri.TopLevelSource);
+		navigationRootSource = topLevelMapping.TopLevelSource;
+		return true;
 	}
 
-	public async Task<string> RenderNavigation(INavigation currentRootNavigation, Cancel ctx = default)
+	public async Task<string> RenderNavigation(INavigation currentRootNavigation, Uri navigationSource, Cancel ctx = default)
 	{
-		if (currentRootNavigation is not TableOfContentsTree tree)
-			throw new InvalidOperationException($"Expected a {nameof(DocumentationGroup)}");
-
-		if (Phantoms.Contains(tree.Source))
+		if (!TryGetNavigationRoot(navigationSource, out var navigationRoot, out var navigationRootSource))
 			return string.Empty;
 
-		var (navigation, source) = GetRealNavigationRoot(tree);
-		if (_renderedNavigationCache.TryGetValue(source, out var value))
+		if (Phantoms.Contains(navigationRootSource))
+			return string.Empty;
+
+		if (_renderedNavigationCache.TryGetValue(navigationRootSource, out var value))
 			return value;
 
-		if (source == new Uri("docs-content:///"))
+		if (navigationRootSource == new Uri("docs-content:///"))
 		{
-			_renderedNavigationCache[source] = string.Empty;
+			_renderedNavigationCache[navigationRootSource] = string.Empty;
 			return string.Empty;
 		}
 
-		Console.WriteLine($"Rendering navigation for {source}");
+		Console.WriteLine($"Rendering navigation for {navigationRootSource}");
 
-		var model = CreateNavigationModel(navigation);
+		var model = CreateNavigationModel(navigationRoot);
 		value = await ((INavigationHtmlWriter)this).Render(model, ctx);
-		_renderedNavigationCache[source] = value;
+		_renderedNavigationCache[navigationRootSource] = value;
 
 		return value;
 	}


### PR DESCRIPTION

https://github.com/user-attachments/assets/4c7b9c64-2c51-470e-b43f-9e7b7a8a978d

Fixes: https://github.com/elastic/docs-builder/issues/854