### PR TITLE
Add landing overview page for detection rules.

### DIFF
--- a/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRule.cs
+++ b/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRule.cs
@@ -48,6 +48,8 @@ public record DetectionRule
 
 	public required string[]? Tags { get; init; }
 
+	public string? Domain => Tags?.FirstOrDefault(t => t.StartsWith("Domain:"))?[7..]?.Trim();
+
 	public required string Severity { get; init; }
 
 	public required string RuleId { get; init; }

--- a/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRulesReference.cs
+++ b/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRulesReference.cs
@@ -6,6 +6,15 @@ using Elastic.Markdown.IO.Configuration;
 
 namespace Elastic.Markdown.Extensions.DetectionRules;
 
+public record RuleOverviewReference(
+	ITableOfContentsScope TableOfContentsScope,
+	string Path,
+	bool Found,
+	IReadOnlyCollection<ITocItem> Children,
+	IReadOnlyCollection<string> DetectionRuleFolders
+)
+	: FileReference(TableOfContentsScope, Path, Found, true, Children);
+
 public record RuleReference(
 	ITableOfContentsScope TableOfContentsScope,
 	string Path,
@@ -13,4 +22,4 @@ public record RuleReference(
 	bool Found,
 	IReadOnlyCollection<ITocItem> Children, DetectionRule Rule
 )
-	: FileReference(TableOfContentsScope, Path, Found, false, Children);
+	: FileReference(TableOfContentsScope, Path, Found, true, Children);

--- a/src/Elastic.Markdown/Extensions/IDocsBuilderExtension.cs
+++ b/src/Elastic.Markdown/Extensions/IDocsBuilderExtension.cs
@@ -7,6 +7,7 @@ using Elastic.Markdown.Exporters;
 using Elastic.Markdown.IO;
 using Elastic.Markdown.IO.Configuration;
 using Elastic.Markdown.IO.Navigation;
+using Elastic.Markdown.Myst;
 
 namespace Elastic.Markdown.Extensions;
 
@@ -44,4 +45,6 @@ public interface IDocsBuilderExtension
 		Func<BuildContext, IDirectoryInfo, DocumentationFile[]> scanDocumentationFiles,
 		Func<IFileInfo, IDirectoryInfo, DocumentationFile> defaultFileHandling
 	);
+
+	MarkdownFile? CreateMarkdownFile(IFileInfo file, IDirectoryInfo sourceDirectory, MarkdownParser markdownParser, BuildContext context, DocumentationSet documentationSet);
 }

--- a/src/Elastic.Markdown/IO/Configuration/TableOfContentsConfiguration.cs
+++ b/src/Elastic.Markdown/IO/Configuration/TableOfContentsConfiguration.cs
@@ -206,9 +206,14 @@ public record TableOfContentsConfiguration : ITableOfContentsScope
 				{
 					var extension = _configuration.EnabledExtensions.OfType<DetectionRulesDocsBuilderExtension>().First();
 					children = extension.CreateTableOfContentItems(_configuration, parentPath, detectionRules, Files);
+					var overviewPath = $"{parentPath}{Path.DirectorySeparatorChar}{file}".TrimStart(Path.DirectorySeparatorChar);
+					var landingPage = new RuleOverviewReference(this, overviewPath, fileFound, children, detectionRules);
+					return [landingPage];
 				}
 			}
-			return [new FileReference(this, $"{parentPath}{Path.DirectorySeparatorChar}{file}".TrimStart(Path.DirectorySeparatorChar), fileFound, hiddenFile, children ?? [])];
+
+			var path = $"{parentPath}{Path.DirectorySeparatorChar}{file}".TrimStart(Path.DirectorySeparatorChar);
+			return [new FileReference(this, path, fileFound, hiddenFile, children ?? [])];
 		}
 
 		if (folder is not null)

--- a/src/Elastic.Markdown/IO/DocumentationSet.cs
+++ b/src/Elastic.Markdown/IO/DocumentationSet.cs
@@ -267,15 +267,15 @@ public class DocumentationSet : INavigationLookups
 			return new SnippetFile(file, SourceDirectory);
 
 		// we ignore files in folders that start with an underscore
