### PR TITLE
Add semantic headings to stepper component

### DIFF
--- a/docs/contribute/locally.md
+++ b/docs/contribute/locally.md
@@ -105,7 +105,7 @@ In this guide, we'll clone the [`docs-content`](https://github.com/elastic/docs-
 git clone https://github.com/elastic/docs-content.git
 ```
 
-### Serve the documentation [#step-three]
+## Serve the documentation [#step-three]
 
 Static-site generators like docs-builder can serve docs locally. This means you can edit the source and see the result in the browser in real time.
 

--- a/docs/contribute/locally.md
+++ b/docs/contribute/locally.md
@@ -105,7 +105,7 @@ In this guide, we'll clone the [`docs-content`](https://github.com/elastic/docs-
 git clone https://github.com/elastic/docs-content.git
 ```
 
-## Serve the documentation [#step-three]
+### Serve the documentation [#step-three]
 
 Static-site generators like docs-builder can serve docs locally. This means you can edit the source and see the result in the browser in real time.
 

--- a/docs/syntax/stepper.md
+++ b/docs/syntax/stepper.md
@@ -6,7 +6,7 @@ to break down processes into manageable stages.
 By default every step title is a link with a generated anchor.
 But you can override the default anchor by adding the `:anchor:` option to the step.
 
-## Basic Stepper
+## Basic stepper
 
 :::::::{tab-set}
 ::::::{tab-item} Output
@@ -75,7 +75,7 @@ npm run test
 
 :::::::
 
-## Advanced Example
+## Advanced example
 
 :::::::{tab-set}
 
@@ -202,23 +202,13 @@ To see how dynamic mapping works, add a new document to the `books` index with a
 
 :::::::
 
-## Table of Contents Integration
+## Table of contents integration
 
 Stepper step titles automatically appear in the page's "On this page" table of contents (ToC) sidebar, making it easier for users to navigate directly to specific steps.
 
-### How it works
-
-- **Automatic inclusion**: Step titles are automatically detected and added to the ToC during document parsing.
-- **Proper nesting**: Steps appear as sub-items under their parent section heading with appropriate indentation.
-- **Clickable navigation**: Users can click on step titles in the ToC to jump directly to that step.
-
 ### Nested steppers
 
-When steppers are nested inside other directive components (like `{tab-set}`, `{dropdown}`, or other containers), their step titles are **not** included in the ToC to avoid:
-
-- Duplicate or competing headings across multiple tabs
-- Links to content that might be collapsed or hidden
-- General confusion about content hierarchy
+When steppers are nested inside other directive components (like `{tab-set}`, `{dropdown}`, or other containers), their step titles are **not** included in the ToC to avoid duplicate or competing headings across multiple tabs or links to content that might be collapsed or hidden.
 
 **Example of excluded stepper:**
 ```markdown
@@ -232,57 +222,6 @@ Content here...
 :::
 ::::
 ```
-
-**Example of included stepper:**
-```markdown
-## Installation Guide
-
-::::{stepper}
-:::{step} Download
-Download the software...
-:::
-
-:::{step} Install  
-Run the installer...
-:::
-::::
-```
-
-In the second example, both "Download" and "Install" steps will appear in the ToC as sub-items under "Installation Guide".
-
 ## Dynamic heading levels
 
 Stepper step titles automatically adjust their heading level based on the preceding heading in the document, ensuring proper document hierarchy and semantic structure.
-
-### Examples
-
-**Stepper after H2 heading:**
-```markdown
-## Installation Guide
-
-::::{stepper}
-:::{step} Download
-Step titles render as H3 (visible in ToC)
-:::
-::::
-```
-
-**Stepper after H3 heading:**
-```markdown
-### Setup Process
-
-::::{stepper}
-:::{step} Configure
-Step titles render as H4 (not in ToC, but proper hierarchy)
-:::
-::::
-```
-
-**Stepper with no preceding heading:**
-```markdown
-::::{stepper}
-:::{step} First Step
-Step titles default to H2 level
-:::
-::::
-```

--- a/docs/syntax/stepper.md
+++ b/docs/syntax/stepper.md
@@ -12,8 +12,6 @@ But you can override the default anchor by adding the `:anchor:` option to the s
 ::::::{tab-item} Output
 :::::{stepper}
 
