### PR TITLE
Add a new job to handle push event matching

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -10,6 +10,13 @@ on:
     branches:
       - main
       - master
+      # TODO remove these need to be added to individual repositories
+      - '\d+.\d+.\d+'
+      - '\d+.\d+'
+      - '\d+.x'
+    tags:
+      - 'v?\d+.\d+.\d+'
+      - 'v?\d+.\d+'
   workflow_call:
     inputs:
       strict:
@@ -44,6 +51,37 @@ permissions:
   pull-requests: read
 
 jobs:
+  match:
+    if: github.event.repository.fork == false # Skip running the job on the fork itself (It still runs on PRs on the upstream from forks)
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref }}
+      cancel-in-progress: ${{ startsWith(github.event_name, 'pull_request') }}
+    runs-on: ubuntu-latest
+    outputs:
+      content-source-match: ${{ steps.event-check.outputs.content-source-match != '' && steps.event-check.outputs.content-source-match || steps.match.outputs.content-source-match }}
+      content-source-name: ${{ steps.event-check.outputs.content-source-name != '' && steps.event-check.outputs.content-source-name || steps.match.outputs.content-source-name }}
+    steps:
+      - name: Not a push event
+        id: event-check
+        if: contains(fromJSON('["merge_group", "pull_request", "pull_request_target"]'), github.event_name)
+        run: |
+          echo "content-source-match=true >> $GITHUB_OUTPUT
+          echo "content-source-name=next >> $GITHUB_OUTPUT
+      - name: Match for push events
+        id: match
+        if: contains(fromJSON('["push"]'), github.event_name)
+        uses: elastic/docs-builder/actions/assembler-match@main
+        with:
+          ref_name: ${{ github.event.ref_name }}
+          repository: ${{ github.event.repository }}
+      - name: Not a push event
+        id: event-check
+        if: contains(fromJSON('["merge_group", "pull_request", "pull_request_target"]'), github.event_name)
+        run: |
+          echo "Non sensitive data, echo'ing here temporarily to validate this job before connecting it further into the build job"
+          echo "content-source-match=${{ steps.event-check.outputs.content-source-match != '' && steps.event-check.outputs.content-source-match || steps.match.outputs.content-source-match }}"
+          echo "content-source-name=${{ steps.event-check.outputs.content-source-name != '' && steps.event-check.outputs.content-source-name || steps.match.outputs.content-source-name }}"
+
   build:
     if: github.event.repository.fork == false # Skip running the job on the fork itself (It still runs on PRs on the upstream from forks)
     concurrency:
@@ -52,6 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_PR_REF_NAME: ${{ github.event.pull_request.head.ref }}
+    needs: [ match ]
     steps:
 
       - name: Checkout

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -73,7 +73,6 @@ jobs:
           ref_name: ${{ github.event.ref_name }}
           repository: ${{ github.event.repository }}
       - name: Not a push event
-        id: match
         if: contains(fromJSON('["merge_group", "pull_request", "pull_request_target"]'), github.event_name)
         run: |
           echo "Non sensitive data, echo'ing here temporarily to validate this job before connecting it further into the build job"

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -64,6 +64,7 @@ jobs:
       - name: Not a push event
         id: event-check
         if: contains(fromJSON('["merge_group", "pull_request", "pull_request_target"]'), github.event_name)
+        # ensure we emit static output to simplify our checks in the build step
         run: |
           echo "content-source-match=true >> $GITHUB_OUTPUT
           echo "content-source-name=next >> $GITHUB_OUTPUT
@@ -75,7 +76,7 @@ jobs:
           ref_name: ${{ github.event.ref_name }}
           repository: ${{ github.event.repository }}
       - name: Not a push event
-        id: event-check
+        id: match
         if: contains(fromJSON('["merge_group", "pull_request", "pull_request_target"]'), github.event_name)
         run: |
           echo "Non sensitive data, echo'ing here temporarily to validate this job before connecting it further into the build job"

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -58,20 +58,16 @@ jobs:
       content-source-match: ${{ steps.event-check.outputs.content-source-match != '' && steps.event-check.outputs.content-source-match || steps.match.outputs.content-source-match }}
       content-source-name: ${{ steps.event-check.outputs.content-source-name != '' && steps.event-check.outputs.content-source-name || steps.match.outputs.content-source-name }}
     steps:
-      - name: Debug One
-        run: |
-          echo "ref=${{ github.ref_name }}"
-          echo "repo=${{ github.repository }}"
       - name: Not a push event
         id: event-check
-        if: contains(fromJSON('["merge_group", "push", "pull_request_target"]'), github.event_name)
+        if: contains(fromJSON('["merge_group", "pull_request", "pull_request_target"]'), github.event_name)
         # ensure we emit static output to simplify our checks in the build step
         run: |
           echo "content-source-match=true" >> $GITHUB_OUTPUT
           echo "content-source-name=next" >> $GITHUB_OUTPUT
       - name: Match for push events
         id: match
