### PR TITLE
Add artifact attestation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,9 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-path: '.artifacts/publish/docs-builder/release/*.zip'
+          subject-path: |
+            .artifacts/publish/docs-builder/release/*.zip
+            .artifacts/publish/docs-assembler/release/*.zip
 
       - name: Attach Distribution to release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   packages: write
+  attestations: write
 
 jobs:
   containers:
@@ -76,6 +77,11 @@ jobs:
       - name: Publish Binaries
         run: ./build.sh publishzip
         shell: bash
+        
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: '.artifacts/publish/docs-builder/release/*.zip'
 
       - name: Attach Distribution to release
         env:


### PR DESCRIPTION
See https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds

Closes #955 