### PR TITLE
Fix lambda release

### DIFF
--- a/.github/workflows/build-link-index-updater-lambda.yml
+++ b/.github/workflows/build-link-index-updater-lambda.yml
@@ -11,16 +11,9 @@ on:
         required: false
         type: string
         default: ${{ github.ref }}
-    outputs:
-      artifact-id:
-        description: 'Artifact ID of the uploaded artifact. Can be used to download the artifact in other workflows.'
-        value: ${{ jobs.build.outputs.artifact-id }}
 
 jobs: 
   build:
-    outputs: 
-      artifact-id: ${{ steps.upload-artifact.outputs.artifact-id }}
-      zip-file: ${{ steps.create-zip.outputs.zip-file }}
     runs-on: ubuntu-latest
     env:
       BINARY_PATH: .artifacts/docs-lambda-index-publisher/release_linux-x64/bootstrap

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,10 +90,11 @@ jobs:
       ZIP_FILE: link-index-updater-lambda.zip
     steps:
 
-      - uses: actions/download-artifact@v4
+      - name: Download bootstrap binary
+        uses: actions/download-artifact@v4
         with: 
-          artifact-ids: ${{ needs.build-lambda.outputs.artifact-id }}
-
+          name: link-index-updater-lambda-binary # Defined in build-link-index-updater-lambda.yml
+          
       - name: Create zip
         run: |
           zip -j "${ZIP_FILE}" ./bootstrap


### PR DESCRIPTION
## Context

The release workflow is broken because downloading an artifact with the `artifact-id` works differently than expected.

## Changes

Just use the artifact name instead of the artifact ID.