### PR TITLE
Added link to assembler.yml file

### DIFF
--- a/docs/migration/versioning.md
+++ b/docs/migration/versioning.md
@@ -47,7 +47,7 @@ Tagged deployment
 
 This is the default. To get started, follow our [guide](guide/index.md) to set up the new docs folder structure and CI configuration
 
-Once setup ensure the repository is added to our `assembler.yml`  under `references`. 
+Once setup ensure the repository is added to our [`assembler.yml`](https://github.com/elastic/docs-builder/blob/main/src/tooling/docs-assembler/assembler.yml)  under `references`. 
 
 For example say you want to onboard `elastic/my-repository` into the production build:
 


### PR DESCRIPTION
The deployment models are nicely explained, but when we explain that the repository needs to be added to assembler.yml I had no clue of where exactly that file resides.

I was suspecting that it was somewhere in the docs-builder repo, but I wasn't even sure about it.

I think a link or a note explaining that the assembler.yml is under `src/tooling/docs-assembler/assembler.yml` of docs-builder would be beneficial.

For the moment I've added only a link, but if anyone prefers a different option I'm ok with that.