### PR TITLE
Optimize hljs

### DIFF
--- a/docs/syntax/code.md
+++ b/docs/syntax/code.md
@@ -316,3 +316,8 @@ This `code` is inline.
 :::
 
 ::::
+
+## Supported Languages
+
+Please refer to [hljs.ts](https://github.com/elastic/docs-builder/blob/main/src/Elastic.Markdown/Assets/hljs.ts)
+for a complete list of supported languages.

--- a/src/Elastic.Markdown/Assets/hljs.ts
+++ b/src/Elastic.Markdown/Assets/hljs.ts
@@ -1,5 +1,84 @@
 import {mergeHTMLPlugin} from "./hljs-merge-html-plugin";
-import hljs from "highlight.js";
+import {$$} from 'select-dom'
+
+import asciidoc from "highlight.js/lib/languages/asciidoc";
+import bash from "highlight.js/lib/languages/bash";
+import c from "highlight.js/lib/languages/c";
+import csharp from "highlight.js/lib/languages/csharp";
+import css from "highlight.js/lib/languages/css";
+import dockerfile from "highlight.js/lib/languages/dockerfile";
+import dos from "highlight.js/lib/languages/dos";
+import ebnf from "highlight.js/lib/languages/ebnf";
+import go from "highlight.js/lib/languages/go";
+import gradle from "highlight.js/lib/languages/gradle";
+import groovy from "highlight.js/lib/languages/groovy";
+import handlebars from "highlight.js/lib/languages/handlebars";
+import hljs from "highlight.js/lib/core";
+import http from "highlight.js/lib/languages/http";
+import ini from "highlight.js/lib/languages/ini";
+import java from "highlight.js/lib/languages/java";
+import javascript from "highlight.js/lib/languages/javascript";
+import json from "highlight.js/lib/languages/json";
+import kotlin from "highlight.js/lib/languages/kotlin";
+import markdown from "highlight.js/lib/languages/markdown";
+import nginx from "highlight.js/lib/languages/nginx";
+import php from "highlight.js/lib/languages/php";
+import plaintext from "highlight.js/lib/languages/plaintext";
+import powershell from "highlight.js/lib/languages/powershell";
+import properties from "highlight.js/lib/languages/properties";
+import python from "highlight.js/lib/languages/python";
+import ruby from "highlight.js/lib/languages/ruby";
+import scala from "highlight.js/lib/languages/scala";
+import shell from "highlight.js/lib/languages/shell";
+import sql from "highlight.js/lib/languages/sql";
+import swift from "highlight.js/lib/languages/swift";
+import typescript from "highlight.js/lib/languages/typescript";
+import xml from "highlight.js/lib/languages/xml";
+import yaml from "highlight.js/lib/languages/yaml";
+import { LanguageFn } from "highlight.js";
+
+const languages: Array<{ name: string, module: LanguageFn, aliases?: string[] }> = [
+	{ name: 'asciidoc', module: asciidoc },
+	{ name: 'bash', module: bash },
+	{ name: 'c', module: c  },
+	{ name: 'csharp', module: csharp },
+	{ name: 'css', module: css },
+	{ name: 'dockerfile', module: dockerfile },
+	{ name: 'dos', module: dos },
+	{ name: 'ebnf', module: ebnf },
+	{ name: 'go', module: go },
+	{ name: 'gradle', module: gradle },
+	{ name: 'groovy', module: groovy },
+	{ name: 'handlebars', module: handlebars },
+	{ name: 'http', module: http },
+	{ name: 'ini', module: ini },
+	{ name: 'java', module: java },
+	{ name: 'javascript', module: javascript },
+	{ name: 'json', module: json },
+	{ name: 'kotlin', module: kotlin},
+	{ name: 'markdown', module: markdown },
+	{ name: 'nginx', module: nginx },
+	{ name: 'php', module: php },
+	{ name: 'plaintext', module: plaintext },
+	{ name: 'powershell', module: powershell },
+	{ name: 'properties', module: properties },
+	{ name: 'python', module: python },
+	{ name: 'ruby', module: ruby },
+	{ name: 'scala', module: scala },
+	{ name: 'shell', module: shell, aliases: ['sh'] },
+	{ name: 'sql', module: sql },
+	{ name: 'swift', module: swift },
+	{ name: 'typescript', module: typescript },
+	{ name: 'xml', module: xml },
+	{ name: 'yaml', module: yaml },
+];
+
+languages.forEach(lang => {
+	hljs.registerLanguage(lang.name, lang.module);
+	if (lang.aliases) {
+		hljs.registerAliases(lang.aliases, { languageName: lang.name });
+	}
+});
 
 hljs.registerLanguage('apiheader', function() {
 	return {
@@ -14,30 +93,17 @@ hljs.registerLanguage('apiheader', function() {
 		],		}
 })
 
-// https://tc39.es/ecma262/#sec-literals-numeric-literals
 const decimalDigits = '[0-9](_?[0-9])*';
 const frac = `\\.(${decimalDigits})`;
-// DecimalIntegerLiteral, including Annex B NonOctalDecimalIntegerLiteral
-// https://tc39.es/ecma262/#sec-additional-syntax-numeric-literals
 const decimalInteger = `0|[1-9](_?[0-9])*|0[0-7]*[89][0-9]*`;
 const NUMBER = {
 	className: 'number',
 	variants: [
-		// DecimalLiteral
-		{ begin: `(\\b(${decimalInteger})((${frac})|\\.)?|(${frac}))` +
-				`[eE][+-]?(${decimalDigits})\\b` },
 		{ begin: `\\b(${decimalInteger})\\b((${frac})\\b|\\.)?|(${frac})\\b` },
-
-		// DecimalBigIntegerLiteral
 		{ begin: `\\b(0|[1-9](_?[0-9])*)n\\b` },
-
-		// NonDecimalIntegerLiteral
 		{ begin: "\\b0[xX][0-9a-fA-F](_?[0-9a-fA-F])*n?\\b" },
 		{ begin: "\\b0[bB][0-1](_?[0-1])*n?\\b" },
 		{ begin: "\\b0[oO][0-7](_?[0-7])*n?\\b" },
-
-		// LegacyOctalIntegerLiteral (does not include underscore separators)
-		// https://tc39.es/ecma262/#sec-additional-syntax-numeric-literals
 		{ begin: "\\b0[0-7]+n?\\b" },
 	],
 	relevance: 0
@@ -63,7 +129,6 @@ hljs.registerLanguage('eql', function() {
 				match: /(?:!?\[|\]|\|)/,
 			},
 			NUMBER,
-
 		]
 	}
 })
@@ -88,7 +153,6 @@ hljs.registerLanguage('painless', function() {
 				match: /(?:!?\[|\]|\|)/,
 			},
 			NUMBER,
-
 		]
 	}
 })
@@ -156,15 +220,17 @@ hljs.registerLanguage('esql', function() {
 				match: /(?:!?\[|\]|\|)/,
 			},
 			NUMBER,
-
 		]
 	}
 })
 
 
 hljs.addPlugin(mergeHTMLPlugin);
+
+// The unescaped HTML warning is caused by the mergeHTMLPlugin which we are using
+// for code callouts
+hljs.configure({ ignoreUnescapedHTML: true });
+
 export function initHighlight() {
-	document.querySelectorAll('#markdown-content pre code:not(.hljs)').forEach((block) => {
-	  hljs.highlightElement(block);
-	});
+	$$('#markdown-content pre code:not([data-highlighted])').forEach(hljs.highlightElement);
 }

--- a/src/Elastic.Markdown/Myst/CodeBlocks/SupportedLanguages.cs
+++ b/src/Elastic.Markdown/Myst/CodeBlocks/SupportedLanguages.cs
@@ -44,8 +44,10 @@ public static class CodeBlock
 		{ "yml", "yaml" }, // YAML
 
 		//CUSTOM, Elastic language we wrote highlighters for
+		{ "apiheader", "" },
 		{ "eql", "" },
