### PR TITLE
Use github.event.release.tag_name explicitly during release workflow to upload artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Attach Distribution to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ github.ref_name }} .artifacts/docs-lambda-index-publisher/release_linux-x64/bootstrap
+        run: gh release upload ${{ github.event.release.tag_name }} .artifacts/docs-lambda-index-publisher/release_linux-x64/bootstrap
         shell: bash
 
   release:
@@ -80,5 +80,5 @@ jobs:
       - name: Attach Distribution to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ github.ref_name }} .artifacts/publish/docs-builder/release/*.zip
+        run: gh release upload ${{ github.event.release.tag_name }} .artifacts/publish/docs-builder/release/*.zip
         shell: bash


### PR DESCRIPTION
See: https://github.com/actions/runner/issues/2788

Apparently this is a known intermittent issue