### PR TITLE
Fix `applies_to` rendering

### DIFF
--- a/docs/testing/req.md
+++ b/docs/testing/req.md
@@ -30,6 +30,7 @@ Current version: **9.0.0**
 | `` {applies_to}`stack: removed 9.0` ``     | {applies_to}`stack: removed 9.0`     |
 | `` {applies_to}`stack: removed 9.1` ``     | {applies_to}`stack: removed 9.1`     |
 | `` {applies_to}`stack: ` ``                | {applies_to}`stack: `                |
+
 {applies_to}`stack: deprecated 9.1, removed 9.4`
 
 

--- a/docs/testing/req.md
+++ b/docs/testing/req.md
@@ -30,7 +30,6 @@ Current version: **9.0.0**
 | `` {applies_to}`stack: removed 9.0` ``     | {applies_to}`stack: removed 9.0`     |
 | `` {applies_to}`stack: removed 9.1` ``     | {applies_to}`stack: removed 9.1`     |
 | `` {applies_to}`stack: ` ``                | {applies_to}`stack: `                |
-
 {applies_to}`stack: deprecated 9.1, removed 9.4`
 
 

--- a/src/Elastic.Markdown/Myst/Components/ApplicableToComponent.cshtml
+++ b/src/Elastic.Markdown/Myst/Components/ApplicableToComponent.cshtml
@@ -145,14 +145,7 @@
 			
 			var lifecycleClass = applicability.GetLifeCycleName().ToLowerInvariant().Replace(" ", "-");
 			<span class="applicable-info" data-tippy-content="@tooltip">
-				@if (name == "Elastic Stack")
-				{
-					@badgeText
-				}
-				else
-				{
 					@name
-				}
 				<span class="applicable-meta applicable-meta-@lifecycleClass">
 				@if (applicability.Lifecycle != ProductLifecycle.GenerallyAvailable && badgeText == name)
 				{
@@ -160,17 +153,16 @@
 				}
 				@if (applicability.Version is not null and not AllVersions)
 				{
-					if (name == "Elastic Stack")
-					{
-						if (applicability.Version <= currentStackVersion)
+					<span class="applicable-version applicable-version-@lifecycleClass">
+						@if (applicability.Version <= currentStackVersion)
 						{
-							<span class="applicable-version applicable-version-@lifecycleClass">@applicability.Version</span>
+							@applicability.Version
 						}
-					}
-					else
-					{
-						<span class="applicable-version applicable-version-@lifecycleClass">@applicability.Version</span>
-					}
+						else
+						{
+							@badgeText
+						}
+					</span>
 				}
 				</span>
 			</span>

--- a/src/Elastic.Markdown/Myst/Components/ApplicableToComponent.cshtml
+++ b/src/Elastic.Markdown/Myst/Components/ApplicableToComponent.cshtml
@@ -153,16 +153,18 @@
 				}
 				@if (applicability.Version is not null and not AllVersions)
 				{
-					<span class="applicable-version applicable-version-@lifecycleClass">
 						@if (name != "Elastic Stack" || applicability.Version <= currentStackVersion)
 						{
-							@applicability.Version
+							<span class="applicable-version applicable-version-@lifecycleClass">
+								@applicability.Version
+							</span>
 						}
 						else
 						{
-							@badgeText
+							<span class="applicable-lifecycle applicable-lifecycle-@lifecycleClass">
+								@badgeText
+							</span>
 						}
-					</span>
 				}
 				</span>
 			</span>

--- a/src/Elastic.Markdown/Myst/Components/ApplicableToComponent.cshtml
+++ b/src/Elastic.Markdown/Myst/Components/ApplicableToComponent.cshtml
@@ -154,7 +154,7 @@
 				@if (applicability.Version is not null and not AllVersions)
 				{
 					<span class="applicable-version applicable-version-@lifecycleClass">
-						@if (applicability.Version <= currentStackVersion)
+						@if (name != "Elastic Stack" || applicability.Version <= currentStackVersion)
 						{
 							@applicability.Version
 						}

--- a/tests/authoring/Inline/AppliesToRole.fs
+++ b/tests/authoring/Inline/AppliesToRole.fs
@@ -29,18 +29,17 @@ This is an inline {applies_to}`stack: preview 9.1` element.
     let ``validate HTML: generates link and alt attr`` () =
         markdown |> convertsToHtml """
         <p>This is an inline
-            <span class="applies-inline">
-                <span class="applicable-info" data-tippy-content="We plan to add this functionality in a future update. Plans may change without notice.">
-                    Elastic Stack
-                    <span class="applicable-meta applicable-meta-technical-preview">
-                        <span class="applicable-version applicable-version-technical-preview">
- 					        Planned
- 				        </span>
-                    </span>
-                </span>
-            </span>
-            element.
-        </p>
+	        <span class="applies-inline">
+		        <span class="applicable-info" data-tippy-content="We plan to add this functionality in a future update. Plans may change without notice.">
+			        Elastic Stack
+			        <span class="applicable-meta applicable-meta-technical-preview">
+				        <span class="applicable-lifecycle applicable-lifecycle-technical-preview">
+					        Planned
+				        </span>
+			        </span>
+		        </span>
+	        </span>
+	        element.</p>
         """
 
 

--- a/tests/authoring/Inline/AppliesToRole.fs
+++ b/tests/authoring/Inline/AppliesToRole.fs
@@ -31,8 +31,11 @@ This is an inline {applies_to}`stack: preview 9.1` element.
         <p>This is an inline
             <span class="applies-inline">
                 <span class="applicable-info" data-tippy-content="We plan to add this functionality in a future update. Plans may change without notice.">
-                    Planned
+                    Elastic Stack
                     <span class="applicable-meta applicable-meta-technical-preview">
+                        <span class="applicable-version applicable-version-technical-preview">
+ 					        Planned
+ 				        </span>
                     </span>
                 </span>
             </span>


### PR DESCRIPTION
## Changes

Also show the applies_to key for Planned status

<img width="853" alt="image" src="https://github.com/user-attachments/assets/dbadc2f2-ab3d-424d-87bf-680860caf639" />

