### PR TITLE
Repo owner annotations

### DIFF
--- a/src/tooling/docs-assembler/assembler.yml
+++ b/src/tooling/docs-assembler/assembler.yml
@@ -89,16 +89,14 @@ references:
   elastic-otel-php:
   elastic-otel-python:
   elastic-serverless-forwarder:
+  integration-docs:
+  integrations:
   logstash-docs-md:
   logstash:
     current: "9.0"
     next: main
   opentelemetry:
-
-  # @elastic/ingest-docs and @elastic/experience-docs
-  integration-docs:
-  integrations:
-
+  
   # @elastic/admin-docs
   cloud-on-k8s:
   cloud:


### PR DESCRIPTION
As docs teams, we often need to work in repositories owned by other teams at Elastic to maintain the docs and docs-related actions and pipelines. 

This PR adds annotations to the repositories that feed into elastic.co/docs (as listed in `assembler.yml`) to help our team to understand who should be on point for maintenance activities for each repo. We don't have to always follow this approach, but it will help us to find task owners when changes are not straightforward or require interfacing with other teams.

as a side effect, this reorders the items in `assembler.yml` so I'll wait on a green light from eng to make sure it's safe to merge.