### PR TITLE
BREAKING CHANGE: Don't allow dots (.) in slug

### DIFF
--- a/src/Elastic.Markdown/Helpers/SlugExtensions.cs
+++ b/src/Elastic.Markdown/Helpers/SlugExtensions.cs
@@ -9,13 +9,17 @@ namespace Elastic.Markdown.Helpers;
 public static class SlugExtensions
 {
 	private static readonly SlugHelper Instance = InitSlugHelper();
+	private static readonly SlugHelper InstanceWithDots = InitSlugHelper(true);
 
-	private static SlugHelper InitSlugHelper()
+	private static SlugHelper InitSlugHelper(bool allowDots = false)
 	{
 		var config = new SlugHelperConfiguration();
-		_ = config.AllowedChars.Remove('.');
+		if (!allowDots)
+			_ = config.AllowedChars.Remove('.');
 		return new SlugHelper(config);
 	}
 
-	public static string Slugify(this string? text) => Instance.GenerateSlug(text);
+	public static string Slugify(this string? text, bool allowDots = false) => allowDots
+		? InstanceWithDots.GenerateSlug(text)
+		: Instance.GenerateSlug(text);
 }

--- a/src/Elastic.Markdown/Helpers/SlugExtensions.cs
+++ b/src/Elastic.Markdown/Helpers/SlugExtensions.cs
@@ -8,8 +8,14 @@ namespace Elastic.Markdown.Helpers;
 
 public static class SlugExtensions
 {
-	private static readonly SlugHelper Instance = new();
+	private static readonly SlugHelper Instance = InitSlugHelper();
+
+	private static SlugHelper InitSlugHelper()
+	{
+		var config = new SlugHelperConfiguration();
+		_ = config.AllowedChars.Remove('.');
+		return new SlugHelper(config);
+	}
 
 	public static string Slugify(this string? text) => Instance.GenerateSlug(text);
-
 }

--- a/src/Elastic.Markdown/Myst/SectionedHeadingRenderer.cs
+++ b/src/Elastic.Markdown/Myst/SectionedHeadingRenderer.cs
@@ -34,7 +34,7 @@ public class SectionedHeadingRenderer : HtmlObjectRenderer<HeadingBlock>
 
 		var slug = anchor ?? header.Slugify();
 		if (slug.Contains('$'))
-			slug = HeadingAnchorParser.InlineAnchors().Replace(slug, "").Slugify();
+			slug = HeadingAnchorParser.InlineAnchors().Replace(slug, "");
 
 		_ = renderer.Write(@"<div class=""heading-wrapper"" id=""")
 			.Write(slug)

--- a/src/Elastic.Markdown/Myst/SectionedHeadingRenderer.cs
+++ b/src/Elastic.Markdown/Myst/SectionedHeadingRenderer.cs
@@ -32,11 +32,9 @@ public class SectionedHeadingRenderer : HtmlObjectRenderer<HeadingBlock>
 		var header = obj.GetData("header") as string;
 		var anchor = obj.GetData("anchor") as string;
 
-		var slugTarget = (anchor ?? header) ?? string.Empty;
-		if (slugTarget.Contains('$'))
-			slugTarget = HeadingAnchorParser.InlineAnchors().Replace(slugTarget, "");
-
-		var slug = slugTarget.Slugify();
+		var slug = anchor ?? header.Slugify();
+		if (slug.Contains('$'))
+			slug = HeadingAnchorParser.InlineAnchors().Replace(slug, "").Slugify();
 
 		_ = renderer.Write(@"<div class=""heading-wrapper"" id=""")
 			.Write(slug)

--- a/src/Elastic.Markdown/Myst/SectionedHeadingRenderer.cs
+++ b/src/Elastic.Markdown/Myst/SectionedHeadingRenderer.cs
@@ -32,9 +32,13 @@ public class SectionedHeadingRenderer : HtmlObjectRenderer<HeadingBlock>
 		var header = obj.GetData("header") as string;
 		var anchor = obj.GetData("anchor") as string;
 
-		var slug = anchor ?? header.Slugify();
-		if (slug.Contains('$'))
-			slug = HeadingAnchorParser.InlineAnchors().Replace(slug, "");
+		var slugTarget = (anchor ?? header) ?? string.Empty;
+		if (slugTarget.Contains('$'))
+			slugTarget = HeadingAnchorParser.InlineAnchors().Replace(slugTarget, "");
+
+		var slug = slugTarget.Slugify();
+		if (anchor != null || slugTarget.Contains('$'))
+			slug = slugTarget.Slugify(true);
 
 		_ = renderer.Write(@"<div class=""heading-wrapper"" id=""")
 			.Write(slug)


### PR DESCRIPTION
## Context

Currently, dots (`.`) are allowed in slugs. This means generated anchors also contain slugs.

If you create a header like

```markdown
## 1. Install
```

Then it's anchor will be `#1.-install`.

However, IDE's are expecting the anchor `#1-install`.

![image](https://github.com/user-attachments/assets/8228b181-a3cd-49e7-9e14-f28bdf31b5a1)


Reported by @flobernd 

## Changes

By removing the `.` from the allowed chars of Slugify, the correct anchor is generated.