### PR TITLE
Assembler match: log level from Error to Information for missing config

### DIFF
--- a/src/Elastic.Documentation/Serialization/SourceGenerationContext.cs
+++ b/src/Elastic.Documentation/Serialization/SourceGenerationContext.cs
@@ -8,7 +8,7 @@ using Elastic.Documentation.State;
 
 namespace Elastic.Documentation.Serialization;
 
-// This configures the source generation for json (de)serialization.
+// This configures the source generation for JSON (de)serialization.
 
 [JsonSourceGenerationOptions(WriteIndented = true, UseStringEnumConverter = true)]
 [JsonSerializable(typeof(GenerationState))]

--- a/src/tooling/docs-assembler/Cli/ContentSourceCommands.cs
+++ b/src/tooling/docs-assembler/Cli/ContentSourceCommands.cs
@@ -57,7 +57,7 @@ internal sealed class ContentSourceCommands(ICoreService githubActionsService, I
 		var matches = assembleContext.Configuration.Match(repo, refName);
 		if (matches == null)
 		{
-			logger.LogError("'{Repository}' '{BranchOrTag}' combination not found in configuration.", repo, refName);
+			logger.LogInformation("'{Repository}' '{BranchOrTag}' combination not found in configuration.", repo, refName);
 			await githubActionsService.SetOutputAsync("content-source-match", "false");
 			await githubActionsService.SetOutputAsync("content-source-name", "");
 		}


### PR DESCRIPTION
The log level was modified to better reflect the non-critical nature of the missing configuration scenario. This prevents unnecessary error logs while maintaining visibility through informational logs.
