### PR TITLE
Fix sub-path resolution in DiagnosticLinkInlineParser

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -13,6 +13,8 @@ jobs:
         include:
           - repository: elastic/docs-content
             landing-page-path-output: /docs/
+          - repository: elastic/elasticsearch
+            landing-page-path-output: /docs/reference
           - repository: elastic/apm-agent-android
             landing-page-path-output: /docs/reference/
             

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -14,7 +14,7 @@ jobs:
           - repository: elastic/docs-content
             landing-page-path-output: /docs/
           - repository: elastic/elasticsearch
-            landing-page-path-output: /docs/reference
+            landing-page-path-output: /docs/reference/
           - repository: elastic/apm-agent-android
             landing-page-path-output: /docs/reference/
             

--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -309,8 +309,9 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 			// './' current path lookups should be relative to sub-path.
 			// If it's not e.g /reference/cloud-k8s/api-docs/ these links should resolve on folder up.
 			var siblingsGoToCurrent = url.StartsWith("./") && markdownPath == "index.md";
-			if (!siblingsGoToCurrent)
-				subPrefix = subPrefix[..subPrefix.LastIndexOf('/')];
+			var lastIndexPath = subPrefix.LastIndexOf('/');
+			if (lastIndexPath > 0 && !siblingsGoToCurrent)
+				subPrefix = subPrefix[..lastIndexPath];
 
 			var combined = '/' + Path.Combine(subPrefix, url).TrimStart('/');
 			url = Path.GetFullPath(combined);

--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -310,7 +310,7 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 			// If it's not e.g /reference/cloud-k8s/api-docs/ these links should resolve on folder up.
 			var siblingsGoToCurrent = url.StartsWith("./") && markdownPath == "index.md";
 			var lastIndexPath = subPrefix.LastIndexOf('/');
-			if (lastIndexPath > 0 && !siblingsGoToCurrent)
+			if (lastIndexPath >= 0 && !siblingsGoToCurrent)
 				subPrefix = subPrefix[..lastIndexPath];
 
 			var combined = '/' + Path.Combine(subPrefix, url).TrimStart('/');


### PR DESCRIPTION
Ensure sub-prefix calculations handle edge cases where lastIndexOf returns -1. This prevents potential runtime errors and ensures correct path resolution for sibling links.

Add `elasticsearch` to our smoke tests since it's a high traffic repository.
