### PR TITLE
Update navigation.yml to add EDOT Troubleshooting

### DIFF
--- a/src/tooling/docs-assembler/navigation.yml
+++ b/src/tooling/docs-assembler/navigation.yml
@@ -590,3 +590,15 @@ toc:
       # ✅ https://github.com/elastic/docs-content/blob/main/reference/glossary/toc.yml
       - toc: docs-content://reference/glossary
         path_prefix: reference/glossary
+
+  ###################
+  # TROUBLESHOOTING #
+  ###################
+
+  - toc: troubleshooting
+    path_prefix: troubleshooting
+    children:
+      # EDOT Troubleshooting
+      # ✅ https://github.com/elastic/opentelemetry/docs/troubleshooting/toc.yml
+      - toc: opentelemetry://troubleshooting
+        path_prefix: troubleshooting/opentelemetry


### PR DESCRIPTION
This adds EDOT Troubleshooting docs to the navigation.

Contributes to https://github.com/elastic/opentelemetry/issues/333

+CC @alexandra5000