-:::::{stepper}
-
 ::::{step} Install
 First install the dependencies.
 ```shell
@@ -203,3 +201,51 @@ To see how dynamic mapping works, add a new document to the `books` index with a
 ::::::
 
 :::::::
+
+## Table of Contents Integration
+
+Stepper step titles automatically appear in the page's "On this page" table of contents (ToC) sidebar, making it easier for users to navigate directly to specific steps.
+
+### How it works
+
+- **Automatic inclusion**: Step titles are automatically detected and added to the ToC during document parsing.
+- **Proper nesting**: Steps appear as sub-items under their parent section heading with appropriate indentation.
+- **Clickable navigation**: Users can click on step titles in the ToC to jump directly to that step.
+
+### Nested steppers
+
+When steppers are nested inside other directive components (like `{tab-set}`, `{dropdown}`, or other containers), their step titles are **not** included in the ToC to avoid:
+
+- Duplicate or competing headings across multiple tabs
+- Links to content that might be collapsed or hidden
+- General confusion about content hierarchy
+
+**Example of excluded stepper:**
+```markdown
+::::{tab-set}
+:::{tab-item} Tab 1
+::{stepper}
+:{step} This step won't appear in ToC
+Content here...
+:
+::
+:::
+::::
+```
+
+**Example of included stepper:**
+```markdown
+## Installation Guide
+
+::::{stepper}
+:::{step} Download
+Download the software...
+:::
+
+:::{step} Install  
+Run the installer...
+:::
+::::
+```
+
+In the second example, both "Download" and "Install" steps will appear in the ToC as sub-items under "Installation Guide".

--- a/docs/syntax/stepper.md
+++ b/docs/syntax/stepper.md
@@ -249,3 +249,40 @@ Run the installer...
 ```
 
 In the second example, both "Download" and "Install" steps will appear in the ToC as sub-items under "Installation Guide".
+
+## Dynamic heading levels
+
+Stepper step titles automatically adjust their heading level based on the preceding heading in the document, ensuring proper document hierarchy and semantic structure.
+
+### Examples
+
+**Stepper after H2 heading:**
+```markdown
+## Installation Guide
+
+::::{stepper}
+:::{step} Download
+Step titles render as H3 (visible in ToC)
+:::
+::::
+```
+
+**Stepper after H3 heading:**
+```markdown
+### Setup Process
+
+::::{stepper}
+:::{step} Configure
+Step titles render as H4 (not in ToC, but proper hierarchy)
+:::
+::::
+```
+
+**Stepper with no preceding heading:**
+```markdown
+::::{stepper}
+:::{step} First Step
+Step titles default to H2 level
+:::
+::::
+```

--- a/src/Elastic.Markdown/IO/MarkdownFile.cs
+++ b/src/Elastic.Markdown/IO/MarkdownFile.cs
@@ -298,7 +298,7 @@ public record MarkdownFile : DocumentationFile, ITableOfContentsScope, INavigati
 				{
 					Heading = step.Title,
 					Slug = step.Anchor,
-					Level = 3 // Same level as h3 elements they render as
+					Level = step.HeadingLevel // Use dynamic heading level
 				},
 				step.Line
 			});

--- a/src/Elastic.Markdown/Myst/Directives/DirectiveHtmlRenderer.cs
+++ b/src/Elastic.Markdown/Myst/Directives/DirectiveHtmlRenderer.cs
@@ -124,7 +124,8 @@ public class DirectiveHtmlRenderer : HtmlObjectRenderer<DirectiveBlock>
 		{
 			DirectiveBlock = block,
 			Title = block.Title,
-			Anchor = block.Anchor
+			Anchor = block.Anchor,
+			HeadingLevel = block.HeadingLevel
 		});
 		RenderRazorSlice(slice, renderer);
 	}

--- a/src/Elastic.Markdown/Myst/Directives/Stepper/StepView.cshtml
+++ b/src/Elastic.Markdown/Myst/Directives/Stepper/StepView.cshtml
@@ -2,11 +2,12 @@
 <li class="step">
 	@if (!string.IsNullOrEmpty(Model.Title))
 	{
-		<h3 id="@Model.Anchor">
-			<a class="title" href="#@Model.Anchor">
+		var headingTag = $"h{Model.HeadingLevel}";
+		<@headingTag id="@Model.Anchor">
+			<a href="#@Model.Anchor">
 				@Model.Title
 			</a>
-		</h3>
+		</@headingTag>
 	}
 	@Model.RenderBlock()
 </li>

--- a/src/Elastic.Markdown/Myst/Directives/Stepper/StepView.cshtml
+++ b/src/Elastic.Markdown/Myst/Directives/Stepper/StepView.cshtml
@@ -2,12 +2,39 @@
 <li class="step">
 	@if (!string.IsNullOrEmpty(Model.Title))
 	{
-		var headingTag = $"h{Model.HeadingLevel}";
-		<@headingTag id="@Model.Anchor">
-			<a href="#@Model.Anchor">
-				@Model.Title
-			</a>
-		</@headingTag>
+		@switch (Model.HeadingLevel)
+		{
+			case 1:
+				<h1 id="@Model.Anchor">
+					<a href="#@Model.Anchor">@Model.Title</a>
+				</h1>
+				break;
+			case 2:
+				<h2 id="@Model.Anchor">
+					<a href="#@Model.Anchor">@Model.Title</a>
+				</h2>
+				break;
+			case 3:
+				<h3 id="@Model.Anchor">
+					<a href="#@Model.Anchor">@Model.Title</a>
+				</h3>
+				break;
+			case 4:
+				<h4 id="@Model.Anchor">
+					<a href="#@Model.Anchor">@Model.Title</a>
+				</h4>
+				break;
+			case 5:
+				<h5 id="@Model.Anchor">
+					<a href="#@Model.Anchor">@Model.Title</a>
+				</h5>
+				break;
+			default:
+				<h6 id="@Model.Anchor">
+					<a href="#@Model.Anchor">@Model.Title</a>
+				</h6>
+				break;
+		}
 	}
 	@Model.RenderBlock()
 </li>

