### PR TITLE
Ensure ordering of navigation items by adding children after the parent's own items

### DIFF
--- a/src/docs-assembler/Navigation/GlobalNavigation.cs
+++ b/src/docs-assembler/Navigation/GlobalNavigation.cs
@@ -83,30 +83,14 @@ public record GlobalNavigation
 			var tocChildren = toc.Children.OfType<TocReference>().ToArray();
 			var tocNavigationItems = BuildNavigation(tocChildren, depth + 1);
 
-			var allNavigationItems = tree.NavigationItems.Concat(tocNavigationItems);
-			var cleanNavigationItems = new List<INavigationItem>();
+			var allNavigationItems = new List<INavigationItem>();
 			var seenSources = new HashSet<Uri>();
-			foreach (var allNavigationItem in allNavigationItems)
-			{
-				if (allNavigationItem is not TocNavigationItem tocNav)
-				{
-					cleanNavigationItems.Add(allNavigationItem);
-					continue;
-				}
-				if (seenSources.Contains(tocNav.Source))
-					continue;
+			var currentOrder = 0;
 
-				if (!_assembleSources.TocTopLevelMappings.TryGetValue(tocNav.Source, out var mapping))
-					continue;
+			AddNavigationItems(allNavigationItems, tree.NavigationItems, seenSources, tree, ref currentOrder);
+			AddNavigationItems(allNavigationItems, tocNavigationItems, seenSources, tree, ref currentOrder);
 
-				if (mapping.ParentSource != tree.Source)
-					continue;
-
-				_ = seenSources.Add(tocNav.Source);
-				cleanNavigationItems.Add(allNavigationItem);
-			}
-
-			tree.NavigationItems = cleanNavigationItems.OrderBy(n => n.Order).ToArray();
+			tree.NavigationItems = allNavigationItems.ToArray();
 			var navigationItem = new TocNavigationItem(i, depth, tree, toc.Source);
 
 			list.Add(navigationItem);
@@ -114,5 +98,32 @@ public record GlobalNavigation
 		}
 
 		return list.ToArray().AsReadOnly();
+	}
+
+	private void AddNavigationItems(List<INavigationItem> navigationItems, IEnumerable<INavigationItem>? toAdd, HashSet<Uri> seenSources, TableOfContentsTree tree, ref int currentOrder)
+	{
+		if (toAdd is null)
+			return;
+		foreach (var navigationItem in toAdd)
+		{
+			if (navigationItem is not TocNavigationItem tocNav)
+			{
+				navigationItems.Add(navigationItem);
+				currentOrder++;
+				continue;
+			}
+			if (seenSources.Contains(tocNav.Source))
+				continue;
+
+			if (!_assembleSources.TocTopLevelMappings.TryGetValue(tocNav.Source, out var mapping))
+				continue;
+
+			if (mapping.ParentSource != tree.Source)
+				continue;
+
+			_ = seenSources.Add(tocNav.Source);
+			navigationItems.Add(navigationItem);
+			currentOrder++;
+		}
 	}
 }

--- a/src/docs-assembler/Navigation/GlobalNavigation.cs
+++ b/src/docs-assembler/Navigation/GlobalNavigation.cs
@@ -85,10 +85,9 @@ public record GlobalNavigation
 
 			var allNavigationItems = new List<INavigationItem>();
 			var seenSources = new HashSet<Uri>();
-			var currentOrder = 0;
 
-			AddNavigationItems(allNavigationItems, tree.NavigationItems, seenSources, tree, ref currentOrder);
-			AddNavigationItems(allNavigationItems, tocNavigationItems, seenSources, tree, ref currentOrder);
+			AddNavigationItems(allNavigationItems, tree.NavigationItems, seenSources, tree);
+			AddNavigationItems(allNavigationItems, tocNavigationItems, seenSources, tree);
 
 			tree.NavigationItems = allNavigationItems.ToArray();
 			var navigationItem = new TocNavigationItem(i, depth, tree, toc.Source);
@@ -100,7 +99,7 @@ public record GlobalNavigation
 		return list.ToArray().AsReadOnly();
 	}
 
-	private void AddNavigationItems(List<INavigationItem> navigationItems, IEnumerable<INavigationItem>? toAdd, HashSet<Uri> seenSources, TableOfContentsTree tree, ref int currentOrder)
+	private void AddNavigationItems(List<INavigationItem> navigationItems, IEnumerable<INavigationItem>? toAdd, HashSet<Uri> seenSources, TableOfContentsTree tree)
 	{
 		if (toAdd is null)
 			return;
@@ -109,7 +108,6 @@ public record GlobalNavigation
 			if (navigationItem is not TocNavigationItem tocNav)
 			{
 				navigationItems.Add(navigationItem);
-				currentOrder++;
 				continue;
 			}
 			if (seenSources.Contains(tocNav.Source))
@@ -123,7 +121,6 @@ public record GlobalNavigation
 
 			_ = seenSources.Add(tocNav.Source);
 			navigationItems.Add(navigationItem);
-			currentOrder++;
 		}
 	}
 }


### PR DESCRIPTION
When assembling navigation where an item contains not only its own Known Issues / Deprecations / Breaking Changes, but also children items, their ordering in the listing would be interleaved due to multiple items having the same Order value.

This PR ensures we add all navigation items inherent to the current tree node before adding extra elements from the TOC.