### PR TITLE
Use `content_soure: current` for edge environment

### DIFF
--- a/src/tooling/docs-assembler/assembler.yml
+++ b/src/tooling/docs-assembler/assembler.yml
@@ -20,7 +20,7 @@ environments:
   edge: 
     uri: https://d34ipnu52o64md.cloudfront.net
     path_prefix: docs
-    content_source: next
+    content_source: current
     google_tag_manager:
       enabled: false
   dev:


### PR DESCRIPTION
So it's closer to the `prod` environment.