### PR TITLE
Add new product to product list

### DIFF
--- a/docs/syntax/frontmatter.md
+++ b/docs/syntax/frontmatter.md
@@ -61,6 +61,7 @@ The products frontmatter is a list of objects, each object has an `id` field.
 | `cloud-terraform`                           | Elastic Cloud Terraform                       |
 | `ecs`                                       | Elastic Common Schema (ECS)                   |
 | `ecs-logging`                               | ECS Logging                                   |
+| `edot-cf`                                   | EDOT Cloud Forwarder                          |
 | `edot-sdk`                                  | Elastic Distribution of OpenTelemetry SDK     |
 | `edot-collector`                            | Elastic Distribution of OpenTelemetry Collector |
 | `elastic-agent`                             | Elastic Agent                                 |

--- a/src/Elastic.Documentation.Configuration/Builder/Products.cs
+++ b/src/Elastic.Documentation.Configuration/Builder/Products.cs
@@ -23,6 +23,7 @@ public static class Products
 		new("cloud-terraform", "Elastic Cloud Terraform"),
 		new("ecs", "Elastic Common Schema (ECS)"),
 		new("ecs-logging", "ECS Logging"),
+		new("edot-cf", "EDOT Cloud Forwarder"),
 		new("edot-sdk", "Elastic Distribution of OpenTelemetry SDK"),
 		new("edot-collector", "Elastic Distribution of OpenTelemetry Collector"),
 		new("elastic-agent", "Elastic Agent"),


### PR DESCRIPTION
This adds the EDOT Cloud Forwarder `product` to the list and the docs. It's a different EDOT family of ingest solutions.

See https://github.com/elastic/edot-cloud-forwarder-aws (slated to launch for 9.1 in its first iteration for AWS).