### PR TITLE
Publish logstash docs from the 9.0 branch

### DIFF
--- a/src/tooling/docs-assembler/assembler.yml
+++ b/src/tooling/docs-assembler/assembler.yml
@@ -106,6 +106,8 @@ references:
   kibana:
   logstash-docs-md:
   logstash:
+    current: "9.0"
+    next: main
   opentelemetry:
   search-ui:
   integration-docs:


### PR DESCRIPTION
Related: 
- https://github.com/elastic/docs-projects/issues/490
- https://github.com/elastic/logstash/issues/17701
- #1345

Update assembler config to publish Logstash documentation from the 9.0 branch.

DO NOT MERGE yet