### PR TITLE
feature/config folder arg

### DIFF
--- a/config/assembler.yml
+++ b/config/assembler.yml
@@ -137,3 +137,4 @@ references:
     current: 9.0
     next: main
     skip: true
+    sparse_paths: ["docs", "config"]

--- a/src/Elastic.Documentation.Configuration/Assembler/AssemblyConfiguration.cs
+++ b/src/Elastic.Documentation.Configuration/Assembler/AssemblyConfiguration.cs
@@ -51,13 +51,13 @@ public record AssemblyConfiguration
 		// ReSharper disable NullCoalescingConditionIsAlwaysNotNullAccordingToAPIContract
 		var repository = r ?? new TRepository();
 		// ReSharper restore NullCoalescingConditionIsAlwaysNotNullAccordingToAPIContract
-		repository.Name = name;
-		if (string.IsNullOrEmpty(repository.GitReferenceCurrent))
-			repository.GitReferenceCurrent = "main";
-		if (string.IsNullOrEmpty(repository.GitReferenceNext))
-			repository.GitReferenceNext = "main";
-		if (string.IsNullOrEmpty(repository.GitReferenceEdge))
-			repository.GitReferenceEdge = "main";
+		repository = repository with
+		{
+			Name = name,
+			GitReferenceCurrent = string.IsNullOrEmpty(repository.GitReferenceCurrent) ? "main" : repository.GitReferenceCurrent,
+			GitReferenceNext = string.IsNullOrEmpty(repository.GitReferenceNext) ? "main" : repository.GitReferenceNext,
+			GitReferenceEdge = string.IsNullOrEmpty(repository.GitReferenceEdge) ? "main" : repository.GitReferenceEdge,
+		};
 		if (string.IsNullOrEmpty(repository.Origin))
 		{
 			if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("GITHUB_ACTIONS")))

--- a/src/Elastic.Documentation.Configuration/Assembler/Repository.cs
+++ b/src/Elastic.Documentation.Configuration/Assembler/Repository.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Collections;
 using System.Runtime.Serialization;
 using YamlDotNet.Serialization;
 
@@ -43,6 +44,9 @@ public record Repository
 
 	[YamlMember(Alias = "edge")]
 	public string GitReferenceEdge { get; set; } = "main";
+
+	[YamlMember(Alias = "sparse_paths")]
+	public string[] SparsePaths { get; set; } = ["docs"];
 
 	public string GetBranch(ContentSource contentSource) => contentSource switch
 	{

--- a/src/tooling/Elastic.Documentation.Tooling/Filters/InfoLoggerFilter.cs
+++ b/src/tooling/Elastic.Documentation.Tooling/Filters/InfoLoggerFilter.cs
@@ -1,0 +1,24 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Reflection;
+using ConsoleAppFramework;
+using Elastic.Documentation.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Elastic.Documentation.Tooling.Filters;
+
+public class InfoLoggerFilter(ConsoleAppFilter next, ILogger<InfoLoggerFilter> logger, ConfigurationFileProvider fileProvider) : ConsoleAppFilter(next)
+{
+	public override async Task InvokeAsync(ConsoleAppContext context, Cancel cancellationToken)
+	{
+		logger.LogInformation("Configuration source: {ConfigurationSource}", fileProvider.ConfigurationSource.ToStringFast(true));
+		if (fileProvider.ConfigurationSource == ConfigurationSource.Checkout)
+			logger.LogInformation("Configuration source git reference: {ConfigurationSourceGitReference}", fileProvider.GitReference);
+		var assemblyVersion = Assembly.GetExecutingAssembly().GetCustomAttributes<AssemblyInformationalVersionAttribute>()
+			.FirstOrDefault()?.InformationalVersion;
+		logger.LogInformation("Version: {Version}", assemblyVersion);
+		await Next.InvokeAsync(context, cancellationToken);
+	}
+}

--- a/src/tooling/docs-assembler/Cli/RepositoryCommands.cs
+++ b/src/tooling/docs-assembler/Cli/RepositoryCommands.cs
@@ -42,6 +42,39 @@ internal sealed class RepositoryCommands(
 		ConsoleApp.LogError = msg => _log.LogError(msg);
 	}
 
+	/// <summary> Clone the configuration folder </summary>
+	/// <param name="gitRef">The git reference of the config, defaults to 'main'</param>
+	[Command("init-config")]
+	public async Task<int> CloneConfigurationFolder(string? gitRef = null, Cancel ctx = default)
+	{
+		await using var collector = new ConsoleDiagnosticsCollector(logFactory, githubActionsService).StartAsync(ctx);
+
+		var fs = new FileSystem();
+		var cachedPath = Path.Combine(Paths.ApplicationData.FullName, "config-clone");
+		var checkoutFolder = fs.DirectoryInfo.New(cachedPath);
+		var cloner = new RepositorySourcer(logFactory, checkoutFolder, fs, collector);
+
+		// relies on the embedded configuration, but we don't expect this to change
+		var repository = assemblyConfiguration.ReferenceRepositories["docs-builder"];
+		repository = repository with
+		{
+			SparsePaths = ["config"]
+		};
+		if (string.IsNullOrEmpty(gitRef))
+			gitRef = "main";
+
+		_log.LogInformation("Cloning configuration ({GitReference})", gitRef);
+		var checkout = cloner.CloneRef(repository, gitRef, appendRepositoryName: false);
+		_log.LogInformation("Cloned configuration ({GitReference}) to {ConfigurationFolder}", checkout.HeadReference, checkout.Directory.FullName);
+
+		var gitRefInformationFile = Path.Combine(cachedPath, "config", "git-ref.txt");
+		await fs.File.WriteAllTextAsync(gitRefInformationFile, checkout.HeadReference, ctx);
+
+		await collector.StopAsync(ctx);
+		return collector.Errors;
+	}
+
+
 	/// <summary> Clones all repositories </summary>
 	/// <param name="strict"> Treat warnings as errors and fail the build on warnings</param>
 	/// <param name="environment"> The environment to build</param>

--- a/src/tooling/docs-assembler/Program.cs
+++ b/src/tooling/docs-assembler/Program.cs
@@ -21,6 +21,7 @@ ConsoleApp.ServiceProvider = serviceProvider;
 
 var app = ConsoleApp.Create();
 app.UseFilter<ReplaceLogFilter>();
+app.UseFilter<InfoLoggerFilter>();
 app.UseFilter<StopwatchFilter>();
 app.UseFilter<CatchExceptionFilter>();
 

--- a/src/tooling/docs-assembler/Sourcing/GitFacade.cs
+++ b/src/tooling/docs-assembler/Sourcing/GitFacade.cs
@@ -17,7 +17,7 @@ public interface IGitRepository
 	bool IsInitialized();
 	void Pull(string branch);
 	void Fetch(string reference);
-	void EnableSparseCheckout(string folder);
+	void EnableSparseCheckout(string[] folders);
 	void DisableSparseCheckout();
 	void Checkout(string reference);
 }
