### PR TITLE
Add EDOT Collector to versions.yml

### DIFF
--- a/docs/syntax/applies.md
+++ b/docs/syntax/applies.md
@@ -227,16 +227,15 @@ applies_to:
   product:
     ecctl:
     curator:
-    apm_agent_android:
     apm_agent_dotnet:
     apm_agent_go:
-    apm_agent_ios:
     apm_agent_java:
     apm_agent_node:
     apm_agent_php:
     apm_agent_python:
     apm_agent_ruby:
     apm_agent_rum:
+    edot_collector:
     edot_ios:
     edot_android:
     edot_dotnet:
@@ -244,6 +243,7 @@ applies_to:
     edot_node:
     edot_php:
     edot_python:
+    edot_cf_aws:
 ---
 ```
 

--- a/src/Elastic.Documentation.Configuration/Versions/Version.cs
+++ b/src/Elastic.Documentation.Configuration/Versions/Version.cs
@@ -84,7 +84,9 @@ public enum VersioningSystemId
 	[Display(Name = "edot_python")]
 	EdotPython,
 	[Display(Name = "edot_cf_aws")]
-	EdotCfAws
+	EdotCfAws,
+	[Display(Name = "edot_collector")]
+	EdotCollector
 }
 
 [YamlSerializable]

--- a/src/Elastic.Documentation.Configuration/versions.yml
+++ b/src/Elastic.Documentation.Configuration/versions.yml
@@ -64,6 +64,9 @@ versioning_systems:
     current: 5.17.0
 
   # EDOTs
+  edot_collector:
+    base: 9.0
+    current: 9.0.3
   edot_ios:
     base: 1.0
     current: 1.2.1

--- a/src/Elastic.Markdown/Myst/Components/ApplicableToComponent.cshtml
+++ b/src/Elastic.Markdown/Myst/Components/ApplicableToComponent.cshtml
@@ -228,6 +228,12 @@
 		@RenderProduct("EDOT CF AWS", "Elastic Distribution of OpenTelemetry Cloud Forwarder for AWS", VersioningSystemId.EdotCfAws, pa.EdotCfAws)
 		;
 	}
+
+	if (pa.EdotCollector is not null)
+	{
+		@RenderProduct("EDOT Collector", "Elastic Distribution of OpenTelemetry Collector", VersioningSystemId.EdotCollector, pa.EdotCollector)
+		;
+	}
 }
 
 @functions {

--- a/src/Elastic.Markdown/Myst/FrontMatter/ApplicableTo.cs
+++ b/src/Elastic.Markdown/Myst/FrontMatter/ApplicableTo.cs
@@ -177,6 +177,9 @@ public record ProductApplicability
 
 	[YamlMember(Alias = "edot_cf_aws")]
 	public AppliesCollection? EdotCfAws { get; set; }
+
+	[YamlMember(Alias = "edot_collector")]
+	public AppliesCollection? EdotCollector { get; set; }
 }
 
 public class ApplicableToConverter : IYamlTypeConverter


### PR DESCRIPTION
This adds the EDOT Collector to the applicability tags. It also updates the docs, removing the apm_agent_ios and apm_agent_android tags from the list (but keeping them in the code).

Contributes to https://github.com/elastic/opentelemetry/issues/334