### PR TITLE
Allow images from the elastic-severless-forwarder repo

### DIFF
--- a/src/docs-assembler/Navigation/GlobalNavigationPathProvider.cs
+++ b/src/docs-assembler/Navigation/GlobalNavigationPathProvider.cs
@@ -78,8 +78,6 @@ public record GlobalNavigationPathProvider : IDocumentationFileOutputProvider
 			return null;
 		if (lookup.StartsWith("elasticsearch-py://sphinx/", StringComparison.Ordinal))
 			return null;
-		if (lookup.StartsWith("elastic-serverless-forwarder://", StringComparison.Ordinal) && lookup.EndsWith(".png"))
-			return null;
 
 		//allow files at root for `docs-content` (index.md 404.md)
 		if (lookup.StartsWith("docs-content://") && !relativePath.Contains('/'))


### PR DESCRIPTION
Related: https://github.com/elastic/elastic-serverless-forwarder/pull/879

I'm not sure why this line was added, but I was unable to get images to appear in my local versions of https://www.elastic.co/docs/reference/aws-forwarder and https://www.elastic.co/docs/reference/aws-forwarder/aws-deploy-elastic-serverless-forwarder until I removed this line.