### PR TITLE
Add `stack` and `stack_next` variables to `assembler.yml`

### DIFF
--- a/src/tooling/docs-assembler/assembler.yml
+++ b/src/tooling/docs-assembler/assembler.yml
@@ -17,7 +17,7 @@ environments:
       auth: nPocPUG0wiH68jsVeyRSxA
       preview: env-507
       cookies_win: x
-  edge: 
+  edge:
     uri: https://d34ipnu52o64md.cloudfront.net
     path_prefix: docs
     content_source: current
@@ -31,7 +31,8 @@ environments:
     path_prefix: docs
 
 named_git_references:
-  stack: &stack 9.0
+  stack: &stack_current 9.0
+  stack_next: &stack_next 9.1
   cloud-hosted: ms-120
 
 ###
@@ -66,8 +67,8 @@ references:
   apm-aws-lambda:
   apm-k8s-attacher:
   beats:
-    current: "9.0"
-    next: main
+    current: *stack_current
+    next: *stack_next
   cloud-on-k8s:
   cloud:
     current: master
@@ -114,8 +115,8 @@ references:
   kibana:
   logstash-docs-md:
   logstash:
-    current: "9.0"
-    next: main
+    current: *stack_current
+    next: *stack_next
   opentelemetry:
   search-ui:
   integration-docs:

--- a/src/tooling/docs-assembler/assembler.yml
+++ b/src/tooling/docs-assembler/assembler.yml
@@ -31,7 +31,7 @@ environments:
     path_prefix: docs
 
 named_git_references:
-  stack: &stack_current 9.0
+  stack: &stack 9.0
   stack_next: &stack_next 9.1
   cloud-hosted: ms-120
 
@@ -67,7 +67,7 @@ references:
   apm-aws-lambda:
   apm-k8s-attacher:
   beats:
-    current: *stack_current
+    current: *stack
     next: *stack_next
   cloud-on-k8s:
   cloud:
@@ -115,7 +115,7 @@ references:
   kibana:
   logstash-docs-md:
   logstash:
-    current: *stack_current
+    current: *stack
     next: *stack_next
   opentelemetry:
   search-ui:


### PR DESCRIPTION
I'm working on updating the docs release checklist for Elastic Stack releases. In the current draft, I'm recommending that the docs release coordinator touches this file twice:

* **The day after feature freeze** (after the new version branch is created): The docs release coordinator will update `stack_next` to the version of the upcoming release. The idea is that we'll be publishing those docs to staging (right?) so we'll be able to catch any build errors (like any broken cross-repo links) ahead of the release date. Does this make sense?
* **The day of the release**: The docs release coordinator will update `stack` to the new version and update `stack_next` to `main` (I don't _think_ any Stack-versioned repos still use `master`).

Let me know what you think of this approach. I'm very open to suggestions. 