### PR TITLE
Add handling for speculative matches in content source logic

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           echo "Non sensitive data, echo'ing here temporarily to validate this job before connecting it further into the build job"
           echo "content-source-match=${{ steps.event-check.outputs.content-source-match != '' && steps.event-check.outputs.content-source-match || steps.match.outputs.content-source-match }}"
-          echo "content-source-name=${{ steps.event-check.outputs.content-source-next != '' && steps.event-check.outputs.content-source-next || steps.match.outputs.content-source-next }}"
+          echo "content-source-next=${{ steps.event-check.outputs.content-source-next != '' && steps.event-check.outputs.content-source-next || steps.match.outputs.content-source-next }}"
           echo "content-source-current=${{ steps.event-check.outputs.content-source-current != '' && steps.event-check.outputs.content-source-current || steps.match.outputs.content-source-current }}"
           echo "ref=${{ github.ref_name }}"
           echo "repo=${{ github.repository }}"

--- a/actions/assembler-match/action.yml
+++ b/actions/assembler-match/action.yml
@@ -20,6 +20,8 @@ outputs:
     description: "true/false indicating the branch acts as the next content source"
   content-source-current:
     description: "true/false indicating the branch acts as the current content source"
+  content-source-speculative:
+    description: "true/false speculative match, used to build version branches before they are marked as current/next"
 
 runs:
   using: 'docker'

--- a/src/Elastic.Documentation/SemVersion.cs
+++ b/src/Elastic.Documentation/SemVersion.cs
@@ -6,7 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.RegularExpressions;
 
-namespace Elastic.Markdown.Helpers;
+namespace Elastic.Documentation;
 
 /// <summary>
 /// A semver2 compatible version.

--- a/src/Elastic.Markdown/Myst/Directives/VersionBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/VersionBlock.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using Elastic.Documentation;
 using Elastic.Markdown.Diagnostics;
 using Elastic.Markdown.Helpers;
 using static System.StringSplitOptions;

--- a/src/Elastic.Markdown/Myst/FrontMatter/AllVersions.cs
+++ b/src/Elastic.Markdown/Myst/FrontMatter/AllVersions.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using Elastic.Documentation;
 using Elastic.Markdown.Helpers;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;

--- a/src/Elastic.Markdown/Myst/FrontMatter/Applicability.cs
+++ b/src/Elastic.Markdown/Myst/FrontMatter/Applicability.cs
@@ -5,6 +5,7 @@
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
+using Elastic.Documentation;
 using Elastic.Markdown.Helpers;
 using YamlDotNet.Serialization;
 

--- a/src/Elastic.Markdown/Myst/Roles/AppliesTo/AppliesToRole.cs
+++ b/src/Elastic.Markdown/Myst/Roles/AppliesTo/AppliesToRole.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System.Diagnostics;
+using Elastic.Documentation;
 using Elastic.Markdown.Diagnostics;
 using Elastic.Markdown.Helpers;
 using Elastic.Markdown.Myst.FrontMatter;

--- a/src/tooling/docs-assembler/Cli/ContentSourceCommands.cs
+++ b/src/tooling/docs-assembler/Cli/ContentSourceCommands.cs
@@ -55,12 +55,13 @@ internal sealed class ContentSourceCommands(ICoreService githubActionsService, I
 			AllowIndexing = false
 		};
 		var matches = assembleContext.Configuration.Match(repo, refName);
-		if (matches is { Current: null, Next: null })
+		if (matches is { Current: null, Next: null, Speculative: false })
 		{
 			logger.LogInformation("'{Repository}' '{BranchOrTag}' combination not found in configuration.", repo, refName);
 			await githubActionsService.SetOutputAsync("content-source-match", "false");
 			await githubActionsService.SetOutputAsync("content-source-next", "false");
 			await githubActionsService.SetOutputAsync("content-source-current", "false");
+			await githubActionsService.SetOutputAsync("content-source-speculative", "false");
 		}
 		else
 		{
@@ -72,6 +73,7 @@ internal sealed class ContentSourceCommands(ICoreService githubActionsService, I
 			await githubActionsService.SetOutputAsync("content-source-match", "true");
 			await githubActionsService.SetOutputAsync("content-source-next", matches.Next is not null ? "true" : "false");
 			await githubActionsService.SetOutputAsync("content-source-current", matches.Current is not null ? "true" : "false");
+			await githubActionsService.SetOutputAsync("content-source-speculative", matches.Speculative ? "true" : "false");
 		}
 
 		await collector.StopAsync(ctx);

--- a/src/tooling/docs-builder/Cli/CheckForUpdatesFilter.cs
+++ b/src/tooling/docs-builder/Cli/CheckForUpdatesFilter.cs
@@ -4,6 +4,7 @@
 
 using System.Reflection;
 using ConsoleAppFramework;
+using Elastic.Documentation;
 using Elastic.Markdown.Helpers;
 using Elastic.Markdown.IO;
 

--- a/tests/Elastic.Markdown.Tests/Directives/VersionTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/VersionTests.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using Elastic.Documentation;
 using Elastic.Markdown.Helpers;
 using Elastic.Markdown.Myst.Directives;
 using FluentAssertions;


### PR DESCRIPTION
This will flag version branches as a speculative match ensuring we'll onboard new version branches before they are actively marked as current / next.

If a current branch is already a version branch we will only build new version branches speculatively.

This also ensures new repositories will speculatively build for `main` / `master` or version branches.

This allows repositories to 

- branch their next `current` (e.g 9.1) branch.
  - We will speculative build and publish the `links.json` from `9.1`.
- They can update the current branch in `assembler.yml` to 9.1 now at anytime because a `links.json` will have been published for it.


Otherwise we can never pull an update to `assembler.yml` because that would break the link resolvers trying to find the `links.json` for the `current` branch.

This also ensures new repositories can onboard their `main` and `master` branches without touching `assembler.yml`.

