### PR TITLE
Make sure release-drafter runs for the current commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
         id: release-drafter
         env:
           GITHUB_TOKEN: ${{ github.token }}
+        with:
+          commitish: ${{ github.sha }}
       - name: Create tag
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
The default is /heads/ref/main, which might be wrong if a PR is merged while this workflow is running
