### PR TITLE
Add `products` frontmatter

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,7 +16,6 @@
     <PackageVersion Include="AWSSDK.Core" Version="4.0.0.2" />
     <PackageVersion Include="AWSSDK.SQS" Version="4.0.0.1" />
     <PackageVersion Include="AWSSDK.S3" Version="4.0.0.1" />
-    <PackageVersion Include="Supernova.Enum.Generators" Version="1.0.17" />
   </ItemGroup>
   <!-- Build -->
   <ItemGroup>
@@ -49,6 +48,7 @@
     <PackageVersion Include="Vecc.YamlDotNet.Analyzers.StaticGenerator" Version="16.1.3" PrivateAssets="All" />
     <PackageVersion Include="Westwind.AspNetCore.LiveReload" Version="0.5.2" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
+    <PackageVersion Include="Supernova.Enum.Generators" Version="1.0.17" />
   </ItemGroup>
   <!-- Test packages -->
   <ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,7 +15,8 @@
     <PackageVersion Include="Amazon.Lambda.SQSEvents" Version="2.2.0" />
     <PackageVersion Include="AWSSDK.Core" Version="4.0.0.2" />
     <PackageVersion Include="AWSSDK.SQS" Version="4.0.0.1" />
-    <PackageVersion Include="AWSSDK.S3" Version="4.0.0.1"/>
+    <PackageVersion Include="AWSSDK.S3" Version="4.0.0.1" />
+    <PackageVersion Include="Supernova.Enum.Generators" Version="1.0.17" />
   </ItemGroup>
   <!-- Build -->
   <ItemGroup>
@@ -32,7 +33,7 @@
     <PackageVersion Include="Crayon" Version="2.0.69" />
     <PackageVersion Include="DotNet.Glob" Version="3.1.3" />
     <PackageVersion Include="Errata" Version="0.14.0" />
-    <PackageVersion Include="Github.Actions.Core" Version="9.0.0"/>
+    <PackageVersion Include="Github.Actions.Core" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.4" />
     <PackageVersion Include="Markdig" Version="0.41.1" />

--- a/docs/syntax/frontmatter.md
+++ b/docs/syntax/frontmatter.md
@@ -12,23 +12,111 @@ navigation_title: This is the navigation title <1>
 description: This is a description of the page <2>
 applies_to: <3>
   serverless: all
