### PR TITLE
Fix crosslinks

### DIFF
--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -185,8 +185,8 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 		if (context.CrossLinkResolver.TryResolve(
 				s => processor.EmitError(link, s),
 				uri, out var resolvedUri)
-		   )
-			link.Url = resolvedUri.AbsolutePath;
+			 )
+			link.Url = resolvedUri.ToString();
 	}
 
 	private static void ProcessInternalLink(LinkInline link, InlineProcessor processor, ParserContext context)

--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -185,8 +185,8 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 		if (context.CrossLinkResolver.TryResolve(
 				s => processor.EmitError(link, s),
 				uri, out var resolvedUri)
-			 )
-			link.Url = resolvedUri.ToString();
+		   )
+			link.Url = resolvedUri.AbsolutePath;
 	}
 
 	private static void ProcessInternalLink(LinkInline link, InlineProcessor processor, ParserContext context)

--- a/src/Elastic.Markdown/Myst/Renderers/HtmxLinkInlineRenderer.cs
+++ b/src/Elastic.Markdown/Myst/Renderers/HtmxLinkInlineRenderer.cs
@@ -41,11 +41,11 @@ public class HtmxLinkInlineRenderer : LinkInlineRenderer
 			{
 				var currentRootNavigation = link.GetData(nameof(MarkdownFile.NavigationRoot)) as INodeNavigationItem<INavigationModel, INavigationItem>;
 				var targetRootNavigation = link.GetData($"Target{nameof(MarkdownFile.NavigationRoot)}") as INodeNavigationItem<INavigationModel, INavigationItem>;
-				var hasSameTopLevelGroup = !isCrossLink && (currentRootNavigation?.Id == targetRootNavigation?.Id);
+				var hasSameTopLevelGroup = !isCrossLink && currentRootNavigation?.Id == targetRootNavigation?.Id;
 				_ = renderer.Write($" hx-select-oob=\"{Htmx.GetHxSelectOob(hasSameTopLevelGroup)}\"");
 				_ = renderer.Write($" preload=\"{Htmx.Preload}\"");
 			}
-			if (isHttpLink && !isCrossLink)
+			if (isHttpLink)
 			{
 				_ = renderer.Write(" target=\"_blank\"");
 				_ = renderer.Write(" rel=\"noopener noreferrer\"");

--- a/src/Elastic.Markdown/Myst/Renderers/HtmxLinkInlineRenderer.cs
+++ b/src/Elastic.Markdown/Myst/Renderers/HtmxLinkInlineRenderer.cs
@@ -37,15 +37,15 @@ public class HtmxLinkInlineRenderer : LinkInlineRenderer
 			_ = renderer.Write('"');
 			_ = renderer.WriteAttributes(link);
 
-			if (link.Url?.StartsWith('/') == true)
+			if (link.Url?.StartsWith('/') == true || isCrossLink)
 			{
 				var currentRootNavigation = link.GetData(nameof(MarkdownFile.NavigationRoot)) as INodeNavigationItem<INavigationModel, INavigationItem>;
 				var targetRootNavigation = link.GetData($"Target{nameof(MarkdownFile.NavigationRoot)}") as INodeNavigationItem<INavigationModel, INavigationItem>;
-				var hasSameTopLevelGroup = !isCrossLink && currentRootNavigation?.Id == targetRootNavigation?.Id;
+				var hasSameTopLevelGroup = !isCrossLink && (currentRootNavigation?.Id == targetRootNavigation?.Id);
 				_ = renderer.Write($" hx-select-oob=\"{Htmx.GetHxSelectOob(hasSameTopLevelGroup)}\"");
 				_ = renderer.Write($" preload=\"{Htmx.Preload}\"");
 			}
-			if (isHttpLink)
+			if (isHttpLink && !isCrossLink)
 			{
 				_ = renderer.Write(" target=\"_blank\"");
 				_ = renderer.Write(" rel=\"noopener noreferrer\"");

--- a/src/Elastic.Markdown/Myst/Renderers/WrappedTableRenderer.cs
+++ b/src/Elastic.Markdown/Myst/Renderers/WrappedTableRenderer.cs
@@ -12,7 +12,7 @@ public class WrappedTableRenderer : HtmlTableRenderer
 	protected override void Write(HtmlRenderer renderer, Table table)
 	{
 		// Wrap the table in a div to allow for overflow scrolling
-		_ = renderer.Write("<div class=\"table-wrapper\" hx-disable=\"true\">");
+		_ = renderer.Write("<div class=\"table-wrapper\">");
 		base.Write(renderer, table);
 		_ = renderer.Write("</div>");
 	}

--- a/tests/Elastic.Markdown.Tests/Inline/InlineLinkTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/InlineLinkTests.cs
@@ -150,7 +150,7 @@ public class CrossLinkTest(ITestOutputHelper output) : LinkTestBase(output,
 	public void GeneratesHtml() =>
 		// language=html
 		Html.Should().Contain(
-			"""<p>Go to <a href="https://docs-v3-preview.elastic.dev/elastic/kibana/tree/main/">test</a></p>"""
+			"""<p>Go to <a href="https://docs-v3-preview.elastic.dev/elastic/kibana/tree/main/" hx-select-oob="#main-container" preload="mousedown">test</a></p>"""
 		);
 
 	[Fact]


### PR DESCRIPTION
## Context

Crosslinks resolved to an absolute URL including the domain. The logic in our parser renderer did not consider this.

## Changes

Also add htmx attributes to crosslinks.