### PR TITLE
Add random query string

### DIFF
--- a/src/Elastic.Markdown/Slices/Layout/_LandingPage.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_LandingPage.cshtml
@@ -252,7 +252,7 @@
 					<h3 class="font-sans font-bold text-2xl">Previous versions</h3>
 					<p class="grow mt-4">Browse the docs for previous Elastic product versions.</p>
 					<div class="mt-6">
-						<a href="https://www.elastic.co/guide" target="_blank" rel="noopener noreferrer" class="link text-white">
+						<a href="https://www.elastic.co/guide?lang=en" target="_blank" rel="noopener noreferrer" class="link text-white">
 							View previous versions
 							<svg class="link-arrow"
 							     xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">


### PR DESCRIPTION
## Context

@florent-leborgne reported that when clicking the "View previous versions" in the landing page, he would be redirected back to elastic.co/docs.

We identified that it's caused by a local cached 301 redirect response.

This might affect public users as well.

## Changes

To avoid a locally cached 301 response redirecting to back to elastic.co/docs I used a random query string `?lang=en` so it does not look totally random like `?xyz`.
