### PR TITLE
feature/api landing page

### DIFF
--- a/src/Elastic.ApiExplorer/Landing/LandingNavigationItem.cs
+++ b/src/Elastic.ApiExplorer/Landing/LandingNavigationItem.cs
@@ -52,7 +52,7 @@ public class LandingNavigationItem : IApiGroupingNavigationItem<ApiLanding, INav
 	}
 
 	/// <inheritdoc />
-	public bool IsUsingNavigationDropdown => NavigationItems.OfType<ClassificationNavigationItem>().Any();
+	public bool IsUsingNavigationDropdown => false;
 }
 
 public interface IApiGroupingNavigationItem<out TGroupingModel, out TNavigationItem> : INodeNavigationItem<TGroupingModel, TNavigationItem>
@@ -106,7 +106,7 @@ public class ClassificationNavigationItem(ApiClassification classification, Land
 	public override string Id { get; } = ShortId.Create(classification.Name);
 
 	/// <inheritdoc />
-	public bool IsUsingNavigationDropdown => true;
+	public bool IsUsingNavigationDropdown => false;
 }
 
 public class TagNavigationItem(ApiTag tag, IRootNavigationItem<IApiGroupingModel, INavigationItem> rootNavigation, INodeNavigationItem<INavigationModel, INavigationItem> parent)

--- a/src/Elastic.ApiExplorer/Landing/LandingView.cshtml
+++ b/src/Elastic.ApiExplorer/Landing/LandingView.cshtml
@@ -82,7 +82,7 @@
 }
 <section id="elastic-docs-v3">
 	<h1>@Model.ApiInfo.Title</h1>
-	<p>@Model.ApiInfo.Description</p>
+	<p>@Model.RenderMarkdown(Model.ApiInfo.Description)</p>
 	<p>License: @Model.ApiInfo.License?.Name</p>
 	<div class="api-overview">
 		<table>

--- a/src/Elastic.ApiExplorer/Landing/LandingView.cshtml
+++ b/src/Elastic.ApiExplorer/Landing/LandingView.cshtml
@@ -1,10 +1,92 @@
 @inherits RazorSliceHttpResult<Elastic.ApiExplorer.Landing.LandingViewModel>
+@using Elastic.ApiExplorer.Landing
+@using Elastic.ApiExplorer.Operations
+@using Elastic.Documentation.Site.Navigation
 @implements IUsesLayout<Elastic.ApiExplorer._Layout, GlobalLayoutViewModel>
 @functions {
 	public GlobalLayoutViewModel LayoutModel => Model.CreateGlobalLayoutModel();
+
+	private IHtmlContent RenderOp(IReadOnlyCollection<OperationNavigationItem> endpointOperations)
+	{
+		<ul class="api-url-listing">
+		@foreach (var overload in endpointOperations)
+		{
+			var method = overload.Model.OperationType.ToString().ToLowerInvariant();
+			<li class="api-url-list-item">
+				<a href="@overload.Url" class="current api-url-list-item-landing" hx-disable="true">
+					<span class="api-method api-method-@method">@method.ToUpperInvariant()</span>
+					<span class="api-url">@overload.Model.Route</span>
+				</a>
+			</li>
+		}
+		</ul>
+
+		return HtmlString.Empty;
+	}
+
+	private IHtmlContent RenderProduct(INavigationItem item)
+	{
+		if (item is INodeNavigationItem<INavigationModel, INavigationItem> node)
+		{
+			foreach (var navigationItem in node.NavigationItems)
+			{
+				if (navigationItem is ClassificationNavigationItem classification)
+				{
+					<tr>
+						<td colspan="2"><h2>@(classification.NavigationTitle)</h2></td>
+					</tr>
+					@RenderProduct(classification)
+				}
+				else if (navigationItem is TagNavigationItem tag)
+				{
+					<tr>
+						<td colspan="2"><h3>@(tag.NavigationTitle)</h3><td>
+					</tr>
+					@RenderProduct(tag)
+				}
+				else if (navigationItem is EndpointNavigationItem endpoint)
+				{
+					var endpointOperations =
+						endpoint is { NavigationItems.Count: > 0 } && endpoint.NavigationItems.All(n => n.Hidden)
+							? endpoint.NavigationItems
+							: [];
+						if (endpointOperations.Count > 0)
+						{
+							<tr>
+								<td class="api-name">@(endpoint.NavigationTitle)</td>
+								<td>@RenderOp(endpointOperations)</td>
+							</tr>
+						}
+						else
+						{
+							@RenderProduct(endpoint)
+						}
+				}
+				else if (navigationItem is OperationNavigationItem operation)
+				{
+					<tr>
+						<td class="api-name">@(operation.NavigationTitle)</td>
+						<td>@RenderOp([operation])</td>
+					</tr>
+				}
+				else
+				{
+					throw new Exception($"Unexpected type: {item.GetType().FullName}");
+				}
+			}
+		}
+
+		return HtmlString.Empty;
+
+	}
 }
 <section id="elastic-docs-v3">
 	<h1>@Model.ApiInfo.Title</h1>
 	<p>@Model.ApiInfo.Description</p>
