### PR TITLE
Redirect health check

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -181,6 +181,9 @@ jobs:
         if: env.MATCH == 'true' && (github.repository == 'elastic/docs-builder' && steps.deployment.outputs.result)
         uses: elastic/docs-builder/.github/actions/bootstrap@main
 
+      - name: Validate Redirect Health
+        uses: elastic/docs-builder/actions/validate-redirects-health@main
+
       # we run our artifact directly, please use the prebuild
       # elastic/docs-builder@main GitHub Action for all other repositories!
       - name: Build documentation

--- a/actions/validate-redirects-health/action.yml
+++ b/actions/validate-redirects-health/action.yml
@@ -1,0 +1,10 @@
+name: 'Validate Redirects Health'
+description: 'Validates moved and deleted files received redirect rules'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate Redirects
+      shell: bash
+      run: |
+        dotnet run --project src/tooling/docs-builder/docs-builder.csproj -- health validate-redirects

--- a/src/tooling/Elastic.Documentation.Tooling/Elastic.Documentation.Tooling.csproj
+++ b/src/tooling/Elastic.Documentation.Tooling/Elastic.Documentation.Tooling.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Github.Actions.Core" />
     <PackageReference Include="Crayon" />
     <PackageReference Include="Errata" />
+    <PackageReference Include="Proc"  />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tooling/Elastic.Documentation.Tooling/ExternalCommands/ExternalCommandExecutor.cs
+++ b/src/tooling/Elastic.Documentation.Tooling/ExternalCommands/ExternalCommandExecutor.cs
@@ -1,0 +1,110 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions;
+using Elastic.Documentation.Diagnostics;
+using ProcNet;
+
+namespace Elastic.Documentation.Tooling.ExternalCommands;
+
+public abstract class ExternalCommandExecutor(DiagnosticsCollector collector, IDirectoryInfo workingDirectory)
+{
+	protected IDirectoryInfo WorkingDirectory => workingDirectory;
+	protected void ExecIn(string binary, params string[] args)
+	{
+		var arguments = new ExecArguments(binary, args)
+		{
+			WorkingDirectory = workingDirectory.FullName,
+			Environment = new Dictionary<string, string>
+			{
+				// Disable git editor prompts:
+				// There are cases where `git pull` would prompt for an editor to write a commit message.
+				// This env variable prevents that.
+				{ "GIT_EDITOR", "true" }
+			},
+		};
+		var result = Proc.Exec(arguments);
+		if (result != 0)
+			collector.EmitError("", $"Exit code: {result} while executing {binary} {string.Join(" ", args)} in {workingDirectory}");
+	}
+
+	protected string[] CaptureMultiple(string binary, params string[] args)
+	{
+		// Try 10 times to capture the output of the command, if it fails, we'll throw an exception on the last try
+		Exception? e = null;
+		for (var i = 0; i <= 9; i++)
+		{
+			try
+			{
+				return CaptureOutput();
+			}
+			catch (Exception ex)
+			{
+				if (ex is not null)
+					e = ex;
+			}
+		}
+
+		if (e is not null)
+			collector.EmitError("", "failure capturing stdout", e);
+
+		return [];
+
+		string[] CaptureOutput()
+		{
+			var arguments = new StartArguments(binary, args)
+			{
+				WorkingDirectory = workingDirectory.FullName,
+				Timeout = TimeSpan.FromSeconds(3),
+				WaitForExit = TimeSpan.FromSeconds(3),
+				ConsoleOutWriter = NoopConsoleWriter.Instance
+			};
+			var result = Proc.Start(arguments);
+			var output = result.ExitCode != 0
+				? throw new Exception($"Exit code is not 0. Received {result.ExitCode} from {binary}: {workingDirectory}")
+				: result.ConsoleOut.Select(x => x.Line).ToArray() ?? throw new Exception($"No output captured for {binary}: {workingDirectory}");
+			return output;
+		}
+	}
+
+
+	protected string Capture(string binary, params string[] args)
+	{
+		// Try 10 times to capture the output of the command, if it fails, we'll throw an exception on the last try
+		Exception? e = null;
+		for (var i = 0; i <= 9; i++)
+		{
+			try
+			{
+				return CaptureOutput();
+			}
+			catch (Exception ex)
+			{
+				if (ex is not null)
+					e = ex;
+			}
+		}
+
+		if (e is not null)
+			collector.EmitError("", "failure capturing stdout", e);
+
+		return string.Empty;
+
+		string CaptureOutput()
+		{
+			var arguments = new StartArguments(binary, args)
+			{
+				WorkingDirectory = workingDirectory.FullName,
+				Timeout = TimeSpan.FromSeconds(3),
+				WaitForExit = TimeSpan.FromSeconds(3),
+				ConsoleOutWriter = NoopConsoleWriter.Instance
+			};
+			var result = Proc.Start(arguments);
+			var line = result.ExitCode != 0
+				? throw new Exception($"Exit code is not 0. Received {result.ExitCode} from {binary}: {workingDirectory}")
+				: result.ConsoleOut.FirstOrDefault()?.Line ?? throw new Exception($"No output captured for {binary}: {workingDirectory}");
+			return line;
+		}
+	}
+}