-		{ "esql", "" }
+		{ "esql", "" },
+		{ "painless", "" }
 	};
 
 	public static HashSet<string> Languages { get; } = new(

--- a/src/Elastic.Markdown/Myst/CodeBlocks/SupportedLanguages.cs
+++ b/src/Elastic.Markdown/Myst/CodeBlocks/SupportedLanguages.cs
@@ -6,185 +6,47 @@ namespace Elastic.Markdown.Myst.CodeBlocks;
 
 public static class CodeBlock
 {
+
 	private static readonly IReadOnlyDictionary<string, string> LanguageMapping = new Dictionary<string, string>
 	{
-		{ "1c", "" }, // 1C
-		{ "abnf", "" }, // ABNF
-		{ "accesslog", "" }, // Access logs
-		{ "ada", "" }, // Ada
-		{ "arduino", "ino" }, // Arduino (C++ w/Arduino libs)
-		{ "armasm", "arm" }, // ARM assembler
-		{ "avrasm", "" }, // AVR assembler
-		{ "actionscript", "as" }, // ActionScript
-		{ "angelscript", "asc" }, // AngelScript
-		{ "apache", "apacheconf" }, // Apache
-		{ "applescript", "osascript" }, // AppleScript
-		{ "arcade", "" }, // Arcade
 		{ "asciidoc", "adoc" }, // AsciiDoc
-		{ "aspectj", "" }, // AspectJ
-		{ "autohotkey", "" }, // AutoHotkey
-		{ "autoit", "" }, // AutoIt
-		{ "awk", "mawk, nawk, gawk" }, // Awk
 		{ "bash", "sh, zsh" }, // Bash
-		{ "basic", "" }, // Basic
-		{ "bnf", "" }, // BNF
-		{ "brainfuck", "bf" }, // Brainfuck
-		{ "csharp", "cs" }, // C#
 		{ "c", "h" }, // C
-		{ "cpp", "hpp, cc, hh, c++, h++, cxx, hxx" }, // C++
-		{ "cal", "" }, // C/AL
-		{ "cos", "cls" }, // Cache Object Script
-		{ "cmake", "cmake.in" }, // CMake
-		{ "coq", "" }, // Coq
-		{ "csp", "" }, // CSP
+		{ "csharp", "cs" }, // C#
 		{ "css", "" }, // CSS
-		{ "capnproto", "capnp" }, // Cap’n Proto
-		{ "clojure", "clj" }, // Clojure
-		{ "coffeescript", "coffee, cson, iced" }, // CoffeeScript
-		{ "crmsh", "crm, pcmk" }, // Crmsh
-		{ "crystal", "cr" }, // Crystal
-		{ "d", "" }, // D
-		{ "dart", "" }, // Dart
-		{ "dpr", "dfm, pas, pascal" }, // Delphi
-		{ "diff", "patch" }, // Diff
-		{ "django", "jinja" }, // Django
-		{ "dns", "zone, bind" }, // DNS Zone file
 		{ "dockerfile", "docker" }, // Dockerfile
 		{ "dos", "bat, cmd" }, // DOS
-		{ "dsconfig", "" }, // dsconfig
-		{ "dts", "" }, // DTS (Device Tree)
-		{ "dust", "dst" }, // Dust
 		{ "ebnf", "" }, // EBNF
-		{ "elixir", "" }, // Elixir
-		{ "elm", "" }, // Elm
-		{ "erlang", "erl" }, // Erlang
-		{ "excel", "xls, xlsx" }, // Excel
-		{ "fsharp", "fs, fsx, fsi, fsscript" }, // F#
-		{ "fix", "" }, // FIX
-		{ "fortran", "f90, f95" }, // Fortran
-		{ "gcode", "nc" }, // G-Code
-		{ "gams", "gms" }, // Gams
-		{ "gauss", "gss" }, // GAUSS
-		{ "gherkin", "" }, // Gherkin
 		{ "go", "golang" }, // Go
-		{ "golo", "gololang" }, // Golo
 		{ "gradle", "" }, // Gradle
-		{ "graphql", "gql" }, // GraphQL
 		{ "groovy", "" }, // Groovy
-		{ "xml", "html, xhtml, rss, atom, xjb, xsd, xsl, plist, svg" }, // HTML, XML
-		{ "http", "https" }, // HTTP
-		{ "haml", "" }, // Haml
 		{ "handlebars", "hbs, html.hbs, html.handlebars" }, // Handlebars
-		{ "haskell", "hs" }, // Haskell
-		{ "haxe", "hx" }, // Haxe
-		{ "hy", "hylang" }, // Hy
+		{ "http", "https" }, // HTTP
 		{ "ini", "toml" }, // Ini, TOML
-		{ "inform7", "i7" }, // Inform7
-		{ "irpf90", "" }, // IRPF90
-		{ "json", "jsonc" }, // JSON
 		{ "java", "jsp" }, // Java
 		{ "javascript", "js, jsx" }, // JavaScript
-		{ "julia", "jl" }, // Julia
-		{ "julia-repl", "" }, // Julia REPL
+		{ "json", "jsonc" }, // JSON
 		{ "kotlin", "kt" }, // Kotlin
-		{ "tex", "" }, // LaTeX
-		{ "leaf", "" }, // Leaf
-		{ "lasso", "ls, lassoscript" }, // Lasso
-		{ "less", "" }, // Less
-		{ "ldif", "" }, // LDIF
-		{ "lisp", "" }, // Lisp
-		{ "livecodeserver", "" }, // LiveCode Server
-		{ "livescript", "ls" }, // LiveScript
-		{ "lua", "pluto" }, // Lua
-		{ "makefile", "mk, mak, make" }, // Makefile
 		{ "markdown", "md, mkdown, mkd" }, // Markdown
-		{ "mathematica", "mma, wl" }, // Mathematica
-		{ "matlab", "" }, // Matlab
-		{ "maxima", "" }, // Maxima
-		{ "mel", "" }, // Maya Embedded Language
-		{ "mercury", "" }, // Mercury
-		{ "mips", "mipsasm" }, // MIPS Assembler
-		{ "mizar", "" }, // Mizar
-		{ "mojolicious", "" }, // Mojolicious
-		{ "monkey", "" }, // Monkey
-		{ "moonscript", "moon" }, // Moonscript
-		{ "n1ql", "" }, // N1QL
-		{ "nsis", "" }, // NSIS
 		{ "nginx", "nginxconf" }, // Nginx
-		{ "nim", "nimrod" }, // Nim
-		{ "nix", "" }, // Nix
-		{ "ocaml", "ml" }, // OCaml
-		{ "objectivec", "mm, objc, obj-c, obj-c++, objective-c++" }, // Objective C
-		{ "openscad", "scad" }, // OpenSCAD
-		{ "ruleslanguage", "" }, // Oracle Rules Language
-		{ "oxygene", "" }, // Oxygene
-		{ "pf", "pf.conf" }, // PF
 		{ "php", "" }, // PHP
-		{ "parser3", "" }, // Parser3
-		{ "perl", "pl, pm" }, // Perl
 		{ "plaintext", "txt, text" }, // Plaintext
-		{ "pony", "" }, // Pony
-		{ "pgsql", "postgres, postgresql" }, // PostgreSQL & PL/pgSQL
 		{ "powershell", "ps, ps1" }, // PowerShell
-		{ "processing", "" }, // Processing
-		{ "prolog", "" }, // Prolog
 		{ "properties", "" }, // Properties
-		{ "proto", "protobuf" }, // Protocol Buffers
-		{ "puppet", "pp" }, // Puppet
 		{ "python", "py, gyp" }, // Python
-		{ "profile", "" }, // Python profiler results
-		{ "python-repl", "pycon" }, // Python REPL
-		{ "k", "kdb" }, // Q
-		{ "qml", "" }, // QML
-		{ "r", "" }, // R
-		{ "reasonml", "re" }, // ReasonML
-		{ "rib", "" }, // RenderMan RIB
-		{ "rsl", "" }, // RenderMan RSL
-		{ "graph", "instances" }, // Roboconf
 		{ "ruby", "rb, gemspec, podspec, thor, irb" }, // Ruby
-		{ "rust", "rs" }, // Rust
-		{ "SAS", "sas" }, // SAS
-		{ "scss", "" }, // SCSS
-		{ "sql", "" }, // SQL
-		{ "p21", "step, stp" }, // STEP Part 21
 		{ "scala", "" }, // Scala
-		{ "scheme", "" }, // Scheme
-		{ "scilab", "sci" }, // Scilab
 		{ "shell", "console" }, // Shell
-		{ "smali", "" }, // Smali
-		{ "smalltalk", "st" }, // Smalltalk
-		{ "sml", "ml" }, // SML
-		{ "stan", "stanfuncs" }, // Stan
-		{ "stata", "" }, // Stata
-		{ "stylus", "styl" }, // Stylus
-		{ "subunit", "" }, // SubUnit
-		{ "svelte", "" }, // Svelte 	highlight.svelte
+		{ "sql", "" }, // SQL
 		{ "swift", "" }, // Swift
-		{ "tcl", "tk" }, // Tcl
-		{ "tap", "" }, // Test Anything Protocol
-		{ "thrift", "" }, // Thrift
-		{ "toit", "" }, // Toit 	toit-highlight
-		{ "tp", "" }, // TP
-		{ "twig", "craftcms" }, // Twig
 		{ "typescript", "ts, tsx, mts, cts" }, // TypeScript
-		{ "vbnet", "vb" }, // VB.Net
-		{ "vbscript", "vbs" }, // VBScript
-		{ "vhdl", "" }, // VHDL
-		{ "vala", "" }, // Vala
-		{ "verilog", "v" }, // Verilog
-		{ "vim", "" }, // Vim Script
-		{ "axapta", "x++" }, // X++
-		{ "x86asm", "" }, // x86 Assembly
-		{ "xl", "tao" }, // XL
-		{ "xquery", "xpath, xq, xqm" }, // XQuery
+		{ "xml", "html, xhtml, rss, atom, xjb, xsd, xsl, plist, svg" }, // HTML, XML
 		{ "yml", "yaml" }, // YAML
-		{ "zephir", "zep" }, // Zephir
 
 		//CUSTOM, Elastic language we wrote highlighters for
 		{ "eql", "" },
 		{ "esql", "" }
 	};
-
 
 	public static HashSet<string> Languages { get; } = new(
 		LanguageMapping.Keys

--- a/src/Elastic.Markdown/package-lock.json
+++ b/src/Elastic.Markdown/package-lock.json
@@ -20,8 +20,9 @@
         "ua-parser-js": "^2.0.2"
       },
       "devDependencies": {
+        "@parcel/reporter-bundle-analyzer": "^2.14.2",
         "@tailwindcss/postcss": "^4.0.3",
-        "parcel": "2.13.3",
+        "parcel": "2.14.2",
         "postcss": "^8.5.1",
         "postcss-import": "^16.1.0"
       }
@@ -247,21 +248,21 @@
       ]
     },
     "node_modules/@parcel/bundler-default": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.13.3.tgz",
-      "integrity": "sha512-mOuWeth0bZzRv1b9Lrvydis/hAzJyePy0gwa0tix3/zyYBvw0JY+xkXVR4qKyD/blc1Ra2qOlfI2uD3ucnsdXA==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.14.2.tgz",
+      "integrity": "sha512-nAUhIPN/7nULJxhRcIUKdtkb7y1WkoKcYXZZZcQzMUu0wFBhyicJzWOQk1zri4LrKJBW4P5JQ4xwdJitc2GGDA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/graph": "3.3.3",
-        "@parcel/plugin": "2.13.3",
-        "@parcel/rust": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/diagnostic": "2.14.2",
+        "@parcel/graph": "3.4.2",
+        "@parcel/plugin": "2.14.2",
+        "@parcel/rust": "2.14.2",
+        "@parcel/utils": "2.14.2",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.2"
       },
       "funding": {
         "type": "opencollective",
@@ -269,14 +270,14 @@
       }
     },
     "node_modules/@parcel/cache": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.13.3.tgz",
-      "integrity": "sha512-Vz5+K5uCt9mcuQAMDo0JdbPYDmVdB8Nvu/A2vTEK2rqZPxvoOTczKeMBA4JqzKqGURHPRLaJCvuR8nDG+jhK9A==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.14.2.tgz",
+      "integrity": "sha512-C3uGFSjDGgVbNMxi9WGTavGPQgyv+QP9bBD+kw1LvgoWIvjw21NqDD3PpJS5iDJusEr8b1YOt/j2ejWJmSq2FQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/fs": "2.13.3",
-        "@parcel/logger": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/fs": "2.14.2",
+        "@parcel/logger": "2.14.2",
+        "@parcel/utils": "2.14.2",
         "lmdb": "2.8.5"
       },
       "engines": {
@@ -287,13 +288,13 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.13.3"
+        "@parcel/core": "^2.14.2"
       }
     },
     "node_modules/@parcel/codeframe": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.13.3.tgz",
-      "integrity": "sha512-L/PQf+PT0xM8k9nc0B+PxxOYO2phQYnbuifu9o4pFRiqVmCtHztP+XMIvRJ2gOEXy3pgAImSPFVJ3xGxMFky4g==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.14.2.tgz",
+      "integrity": "sha512-sjXiM+XUWiq7OOeTDsWUaNvKkrcCA89w0lvLFFXbtxxDXVBnM8SERP8nosA95izKWEy3fA6LopCuPbfz9v7FmA==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.2"
@@ -307,16 +308,16 @@
       }
     },
     "node_modules/@parcel/compressor-raw": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.13.3.tgz",
-      "integrity": "sha512-C6vjDlgTLjYc358i7LA/dqcL0XDQZ1IHXFw6hBaHHOfxPKW2T4bzUI6RURyToEK9Q1X7+ggDKqgdLxwp4veCFg==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.14.2.tgz",
+      "integrity": "sha512-u8fJO1M/BcaJ/Um7pq6/OstJd0Rrs532NHJDc9UQHhreDlrjB2W97vVVMyF0aL23ebzfP3Hta3WnH7Eg64gAJg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.13.3"
+        "@parcel/plugin": "2.14.2"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.2"
       },
       "funding": {
         "type": "opencollective",
@@ -324,73 +325,74 @@
       }
     },
     "node_modules/@parcel/config-default": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.13.3.tgz",
-      "integrity": "sha512-WUsx83ic8DgLwwnL1Bua4lRgQqYjxiTT+DBxESGk1paNm1juWzyfPXEQDLXwiCTcWMQGiXQFQ8OuSISauVQ8dQ==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.14.2.tgz",
+      "integrity": "sha512-ntqWdRJTyEX48OWnUL6BXCE9tEuVejZfzmdy8FvzeXHnVkQE09d1g8cmerm3B1cN+DoRxKIyLi5Qq1nyI0V9Tw==",
       "dev": true,
       "dependencies": {
-        "@parcel/bundler-default": "2.13.3",
-        "@parcel/compressor-raw": "2.13.3",
-        "@parcel/namer-default": "2.13.3",
-        "@parcel/optimizer-css": "2.13.3",
-        "@parcel/optimizer-htmlnano": "2.13.3",
-        "@parcel/optimizer-image": "2.13.3",
-        "@parcel/optimizer-svgo": "2.13.3",
-        "@parcel/optimizer-swc": "2.13.3",
-        "@parcel/packager-css": "2.13.3",
-        "@parcel/packager-html": "2.13.3",
-        "@parcel/packager-js": "2.13.3",
-        "@parcel/packager-raw": "2.13.3",
-        "@parcel/packager-svg": "2.13.3",
-        "@parcel/packager-wasm": "2.13.3",
-        "@parcel/reporter-dev-server": "2.13.3",
-        "@parcel/resolver-default": "2.13.3",
-        "@parcel/runtime-browser-hmr": "2.13.3",
-        "@parcel/runtime-js": "2.13.3",
-        "@parcel/runtime-react-refresh": "2.13.3",
-        "@parcel/runtime-service-worker": "2.13.3",
-        "@parcel/transformer-babel": "2.13.3",
-        "@parcel/transformer-css": "2.13.3",
-        "@parcel/transformer-html": "2.13.3",
-        "@parcel/transformer-image": "2.13.3",
-        "@parcel/transformer-js": "2.13.3",
-        "@parcel/transformer-json": "2.13.3",
-        "@parcel/transformer-postcss": "2.13.3",
-        "@parcel/transformer-posthtml": "2.13.3",
-        "@parcel/transformer-raw": "2.13.3",
-        "@parcel/transformer-react-refresh-wrap": "2.13.3",
-        "@parcel/transformer-svg": "2.13.3"
+        "@parcel/bundler-default": "2.14.2",
+        "@parcel/compressor-raw": "2.14.2",
+        "@parcel/namer-default": "2.14.2",
+        "@parcel/optimizer-css": "2.14.2",
+        "@parcel/optimizer-htmlnano": "2.14.2",
+        "@parcel/optimizer-image": "2.14.2",
+        "@parcel/optimizer-svgo": "2.14.2",
+        "@parcel/optimizer-swc": "2.14.2",
+        "@parcel/packager-css": "2.14.2",
+        "@parcel/packager-html": "2.14.2",
+        "@parcel/packager-js": "2.14.2",
+        "@parcel/packager-raw": "2.14.2",
+        "@parcel/packager-svg": "2.14.2",
+        "@parcel/packager-wasm": "2.14.2",
+        "@parcel/reporter-dev-server": "2.14.2",
+        "@parcel/resolver-default": "2.14.2",
+        "@parcel/runtime-browser-hmr": "2.14.2",
+        "@parcel/runtime-js": "2.14.2",
+        "@parcel/runtime-rsc": "2.14.2",
+        "@parcel/runtime-service-worker": "2.14.2",
+        "@parcel/transformer-babel": "2.14.2",
+        "@parcel/transformer-css": "2.14.2",
+        "@parcel/transformer-html": "2.14.2",
+        "@parcel/transformer-image": "2.14.2",
+        "@parcel/transformer-js": "2.14.2",
+        "@parcel/transformer-json": "2.14.2",
+        "@parcel/transformer-node": "2.14.2",
+        "@parcel/transformer-postcss": "2.14.2",
+        "@parcel/transformer-posthtml": "2.14.2",
+        "@parcel/transformer-raw": "2.14.2",
+        "@parcel/transformer-react-refresh-wrap": "2.14.2",
+        "@parcel/transformer-svg": "2.14.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.13.3"
+        "@parcel/core": "^2.14.2"
       }
     },
     "node_modules/@parcel/core": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.13.3.tgz",
