### PR TITLE
fix(install): update x64 download link in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ ARCH=$(uname -m)
 
 # Map architecture naming
 if [ "$ARCH" = "x86_64" ]; then
-  ARCH="amd64"
+  ARCH="x64"
 elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
   ARCH="arm64"
 fi


### PR DESCRIPTION
The install script currently attempts to download a file for "amd64", which does not exist. This results in a broken download link on linux/darwin x86_64:

	$ curl -sL https://ela.st/docs-builder-install | sh
	Note: Installing to /usr/local/bin requires administrator privileges.
	docs-builder is already installed.
	Running in non-interactive mode. Proceeding with installation...
	Downloading docs-builder for linux/amd64...
	  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
									 Dload  Upload   Total   Spent    Left  Speed
	  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
	100     9  100     9    0     0     17      0 --:--:-- --:--:-- --:--:--     0
	Archive:  docs-builder-linux-amd64.zip
	  End-of-central-directory signature not found.  Either this file is not
	  a zipfile, or it constitutes one disk of a multi-part archive.  In the
	  latter case the central directory and zipfile comment will be found on
	  the last disk(s) of this archive.
	unzip:  cannot find zipfile directory in one of docs-builder-linux-amd64.zip or
			docs-builder-linux-amd64.zip.zip, and cannot find docs-builder-linux-amd64.zip.ZIP, period.
	Error: Failed to extract docs-builder from docs-builder-linux-amd64.zip.

Looking at the releases on github there is no "amd64" release, it was changed at some point to "x64".

The fact that this went unnoticed suggests we don't have active tests for the install script across different systems. Adding such tests would be a good follow up.