### PR TITLE
Create dependabot group for System.IO.Abstractions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,5 +24,10 @@ updates:
       interval: 'weekly'
       day: 'monday'
       time: '08:00'
+    groups: 
+      system-io-abstractions:
+        patterns:
+          - 'System.IO.Abstractions'
+          - 'System.IO.Abstractions.*'
     labels:
       - chore


### PR DESCRIPTION
I'm actually not sure if this works as expected. But let's try it.

But I actually found the same configuration in a random repository [here](https://github.com/xt0rted/dotnet-rimraf/blob/f8da9691d903a041f3f163be7583c10e2affb64c/.github/dependabot.yml#L33).