### PR TITLE
Remove tab from install docs

### DIFF
--- a/docs/contribute/locally.md
+++ b/docs/contribute/locally.md
@@ -28,7 +28,7 @@ This guide uses the first option. If you'd like to clone the repository and buil
 
 ::::{tab-set}
 
-:::{tab-item} macOS
+:::{tab-item} macOS & Linux
 
 1. **Download and run the install script**   
 
@@ -70,29 +70,6 @@ This guide uses the first option. If you'd like to clone the repository and buil
    ```
 
 :::
-
-:::{tab-item} Linux
-
-1. **Download the Binary:**
-   Download the latest Linux binary from [releases](https://github.com/elastic/docs-builder/releases/latest/):
-   ```sh
-   wget https://github.com/elastic/docs-builder/releases/latest/download/docs-builder-linux-x64.zip
-   ```
-
-2. **Extract the Binary:**
-   Unzip the downloaded file:
-   ```sh
-   unzip docs-builder-linux-x64.zip
-   ```
-
-3. **Run the Binary:**
-   Use the `serve` command to start serving the documentation at http://localhost:3000. The path to the `docset.yml` file that you want to build can be specified with `-p`:
-   ```sh
-   ./docs-builder serve -p ./path/to/docs
-   ```
-
-:::
-
 ::::
 
 :::{tip}

--- a/docs/contribute/locally.md
+++ b/docs/contribute/locally.md
@@ -47,6 +47,8 @@ This guide uses the first option. If you'd like to clone the repository and buil
    docs-builder serve
    ```
 
+To download and install the binary file manually, refer to [Releases](https://github.com/elastic/docs-builder/releases) on GitHub.
+
 :::
 
 :::{tab-item} Windows
@@ -68,6 +70,8 @@ This guide uses the first option. If you'd like to clone the repository and buil
    ```sh
    docs-builder serve
    ```
+
+To download and install the binary file manually, refer to [Releases](https://github.com/elastic/docs-builder/releases) on GitHub.
 
 :::
 ::::


### PR DESCRIPTION
macOS and Linux instructions are the same now. Also added links to the zip files for manual install.