### PR TITLE
Simplify version dropdown messaging for external users

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/web-components/VersionDropdown.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/VersionDropdown.tsx
@@ -172,8 +172,8 @@ const VersionDropdown = ({
                               renderItem: () => (
                                   <EuiPanel paddingSize="s" hasShadow={false}>
                                       <EuiText size="xs" color="subdued">
-                                          This page was fully migrated to the
-                                          current version.
+                                          There are no other versions available
+                                          for this page.
                                       </EuiText>
                                   </EuiPanel>
                               ),


### PR DESCRIPTION
The current messaging talks about pages being migrated, which may be confusing for external users. We can use the same message as in the other case a few lines above.

IMO, there are only 2 cases from a messaging standpoint:
- There is another version of this page that exists --> Show these versions
- There is not --> Indicate that there is not