--- a/src/Elastic.Markdown/Myst/Directives/Stepper/StepView.cshtml
+++ b/src/Elastic.Markdown/Myst/Directives/Stepper/StepView.cshtml
@@ -2,11 +2,11 @@
 <li class="step">
 	@if (!string.IsNullOrEmpty(Model.Title))
 	{
-		<p id="@Model.Anchor">
+		<h3 id="@Model.Anchor">
 			<a class="title" href="#@Model.Anchor">
 				@Model.Title
 			</a>
-		</p>
+		</h3>
 	}
 	@Model.RenderBlock()
 </li>

--- a/src/Elastic.Markdown/Myst/Directives/Stepper/StepViewModel.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Stepper/StepViewModel.cs
@@ -8,4 +8,5 @@ public class StepViewModel : DirectiveViewModel
 {
 	public required string Title { get; init; }
 	public required string Anchor { get; init; }
+	public required int HeadingLevel { get; init; }
 }

--- a/src/Elastic.Markdown/Myst/Directives/Stepper/StepperBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Stepper/StepperBlock.cs
@@ -25,5 +25,11 @@ public class StepBlock(DirectiveBlockParser parser, ParserContext context) : Dir
 	{
 		Title = Arguments ?? string.Empty;
 		Anchor = Prop("anchor") ?? Title.Slugify();
+
+		// Set CrossReferenceName so this step can be found by ToC generation
+		if (!string.IsNullOrEmpty(Title))
+		{
+			CrossReferenceName = Anchor;
+		}
 	}
 }

--- a/src/Elastic.Markdown/Myst/Directives/Stepper/StepperBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Stepper/StepperBlock.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using Elastic.Markdown.Helpers;
+using Markdig.Syntax;
 
 namespace Elastic.Markdown.Myst.Directives.Stepper;
 
@@ -20,16 +21,48 @@ public class StepBlock(DirectiveBlockParser parser, ParserContext context) : Dir
 	public override string Directive => "step";
 	public string Title { get; private set; } = string.Empty;
 	public string Anchor { get; private set; } = string.Empty;
+	public int HeadingLevel { get; private set; } = 3; // Default to h3
 
 	public override void FinalizeAndValidate(ParserContext context)
 	{
 		Title = Arguments ?? string.Empty;
 		Anchor = Prop("anchor") ?? Title.Slugify();
 
+		// Calculate heading level based on preceding heading
+		HeadingLevel = CalculateHeadingLevel();
+
 		// Set CrossReferenceName so this step can be found by ToC generation
 		if (!string.IsNullOrEmpty(Title))
 		{
 			CrossReferenceName = Anchor;
 		}
+	}
+
+	private int CalculateHeadingLevel()
+	{
+		// Find the document root
+		var current = (ContainerBlock)this;
+		while (current.Parent != null)
+			current = current.Parent;
+
+		// Find all headings that come before this step in document order
+		var allBlocks = current.Descendants().ToList();
+		var thisIndex = allBlocks.IndexOf(this);
+
+		if (thisIndex == -1)
+			return 3; // Default fallback
+
+		// Look backwards for the most recent heading
+		for (var i = thisIndex - 1; i >= 0; i--)
+		{
+			if (allBlocks[i] is HeadingBlock heading)
+			{
+				// Step should be one level deeper than the preceding heading
+				return Math.Min(heading.Level + 1, 6); // Cap at h6
+			}
+		}
+
+		// No preceding heading found, default to h2 (level 2)
+		return 2;
 	}
 }


### PR DESCRIPTION
This PR updates the Stepper component so that:

- Step titles are rendered as an `<Hn>`  heading, where `n` is the level of the preceding heading + 1.
- Heading thus appear in the table of content if they're of level 3.
- Step titles are *not* included in the ToC if they're nested inside another directive to avoid weird situations, such as competing headings in tabs using steppers and headings hidden inside a dropdown. Strange, but could happen.

Fixes https://github.com/elastic/docs-builder/issues/1464

### Example of dynamic headings (h4 after an h3)

<img width="667" alt="headings" src="https://github.com/user-attachments/assets/948d6068-6273-464c-88d0-d7acd44fa805" />

### Example of H3 step titles appearing in ToC

<img width="1119" alt="Screenshot 2025-06-30 at 10 57 55" src="https://github.com/user-attachments/assets/7ad3eaaf-8975-473e-b796-ec8781534e27" />
