### PR TITLE
Fix link-index-updater lambda deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
           
       - name: Upload Lambda function
         run: |        
-          zip "${ZIP_FILE}" .artifacts/docs-lambda-index-publisher/release_linux-x64/bootstrap
+          zip -j "${ZIP_FILE}" .artifacts/docs-lambda-index-publisher/release_linux-x64/bootstrap
           aws lambda update-function-code \
             --function-name elastic-docs-v3-link-index-updater \
             --zip-file "fileb://${ZIP_FILE}"


### PR DESCRIPTION
## Changes

This makes sure that the `bootstrap` binary is the top-level file in the zip, while ignoring the folder structure.