### PR TITLE
Replace APM agents with OpenTelemetry in landing page

### DIFF
--- a/src/Elastic.Markdown/Slices/Layout/_LandingPage.cshtml
+++ b/src/Elastic.Markdown/Slices/Layout/_LandingPage.cshtml
@@ -188,10 +188,10 @@
 					</div>
 				</div>
 				<div class="flex flex-col rounded-xl bg-white">
-					<h3 class="font-sans font-bold text-ink-dark text-2xl">APM agents</h3>
-					<p class="grow mt-3">Browse the APM agent docs for RUM JavaScript, Java, .NET, and more.</p>
+					<h3 class="font-sans font-bold text-ink-dark text-2xl">OpenTelemetry</h3>
+					<p class="grow mt-3">Browse the docs for the Elastic Distributions of OpenTelemetry (EDOT).</p>
 					<div class="mt-6">
-						<a href="@Model.Link("/reference/apm-agents/")" class="link">
+						<a href="@Model.Link("/reference/opentelemetry/")" class="link">
 							View docs
 						</a>
 					</div>


### PR DESCRIPTION
This replaces the "APM agents" box of the https://www.elastic.co/docs with "OpenTelemetry", linking to the EDOT reference documentation. Strategically, this is where we want to go; it's a small step in a long walk of changes we have to make. 

Whether it's the right time to do so right now can be debated, of course. I would argue that it's more symbolic than anything, with very limited impact on clicks. Symbolically, it's significant.

Before going forward, I'd like to hear from @colleenmcginnis @bmorelli25.