### PR TITLE
Fix `docs-builder serve` command

### DIFF
--- a/src/Elastic.Documentation.Site/FileProviders/EmbeddedOrPhysicalFileProvider.cs
+++ b/src/Elastic.Documentation.Site/FileProviders/EmbeddedOrPhysicalFileProvider.cs
@@ -10,7 +10,7 @@ namespace Elastic.Documentation.Site.FileProviders;
 
 public sealed class EmbeddedOrPhysicalFileProvider : IFileProvider, IDisposable
 {
-	private readonly EmbeddedFileProvider _embeddedProvider = new(typeof(IDocumentationContext).Assembly, "Elastic.Documentation.Site._static");
+	private readonly EmbeddedFileProvider _embeddedProvider = new(typeof(EmbeddedOrPhysicalFileProvider).Assembly, "Elastic.Documentation.Site._static");
 	private readonly PhysicalFileProvider? _staticFilesInDocsFolder;
 
 	private readonly PhysicalFileProvider? _staticWebFilesDuringDebug;


### PR DESCRIPTION
Closes https://github.com/elastic/docs-builder/issues/1355

## How to test

1. Create binaries with `./build.sh publishzip`
2. Go to the release folder and unzip the zip file
   ```
   cd .artifacts/publish/docs-builder/release
   unzip docs-builder-mac-arm64.zip
   ```
3. Use the unzipped binary to run `docs-builder serve`