### PR TITLE
Fix navigation render result

### DIFF
--- a/src/tooling/docs-assembler/Navigation/GlobalNavigationHtmlWriter.cs
+++ b/src/tooling/docs-assembler/Navigation/GlobalNavigationHtmlWriter.cs
@@ -57,7 +57,13 @@ public class GlobalNavigationHtmlWriter(
 		var navigationId = ShortId.Create($"{(navigationRootSource, maxLevel).GetHashCode()}");
 
 		if (_renderedNavigationCache.TryGetValue((navigationRootSource, maxLevel), out var value))
-			return NavigationRenderResult.Empty;
+		{
+			return new NavigationRenderResult
+			{
+				Html = value,
+				Id = navigationId
+			};
+		}
 
 		if (navigationRootSource == new Uri("docs-content:///"))
 		{


### PR DESCRIPTION
The returned value should not be empty here

Caused by [6496675](https://github.com/elastic/docs-builder/pull/1514/commits/64966753aa8eb7150b3cedb9e43f2ea4e556b306)