--- a/src/tooling/Elastic.Documentation.Tooling/ExternalCommands/ExternalCommandExecutor.cs
+++ b/src/tooling/Elastic.Documentation.Tooling/ExternalCommands/ExternalCommandExecutor.cs
@@ -58,7 +58,8 @@ public abstract class ExternalCommandExecutor(DiagnosticsCollector collector, ID
 			{
 				WorkingDirectory = workingDirectory.FullName,
 				Timeout = TimeSpan.FromSeconds(3),
-				WaitForExit = TimeSpan.FromSeconds(3)
+				WaitForExit = TimeSpan.FromSeconds(3),
+				ConsoleOutWriter = NoopConsoleWriter.Instance
 			};
 			var result = Proc.Start(arguments);
 			var output = result.ExitCode != 0

--- a/src/tooling/Elastic.Documentation.Tooling/ExternalCommands/ExternalCommandExecutor.cs
+++ b/src/tooling/Elastic.Documentation.Tooling/ExternalCommands/ExternalCommandExecutor.cs
@@ -5,6 +5,7 @@
 using System.IO.Abstractions;
 using Elastic.Documentation.Diagnostics;
 using ProcNet;
+using ProcNet.Std;
 
 namespace Elastic.Documentation.Tooling.ExternalCommands;
 
@@ -57,8 +58,7 @@ public abstract class ExternalCommandExecutor(DiagnosticsCollector collector, ID
 			{
 				WorkingDirectory = workingDirectory.FullName,
 				Timeout = TimeSpan.FromSeconds(3),
-				WaitForExit = TimeSpan.FromSeconds(3),
-				ConsoleOutWriter = NoopConsoleWriter.Instance
+				WaitForExit = TimeSpan.FromSeconds(3)
 			};
 			var result = Proc.Start(arguments);
 			var output = result.ExitCode != 0

--- a/src/tooling/Elastic.Documentation.Tooling/ExternalCommands/NoopConsoleWriter.cs
+++ b/src/tooling/Elastic.Documentation.Tooling/ExternalCommands/NoopConsoleWriter.cs
@@ -1,0 +1,16 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using ProcNet.Std;
+
+namespace Elastic.Documentation.Tooling.ExternalCommands;
+
+public class NoopConsoleWriter : IConsoleOutWriter
+{
+	public static readonly NoopConsoleWriter Instance = new();
+
+	public void Write(Exception e) { }
+
+	public void Write(ConsoleOut consoleOut) { }
+}

--- a/src/tooling/docs-assembler/Sourcing/GitFacade.cs
+++ b/src/tooling/docs-assembler/Sourcing/GitFacade.cs
@@ -4,7 +4,7 @@
 
 using System.IO.Abstractions;
 using Elastic.Documentation.Diagnostics;
-using ProcNet;
+using Elastic.Documentation.Tooling.ExternalCommands;
 
 namespace Documentation.Assembler.Sourcing;
 
@@ -24,12 +24,12 @@ public interface IGitRepository
 
 // This git repository implementation is optimized for pull and fetching single commits.
 // It uses `git pull --depth 1` and `git fetch --depth 1` to minimize the amount of data transferred.
-public class SingleCommitOptimizedGitRepository(DiagnosticsCollector collector, IDirectoryInfo workingDirectory) : IGitRepository
+public class SingleCommitOptimizedGitRepository(DiagnosticsCollector collector, IDirectoryInfo workingDirectory) : ExternalCommandExecutor(collector, workingDirectory), IGitRepository
 {
 	public string GetCurrentCommit() => Capture("git", "rev-parse", "HEAD");
 
 	public void Init() => ExecIn("git", "init");
-	public bool IsInitialized() => Directory.Exists(Path.Combine(workingDirectory.FullName, ".git"));
+	public bool IsInitialized() => Directory.Exists(Path.Combine(WorkingDirectory.FullName, ".git"));
 	public void Pull(string branch) => ExecIn("git", "pull", "--depth", "1", "--allow-unrelated-histories", "--no-ff", "origin", branch);
 	public void Fetch(string reference) => ExecIn("git", "fetch", "--no-tags", "--prune", "--no-recurse-submodules", "--depth", "1", "origin", reference);
 	public void EnableSparseCheckout(string folder) => ExecIn("git", "sparse-checkout", "set", folder);
@@ -37,60 +37,4 @@ public class SingleCommitOptimizedGitRepository(DiagnosticsCollector collector, 
 	public void Checkout(string reference) => ExecIn("git", "checkout", "--force", reference);
 
 	public void GitAddOrigin(string origin) => ExecIn("git", "remote", "add", "origin", origin);
-
-	private void ExecIn(string binary, params string[] args)
-	{
-		var arguments = new ExecArguments(binary, args)
-		{
-			WorkingDirectory = workingDirectory.FullName,
-			Environment = new Dictionary<string, string>
-			{
-				// Disable git editor prompts:
-				// There are cases where `git pull` would prompt for an editor to write a commit message.
-				// This env variable prevents that.
-				{ "GIT_EDITOR", "true" }
-			},
-		};
-		var result = Proc.Exec(arguments);
-		if (result != 0)
-			collector.EmitError("", $"Exit code: {result} while executing {binary} {string.Join(" ", args)} in {workingDirectory}");
-	}
-	private string Capture(string binary, params string[] args)
-	{
-		// Try 10 times to capture the output of the command, if it fails, we'll throw an exception on the last try
-		Exception? e = null;
-		for (var i = 0; i <= 9; i++)
-		{
-			try
-			{
-				return CaptureOutput();
-			}
-			catch (Exception ex)
-			{
-				if (ex is not null)
-					e = ex;
-			}
-		}
-
-		if (e is not null)
-			collector.EmitError("", "failure capturing stdout", e);
-
-		return string.Empty;
-
-		string CaptureOutput()
-		{
-			var arguments = new StartArguments(binary, args)
-			{
-				WorkingDirectory = workingDirectory.FullName,
-				Timeout = TimeSpan.FromSeconds(3),
-				WaitForExit = TimeSpan.FromSeconds(3),
-				ConsoleOutWriter = NoopConsoleWriter.Instance
-			};
-			var result = Proc.Start(arguments);
-			var line = result.ExitCode != 0
-				? throw new Exception($"Exit code is not 0. Received {result.ExitCode} from {binary}: {workingDirectory}")
-				: result.ConsoleOut.FirstOrDefault()?.Line ?? throw new Exception($"No output captured for {binary}: {workingDirectory}");
-			return line;
-		}
-	}
 }

--- a/src/tooling/docs-assembler/Sourcing/RepositorySourcesFetcher.cs
+++ b/src/tooling/docs-assembler/Sourcing/RepositorySourcesFetcher.cs
@@ -238,15 +238,6 @@ public class RepositorySourcer(ILoggerFactory logger, IDirectoryInfo checkoutDir
 	}
 }
 
-public class NoopConsoleWriter : IConsoleOutWriter
-{
-	public static readonly NoopConsoleWriter Instance = new();
-
-	public void Write(Exception e) { }
-
-	public void Write(ConsoleOut consoleOut) { }
-}
-
 public record CheckoutResult
 {
 	public static string LinkRegistrySnapshotFileName => "link-index.snapshot.json";

--- a/src/tooling/docs-builder/Program.cs
+++ b/src/tooling/docs-builder/Program.cs
@@ -18,5 +18,6 @@ ConsoleApp.ServiceProvider = serviceProvider;
 var app = ConsoleApp.Create();
 app.Add<Commands>();
 app.Add<InboundLinkCommands>("inbound-links");
+app.Add<LinkHealthCommands>("health");
 
 await app.RunAsync(args).ConfigureAwait(false);

--- a/src/tooling/docs-builder/Tracking/GitRepositoryTracker.cs
+++ b/src/tooling/docs-builder/Tracking/GitRepositoryTracker.cs
@@ -10,5 +10,15 @@ namespace Documentation.Builder.Tracking;
 
 public class GitRepositoryTracker(DiagnosticsCollector collector, IDirectoryInfo workingDirectory) : ExternalCommandExecutor(collector, workingDirectory), IRepositoryTracker
 {
-	public IEnumerable<string> GetChangedFiles() => CaptureMultiple("git", "diff", "--name-status", "main...HEAD", "--", "\"./docs\"");
+	public IEnumerable<string> GetChangedFiles()
+	{
+		var output = CaptureMultiple("git", "diff", "--name-status", "main...HEAD", "--", "./docs");
+		if (output.Length == 0)
+			return [];
+
+		var movedOrDeleted = output
+			.Where(line => line.StartsWith('R') || line.StartsWith('D'))
+			.Select(line => line.Split('\t')[1]);
+		return movedOrDeleted;
+	}
 }

--- a/src/tooling/docs-builder/Tracking/GitRepositoryTracker.cs
+++ b/src/tooling/docs-builder/Tracking/GitRepositoryTracker.cs
@@ -1,0 +1,14 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions;
+using Elastic.Documentation.Diagnostics;
+using Elastic.Documentation.Tooling.ExternalCommands;
+
+namespace Documentation.Builder.Tracking;
+
+public class GitRepositoryTracker(DiagnosticsCollector collector, IDirectoryInfo workingDirectory) : ExternalCommandExecutor(collector, workingDirectory), IRepositoryTracker
+{
+	public IEnumerable<string> GetChangedFiles() => CaptureMultiple("git", "diff", "--name-status", "main...HEAD", "--", "\"./docs\"");
+}

--- a/src/tooling/docs-builder/Tracking/GitRepositoryTracker.cs
+++ b/src/tooling/docs-builder/Tracking/GitRepositoryTracker.cs
@@ -3,12 +3,13 @@
 // See the LICENSE file in the project root for more information
 
 using System.IO.Abstractions;
+using System.Text.RegularExpressions;
 using Elastic.Documentation.Diagnostics;
 using Elastic.Documentation.Tooling.ExternalCommands;
 
 namespace Documentation.Builder.Tracking;
 
-public class GitRepositoryTracker(DiagnosticsCollector collector, IDirectoryInfo workingDirectory) : ExternalCommandExecutor(collector, workingDirectory), IRepositoryTracker
+public partial class GitRepositoryTracker(DiagnosticsCollector collector, IDirectoryInfo workingDirectory) : ExternalCommandExecutor(collector, workingDirectory), IRepositoryTracker
 {
 	public IEnumerable<string> GetChangedFiles()
 	{
@@ -18,7 +19,11 @@ public class GitRepositoryTracker(DiagnosticsCollector collector, IDirectoryInfo
 
 		var movedOrDeleted = output
 			.Where(line => line.StartsWith('R') || line.StartsWith('D'))
-			.Select(line => line.Split('\t')[1]);
+			.Select(line => line.Split('\t')[1])
+			.Select(line => DocsFolderRegex().Split(line)[1]);
 		return movedOrDeleted;
 	}
+
+	[GeneratedRegex("docs/")]
+	private static partial Regex DocsFolderRegex();
 }

--- a/src/tooling/docs-builder/Tracking/IRepositoryTracker.cs
+++ b/src/tooling/docs-builder/Tracking/IRepositoryTracker.cs
@@ -1,0 +1,10 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Documentation.Builder.Tracking;
+
+public interface IRepositoryTracker
+{
+	IEnumerable<string> GetChangedFiles();
+}


### PR DESCRIPTION
Closes #759 

This PR introduces a new subcommand for `docs-builder` under `health`: `validate-redirects`.

A corresponding CI action has been added and placed before document creation on `preview-build`.

As we have different interfaces on both `builder` and `assembler` now that leverage external commands, I saw fit to do a minor refactoring and move the functionality to a base class, and extended it to serve multiple-line outputs as well.