### PR TITLE
Use text-wrap pretty more

### DIFF
--- a/src/Elastic.Markdown/Assets/markdown/typography.css
+++ b/src/Elastic.Markdown/Assets/markdown/typography.css
@@ -1,5 +1,5 @@
 .markdown-content {
-	@apply text-ink font-body text-base;
+	@apply text-ink font-body text-base text-pretty;
 
 	h1 {
 		@apply text-ink-dark text-5xl font-semibold;
@@ -46,7 +46,6 @@
 	p {
 		@apply mt-4;
 		line-height: 1.5em;
-		text-wrap: pretty;
 	}
 
 	a {

--- a/src/Elastic.Markdown/Assets/styles.css
+++ b/src/Elastic.Markdown/Assets/styles.css
@@ -91,7 +91,7 @@
 		}
 
 		.sidebar-link {
-			@apply text-ink-light text-pretty inline-block leading-[1.2em] hover:text-black md:text-sm;
+			@apply text-ink-light inline-block leading-[1.2em] text-pretty hover:text-black md:text-sm;
 		}
 	}
 

--- a/src/Elastic.Markdown/Assets/styles.css
+++ b/src/Elastic.Markdown/Assets/styles.css
@@ -91,7 +91,7 @@
 		}
 
 		.sidebar-link {
-			@apply text-ink-light inline-block leading-[1.2em] text-wrap hover:text-black md:text-sm;
+			@apply text-ink-light text-pretty inline-block leading-[1.2em] hover:text-black md:text-sm;
 		}
 	}
 


### PR DESCRIPTION
## Changes

- Use `text-wrap: pretty` for all markdown content.
- And also use it for navigation items.