-        if: contains(fromJSON('["pull_request"]'), github.event_name)
+        if: contains(fromJSON('["push"]'), github.event_name)
         uses: elastic/docs-builder/actions/assembler-match@main
         with:
           ref_name: ${{ github.ref_name }}

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -71,13 +71,15 @@ jobs:
         uses: elastic/docs-builder/actions/assembler-match@main
         with:
           ref_name: ${{ github.event.ref_name }}
-          repository: ${{ github.event.repository }}
+          repository: ${{ github.repository }}
       - name: Debug
         if: contains(fromJSON('["merge_group", "pull_request", "pull_request_target"]'), github.event_name)
         run: |
           echo "Non sensitive data, echo'ing here temporarily to validate this job before connecting it further into the build job"
           echo "content-source-match=${{ steps.event-check.outputs.content-source-match != '' && steps.event-check.outputs.content-source-match || steps.match.outputs.content-source-match }}"
           echo "content-source-name=${{ steps.event-check.outputs.content-source-name != '' && steps.event-check.outputs.content-source-name || steps.match.outputs.content-source-name }}"
+          echo "ref=${{ github.event.ref_name }}"
+          echo "repo=${{ github.repository }}"
 
   build:
     if: github.event.repository.fork == false # Skip running the job on the fork itself (It still runs on PRs on the upstream from forks)

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -63,8 +63,8 @@ jobs:
         if: contains(fromJSON('["merge_group", "pull_request", "pull_request_target"]'), github.event_name)
         # ensure we emit static output to simplify our checks in the build step
         run: |
-          echo "content-source-match=true >> $GITHUB_OUTPUT
-          echo "content-source-name=next >> $GITHUB_OUTPUT
+          echo "content-source-match=true" >> $GITHUB_OUTPUT
+          echo "content-source-name=next" >> $GITHUB_OUTPUT
       - name: Match for push events
         id: match
         if: contains(fromJSON('["push"]'), github.event_name)
@@ -72,7 +72,7 @@ jobs:
         with:
           ref_name: ${{ github.event.ref_name }}
           repository: ${{ github.event.repository }}
-      - name: Not a push event
+      - name: Debug
         if: contains(fromJSON('["merge_group", "pull_request", "pull_request_target"]'), github.event_name)
         run: |
           echo "Non sensitive data, echo'ing here temporarily to validate this job before connecting it further into the build job"

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -1,6 +1,11 @@
 name: preview-build
 
 on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
   pull_request_target:
     types:
       - opened

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -2,10 +2,7 @@ name: preview-build
 
 on:
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
+
   pull_request_target:
     types:
       - opened

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -58,6 +58,10 @@ jobs:
       content-source-match: ${{ steps.event-check.outputs.content-source-match != '' && steps.event-check.outputs.content-source-match || steps.match.outputs.content-source-match }}
       content-source-name: ${{ steps.event-check.outputs.content-source-name != '' && steps.event-check.outputs.content-source-name || steps.match.outputs.content-source-name }}
     steps:
+      - name: Debug One
+        run: |
+          echo "ref=${{ github.ref_name }}"
+          echo "repo=${{ github.repository }}"
       - name: Not a push event
         id: event-check
         if: contains(fromJSON('["merge_group", "push", "pull_request_target"]'), github.event_name)

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -1,8 +1,11 @@
 name: preview-build
 
 on:
-  pull_request:
-
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
   push:
     branches:
       - main

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -3,11 +3,6 @@ name: preview-build
 on:
   pull_request:
 
-  pull_request_target:
-    types:
-      - opened
-      - synchronize
-      - reopened
   push:
     branches:
       - main

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -70,7 +70,7 @@ jobs:
         if: contains(fromJSON('["pull_request"]'), github.event_name)
         uses: elastic/docs-builder/actions/assembler-match@main
         with:
-          ref_name: ${{ github.event.ref_name }}
+          ref_name: ${{ github.ref_name }}
           repository: ${{ github.repository }}
       - name: Debug
         if: contains(fromJSON('["merge_group", "pull_request", "pull_request_target"]'), github.event_name)
@@ -78,7 +78,7 @@ jobs:
           echo "Non sensitive data, echo'ing here temporarily to validate this job before connecting it further into the build job"
           echo "content-source-match=${{ steps.event-check.outputs.content-source-match != '' && steps.event-check.outputs.content-source-match || steps.match.outputs.content-source-match }}"
           echo "content-source-name=${{ steps.event-check.outputs.content-source-name != '' && steps.event-check.outputs.content-source-name || steps.match.outputs.content-source-name }}"
-          echo "ref=${{ github.event.ref_name }}"
+          echo "ref=${{ github.ref_name }}"
           echo "repo=${{ github.repository }}"
 
   build:

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -60,14 +60,14 @@ jobs:
     steps:
       - name: Not a push event
         id: event-check