-	<p>License: @Model.ApiInfo.License?.Identifier</p>
+	<p>License: @Model.ApiInfo.License?.Name</p>
+	<div class="api-overview">
+		<table>
+			@RenderProduct(Model.CurrentNavigationItem.NavigationRoot)
+		</table>
+	</div>
 </section>

--- a/src/Elastic.ApiExplorer/Operations/OperationView.cshtml
+++ b/src/Elastic.ApiExplorer/Operations/OperationView.cshtml
@@ -7,10 +7,9 @@
 	public GlobalLayoutViewModel LayoutModel => Model.CreateGlobalLayoutModel();
 }
 @{
-	var parent = Model.CurrentNavigationItem.Parent as EndpointNavigationItem;
 	var self = Model.CurrentNavigationItem as OperationNavigationItem;
 	var allOperations =
-		parent is not null && parent.NavigationItems.Count > 0 && parent.NavigationItems.All(n => n.Hidden)
+		Model.CurrentNavigationItem.Parent is EndpointNavigationItem { NavigationItems.Count: > 0 } parent && parent.NavigationItems.All(n => n.Hidden)
 			? parent.NavigationItems
 			: self is not null
 				? [self]

--- a/src/Elastic.Documentation.Site/Assets/api-docs.css
+++ b/src/Elastic.Documentation.Site/Assets/api-docs.css
@@ -42,6 +42,12 @@
 			@apply border-grey-30 text-grey-120 bg-white;
 			font-weight: bold;
 		}
+		a.api-url-list-item-landing {
+			font-weight: normal !important;
+		}
+		a.api-url-list-item-landing:hover {
+			font-weight: normal !important;
+		}
 	}
 	li:only-child {
 		a.current {
@@ -51,52 +57,110 @@
 			@apply border-grey-20 bg-white;
 		}
 	}
-	.api-method {
-		@apply rounded-sm border;
-		padding-left: var(--spacing);
-		padding-right: var(--spacing);
-		font-family: var(
-			--default-mono-font-family,
-			ui-monospace,
-			SFMono-Regular,
-			Menlo,
-			Monaco,
-			Consolas,
-			'Liberation Mono',
-			'Courier New',
-			monospace
-		);
-		font-feature-settings: var(
-			--default-mono-font-feature-settings,
-			normal
-		);
-		font-variation-settings: var(
-			--default-mono-font-variation-settings,
-			normal
-		);
-		font-size: 0.8em;
-		display: inline-block;
-		font-weight: bold;
-	}
-	.api-method-get {
-		@apply border-blue-elastic-30 bg-blue-elastic-10 text-blue-elastic;
-	}
-	.api-method-put {
-		@apply border-yellow-30 bg-yellow-10 text-yellow-90;
-	}
-	.api-method-post {
-		@apply border-green-30 bg-green-10 text-green-90;
-	}
-	.api-method-delete {
-		@apply border-red-30 bg-red-10 text-red-90;
-	}
-	.api-url {
-		margin-left: calc(var(--spacing) * 2);
-		display: inline-block;
-	}
 	.api-url-list-item {
 		@apply mt-4;
 	}
