### PR TITLE
Disable 'Update Reference Index' action

### DIFF
--- a/actions/update-reference-index/action.yml
+++ b/actions/update-reference-index/action.yml
@@ -5,6 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Update Reference Index
-      run: |
-        curl -v https://kaqcb6pumme57zlb63wmoqcjxq0fhkdl.lambda-url.us-east-1.on.aws
+      run: exit 0;
+#      run: |
+#        curl -v https://kaqcb6pumme57zlb63wmoqcjxq0fhkdl.lambda-url.us-east-1.on.aws
       shell: bash


### PR DESCRIPTION
## Changes

Just exit with 0 for now. (Remove entirely when it's proved to work as expected)

## Context

This is not needed anymore with the implementation in https://github.com/elastic/docs-builder/issues/971
