### PR TITLE
Reorder Extend section

### DIFF
--- a/src/docs-assembler/navigation.yml
+++ b/src/docs-assembler/navigation.yml
@@ -35,12 +35,12 @@ toc:
         path_prefix: extend/kibana
       - toc: logstash://extend
         path_prefix: extend/logstash
+      - toc: beats://extend
+        path_prefix: extend/beats
       - toc: elasticsearch://extend
         path_prefix: extend/elasticsearch
       - toc: integrations://extend
         path_prefix: extend/integrations
-      - toc: beats://extend
-        path_prefix: extend/beats
 
  #################
   # RELEASE NOTES #


### PR DESCRIPTION
This puts the threee contribution pages first and then the 2 around creation. This makes the ToC flow smoother for the extend section.

@KOTungseth This reorders the ToC for the Extend section based on the feedback you provided in our Landing page and Nav UX. 