### PR TITLE
Use boosted and inherited HTMX attributes for side navigation

### DIFF
--- a/src/Elastic.Markdown/Assets/pages-nav.ts
+++ b/src/Elastic.Markdown/Assets/pages-nav.ts
@@ -49,7 +49,7 @@ export function initNav() {
     }
     const allNavItems = $$('a', pagesNav)
     allNavItems.forEach((link) => {
-        link.addEventListener('click', (_) => {
+        link.addEventListener('click', () => {
             link.closest('details').removeAttribute('open')
         })
     })

--- a/src/Elastic.Markdown/Assets/pages-nav.ts
+++ b/src/Elastic.Markdown/Assets/pages-nav.ts
@@ -47,9 +47,9 @@ export function initNav() {
     if (!pagesNav) {
         return
     }
-    const allNavItems = $$('a', pagesNav);
+    const allNavItems = $$('a', pagesNav)
     allNavItems.forEach((link) => {
-        link.addEventListener('click', _ => {
+        link.addEventListener('click', (_) => {
             link.closest('details').removeAttribute('open')
         })
     })

--- a/src/Elastic.Markdown/Assets/pages-nav.ts
+++ b/src/Elastic.Markdown/Assets/pages-nav.ts
@@ -47,6 +47,13 @@ export function initNav() {
     if (!pagesNav) {
         return
     }
+    const allNavItems = $$('a', pagesNav);
+    allNavItems.forEach((link) => {
+        link.addEventListener('click', _ => {
+            link.closest('details').removeAttribute('open')
+        })
+    })
+
     const navItems = $$(
         'a[href="' +
             window.location.pathname +

--- a/src/Elastic.Markdown/Assets/toc-nav.ts
+++ b/src/Elastic.Markdown/Assets/toc-nav.ts
@@ -132,7 +132,6 @@ function updateIndicator(elements: TocElements) {
 function setupSmoothScrolling(elements: TocElements) {
     elements.tocLinks.forEach((link) => {
         link.addEventListener('click', (e) => {
-            link.closest('details').removeAttribute('open')
             const href = link.getAttribute('href')
             if (href?.charAt(0) === '#') {
                 const target = document.getElementById(href.slice(1))

--- a/src/Elastic.Markdown/Assets/toc-nav.ts
+++ b/src/Elastic.Markdown/Assets/toc-nav.ts
@@ -132,6 +132,7 @@ function updateIndicator(elements: TocElements) {
 function setupSmoothScrolling(elements: TocElements) {
     elements.tocLinks.forEach((link) => {
         link.addEventListener('click', (e) => {
+            link.closest('details').removeAttribute('open')
             const href = link.getAttribute('href')
             if (href?.charAt(0) === '#') {
                 const target = document.getElementById(href.slice(1))

--- a/src/Elastic.Markdown/Helpers/Htmx.cs
+++ b/src/Elastic.Markdown/Helpers/Htmx.cs
@@ -32,7 +32,8 @@ public static class Htmx
 	)
 	{
 		var attributes = new StringBuilder();
-		_ = attributes.Append($" hx-get={targetUrl}");
+		if (!string.IsNullOrEmpty(targetUrl))
+			_ = attributes.Append($" hx-get={targetUrl}");
 		_ = attributes.Append($" hx-select-oob={hxSwapOob ?? GetHxSelectOob(hasSameTopLevelGroup)}");
 		_ = attributes.Append($" hx-swap={hxSwap}");
 		_ = attributes.Append($" hx-push-url={hxPushUrl}");
@@ -40,4 +41,13 @@ public static class Htmx
 		_ = attributes.Append($" preload={preload}");
 		return attributes.ToString();
 	}
+
+	public static string GetHxAttributes(
+		bool hasSameTopLevelGroup = false,
+		string? preload = Preload,
+		string? hxSwapOob = null,
+		string? hxSwap = HxSwap,
+		string? hxPushUrl = HxPushUrl,
+		string? hxIndicator = HxIndicator
+	) => GetHxAttributes(string.Empty, hasSameTopLevelGroup, preload, hxSwapOob, hxSwap, hxPushUrl, hxIndicator);
 }

--- a/src/Elastic.Markdown/Helpers/Htmx.cs
+++ b/src/Elastic.Markdown/Helpers/Htmx.cs
@@ -32,8 +32,7 @@ public static class Htmx
 	)
 	{
 		var attributes = new StringBuilder();
-		if (!string.IsNullOrEmpty(targetUrl))
-			_ = attributes.Append($" hx-get={targetUrl}");
+		_ = attributes.Append($" hx-get={targetUrl}");
 		_ = attributes.Append($" hx-select-oob={hxSwapOob ?? GetHxSelectOob(hasSameTopLevelGroup)}");
 		_ = attributes.Append($" hx-swap={hxSwap}");
 		_ = attributes.Append($" hx-push-url={hxPushUrl}");
@@ -42,12 +41,11 @@ public static class Htmx
 		return attributes.ToString();
 	}
 
-	public static string GetHxAttributes(
-		bool hasSameTopLevelGroup = false,
-		string? preload = Preload,
-		string? hxSwapOob = null,
-		string? hxSwap = HxSwap,
-		string? hxPushUrl = HxPushUrl,
-		string? hxIndicator = HxIndicator
-	) => GetHxAttributes(string.Empty, hasSameTopLevelGroup, preload, hxSwapOob, hxSwap, hxPushUrl, hxIndicator);
+	public static string GetNavHxAttributes(bool hasSameTopLevelGroup = false, string? preload = Preload)
+	{
+		var attributes = new StringBuilder();
+		_ = attributes.Append($" hx-select-oob={GetHxSelectOob(hasSameTopLevelGroup)}");
+		_ = attributes.Append($" preload={preload}");
+		return attributes.ToString();
+	}
 }

--- a/src/Elastic.Markdown/Slices/Layout/_TocTree.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_TocTree.cshtml
@@ -1,6 +1,6 @@
 @using Elastic.Markdown.Helpers
 @inherits RazorSlice<NavigationViewModel>
-<div class="pb-20 font-body">
+<div class="pb-20 font-body" hx-boost="true">
 	@{
 		var current = Model.TopLevelItems.FirstOrDefault(i => i.Id == Model.Tree.Id);
 	} 
@@ -14,7 +14,7 @@
 							onclick="this.closest('details').removeAttribute('open')"
 							class="hover:underline text-blue-elastic hover:text-blue-elastic-100"
 							href="@current.Group.Index?.Url"
-							@Htmx.GetHxAttributes(current.Group.Index?.Url!, true)
+							@Htmx.GetHxAttributes(true)
 						>
 							@current.Group.Index?.NavigationTitle
 						</a>
@@ -41,7 +41,7 @@
 								onclick="this.closest('details').removeAttribute('open')"
 								class="block py-2 px-4 hover:underline hover:text-black hover:bg-grey-10 active:bg-blue-elastic-70 active:text-white font-semibold @(item.Group.Id == Model.Tree.Id ? "text-blue-elastic" : "")"
 								href="@item.Group.Index.Url"
-								@Htmx.GetHxAttributes(item.Group.Index.Url, false, "mouseover")>
+								@Htmx.GetHxAttributes(false, "mouseover")>
 								@item.Group.Index.NavigationTitle
 							</a>
 						</li>
@@ -54,7 +54,7 @@
 	{
 		<a
 			href="@Model.TitleUrl"
-			@Htmx.GetHxAttributes(Model.TitleUrl, current is null || Model.Tree.Id == current.Id)
+			@Htmx.GetHxAttributes(current is null || Model.Tree.Id == current.Id)
 			class="inline-block mx-4 mt-6 font-semibold text-ink hover:text-black">
 			@Model.Title
 		</a>

--- a/src/Elastic.Markdown/Slices/Layout/_TocTree.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_TocTree.cshtml
@@ -1,6 +1,6 @@
 @using Elastic.Markdown.Helpers
 @inherits RazorSlice<NavigationViewModel>
-<div class="pb-20 font-body" hx-boost="true">
+<div class="pb-20 font-body" hx-boost="true" hx-swap="none" hx-push-url="true" hx-indicator="#htmx-indicator">
 	@{
 		var current = Model.TopLevelItems.FirstOrDefault(i => i.Id == Model.Tree.Id);
 	} 
@@ -11,10 +11,9 @@
 				<summary class="grid grid-cols-[1fr_auto] cursor-pointer font-semibold gap-1 hover:text-black pl-4 pr-2 py-2 group-open:border-b-1 border-grey-20">
 					<span>
 						<a 
-							onclick="this.closest('details').removeAttribute('open')"
 							class="hover:underline text-blue-elastic hover:text-blue-elastic-100"
 							href="@current.Group.Index?.Url"
-							@Htmx.GetHxAttributes(true)
+							@Htmx.GetNavHxAttributes(true)
 						>
 							@current.Group.Index?.NavigationTitle
 						</a>
@@ -38,10 +37,9 @@
 						if (item.Id == current?.Id) continue;
 						<li class="block">
 							<a
-								onclick="this.closest('details').removeAttribute('open')"
 								class="block py-2 px-4 hover:underline hover:text-black hover:bg-grey-10 active:bg-blue-elastic-70 active:text-white font-semibold @(item.Group.Id == Model.Tree.Id ? "text-blue-elastic" : "")"
 								href="@item.Group.Index.Url"
-								@Htmx.GetHxAttributes(false, "mouseover")>
+								@Htmx.GetNavHxAttributes(false, "mouseover")>
 								@item.Group.Index.NavigationTitle
 							</a>
 						</li>
@@ -54,7 +52,7 @@
 	{
 		<a
 			href="@Model.TitleUrl"
-			@Htmx.GetHxAttributes(current is null || Model.Tree.Id == current.Id)
+			@Htmx.GetNavHxAttributes(current is null || Model.Tree.Id == current.Id)
 			class="inline-block mx-4 mt-6 font-semibold text-ink hover:text-black">
 			@Model.Title
 		</a>

--- a/src/Elastic.Markdown/Slices/Layout/_TocTreeNav.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_TocTreeNav.cshtml
@@ -13,7 +13,7 @@
 		<li class="flex group/li pr-4 @(isTopLevel ? "font-semibold py-8 pr-4 not-last:border-b-1 border-grey-20" : "ml-5 lg:ml-4 mt-4 lg:mt-3")">
 			<a
 				href="@f.Url"
-				@Htmx.GetHxAttributes(Model.IsPrimaryNavEnabled && f.NavigationRoot.Id == Model.RootNavigationId || true)
+				@Htmx.GetNavHxAttributes(Model.IsPrimaryNavEnabled && f.NavigationRoot.Id == Model.RootNavigationId || true)
 				class="sidebar-link group-[.current]/li:text-blue-elastic!"
 				id="page-@id"
 				>
@@ -27,7 +27,7 @@
 		<li class="flex group/li pr-4 @(isTopLevel ? "font-semibold py-8 pr-4 not-last:border-b-1 border-grey-20" : "ml-5 lg:ml-4 mt-4 lg:mt-3")">
 			<a
 				href="@f.Url"
-				@Htmx.GetHxAttributes(Model.IsPrimaryNavEnabled && f.NavigationRoot.Id == Model.RootNavigationId || true)
+				@Htmx.GetNavHxAttributes(Model.IsPrimaryNavEnabled && f.NavigationRoot.Id == Model.RootNavigationId || true)
 				class="sidebar-link group-[.current]/li:text-blue-elastic!"
 				id="page-@id"
 			>
@@ -59,7 +59,7 @@
 				</label>
 				<a
 					href="@(g.Index?.Url ?? "")"
-					@Htmx.GetHxAttributes(Model.IsPrimaryNavEnabled && g.NavigationRootId == Model.RootNavigationId || true)
+					@Htmx.GetNavHxAttributes(Model.IsPrimaryNavEnabled && g.NavigationRootId == Model.RootNavigationId || true)
 					id="page-@(g.Index?.Id ?? id)"
 					class="sidebar-link @(isTopLevel ? "font-semibold font-sans text-base" : "") @(isTopLevel ? "order-0" : "order-1")">
 					@(g.Index?.NavigationTitle ?? (g as TableOfContentsTree)?.Source.ToString() ?? "Untitled")

--- a/src/Elastic.Markdown/Slices/Layout/_TocTreeNav.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_TocTreeNav.cshtml
@@ -13,7 +13,7 @@
 		<li class="flex group/li pr-4 @(isTopLevel ? "font-semibold py-8 pr-4 not-last:border-b-1 border-grey-20" : "ml-5 lg:ml-4 mt-4 lg:mt-3")">
 			<a
 				href="@f.Url"
-				@Htmx.GetHxAttributes(f.Url, Model.IsPrimaryNavEnabled && f.NavigationRoot.Id == Model.RootNavigationId || true)
+				@Htmx.GetHxAttributes(Model.IsPrimaryNavEnabled && f.NavigationRoot.Id == Model.RootNavigationId || true)
 				class="sidebar-link group-[.current]/li:text-blue-elastic!"
 				id="page-@id"
 				>
@@ -27,7 +27,7 @@
 		<li class="flex group/li pr-4 @(isTopLevel ? "font-semibold py-8 pr-4 not-last:border-b-1 border-grey-20" : "ml-5 lg:ml-4 mt-4 lg:mt-3")">
 			<a
 				href="@f.Url"
-				@Htmx.GetHxAttributes(f.Url, Model.IsPrimaryNavEnabled && f.NavigationRoot.Id == Model.RootNavigationId || true)
+				@Htmx.GetHxAttributes(Model.IsPrimaryNavEnabled && f.NavigationRoot.Id == Model.RootNavigationId || true)
 				class="sidebar-link group-[.current]/li:text-blue-elastic!"
 				id="page-@id"
 			>
@@ -59,7 +59,7 @@
 				</label>
 				<a
 					href="@(g.Index?.Url ?? "")"
-					@Htmx.GetHxAttributes(g.Index?.Url ?? "", Model.IsPrimaryNavEnabled && g.NavigationRootId == Model.RootNavigationId || true)
+					@Htmx.GetHxAttributes(Model.IsPrimaryNavEnabled && g.NavigationRootId == Model.RootNavigationId || true)
 					id="page-@(g.Index?.Id ?? id)"
 					class="sidebar-link @(isTopLevel ? "font-semibold font-sans text-base" : "") @(isTopLevel ? "order-0" : "order-1")">
 					@(g.Index?.NavigationTitle ?? (g as TableOfContentsTree)?.Source.ToString() ?? "Untitled")


### PR DESCRIPTION
From 31gb:

![image](https://github.com/user-attachments/assets/13980474-2116-470e-a842-7410ef9e6dac)

To 23GB

<img width="656" alt="image" src="https://github.com/user-attachments/assets/6cb56592-b07a-4186-9350-f2b9672c4e1e" />