-      "integrity": "sha512-SRZFtqGiaKHlZ2YAvf+NHvBFWS3GnkBvJMfOJM7kxJRK3M1bhbwJa/GgSdzqro5UVf9Bfj6E+pkdrRQIOZ7jMQ==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.14.2.tgz",
+      "integrity": "sha512-VIgo7dgwY9nHJTnxaa86xxQmUX6K5pEAxfsjkFxOhrviTG+KAI5bOHQAbsY61ytTO/x+uSDEnMoIkR8TAIVc3Q==",
       "dev": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/cache": "2.13.3",
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/events": "2.13.3",
-        "@parcel/feature-flags": "2.13.3",
-        "@parcel/fs": "2.13.3",
-        "@parcel/graph": "3.3.3",
-        "@parcel/logger": "2.13.3",
-        "@parcel/package-manager": "2.13.3",
-        "@parcel/plugin": "2.13.3",
-        "@parcel/profiler": "2.13.3",
-        "@parcel/rust": "2.13.3",
+        "@parcel/cache": "2.14.2",
+        "@parcel/diagnostic": "2.14.2",
+        "@parcel/events": "2.14.2",
+        "@parcel/feature-flags": "2.14.2",
+        "@parcel/fs": "2.14.2",
+        "@parcel/graph": "3.4.2",
+        "@parcel/logger": "2.14.2",
+        "@parcel/package-manager": "2.14.2",
+        "@parcel/plugin": "2.14.2",
+        "@parcel/profiler": "2.14.2",
+        "@parcel/rust": "2.14.2",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/types": "2.13.3",
-        "@parcel/utils": "2.13.3",
-        "@parcel/workers": "2.13.3",
+        "@parcel/types": "2.14.2",
+        "@parcel/utils": "2.14.2",
+        "@parcel/workers": "2.14.2",
         "base-x": "^3.0.8",
         "browserslist": "^4.6.6",
         "clone": "^2.1.1",
@@ -410,9 +412,9 @@
       }
     },
     "node_modules/@parcel/diagnostic": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.13.3.tgz",
-      "integrity": "sha512-C70KXLBaXLJvr7XCEVu8m6TqNdw1gQLxqg5BQ8roR62R4vWWDnOq8PEksxDi4Y8Z/FF4i3Sapv6tRx9iBNxDEg==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.14.2.tgz",
+      "integrity": "sha512-xoq9gf08Pv4q3zJUJqG9zsA1IBIr328HsEJpRC7b7zDd8j6DVJjrWTYDWnBybHAMXQ34x1qjsTDyvJcGA7uyWA==",
       "dev": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
@@ -426,10 +428,23 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@parcel/error-overlay": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/error-overlay/-/error-overlay-2.14.2.tgz",
+      "integrity": "sha512-/xFL4dVb5bh9L+31Zo3whI5RdhPDgSJNZ/yIPuITKiC7UWWEZpLdGvdCwP0EV3NVA4RauYJovkcgCgtkM61LBQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/@parcel/events": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.13.3.tgz",
-      "integrity": "sha512-ZkSHTTbD/E+53AjUzhAWTnMLnxLEU5yRw0H614CaruGh+GjgOIKyukGeToF5Gf/lvZ159VrJCGE0Z5EpgHVkuQ==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.14.2.tgz",
+      "integrity": "sha512-ZwHOicEfnr0DVlA2+I9HN/wAIOKqpjVe/kRLZfKA3N5R2xLB+Mx3e5zDMSi2kCxkkqW5Yg0qxSI9hy3kTNgM0A==",
       "dev": true,
       "engines": {
         "node": ">= 16.0.0"
@@ -440,9 +455,9 @@
       }
     },
     "node_modules/@parcel/feature-flags": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/feature-flags/-/feature-flags-2.13.3.tgz",
-      "integrity": "sha512-UZm14QpamDFoUut9YtCZSpG1HxPs07lUwUCpsAYL0PpxASD3oWJQxIJGfDZPa2272DarXDG9adTKrNXvkHZblw==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/feature-flags/-/feature-flags-2.14.2.tgz",
+      "integrity": "sha512-TqurCACfUVoCRNWYSNHdIStc8ibWl+ZHPZWKOpnZSnBOgYf0lppmeq1W/dHTeaBDCB57VZM9d0ucFd0Xd0SZlA==",
       "dev": true,
       "engines": {
         "node": ">= 16.0.0"
@@ -453,17 +468,17 @@
       }
     },
     "node_modules/@parcel/fs": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.13.3.tgz",
-      "integrity": "sha512-+MPWAt0zr+TCDSlj1LvkORTjfB/BSffsE99A9AvScKytDSYYpY2s0t4vtV9unSh0FHMS2aBCZNJ4t7KL+DcPIg==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.14.2.tgz",
+      "integrity": "sha512-SOKgXMGA4buLs56kEVqymdpysb9Lpmo7QQn9QRcSZYX0u+vkD5JORCK0SiO7etvPWFttXNKjdlYE9IvvrRweaQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/feature-flags": "2.13.3",
-        "@parcel/rust": "2.13.3",
-        "@parcel/types-internal": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/feature-flags": "2.14.2",
+        "@parcel/rust": "2.14.2",
+        "@parcel/types-internal": "2.14.2",
+        "@parcel/utils": "2.14.2",
         "@parcel/watcher": "^2.0.7",
-        "@parcel/workers": "2.13.3"
+        "@parcel/workers": "2.14.2"
       },
       "engines": {
         "node": ">= 16.0.0"
@@ -473,16 +488,16 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.13.3"
+        "@parcel/core": "^2.14.2"
       }
     },
     "node_modules/@parcel/graph": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.3.3.tgz",
-      "integrity": "sha512-pxs4GauEdvCN8nRd6wG3st6LvpHske3GfqGwUSR0P0X0pBPI1/NicvXz6xzp3rgb9gPWfbKXeI/2IOTfIxxVfg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.4.2.tgz",
+      "integrity": "sha512-yMP3Adz/zSkxPtTu9rh8XELkYyJfhysnw8PFA9UJlfvVWZsyir0ZWQC6R6cchlVthpVRAn29VIBOy67vmcgqjg==",
       "dev": true,
       "dependencies": {
-        "@parcel/feature-flags": "2.13.3",
+        "@parcel/feature-flags": "2.14.2",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -494,13 +509,13 @@
       }
     },
     "node_modules/@parcel/logger": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.13.3.tgz",
-      "integrity": "sha512-8YF/ZhsQgd7ohQ2vEqcMD1Ag9JlJULROWRPGgGYLGD+twuxAiSdiFBpN3f+j4gQN4PYaLaIS/SwUFx11J243fQ==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.14.2.tgz",
+      "integrity": "sha512-gnG/0J2mj1Ot/1XoKbTh0YdEt+vWnODc022FgG+df5+qBiPwonwsIThSv1feUHX2EqHCEtbpXJ+OzZdzXRH9yA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/events": "2.13.3"
+        "@parcel/diagnostic": "2.14.2",
+        "@parcel/events": "2.14.2"
       },
       "engines": {
         "node": ">= 16.0.0"
@@ -511,9 +526,9 @@
       }
     },
     "node_modules/@parcel/markdown-ansi": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.13.3.tgz",
-      "integrity": "sha512-B4rUdlNUulJs2xOQuDbN7Hq5a9roq8IZUcJ1vQ8PAv+zMGb7KCfqIIr/BSCDYGhayfAGBVWW8x55Kvrl1zrDYw==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.14.2.tgz",
+      "integrity": "sha512-9wSiT2C7kW9pcvh2PyiuN/jWvIkDWpZvlGpCGmFU87qYAJbOjsjC7cybqDbqVEMQUplFPs8RL5vcTGU88vrzvA==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.2"
@@ -527,18 +542,18 @@
       }
     },
     "node_modules/@parcel/namer-default": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.13.3.tgz",
-      "integrity": "sha512-A2a5A5fuyNcjSGOS0hPcdQmOE2kszZnLIXof7UMGNkNkeC62KAG8WcFZH5RNOY3LT5H773hq51zmc2Y2gE5Rnw==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.14.2.tgz",
+      "integrity": "sha512-4Om4hEOZCX08uWqNvh6M4AX6344rtt1YT0Yup7uuLw2N5H8dr0Xpy4SXLabD52SAoi57gG2B0yX8g7tV142QzQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
+        "@parcel/diagnostic": "2.14.2",
+        "@parcel/plugin": "2.14.2",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.2"
       },
       "funding": {
         "type": "opencollective",
@@ -546,16 +561,16 @@
       }
     },
     "node_modules/@parcel/node-resolver-core": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.4.3.tgz",
-      "integrity": "sha512-IEnMks49egEic1ITBp59VQyHzkSQUXqpU9hOHwqN3KoSTdZ6rEgrXcS3pa6tdXay4NYGlcZ88kFCE8i/xYoVCg==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.5.2.tgz",
+      "integrity": "sha512-cUSsfwd+Phatm5oeiJIzev6TojbDGL09/GUzoWKwpx3exT2VqcrFfHEt4GQLBUJsTf/bqk5FzyzK548ue09loQ==",
       "dev": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/fs": "2.13.3",
-        "@parcel/rust": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/diagnostic": "2.14.2",
+        "@parcel/fs": "2.14.2",
+        "@parcel/rust": "2.14.2",
+        "@parcel/utils": "2.14.2",
         "nullthrows": "^1.1.1",
         "semver": "^7.5.2"
       },
@@ -568,22 +583,22 @@
       }
     },
     "node_modules/@parcel/optimizer-css": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.13.3.tgz",
-      "integrity": "sha512-A8o9IVCv919vhv69SkLmyW2WjJR5WZgcMqV6L1uiGF8i8z18myrMhrp2JuSHx29PRT9uNyzNC4Xrd4StYjIhJg==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.14.2.tgz",
+      "integrity": "sha512-wg9BlMvBUo4kwKVuQ8ec/GlNyCMyx9Xg36Y8DBgj55sBHhk7M4/+C8yTGbxDlu6NU0+/Tx0yuypCe/Fq17wWaA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
+        "@parcel/diagnostic": "2.14.2",
+        "@parcel/plugin": "2.14.2",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.13.3",
+        "@parcel/utils": "2.14.2",
         "browserslist": "^4.6.6",
         "lightningcss": "^1.22.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.2"
       },
       "funding": {
         "type": "opencollective",
@@ -591,21 +606,21 @@
       }
     },
     "node_modules/@parcel/optimizer-htmlnano": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.13.3.tgz",
-      "integrity": "sha512-K4Uvg0Sy2pECP7pdvvbud++F0pfcbNkq+IxTrgqBX5HJnLEmRZwgdvZEKF43oMEolclMnURMQRGjRplRaPdbXg==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.14.2.tgz",
+      "integrity": "sha512-Z9W8FMasZfRTI9rLTYgjxAABaZRG6zfPaMLQPXCv5KmDuQcrm9UcpGEuboFd7UCTA/ajPpFLWFZroRfmG9Ox1w==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/diagnostic": "2.14.2",
+        "@parcel/plugin": "2.14.2",
+        "@parcel/utils": "2.14.2",
         "htmlnano": "^2.0.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.2"
       },
       "funding": {
         "type": "opencollective",
@@ -613,42 +628,42 @@
       }
     },
     "node_modules/@parcel/optimizer-image": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.13.3.tgz",
