### PR TITLE
Add Elasticsearch Rust to assembler

### DIFF
--- a/src/docs-assembler/assembler.yml
+++ b/src/docs-assembler/assembler.yml
@@ -90,9 +90,7 @@ references:
   elasticsearch-net:
   elasticsearch-php:
   elasticsearch-py:
-    # https://github.com/elastic/elasticsearch-rs ci checks not running?
-  # elasticsearch-rs:
-  #   skip: true
+  elasticsearch-rs:
   elasticsearch-ruby:
   elasticsearch:
     current: *stack

--- a/src/docs-assembler/navigation.yml
+++ b/src/docs-assembler/navigation.yml
@@ -233,8 +233,8 @@ toc:
 
               # Rust
               # ✅ https://github.com/elastic/elasticsearch-rs/blob/main/docs/reference/toc.yml
-              #- toc: elasticsearch-rs://reference
-              #  path_prefix: reference/elasticsearch/clients/rust
+              - toc: elasticsearch-rs://reference
+                path_prefix: reference/elasticsearch/clients/rust
                 # Children include the entire AsciiDoc book
 
               # Community-contributed clients


### PR DESCRIPTION
Adds elasticsearch-rs to the assembler and navigation configs. 