+}
+.api-overview {
+	.api-url-listing {
+		@apply mt-1;
+	}
+	.api-url-list-item {
+		@apply mt-1;
+	}
+	li {
+		a {
+			@apply text-grey-80 inline-block w-full p-2 pr-2 pl-2 no-underline;
+			@apply border-white rounded-sm border;
+		}
+		a:hover {
+			@apply bg-grey-10;
+			@apply border-grey-20;
+		}
+		a.current {
+			@apply text-grey-80 inline-block w-full p-2 pr-2 pl-2 no-underline;
+			@apply border-white rounded-sm border;
+		}
+		a.current:hover {
+			@apply bg-grey-10;
+			@apply border-grey-20;
+		}
+	}
+	li:only-child {
+		a.current {
+			@apply text-grey-80 inline-block w-full p-2 pr-2 pl-2 no-underline;
+			@apply border-white rounded-sm border;
+		}
+		a.current:hover {
+			@apply bg-grey-10;
+		}
+	}
+	table {
+		td {
+			text-align: left;
+			vertical-align: top;
+		}
+		td:has(h2) {
+		}
+		td:has(h3) {
+			@apply border-b-grey-20 border-b-1 pb-2 mb-2;
+		}
+		td.api-name {
+			@apply pr-2;
+			text-align: left;
+			font-weight: bold;
+		}
+		tr:has(td.api-name) {
+			@apply border-b-grey-10 border-b-1;
+		}
+		tr:has(td.api-name) td {
+			@apply pt-4 mt-4 pb-4 mb-4;
+		}
+	}
+}
+
+.api-method {
+	@apply rounded-sm border;
+	padding-left: var(--spacing);
+	padding-right: var(--spacing);
+	font-family: var(
+		--default-mono-font-family,
+		ui-monospace,
+		SFMono-Regular,
+		Menlo,
+		Monaco,
+		Consolas,
+		'Liberation Mono',
+		'Courier New',
+		monospace
+	);
+	font-feature-settings: var(
+		--default-mono-font-feature-settings,
+		normal
+	);
+	font-variation-settings: var(
+		--default-mono-font-variation-settings,
+		normal
+	);
+	font-size: 0.8em;
+	display: inline-block;
+	font-weight: bold;
+}
+.api-method-get {
+	@apply border-blue-elastic-30 bg-blue-elastic-10 text-blue-elastic;
+}
+.api-method-put {
+	@apply border-yellow-30 bg-yellow-10 text-yellow-90;
+}
+.api-method-post {
+	@apply border-green-30 bg-green-10 text-green-90;
+}
+.api-method-delete {
+	@apply border-red-30 bg-red-10 text-red-90;
+}
+.api-url {
+	margin-left: calc(var(--spacing) * 2);
+	display: inline-block;
 }
 #elastic-api-v3 {
 	dt a {

--- a/src/Elastic.Documentation.Site/Assets/api-docs.css
+++ b/src/Elastic.Documentation.Site/Assets/api-docs.css
@@ -71,7 +71,7 @@
 	li {
 		a {
 			@apply text-grey-80 inline-block w-full p-2 pr-2 pl-2 no-underline;
-			@apply border-white rounded-sm border;
+			@apply rounded-sm border border-white;
 		}
 		a:hover {
 			@apply bg-grey-10;
@@ -79,7 +79,7 @@
 		}
 		a.current {
 			@apply text-grey-80 inline-block w-full p-2 pr-2 pl-2 no-underline;
-			@apply border-white rounded-sm border;
+			@apply rounded-sm border border-white;
 		}
 		a.current:hover {
 			@apply bg-grey-10;
@@ -89,7 +89,7 @@
 	li:only-child {
 		a.current {
 			@apply text-grey-80 inline-block w-full p-2 pr-2 pl-2 no-underline;
-			@apply border-white rounded-sm border;
+			@apply rounded-sm border border-white;
 		}
 		a.current:hover {
 			@apply bg-grey-10;
@@ -103,7 +103,7 @@
 		td:has(h2) {
 		}
 		td:has(h3) {
-			@apply border-b-grey-20 border-b-1 pb-2 mb-2;
+			@apply border-b-grey-20 mb-2 border-b-1 pb-2;
 		}
 		td.api-name {
 			@apply pr-2;
@@ -114,7 +114,7 @@
 			@apply border-b-grey-10 border-b-1;
 		}
 		tr:has(td.api-name) td {
-			@apply pt-4 mt-4 pb-4 mb-4;
+			@apply mt-4 mb-4 pt-4 pb-4;
 		}
 	}
 }
@@ -134,10 +134,7 @@
 		'Courier New',
 		monospace
 	);
-	font-feature-settings: var(
-		--default-mono-font-feature-settings,
-		normal
-	);
+	font-feature-settings: var(--default-mono-font-feature-settings, normal);
 	font-variation-settings: var(
 		--default-mono-font-variation-settings,
 		normal

--- a/src/Elastic.Documentation.Site/Navigation/_TocTree.cshtml
+++ b/src/Elastic.Documentation.Site/Navigation/_TocTree.cshtml
@@ -6,44 +6,44 @@
 		var currentTopLevelItem = Model.TopLevelItems.FirstOrDefault(i => i.Id == Model.Tree.Id) ?? Model.Tree;
 	} 
 	@if (Model.IsUsingNavigationDropdown && currentTopLevelItem is { Index: not null })
-	{
-		<div class="sticky top-0 py-6 bg-white z-10 border-b-1 border-grey-20 pr-4">
-			<div tabindex="0" id="pages-dropdown" class="block group border-1 border-grey-20 rounded-sm font-sans relative">
-				<button class="w-full text-left grid grid-cols-[1fr_auto] cursor-pointer font-semibold gap-1 hover:text-black pl-4 pr-2 py-2 group-open:border-b-1 border-grey-20">
-					<div>
-						<a
-							class="pages-dropdown_active hover:underline text-blue-elastic hover:text-blue-elastic-100"
-							href="@currentTopLevelItem.Url"
-							@Htmx.GetNavHxAttributes(true)>
-							@currentTopLevelItem.NavigationTitle
-						</a>
-					</div>
-					<div class="flex items-center justify-center size-6 hover:bg-grey-20 rounded-sm">
-						<svg
-							xmlns="http://www.w3.org/2000/svg"
-							fill="none"
-							viewBox="0 0 24 24"
-							stroke-width="1.5"
-							stroke="currentColor"
-							class="w-4 group-open:rotate-180">
-							<path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/>
-						</svg>
-					</div>
-				</button>
+		{
+			<div class="sticky top-0 py-6 bg-white z-10 border-b-1 border-grey-20 pr-4">
+				<div tabindex="0" id="pages-dropdown" class="block group border-1 border-grey-20 rounded-sm font-sans relative">
+					<button class="w-full text-left grid grid-cols-[1fr_auto] cursor-pointer font-semibold gap-1 hover:text-black pl-4 pr-2 py-2 group-open:border-b-1 border-grey-20">
+						<div>
+							<a
+								class="pages-dropdown_active hover:underline text-blue-elastic hover:text-blue-elastic-100"
+								href="@currentTopLevelItem.Url"
+								@Htmx.GetNavHxAttributes(true)>
+								@currentTopLevelItem.NavigationTitle
+							</a>
+						</div>
+						<div class="flex items-center justify-center size-6 hover:bg-grey-20 rounded-sm">
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								fill="none"
+								viewBox="0 0 24 24"
+								stroke-width="1.5"
+								stroke="currentColor"
+								class="w-4 group-open:rotate-180">
+								<path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/>
+							</svg>
+						</div>
+					</button>
 				<div class="hidden group-focus-within:block left-0 right-0 absolute top-full">
 					<ul class="mt-1 py-2 bg-white border-1 border-grey-20 rounded-sm shadow-md">
-						@foreach (var item in Model.TopLevelItems)
-						{
+			@foreach (var item in Model.TopLevelItems)
+			{
 							<li class="block">
 								<a
 									class="block py-2 px-4 hover:underline hover:text-black hover:bg-grey-10 active:bg-blue-elastic-70 active:text-white font-semibold @(item.NavigationRoot.Id == Model.Tree.Id ? "text-blue-elastic" : "")"
 									href="@item.Url"
 									@Htmx.GetNavHxAttributes(false, "mouseover")>
-									@item.NavigationTitle
-								</a>
-							</li>
-						}
-					</ul>
+						@item.NavigationTitle
+					</a>
+				</li>
+			}
+			</ul>
 				</div>
 			</div>
 		</div>
@@ -57,16 +57,16 @@
 			@Model.Title
 		</a>
 	}
-	
-	<ul class="block px-4">
-		@await RenderPartialAsync(_TocTreeNav.Create(new NavigationTreeItem
-		{
-			IsPrimaryNavEnabled = Model.IsPrimaryNavEnabled,
-			IsGlobalAssemblyBuild = Model.IsGlobalAssemblyBuild,
-			Level = 0,
-			SubTree = Model.Tree,
-			RootNavigationId = Model.Tree.Id,
-			MaxLevel = Model.MaxLevel
-		}))
-	</ul>
+
+		<ul class="block px-4">
+			@await RenderPartialAsync(_TocTreeNav.Create(new NavigationTreeItem
+			{
+				IsPrimaryNavEnabled = Model.IsPrimaryNavEnabled,
+				IsGlobalAssemblyBuild = Model.IsGlobalAssemblyBuild,
+				Level = 0,
+				SubTree = Model.Tree,
+				RootNavigationId = Model.Tree.Id,
+				MaxLevel = Model.MaxLevel
+			}))
+		</ul>
 </div>

--- a/src/tooling/docs-builder/Http/DocumentationWebHost.cs
+++ b/src/tooling/docs-builder/Http/DocumentationWebHost.cs
@@ -165,6 +165,9 @@ public class DocumentationWebHost
 
 	private async Task<IResult> ServeApiFile(ReloadableGeneratorState holder, string slug, Cancel ctx)
 	{
+#if DEBUG
+		await holder.ReloadApiReferences(ctx);
+#endif
 		var path = Path.Combine(holder.ApiPath.FullName, slug.Trim('/'), "index.html");
 		var info = _writeFileSystem.FileInfo.New(path);
 		if (info.Exists)

--- a/src/tooling/docs-builder/Http/DocumentationWebHost.cs
+++ b/src/tooling/docs-builder/Http/DocumentationWebHost.cs
@@ -166,7 +166,9 @@ public class DocumentationWebHost
 	private async Task<IResult> ServeApiFile(ReloadableGeneratorState holder, string slug, Cancel ctx)
 	{
 #if DEBUG
-		await holder.ReloadApiReferences(ctx);
+		// only reload when actually debugging
+		if (System.Diagnostics.Debugger.IsAttached)
+			await holder.ReloadApiReferences(ctx);
 #endif
 		var path = Path.Combine(holder.ApiPath.FullName, slug.Trim('/'), "index.html");
 		var info = _writeFileSystem.FileInfo.New(path);

--- a/src/tooling/docs-builder/Http/ReloadableGeneratorState.cs
+++ b/src/tooling/docs-builder/Http/ReloadableGeneratorState.cs
@@ -40,6 +40,8 @@ public class ReloadableGeneratorState(
 		await ReloadApiReferences(generator.MarkdownStringRenderer, ctx);
 	}
 
+	public async Task ReloadApiReferences(Cancel ctx) => await ReloadApiReferences(_generator.MarkdownStringRenderer, ctx);
+
 	private async Task ReloadApiReferences(IMarkdownStringRenderer markdownStringRenderer, Cancel ctx)
 	{
 		if (ApiPath.Exists)


### PR DESCRIPTION


https://github.com/user-attachments/assets/f903dab1-26bc-4b98-a90a-e4765769afc3

Adds a new API landing page that lists all the API's in a single openapi reference. 

Simplifies our navigation to always use a fully browsable tree, no dropdowns.

Taking inspiration from https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#about-pull-requests which also contains a nice big list. 

Our `tag grouping` concept helps a great deal making the tree navigable.