-      "integrity": "sha512-wlDUICA29J4UnqkKrWiyt68g1e85qfYhp4zJFcFJL0LX1qqh1QwsLUz3YJ+KlruoqPxJSFEC8ncBEKiVCsqhEQ==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.14.2.tgz",
+      "integrity": "sha512-pVEKAfpFRgjjmjU+mJ17uA9tycMinZz4v1J7TWo+nq0z5D4ifKSusTvhIEnY6aj2WZnYZKN8II2dCdT9OkOO2A==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
-        "@parcel/rust": "2.13.3",
-        "@parcel/utils": "2.13.3",
-        "@parcel/workers": "2.13.3"
+        "@parcel/diagnostic": "2.14.2",
+        "@parcel/plugin": "2.14.2",
+        "@parcel/rust": "2.14.2",
+        "@parcel/utils": "2.14.2",
+        "@parcel/workers": "2.14.2"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.13.3"
+        "@parcel/core": "^2.14.2"
       }
     },
     "node_modules/@parcel/optimizer-svgo": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.13.3.tgz",
-      "integrity": "sha512-piIKxQKzhZK54dJR6yqIcq+urZmpsfgUpLCZT3cnWlX4ux5+S2iN66qqZBs0zVn+a58LcWcoP4Z9ieiJmpiu2w==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.14.2.tgz",
+      "integrity": "sha512-2uU50h/wEEX8F2TdJKXN3zpGJqBGeraa9s5354WCC84TqJprb1ZMdweVpi2KZn+GjjOrjAxDKe3a8/Z6EavLmQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
-        "@parcel/utils": "2.13.3"
+        "@parcel/diagnostic": "2.14.2",
+        "@parcel/plugin": "2.14.2",
+        "@parcel/utils": "2.14.2"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.2"
       },
       "funding": {
         "type": "opencollective",
@@ -656,21 +671,21 @@
       }
     },
     "node_modules/@parcel/optimizer-swc": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-swc/-/optimizer-swc-2.13.3.tgz",
-      "integrity": "sha512-zNSq6oWqLlW8ksPIDjM0VgrK6ZAJbPQCDvs1V+p0oX3CzEe85lT5VkRpnfrN1+/vvEJNGL8e60efHKpI+rXGTA==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-swc/-/optimizer-swc-2.14.2.tgz",
+      "integrity": "sha512-oqzukZcW56+W/vfNBNDh9TvBJYMB038eXZg5Fz6pamY/vHLuaZT5G1P1/znpsVcVwAAvzK0fCJsfG3KQ6RxjgQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
+        "@parcel/diagnostic": "2.14.2",
+        "@parcel/plugin": "2.14.2",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.13.3",
-        "@swc/core": "^1.7.26",
+        "@parcel/utils": "2.14.2",
+        "@swc/core": "^1.11.5",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.2"
       },
       "funding": {
         "type": "opencollective",
@@ -678,19 +693,19 @@
       }
     },
     "node_modules/@parcel/package-manager": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.13.3.tgz",
-      "integrity": "sha512-FLNI5OrZxymGf/Yln0E/kjnGn5sdkQAxW7pQVdtuM+5VeN75yibJRjsSGv88PvJ+KvpD2ANgiIJo1RufmoPcww==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.14.2.tgz",
+      "integrity": "sha512-vagjbhRxYAfU1dQP5qAbBA9KpYROKDtqsa9YV5+5ni7HTkQR3PdSkjd9dIV/7UnsN9kiYHu/jhxTFM0cxjC3pw==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/fs": "2.13.3",
-        "@parcel/logger": "2.13.3",
-        "@parcel/node-resolver-core": "3.4.3",
-        "@parcel/types": "2.13.3",
-        "@parcel/utils": "2.13.3",
-        "@parcel/workers": "2.13.3",
-        "@swc/core": "^1.7.26",
+        "@parcel/diagnostic": "2.14.2",
+        "@parcel/fs": "2.14.2",
+        "@parcel/logger": "2.14.2",
+        "@parcel/node-resolver-core": "3.5.2",
+        "@parcel/types": "2.14.2",
+        "@parcel/utils": "2.14.2",
+        "@parcel/workers": "2.14.2",
+        "@swc/core": "^1.11.5",
         "semver": "^7.5.2"
       },
       "engines": {
@@ -701,25 +716,25 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.13.3"
+        "@parcel/core": "^2.14.2"
       }
     },
     "node_modules/@parcel/packager-css": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.13.3.tgz",
-      "integrity": "sha512-ghDqRMtrUwaDERzFm9le0uz2PTeqqsjsW0ihQSZPSAptElRl9o5BR+XtMPv3r7Ui0evo+w35gD55oQCJ28vCig==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.14.2.tgz",
+      "integrity": "sha512-WD2vTHWIc1ETCLgKslyC4lTKqCG9Rj//EUaGw8HW7krL8dAEAdIhEvUJWzzAHsyiyORcqo+as8QFT4Wf+Fx9Jg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
+        "@parcel/diagnostic": "2.14.2",
+        "@parcel/plugin": "2.14.2",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.13.3",
+        "@parcel/utils": "2.14.2",
         "lightningcss": "^1.22.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.2"
       },
       "funding": {
         "type": "opencollective",
@@ -727,20 +742,20 @@
       }
     },
     "node_modules/@parcel/packager-html": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.13.3.tgz",
-      "integrity": "sha512-jDLnKSA/EzVEZ3/aegXO3QJ/Ij732AgBBkIQfeC8tUoxwVz5b3HiPBAjVjcUSfZs7mdBSHO+ELWC3UD+HbsIrQ==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.14.2.tgz",
+      "integrity": "sha512-cWkUQGGcaMcag3MqzxurqP5Ffz3rmaF572cY828aEuTfdER1rXvA4VdTJxrYWbpILe2YBYxlZPtGQYKYV5rKSQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
-        "@parcel/types": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/plugin": "2.14.2",
+        "@parcel/types": "2.14.2",
+        "@parcel/utils": "2.14.2",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.2"
       },
       "funding": {
         "type": "opencollective",
@@ -748,23 +763,23 @@
       }
     },
     "node_modules/@parcel/packager-js": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.13.3.tgz",
-      "integrity": "sha512-0pMHHf2zOn7EOJe88QJw5h/wcV1bFfj6cXVcE55Wa8GX3V+SdCgolnlvNuBcRQ1Tlx0Xkpo+9hMFVIQbNQY6zw==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.14.2.tgz",
+      "integrity": "sha512-Yw9Le3UBb/vwOCyAr1gdOPTDUyLC2Ulx8IXpP/BM7XGoGu2k7xGtGRz//2ytH0N18Et9F/1FAw9CJxMRsd/abg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
-        "@parcel/rust": "2.13.3",
+        "@parcel/diagnostic": "2.14.2",
+        "@parcel/plugin": "2.14.2",
+        "@parcel/rust": "2.14.2",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/types": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/types": "2.14.2",
+        "@parcel/utils": "2.14.2",
         "globals": "^13.2.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.2"
       },
       "funding": {
         "type": "opencollective",
@@ -772,16 +787,16 @@
       }
     },
     "node_modules/@parcel/packager-raw": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.13.3.tgz",
-      "integrity": "sha512-AWu4UB+akBdskzvT3KGVHIdacU9f7cI678DQQ1jKQuc9yZz5D0VFt3ocFBOmvDfEQDF0uH3jjtJR7fnuvX7Biw==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.14.2.tgz",
+      "integrity": "sha512-nDIh3FNiUhQR22U3RNcLt1N2vBc/OGwGRvqivs9yqqyiyUWX95cVcBwB9zkFH7Gd5u8R8w4u+zQP/IGSvA5gVQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.13.3"
+        "@parcel/plugin": "2.14.2"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.2"
       },
       "funding": {
         "type": "opencollective",
@@ -789,19 +804,19 @@
       }
     },
     "node_modules/@parcel/packager-svg": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.13.3.tgz",
-      "integrity": "sha512-tKGRiFq/4jh5u2xpTstNQ7gu+RuZWzlWqpw5NaFmcKe6VQe5CMcS499xTFoREAGnRvevSeIgC38X1a+VOo+/AA==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.14.2.tgz",
+      "integrity": "sha512-J+unuT121omswg0HIIRU3Ow4BeuZkos3WGwZI8RFZ5OFC4sdrCqoCEFllWKLeTMFmGrCJki0SGH6ZPRjf1hcaQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
-        "@parcel/types": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/plugin": "2.14.2",
+        "@parcel/types": "2.14.2",
+        "@parcel/utils": "2.14.2",
         "posthtml": "^0.16.4"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.2"
       },
       "funding": {
         "type": "opencollective",
@@ -809,16 +824,16 @@
       }
     },
     "node_modules/@parcel/packager-wasm": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-wasm/-/packager-wasm-2.13.3.tgz",
-      "integrity": "sha512-SZB56/b230vFrSehVXaUAWjJmWYc89gzb8OTLkBm7uvtFtov2J1R8Ig9TTJwinyXE3h84MCFP/YpQElSfoLkJw==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-wasm/-/packager-wasm-2.14.2.tgz",
+      "integrity": "sha512-RlysqyEiyTEPXgesZWiWXT5va/Kn1Sh9hrFHq+3CQJvhDBMlPqNBCOq4W4swwge8DBLKOi3J5YVSSVZL6LZybQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.13.3"
+        "@parcel/plugin": "2.14.2"
       },
       "engines": {
         "node": ">=16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.2"
       },
       "funding": {
         "type": "opencollective",
@@ -826,12 +841,12 @@
       }
     },
     "node_modules/@parcel/plugin": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.13.3.tgz",
-      "integrity": "sha512-cterKHHcwg6q11Gpif/aqvHo056TR+yDVJ3fSdiG2xr5KD1VZ2B3hmofWERNNwjMcnR1h9Xq40B7jCKUhOyNFA==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.14.2.tgz",
+      "integrity": "sha512-iUL6eJFcJkMmvTpaav+SA4bR+MEG/d5+QO6MQFsl+jkGEohDCbJlm2kCjnhjY9Gu2UAl2GMC0k+DFb5R2v9HYg==",
       "dev": true,
       "dependencies": {
-        "@parcel/types": "2.13.3"
+        "@parcel/types": "2.14.2"
       },
       "engines": {
         "node": ">= 16.0.0"
@@ -842,14 +857,14 @@
       }
     },
     "node_modules/@parcel/profiler": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.13.3.tgz",
-      "integrity": "sha512-ok6BwWSLvyHe5TuSXjSacYnDStFgP5Y30tA9mbtWSm0INDsYf+m5DqzpYPx8U54OaywWMK8w3MXUClosJX3aPA==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.14.2.tgz",
+      "integrity": "sha512-kNgEz7FDC1hb7gpA/Z3s9vp6NiAJ5tEvxGhRAV64CDx98Jd/FES5MJLZ7A0vDWMHqDChgtprCkh0u3KnWrXRqg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/events": "2.13.3",
-        "@parcel/types-internal": "2.13.3",
+        "@parcel/diagnostic": "2.14.2",
+        "@parcel/events": "2.14.2",
+        "@parcel/types-internal": "2.14.2",
         "chrome-trace-event": "^1.0.2"
       },
       "engines": {
@@ -860,21 +875,41 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@parcel/reporter-bundle-analyzer": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-bundle-analyzer/-/reporter-bundle-analyzer-2.14.2.tgz",
+      "integrity": "sha512-Zr2aH2INpNrhpsuUS06ypAyWVK7uc7CKxziGD0Tawgz8q6NWon7TUT7qTP+vH3/T6INIoBmIPmMUakCUTZEF2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@parcel/plugin": "2.14.2",
+        "@parcel/utils": "2.14.2",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0",
+        "parcel": "^2.14.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/@parcel/reporter-cli": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.13.3.tgz",
-      "integrity": "sha512-EA5tKt/6bXYNMEavSs35qHlFdx6cZmRazlZxPBgxPePQYoouNAPMNLUOEQozaPhz9f5fvNDN7EHOFaAWcdO2LA==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.14.2.tgz",
+      "integrity": "sha512-qzsn8GXBsl6dc8rLdmFsVVYAvzzSP+q+c6dvxvspC5NMu9N/fE4zfeZ0ShLexsxlpjn/ipa7cJo0gZa6E8F8qg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
-        "@parcel/types": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/plugin": "2.14.2",
+        "@parcel/types": "2.14.2",
+        "@parcel/utils": "2.14.2",
         "chalk": "^4.1.2",
         "term-size": "^2.2.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.2"
       },
       "funding": {
         "type": "opencollective",
@@ -882,17 +917,19 @@
       }
     },
     "node_modules/@parcel/reporter-dev-server": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.13.3.tgz",
-      "integrity": "sha512-ZNeFp6AOIQFv7mZIv2P5O188dnZHNg0ymeDVcakfZomwhpSva2dFNS3AnvWo4eyWBlUxkmQO8BtaxeWTs7jAuA==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.14.2.tgz",
+      "integrity": "sha512-a5AY9+MImQAg4rJ60BlGtOf813JOlFABDpw6QJ85OEw5wp5a8BAbYUgxj7eX/gr8l2k8pSY5BZcSA9PUC3YFeg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
-        "@parcel/utils": "2.13.3"
+        "@parcel/codeframe": "2.14.2",
+        "@parcel/plugin": "2.14.2",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.14.2"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.2"
       },
       "funding": {
         "type": "opencollective",
@@ -900,19 +937,19 @@
       }
     },
     "node_modules/@parcel/reporter-tracer": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-tracer/-/reporter-tracer-2.13.3.tgz",
