### PR TITLE
Add content-source matching functionality to the assembler

### DIFF
--- a/actions/assembler-match/action.yml
+++ b/actions/assembler-match/action.yml
@@ -1,0 +1,26 @@
+name: 'Documentation Assembler Match'
+description: 'Checks if the current commit is on either a current or next branch'
+
+branding:
+  icon: 'filter'
+  color: 'blue'
+
+inputs:
+  repository:
+    description: 'the repository name'
+    required: true
+  ref_name:
+    description: 'The branch or tag name'
+    required: true
+
+outputs:
+  content-source-match:
+    description: 'true/false indicating the branch matches a content-source'
+  content-source-name:
+    description: "The name of the content source that matches (current/next) or empty"
+
+runs:
+  using: 'docker'
+  image: "docker://ghcr.io/elastic/docs-assembler:edge"
+  env:
+    INPUT_COMMAND: "content-source match"

--- a/docs-builder.sln
+++ b/docs-builder.sln
@@ -89,6 +89,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tooling", "tooling", "{73AB
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "authoring", "authoring", "{059E787F-85C1-43BE-9DD6-CE319E106383}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "assembler-filter", "assembler-filter", "{FB1C1954-D8E2-4745-BA62-04DD82FB4792}"
+	ProjectSection(SolutionItems) = preProject
+		actions\assembler-filter\action.yml = actions\assembler-filter\action.yml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -172,5 +177,6 @@ Global
 		{4CCE599A-B9FE-4DF2-8763-34CF0A99D4AA} = {73ABAE37-118F-4A53-BC2C-F19333555C90}
 		{059E787F-85C1-43BE-9DD6-CE319E106383} = {BE6011CC-1200-4957-B01F-FCCA10C5CF5A}
 		{7D36DDDA-9E0B-4D2C-8033-5D62FF8B6166} = {059E787F-85C1-43BE-9DD6-CE319E106383}
+		{FB1C1954-D8E2-4745-BA62-04DD82FB4792} = {245023D2-D3CA-47B9-831D-DAB91A2FFDC7}
 	EndGlobalSection
 EndGlobal

--- a/src/Elastic.Documentation.Configuration/Assembler/AssemblyConfiguration.cs
+++ b/src/Elastic.Documentation.Configuration/Assembler/AssemblyConfiguration.cs
@@ -78,4 +78,29 @@ public record AssemblyConfiguration
 
 	[YamlMember(Alias = "named_git_references")]
 	public Dictionary<string, string> NamedGitReferences { get; set; } = [];
+
+	/// Returns whether the <paramref name="branchOrTag"/> is configured as an integration branch or tag for the given
+	/// <paramref name="repository"/>.
+	public ContentSource? Match(string repository, string branchOrTag)
+	{
+		var repositoryName = repository.Split('/').Last();
+		if (ReferenceRepositories.TryGetValue(repositoryName, out var r))
+		{
+			if (r.GetBranch(ContentSource.Current) == branchOrTag)
+				return ContentSource.Current;
+			if (r.GetBranch(ContentSource.Next) == branchOrTag)
+				return ContentSource.Next;
+			return null;
+		}
+
+		if (repositoryName == NarrativeRepository.RepositoryName)
+		{
+			if (Narrative.GetBranch(ContentSource.Current) == branchOrTag)
+				return ContentSource.Current;
+			if (Narrative.GetBranch(ContentSource.Next) == branchOrTag)
+				return ContentSource.Next;
+		}
+
+		return null;
+	}
 }

