### PR TITLE
Allow specifying which version to install

### DIFF
--- a/docs/contribute/locally.md
+++ b/docs/contribute/locally.md
@@ -39,6 +39,11 @@ This guide uses the first option. If you'd like to clone the repository and buil
    ```
    
    This downloads the latest binary, makes it executable, and installs it to your user PATH.
+   You can optionally specify a specific version to install:
+
+   ```sh
+   DOCS_BUILDER_VERSION=0.40.0 curl -sL https://ela.st/docs-builder-install | sh
+   ```
 
    To download and install the binary file manually, refer to [Releases](https://github.com/elastic/docs-builder/releases) on GitHub.
 
@@ -68,6 +73,11 @@ If you get a `Permission denied` error, make sure that you aren't trying to run 
    ```
 
    This downloads the latest binary, makes it executable, and installs it to your user PATH.
+   You can optionally specify a specific version to install:
+
+   ```powershell
+   $env:DOCS_BUILDER_VERSION = '0.40.0'; iwr -useb https://ela.st/docs-builder-install.ps1 | iex
+   ```
 
    To download and install the binary file manually, refer to [Releases](https://github.com/elastic/docs-builder/releases) on GitHub.
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,8 +1,11 @@
 # PowerShell script to install docs-builder binary
 
 # Use AppData\Local for user-specific installation instead of Program Files
-$targetDir = Join-Path -Path $env:LOCALAPPDATA -ChildPath "docs-builder"
+$targetDir  = Join-Path -Path $env:LOCALAPPDATA -ChildPath "docs-builder"
 $targetPath = Join-Path -Path $targetDir -ChildPath "docs-builder.exe"
+
+$version = $env:DOCS_BUILDER_VERSION
+if (-not $version) { $version = 'latest' }
 
 # Check if docs-builder already exists
 if (Test-Path -Path $targetPath) {
@@ -20,10 +23,15 @@ if (-not (Test-Path -Path $targetDir)) {
     New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
 }
 
-# Download the latest Windows binary from releases
+if ($version -eq 'latest') {
+    $downloadUrl = "https://github.com/elastic/docs-builder/releases/latest/download/docs-builder-win-x64.zip"
+} else {
+    $downloadUrl = "https://github.com/elastic/docs-builder/releases/download/$version/docs-builder-win-x64.zip"
+}
+
 $tempZipPath = "$env:TEMP\docs-builder-win-x64.zip"
 Write-Host "Downloading docs-builder binary..."
-Invoke-WebRequest -Uri "https://github.com/elastic/docs-builder/releases/latest/download/docs-builder-win-x64.zip" -OutFile $tempZipPath
+Invoke-WebRequest -Uri $downloadUrl -OutFile $tempZipPath
 
 # Create a temporary directory for extraction
 $tempExtractPath = "$env:TEMP\docs-builder-extract"
@@ -53,8 +61,8 @@ if ($currentPath -notlike "*$targetDir*") {
 }
 
 # Clean up temporary files
-Remove-Item -Path $tempZipPath -Force
+Remove-Item -Path $tempZipPath    -Force
 Remove-Item -Path $tempExtractPath -Recurse -Force
 
-Write-Host "docs-builder has been installed successfully and is available in your PATH."
+Write-Host "docs-builder ($version) has been installed successfully and is available in your PATH."
 Write-Host "You may need to restart your terminal or PowerShell session for the PATH changes to take effect."

--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,8 @@ elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
   ARCH="arm64"
 fi
 
+VERSION="${DOCS_BUILDER_VERSION:-latest}"
+
 # Determine binary to download based on OS
 if [ "$OS" = "darwin" ]; then
   BINARY="docs-builder-mac-$ARCH.zip"
@@ -55,8 +57,14 @@ fi
 
 echo "Downloading docs-builder for $OS/$ARCH..."
 
+if [ "$VERSION" = "latest" ]; then
+  DOWNLOAD_URL="https://github.com/elastic/docs-builder/releases/latest/download/$BINARY"
+else
+  DOWNLOAD_URL="https://github.com/elastic/docs-builder/releases/download/$VERSION/$BINARY"
+fi
+
 # Download the appropriate binary
-if ! curl -LO "https://github.com/elastic/docs-builder/releases/latest/download/$BINARY"; then
+if ! curl -LO "$DOWNLOAD_URL"; then
   echo "Error: Failed to download $BINARY. Please check your internet connection."
   exit 1
 fi
@@ -87,5 +95,5 @@ fi
 # Clean up the downloaded zip file
 rm -f "$BINARY"
 
-echo "docs-builder has been installed successfully and is available in your PATH."
+echo "docs-builder ($VERSION) has been installed successfully and is available in your PATH."
 echo "You can run 'docs-builder --help' to see available commands."


### PR DESCRIPTION
We have a couple folks that are blocked because the current release of docs-builder is broken. They're unsure how to go about installing a previous version. This fix allows a specific version to be specified if necessary but defaults to latest.