-      "integrity": "sha512-aBsVPI8jLZTDkFYrI69GxnsdvZKEYerkPsu935LcX9rfUYssOnmmUP+3oI+8fbg+qNjJuk9BgoQ4hCp9FOphMQ==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-tracer/-/reporter-tracer-2.14.2.tgz",
+      "integrity": "sha512-zGtM2GYGpT9wrFTebrKcs7aMeCVLE+aHpfeI4dQDGFkYE5QTVswkpbZkqdhp8bVRcX+p6E8YQnRb88cJhpcDqA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/plugin": "2.14.2",
+        "@parcel/utils": "2.14.2",
         "chrome-trace-event": "^1.0.3",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.2"
       },
       "funding": {
         "type": "opencollective",
@@ -920,17 +957,17 @@
       }
     },
     "node_modules/@parcel/resolver-default": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.13.3.tgz",
-      "integrity": "sha512-urBZuRALWT9pFMeWQ8JirchLmsQEyI9lrJptiwLbJWrwvmlwSUGkcstmPwoNRf/aAQjICB7ser/247Vny0pFxA==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.14.2.tgz",
+      "integrity": "sha512-HzfLPK1NUiYYuONlfPg92Lv0qfF/GtZ3hP4bNI7L0MI/eOtkd19dDxXADVaF4bTY2WmnL7m2pfaZ0+Y1+zuJuw==",
       "dev": true,
       "dependencies": {
-        "@parcel/node-resolver-core": "3.4.3",
-        "@parcel/plugin": "2.13.3"
+        "@parcel/node-resolver-core": "3.5.2",
+        "@parcel/plugin": "2.14.2"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.2"
       },
       "funding": {
         "type": "opencollective",
@@ -938,17 +975,17 @@
       }
     },
     "node_modules/@parcel/runtime-browser-hmr": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.13.3.tgz",
-      "integrity": "sha512-EAcPojQFUNUGUrDk66cu3ySPO0NXRVS5CKPd4QrxPCVVbGzde4koKu8krC/TaGsoyUqhie8HMnS70qBP0GFfcQ==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.14.2.tgz",
+      "integrity": "sha512-YJrnc52/2RMx4FaT4rt/1SCZIux9l/v3YFc9v+jCl+NEpBhDou//GBI3RPRJ0EPUgFOwmj3IZ9uPzm5WxokhGA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
-        "@parcel/utils": "2.13.3"
+        "@parcel/plugin": "2.14.2",
+        "@parcel/utils": "2.14.2"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.2"
       },
       "funding": {
         "type": "opencollective",
@@ -956,39 +993,39 @@
       }
     },
     "node_modules/@parcel/runtime-js": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.13.3.tgz",
-      "integrity": "sha512-62OucNAnxb2Q0uyTFWW/0Hvv2DJ4b5H6neh/YFu2/wmxaZ37xTpEuEcG2do7KW54xE5DeLP+RliHLwi4NvR3ww==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.14.2.tgz",
+      "integrity": "sha512-CqcCiURZh7hPNXF+wudsPbEbGPpANHFvHdR3O6IkQxKoWluqu2EyOzS89j1jMU4wprIK91D4snVYuZjYERTh/w==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/diagnostic": "2.14.2",
+        "@parcel/plugin": "2.14.2",
+        "@parcel/utils": "2.14.2",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/runtime-react-refresh": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.13.3.tgz",
-      "integrity": "sha512-PYZ1klpJVwqE3WuifILjtF1dugtesHEuJcXYZI85T6UoRSD5ctS1nAIpZzT14Ga1lRt/jd+eAmhWL1l3m/Vk1Q==",
+    "node_modules/@parcel/runtime-rsc": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-rsc/-/runtime-rsc-2.14.2.tgz",
+      "integrity": "sha512-d58QQ/MQBlL4jvjWw3CaCAHJtwhRVuhvm0g523yor3fgbG6Iu4KFea5t5yml1C86sXMCBxWpqKJI93+bQHK1sA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
-        "@parcel/utils": "2.13.3",
-        "react-error-overlay": "6.0.9",
-        "react-refresh": ">=0.9 <=0.14"
+        "@parcel/plugin": "2.14.2",
+        "@parcel/rust": "2.14.2",
+        "@parcel/utils": "2.14.2",
+        "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "node": ">= 12.0.0",
+        "parcel": "^2.14.2"
       },
       "funding": {
         "type": "opencollective",
@@ -996,18 +1033,18 @@
       }
     },
     "node_modules/@parcel/runtime-service-worker": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.13.3.tgz",
-      "integrity": "sha512-BjMhPuT7Us1+YIo31exPRwomPiL+jrZZS5UUAwlEW2XGHDceEotzRM94LwxeFliCScT4IOokGoxixm19qRuzWg==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.14.2.tgz",
+      "integrity": "sha512-atFl7z3DBH5nQeRW+rdt2JulZJVergEtAK4sWfSsUIbEiBaTiK2/v7Jjxm4UDF4laHFp6d5AGixIr9TxJl7x5w==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/plugin": "2.14.2",
+        "@parcel/utils": "2.14.2",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.2"
       },
       "funding": {
         "type": "opencollective",
@@ -1015,9 +1052,9 @@
       }
     },
     "node_modules/@parcel/rust": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.13.3.tgz",
-      "integrity": "sha512-dLq85xDAtzr3P5200cvxk+8WXSWauYbxuev9LCPdwfhlaWo/JEj6cu9seVdWlkagjGwkoV1kXC+GGntgUXOLAQ==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.14.2.tgz",
+      "integrity": "sha512-NPXebSTdhLttERkWgJZf/QRIIvQ8DpGby84T6FGM0pfFzocnHmuL/36J5xjquEncbSjFEVUBGomCpJNQLBwK9g==",
       "dev": true,
       "engines": {
         "node": ">= 16.0.0"
@@ -1025,6 +1062,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "napi-wasm": "^1.1.2"
+      },
+      "peerDependenciesMeta": {
+        "napi-wasm": {
+          "optional": true
+        }
       }
     },
     "node_modules/@parcel/source-map": {
@@ -1040,15 +1085,15 @@
       }
     },
     "node_modules/@parcel/transformer-babel": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.13.3.tgz",
-      "integrity": "sha512-ikzK9f5WTFrdQsPitQgjCPH6HmVU8AQPRemIJ2BndYhtodn5PQut5cnSvTrqax8RjYvheEKCQk/Zb/uR7qgS3g==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.14.2.tgz",
+      "integrity": "sha512-tVGRmHRys71AQhm4vHf9RCSYiMj5C+c7Qr0dj4RRNy8uLY+NTCi/Zdvb3ZVN069DikP1T2TpGd57gALcqK6zDQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
+        "@parcel/diagnostic": "2.14.2",
+        "@parcel/plugin": "2.14.2",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.13.3",
+        "@parcel/utils": "2.14.2",
         "browserslist": "^4.6.6",
         "json5": "^2.2.0",
         "nullthrows": "^1.1.1",
@@ -1056,7 +1101,7 @@
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.2"
       },
       "funding": {
         "type": "opencollective",
@@ -1064,22 +1109,22 @@
       }
     },
     "node_modules/@parcel/transformer-css": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.13.3.tgz",
-      "integrity": "sha512-zbrNURGph6JeVADbGydyZ7lcu/izj41kDxQ9xw4RPRW/3rofQiTU0OTREi+uBWiMENQySXVivEdzHA9cA+aLAA==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.14.2.tgz",
+      "integrity": "sha512-Q7QOwty7R/VWx1wPhnOKY7CZb4GRK/GBJH9HP6vo/1+Zf5fm9jbYhItZb3tDl7ufKqZz5UfbJhBhybaETO6umg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
+        "@parcel/diagnostic": "2.14.2",
+        "@parcel/plugin": "2.14.2",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.13.3",
+        "@parcel/utils": "2.14.2",
         "browserslist": "^4.6.6",
         "lightningcss": "^1.22.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.2"
       },
       "funding": {
         "type": "opencollective",
@@ -1087,14 +1132,14 @@
       }
     },
     "node_modules/@parcel/transformer-html": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.13.3.tgz",
-      "integrity": "sha512-Yf74FkL9RCCB4+hxQRVMNQThH9+fZ5w0NLiQPpWUOcgDEEyxTi4FWPQgEBsKl/XK2ehdydbQB9fBgPQLuQxwPg==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.14.2.tgz",
+      "integrity": "sha512-6HGo7m/ARInEeXoYWCIYz1wtK9pJPbRkxdqZr/lSKQAbLsyTZQZx/GgnkgKRtsmcLp8vCffMI4Yul/2RPcTJ0A==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
-        "@parcel/rust": "2.13.3",
+        "@parcel/diagnostic": "2.14.2",
+        "@parcel/plugin": "2.14.2",
+        "@parcel/rust": "2.14.2",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.12.1",
@@ -1104,7 +1149,7 @@
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.2"
       },
       "funding": {
         "type": "opencollective",
@@ -1124,36 +1169,36 @@
       }
     },
     "node_modules/@parcel/transformer-image": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.13.3.tgz",
-      "integrity": "sha512-wL1CXyeFAqbp2wcEq/JD3a/tbAyVIDMTC6laQxlIwnVV7dsENhK1qRuJZuoBdixESeUpFQSmmQvDIhcfT/cUUg==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.14.2.tgz",
+      "integrity": "sha512-av3JZ5sizv6cIspSusZErk6yGd23UpWGIbQJsIMFnxMF9miBgmN0er92d40LI9gIGyEcpWMBYyUPH2jHEQnaNg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
-        "@parcel/utils": "2.13.3",
-        "@parcel/workers": "2.13.3",
+        "@parcel/plugin": "2.14.2",
+        "@parcel/utils": "2.14.2",
+        "@parcel/workers": "2.14.2",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.2"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.13.3"
+        "@parcel/core": "^2.14.2"
       }
     },
     "node_modules/@parcel/transformer-js": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.13.3.tgz",
-      "integrity": "sha512-KqfNGn1IHzDoN2aPqt4nDksgb50Xzcny777C7A7hjlQ3cmkjyJrixYjzzsPaPSGJ+kJpknh3KE8unkQ9mhFvRQ==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.14.2.tgz",
+      "integrity": "sha512-8urpoFlRpFUHEwbOxXPbqmAI+bRjcg0ED6msuSbzVODIc4qsztVt48gXuSfEBfcQIfFJzDpRTh01GOYjMQQKRA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
-        "@parcel/rust": "2.13.3",
+        "@parcel/diagnostic": "2.14.2",
+        "@parcel/plugin": "2.14.2",
+        "@parcel/rust": "2.14.2",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.13.3",
-        "@parcel/workers": "2.13.3",
+        "@parcel/utils": "2.14.2",
+        "@parcel/workers": "2.14.2",
         "@swc/helpers": "^0.5.0",
         "browserslist": "^4.6.6",
         "nullthrows": "^1.1.1",
@@ -1162,28 +1207,45 @@
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.13.3"
+        "@parcel/core": "^2.14.2"
       }
     },
     "node_modules/@parcel/transformer-json": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.13.3.tgz",
-      "integrity": "sha512-rrq0ab6J0w9ePtsxi0kAvpCmrUYXXAx1Z5PATZakv89rSYbHBKEdXxyCoKFui/UPVCUEGVs5r0iOFepdHpIyeA==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.14.2.tgz",
+      "integrity": "sha512-wcQrlDJAmCVZ1PHVKb1ayHWzfdqpCMN8TUoYA6kB1626K6wBv5FD9NqQZA4Fs5u8cVy/ZhtZ+LfogzS7wQSpwQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
+        "@parcel/plugin": "2.14.2",
         "json5": "^2.2.0"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/transformer-node": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-node/-/transformer-node-2.14.2.tgz",
+      "integrity": "sha512-Y2Wz4ziyqOwOe+6/yayKdvYhoz6AvfblY38upfjOCh8amZcmcXCZRxVf8uZAm5y2BvbVbWZTdNYaK0o+MDud5g==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/plugin": "2.14.2"
+      },
+      "engines": {
+        "node": ">= 16.0.0",
+        "parcel": "^2.14.2"
       },
       "funding": {
         "type": "opencollective",
@@ -1191,15 +1253,15 @@
       }
     },
     "node_modules/@parcel/transformer-postcss": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.13.3.tgz",
