### PR TITLE
Update historymapping.yml to exclude Serverless mappings

### DIFF
--- a/src/docs-assembler/historymapping.yml
+++ b/src/docs-assembler/historymapping.yml
@@ -61,6 +61,7 @@ mappings:
   en/logstash-versioned-plugins: undefined
   en/search-ui: undefined
   en/security: stack
+  en/serverless: undefined
   en/starting-with-the-elasticsearch-platform-and-its-solutions: stack
   en/observability: stack
   en/elasticsearch/painless: stack


### PR DESCRIPTION
## Summary

There is no Serverless previous version to link to.

@cotti can you confirm that if there are multiple mapped pages and the first is an `undefined` mapping that the logic will still look at the other mapped pages to determine if there is somewhere to link to?