-		if (relativePath.IndexOf($"{Path.DirectorySeparatorChar}_", StringComparison.Ordinal) > 0 || relativePath.StartsWith('_'))
+		var folder = Path.GetDirectoryName(relativePath);
+		if (folder is not null && (folder.Contains($"{Path.DirectorySeparatorChar}_", StringComparison.Ordinal) || folder.StartsWith('_')))
 			return new ExcludedFile(file, SourceDirectory);
 
 		if (Configuration.Files.Contains(relativePath))
 			return ExtensionOrDefaultMarkdown();
 
 		if (Configuration.Globs.Any(g => g.IsMatch(relativePath)))
-			return new MarkdownFile(file, SourceDirectory, MarkdownParser, context, this);
-
+			return ExtensionOrDefaultMarkdown();
 
 		context.EmitError(Configuration.SourceFile, $"Not linked in toc: {relativePath}");
 		return new ExcludedFile(file, SourceDirectory);

--- a/src/Elastic.Markdown/IO/DocumentationSet.cs
+++ b/src/Elastic.Markdown/IO/DocumentationSet.cs
@@ -263,22 +263,33 @@ public class DocumentationSet : INavigationLookups
 		if (Configuration.Exclude.Any(g => g.IsMatch(relativePath)))
 			return new ExcludedFile(file, SourceDirectory);
 
-		// we ignore files in folders that start with an underscore
 		if (relativePath.Contains("_snippets"))
 			return new SnippetFile(file, SourceDirectory);
-
-		if (Configuration.Files.Contains(relativePath))
-			return new MarkdownFile(file, SourceDirectory, MarkdownParser, context, this);
-
-		if (Configuration.Globs.Any(g => g.IsMatch(relativePath)))
-			return new MarkdownFile(file, SourceDirectory, MarkdownParser, context, this);
 
 		// we ignore files in folders that start with an underscore
 		if (relativePath.IndexOf($"{Path.DirectorySeparatorChar}_", StringComparison.Ordinal) > 0 || relativePath.StartsWith('_'))
 			return new ExcludedFile(file, SourceDirectory);
 
+		if (Configuration.Files.Contains(relativePath))
+			return ExtensionOrDefaultMarkdown();
+
+		if (Configuration.Globs.Any(g => g.IsMatch(relativePath)))
+			return new MarkdownFile(file, SourceDirectory, MarkdownParser, context, this);
+
+
 		context.EmitError(Configuration.SourceFile, $"Not linked in toc: {relativePath}");
 		return new ExcludedFile(file, SourceDirectory);
+
+		MarkdownFile ExtensionOrDefaultMarkdown()
+		{
+			foreach (var extension in Configuration.EnabledExtensions)
+			{
+				var documentationFile = extension.CreateMarkdownFile(file, SourceDirectory, MarkdownParser, context, this);
+				if (documentationFile is not null)
+					return documentationFile;
+			}
+			return new MarkdownFile(file, SourceDirectory, MarkdownParser, context, this);
+		}
 	}
 	public void ClearOutputDirectory()
 	{

--- a/src/Elastic.Markdown/IO/Navigation/DocumentationGroup.cs
+++ b/src/Elastic.Markdown/IO/Navigation/DocumentationGroup.cs
@@ -251,6 +251,7 @@ public class DocumentationGroup : INavigation
 						}, NavigationSource, ref fileIndex, depth + 1, topLevelGroup, this, virtualIndex);
 					groups.Add(group);
 					navigationItems.Add(new GroupNavigationItem(index, depth, group));
+					indexFile ??= virtualIndex;
 					continue;
 				}
 

--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -318,6 +318,10 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 		if (!string.IsNullOrWhiteSpace(url) && !string.IsNullOrWhiteSpace(urlPathPrefix))
 			url = $"{urlPathPrefix.TrimEnd('/')}{url}";
 
+		// TODO this is hardcoded should be part of extension system
+		if (url.EndsWith(".toml"))
+			url = url[..^5];
+
 		link.Url = string.IsNullOrEmpty(anchor) ? url : $"{url}#{anchor}";
 	}
 


### PR DESCRIPTION
Also fixes a few issues with how we were grouping these rules as they were not part of a `DocumentationGroup` breaking a few assumptions.


https://github.com/user-attachments/assets/5015a2df-db40-4242-b813-03c5ee8b6a15


