### PR TITLE
Fix anchors in "On this page" nav

### DIFF
--- a/src/Elastic.Markdown/IO/MarkdownFile.cs
+++ b/src/Elastic.Markdown/IO/MarkdownFile.cs
@@ -292,7 +292,12 @@ public record MarkdownFile : DocumentationFile, INavigationScope, ITableOfConten
 			.Select(h =>
 			{
 				var header = h.Item1!.StripMarkdown();
-				return new PageTocItem { Heading = header, Slug = (h.Item2 ?? header).Slugify(), Level = h.Level };
+				return new PageTocItem
+				{
+					Heading = header,
+					Slug = (h.Item2 ?? h.Item1).Slugify(),
+					Level = h.Level
+				};
 			})
 			.Concat(includedTocs)
 			.Select(toc => subs.Count == 0


### PR DESCRIPTION
## Context

It seems like `StripMarkdown` removes all valid markdown syntax such as `1.`.

This causes a wrong anchor if a heading starts with `1.`.

## Changes

Use the original string instead of the one with stripped markdown.