### PR TITLE
Fix table header appearance when a cell is empty

### DIFF
--- a/src/Elastic.Markdown/Assets/markdown/table.css
+++ b/src/Elastic.Markdown/Assets/markdown/table.css
@@ -25,7 +25,8 @@
 
 		thead {
 			@apply border-grey-20 bg-grey-10 border-b-1 text-left align-top font-sans font-semibold;
-			:empty {
+			&:not(:has(th:not(:empty))) {
+				/* If no th within thead is not empty, all are empty, so hide the thead */
 				display: none;
 			}
 		}


### PR DESCRIPTION
Closes https://github.com/elastic/docs-builder/issues/957

![image](https://github.com/user-attachments/assets/08bc34ef-8468-4c5d-b281-dfd0abf35a68)
