### PR TITLE
Downgrade xUnit v3 to 1.1.0

### DIFF
--- a/tests/Elastic.Markdown.Tests/Elastic.Markdown.Tests.csproj
+++ b/tests/Elastic.Markdown.Tests/Elastic.Markdown.Tests.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0"/>
-    <PackageReference Include="xunit.v3" Version="2.0.0"/>
+    <PackageReference Include="xunit.v3" Version="1.1.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2"/>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
 

--- a/tests/authoring/authoring.fsproj
+++ b/tests/authoring/authoring.fsproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0"/>
-    <PackageReference Include="xunit.v3" Version="2.0.0"/>
+    <PackageReference Include="xunit.v3" Version="1.1.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2"/>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1"/>
 

--- a/tests/docs-assembler.Tests/src/docs-assembler.Tests/GlobalNavigationTests.cs
+++ b/tests/docs-assembler.Tests/src/docs-assembler.Tests/GlobalNavigationTests.cs
@@ -28,7 +28,7 @@ public class GlobalNavigationPathProviderTests
 		var checkoutDirectory = FileSystem.DirectoryInfo.New(
 			FileSystem.Path.Combine(Paths.GetSolutionDirectory()!.FullName, ".artifacts", "checkouts")
 		);
-		CheckoutDirectory = checkoutDirectory.GetDirectories().First(d => d.Name is "next" or "current");
+		CheckoutDirectory = checkoutDirectory.GetDirectories().FirstOrDefault(d => d.Name is "next" or "current") ?? checkoutDirectory;
 		Collector = new DiagnosticsCollector([]);
 		Context = new AssembleContext("dev", Collector, FileSystem, FileSystem, CheckoutDirectory.FullName, null);
 	}
@@ -64,6 +64,8 @@ public class GlobalNavigationPathProviderTests
 	[Fact]
 	public async Task ReadAllPathPrefixes()
 	{
+		Assert.SkipUnless(HasCheckouts(), $"Requires local checkout folder: {CheckoutDirectory.FullName}");
+
 		await using var collector = new DiagnosticsCollector([]);
 
 		var assembleContext = new AssembleContext("dev", collector, new FileSystem(), new FileSystem(), null, null);

--- a/tests/docs-assembler.Tests/src/docs-assembler.Tests/GlobalNavigationTests.cs
+++ b/tests/docs-assembler.Tests/src/docs-assembler.Tests/GlobalNavigationTests.cs
@@ -28,7 +28,9 @@ public class GlobalNavigationPathProviderTests
 		var checkoutDirectory = FileSystem.DirectoryInfo.New(
 			FileSystem.Path.Combine(Paths.GetSolutionDirectory()!.FullName, ".artifacts", "checkouts")
 		);
-		CheckoutDirectory = checkoutDirectory.GetDirectories().FirstOrDefault(d => d.Name is "next" or "current") ?? checkoutDirectory;
+		CheckoutDirectory = checkoutDirectory.Exists
+			? checkoutDirectory.GetDirectories().FirstOrDefault(d => d.Name is "next" or "current") ?? checkoutDirectory
+			: checkoutDirectory;
 		Collector = new DiagnosticsCollector([]);
 		Context = new AssembleContext("dev", Collector, FileSystem, FileSystem, CheckoutDirectory.FullName, null);
 	}

--- a/tests/docs-assembler.Tests/src/docs-assembler.Tests/GlobalNavigationTests.cs
+++ b/tests/docs-assembler.Tests/src/docs-assembler.Tests/GlobalNavigationTests.cs
@@ -25,9 +25,10 @@ public class GlobalNavigationPathProviderTests
 	public GlobalNavigationPathProviderTests()
 	{
 		FileSystem = new FileSystem();
-		CheckoutDirectory = FileSystem.DirectoryInfo.New(
+		var checkoutDirectory = FileSystem.DirectoryInfo.New(
 			FileSystem.Path.Combine(Paths.GetSolutionDirectory()!.FullName, ".artifacts", "checkouts")
 		);
+		CheckoutDirectory = checkoutDirectory.GetDirectories().First(d => d.Name is "next" or "current");
 		Collector = new DiagnosticsCollector([]);
 		Context = new AssembleContext("dev", Collector, FileSystem, FileSystem, CheckoutDirectory.FullName, null);
 	}

--- a/tests/docs-assembler.Tests/src/docs-assembler.Tests/docs-assembler.Tests.csproj
+++ b/tests/docs-assembler.Tests/src/docs-assembler.Tests/docs-assembler.Tests.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0"/>
-    <PackageReference Include="xunit.v3" Version="2.0.0"/>
+    <PackageReference Include="xunit.v3" Version="1.1.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2"/>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
 


### PR DESCRIPTION
This release had some breaking changes that broke the rider tests tool window.

https://youtrack.jetbrains.com/issue/RSRP-500210/Updating-to-xunit.v3-2.0.0-results-in-MethodNotFoundException

https://github.com/xunit/xunit/issues/3196