### PR TITLE
Fix rendering of `DC.identifier` and `product_version` meta tag

### DIFF
--- a/src/Elastic.Markdown/Page/Index.cshtml
+++ b/src/Elastic.Markdown/Page/Index.cshtml
@@ -44,8 +44,8 @@
 	{
 		if (name == GlobalSections.Head)
 		{
-			<meta class="elastic" name="product_version" content="@Model.CurrentVersion"/>
-			<meta name="DC.identifier" content="@Model.CurrentVersion"/>
+			<meta class="elastic" name="product_version" content="@(new HtmlString(Model.CurrentVersion))"/>
+			<meta name="DC.identifier" content="@(new HtmlString(Model.CurrentVersion))"/>
 		}
 		if (name == GlobalSections.Head && Model.Products is { Count: > 0 })
 		{


### PR DESCRIPTION
It's currently rendering the `+` as hex code.

<img width="609" alt="image" src="https://github.com/user-attachments/assets/a2b68219-e272-49a4-ad91-81758a878052" />

this should fix it to 

```html
<meta class="elastic" name="product_name" content="9.0+"/>
<meta name="DC.subject" content="9.0+"/>
```