### PR TITLE
Fix RoleParser

### DIFF
--- a/docs/testing/req.md
+++ b/docs/testing/req.md
@@ -12,6 +12,9 @@ mapped_pages:
 stack: preview 9.0, ga 9.1
 ```
 
+1. Select **Create** to create a new policy, or select **Edit** {icon}`pencil` to open an existing policy.
+1. Select **Create** to create a new policy, or select **Edit** {icon}`logo_vulnerability_management` to open an existing policy.
+
 
 {applies_to}`stack: preview 9.0` This tutorial is based on Elasticsearch 9.0.
 This tutorial is based on Elasticsearch 9.0. This tutorial is based on Elasticsearch 9.0.

--- a/src/Elastic.Markdown/Myst/Roles/RoleParser.cs
+++ b/src/Elastic.Markdown/Myst/Roles/RoleParser.cs
@@ -65,10 +65,6 @@ public abstract class RoleParser<TRole> : InlineParser
 		if (!Matches(roleContent))
 			return false;
 
-		// {role} has to be followed by `content`
-		if ((uint)i >= (uint)span.Length || span[i] != '`')
-			return false;
-
 		var openingBacktickPos = i;
 		var contentStartPos = i + 1; // Skip the opening backtick
 


### PR DESCRIPTION
Closes https://github.com/elastic/docs-builder/issues/1523

## Context

Only in some cases (depending on the content length) the RoleParser would parse incorrect content.

E.g. if the icon is `` {icon}`pencil` ``, `contentSpan` would result in ``pencil` `` (a trailing space and trailing backtick)

The previous fix to this problem was just to add `.Trim()` to the existing ``contentSpan.Trim('`')``.

But this caused the trailing space to also disappear in the final HTML output, which was reported in https://github.com/elastic/docs-builder/issues/1523.

![image](https://github.com/user-attachments/assets/ba0946f9-c423-4734-8d63-bf685bd01a1e)

## Changes

Fix the logic to determine the closing backtick.

## Preview 

Here you can see that the space is now correctly rendered in the final html output.

<img width="667" alt="image" src="https://github.com/user-attachments/assets/330ec438-ed86-4032-bdb0-bbf54a4ecc74" />