-      "integrity": "sha512-AIiWpU0QSFBrPcYIqAnhqB8RGE6yHFznnxztfg1t2zMSOnK3xoU6xqYKv8H/MduShGGrC3qVOeDfM8MUwzL3cw==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.14.2.tgz",
+      "integrity": "sha512-ny74JKyYDx0mW+6r7pkRrKRe/vxq+9l035dynTs4blBJloI1gwpelnpbK0kA9t13hb7So1XxkXphO90GRB202A==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
-        "@parcel/rust": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/diagnostic": "2.14.2",
+        "@parcel/plugin": "2.14.2",
+        "@parcel/rust": "2.14.2",
+        "@parcel/utils": "2.14.2",
         "clone": "^2.1.1",
         "nullthrows": "^1.1.1",
         "postcss-value-parser": "^4.2.0",
@@ -1207,7 +1269,7 @@
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.2"
       },
       "funding": {
         "type": "opencollective",
@@ -1215,13 +1277,13 @@
       }
     },
     "node_modules/@parcel/transformer-posthtml": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.13.3.tgz",
-      "integrity": "sha512-5GSLyccpHASwFAu3uJ83gDIBSvfsGdVmhJvy0Vxe+K1Fklk2ibhvvtUHMhB7mg6SPHC+R9jsNc3ZqY04ZLeGjw==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.14.2.tgz",
+      "integrity": "sha512-U4Lt7j1EYkxiDiLpem05m1xSEebcpWU8VPdc4n4Y3P5NjbW3lFivMvIK30QRkjoDofpY2tiLFROrdNy8EFqe1A==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/plugin": "2.14.2",
+        "@parcel/utils": "2.14.2",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.12.1",
@@ -1230,7 +1292,7 @@
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.2"
       },
       "funding": {
         "type": "opencollective",
@@ -1238,16 +1300,16 @@
       }
     },
     "node_modules/@parcel/transformer-raw": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.13.3.tgz",
-      "integrity": "sha512-BFsAbdQF0l8/Pdb7dSLJeYcd8jgwvAUbHgMink2MNXJuRUvDl19Gns8jVokU+uraFHulJMBj40+K/RTd33in4g==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.14.2.tgz",
+      "integrity": "sha512-ufGaypQLRsnZBZqylaJQQ0W5PWre+dGVlnBBkuQYY9qVo2wvGfP0sPY+xKK2i6IFfegmigFKeigViDeSoo6Ldw==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.13.3"
+        "@parcel/plugin": "2.14.2"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.2"
       },
       "funding": {
         "type": "opencollective",
@@ -1255,18 +1317,19 @@
       }
     },
     "node_modules/@parcel/transformer-react-refresh-wrap": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.13.3.tgz",
-      "integrity": "sha512-mOof4cRyxsZRdg8kkWaFtaX98mHpxUhcGPU+nF9RQVa9q737ItxrorsPNR9hpZAyE2TtFNflNW7RoYsgvlLw8w==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.14.2.tgz",
+      "integrity": "sha512-gSqqjxN6qEQQtloL2QNleL0RfU5TeZEHz9IAYxTgo/kpzLv8Oiz0T93CmutbzkF38uyjI1xKO0Qj8X+lGhO9zQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
-        "@parcel/utils": "2.13.3",
-        "react-refresh": ">=0.9 <=0.14"
+        "@parcel/error-overlay": "2.14.2",
+        "@parcel/plugin": "2.14.2",
+        "@parcel/utils": "2.14.2",
+        "react-refresh": ">=0.9 <=0.16"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.2"
       },
       "funding": {
         "type": "opencollective",
@@ -1274,14 +1337,14 @@
       }
     },
     "node_modules/@parcel/transformer-svg": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.13.3.tgz",
-      "integrity": "sha512-9jm7ZF4KHIrGLWlw/SFUz5KKJ20nxHvjFAmzde34R9Wu+F1BOjLZxae7w4ZRwvIc+UVOUcBBQFmhSVwVDZg6Dw==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.14.2.tgz",
+      "integrity": "sha512-WFyh/JwAeJWwQX2NUrKGWolXrtL6Uu/BbrYAFvWIH9GHVlq24GofRDKnncrbtF8CJ4y3K7S5ztExLpirLQT0Tg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
-        "@parcel/rust": "2.13.3",
+        "@parcel/diagnostic": "2.14.2",
+        "@parcel/plugin": "2.14.2",
+        "@parcel/rust": "2.14.2",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.12.1",
@@ -1290,7 +1353,7 @@
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.2"
       },
       "funding": {
         "type": "opencollective",
@@ -1298,38 +1361,38 @@
       }
     },
     "node_modules/@parcel/types": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.13.3.tgz",
-      "integrity": "sha512-+RpFHxx8fy8/dpuehHUw/ja9PRExC3wJoIlIIF42E7SLu2SvlTHtKm6EfICZzxCXNEBzjoDbamCRcN0nmTPlhw==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.14.2.tgz",
+      "integrity": "sha512-15vSnfdjWB3fLkqGGZ0dEZVeHheH4XgtkSBnmwhgLN7LgigK1P9BwwN8/cN/tIKMP+YfcvjVpHCtaeKRGpje9A==",
       "dev": true,
       "dependencies": {
-        "@parcel/types-internal": "2.13.3",
-        "@parcel/workers": "2.13.3"
+        "@parcel/types-internal": "2.14.2",
+        "@parcel/workers": "2.14.2"
       }
     },
     "node_modules/@parcel/types-internal": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.13.3.tgz",
-      "integrity": "sha512-Lhx0n+9RCp+Ipktf/I+CLm3zE9Iq9NtDd8b2Vr5lVWyoT8AbzBKIHIpTbhLS4kjZ80L3I6o93OYjqAaIjsqoZw==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.14.2.tgz",
+      "integrity": "sha512-ylh2LMQtPPhc20RtygT1Qpji6zK4fSdpnokWyImJG6GYLN5tqN7tS0F0o6nPo6/1ll+X11CxTa/MPO6g+NaphQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/feature-flags": "2.13.3",
+        "@parcel/diagnostic": "2.14.2",
+        "@parcel/feature-flags": "2.14.2",
         "@parcel/source-map": "^2.1.1",
         "utility-types": "^3.10.0"
       }
     },
     "node_modules/@parcel/utils": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.13.3.tgz",
-      "integrity": "sha512-yxY9xw2wOUlJaScOXYZmMGoZ4Ck4Kqj+p6Koe5kLkkWM1j98Q0Dj2tf/mNvZi4yrdnlm+dclCwNRnuE8Q9D+pw==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.14.2.tgz",
+      "integrity": "sha512-jgDQrzPOU4IfWnYjRL2zGMbc439334ia1nRa13XcID3+oEp10HWTxw26PGhnYQ02mlOwxg8mtrb5ugZOL+dEIQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/codeframe": "2.13.3",
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/logger": "2.13.3",
-        "@parcel/markdown-ansi": "2.13.3",
-        "@parcel/rust": "2.13.3",
+        "@parcel/codeframe": "2.14.2",
+        "@parcel/diagnostic": "2.14.2",
+        "@parcel/logger": "2.14.2",
+        "@parcel/markdown-ansi": "2.14.2",
+        "@parcel/rust": "2.14.2",
         "@parcel/source-map": "^2.1.1",
         "chalk": "^4.1.2",
         "nullthrows": "^1.1.1"
@@ -1638,16 +1701,16 @@
       }
     },
     "node_modules/@parcel/workers": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.13.3.tgz",
-      "integrity": "sha512-oAHmdniWTRwwwsKbcF4t3VjOtKN+/W17Wj5laiYB+HLkfsjGTfIQPj3sdXmrlBAGpI4omIcvR70PHHXnfdTfwA==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.14.2.tgz",
+      "integrity": "sha512-tbM71fwlmwOL62v+B1cxnte0oS/D9sNVW2CxFZJROpi4jiBJYi2SWCJsQPNVbXYdnU2gzSbQX7ozX0CaE4f9Qw==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/logger": "2.13.3",
-        "@parcel/profiler": "2.13.3",
-        "@parcel/types-internal": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/diagnostic": "2.14.2",
+        "@parcel/logger": "2.14.2",
+        "@parcel/profiler": "2.14.2",
+        "@parcel/types-internal": "2.14.2",
+        "@parcel/utils": "2.14.2",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -1658,18 +1721,18 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.13.3"
+        "@parcel/core": "^2.14.2"
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.10.12",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.10.12.tgz",
-      "integrity": "sha512-+iUL0PYpPm6N9AdV1wvafakvCqFegQus1aoEDxgFsv3/uNVNIyRaupf/v/Zkp5hbep2EzhtoJR0aiJIzDbXWHg==",
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.11.13.tgz",
+      "integrity": "sha512-9BXdYz12Wl0zWmZ80PvtjBWeg2ncwJ9L5WJzjhN6yUTZWEV/AwAdVdJnIEp4pro3WyKmAaMxcVOSbhuuOZco5g==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
-        "@swc/types": "^0.1.17"
+        "@swc/types": "^0.1.19"
       },
       "engines": {
         "node": ">=10"
@@ -1679,16 +1742,16 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.10.12",
-        "@swc/core-darwin-x64": "1.10.12",
-        "@swc/core-linux-arm-gnueabihf": "1.10.12",
-        "@swc/core-linux-arm64-gnu": "1.10.12",
-        "@swc/core-linux-arm64-musl": "1.10.12",
-        "@swc/core-linux-x64-gnu": "1.10.12",
-        "@swc/core-linux-x64-musl": "1.10.12",
-        "@swc/core-win32-arm64-msvc": "1.10.12",
-        "@swc/core-win32-ia32-msvc": "1.10.12",
-        "@swc/core-win32-x64-msvc": "1.10.12"
+        "@swc/core-darwin-arm64": "1.11.13",
+        "@swc/core-darwin-x64": "1.11.13",
+        "@swc/core-linux-arm-gnueabihf": "1.11.13",
+        "@swc/core-linux-arm64-gnu": "1.11.13",
+        "@swc/core-linux-arm64-musl": "1.11.13",
+        "@swc/core-linux-x64-gnu": "1.11.13",
+        "@swc/core-linux-x64-musl": "1.11.13",
+        "@swc/core-win32-arm64-msvc": "1.11.13",
+        "@swc/core-win32-ia32-msvc": "1.11.13",
+        "@swc/core-win32-x64-msvc": "1.11.13"
       },
       "peerDependencies": {
         "@swc/helpers": "*"
@@ -1700,9 +1763,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.10.12",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.10.12.tgz",
-      "integrity": "sha512-pOANQegUTAriW7jq3SSMZGM5l89yLVMs48R0F2UG6UZsH04SiViCnDctOGlA/Sa++25C+rL9MGMYM1jDLylBbg==",
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.11.13.tgz",
+      "integrity": "sha512-loSERhLaQ9XDS+5Kdx8cLe2tM1G0HLit8MfehipAcsdctpo79zrRlkW34elOf3tQoVPKUItV0b/rTuhjj8NtHg==",
       "cpu": [
         "arm64"
       ],
@@ -1716,9 +1779,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.10.12",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.10.12.tgz",
-      "integrity": "sha512-m4kbpIDDsN1FrwfNQMU+FTrss356xsXvatLbearwR+V0lqOkjLBP0VmRvQfHEg+uy13VPyrT9gj4HLoztlci7w==",
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.11.13.tgz",
+      "integrity": "sha512-uSA4UwgsDCIysUPfPS8OrQTH2h9spO7IYFd+1NB6dJlVGUuR6jLKuMBOP1IeLeax4cGHayvkcwSJ3OvxHwgcZQ==",
       "cpu": [
         "x64"
       ],
@@ -1732,9 +1795,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.10.12",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.10.12.tgz",
-      "integrity": "sha512-OY9LcupgqEu8zVK+rJPes6LDJJwPDmwaShU96beTaxX2K6VrXbpwm5WbPS/8FfQTsmpnuA7dCcMPUKhNgmzTrQ==",
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.11.13.tgz",
+      "integrity": "sha512-boVtyJzS8g30iQfe8Q46W5QE/cmhKRln/7NMz/5sBP/am2Lce9NL0d05NnFwEWJp1e2AMGHFOdRr3Xg1cDiPKw==",
       "cpu": [
         "arm"
       ],
@@ -1748,9 +1811,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.10.12",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.10.12.tgz",
-      "integrity": "sha512-nJD587rO0N4y4VZszz3xzVr7JIiCzSMhEMWnPjuh+xmPxDBz0Qccpr8xCr1cSxpl1uY7ERkqAGlKr6CwoV5kVg==",
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.11.13.tgz",
+      "integrity": "sha512-+IK0jZ84zHUaKtwpV+T+wT0qIUBnK9v2xXD03vARubKF+eUqCsIvcVHXmLpFuap62dClMrhCiwW10X3RbXNlHw==",
       "cpu": [
         "arm64"
       ],
@@ -1764,9 +1827,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.10.12",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.10.12.tgz",
-      "integrity": "sha512-oqhSmV+XauSf0C//MoQnVErNUB/5OzmSiUzuazyLsD5pwqKNN+leC3JtRQ/QVzaCpr65jv9bKexT9+I2Tt3xDw==",
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.11.13.tgz",
+      "integrity": "sha512-+ukuB8RHD5BHPCUjQwuLP98z+VRfu+NkKQVBcLJGgp0/+w7y0IkaxLY/aKmrAS5ofCNEGqKL+AOVyRpX1aw+XA==",
       "cpu": [
         "arm64"
       ],
@@ -1780,9 +1843,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.10.12",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.10.12.tgz",
-      "integrity": "sha512-XldSIHyjD7m1Gh+/8rxV3Ok711ENLI420CU2EGEqSe3VSGZ7pHJvJn9ZFbYpWhsLxPqBYMFjp3Qw+J6OXCPXCA==",
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.11.13.tgz",
+      "integrity": "sha512-q9H3WI3U3dfJ34tdv60zc8oTuWvSd5fOxytyAO9Pc5M82Hic3jjWaf2xBekUg07ubnMZpyfnv+MlD+EbUI3Llw==",
       "cpu": [
         "x64"
       ],
@@ -1796,9 +1859,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.10.12",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.10.12.tgz",
-      "integrity": "sha512-wvPXzJxzPgTqhyp1UskOx1hRTtdWxlyFD1cGWOxgLsMik0V9xKRgqKnMPv16Nk7L9xl6quQ6DuUHj9ID7L3oVw==",
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.11.13.tgz",
+      "integrity": "sha512-9aaZnnq2pLdTbAzTSzy/q8dr7Woy3aYIcQISmw1+Q2/xHJg5y80ZzbWSWKYca/hKonDMjIbGR6dp299I5J0aeA==",
       "cpu": [
         "x64"
       ],
@@ -1812,9 +1875,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.10.12",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.10.12.tgz",
-      "integrity": "sha512-TUYzWuu1O7uyIcRfxdm6Wh1u+gNnrW5M1DUgDOGZLsyQzgc2Zjwfh2llLhuAIilvCVg5QiGbJlpibRYJ/8QGsg==",
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.11.13.tgz",
+      "integrity": "sha512-n3QZmDewkHANcoHvtwvA6yJbmS4XJf0MBMmwLZoKDZ2dOnC9D/jHiXw7JOohEuzYcpLoL5tgbqmjxa3XNo9Oow==",
       "cpu": [
         "arm64"
       ],
@@ -1828,9 +1891,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.10.12",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.10.12.tgz",
-      "integrity": "sha512-4Qrw+0Xt+Fe2rz4OJ/dEPMeUf/rtuFWWAj/e0vL7J5laUHirzxawLRE5DCJLQTarOiYR6mWnmadt9o3EKzV6Xg==",
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.11.13.tgz",
+      "integrity": "sha512-wM+Nt4lc6YSJFthCx3W2dz0EwFNf++j0/2TQ0Js9QLJuIxUQAgukhNDVCDdq8TNcT0zuA399ALYbvj5lfIqG6g==",
       "cpu": [
         "ia32"
       ],
@@ -1844,9 +1907,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.10.12",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.10.12.tgz",
-      "integrity": "sha512-YiloZXLW7rUxJpALwHXaGjVaAEn+ChoblG7/3esque+Y7QCyheoBUJp2DVM1EeVA43jBfZ8tvYF0liWd9Tpz1A==",
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.11.13.tgz",
+      "integrity": "sha512-+X5/uW3s1L5gK7wAo0E27YaAoidJDo51dnfKSfU7gF3mlEUuWH8H1bAy5OTt2mU4eXtfsdUMEVXSwhDlLtQkuA==",
       "cpu": [
         "x64"
       ],
@@ -1875,9 +1938,9 @@
       }
     },
     "node_modules/@swc/types": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.17.tgz",
