### PR TITLE
Use CrtChecksums explicitly to download S3 objects inside lambda function

### DIFF
--- a/src/infra/docs-lambda-index-publisher/aws-lambda-tools-defaults.json
+++ b/src/infra/docs-lambda-index-publisher/aws-lambda-tools-defaults.json
@@ -5,8 +5,8 @@
     "dotnet lambda help",
     "All the command line options for the Lambda command can be specified in this file."
   ],
-  "profile": "",
-  "region": "",
+  "profile": "default",
+  "region": "us-west-2",
   "configuration": "Release",
   "function-runtime": "provided.al2",
   "function-memory-size": 512,

--- a/src/infra/docs-lambda-index-publisher/docs-lambda-index-publisher.csproj
+++ b/src/infra/docs-lambda-index-publisher/docs-lambda-index-publisher.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4"/>
     <PackageReference Include="AWSSDK.S3" Version="3.7.414.5"/>
     <PackageReference Include="AWSSDK.Extensions.CrtIntegration" Version="3.7.400" />
+    <PackageReference Include="System.Private.Uri" Version="4.3.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Elastic.Markdown\Elastic.Markdown.csproj"/>

--- a/src/infra/docs-lambda-index-publisher/docs-lambda-index-publisher.csproj
+++ b/src/infra/docs-lambda-index-publisher/docs-lambda-index-publisher.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.5.0"/>
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4"/>
     <PackageReference Include="AWSSDK.S3" Version="3.7.414.5"/>
+    <PackageReference Include="AWSSDK.Extensions.CrtIntegration" Version="3.7.400" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Elastic.Markdown\Elastic.Markdown.csproj"/>

--- a/src/infra/docs-lambda-index-publisher/docs-lambda-index-publisher.csproj
+++ b/src/infra/docs-lambda-index-publisher/docs-lambda-index-publisher.csproj
@@ -23,8 +23,6 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.5.0"/>
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4"/>
     <PackageReference Include="AWSSDK.S3" Version="3.7.414.5"/>
-    <PackageReference Include="AWSSDK.Extensions.CrtIntegration" Version="3.7.400" />
-    <PackageReference Include="System.Private.Uri" Version="4.3.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Elastic.Markdown\Elastic.Markdown.csproj"/>


### PR DESCRIPTION
This should address all the unknown `ref`'s current at: 

https://elastic-docs-link-index.s3.us-east-2.amazonaws.com/link-index.json