### PR TITLE
Use the lastest patch version for `stack.current` in `versions.yml`

### DIFF
--- a/config/versions.yml
+++ b/config/versions.yml
@@ -1,7 +1,7 @@
 versioning_systems:
   stack: &stack
     base: 9.0
-    current: 9.0
+    current: 9.0.3
   
   # Using an unlikely high version
   # So that our logic that would display "planned" doesn't trigger


### PR DESCRIPTION
Right now the current Elastic Stack version is 9.0.3. I noticed that `applies_to` labels for `9.0.1`, `9.0.2`, and `9.0.3` are being rendered as `Planned`. I think it's because of the `stack.current` in the `config/versions.yml`. I tested out the changes in this PR locally and it seems to be rendered as expected.