@@ -40,7 +40,7 @@ public class SingleCommitOptimizedGitRepository(DiagnosticsCollector collector, 
 	public bool IsInitialized() => Directory.Exists(Path.Combine(WorkingDirectory.FullName, ".git"));
 	public void Pull(string branch) => ExecIn(EnvironmentVars, "git", "pull", "--depth", "1", "--allow-unrelated-histories", "--no-ff", "origin", branch);
 	public void Fetch(string reference) => ExecIn(EnvironmentVars, "git", "fetch", "--no-tags", "--prune", "--no-recurse-submodules", "--depth", "1", "origin", reference);
-	public void EnableSparseCheckout(string folder) => ExecIn(EnvironmentVars, "git", "sparse-checkout", "set", folder);
+	public void EnableSparseCheckout(string[] folders) => ExecIn(EnvironmentVars, "git", ["sparse-checkout", "set", .. folders]);
 	public void DisableSparseCheckout() => ExecIn(EnvironmentVars, "git", "sparse-checkout", "disable");
 	public void Checkout(string reference) => ExecIn(EnvironmentVars, "git", "checkout", "--force", reference);
 

--- a/src/tooling/docs-assembler/Sourcing/RepositorySourcesFetcher.cs
+++ b/src/tooling/docs-assembler/Sourcing/RepositorySourcesFetcher.cs
@@ -130,9 +130,12 @@ public class RepositorySourcer(ILoggerFactory logFactory, IDirectoryInfo checkou
 	// </summary>
 	// <param name="repository">The repository to clone.</param>
 	// <param name="gitRef">The git reference to check out. Branch, commit or tag</param>
-	public Checkout CloneRef(Repository repository, string gitRef, bool pull = false, int attempt = 1)
+	public Checkout CloneRef(Repository repository, string gitRef, bool pull = false, int attempt = 1, bool appendRepositoryName = true)
 	{
-		var checkoutFolder = readFileSystem.DirectoryInfo.New(Path.Combine(checkoutDirectory.FullName, repository.Name));
+		var checkoutFolder =
+			appendRepositoryName
+				? readFileSystem.DirectoryInfo.New(Path.Combine(checkoutDirectory.FullName, repository.Name))
+				: checkoutDirectory;
 		IGitRepository git = new SingleCommitOptimizedGitRepository(collector, checkoutFolder);
 		if (attempt > 3)
 		{
@@ -228,7 +231,7 @@ public class RepositorySourcer(ILoggerFactory logFactory, IDirectoryInfo checkou
 				git.DisableSparseCheckout();
 				break;
 			case CheckoutStrategy.Partial:
-				git.EnableSparseCheckout("docs");
+				git.EnableSparseCheckout(repository.SparsePaths);
 				break;
 			default:
 				throw new ArgumentOutOfRangeException(nameof(repository), repository.CheckoutStrategy, null);

--- a/src/tooling/docs-builder/Program.cs
+++ b/src/tooling/docs-builder/Program.cs
@@ -15,6 +15,7 @@ ConsoleApp.ServiceProvider = serviceProvider;
 var app = ConsoleApp.Create();
 
 app.UseFilter<ReplaceLogFilter>();
+app.UseFilter<InfoLoggerFilter>();
 app.UseFilter<StopwatchFilter>();
 app.UseFilter<CatchExceptionFilter>();
 app.UseFilter<CheckForUpdatesFilter>();


### PR DESCRIPTION
This allows the build to source the configuration prior to cloning and building

docs-assembler repo init-config
docs-assembler repo clone-all
docs-assembler repo build-all

On production we can lock the configuration to a commit using `--git-ref sha`.

I think we want to automate opening PR's to update that sha to the last commit on our `config` folder. We can then merge it once we know staging is still good.

ConfigurationFileProvider will look at

- {pwd}/config, development
- {app_data}/config, (where init-config clones too)
- embedded sources

We also now log the configuration source and in case of app_data also the git reference.