### PR TITLE
Fix dropdown notice pt2

### DIFF
--- a/src/tooling/docs-assembler/Legacy/PageLegacyUrlMapper.cs
+++ b/src/tooling/docs-assembler/Legacy/PageLegacyUrlMapper.cs
@@ -18,10 +18,10 @@ public record PageLegacyUrlMapper : ILegacyUrlMapper
 		LegacyPageChecker = legacyPageChecker;
 	}
 
-	public IReadOnlyCollection<LegacyPageMapping> MapLegacyUrl(IReadOnlyCollection<string>? mappedPages)
+	public IReadOnlyCollection<LegacyPageMapping>? MapLegacyUrl(IReadOnlyCollection<string>? mappedPages)
 	{
 		if (mappedPages is null)
-			return [];
+			return null;
 
 		if (mappedPages.Count == 0)
 			return [new LegacyPageMapping(mappedPages.FirstOrDefault() ?? string.Empty, string.Empty, false)];


### PR DESCRIPTION
Fix for the changes introduced in https://github.com/elastic/docs-builder/pull/1381.

Without this, the legacy paging would never be `null`. Hence, the condition in the view would never trigger.