### PR TITLE
Add preview links comment to PRs

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -239,7 +239,7 @@ jobs:
           
       - name: Comment on PR
         continue-on-error: true
-        if: inputs.disable-comments != 'true' && env.MATCH == 'true' && steps.deployment.outputs.result && steps.check-files.outputs.all_changed_files
+        if: startsWith(github.event_name, 'pull_request') && inputs.disable-comments != 'true' && env.MATCH == 'true' && steps.deployment.outputs.result && steps.check-files.outputs.all_changed_files
         uses: actions/github-script@v7
         env:
           ALL_CHANGED_FILES: ${{ steps.check-files.outputs.all_changed_files }}


### PR DESCRIPTION
Closes https://github.com/elastic/docs-builder/issues/1395

## Changes

When the upload to s3 completes, comment on the PR with a list of changed files.

## Related Issues

- Depends on linked PRs in https://github.com/elastic/docs-builder/issues/1395 to be merged. (Adding the `pull-requests: write` permission)

