### PR TITLE
[Fix] Clarify path specification for the serve command

### DIFF
--- a/docs/contribute/locally.md
+++ b/docs/contribute/locally.md
@@ -44,11 +44,12 @@ This guide uses the first option. If you'd like to clone the repository and buil
 
 2. **Run docs-builder from a docs folder**
 
-   Use the `serve` command from any docs folder to start serving the documentation at http://localhost:3000. The path to the `docset.yml` file that you want to build can be specified with `-p`:
+   Use the `serve` command from any docs folder to start serving the documentation at http://localhost:3000:
 
    ```sh
    docs-builder serve
    ```
+   The path to the `docset.yml` file that you want to build can be specified with `-p`.
 
 To download and install the binary file manually, refer to [Releases](https://github.com/elastic/docs-builder/releases) on GitHub. 
 
@@ -72,12 +73,12 @@ If you get a `Permission denied` error, make sure that you aren't trying to run 
 
 2. **Run docs-builder from a docs folder**
 
-   Use the `serve` command from any docs folder to start serving the documentation at http://localhost:3000. The path to the `docset.yml` file that you want to build can be specified with `-p`:
+   Use the `serve` command from any docs folder to start serving the documentation at http://localhost:3000:
 
    ```sh
    docs-builder serve
    ```
-   
+   The path to the `docset.yml` file that you want to build can be specified with `-p`.
 :::
 ::::
 
@@ -111,7 +112,7 @@ cd docs-content
 
 :::::{step} Run docs-builder
 
-Run the `docs-builder` binary with the `serve` command to build and serve the content set to http://localhost:3000. Specify the path to the `docset.yml` file that you want to build with `-p`.
+Run the `docs-builder` binary with the `serve` command to build and serve the content set to http://localhost:3000. If necessary, specify the path to the `docset.yml` file that you want to build with `-p`.
 
 For example:
 


### PR DESCRIPTION
This PR clarifies how to specify the path when using the `serve` command. The updated wording makes it easier for users to understand how to correctly point to the `docset.yml` file.