### PR TITLE
Update `NavigationPrefixChecker` to skip phantom paths during link resolution.

### DIFF
--- a/src/tooling/docs-assembler/Links/NavigationPrefixChecker.cs
+++ b/src/tooling/docs-assembler/Links/NavigationPrefixChecker.cs
@@ -98,7 +98,7 @@ public class NavigationPrefixChecker
 
 			// Todo publish all relative folders as part of the link reference
 			// That way we don't need to iterate over all links and find all permutations of their relative paths
-			foreach (var (relativeLink, _) in linkReference.Links)
+			foreach (var (relativeLink, linkMetadata) in linkReference.Links)
 			{
 				var navigationPaths = _uriResolver.ResolveToSubPaths(new Uri($"{repository}://{relativeLink}"), relativeLink);
 				foreach (var navigationPath in navigationPaths)
@@ -116,6 +116,9 @@ public class NavigationPrefixChecker
 					}
 					else
 					{
+						if (_phantoms.Count > 0 && _phantoms.Contains(new Uri($"{repository}://{navigationPath}")))
+							continue;
+
 						dictionary.Add(navigationPath, new SeenPaths
 						{
 							Repository = repository,


### PR DESCRIPTION
We need to do this on both branches as otherwise it requires a certain order for phantom branches to not be validated.

Fixes: https://github.com/elastic/elastic-otel-node/actions/runs/15825603447/job/44606696330

The check was failing unrelated to anything `elastic-otel-node`. Our check relied on `elasticsearch://reference` being checked before `docs-content://reference` but in the current iteration of the links.json checks this did not happen because our dictionaries are unordered (as they should be).