-      "integrity": "sha512-V5gRru+aD8YVyCOMAjMpWR1Ui577DD5KSJsHP8RAxopAH22jFz6GZd/qxqjO6MJHQhcsjvjOFXyDhyLQUnMveQ==",
+      "version": "0.1.20",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.20.tgz",
+      "integrity": "sha512-/rlIpxwKrhz4BIplXf6nsEHtqlhzuNN34/k3kMAXH4/lvVoA3cdq+60aqVNnyvw2uITEaCi0WV3pxBe4dQqoXQ==",
       "dev": true,
       "dependencies": {
         "@swc/counter": "^0.1.3"
@@ -2106,17 +2169,6 @@
         "tailwindcss": "4.0.3"
       }
     },
-    "node_modules/@trysound/sax": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
-      "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/@types/node": {
       "version": "22.13.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
@@ -2168,14 +2220,6 @@
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
-    },
-    "node_modules/boolbase": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "node_modules/braces": {
       "version": "3.0.3",
@@ -2240,20 +2284,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/caniuse-api": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
-      "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "browserslist": "^4.0.0",
-        "caniuse-lite": "^1.0.0",
-        "lodash.memoize": "^4.1.2",
-        "lodash.uniq": "^4.5.0"
       }
     },
     "node_modules/caniuse-lite": {
@@ -2339,14 +2369,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "node_modules/colord": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
-      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -2392,202 +2414,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/css-declaration-sorter": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.2.0.tgz",
-      "integrity": "sha512-h70rUM+3PNFuaBDTLe8wF/cdWu+dOZmb7pJt8Z2sedYbAcQVQV/tEchueg3GWxwqS0cxtbxmaHEdkNACqcvsow==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "^14 || ^16 || >=18"
-      },
-      "peerDependencies": {
-        "postcss": "^8.0.9"
-      }
-    },
-    "node_modules/css-select": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.1.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/css-tree": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
-      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "mdn-data": "2.0.30",
-        "source-map-js": "^1.0.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      }
-    },
-    "node_modules/css-what": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/cssesc": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "cssesc": "bin/cssesc"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/cssnano": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.0.6.tgz",
-      "integrity": "sha512-54woqx8SCbp8HwvNZYn68ZFAepuouZW4lTwiMVnBErM3VkO7/Sd4oTOt3Zz3bPx3kxQ36aISppyXj2Md4lg8bw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "cssnano-preset-default": "^7.0.6",
-        "lilconfig": "^3.1.2"
-      },
-      "engines": {
-        "node": "^18.12.0 || ^20.9.0 || >=22.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/cssnano"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/cssnano-preset-default": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-7.0.6.tgz",
-      "integrity": "sha512-ZzrgYupYxEvdGGuqL+JKOY70s7+saoNlHSCK/OGn1vB2pQK8KSET8jvenzItcY+kA7NoWvfbb/YhlzuzNKjOhQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "browserslist": "^4.23.3",
-        "css-declaration-sorter": "^7.2.0",
-        "cssnano-utils": "^5.0.0",
-        "postcss-calc": "^10.0.2",
-        "postcss-colormin": "^7.0.2",
-        "postcss-convert-values": "^7.0.4",
-        "postcss-discard-comments": "^7.0.3",
-        "postcss-discard-duplicates": "^7.0.1",
-        "postcss-discard-empty": "^7.0.0",
-        "postcss-discard-overridden": "^7.0.0",
-        "postcss-merge-longhand": "^7.0.4",
-        "postcss-merge-rules": "^7.0.4",
-        "postcss-minify-font-values": "^7.0.0",
-        "postcss-minify-gradients": "^7.0.0",
-        "postcss-minify-params": "^7.0.2",
-        "postcss-minify-selectors": "^7.0.4",
-        "postcss-normalize-charset": "^7.0.0",
-        "postcss-normalize-display-values": "^7.0.0",
-        "postcss-normalize-positions": "^7.0.0",
-        "postcss-normalize-repeat-style": "^7.0.0",
-        "postcss-normalize-string": "^7.0.0",
-        "postcss-normalize-timing-functions": "^7.0.0",
-        "postcss-normalize-unicode": "^7.0.2",
-        "postcss-normalize-url": "^7.0.0",
-        "postcss-normalize-whitespace": "^7.0.0",
-        "postcss-ordered-values": "^7.0.1",
-        "postcss-reduce-initial": "^7.0.2",
-        "postcss-reduce-transforms": "^7.0.0",
-        "postcss-svgo": "^7.0.1",
-        "postcss-unique-selectors": "^7.0.3"
-      },
-      "engines": {
-        "node": "^18.12.0 || ^20.9.0 || >=22.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/cssnano-utils": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-5.0.0.tgz",
-      "integrity": "sha512-Uij0Xdxc24L6SirFr25MlwC2rCFX6scyUmuKpzI+JQ7cyqDEwD42fJ0xfB3yLfOnRDU5LKGgjQ9FA6LYh76GWQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "^18.12.0 || ^20.9.0 || >=22.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/csso": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
-      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "css-tree": "~2.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/csso/node_modules/css-tree": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
-      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "mdn-data": "2.0.28",
-        "source-map-js": "^1.0.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/csso/node_modules/mdn-data": {
-      "version": "2.0.28",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
-      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -3088,9 +2914,9 @@
       "integrity": "sha512-HLxMCdfXDOJirs3vBZl/ZLoY+c7PfM4Ahr2Ad4YXh6d22T5ltbTXFFkpx9Tgb2vvmWFMbIc3LqN2ToNkZJvyYQ=="
     },
     "node_modules/import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -3460,20 +3286,6 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/lilconfig": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
-      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antonk52"
-      }
-    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -3511,22 +3323,6 @@
       "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
       "dev": true
     },
-    "node_modules/lodash.memoize": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/lodash.uniq": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3534,14 +3330,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/mdn-data": {
-      "version": "2.0.30",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -6151,20 +5939,6 @@
       "inBundle": true,
       "license": "ISC"
     },
-    "node_modules/nth-check": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "boolbase": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/nth-check?sponsor=1"
-      }
-    },
     "node_modules/nullthrows": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
@@ -6178,23 +5952,23 @@
       "dev": true
     },
     "node_modules/parcel": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.13.3.tgz",
