### PR TITLE
Add CrtIntegration instantiation for AOT

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,11 +16,13 @@
     <PackageVersion Include="AWSSDK.CloudFront" Version="4.0.0.10" />
     <PackageVersion Include="AWSSDK.CloudFrontKeyValueStore" Version="4.0.0.9" />
     <PackageVersion Include="AWSSDK.Core" Version="4.0.0.2" />
+    <PackageVersion Include="AWSSDK.Extensions.CrtIntegration" Version="4.0.0" />
     <PackageVersion Include="AWSSDK.SQS" Version="4.0.0.1" />
     <PackageVersion Include="AWSSDK.S3" Version="4.0.0.1" />
     <PackageVersion Include="FakeItEasy" Version="8.3.0" />
     <PackageVersion Include="Elastic.Ingest.Elasticsearch" Version="0.11.3" />
     <PackageVersion Include="Microsoft.OpenApi" Version="2.0.0-preview9" />
+    <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     <PackageVersion Include="System.Text.Json" Version="9.0.5" />
   </ItemGroup>
   <!-- Build -->

--- a/src/tooling/docs-assembler/Cli/DeployCommands.cs
+++ b/src/tooling/docs-assembler/Cli/DeployCommands.cs
@@ -9,6 +9,8 @@ using Actions.Core.Services;
 using Amazon.CloudFront;
 using Amazon.CloudFrontKeyValueStore;
 using Amazon.CloudFrontKeyValueStore.Model;
+using Amazon.Extensions.CrtIntegration;
+using Amazon.RuntimeDependencies;
 using Amazon.S3;
 using Amazon.S3.Transfer;
 using ConsoleAppFramework;
@@ -131,6 +133,9 @@ internal sealed class DeployCommands(ILoggerFactory logger, ICoreService githubA
 			await collector.StopAsync(ctx);
 			return collector.Errors;
 		}
+
+		GlobalRuntimeDependencyRegistry.Instance.RegisterSigV4aProvider((context)
+			=> new CrtAWS4aSigner(context.SigV4aCrtSignerContextData.SignPayload));
 
 		ConsoleApp.Log("Parsing redirects mapping");
 		var jsonContent = await File.ReadAllTextAsync(redirectsFile, ctx);

--- a/src/tooling/docs-assembler/docs-assembler.csproj
+++ b/src/tooling/docs-assembler/docs-assembler.csproj
@@ -19,11 +19,14 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.CloudFront" />
     <PackageReference Include="AWSSDK.CloudFrontKeyValueStore" />
+    <PackageReference Include="AWSSDK.Extensions.CrtIntegration" />
     <PackageReference Include="AWSSDK.S3"/>
     <PackageReference Include="ConsoleAppFramework.Abstractions"/>
     <PackageReference Include="ConsoleAppFramework" />
     <PackageReference Include="Elastic.Ingest.Elasticsearch" />
     <PackageReference Include="Proc"  />
+    <!-- System.Private.Uri is added explicitly due to vulnerabilities on 4.3.0 which AWSSDK.Extensions.CrtIntegration requires -->
+    <PackageReference Include="System.Private.Uri" />
     <PackageReference Include="YamlDotNet"  />
     <PackageReference Include="NetEscapades.EnumGenerators" />
     <PackageReference Include="Vecc.YamlDotNet.Analyzers.StaticGenerator" />


### PR DESCRIPTION
Upon running the workflow for deploying redirects, `docs-assembler` returned the following error:

`Amazon.RuntimeDependencies.MissingRuntimeDependencyException: Operation failed because of a missing runtime dependency. In Native AOT builds runtime dependencies can not be dynamically loaded from assembles. Instead the runtime dependency needs to be explicitly registered. To complete this operation register an instance of Amazon.Extensions.CrtIntegration.CrtAWS4aSigner from package AWSSDK.Extensions.CrtIntegration using the operation Amazon.RuntimeDependencies.GlobalRuntimeDependencyRegistry.Instance.RegisterSigV4aProvider.`

This PR adds the necessary changes. `System.Private.Uri` is explicitly added due to vulnerabilities present in a previous version that `AWSSDK.Extensions.CrtIntegration` has a dependency on, fixed in the newest version.