+products: <4>
+  - apm-java-agent
+  - edot-java
 ---
 ```
+
 1. [`navigation_title`](#navigation-title)
 2. [`description`](#description)
 3. [`applies_to`](#applies-to)
+4. [`products](#products)
 
 ## Navigation Title
+
 See [](./titles.md)
 
 ## Description
 
-Use the `description` frontmatter to set the description meta tag for a page. 
+Use the `description` frontmatter to set the description meta tag for a page.
 This helps search engines and social media.
 It also sets the `og:description` and `twitter:description` meta tags.
 
-The `description` frontmatter is a string, recommended to be around 150 characters. If you don't set a `description`, 
+The `description` frontmatter is a string, recommended to be around 150 characters. If you don't set a `description`,
 it will be generated from the first few paragraphs of the page until it reaches 150 characters.
 
 ## Applies to
+
 See [](./applies.md)
+
+## Products
+
+The products frontmatter is a list of products that the page relates to.
+This is used for the "Products" filter in the Search UI.
+
+The products frontmatter is a list of strings, each string is the id of a product.
+
+| Product ID                                  | Product Name                                  |
+|---------------------------------------------|-----------------------------------------------|
+| `apm`                                       | APM                                           |
+| `apm-android-agent`                         | APM Android Agent                             |
+| `apm-attacher`                              | APM Attacher                                  |
+| `apm-aws-lambda-extension`                  | APM AWS Lambda extension                      |
+| `apm-dotnet-agent`                          | APM .NET Agent                                |
+| `apm-go-agent`                              | APM Go Agent                                  |
+| `apm-ios-agent`                             | APM iOS Agent                                 |
+| `apm-java-agent`                            | APM Java Agent                                |
+| `apm-node-agent`                            | APM Node.js Agent                             |
+| `apm-php-agent`                             | APM PHP Agent                                 |
+| `apm-python-agent`                          | APM Python Agent                              |
+| `apm-ruby-agent`                            | APM Ruby Agent                                |
+| `apm-rum-agent`                             | APM RUM Agent                                 |
+| `beats-logging-plugin`                      | Beats Logging plugin                          |
+| `cloud-control-ecctl`                       | Cloud Control ECCTL                           |
+| `cloud-enterprise`                          | Cloud Enterprise                              |
+| `cloud-hosted`                              | Cloud Hosted                                  |
+| `cloud-kubernetes`                          | Cloud Kubernetes                              |
+| `cloud-native-ingest`                       | Cloud Native Ingest                           |
+| `cloud-serverless`                          | Cloud Serverless                              |
+| `cloud-terraform`                           | Cloud Terraform                               |
+| `ecs`                                       | Elastic Common Schema (ECS)                   |
+| `ecs-logging-dotnet`                        | ECS Logging .NET                              |
+| `ecs-logging-go-logrus`                     | ECS Logging Go Logrus                         |
+| `ecs-logging-go-zap`                        | ECS Logging Go Zap                            |
+| `ecs-logging-go-zerolog`                    | ECS Logging Go Zerolog                        |
+| `ecs-logging-java`                          | ECS Logging Java                              |
+| `ecs-logging-node`                          | ECS Logging Node.js                           |
+| `ecs-logging-php`                           | ECS Logging PHP                               |
+| `ecs-logging-python`                        | ECS Logging Python                            |
+| `ecs-logging-ruby`                          | ECS Logging Ruby                              |
+| `edot-android`                              | Elastic Distribution of OpenTelemetry Android |
+| `edot-collector`                            | Elastic Distribution of OpenTelemetry Collector |
+| `edot-dotnet`                               | Elastic Distribution of OpenTelemetry .NET     |
+| `edot-ios`                                  | Elastic Distribution of OpenTelemetry iOS     |
+| `edot-java`                                 | Elastic Distribution of OpenTelemetry Java     |
+| `edot-nodejs`                               | Elastic Distribution of OpenTelemetry Node.js   |
+| `edot-php`                                  | Elastic Distribution of OpenTelemetry PHP     |
+| `edot-python`                               | Elastic Distribution of OpenTelemetry Python   |
+| `elastic-agent`                             | Elastic Agent                                 |
+| `elastic-products-platform`                 | Elastic Products platform                     |
+| `elastic-stack`                             | Elastic Stack                                 |
+| `elasticsearch`                             | Elasticsearch                                 |
+| `elasticsearch-apache-hadoop`               | Elasticsearch Apache Hadoop                   |
+| `elasticsearch-cloud-hosted-heroku`         | Elasticsearch Cloud Hosted Heroku             |
+| `elasticsearch-community-clients`           | Elasticsearch community clients               |
+| `elasticsearch-curator`                     | Elasticsearch Curator                         |
+| `elasticsearch-dotnet-client`               | Elasticsearch .NET Client                     |
+| `elasticsearch-eland-python-client`         | Elasticsearch Eland Python Client             |
+| `elasticsearch-go-client`                   | Elasticsearch Go Client                       |
+| `elasticsearch-groovy-client`               | Elasticsearch Groovy Client                   |
+| `elasticsearch-java-client`                 | Elasticsearch Java Client                     |
+| `elasticsearch-java-script-client`          | Elasticsearch JavaScript Client               |
+| `elasticsearch-painless-scripting-language` | Elasticsearch Painless scripting language     |
+| `elasticsearch-perl-client`                 | Elasticsearch Perl Client                     |
+| `elasticsearch-php-client`                  | Elasticsearch PHP Client                      |
+| `elasticsearch-plugins`                     | Elasticsearch plugins                         |
+| `elasticsearch-python-client`               | Elasticsearch Python Client                   |
+| `elasticsearch-resiliency-status`           | Elasticsearch Resiliency Status               |
+| `elasticsearch-ruby-client`                 | Elasticsearch Ruby Client                     |
+| `elasticsearch-rust-client`                 | Elasticsearch Rust Client                     |
+| `fleet`                                     | Fleet                                         |
+| `ingest`                                    | Ingest                                        |
+| `integrations`                              | Integrations                                  |
+| `kibana`                                    | Kibana                                        |
+| `logstash`                                  | Logstash                                      |
+| `machine-learning`                          | Machine Learning                              |
+| `observability`                             | Observability                                 |
+| `reference-architectures`                   | Reference Architectures                       |
+| `search-ui`                                 | Search UI                                     |
+| `security`                                  | Security                                      |

--- a/docs/syntax/frontmatter.md
+++ b/docs/syntax/frontmatter.md
@@ -21,7 +21,7 @@ products: <4>
 1. [`navigation_title`](#navigation-title)
 2. [`description`](#description)
 3. [`applies_to`](#applies-to)
-4. [`products](#products)
+4. [`products`](#products)
 
 ## Navigation Title
 

--- a/src/Elastic.Markdown/Elastic.Markdown.csproj
+++ b/src/Elastic.Markdown/Elastic.Markdown.csproj
@@ -56,6 +56,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="RazorSlices" />
     <PackageReference Include="Slugify.Core" />
+    <PackageReference Include="Supernova.Enum.Generators" />
     <PackageReference Include="Utf8StreamReader" />
     <PackageReference Include="Vecc.YamlDotNet.Analyzers.StaticGenerator" />
     <PackageReference Include="YamlDotNet" />

--- a/src/Elastic.Markdown/IO/MarkdownFile.cs
+++ b/src/Elastic.Markdown/IO/MarkdownFile.cs
@@ -330,6 +330,12 @@ public record MarkdownFile : DocumentationFile, INavigationScope, ITableOfConten
 		{
 			return YamlSerialization.Deserialize<YamlFrontMatter>(raw);
 		}
+		catch (InvalidProductException e)
+		{
+			Collector.EmitHint(FilePath, "What");
+			Collector.EmitError(FilePath, "Invalid product in yaml front matter.", e);
+			return new YamlFrontMatter();
+		}
 		catch (Exception e)
 		{
 			Collector.EmitError(FilePath, "Failed to parse yaml front matter block.", e);

--- a/src/Elastic.Markdown/IO/MarkdownFile.cs
+++ b/src/Elastic.Markdown/IO/MarkdownFile.cs
@@ -332,7 +332,6 @@ public record MarkdownFile : DocumentationFile, INavigationScope, ITableOfConten
 		}
 		catch (InvalidProductException e)
 		{
-			Collector.EmitHint(FilePath, "What");
 			Collector.EmitError(FilePath, "Invalid product in yaml front matter.", e);
 			return new YamlFrontMatter();
 		}

--- a/src/Elastic.Markdown/Myst/FrontMatter/FrontMatterParser.cs
+++ b/src/Elastic.Markdown/Myst/FrontMatter/FrontMatterParser.cs
@@ -2,17 +2,9 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-using System.Runtime.Serialization;
 using YamlDotNet.Serialization;
 
 namespace Elastic.Markdown.Myst.FrontMatter;
-
-public enum LayoutName
-{
-	[EnumMember(Value = "landing-page")] LandingPage,
-	[EnumMember(Value = "not-found")] NotFound,
-	[EnumMember(Value = "archive")] Archive
-}
 
 [YamlSerializable]
 public class YamlFrontMatter
@@ -38,4 +30,7 @@ public class YamlFrontMatter
 
 	[YamlMember(Alias = "mapped_pages")]
 	public IReadOnlyCollection<string>? MappedPages { get; set; }
+
+	[YamlMember(Alias = "products")]
+	public IReadOnlyCollection<Product>? Products { get; set; }
 }

--- a/src/Elastic.Markdown/Myst/FrontMatter/Layout.cs
+++ b/src/Elastic.Markdown/Myst/FrontMatter/Layout.cs
@@ -1,0 +1,14 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Runtime.Serialization;
+
+namespace Elastic.Markdown.Myst.FrontMatter;
+
+public enum LayoutName
+{
+	[EnumMember(Value = "landing-page")] LandingPage,
+	[EnumMember(Value = "not-found")] NotFound,
+	[EnumMember(Value = "archive")] Archive
+}

--- a/src/Elastic.Markdown/Myst/FrontMatter/Products.cs
+++ b/src/Elastic.Markdown/Myst/FrontMatter/Products.cs
@@ -3,301 +3,230 @@
 // See the LICENSE file in the project root for more information
 
 using System.ComponentModel.DataAnnotations;
-using System.Runtime.Serialization;
+using EnumFastToStringGenerated;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
 using YamlDotNet.Serialization;
 
 namespace Elastic.Markdown.Myst.FrontMatter;
 
+[EnumGenerator]
 public enum Product
 {
-	[Display(Name = "APM")]
-	[EnumMember(Value = "apm")]
+	[Display(Name = "apm", Description = "APM")]
 	Apm,
 
-	[Display(Name = "APM .NET Agent")]
-	[EnumMember(Value = "apm-dotnet-agent")]
+	[Display(Name = "apm-dotnet-agent", Description = "APM .NET Agent")]
 	ApmDotnetAgent,
 
-	[Display(Name = "APM Android Agent")]
-	[EnumMember(Value = "apm-android-agent")]
+	[Display(Name = "apm-android-agent", Description = "APM Android Agent")]
 	ApmAndroidAgent,
 
-	[Display(Name = "APM Attacher")]
-	[EnumMember(Value = "apm-attacher")]
+	[Display(Name = "apm-attacher", Description = "APM Attacher")]
 	ApmAttacher,
 
-	[Display(Name = "APM AWS Lambda extension")]
-	[EnumMember(Value = "apm-aws-lambda-extension")]
+	[Display(Name = "apm-aws-lambda-extension", Description = "APM AWS Lambda extension")]
 	ApmAwsLambdaExtension,
 
-	[Display(Name = "APM Go Agent")]
-	[EnumMember(Value = "apm-go-agent")]
+	[Display(Name = "apm-go-agent", Description = "APM Go Agent")]
 	ApmGoAgent,
 
-	[Display(Name = "APM iOS Agent")]
-	[EnumMember(Value = "apm-ios-agent")]
+	[Display(Name = "apm-ios-agent", Description = "APM iOS Agent")]
 	ApmIosAgent,
 
-	[Display(Name = "APM Java Agent")]
-	[EnumMember(Value = "apm-java-agent")]
+	[Display(Name = "apm-java-agent", Description = "APM Java Agent")]
 	ApmJavaAgent,
 
-	[Display(Name = "APM Node.js Agent")]
-	[EnumMember(Value = "apm-node-agent")]
+	[Display(Name = "apm-node-agent", Description = "APM Node.js Agent")]
 	ApmNodeAgent,
 
-	[Display(Name = "APM PHP Agent")]
-	[EnumMember(Value = "apm-php-agent")]
+	[Display(Name = "apm-php-agent", Description = "APM PHP Agent")]
 	ApmPhpAgent,
 
-	[Display(Name = "APM Python Agent")]
-	[EnumMember(Value = "apm-python-agent")]
+	[Display(Name = "apm-python-agent", Description = "APM Python Agent")]
 	ApmPythonAgent,
 
-	[Display(Name = "APM Ruby Agent")]
-	[EnumMember(Value = "apm-ruby-agent")]
+	[Display(Name = "apm-ruby-agent", Description = "APM Ruby Agent")]
 	ApmRubyAgent,
 
-	[Display(Name = "APM RUM Agent")]
-	[EnumMember(Value = "apm-rum-agent")]
+	[Display(Name = "apm-rum-agent", Description = "APM RUM Agent")]
 	ApmRumAgent,
 
-	[Display(Name = "Beats Logging plugin")]
-	[EnumMember(Value = "beats-logging-plugin")]
+	[Display(Name = "beats-logging-plugin", Description = "Beats Logging plugin")]
 	BeatsLoggingPlugin,
 
-	[Display(Name = "Cloud Control ECCTL")]
-	[EnumMember(Value = "cloud-control-ecctl")]
+	[Display(Name = "cloud-control-ecctl", Description = "Cloud Control ECCTL")]
 	CloudControlEcctl,
 
-	[Display(Name = "Cloud Enterprise")]
-	[EnumMember(Value = "cloud-enterprise")]
+	[Display(Name = "cloud-enterprise", Description = "Cloud Enterprise")]
 	CloudEnterprise,
 
-	[Display(Name = "Cloud Hosted")]
-	[EnumMember(Value = "cloud-hosted")]
+	[Display(Name = "cloud-hosted", Description = "Cloud Hosted")]
 	CloudHosted,
 
-	[Display(Name = "Cloud Kubernetes")]
-	[EnumMember(Value = "cloud-kubernetes")]
+	[Display(Name = "cloud-kubernetes", Description = "Cloud Kubernetes")]
 	CloudKubernetes,
 
-	[Display(Name = "Cloud Native Ingest")]
-	[EnumMember(Value = "cloud-native-ingest")]
+	[Display(Name = "cloud-native-ingest", Description = "Cloud Native Ingest")]
 	CloudNativeIngest,
 
-	[Display(Name = "Cloud Serverless")]
-	[EnumMember(Value = "cloud-serverless")]
+	[Display(Name = "cloud-serverless", Description = "Cloud Serverless")]
 	CloudServerless,
 
-	[Display(Name = "Cloud Terraform")]
-	[EnumMember(Value = "cloud-terraform")]
+	[Display(Name = "cloud-terraform", Description = "Cloud Terraform")]
 	CloudTerraform,
 
-	[Display(Name = "ECS Logging")]
-	[EnumMember(Value = "ecs-logging")]
+	[Display(Name = "ecs-logging", Description = "ECS Logging")]
 	EcsLogging,
 
-	[Display(Name = "ECS Logging .NET")]
-	[EnumMember(Value = "ecs-logging-dotnet")]
+	[Display(Name = "ecs-logging-dotnet", Description = "ECS Logging .NET")]
 	EcsLoggingDotnet,
 
-	[Display(Name = "ECS Logging Go Logrus")]
-	[EnumMember(Value = "ecs-logging-go-logrus")]
+	[Display(Name = "ecs-logging-go-logrus", Description = "ECS Logging Go Logrus")]
 	EcsLoggingGoLogrus,
 
-	[Display(Name = "ECS Logging Go Zap")]
-	[EnumMember(Value = "ecs-logging-go-zap")]
+	[Display(Name = "ecs-logging-go-zap", Description = "ECS Logging Go Zap")]
 	EcsLoggingGoZap,
 
-	[Display(Name = "ECS Logging Go Zerolog")]
-	[EnumMember(Value = "ecs-logging-go-zerolog")]
+	[Display(Name = "ecs-logging-go-zerolog", Description = "ECS Logging Go Zerolog")]
 	EcsLoggingGoZerolog,
 
-	[Display(Name = "ECS Logging Java")]
-	[EnumMember(Value = "ecs-logging-java")]
+	[Display(Name = "ecs-logging-java", Description = "ECS Logging Java")]
 	EcsLoggingJava,
 
-	[Display(Name = "ECS Logging Node.js")]
-	[EnumMember(Value = "ecs-logging-node")]
+	[Display(Name = "ecs-logging-node", Description = "ECS Logging Node.js")]
 	EcsLoggingNode,
 
-	[Display(Name = "ECS Logging PHP")]
-	[EnumMember(Value = "ecs-logging-php")]
+	[Display(Name = "ecs-logging-php", Description = "ECS Logging PHP")]
 	EcsLoggingPhp,
 
-	[Display(Name = "ECS Logging Python")]
-	[EnumMember(Value = "ecs-logging-python")]
+	[Display(Name = "ecs-logging-python", Description = "ECS Logging Python")]
 	EcsLoggingPython,
 
-	[Display(Name = "ECS Logging Ruby")]
-	[EnumMember(Value = "ecs-logging-ruby")]
+	[Display(Name = "ecs-logging-ruby", Description = "ECS Logging Ruby")]
 	EcsLoggingRuby,
 
-	[Display(Name = "Elastic Agent")]
-	[EnumMember(Value = "elastic-agent")]
+	[Display(Name = "elastic-agent", Description = "Elastic Agent")]
 	ElasticAgent,
 
-	[Display(Name = "Elastic Common Schema (ECS)")]
-	[EnumMember(Value = "ecs")]
+	[Display(Name = "ecs", Description = "Elastic Common Schema (ECS)")]
 	Ecs,
 
-	[Display(Name = "Elastic Products platform")]
-	[EnumMember(Value = "elastic-products-platform")]
+	[Display(Name = "elastic-products-platform", Description = "Elastic Products platform")]
 	ElasticProductsPlatform,
 
-	[Display(Name = "Elastic Stack")]
-	[EnumMember(Value = "elastic-stack")]
+	[Display(Name = "elastic-stack", Description = "Elastic Stack")]
 	ElasticStack,
 
-	[Display(Name = "Elasticsearch")]
-	[EnumMember(Value = "elasticsearch")]
+	[Display(Name = "elasticsearch", Description = "Elasticsearch")]
 	Elasticsearch,
 
-	[Display(Name = "Elasticsearch .NET Client")]
-	[EnumMember(Value = "elasticsearch-dotnet-client")]
+	[Display(Name = "elasticsearch-dotnet-client", Description = "Elasticsearch .NET Client")]
 	ElasticsearchDotnetClient,
 
-	[Display(Name = "Elasticsearch Apache Hadoop")]
-	[EnumMember(Value = "elasticsearch-apache-hadoop")]
+	[Display(Name = "elasticsearch-apache-hadoop", Description = "Elasticsearch Apache Hadoop")]
 	ElasticsearchApacheHadoop,
 
-	[Display(Name = "Elasticsearch Cloud Hosted Heroku")]
-	[EnumMember(Value = "elasticsearch-cloud-hosted-heroku")]
+	[Display(Name = "elasticsearch-cloud-hosted-heroku", Description = "Elasticsearch Cloud Hosted Heroku")]
 	ElasticsearchCloudHostedHeroku,
 
-	[Display(Name = "Elasticsearch community clients")]
-	[EnumMember(Value = "elasticsearch-community-clients")]
+	[Display(Name = "elasticsearch-community-clients", Description = "Elasticsearch community clients")]
 	ElasticsearchCommunityClients,
 
-	[Display(Name = "Elasticsearch Curator")]
-	[EnumMember(Value = "elasticsearch-curator")]
+	[Display(Name = "elasticsearch-curator", Description = "Elasticsearch Curator")]
 	ElasticsearchCurator,
 
-	[Display(Name = "Elasticsearch Eland Python Client")]
-	[EnumMember(Value = "elasticsearch-eland-python-client")]
+	[Display(Name = "elasticsearch-eland-python-client", Description = "Elasticsearch Eland Python Client")]
 	ElasticsearchElandPythonClient,
 
-	[Display(Name = "Elasticsearch Go Client")]
-	[EnumMember(Value = "elasticsearch-go-client")]
+	[Display(Name = "elasticsearch-go-client", Description = "Elasticsearch Go Client")]
 	ElasticsearchGoClient,
 
-	[Display(Name = "Elasticsearch Groovy Client")]
-	[EnumMember(Value = "elasticsearch-groovy-client")]
+	[Display(Name = "elasticsearch-groovy-client", Description = "Elasticsearch Groovy Client")]
 	ElasticsearchGroovyClient,
 
-	[Display(Name = "Elasticsearch Java Client")]
-	[EnumMember(Value = "elasticsearch-java-client")]
+	[Display(Name = "elasticsearch-java-client", Description = "Elasticsearch Java Client")]
 	ElasticsearchJavaClient,
 
-	[Display(Name = "Elasticsearch JavaScript Client")]
-	[EnumMember(Value = "elasticsearch-java-script-client")]
+	[Display(Name = "elasticsearch-java-script-client", Description = "Elasticsearch JavaScript Client")]
 	ElasticsearchJavaScriptClient,
 
-	[Display(Name = "Elasticsearch Painless scripting language")]
-	[EnumMember(Value = "elasticsearch-painless-scripting-language")]
+	[Display(Name = "elasticsearch-painless-scripting-language", Description = "Elasticsearch Painless scripting language")]
 	ElasticsearchPainlessScriptingLanguage,
 
-	[Display(Name = "Elasticsearch Perl Client")]
-	[EnumMember(Value = "elasticsearch-perl-client")]
+	[Display(Name = "elasticsearch-perl-client", Description = "Elasticsearch Perl Client")]
 	ElasticsearchPerlClient,
 
-	[Display(Name = "Elasticsearch PHP Client")]
-	[EnumMember(Value = "elasticsearch-php-client")]
+	[Display(Name = "elasticsearch-php-client", Description = "Elasticsearch PHP Client")]
 	ElasticsearchPhpClient,
 
-	[Display(Name = "Elasticsearch plugins")]
-	[EnumMember(Value = "elasticsearch-plugins")]
+	[Display(Name = "elasticsearch-plugins", Description = "Elasticsearch plugins")]
 	ElasticsearchPlugins,
 
-	[Display(Name = "Elasticsearch Python Client")]
-	[EnumMember(Value = "elasticsearch-python-client")]
+	[Display(Name = "elasticsearch-python-client", Description = "Elasticsearch Python Client")]
 	ElasticsearchPythonClient,
 
-	[Display(Name = "Elasticsearch Resiliency Status")]
-	[EnumMember(Value = "elasticsearch-resiliency-status")]
+	[Display(Name = "elasticsearch-resiliency-status", Description = "Elasticsearch Resiliency Status")]
 	ElasticsearchResiliencyStatus,
 
-	[Display(Name = "Elasticsearch Ruby Client")]
-	[EnumMember(Value = "elasticsearch-ruby-client")]
+	[Display(Name = "elasticsearch-ruby-client", Description = "Elasticsearch Ruby Client")]
 	ElasticsearchRubyClient,
 
-	[Display(Name = "Elasticsearch Rust Client")]
-	[EnumMember(Value = "elasticsearch-rust-client")]
+	[Display(Name = "elasticsearch-rust-client", Description = "Elasticsearch Rust Client")]
 	ElasticsearchRustClient,
 
-	[Display(Name = "Fleet")]
-	[EnumMember(Value = "fleet")]
+	[Display(Name = "fleet", Description = "Fleet")]
 	Fleet,
 
-	[Display(Name = "Ingest")]
-	[EnumMember(Value = "ingest")]
+	[Display(Name = "ingest", Description = "Ingest")]
 	Ingest,
 
-	[Display(Name = "Integrations")]
-	[EnumMember(Value = "integrations")]
+	[Display(Name = "integrations", Description = "Integrations")]
 	Integrations,
 
-	[Display(Name = "Kibana")]
-	[EnumMember(Value = "kibana")]
+	[Display(Name = "kibana", Description = "Kibana")]
 	Kibana,
 
-	[Display(Name = "Logstash")]
-	[EnumMember(Value = "logstash")]
+	[Display(Name = "logstash", Description = "Logstash")]
 	Logstash,
 
-	[Display(Name = "Machine Learning")]
-	[EnumMember(Value = "machine-learning")]
+	[Display(Name = "machine-learning", Description = "Machine Learning")]
 	MachineLearning,
 
-	[Display(Name = "Observability")]
-	[EnumMember(Value = "observability")]
+	[Display(Name = "observability", Description = "Observability")]
 	Observability,
 
-	[Display(Name = "Reference Architectures")]
-	[EnumMember(Value = "reference-architectures")]
+	[Display(Name = "reference-architectures", Description = "Reference Architectures")]
 	ReferenceArchitectures,
 
-	[Display(Name = "Search UI")]
-	[EnumMember(Value = "search-ui")]
+	[Display(Name = "search-ui", Description = "Search UI")]
 	SearchUi,
 
-	[Display(Name = "Security")]
-	[EnumMember(Value = "security")]
+	[Display(Name = "security", Description = "Security")]
 	Security,
 
-	[Display(Name = "Elastic Distribution of OpenTelemetry Collector")]
-	[EnumMember(Value = "edot-collector")]
+	[Display(Name = "edot-collector", Description = "Elastic Distribution of OpenTelemetry Collector")]
 	EdotCollector,
 
-	[Display(Name = "Elastic Distribution of OpenTelemetry Java")]
-	[EnumMember(Value = "edot-java")]
+	[Display(Name = "edot-java", Description = "Elastic Distribution of OpenTelemetry Java")]
 	EdotJava,
 
-	[Display(Name = "Elastic Distribution of OpenTelemetry .NET")]
-	[EnumMember(Value = "edot-dotnet")]
+	[Display(Name = "edot-dotnet", Description = "Elastic Distribution of OpenTelemetry .NET")]
 	EdotDotnet,
 
-	[Display(Name = "Elastic Distribution of OpenTelemetry Node.js")]
-	[EnumMember(Value = "edot-nodejs")]
+	[Display(Name = "edot-nodejs", Description = "Elastic Distribution of OpenTelemetry Node.js")]
 	EdotNodeJs,
 
-	[Display(Name = "Elastic Distribution of OpenTelemetry PHP")]
-	[EnumMember(Value = "edot-php")]
+	[Display(Name = "edot-php", Description = "Elastic Distribution of OpenTelemetry PHP")]
 	EdotPhp,
 
-	[Display(Name = "Elastic Distribution of OpenTelemetry Python")]
-	[EnumMember(Value = "edot-python")]
+	[Display(Name = "edot-python", Description = "Elastic Distribution of OpenTelemetry Python")]
 	EdotPython,
 
-	[Display(Name = "Elastic Distribution of OpenTelemetry Android")]
-	[EnumMember(Value = "edot-android")]
+	[Display(Name = "edot-android", Description = "Elastic Distribution of OpenTelemetry Android")]
 	EdotAndroid,
 
-	[Display(Name = "Elastic Distribution of OpenTelemetry iOS")]
-	[EnumMember(Value = "edot-ios")]
+	[Display(Name = "edot-ios", Description = "Elastic Distribution of OpenTelemetry iOS")]
 	EdotIos,
 }
 
@@ -309,68 +238,34 @@ public class ProductConverter : IYamlTypeConverter
 	{
 		var value = parser.Consume<Scalar>();
 		if (string.IsNullOrWhiteSpace(value.Value))
-			throw new InvalidProductException("empty value");
+			throw new InvalidProductException("");
 
 		var product = Enum.GetValues<Product>()
-			.FirstOrDefault(p =>
-			{
-				var enumMemberAttr = typeof(Product)
-					.GetField(p.ToString())
-					?.GetCustomAttributes(typeof(EnumMemberAttribute), false)
-					.FirstOrDefault() as EnumMemberAttribute;
-				return enumMemberAttr?.Value?.Equals(value.Value, StringComparison.OrdinalIgnoreCase) ?? false;
-			});
+			.FirstOrDefault(p => p.ToDisplayFast()?.Equals(value.Value, StringComparison.Ordinal) ?? false);
 
-		if (Enum.IsDefined(product) && product.GetEnumMemberValue()?.Equals(value.Value) == true)
+		if (ProductEnumExtensions.IsDefinedFast(product) && product.ToDisplayFast()?.Equals(value.Value) == true)
 			return product;
 
 		throw new InvalidProductException(value.Value);
 	}
 
-	public void WriteYaml(IEmitter emitter, object? value, Type type, ObjectSerializer serializer) => throw new NotImplementedException();
+	public void WriteYaml(IEmitter emitter, object? value, Type type, ObjectSerializer serializer) => serializer.Invoke(value, type);
 }
 
 public class InvalidProductException(string invalidValue)
 	: Exception(
-		$"Invalid products frontmatter value: \"{invalidValue}\". Did you mean \"{ProductExtensions.Suggestion(invalidValue)}\"?\nYou can find the full list at https://docs-v3-preview.elastic.dev/elastic/docs-builder/tree/main/syntax/frontmatter#products.");
+		$"Invalid products frontmatter value: \"{invalidValue}\"." +
+		(!string.IsNullOrWhiteSpace(invalidValue) ? $" Did you mean \"{ProductExtensions.Suggestion(invalidValue)}\"?" : "") +
+		"\nYou can find the full list at https://docs-v3-preview.elastic.dev/elastic/docs-builder/tree/main/syntax/frontmatter#products.");
 
 public static class ProductExtensions
 {
-	public static string GetProductDisplayName(this Product product)
-	{
-		var displayAttr = typeof(Product)
-			.GetField(product.ToString())
-			?.GetCustomAttributes(typeof(DisplayAttribute), false)
-			.FirstOrDefault() as DisplayAttribute;
-		return displayAttr?.Name ?? product.ToString();
-	}
-
-	public static string? GetEnumMemberValue(this Product product)
-	{
-		var enumMemberAttr = typeof(Product)
-			.GetField(product.ToString())
-			?.GetCustomAttributes(typeof(EnumMemberAttribute), false)
-			.FirstOrDefault() as EnumMemberAttribute;
-		return enumMemberAttr?.Value;
-	}
-
-
-	private static List<string> GetEnumMemberValues() => Enum.GetValues<Product>()
-		.Select(p =>
-		{
-			var enumMemberAttr = typeof(Product)
-				.GetField(p.ToString())
-				?.GetCustomAttributes(typeof(EnumMemberAttribute), false)
-				.FirstOrDefault() as EnumMemberAttribute;
-
-			return enumMemberAttr?.Value;
-		})
-		.Where(value => value != null)
-		.Select(value => value!)
-		.ToList();
+	private static IReadOnlyCollection<string> GetProductIds() =>
+		ProductEnumExtensions.GetValuesFast()
+			.Select(p => p.ToDisplayFast()).ToList();
 
 	public static string Suggestion(string input) =>
-		GetEnumMemberValues()
+		GetProductIds()
 			.OrderBy(p => LevenshteinDistance(input, p))
 			.First();
 

--- a/src/Elastic.Markdown/Myst/FrontMatter/Products.cs
+++ b/src/Elastic.Markdown/Myst/FrontMatter/Products.cs
@@ -1,0 +1,418 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+using YamlDotNet.Serialization;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+
+namespace Elastic.Markdown.Myst.FrontMatter;
+
+public enum Product
+{
+	[Display(Name = "APM")]
+	[EnumMember(Value = "apm")]
+	Apm,
+
+	[Display(Name = "APM .NET Agent")]
+	[EnumMember(Value = "apm-dotnet-agent")]
+	ApmDotnetAgent,
+
+	[Display(Name = "APM Android Agent")]
+	[EnumMember(Value = "apm-android-agent")]
+	ApmAndroidAgent,
+
+	[Display(Name = "APM Attacher")]
+	[EnumMember(Value = "apm-attacher")]
+	ApmAttacher,
+
+	[Display(Name = "APM AWS Lambda extension")]
+	[EnumMember(Value = "apm-aws-lambda-extension")]
+	ApmAwsLambdaExtension,
+
+	[Display(Name = "APM Go Agent")]
+	[EnumMember(Value = "apm-go-agent")]
+	ApmGoAgent,
+
+	[Display(Name = "APM iOS Agent")]
+	[EnumMember(Value = "apm-ios-agent")]
+	ApmIosAgent,
+
+	[Display(Name = "APM Java Agent")]
+	[EnumMember(Value = "apm-java-agent")]
+	ApmJavaAgent,
+
+	[Display(Name = "APM Node.js Agent")]
+	[EnumMember(Value = "apm-node-agent")]
+	ApmNodeAgent,
+
+	[Display(Name = "APM PHP Agent")]
+	[EnumMember(Value = "apm-php-agent")]
+	ApmPhpAgent,
+
+	[Display(Name = "APM Python Agent")]
+	[EnumMember(Value = "apm-python-agent")]
+	ApmPythonAgent,
+
+	[Display(Name = "APM Ruby Agent")]
+	[EnumMember(Value = "apm-ruby-agent")]
+	ApmRubyAgent,
+
+	[Display(Name = "APM RUM Agent")]
+	[EnumMember(Value = "apm-rum-agent")]
+	ApmRumAgent,
+
+	[Display(Name = "Beats Logging plugin")]
+	[EnumMember(Value = "beats-logging-plugin")]
+	BeatsLoggingPlugin,
+
+	[Display(Name = "Cloud Control ECCTL")]
+	[EnumMember(Value = "cloud-control-ecctl")]
+	CloudControlEcctl,
+
+	[Display(Name = "Cloud Enterprise")]
+	[EnumMember(Value = "cloud-enterprise")]
+	CloudEnterprise,
+
+	[Display(Name = "Cloud Hosted")]
+	[EnumMember(Value = "cloud-hosted")]
+	CloudHosted,
+
+	[Display(Name = "Cloud Kubernetes")]
+	[EnumMember(Value = "cloud-kubernetes")]
+	CloudKubernetes,
+
+	[Display(Name = "Cloud Native Ingest")]
+	[EnumMember(Value = "cloud-native-ingest")]
+	CloudNativeIngest,
+
+	[Display(Name = "Cloud Serverless")]
+	[EnumMember(Value = "cloud-serverless")]
+	CloudServerless,
+
+	[Display(Name = "Cloud Terraform")]
+	[EnumMember(Value = "cloud-terraform")]
+	CloudTerraform,
+
+	[Display(Name = "ECS Logging")]
+	[EnumMember(Value = "ecs-logging")]
+	EcsLogging,
+
+	[Display(Name = "ECS Logging .NET")]
+	[EnumMember(Value = "ecs-logging-dotnet")]
+	EcsLoggingDotnet,
+
+	[Display(Name = "ECS Logging Go Logrus")]
+	[EnumMember(Value = "ecs-logging-go-logrus")]
+	EcsLoggingGoLogrus,
+
+	[Display(Name = "ECS Logging Go Zap")]
+	[EnumMember(Value = "ecs-logging-go-zap")]
+	EcsLoggingGoZap,
+
+	[Display(Name = "ECS Logging Go Zerolog")]
+	[EnumMember(Value = "ecs-logging-go-zerolog")]
+	EcsLoggingGoZerolog,
+
+	[Display(Name = "ECS Logging Java")]
+	[EnumMember(Value = "ecs-logging-java")]
+	EcsLoggingJava,
+
+	[Display(Name = "ECS Logging Node.js")]
+	[EnumMember(Value = "ecs-logging-node")]
+	EcsLoggingNode,
+
+	[Display(Name = "ECS Logging PHP")]
+	[EnumMember(Value = "ecs-logging-php")]
+	EcsLoggingPhp,
+
+	[Display(Name = "ECS Logging Python")]
+	[EnumMember(Value = "ecs-logging-python")]
+	EcsLoggingPython,
+
+	[Display(Name = "ECS Logging Ruby")]
+	[EnumMember(Value = "ecs-logging-ruby")]
+	EcsLoggingRuby,
+
+	[Display(Name = "Elastic Agent")]
+	[EnumMember(Value = "elastic-agent")]
+	ElasticAgent,
+
+	[Display(Name = "Elastic Common Schema (ECS)")]
+	[EnumMember(Value = "ecs")]
+	Ecs,
+
+	[Display(Name = "Elastic Products platform")]
+	[EnumMember(Value = "elastic-products-platform")]
+	ElasticProductsPlatform,
+
+	[Display(Name = "Elastic Stack")]
+	[EnumMember(Value = "elastic-stack")]
+	ElasticStack,
+
+	[Display(Name = "Elasticsearch")]
+	[EnumMember(Value = "elasticsearch")]
+	Elasticsearch,
+
+	[Display(Name = "Elasticsearch .NET Client")]
+	[EnumMember(Value = "elasticsearch-dotnet-client")]
+	ElasticsearchDotnetClient,
+
+	[Display(Name = "Elasticsearch Apache Hadoop")]
+	[EnumMember(Value = "elasticsearch-apache-hadoop")]
+	ElasticsearchApacheHadoop,
+
+	[Display(Name = "Elasticsearch Cloud Hosted Heroku")]
+	[EnumMember(Value = "elasticsearch-cloud-hosted-heroku")]
+	ElasticsearchCloudHostedHeroku,
+
+	[Display(Name = "Elasticsearch community clients")]
+	[EnumMember(Value = "elasticsearch-community-clients")]
+	ElasticsearchCommunityClients,
+
+	[Display(Name = "Elasticsearch Curator")]
+	[EnumMember(Value = "elasticsearch-curator")]
+	ElasticsearchCurator,
+
+	[Display(Name = "Elasticsearch Eland Python Client")]
+	[EnumMember(Value = "elasticsearch-eland-python-client")]
+	ElasticsearchElandPythonClient,
+
+	[Display(Name = "Elasticsearch Go Client")]
+	[EnumMember(Value = "elasticsearch-go-client")]
+	ElasticsearchGoClient,
+
+	[Display(Name = "Elasticsearch Groovy Client")]
+	[EnumMember(Value = "elasticsearch-groovy-client")]
+	ElasticsearchGroovyClient,
+
+	[Display(Name = "Elasticsearch Java Client")]
+	[EnumMember(Value = "elasticsearch-java-client")]
+	ElasticsearchJavaClient,
+
+	[Display(Name = "Elasticsearch JavaScript Client")]
+	[EnumMember(Value = "elasticsearch-java-script-client")]
+	ElasticsearchJavaScriptClient,
+
+	[Display(Name = "Elasticsearch Painless scripting language")]
+	[EnumMember(Value = "elasticsearch-painless-scripting-language")]
+	ElasticsearchPainlessScriptingLanguage,
+
+	[Display(Name = "Elasticsearch Perl Client")]
+	[EnumMember(Value = "elasticsearch-perl-client")]
+	ElasticsearchPerlClient,
+
+	[Display(Name = "Elasticsearch PHP Client")]
+	[EnumMember(Value = "elasticsearch-php-client")]
+	ElasticsearchPhpClient,
+
+	[Display(Name = "Elasticsearch plugins")]
+	[EnumMember(Value = "elasticsearch-plugins")]
+	ElasticsearchPlugins,
+
+	[Display(Name = "Elasticsearch Python Client")]
+	[EnumMember(Value = "elasticsearch-python-client")]
+	ElasticsearchPythonClient,
+
+	[Display(Name = "Elasticsearch Resiliency Status")]
+	[EnumMember(Value = "elasticsearch-resiliency-status")]
+	ElasticsearchResiliencyStatus,
+
+	[Display(Name = "Elasticsearch Ruby Client")]
+	[EnumMember(Value = "elasticsearch-ruby-client")]
+	ElasticsearchRubyClient,
+
+	[Display(Name = "Elasticsearch Rust Client")]
+	[EnumMember(Value = "elasticsearch-rust-client")]
+	ElasticsearchRustClient,
+
+	[Display(Name = "Fleet")]
+	[EnumMember(Value = "fleet")]
+	Fleet,
+
+	[Display(Name = "Ingest")]
+	[EnumMember(Value = "ingest")]
+	Ingest,
+
+	[Display(Name = "Integrations")]
+	[EnumMember(Value = "integrations")]
+	Integrations,
+
+	[Display(Name = "Kibana")]
+	[EnumMember(Value = "kibana")]
+	Kibana,
+
+	[Display(Name = "Logstash")]
+	[EnumMember(Value = "logstash")]
+	Logstash,
+
+	[Display(Name = "Machine Learning")]
+	[EnumMember(Value = "machine-learning")]
+	MachineLearning,
+
+	[Display(Name = "Observability")]
+	[EnumMember(Value = "observability")]
+	Observability,
+
+	[Display(Name = "Reference Architectures")]
+	[EnumMember(Value = "reference-architectures")]
+	ReferenceArchitectures,
+
+	[Display(Name = "Search UI")]
+	[EnumMember(Value = "search-ui")]
+	SearchUi,
+
+	[Display(Name = "Security")]
+	[EnumMember(Value = "security")]
+	Security,
+
+	[Display(Name = "Elastic Distribution of OpenTelemetry Collector")]
+	[EnumMember(Value = "edot-collector")]
+	EdotCollector,
+
+	[Display(Name = "Elastic Distribution of OpenTelemetry Java")]
+	[EnumMember(Value = "edot-java")]
+	EdotJava,
+
+	[Display(Name = "Elastic Distribution of OpenTelemetry .NET")]
+	[EnumMember(Value = "edot-dotnet")]
+	EdotDotnet,
+
+	[Display(Name = "Elastic Distribution of OpenTelemetry Node.js")]
+	[EnumMember(Value = "edot-nodejs")]
+	EdotNodeJs,
+
+	[Display(Name = "Elastic Distribution of OpenTelemetry PHP")]
+	[EnumMember(Value = "edot-php")]
+	EdotPhp,
+
+	[Display(Name = "Elastic Distribution of OpenTelemetry Python")]
+	[EnumMember(Value = "edot-python")]
+	EdotPython,
+
+	[Display(Name = "Elastic Distribution of OpenTelemetry Android")]
+	[EnumMember(Value = "edot-android")]
+	EdotAndroid,
+
+	[Display(Name = "Elastic Distribution of OpenTelemetry iOS")]
+	[EnumMember(Value = "edot-ios")]
+	EdotIos,
+}
+
+public class ProductConverter : IYamlTypeConverter
+{
+	public bool Accepts(Type type) => type == typeof(Product);
+
+	public object ReadYaml(IParser parser, Type type, ObjectDeserializer rootDeserializer)
+	{
+		var value = parser.Consume<Scalar>();
+		if (string.IsNullOrWhiteSpace(value.Value))
+			throw new InvalidProductException("empty value");
+
+		var product = Enum.GetValues<Product>()
+			.FirstOrDefault(p =>
+			{
+				var enumMemberAttr = typeof(Product)
+					.GetField(p.ToString())
+					?.GetCustomAttributes(typeof(EnumMemberAttribute), false)
+					.FirstOrDefault() as EnumMemberAttribute;
+				return enumMemberAttr?.Value?.Equals(value.Value, StringComparison.OrdinalIgnoreCase) ?? false;
+			});
+
+		if (product != default)
+			return product;
+
+		throw new InvalidProductException(value.Value);
+	}
+
+	public void WriteYaml(IEmitter emitter, object? value, Type type, ObjectSerializer serializer)
+	{
+		if (value == null)
+			return;
+		var product = (Product)value;
+		var enumMemberAttr = typeof(Product)
+			.GetField(product.ToString())
+			?.GetCustomAttributes(typeof(EnumMemberAttribute), false)
+			.FirstOrDefault() as EnumMemberAttribute;
+
+		emitter.Emit(new Scalar(enumMemberAttr?.Value ?? product.ToString().ToLowerInvariant()));
+	}
+}
+
+public class InvalidProductException(string invalidValue)
+	: Exception(
+		$"Invalid products frontmatter value: \"{invalidValue}\". Did you mean \"{ProductExtensions.Suggestion(invalidValue)}\"?");
+
+public static class ProductExtensions
+{
+	public static string GetProductDisplayName(this Product product)
+	{
+		var displayAttr = typeof(Product)
+			.GetField(product.ToString())
+			?.GetCustomAttributes(typeof(DisplayAttribute), false)
+			.FirstOrDefault() as DisplayAttribute;
+		return displayAttr?.Name ?? product.ToString();
+	}
+
+
+	private static List<string> GetEnumMemberValues() => Enum.GetValues<Product>()
+		.Select(p =>
+		{
+			var enumMemberAttr = typeof(Product)
+				.GetField(p.ToString())
+				?.GetCustomAttributes(typeof(EnumMemberAttribute), false)
+				.FirstOrDefault() as EnumMemberAttribute;
+
+			return enumMemberAttr?.Value;
+		})
+		.Where(value => value != null)
+		.Select(value => value!)
+		.ToList();
+
+	public static string Suggestion(string input) =>
+		GetEnumMemberValues()
+			.OrderBy(p => LevenshteinDistance(input, p))
+			.First();
+
+	// Based on https://rosettacode.org/wiki/Levenshtein_distance#C#
+	private static int LevenshteinDistance(string input, string product)
+	{
+		if (string.IsNullOrEmpty(product))
+			return int.MaxValue;
+
+		var inputLength = input.Length;
+		var productLength = product.Length;
+
+		if (inputLength == 0)
+			return productLength;
+
+		if (productLength == 0)
+			return inputLength;
+
+		var distance = new int[inputLength + 1, productLength + 1];
+
+		for (var i = 0; i <= inputLength; i++)
+			distance[i, 0] = i;
+
+		for (var j = 0; j <= productLength; j++)
+			distance[0, j] = j;
+
+		for (var i = 1; i <= inputLength; i++)
+		{
+			for (var j = 1; j <= productLength; j++)
+			{
+				var cost = (input[i - 1] == product[j - 1]) ? 0 : 1;
+
+				distance[i, j] = Math.Min(
+					Math.Min(
+						distance[i - 1, j] + 1,
+						distance[i, j - 1] + 1),
+					distance[i - 1, j - 1] + cost);
+			}
+		}
+
+		return distance[inputLength, productLength];
+	}
+}

--- a/src/Elastic.Markdown/Myst/FrontMatter/Products.cs
+++ b/src/Elastic.Markdown/Myst/FrontMatter/Products.cs
@@ -343,7 +343,7 @@ public class ProductConverter : IYamlTypeConverter
 
 public class InvalidProductException(string invalidValue)
 	: Exception(
-		$"Invalid products frontmatter value: \"{invalidValue}\". Did you mean \"{ProductExtensions.Suggestion(invalidValue)}\"?");
+		$"Invalid products frontmatter value: \"{invalidValue}\". Did you mean \"{ProductExtensions.Suggestion(invalidValue)}\"?\nYou can find the full list at https://docs-v3-preview.elastic.dev/elastic/docs-builder/tree/main/syntax/frontmatter#products.");
 
 public static class ProductExtensions
 {

--- a/src/Elastic.Markdown/Myst/FrontMatter/Products.cs
+++ b/src/Elastic.Markdown/Myst/FrontMatter/Products.cs
@@ -4,9 +4,9 @@
 
 using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
-using YamlDotNet.Serialization;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization;
 
 namespace Elastic.Markdown.Myst.FrontMatter;
 

--- a/src/Elastic.Markdown/Myst/FrontMatter/Products.cs
+++ b/src/Elastic.Markdown/Myst/FrontMatter/Products.cs
@@ -321,24 +321,13 @@ public class ProductConverter : IYamlTypeConverter
 				return enumMemberAttr?.Value?.Equals(value.Value, StringComparison.OrdinalIgnoreCase) ?? false;
 			});
 
-		if (product != default)
+		if (Enum.IsDefined(product) && product.GetEnumMemberValue()?.Equals(value.Value) == true)
 			return product;
 
 		throw new InvalidProductException(value.Value);
 	}
 
-	public void WriteYaml(IEmitter emitter, object? value, Type type, ObjectSerializer serializer)
-	{
-		if (value == null)
-			return;
-		var product = (Product)value;
-		var enumMemberAttr = typeof(Product)
-			.GetField(product.ToString())
-			?.GetCustomAttributes(typeof(EnumMemberAttribute), false)
-			.FirstOrDefault() as EnumMemberAttribute;
-
-		emitter.Emit(new Scalar(enumMemberAttr?.Value ?? product.ToString().ToLowerInvariant()));
-	}
+	public void WriteYaml(IEmitter emitter, object? value, Type type, ObjectSerializer serializer) => throw new NotImplementedException();
 }
 
 public class InvalidProductException(string invalidValue)
@@ -354,6 +343,15 @@ public static class ProductExtensions
 			?.GetCustomAttributes(typeof(DisplayAttribute), false)
 			.FirstOrDefault() as DisplayAttribute;
 		return displayAttr?.Name ?? product.ToString();
+	}
+
+	public static string? GetEnumMemberValue(this Product product)
+	{
+		var enumMemberAttr = typeof(Product)
+			.GetField(product.ToString())
+			?.GetCustomAttributes(typeof(EnumMemberAttribute), false)
+			.FirstOrDefault() as EnumMemberAttribute;
+		return enumMemberAttr?.Value;
 	}
 
 

--- a/src/Elastic.Markdown/Myst/YamlSerialization.cs
+++ b/src/Elastic.Markdown/Myst/YamlSerialization.cs
@@ -19,6 +19,7 @@ public static class YamlSerialization
 			.IgnoreUnmatchedProperties()
 			.WithEnumNamingConvention(HyphenatedNamingConvention.Instance)
 			.WithTypeConverter(new SemVersionConverter())
+			.WithTypeConverter(new ProductConverter())
 #pragma warning disable CS0618 // Type or member is obsolete
 			.WithTypeConverter(new DeploymentConverter())
 			.WithTypeConverter(new ApplicableToConverter())

--- a/src/Elastic.Markdown/Slices/Index.cshtml
+++ b/src/Elastic.Markdown/Slices/Index.cshtml
@@ -1,5 +1,6 @@
 @using Elastic.Markdown.Myst.FrontMatter
 @using Elastic.Markdown.Slices.Components
+@using EnumFastToStringGenerated
 @using Markdig
 @inherits RazorSliceHttpResult<IndexViewModel>
 @implements IUsesLayout<Elastic.Markdown.Slices._Layout, LayoutViewModel>
@@ -24,7 +25,7 @@
 		StaticFileContentHashProvider = Model.StaticFileContentHashProvider,
 		ReportIssueUrl = Model.ReportIssueUrl,
 		LegacyPage = Model.LegacyPage,
-		Products = Model.CurrentDocument.YamlFrontMatter?.Products is { Count: > 0} products ? string.Join(",", products.Select(p => p.GetProductDisplayName()).ToList()) : null,
+		Products = Model.CurrentDocument.YamlFrontMatter?.Products is { Count: > 0} products ? string.Join(",", products.Select(p => p.ToDescriptionFast()).ToList()) : null,
 	};
 }
 <section id="elastic-docs-v3">

--- a/src/Elastic.Markdown/Slices/Index.cshtml
+++ b/src/Elastic.Markdown/Slices/Index.cshtml
@@ -1,3 +1,4 @@
+@using Elastic.Markdown.Myst.FrontMatter
 @using Elastic.Markdown.Slices.Components
 @using Markdig
 @inherits RazorSliceHttpResult<IndexViewModel>
@@ -22,7 +23,8 @@
 		Features = Model.Features,
 		StaticFileContentHashProvider = Model.StaticFileContentHashProvider,
 		ReportIssueUrl = Model.ReportIssueUrl,
-		LegacyPage = Model.LegacyPage
+		LegacyPage = Model.LegacyPage,
+		Products = Model.CurrentDocument.YamlFrontMatter?.Products is { Count: > 0} products ? string.Join(",", products.Select(p => p.GetProductDisplayName()).ToList()) : null,
 	};
 }
 <section id="elastic-docs-v3">

--- a/src/Elastic.Markdown/Slices/Layout/_Head.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_Head.cshtml
@@ -1,6 +1,5 @@
 @inherits RazorSlice<LayoutViewModel>
 @using Elastic.Markdown.Helpers
-@using Elastic.Markdown.Myst.FrontMatter
 <head hx-head="merge">
 	<meta charset="utf-8">
 	<title>@Model.Title</title>

--- a/src/Elastic.Markdown/Slices/Layout/_Head.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_Head.cshtml
@@ -1,5 +1,6 @@
 @inherits RazorSlice<LayoutViewModel>
 @using Elastic.Markdown.Helpers
+@using Elastic.Markdown.Myst.FrontMatter
 <head hx-head="merge">
 	<meta charset="utf-8">
 	<title>@Model.Title</title>
@@ -34,5 +35,10 @@
 	@if (!string.IsNullOrEmpty(Model.CanonicalUrl))
 	{
 		<meta property="og:url" content="@Model.CanonicalUrl" />
+	}
+	@if (!string.IsNullOrEmpty(Model.Products))
+	{	
+		<meta class="elastic" name="product_name" content="@(Model.Products)"/>
+		<meta name="DC.subject" content="@(Model.Products)"/>
 	}
 </head>

--- a/src/Elastic.Markdown/Slices/_ViewModels.cs
+++ b/src/Elastic.Markdown/Slices/_ViewModels.cs
@@ -68,6 +68,8 @@ public class LayoutViewModel
 
 	public required MarkdownFile[] Parents { get; init; }
 
+	public required string? Products { get; init; }
+
 	public string Static(string path)
 	{
 		var staticPath = $"_static/{path.TrimStart('/')}";

--- a/src/Elastic.Markdown/Suggestions/Suggestions.cs
+++ b/src/Elastic.Markdown/Suggestions/Suggestions.cs
@@ -1,0 +1,65 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic.Markdown.Suggestions;
+
+public class Suggestion(IReadOnlySet<string> candidates, string input)
+{
+	private IReadOnlyCollection<string> GetSuggestions() =>
+		candidates
+			.Select(source => (source, Distance: LevenshteinDistance(input, source)))
+			.OrderBy(suggestion => suggestion.Distance)
+			.Where(suggestion => suggestion.Distance <= 2)
+			.Select(suggestion => suggestion.source)
+			.Take(3)
+			.ToList();
+
+	public string GetSuggestionQuestion()
+	{
+		var suggestions = GetSuggestions();
+		if (suggestions.Count == 0)
+			return string.Empty;
+
+		return "Did you mean " + string.Join(", ", suggestions.SkipLast(1).Select(s => $"\"{s}\"")) + (suggestions.Count > 1 ? " or " : "") + (suggestions.LastOrDefault() != null ? $"\"{suggestions.LastOrDefault()}\"" : "") + "?";
+	}
+
+	private static int LevenshteinDistance(string source, string target)
+	{
+		if (string.IsNullOrEmpty(target))
+			return int.MaxValue;
+
+		var sourceLength = source.Length;
+		var targetLength = target.Length;
+
+		if (sourceLength == 0)
+			return targetLength;
+
+		if (targetLength == 0)
+			return sourceLength;
+
+		var distance = new int[sourceLength + 1, targetLength + 1];
+
+		for (var i = 0; i <= sourceLength; i++)
+			distance[i, 0] = i;
+
+		for (var j = 0; j <= targetLength; j++)
+			distance[0, j] = j;
+
+		for (var i = 1; i <= sourceLength; i++)
+		{
+			for (var j = 1; j <= targetLength; j++)
+			{
+				var cost = (source[i - 1] == target[j - 1]) ? 0 : 1;
+
+				distance[i, j] = Math.Min(
+					Math.Min(
+						distance[i - 1, j] + 1,
+						distance[i, j - 1] + 1),
+					distance[i - 1, j - 1] + cost);
+			}
+		}
+
+		return distance[sourceLength, targetLength];
+	}
+}

--- a/tests/Elastic.Markdown.Tests/FrontMatter/YamlFrontMatterTests.cs
+++ b/tests/Elastic.Markdown.Tests/FrontMatter/YamlFrontMatterTests.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using Elastic.Markdown.Myst.FrontMatter;
 using Elastic.Markdown.Tests.Directives;
 using FluentAssertions;
 
@@ -62,4 +63,82 @@ sub:
 {
 	[Fact]
 	public void ReadsNavigationTitle() => File.NavigationTitle.Should().Be("Documentation Guide: value");
+}
+
+public class Products(ITestOutputHelper output) : DirectiveTest(output,
+	"""
+	---
+	products:
+	  - "apm"
+	---
+
+	# APM
+	"""
+)
+{
+	[Fact]
+	public void ReadsProducts()
+	{
+		File.YamlFrontMatter.Should().NotBeNull();
+		File.YamlFrontMatter!.Products.Should().NotBeNull()
+			.And.HaveCount(1)
+			.And.Contain(Product.Apm);
+	}
+}
+
+public class ProductsSuggestionWhenMispelled(ITestOutputHelper output) : DirectiveTest(output,
+	"""
+	---
+	products:
+	  - aapm
+	---
+
+	# APM
+	"""
+)
+{
+	[Fact]
+	public void HasErrors()
+	{
+		Collector.Diagnostics.Should().HaveCount(1);
+		Collector.Diagnostics.Should().Contain(d => d.Message.Contains("Invalid products frontmatter value: \"aapm\". Did you mean \"apm\"?"));
+	}
+}
+
+public class ProductsSuggestionWhenMispelled2(ITestOutputHelper output) : DirectiveTest(output,
+	"""
+	---
+	products:
+	  - apm-javaagent
+	---
+
+	# APM
+	"""
+)
+{
+	[Fact]
+	public void HasErrors()
+	{
+		Collector.Diagnostics.Should().HaveCount(1);
+		Collector.Diagnostics.Should().Contain(d => d.Message.Contains("Invalid products frontmatter value: \"apm-javaagent\". Did you mean \"apm-java-agent\"?"));
+	}
+}
+
+public class ProductsSuggestionWhenCasingError(ITestOutputHelper output) : DirectiveTest(output,
+	"""
+	---
+	products:
+	  - Apm
+	---
+
+	# APM
+	"""
+)
+{
+	[Fact]
+	public void HasErrors()
+	{
+		Collector.Diagnostics.Should().HaveCount(1);
+		Collector.Diagnostics.Should().Contain(d => d.Message.Contains("Invalid products frontmatter value: \"Apm\". Did you mean \"apm\"?"));
+	}
 }

--- a/tests/Elastic.Markdown.Tests/FrontMatter/YamlFrontMatterTests.cs
+++ b/tests/Elastic.Markdown.Tests/FrontMatter/YamlFrontMatterTests.cs
@@ -65,7 +65,7 @@ sub:
 	public void ReadsNavigationTitle() => File.NavigationTitle.Should().Be("Documentation Guide: value");
 }
 
-public class Products(ITestOutputHelper output) : DirectiveTest(output,
+public class ProductsSingle(ITestOutputHelper output) : DirectiveTest(output,
 	"""
 	---
 	products:
@@ -83,6 +83,29 @@ public class Products(ITestOutputHelper output) : DirectiveTest(output,
 		File.YamlFrontMatter!.Products.Should().NotBeNull()
 			.And.HaveCount(1)
 			.And.Contain(Product.Apm);
+	}
+}
+
+public class ProductsMultiple(ITestOutputHelper output) : DirectiveTest(output,
+	"""
+	---
+	products:
+	  - "apm"
+	  - "elasticsearch"
+	---
+
+	# APM
+	"""
+)
+{
+	[Fact]
+	public void ReadsProducts()
+	{
+		File.YamlFrontMatter.Should().NotBeNull();
+		File.YamlFrontMatter!.Products.Should().NotBeNull()
+			.And.HaveCount(2)
+			.And.Contain(Product.Apm)
+			.And.Contain(Product.Elasticsearch);
 	}
 }
 
@@ -140,5 +163,24 @@ public class ProductsSuggestionWhenCasingError(ITestOutputHelper output) : Direc
 	{
 		Collector.Diagnostics.Should().HaveCount(1);
 		Collector.Diagnostics.Should().Contain(d => d.Message.Contains("Invalid products frontmatter value: \"Apm\". Did you mean \"apm\"?"));
+	}
+}
+
+public class ProductsSuggestionWhenEmpty(ITestOutputHelper output) : DirectiveTest(output,
+	"""
+	---
+	products:
+	  - ""
+	---
+
+	# APM
+	"""
+)
+{
+	[Fact]
+	public void HasErrors()
+	{
+		Collector.Diagnostics.Should().HaveCount(1);
+		Collector.Diagnostics.Should().Contain(d => d.Message.Contains("Invalid products frontmatter value: \"\".\nYou can find the full list at https://docs-v3-preview.elastic.dev/elastic/docs-builder/tree/main/syntax/frontmatter#products."));
 	}
 }


### PR DESCRIPTION
Part of #1200 

## Changes

Add `products` frontmatter. A list of product IDs.

Example

```markdown
---
products:
  - apm-java-agent
  - edot-java
---
```

You can find the full list of available product IDs at https://docs-v3-preview.elastic.dev/elastic/docs-builder/pull/1226/syntax/frontmatter#products