-        if: contains(fromJSON('["merge_group", "pull_request", "pull_request_target"]'), github.event_name)
+        if: contains(fromJSON('["merge_group", "push", "pull_request_target"]'), github.event_name)
         # ensure we emit static output to simplify our checks in the build step
         run: |
           echo "content-source-match=true" >> $GITHUB_OUTPUT
           echo "content-source-name=next" >> $GITHUB_OUTPUT
       - name: Match for push events
         id: match
-        if: contains(fromJSON('["push"]'), github.event_name)
+        if: contains(fromJSON('["pull_request"]'), github.event_name)
         uses: elastic/docs-builder/actions/assembler-match@main
         with:
           ref_name: ${{ github.event.ref_name }}

--- a/docs-builder.sln
+++ b/docs-builder.sln
@@ -89,9 +89,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tooling", "tooling", "{73AB
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "authoring", "authoring", "{059E787F-85C1-43BE-9DD6-CE319E106383}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "assembler-filter", "assembler-filter", "{FB1C1954-D8E2-4745-BA62-04DD82FB4792}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "assembler-match", "assembler-match", "{FB1C1954-D8E2-4745-BA62-04DD82FB4792}"
 	ProjectSection(SolutionItems) = preProject
-		actions\assembler-filter\action.yml = actions\assembler-filter\action.yml
+		actions\assembler-match\action.yml = actions\assembler-match\action.yml
 	EndProjectSection
 EndProject
 Global

--- a/src/tooling/docs-assembler/AssembleSources.cs
+++ b/src/tooling/docs-assembler/AssembleSources.cs
@@ -65,7 +65,7 @@ public class AssembleSources
 		UriResolver = new PublishEnvironmentUriResolver(TocTopLevelMappings, assembleContext.Environment);
 		var crossLinkResolver = new CrossLinkResolver(crossLinkFetcher, UriResolver);
 		AssembleSets = checkouts
-			.Where(c => !c.Repository.Skip)
+			.Where(c => c.Repository is { Skip: false })
 			.Select(c => new AssemblerDocumentationSet(NullLoggerFactory.Instance, assembleContext, c, crossLinkResolver, TreeCollector))
 			.ToDictionary(s => s.Checkout.Repository.Name, s => s)
 			.ToFrozenDictionary();

--- a/src/tooling/docs-assembler/Sourcing/RepositorySourcesFetcher.cs
+++ b/src/tooling/docs-assembler/Sourcing/RepositorySourcesFetcher.cs
@@ -142,8 +142,7 @@ public class RepositorySourcer(ILoggerFactory logger, IDirectoryInfo checkoutDir
 		return true;
 	}
 
-	private string CheckoutFromScratch(Repository repository, string name, string branch, string relativePath,
-		IDirectoryInfo checkoutFolder)
+	private string CheckoutFromScratch(Repository repository, string name, string branch, string relativePath, IDirectoryInfo checkoutFolder)
 	{
 		_logger.LogInformation("Checkout: {Name}\t{Branch}\t{RelativePath}", name, branch, relativePath);
 		switch (repository.CheckoutStrategy)

--- a/src/tooling/docs-assembler/assembler.yml
+++ b/src/tooling/docs-assembler/assembler.yml
@@ -101,3 +101,6 @@ references:
   opentelemetry:
   search-ui:
   integration-docs:
+
+  docs-builder:
+    skip: true

--- a/src/tooling/docs-assembler/assembler.yml
+++ b/src/tooling/docs-assembler/assembler.yml
@@ -81,7 +81,6 @@ references:
   ecs-logging-python:
   ecs-logging-ruby:
   ecs-logging:
-  ecs:
   eland:
   elastic-serverless-forwarder:
   elasticsearch-hadoop:

--- a/src/tooling/docs-assembler/assembler.yml
+++ b/src/tooling/docs-assembler/assembler.yml
@@ -101,3 +101,5 @@ references:
   opentelemetry:
   search-ui:
   integration-docs:
+  docs-builder:
+    skip: true

--- a/src/tooling/docs-assembler/assembler.yml
+++ b/src/tooling/docs-assembler/assembler.yml
@@ -101,6 +101,3 @@ references:
   opentelemetry:
   search-ui:
   integration-docs:
-
-  docs-builder:
-    skip: true

--- a/src/tooling/docs-assembler/assembler.yml
+++ b/src/tooling/docs-assembler/assembler.yml
@@ -81,6 +81,7 @@ references:
   ecs-logging-python:
   ecs-logging-ruby:
   ecs-logging:
+  ecs:
   eland:
   elastic-serverless-forwarder:
   elasticsearch-hadoop:


### PR DESCRIPTION
Introduce a "match" job to process push event-specific logic and outputs, ensuring proper handling of event types. This includes conditional steps for different event contexts and prepares outputs for downstream "build" job dependencies.
