### PR TITLE
Remove deprecated `legacy_versions` property

### DIFF
--- a/src/Elastic.Documentation.Configuration/Assembler/VersionEntry.cs
+++ b/src/Elastic.Documentation.Configuration/Assembler/VersionEntry.cs
@@ -13,7 +13,4 @@ public record VersionEntry
 
 	[YamlMember(Alias = "current")]
 	public string? Current { get; set; }
-
-	[YamlMember(Alias = "legacy_versions")]
-	public IReadOnlyList<string> LegacyVersions { get; set; } = [];
 }


### PR DESCRIPTION
We kept the legacy versions in the legacy-url-mapping config.