### PR TITLE
Publish beats docs from the `9.0` branch

### DIFF
--- a/src/tooling/docs-assembler/assembler.yml
+++ b/src/tooling/docs-assembler/assembler.yml
@@ -65,6 +65,8 @@ references:
   apm-aws-lambda:
   apm-k8s-attacher:
   beats:
+    current: "9.0"
+    next: main
   cloud-on-k8s:
   cloud:
     current: master


### PR DESCRIPTION
⚠️  Wait until https://github.com/elastic/beats/pull/44682 + backport are merged

Update assembler config to publish Beats documentation from the `9.0` branch. 

cc @belimawr 