### PR TITLE
Refactor ImageBlock URL handling and file resolution logic.

### DIFF
--- a/src/Elastic.Markdown/Myst/Directives/DirectiveHtmlRenderer.cs
+++ b/src/Elastic.Markdown/Myst/Directives/DirectiveHtmlRenderer.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using Elastic.Markdown.Diagnostics;
+using Elastic.Markdown.Myst.InlineParsers;
 using Elastic.Markdown.Myst.InlineParsers.Substitution;
 using Elastic.Markdown.Myst.Settings;
 using Elastic.Markdown.Slices.Directives;
@@ -85,23 +86,7 @@ public class DirectiveHtmlRenderer(MarkdownParser markdownParser) : HtmlObjectRe
 	private static void WriteImage(HtmlRenderer renderer, ImageBlock block)
 	{
 		var imageUrl = block.ImageUrl;
-		if (!string.IsNullOrEmpty(block.ImageUrl))
-		{
-			if (block.ImageUrl.StartsWith('/') || block.ImageUrl.StartsWith("_static"))
-				imageUrl = $"{block.Build.UrlPathPrefix}/{block.ImageUrl.TrimStart('/')}";
-			else
-			{
-				// `block.Build.ConfigurationPath.DirectoryName` is the directory of the docset.yml file
-				// which is the root of the documentation source
-				// e.g. `/User/username/Projects/docs-builder/docs`
-				// `block.CurrentFile.DirectoryName` is the directory of the current markdown file where the image is referenced
-				// e.g. `/User/username/Projects/docs-builder/docs/page/with/image`
-				// `Path.GetRelativePath` will return the relative path to the docset.yml directory
-				// e.g. `page/with/image`
-				// Hence the full imageUrl will be something like /path-prefix/page/with/image/image.png
-				imageUrl = block.Build.UrlPathPrefix + '/' + Path.GetRelativePath(block.Build.ConfigurationPath.DirectoryName!, block.CurrentFile.DirectoryName!) + "/" + block.ImageUrl;
-			}
-		}
+
 		var slice = Image.Create(new ImageViewModel
 		{
 			Label = block.Label,

--- a/src/Elastic.Markdown/Myst/Directives/ImageBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/ImageBlock.cs
@@ -4,6 +4,7 @@
 
 using Elastic.Markdown.Diagnostics;
 using Elastic.Markdown.IO;
+using Elastic.Markdown.Myst.InlineParsers;
 
 namespace Elastic.Markdown.Myst.Directives;
 
@@ -96,17 +97,14 @@ public class ImageBlock(DirectiveBlockParser parser, ParserContext context)
 			return;
 		}
 
-		var includeFrom = context.MarkdownSourcePath.Directory!.FullName;
-		if (imageUrl.StartsWith('/'))
-			includeFrom = context.Build.DocumentationSourceDirectory.FullName;
+		ImageUrl = DiagnosticLinkInlineParser.UpdateRelativeUrl(context, imageUrl);
 
-		ImageUrl = imageUrl;
-		var imagePath = Path.Combine(includeFrom, imageUrl.TrimStart('/'));
-		var file = context.Build.ReadFileSystem.FileInfo.New(imagePath);
+
+		var file = DiagnosticLinkInlineParser.ResolveFile(context, imageUrl);
 		if (file.Exists)
 			Found = true;
 		else
-			this.EmitError($"`{imageUrl}` does not exist. resolved to `{imagePath}");
+			this.EmitError($"`{imageUrl}` does not exist. resolved to `{file}");
 
 		if (context.DocumentationFileLookup(context.MarkdownSourcePath) is MarkdownFile currentMarkdown)
 		{

--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -279,7 +279,7 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 			_ = link.AppendChild(new LiteralInline(title));
 	}
 
-	private static IFileInfo ResolveFile(ParserContext context, string url) =>
+	public static IFileInfo ResolveFile(ParserContext context, string url) =>
 		string.IsNullOrWhiteSpace(url)
 			? context.MarkdownSourcePath
 			: url.StartsWith('/')
@@ -302,49 +302,8 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 				newUrl = linkMarkdown.Url;
 		}
 		else
-		{
-			// TODO revisit when we refactor our documentation set graph
-			// This method grew too complex, we need to revisit our documentation set graph generation so we can ask these questions
-			// on `DocumentationFile` that are mostly precomputed
-			var urlPathPrefix = context.Build.UrlPathPrefix ?? string.Empty;
+			newUrl = UpdateRelativeUrl(context, url);
 
-			if (!newUrl.StartsWith('/') && !string.IsNullOrEmpty(newUrl))
-			{
-				// eat overall path prefix since its gets appended later
-				var subPrefix = context.CurrentUrlPath.Length >= urlPathPrefix.Length
-					? context.CurrentUrlPath[urlPathPrefix.Length..]
-					: urlPathPrefix;
-
-				// if we are trying to resolve a relative url from a _snippet folder ensure we eat the _snippet folder
-				// as it's not part of url by chopping of the extra parent navigation
-				if (newUrl.StartsWith("../") && context.DocumentationFileLookup(context.MarkdownSourcePath) is SnippetFile snippetFile)
-					newUrl = url.Substring(3);
-
-				// TODO check through context.DocumentationFileLookup if file is index vs "index.md" check
-				var markdownPath = context.MarkdownSourcePath;
-				// if the current path is an index e.g /reference/cloud-k8s/
-				// './' current path lookups should be relative to sub-path.
-				// If it's not e.g /reference/cloud-k8s/api-docs/ these links should resolve on folder up.
-				var lastIndexPath = subPrefix.LastIndexOf('/');
-				if (lastIndexPath >= 0 && markdownPath.Name != "index.md")
-					subPrefix = subPrefix[..lastIndexPath];
-				var combined = '/' + Path.Combine(subPrefix, newUrl).TrimStart('/');
-				newUrl = Path.GetFullPath(combined);
-			}
-
-			// When running on Windows, path traversal results must be normalized prior to being used in a URL
-			// Path.GetFullPath() will result in the drive letter being appended to the path, which needs to be pruned back.
-			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-			{
-				newUrl = newUrl.Replace('\\', '/');
-				if (newUrl.Length > 2 && newUrl[1] == ':')
-					newUrl = newUrl[2..];
-			}
-
-			if (!string.IsNullOrWhiteSpace(newUrl) && !string.IsNullOrWhiteSpace(urlPathPrefix))
-				newUrl = $"{urlPathPrefix.TrimEnd('/')}{newUrl}";
-
-		}
 
 		if (newUrl.EndsWith(".md"))
 		{
@@ -362,6 +321,52 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 				? $"#{anchor}"
 				: $"{newUrl}#{anchor}"
 			: newUrl;
+	}
+
+	// TODO revisit when we refactor our documentation set graph
+	// This method grew too complex, we need to revisit our documentation set graph generation so we can ask these questions
+	// on `DocumentationFile` that are mostly precomputed
+	public static string UpdateRelativeUrl(ParserContext context, string url)
+	{
+		var urlPathPrefix = context.Build.UrlPathPrefix ?? string.Empty;
+		var newUrl = url;
+		if (newUrl.StartsWith('/') || string.IsNullOrEmpty(newUrl))
+			return newUrl;
+
+		// eat overall path prefix since its gets appended later
+		var subPrefix = context.CurrentUrlPath.Length >= urlPathPrefix.Length
+			? context.CurrentUrlPath[urlPathPrefix.Length..]
+			: urlPathPrefix;
+
+		// if we are trying to resolve a relative url from a _snippet folder ensure we eat the _snippet folder
+		// as it's not part of url by chopping of the extra parent navigation
+		if (newUrl.StartsWith("../") && context.DocumentationFileLookup(context.MarkdownSourcePath) is SnippetFile)
+			newUrl = url[3..];
+
+		// TODO check through context.DocumentationFileLookup if file is index vs "index.md" check
+		var markdownPath = context.MarkdownSourcePath;
+		// if the current path is an index e.g /reference/cloud-k8s/
+		// './' current path lookups should be relative to sub-path.
+		// If it's not e.g /reference/cloud-k8s/api-docs/ these links should resolve on folder up.
+		var lastIndexPath = subPrefix.LastIndexOf('/');
+		if (lastIndexPath >= 0 && markdownPath.Name != "index.md")
+			subPrefix = subPrefix[..lastIndexPath];
+		var combined = '/' + Path.Combine(subPrefix, newUrl).TrimStart('/');
+		newUrl = Path.GetFullPath(combined);
+
+		// When running on Windows, path traversal results must be normalized prior to being used in a URL
+		// Path.GetFullPath() will result in the drive letter being appended to the path, which needs to be pruned back.
+		if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+		{
+			newUrl = newUrl.Replace('\\', '/');
+			if (newUrl.Length > 2 && newUrl[1] == ':')
+				newUrl = newUrl[2..];
+		}
+
+		if (!string.IsNullOrWhiteSpace(newUrl) && !string.IsNullOrWhiteSpace(urlPathPrefix))
+			newUrl = $"{urlPathPrefix.TrimEnd('/')}{newUrl}";
+
+		return newUrl;
 	}
 
 	private static bool IsCrossLink([NotNullWhen(true)] Uri? uri) =>

--- a/tests/Elastic.Markdown.Tests/Directives/ImageTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/ImageTests.cs
@@ -31,7 +31,7 @@ public class ImageBlockTests(ITestOutputHelper output) : DirectiveTest<ImageBloc
 	{
 		Block!.Alt.Should().Be("Elasticsearch");
 		Block!.Width.Should().Be("250px");
-		Block!.ImageUrl.Should().Be("img/observability.png");
+		Block!.ImageUrl.Should().Be("/img/observability.png");
 		Block!.Screenshot.Should().Be("screenshot");
 	}
 

--- a/tests/authoring/Blocks/ImageBlocks.fs
+++ b/tests/authoring/Blocks/ImageBlocks.fs
@@ -1,0 +1,81 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+module ``block elements``.``image blocks``
+
+open Xunit
+open authoring
+
+type ``static path to image`` () =
+    static let markdown = Setup.Markdown """
+:::{image} img/observability.png
+:alt: Elasticsearch
+:width: 250px
+:screenshot:
+:::
+"""
+
+    [<Fact>]
+    let ``validate src is anchored`` () =
+        markdown |> convertsToContainingHtml """
+            <img loading="lazy" alt="Elasticsearch" src="/img/observability.png" style="width: 250px;" class="screenshot">
+       """
+
+type ``supports --url-path-prefix`` () =
+    static let docs = Setup.GenerateWithOptions { UrlPathPrefix = Some "/docs" } [
+        Static "img/observability.png"
+
+        Index """# Testing nested inline anchors
+:::{image} img/observability.png
+:alt: Elasticsearch
+:width: 250px
+:screenshot:
+:::
+"""
+
+        Markdown "folder/relative.md" """
+:::{image} ../img/observability.png
+:alt: Elasticsearch
+:width: 250px
+:screenshot:
+:::
+        """
+    ]
+
+    [<Fact>]
+    let ``validate image src contains prefix`` () =
+        docs |> convertsToContainingHtml """
+            <img loading="lazy" alt="Elasticsearch" src="/docs/img/observability.png" style="width: 250px;" class="screenshot">
+       """
+
+    [<Fact>]
+    let ``validate image src contains prefix when referenced relatively`` () =
+        docs |> converts "folder/relative.md" |> containsHtml """
+            <img loading="lazy" alt="Elasticsearch" src="/docs/img/observability.png" style="width: 250px;" class="screenshot">
+       """
+
+    [<Fact>]
+    let ``has no errors`` () = docs |> hasNoErrors
+
+type ``image ref out of scope`` () =
+    static let docs = Setup.GenerateWithOptions { UrlPathPrefix = Some "/docs" } [
+        Static "img/observability.png"
+
+        Index """# Testing nested inline anchors
+:::{image} ../img/observability.png
+:alt: Elasticsearch
+:width: 250px
+:screenshot:
+:::
+"""
+    ]
+
+    [<Fact>]
+    let ``validate image src contains prefix and is anchored to documentation scope root`` () =
+        docs |> convertsToContainingHtml """
+            <img loading="lazy" alt="Elasticsearch" src="/docs/img/observability.png" style="width: 250px;" class="screenshot">
+       """
+
+    [<Fact>]
+    let ``emits an error image reference is outside of documentation scope`` () =
+        docs |> hasError "./img/observability.png` does not exist. resolved to"

--- a/tests/authoring/Container/DefinitionLists.fs
+++ b/tests/authoring/Container/DefinitionLists.fs
@@ -67,6 +67,7 @@ This is my `definition`
  	            </dd>
              </dl>
             """
+
     [<Fact>]
     let ``has no errors 2`` () = markdown |> hasNoErrors
 

--- a/tests/authoring/authoring.fsproj
+++ b/tests/authoring/authoring.fsproj
@@ -52,6 +52,7 @@
     <Compile Include="Blocks\CodeBlocks\CodeBlocks.fs"/>
     <Compile Include="Blocks\Lists.fs"/>
     <Compile Include="Blocks\Admonitions.fs"/>
+    <Compile Include="Blocks\ImageBlocks.fs" />
     <Compile Include="Applicability\AppliesToFrontMatter.fs" />
     <Compile Include="Applicability\AppliesToDirective.fs" />
     <Compile Include="Directives\IncludeBlocks.fs" />


### PR DESCRIPTION
Streamline URL updates and file resolution by leveraging `DiagnosticLinkInlineParser`. This reduces redundancy and ensures consistent handling of relative URLs. Improved error messaging for nonexistent files.

Fixes #1134

<img width="1451" alt="image" src="https://github.com/user-attachments/assets/4e611a2c-50c3-4725-9c5b-7efc6671b87e" />

