### PR TITLE
Refactor communication with AWS for KeyValueStore updates

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,8 +13,6 @@
     <PackageVersion Include="Amazon.Lambda.S3Events" Version="3.1.0" />
     <PackageVersion Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4" />
     <PackageVersion Include="Amazon.Lambda.SQSEvents" Version="2.2.0" />
-    <PackageVersion Include="AWSSDK.CloudFront" Version="4.0.0.10" />
-    <PackageVersion Include="AWSSDK.CloudFrontKeyValueStore" Version="4.0.0.9" />
     <PackageVersion Include="AWSSDK.Core" Version="4.0.0.2" />
     <PackageVersion Include="AWSSDK.SQS" Version="4.0.0.1" />
     <PackageVersion Include="AWSSDK.S3" Version="4.0.0.1" />

--- a/src/tooling/Elastic.Documentation.Tooling/ExternalCommands/ExternalCommandExecutor.cs
+++ b/src/tooling/Elastic.Documentation.Tooling/ExternalCommands/ExternalCommandExecutor.cs
@@ -12,6 +12,7 @@ namespace Elastic.Documentation.Tooling.ExternalCommands;
 public abstract class ExternalCommandExecutor(DiagnosticsCollector collector, IDirectoryInfo workingDirectory)
 {
 	protected IDirectoryInfo WorkingDirectory => workingDirectory;
+	protected DiagnosticsCollector Collector => collector;
 	protected void ExecIn(Dictionary<string, string> environmentVars, string binary, params string[] args)
 	{
 		var arguments = new ExecArguments(binary, args)
@@ -77,13 +78,13 @@ public abstract class ExternalCommandExecutor(DiagnosticsCollector collector, ID
 	}
 
 
-	protected string Capture(string binary, params string[] args) => Capture(false, binary, args);
-
-	protected string Capture(bool muteExceptions, string binary, params string[] args)
+	protected string Capture(string binary, params string[] args) => Capture(false, 10, binary, args);
+	protected string Capture(bool muteExceptions, string binary, params string[] args) => Capture(muteExceptions, 10, binary, args);
+	protected string Capture(bool muteExceptions, int attempts, string binary, params string[] args)
 	{
 		// Try 10 times to capture the output of the command, if it fails, we'll throw an exception on the last try
 		Exception? e = null;
-		for (var i = 0; i <= 9; i++)
+		for (var i = 1; i <= attempts; i++)
 		{
 			try
 			{

--- a/src/tooling/docs-assembler/Deploying/AwsCloudFrontKeyValueStoreProxy.cs
+++ b/src/tooling/docs-assembler/Deploying/AwsCloudFrontKeyValueStoreProxy.cs
@@ -108,7 +108,7 @@ public class AwsCloudFrontKeyValueStoreProxy(DiagnosticsCollector collector, IDi
 						AwsCloudFrontKeyValueStoreJsonContext.Default.ListDeleteKeyRequestListItem),
 					_ => string.Empty
 				};
-				var responseJson = Capture("aws", "cloudfront-key-value-store", "update-keys", "--kvs-arn", kvsArn, "--if-match", eTag,
+				var responseJson = Capture(false, 1, "aws", "cloudfront-key-value-store", "update-keys", "--kvs-arn", kvsArn, "--if-match", eTag,
 					$"--{operation.ToString().ToLowerInvariant()}", "--payload", payload);
 				var updateResponse = JsonSerializer.Deserialize<UpdateKeysResponse>(responseJson, AwsCloudFrontKeyValueStoreJsonContext.Default.UpdateKeysResponse);
 

--- a/src/tooling/docs-assembler/Deploying/AwsCloudFrontKeyValueStoreProxy.cs
+++ b/src/tooling/docs-assembler/Deploying/AwsCloudFrontKeyValueStoreProxy.cs
@@ -1,0 +1,127 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions;
+using System.Text.Json;
+using ConsoleAppFramework;
+using Documentation.Assembler.Deploying.Serialization;
+using Elastic.Documentation.Diagnostics;
+using Elastic.Documentation.Tooling.ExternalCommands;
+
+namespace Documentation.Assembler.Deploying;
+
+internal enum KvsOperation
+{
+	Puts,
+	Deletes
+}
+
+public class AwsCloudFrontKeyValueStoreProxy(DiagnosticsCollector collector, IDirectoryInfo workingDirectory) : ExternalCommandExecutor(collector, workingDirectory)
+{
+	public void UpdateRedirects(string kvsName, IReadOnlyDictionary<string, string> sourcedRedirects)
+	{
+		var (kvsArn, eTag) = DescribeKeyValueStore(kvsName);
+		if (string.IsNullOrEmpty(kvsArn) || string.IsNullOrEmpty(eTag))
+			return;
+
+		var existingRedirects = ListAllKeys(kvsArn);
+
+		var toPut = sourcedRedirects
+			.Select(kvp => new PutKeyRequestListItem { Key = kvp.Key, Value = kvp.Value });
+		var toDelete = existingRedirects
+			.Except(sourcedRedirects.Keys)
+			.Select(k => new DeleteKeyRequestListItem { Key = k });
+
+		eTag = ProcessBatchUpdates(kvsArn, eTag, toPut, KvsOperation.Puts);
+		_ = ProcessBatchUpdates(kvsArn, eTag, toDelete, KvsOperation.Deletes);
+	}
+
+	private (string? Arn, string? ETag) DescribeKeyValueStore(string kvsName)
+	{
+		ConsoleApp.Log("Describing KeyValueStore");
+		try
+		{
+			var json = Capture("aws", "cloudfront", "describe-key-value-store", "--name", kvsName);
+			var describeResponse = JsonSerializer.Deserialize<DescribeKeyValueStoreResponse>(json, AwsCloudFrontKeyValueStoreJsonContext.Default.DescribeKeyValueStoreResponse);
+			if (describeResponse?.ETag is not null && describeResponse.KeyValueStore is { ARN.Length: > 0 })
+				return (describeResponse.KeyValueStore.ARN, describeResponse.ETag);
+
+			Collector.EmitError("", "Could not deserialize the DescribeKeyValueStoreResponse");
+			return (null, null);
+		}
+		catch (Exception e)
+		{
+			Collector.EmitError("", "An error occurred while describing the KeyValueStore", e);
+			return (null, null);
+		}
+	}
+
+	private HashSet<string> ListAllKeys(string kvsArn)
+	{
+		ConsoleApp.Log("Acquiring existing redirects");
+		var allKeys = new HashSet<string>();
+		string[] baseArgs = ["cloudfront-key-value-store", "list-keys", "--kvs-arn", kvsArn];
+		string? nextToken = null;
+		try
+		{
+			do
+			{
+				var json = Capture("aws", [.. baseArgs, .. nextToken is not null ? (string[])["--next-token", nextToken] : []]);
+				var response = JsonSerializer.Deserialize<ListKeysResponse>(json, AwsCloudFrontKeyValueStoreJsonContext.Default.ListKeysResponse);
+
+				if (response?.Items != null)
+				{
+					foreach (var item in response.Items)
+						_ = allKeys.Add(item.Key);
+				}
+
+				nextToken = response?.NextToken;
+			} while (!string.IsNullOrEmpty(nextToken));
+		}
+		catch (Exception e)
+		{
+			Collector.EmitError("", "An error occurred while acquiring existing redirects in the KeyValueStore", e);
+			return [];
+		}
+		return allKeys;
+	}
+
+
+	private string ProcessBatchUpdates(
+		string kvsArn,
+		string eTag,
+		IEnumerable<object> items,
+		KvsOperation operation)
+	{
+		const int batchSize = 50;
+		ConsoleApp.Log($"Processing {items.Count()} items in batches of {batchSize} for {operation} update operation.");
+		try
+		{
+			foreach (var batch in items.Chunk(batchSize))
+			{
+				var payload = operation switch
+				{
+					KvsOperation.Puts => JsonSerializer.Serialize(batch.Cast<PutKeyRequestListItem>().ToList(),
+						AwsCloudFrontKeyValueStoreJsonContext.Default.ListPutKeyRequestListItem),
+					KvsOperation.Deletes => JsonSerializer.Serialize(batch.Cast<DeleteKeyRequestListItem>().ToList(),
+						AwsCloudFrontKeyValueStoreJsonContext.Default.ListDeleteKeyRequestListItem),
+					_ => string.Empty
+				};
+				var responseJson = Capture("aws", "cloudfront-key-value-store", "update-keys", "--kvs-arn", kvsArn, "--if-match", eTag,
+					$"--{operation.ToString().ToLowerInvariant()}", "--payload", payload);
+				var updateResponse = JsonSerializer.Deserialize<UpdateKeysResponse>(responseJson, AwsCloudFrontKeyValueStoreJsonContext.Default.UpdateKeysResponse);
+
+				if (string.IsNullOrEmpty(updateResponse?.ETag))
+					throw new Exception("Failed to get new ETag after update operation.");
+
+				eTag = updateResponse.ETag;
+			}
+		}
+		catch (Exception e)
+		{
+			Collector.EmitError("", $"An error occurred while performing a {operation} update to the KeyValueStore", e);
+		}
+		return eTag;
+	}
+}

--- a/src/tooling/docs-assembler/Deploying/Serialization/AwsCloudFrontKeyValueStoreModels.cs
+++ b/src/tooling/docs-assembler/Deploying/Serialization/AwsCloudFrontKeyValueStoreModels.cs
@@ -1,0 +1,37 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text.Json.Serialization;
+
+namespace Documentation.Assembler.Deploying.Serialization;
+
+public record DescribeKeyValueStoreResponse([property: JsonPropertyName("ETag")] string ETag, [property: JsonPropertyName("KeyValueStore")] KeyValueStore KeyValueStore);
+public record KeyValueStore([property: JsonPropertyName("ARN")] string ARN);
+
+public record ListKeysResponse([property: JsonPropertyName("NextToken")] string? NextToken, [property: JsonPropertyName("Items")] List<KeyItem> Items);
+public record KeyItem([property: JsonPropertyName("Key")] string Key);
+
+public record UpdateKeysResponse([property: JsonPropertyName("ETag")] string ETag);
+
+public record PutKeyRequestListItem
+{
+	[JsonPropertyName("Key")]
+	public required string Key { get; init; }
+	[JsonPropertyName("Value")]
+	public required string Value { get; init; }
+}
+
+public record DeleteKeyRequestListItem
+{
+	[JsonPropertyName("Key")]
+	public required string Key { get; init; }
+}
+
+[JsonSourceGenerationOptions(WriteIndented = true, UseStringEnumConverter = true)]
+[JsonSerializable(typeof(DescribeKeyValueStoreResponse))]
+[JsonSerializable(typeof(ListKeysResponse))]
+[JsonSerializable(typeof(UpdateKeysResponse))]
+[JsonSerializable(typeof(List<PutKeyRequestListItem>))]
+[JsonSerializable(typeof(List<DeleteKeyRequestListItem>))]
+internal sealed partial class AwsCloudFrontKeyValueStoreJsonContext : JsonSerializerContext;

--- a/src/tooling/docs-assembler/docs-assembler.csproj
+++ b/src/tooling/docs-assembler/docs-assembler.csproj
@@ -17,8 +17,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudFront" />
-    <PackageReference Include="AWSSDK.CloudFrontKeyValueStore" />
     <PackageReference Include="AWSSDK.S3"/>
     <PackageReference Include="ConsoleAppFramework.Abstractions"/>
     <PackageReference Include="ConsoleAppFramework" />


### PR DESCRIPTION
Given AWSSDK's Cloudfront KeyValueStore APIs still depend on CrtIntegration, which isn't AOT-compatible, we need to fallback to an alternative method of communicating with AWS to update the Cloudfront KVS.

This PR introduces communication via CLI.

### More information:

- There is an [issue](https://github.com/aws/aws-sdk-net/issues/3881) on `aws-sdk-net` to discuss a new library to substitute AWSSDK.Extensions.CrtIntegration, but no implementation yet.