--- a/src/tooling/docs-assembler/Cli/ContentSourceCommands.cs
+++ b/src/tooling/docs-assembler/Cli/ContentSourceCommands.cs
@@ -1,0 +1,74 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Diagnostics.CodeAnalysis;
+using System.IO.Abstractions;
+using Actions.Core.Services;
+using ConsoleAppFramework;
+using Elastic.Documentation.Configuration.Assembler;
+using Elastic.Documentation.Tooling.Diagnostics.Console;
+using Microsoft.Extensions.Logging;
+
+namespace Documentation.Assembler.Cli;
+
+internal sealed class ContentSourceCommands(ICoreService githubActionsService, ILoggerFactory logFactory)
+{
+	[SuppressMessage("Usage", "CA2254:Template should be a static expression")]
+	private void AssignOutputLogger()
+	{
+		var log = logFactory.CreateLogger<Program>();
+		ConsoleApp.Log = msg => log.LogInformation(msg);
+		ConsoleApp.LogError = msg => log.LogError(msg);
+	}
+
+	/// <summary>  </summary>
+	/// <param name="repository"></param>
+	/// <param name="branchOrTag"></param>
+	/// <param name="ctx"></param>
+	[Command("match")]
+	public async Task<int> Match([Argument] string? repository = null, [Argument] string? branchOrTag = null, Cancel ctx = default)
+	{
+		AssignOutputLogger();
+		var repo = repository ?? githubActionsService.GetInput("repository");
+		if (string.IsNullOrEmpty(repo))
+			throw new ArgumentNullException(nameof(repository));
+		var refName = branchOrTag ?? githubActionsService.GetInput("ref_name");
+		if (string.IsNullOrEmpty(refName))
+			throw new ArgumentNullException(nameof(branchOrTag));
+
+		await using var collector = new ConsoleDiagnosticsCollector(logFactory, githubActionsService)
+		{
+			NoHints = true
+		};
+
+		_ = collector.StartAsync(ctx);
+
+		// environment does not matter to check the configuration, defaulting to dev
+		var assembleContext = new AssembleContext("dev", collector, new FileSystem(), new FileSystem(), null, null)
+		{
+			Force = false,
+			AllowIndexing = false
+		};
+		var logger = logFactory.CreateLogger<ContentSourceCommands>();
+		var matches = assembleContext.Configuration.Match(repo, refName);
+		if (matches == null)
+		{
+			logger.LogInformation("'{Repository}' '{BranchOrTag}' combination not found in configuration.", repository, branchOrTag);
+			await githubActionsService.SetOutputAsync("content-source-match", "false");
+			await githubActionsService.SetOutputAsync("content-source-name", "");
+		}
+		else
+		{
+			var name = matches.Value.ToStringFast(true);
+			logger.LogInformation("'{Repository}' '{BranchOrTag}' is configured as '{Matches}' content-source", repository, branchOrTag, name);
+
+			await githubActionsService.SetOutputAsync("content-source-match", "true");
+			await githubActionsService.SetOutputAsync("content-source-name", name);
+		}
+
+		await collector.StopAsync(ctx);
+		return matches != null && collector.Errors == 0 ? 0 : 1;
+	}
+
+}

--- a/src/tooling/docs-assembler/Cli/RepositoryCommands.cs
+++ b/src/tooling/docs-assembler/Cli/RepositoryCommands.cs
@@ -90,7 +90,7 @@ internal sealed class RepositoryCommands(ICoreService githubActionsService, ILog
 		var assembleContext = new AssembleContext(environment, collector, new FileSystem(), new FileSystem(), null, null)
 		{
 			Force = force ?? false,
-			AllowIndexing = allowIndexing ?? false,
+			AllowIndexing = allowIndexing ?? false
 		};
 
 		// this validates all path prefixes are unique, early exit if duplicates are detected

--- a/src/tooling/docs-assembler/Program.cs
+++ b/src/tooling/docs-assembler/Program.cs
@@ -25,9 +25,10 @@ app.UseFilter<CatchExceptionFilter>();
 app.Add<InboundLinkCommands>("inbound-links");
 app.Add<RepositoryCommands>("repo");
 app.Add<NavigationCommands>("navigation");
+app.Add<ContentSourceCommands>("content-source");
 
 var githubActions = ConsoleApp.ServiceProvider.GetService<ICoreService>();
-var command = githubActions?.GetInput("COMMAND") ?? Environment.GetEnvironmentVariable("INPUT_COMMAND");
+var command = githubActions?.GetInput("COMMAND");
 if (!string.IsNullOrEmpty(command))
 	args = command.Split(' ');
 


### PR DESCRIPTION
Introduce logic to match branches or tags against configured content sources. Extend CLI with 'content-source' commands and integrate GitHub action for content-source validation. Update project solution and configuration accordingly.
