### PR TITLE
Add extension method for relative path trimming when using ReadOnlySpan<char>

### DIFF
--- a/src/docs-assembler/Building/PublishEnvironmentUriResolver.cs
+++ b/src/docs-assembler/Building/PublishEnvironmentUriResolver.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Frozen;
 using Documentation.Assembler.Configuration;
+using Documentation.Assembler.Extensions;
 using Elastic.Markdown.Links.CrossLinks;
 
 namespace Documentation.Assembler.Building;
@@ -142,10 +143,9 @@ public class PublishEnvironmentUriResolver : IUriEnvironmentResolver
 		if (originalPath == toc.SourcePathPrefix)
 			return string.Empty;
 
-		var newRelativePath = path.TrimStart('/').AsSpan().TrimStart(originalPath).ToString();
-		path = Path.Combine(toc.SourcePathPrefix, newRelativePath.TrimStart('/'));
+		var newRelativePath = path.AsSpan().GetTrimmedRelativePath(originalPath);
+		path = Path.Combine(toc.SourcePathPrefix, newRelativePath);
 
 		return string.Empty;
 	}
-
 }

--- a/src/docs-assembler/Extensions/SpanExtensions.cs
+++ b/src/docs-assembler/Extensions/SpanExtensions.cs
@@ -1,0 +1,17 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Documentation.Assembler.Extensions;
+
+public static class SpanExtensions
+{
+	public static string GetTrimmedRelativePath(this ReadOnlySpan<char> relativePath, string originalPath)
+	{
+		var trimmedInput = relativePath.TrimStart('/');
+		var newRelativePath = trimmedInput.StartsWith(originalPath, StringComparison.Ordinal)
+			? trimmedInput.Slice(originalPath.Length).TrimStart('/').ToString()
+			: trimmedInput.ToString();
+		return newRelativePath;
+	}
+}

--- a/src/docs-assembler/Navigation/GlobalNavigationPathProvider.cs
+++ b/src/docs-assembler/Navigation/GlobalNavigationPathProvider.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Immutable;
 using System.IO.Abstractions;
+using Documentation.Assembler.Extensions;
 using Elastic.Markdown;
 using Elastic.Markdown.Diagnostics;
 using Elastic.Markdown.Extensions.DetectionRules;
@@ -118,9 +119,7 @@ public record GlobalNavigationPathProvider : IDocumentationFileOutputProvider
 
 		var originalPath = Path.Combine(match.Host, match.AbsolutePath.Trim('/')).TrimStart('/');
 		var relativePathSpan = relativePath.AsSpan();
-		var newRelativePath = relativePathSpan.StartsWith(originalPath, StringComparison.Ordinal)
-			? relativePathSpan.Slice(originalPath.Length).TrimStart('/').ToString()
-			: relativePathSpan.TrimStart(originalPath).TrimStart('/').ToString();
+		var newRelativePath = relativePathSpan.GetTrimmedRelativePath(originalPath);
 
 		var path = fs.Path.Combine(outputDirectory.FullName, toc.SourcePathPrefix, newRelativePath);
 


### PR DESCRIPTION
Follow-up to #835 

As mentioned by @bmorelli25 on https://github.com/elastic/docs-builder/issues/873#issuecomment-2762175027, there was another place using `TrimStart(string)` that cut away portions of the resulting path. This PR introduces an extension method for `ReadOnlySpan<char>` and applies it in the appropriate places.