### PR TITLE
Add current version meta tag

### DIFF
--- a/src/Elastic.Markdown/Slices/Index.cshtml
+++ b/src/Elastic.Markdown/Slices/Index.cshtml
@@ -36,13 +36,17 @@
 	};
 	protected override Task ExecuteSectionAsync(string name)
 	{
+		if (name == GlobalSections.Head)
+		{
+			<meta class="elastic" name="product_version" content="@Model.CurrentVersion"/>
+			<meta name="DC.identifier" content="@Model.CurrentVersion"/>
+		}
 		if (name == GlobalSections.Head && Model.Products is { Count: > 0 })
 		{
 			var products = string.Join(",", Model.Products.Select(p => p.DisplayName));
 			<meta class="elastic" name="product_name" content="@(products)"/>
 			<meta name="DC.subject" content="@(products)"/>
 		}
-
 		return Task.CompletedTask;
 	}
 }


### PR DESCRIPTION
This pull request introduces a minor enhancement to the `ExecuteSectionAsync` method in `src/Elastic.Markdown/Slices/Index.cshtml`. The change adds metadata tags for product version (`product_version`) and identifier (`DC.identifier`) when the `GlobalSections.Head` section is rendered.