### PR TITLE
[Experiment] Add glob redirects

### DIFF
--- a/docs/contribute/redirects.md
+++ b/docs/contribute/redirects.md
@@ -104,3 +104,45 @@ redirects:
       'old-anchor': 'active-anchor'
       'removed-anchor':
 ```
+
+## Glob pattern redirects
+
+The redirect system also supports glob patterns for redirecting multiple pages at once. This is useful when moving entire sections or directories.
+
+### Trailing wildcard redirects
+
+Use the `**` pattern at the end of a path to match all content under a specific path prefix and redirect it to a new location while preserving the path structure.
+
+```yaml
+redirects:
+  'reference/apm/agents/android/**': 'reference/opentelemetry/edot-sdks/android/**'
+  'old-section/**': 'new-section/**'
+```
+
+This redirects:
+- `reference/apm/agents/android/setup` → `reference/opentelemetry/edot-sdks/android/setup`
+- `reference/apm/agents/android/api/classes` → `reference/opentelemetry/edot-sdks/android/api/classes`
+
+### Simple glob pattern redirects
+
+You can use basic glob patterns with `*` (single segment wildcard) and `?` (single character wildcard).
+
+```yaml
+redirects:
+  'guides/*/intro': 'tutorials/*/getting-started'
+  'api/v1/user?.json': 'api/v2/users'
+```
+
+For simple cases where the target doesn't contain wildcards, the target is used directly:
+
+```yaml
+redirects:
+  'docs/v*/setup': 'documentation/setup-guide'
+```
+
+### Best practices for glob patterns
+
+1. Use exact path redirects when possible.
+2. Use trailing `**` wildcards for redirecting entire directory trees.
+3. Keep glob patterns simple, with wildcards in predictable positions.
+4. Test your redirects thoroughly, especially when using complex patterns.

--- a/src/Elastic.Documentation.Configuration/Elastic.Documentation.Configuration.csproj
+++ b/src/Elastic.Documentation.Configuration/Elastic.Documentation.Configuration.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNet.Glob" />
+    <PackageReference Include="DotNet.Glob"/>
     <PackageReference Include="Samboy063.Tomlet" />
     <PackageReference Include="Vecc.YamlDotNet.Analyzers.StaticGenerator"/>
     <PackageReference Include="YamlDotNet"/>


### PR DESCRIPTION
This is a concept PR that tries to add glob support to our redirect system using https://github.com/dazinator/DotNet.Glob.

With this change (which I couldn't test), we could use the following patterns:

## Trailing Wildcard Redirects
Uses `**` to match all content under a path prefix.
```yaml
redirects:
  '/reference/apm/agents/android/**': '/reference/opentelemetry/edot-sdks/android/**'
```
Example: `/reference/apm/agents/android/setup` → `/reference/opentelemetry/edot-sdks/android/setup`

## Single Segment Wildcard Redirects
Uses `*` to match any characters within a single path segment.
```yaml
redirects:
  '/guides/*/intro': '/tutorials/*/getting-started'
```
Example: `/guides/elasticsearch/intro` → `/tutorials/elasticsearch/getting-started`

## Single Character Wildcard Redirects
Uses `?` to match a single character.
```yaml
redirects:
  '/api/v1/user?.json': '/api/v2/users'
```
Example: `/api/v1/user1.json` → `/api/v2/users`
