### PR TITLE
Remove hardcoded root breadcrumb

### DIFF
--- a/src/Elastic.Markdown/Slices/Layout/_Breadcrumbs.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_Breadcrumbs.cshtml
@@ -12,21 +12,9 @@
 }
 
 <ol id="breadcrumbs" class="block items-center w-full py-6" itemscope="" itemtype="https://schema.org/BreadcrumbList">
-	<li class="inline text-ink-light text-sm leading-[1.2em]" itemprop="itemListElement" itemscope="" itemtype="https://schema.org/ListItem">
-		<a
-			itemprop="item"
-			href="@Model.Link("/")"
-		>
-			<span itemprop="name" class="hover:text-black">
-				Docs
-			</span>
-		</a>
-		<meta itemprop="position" content="1">
-	</li>
 	@if (firstCrumb != null)
 	{
 		<li class="inline text-ink-light text-sm leading-[1.2em]" itemprop="itemListElement" itemscope="" itemtype="https://schema.org/ListItem">
-			<span class="px-1">/</span>
 			<a
 				itemprop="item"
 				href="@firstCrumb.Url"
@@ -34,7 +22,7 @@
 			>
 				<span itemprop="name" class="hover:text-black">@firstCrumb.NavigationTitle</span>
 			</a>
-			<meta itemprop="position" content="2">
+			<meta itemprop="position" content="1">
 		</li>
 	}
 	@if (crumbs.Count > 0 && parents.Count > 3)
@@ -57,7 +45,7 @@
 			>
 				<span itemprop="name" class="hover:text-black">@item.NavigationTitle</span>
 			</a>
-			<meta itemprop="position" content="@(i+3)">
+			<meta itemprop="position" content="@(i+2)">
 		</li>
 	}
 	<li class="inline text-ink-light text-sm leading-[1.2em]" itemprop="itemListElement" itemscope="" itemtype="https://schema.org/ListItem">


### PR DESCRIPTION
## Context

It's not needed anymore since the navigation refactoring

Currently it looks likes this on https://www.elastic.co/docs/cloud-account/add-a-login-method

<img width="538" alt="image" src="https://github.com/user-attachments/assets/ef46c618-390e-473c-abc6-7f93d1163255" />

## Changes

Removes the hardcoded root breadcrumb