-      "integrity": "sha512-8GrC8C7J8mwRpAlk7EJ7lwdFTbCN+dcXH2gy5AsEs9pLfzo9wvxOTx6W0fzSlvCOvZOita+8GdfYlGfEt0tRgA==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.14.2.tgz",
+      "integrity": "sha512-dqB4/Oo8L7HfWyrxAQKnizQ/XzQM2iAY5fEaZUgS4wh+B3FE4LO5JVgobhVBBrIOoT02sV4gUEQhNJeU3raSuA==",
       "dev": true,
       "dependencies": {
-        "@parcel/config-default": "2.13.3",
-        "@parcel/core": "2.13.3",
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/events": "2.13.3",
-        "@parcel/feature-flags": "2.13.3",
-        "@parcel/fs": "2.13.3",
-        "@parcel/logger": "2.13.3",
-        "@parcel/package-manager": "2.13.3",
-        "@parcel/reporter-cli": "2.13.3",
-        "@parcel/reporter-dev-server": "2.13.3",
-        "@parcel/reporter-tracer": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/config-default": "2.14.2",
+        "@parcel/core": "2.14.2",
+        "@parcel/diagnostic": "2.14.2",
+        "@parcel/events": "2.14.2",
+        "@parcel/feature-flags": "2.14.2",
+        "@parcel/fs": "2.14.2",
+        "@parcel/logger": "2.14.2",
+        "@parcel/package-manager": "2.14.2",
+        "@parcel/reporter-cli": "2.14.2",
+        "@parcel/reporter-dev-server": "2.14.2",
+        "@parcel/reporter-tracer": "2.14.2",
+        "@parcel/utils": "2.14.2",
         "chalk": "^4.1.2",
         "commander": "^12.1.0",
         "get-port": "^4.2.0"
@@ -6301,136 +6075,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/postcss-calc": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-10.1.1.tgz",
-      "integrity": "sha512-NYEsLHh8DgG/PRH2+G9BTuUdtf9ViS+vdoQ0YA5OQdGsfN4ztiwtDWNtBl9EKeqNMFnIu8IKZ0cLxEQ5r5KVMw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "postcss-selector-parser": "^7.0.0",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^18.12 || ^20.9 || >=22.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.38"
-      }
-    },
-    "node_modules/postcss-colormin": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-7.0.2.tgz",
-      "integrity": "sha512-YntRXNngcvEvDbEjTdRWGU606eZvB5prmHG4BF0yLmVpamXbpsRJzevyy6MZVyuecgzI2AWAlvFi8DAeCqwpvA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "browserslist": "^4.23.3",
-        "caniuse-api": "^3.0.0",
-        "colord": "^2.9.3",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^18.12.0 || ^20.9.0 || >=22.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-convert-values": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-7.0.4.tgz",
-      "integrity": "sha512-e2LSXPqEHVW6aoGbjV9RsSSNDO3A0rZLCBxN24zvxF25WknMPpX8Dm9UxxThyEbaytzggRuZxaGXqaOhxQ514Q==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "browserslist": "^4.23.3",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^18.12.0 || ^20.9.0 || >=22.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-discard-comments": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-7.0.3.tgz",
-      "integrity": "sha512-q6fjd4WU4afNhWOA2WltHgCbkRhZPgQe7cXF74fuVB/ge4QbM9HEaOIzGSiMvM+g/cOsNAUGdf2JDzqA2F8iLA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "postcss-selector-parser": "^6.1.2"
-      },
-      "engines": {
-        "node": "^18.12.0 || ^20.9.0 || >=22.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-discard-comments/node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postcss-discard-duplicates": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-7.0.1.tgz",
-      "integrity": "sha512-oZA+v8Jkpu1ct/xbbrntHRsfLGuzoP+cpt0nJe5ED2FQF8n8bJtn7Bo28jSmBYwqgqnqkuSXJfSUEE7if4nClQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "^18.12.0 || ^20.9.0 || >=22.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-discard-empty": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-7.0.0.tgz",
-      "integrity": "sha512-e+QzoReTZ8IAwhnSdp/++7gBZ/F+nBq9y6PomfwORfP7q9nBpK5AMP64kOt0bA+lShBFbBDcgpJ3X4etHg4lzA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "^18.12.0 || ^20.9.0 || >=22.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-discard-overridden": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-7.0.0.tgz",
-      "integrity": "sha512-GmNAzx88u3k2+sBTZrJSDauR0ccpE24omTQCVmaTTZFz1du6AasspjaUPMJ2ud4RslZpoFKyf+6MSPETLojc6w==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "^18.12.0 || ^20.9.0 || >=22.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
     "node_modules/postcss-import": {
       "version": "16.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-16.1.0.tgz",
@@ -6446,416 +6090,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.0.0"
-      }
-    },
-    "node_modules/postcss-merge-longhand": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-7.0.4.tgz",
-      "integrity": "sha512-zer1KoZA54Q8RVHKOY5vMke0cCdNxMP3KBfDerjH/BYHh4nCIh+1Yy0t1pAEQF18ac/4z3OFclO+ZVH8azjR4A==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0",
-        "stylehacks": "^7.0.4"
-      },
-      "engines": {
-        "node": "^18.12.0 || ^20.9.0 || >=22.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-merge-rules": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-7.0.4.tgz",
-      "integrity": "sha512-ZsaamiMVu7uBYsIdGtKJ64PkcQt6Pcpep/uO90EpLS3dxJi6OXamIobTYcImyXGoW0Wpugh7DSD3XzxZS9JCPg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "browserslist": "^4.23.3",
-        "caniuse-api": "^3.0.0",
-        "cssnano-utils": "^5.0.0",
-        "postcss-selector-parser": "^6.1.2"
-      },
-      "engines": {
-        "node": "^18.12.0 || ^20.9.0 || >=22.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-merge-rules/node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postcss-minify-font-values": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-7.0.0.tgz",
-      "integrity": "sha512-2ckkZtgT0zG8SMc5aoNwtm5234eUx1GGFJKf2b1bSp8UflqaeFzR50lid4PfqVI9NtGqJ2J4Y7fwvnP/u1cQog==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^18.12.0 || ^20.9.0 || >=22.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-minify-gradients": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-7.0.0.tgz",
-      "integrity": "sha512-pdUIIdj/C93ryCHew0UgBnL2DtUS3hfFa5XtERrs4x+hmpMYGhbzo6l/Ir5de41O0GaKVpK1ZbDNXSY6GkXvtg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "colord": "^2.9.3",
-        "cssnano-utils": "^5.0.0",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^18.12.0 || ^20.9.0 || >=22.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-minify-params": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-7.0.2.tgz",
-      "integrity": "sha512-nyqVLu4MFl9df32zTsdcLqCFfE/z2+f8GE1KHPxWOAmegSo6lpV2GNy5XQvrzwbLmiU7d+fYay4cwto1oNdAaQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "browserslist": "^4.23.3",
-        "cssnano-utils": "^5.0.0",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^18.12.0 || ^20.9.0 || >=22.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-minify-selectors": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-7.0.4.tgz",
-      "integrity": "sha512-JG55VADcNb4xFCf75hXkzc1rNeURhlo7ugf6JjiiKRfMsKlDzN9CXHZDyiG6x/zGchpjQS+UAgb1d4nqXqOpmA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "postcss-selector-parser": "^6.1.2"
-      },
-      "engines": {
-        "node": "^18.12.0 || ^20.9.0 || >=22.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-minify-selectors/node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postcss-normalize-charset": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-7.0.0.tgz",
-      "integrity": "sha512-ABisNUXMeZeDNzCQxPxBCkXexvBrUHV+p7/BXOY+ulxkcjUZO0cp8ekGBwvIh2LbCwnWbyMPNJVtBSdyhM2zYQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "^18.12.0 || ^20.9.0 || >=22.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-normalize-display-values": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-7.0.0.tgz",
-      "integrity": "sha512-lnFZzNPeDf5uGMPYgGOw7v0BfB45+irSRz9gHQStdkkhiM0gTfvWkWB5BMxpn0OqgOQuZG/mRlZyJxp0EImr2Q==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^18.12.0 || ^20.9.0 || >=22.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-normalize-positions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-7.0.0.tgz",
-      "integrity": "sha512-I0yt8wX529UKIGs2y/9Ybs2CelSvItfmvg/DBIjTnoUSrPxSV7Z0yZ8ShSVtKNaV/wAY+m7bgtyVQLhB00A1NQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^18.12.0 || ^20.9.0 || >=22.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-normalize-repeat-style": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-7.0.0.tgz",
-      "integrity": "sha512-o3uSGYH+2q30ieM3ppu9GTjSXIzOrRdCUn8UOMGNw7Af61bmurHTWI87hRybrP6xDHvOe5WlAj3XzN6vEO8jLw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^18.12.0 || ^20.9.0 || >=22.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-normalize-string": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-7.0.0.tgz",
-      "integrity": "sha512-w/qzL212DFVOpMy3UGyxrND+Kb0fvCiBBujiaONIihq7VvtC7bswjWgKQU/w4VcRyDD8gpfqUiBQ4DUOwEJ6Qg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^18.12.0 || ^20.9.0 || >=22.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-normalize-timing-functions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-7.0.0.tgz",
-      "integrity": "sha512-tNgw3YV0LYoRwg43N3lTe3AEWZ66W7Dh7lVEpJbHoKOuHc1sLrzMLMFjP8SNULHaykzsonUEDbKedv8C+7ej6g==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^18.12.0 || ^20.9.0 || >=22.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-normalize-unicode": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-7.0.2.tgz",
-      "integrity": "sha512-ztisabK5C/+ZWBdYC+Y9JCkp3M9qBv/XFvDtSw0d/XwfT3UaKeW/YTm/MD/QrPNxuecia46vkfEhewjwcYFjkg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "browserslist": "^4.23.3",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^18.12.0 || ^20.9.0 || >=22.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-normalize-url": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-7.0.0.tgz",
-      "integrity": "sha512-+d7+PpE+jyPX1hDQZYG+NaFD+Nd2ris6r8fPTBAjE8z/U41n/bib3vze8x7rKs5H1uEw5ppe9IojewouHk0klQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^18.12.0 || ^20.9.0 || >=22.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-normalize-whitespace": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-7.0.0.tgz",
-      "integrity": "sha512-37/toN4wwZErqohedXYqWgvcHUGlT8O/m2jVkAfAe9Bd4MzRqlBmXrJRePH0e9Wgnz2X7KymTgTOaaFizQe3AQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^18.12.0 || ^20.9.0 || >=22.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-ordered-values": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-7.0.1.tgz",
-      "integrity": "sha512-irWScWRL6nRzYmBOXReIKch75RRhNS86UPUAxXdmW/l0FcAsg0lvAXQCby/1lymxn/o0gVa6Rv/0f03eJOwHxw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "cssnano-utils": "^5.0.0",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^18.12.0 || ^20.9.0 || >=22.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-reduce-initial": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-7.0.2.tgz",
-      "integrity": "sha512-pOnu9zqQww7dEKf62Nuju6JgsW2V0KRNBHxeKohU+JkHd/GAH5uvoObqFLqkeB2n20mr6yrlWDvo5UBU5GnkfA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "browserslist": "^4.23.3",
-        "caniuse-api": "^3.0.0"
-      },
-      "engines": {
-        "node": "^18.12.0 || ^20.9.0 || >=22.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-reduce-transforms": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-7.0.0.tgz",
-      "integrity": "sha512-pnt1HKKZ07/idH8cpATX/ujMbtOGhUfE+m8gbqwJE05aTaNw8gbo34a2e3if0xc0dlu75sUOiqvwCGY3fzOHew==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^18.12.0 || ^20.9.0 || >=22.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-selector-parser": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz",
-      "integrity": "sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postcss-svgo": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-7.0.1.tgz",
-      "integrity": "sha512-0WBUlSL4lhD9rA5k1e5D8EN5wCEyZD6HJk0jIvRxl+FDVOMlJ7DePHYWGGVc5QRqrJ3/06FTXM0bxjmJpmTPSA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0",
-        "svgo": "^3.3.2"
-      },
-      "engines": {
-        "node": "^18.12.0 || ^20.9.0 || >= 18"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-unique-selectors": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-7.0.3.tgz",
-      "integrity": "sha512-J+58u5Ic5T1QjP/LDV9g3Cx4CNOgB5vz+kM6+OxHHhFACdcDeKhBXjQmB7fnIZM12YSTvsL0Opwco83DmacW2g==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "postcss-selector-parser": "^6.1.2"
-      },
-      "engines": {
-        "node": "^18.12.0 || ^20.9.0 || >=22.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-unique-selectors/node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/postcss-value-parser": {
@@ -6996,16 +6230,10 @@
         "node": ">=12"
       }
     },
-    "node_modules/react-error-overlay": {
-      "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
-      "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
-      "dev": true
-    },
     "node_modules/react-refresh": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
-      "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.16.0.tgz",
+      "integrity": "sha512-FPvF2XxTSikpJxcr+bHut2H4gJ17+18Uy20D5/F+SKzFap62R3cM5wH6b8WN3LyGSYeQilLEcJcR1fjBSI2S1A==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -7130,39 +6358,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/stylehacks": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-7.0.4.tgz",
-      "integrity": "sha512-i4zfNrGMt9SB4xRK9L83rlsFCgdGANfeDAYacO1pkqcE7cRHPdWHwnKZVz7WY17Veq/FvyYsRAU++Ga+qDFIww==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "browserslist": "^4.23.3",
-        "postcss-selector-parser": "^6.1.2"
-      },
-      "engines": {
-        "node": "^18.12.0 || ^20.9.0 || >=22.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/stylehacks/node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -7185,44 +6380,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/svgo": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.2.tgz",
-      "integrity": "sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@trysound/sax": "0.2.0",
-        "commander": "^7.2.0",
-        "css-select": "^5.1.0",
-        "css-tree": "^2.3.1",
-        "css-what": "^6.1.0",
-        "csso": "^5.0.5",
-        "picocolors": "^1.0.0"
-      },
-      "bin": {
-        "svgo": "bin/svgo"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/svgo"
-      }
-    },
-    "node_modules/svgo/node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/tailwindcss": {
@@ -7388,14 +6545,6 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "node_modules/utility-types": {
       "version": "3.11.0",

--- a/src/Elastic.Markdown/package.json
+++ b/src/Elastic.Markdown/package.json
@@ -24,8 +24,9 @@
   },
   "private": true,
   "devDependencies": {
+    "@parcel/reporter-bundle-analyzer": "^2.14.2",
     "@tailwindcss/postcss": "^4.0.3",
-    "parcel": "2.13.3",
+    "parcel": "2.14.2",
     "postcss": "^8.5.1",
     "postcss-import": "^16.1.0"
   },


### PR DESCRIPTION
## Details

Only install and register a subset of languages to shrink the final JS bundle size.

The list of languages was determined by the following command on assembler build artifacts.

```
find . -type f -name "*.html" -exec grep -ho "class=\"language-[^ \"']*" {} \; | sort -u
```

## Result

Bundle size of ~260kb instead of +1mb.

<img width="1840" alt="Screenshot 2025-03-27 at 17 19 13" src="https://github.com/user-attachments/assets/7401f3ed-1de5-44fb-8643-d43a7596ff7e" />

