### PR TITLE
Only filter out detection rules that are within an '_deprecated' folder

### DIFF
--- a/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRulesDocsBuilderExtension.cs
+++ b/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRulesDocsBuilderExtension.cs
@@ -124,7 +124,7 @@ public class DetectionRulesDocsBuilderExtension(BuildContext build) : IDocsBuild
 			.Where(f => !f.Directory!.Attributes.HasFlag(FileAttributes.Hidden) && !f.Directory!.Attributes.HasFlag(FileAttributes.System))
 			.Where(f => f.Extension is ".md" or ".toml")
 			.Where(f => f.Name != "README.md")
-			.Where(f => !f.FullName.Contains("_deprecated"))
+			.Where(f => !f.FullName.Contains($"{Path.DirectorySeparatorChar}_deprecated{Path.DirectorySeparatorChar}"))
 			.Select(f =>
 			{
 				var relativePath = Path.GetRelativePath(sourceDirectory.FullName, f.FullName);

--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -309,7 +309,7 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 			// './' current path lookups should be relative to sub-path.
 			// If it's not e.g /reference/cloud-k8s/api-docs/ these links should resolve on folder up.
 			var siblingsGoToCurrent = url.StartsWith("./") && markdownPath == "index.md";
-			if (!siblingsGoToCurrent && subPrefix.LastIndexOf('/') >= 0)
+			if (!siblingsGoToCurrent)
 				subPrefix = subPrefix[..subPrefix.LastIndexOf('/')];
 
 			var combined = '/' + Path.Combine(subPrefix, url).TrimStart('/');

--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -309,7 +309,7 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 			// './' current path lookups should be relative to sub-path.
 			// If it's not e.g /reference/cloud-k8s/api-docs/ these links should resolve on folder up.
 			var siblingsGoToCurrent = url.StartsWith("./") && markdownPath == "index.md";
-			if (!siblingsGoToCurrent)
+			if (!siblingsGoToCurrent && subPrefix.LastIndexOf('/') >= 0)
 				subPrefix = subPrefix[..subPrefix.LastIndexOf('/')];
 
 			var combined = '/' + Path.Combine(subPrefix, url).TrimStart('/');


### PR DESCRIPTION
Closes https://github.com/elastic/docs-builder/issues/874