### PR TITLE
Adds an xref to the subs syntax

### DIFF
--- a/docs/syntax/code.md
+++ b/docs/syntax/code.md
@@ -309,6 +309,11 @@ GET /mydocuments/_search
 
 ::::
 
+### Code block substitutions
+
+You can use substitutions to insert reusable values into your code block examples.
+Check the [code blocks substitutions syntax](./substitutions.md#code-blocks) for more information.
+
 ## Inline code
 
 Use backticks to create an inline code span.


### PR DESCRIPTION
Adding a link to the [code blocks substitution](url) syntax from the [Code blocks](https://elastic.github.io/docs-builder/syntax/code/#code-block) page.

<img width="880" height="155" alt="image" src="https://github.com/user-attachments/assets/dddfddcb-ff48-4b2f-9c35-f47972e0ded5" />

