### PR TITLE
Fix misplaced guard for checking for updates on CI

### DIFF
--- a/src/docs-builder/Cli/CheckForUpdatesFilter.cs
+++ b/src/docs-builder/Cli/CheckForUpdatesFilter.cs
@@ -16,6 +16,9 @@ internal sealed class CheckForUpdatesFilter(ConsoleAppFilter next) : ConsoleAppF
 	public override async Task InvokeAsync(ConsoleAppContext context, Cancel ctx)
 	{
 		await Next.InvokeAsync(context, ctx);
+		if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CI")))
+			return;
+
 		var latestVersionUrl = await GetLatestVersion(ctx);
 		if (latestVersionUrl is null)
 			ConsoleApp.LogError("Unable to determine latest version");
@@ -54,9 +57,6 @@ internal sealed class CheckForUpdatesFilter(ConsoleAppFilter next) : ConsoleAppF
 
 	private async ValueTask<Uri?> GetLatestVersion(Cancel ctx)
 	{
-		if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CI")))
-			return null;
-
 		// only check for new versions once per hour
 		if (_stateFile.Exists && _stateFile.LastWriteTimeUtc >= DateTime.UtcNow.Subtract(TimeSpan.FromHours(1)))
 		{


### PR DESCRIPTION
We had a guard in place to not check for updates on CI however we were still logging an error  which had no influence over the exit code. 


Edge case here since these filters log directly to `ConsoleApp.Error` because we don't want it to influence the exit code but on CI this looks scary 😸 