### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,12 +6,13 @@ on:
 permissions:
   contents: read
   packages: write
+    
+concurrency:
+  group: release-drafter
 
 jobs:
   
   release-drafter:
-    concurrency: 
-      group: release-drafter
     outputs:
       tag_name: ${{ steps.release-drafter.outputs.tag_name }}
     permissions:
@@ -145,4 +146,4 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG_NAME: ${{ needs.release-drafter.outputs.tag_name }}
         run: |
-          gh release edit ${{ needs.release-drafter.outputs.tag_name }} --draft=false --latest
+          gh release edit ${{ needs.release-drafter.outputs.tag_name }} --draft=false --latest --repo ${{ github.repository }}


### PR DESCRIPTION
## Context

The release workflow failed at the final step.

https://github.com/elastic/docs-builder/actions/runs/14706621685/job/41268943762

However, the assets were uploaded successfully in https://github.com/elastic/docs-builder/releases/tag/0.30.6 

I only manually published the release.

## Changes

- Fix publish release command
- Set concurrency at workflow level to ensure the current release is not updated by release-drafter while the release is running.