### PR TITLE
Better approach to set the title on directives in LLM markdown output

### DIFF
--- a/src/Elastic.Markdown/Myst/Directives/Admonition/AdmonitionBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Admonition/AdmonitionBlock.cs
@@ -8,7 +8,7 @@ namespace Elastic.Markdown.Myst.Directives.Admonition;
 
 public class DropdownBlock(DirectiveBlockParser parser, ParserContext context) : AdmonitionBlock(parser, "dropdown", context);
 
-public class AdmonitionBlock : DirectiveBlock, ITitledBlock
+public class AdmonitionBlock : DirectiveBlock, IBlockTitle
 {
 	public AdmonitionBlock(DirectiveBlockParser parser, string admonition, ParserContext context) : base(parser, context)
 	{

--- a/src/Elastic.Markdown/Myst/Directives/Admonition/AdmonitionBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Admonition/AdmonitionBlock.cs
@@ -8,7 +8,7 @@ namespace Elastic.Markdown.Myst.Directives.Admonition;
 
 public class DropdownBlock(DirectiveBlockParser parser, ParserContext context) : AdmonitionBlock(parser, "dropdown", context);
 
-public class AdmonitionBlock : DirectiveBlock
+public class AdmonitionBlock : DirectiveBlock, ITitledBlock
 {
 	public AdmonitionBlock(DirectiveBlockParser parser, string admonition, ParserContext context) : base(parser, context)
 	{
@@ -45,5 +45,3 @@ public class AdmonitionBlock : DirectiveBlock
 		Title = Title.ReplaceSubstitutions(context);
 	}
 }
-
-

--- a/src/Elastic.Markdown/Myst/Directives/DirectiveBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/DirectiveBlock.cs
@@ -13,7 +13,7 @@ using Markdig.Syntax;
 
 namespace Elastic.Markdown.Myst.Directives;
 
-public interface ITitledBlock
+public interface IBlockTitle
 {
 	string Title { get; }
 }

--- a/src/Elastic.Markdown/Myst/Directives/DirectiveBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/DirectiveBlock.cs
@@ -13,6 +13,11 @@ using Markdig.Syntax;
 
 namespace Elastic.Markdown.Myst.Directives;
 
+public interface ITitledBlock
+{
+	string Title { get; }
+}
+
 public interface IBlockExtension : IBlock
 {
 	BuildContext Build { get; }

--- a/src/Elastic.Markdown/Myst/Directives/Stepper/StepperBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Stepper/StepperBlock.cs
@@ -16,7 +16,7 @@ public class StepperBlock(DirectiveBlockParser parser, ParserContext context) : 
 	}
 }
 
-public class StepBlock(DirectiveBlockParser parser, ParserContext context) : DirectiveBlock(parser, context), ITitledBlock
+public class StepBlock(DirectiveBlockParser parser, ParserContext context) : DirectiveBlock(parser, context), IBlockTitle
 {
 	public override string Directive => "step";
 	public string Title { get; private set; } = string.Empty;

--- a/src/Elastic.Markdown/Myst/Directives/Stepper/StepperBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Stepper/StepperBlock.cs
@@ -16,7 +16,7 @@ public class StepperBlock(DirectiveBlockParser parser, ParserContext context) : 
 	}
 }
 
-public class StepBlock(DirectiveBlockParser parser, ParserContext context) : DirectiveBlock(parser, context)
+public class StepBlock(DirectiveBlockParser parser, ParserContext context) : DirectiveBlock(parser, context), ITitledBlock
 {
 	public override string Directive => "step";
 	public string Title { get; private set; } = string.Empty;

--- a/src/Elastic.Markdown/Myst/Directives/Tabs/TabSetBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Tabs/TabSetBlock.cs
@@ -33,7 +33,7 @@ public class TabSetBlock(DirectiveBlockParser parser, ParserContext context)
 }
 
 public class TabItemBlock(DirectiveBlockParser parser, ParserContext context)
-	: DirectiveBlock(parser, context), ITitledBlock
+	: DirectiveBlock(parser, context), IBlockTitle
 {
 	public override string Directive => "tab-item";
 

--- a/src/Elastic.Markdown/Myst/Directives/Tabs/TabSetBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Tabs/TabSetBlock.cs
@@ -33,7 +33,7 @@ public class TabSetBlock(DirectiveBlockParser parser, ParserContext context)
 }
 
 public class TabItemBlock(DirectiveBlockParser parser, ParserContext context)
-	: DirectiveBlock(parser, context)
+	: DirectiveBlock(parser, context), ITitledBlock
 {
 	public override string Directive => "tab-item";
 

--- a/src/Elastic.Markdown/Myst/Renderers/LlmMarkdown/LlmBlockRenderers.cs
+++ b/src/Elastic.Markdown/Myst/Renderers/LlmMarkdown/LlmBlockRenderers.cs
@@ -5,10 +5,8 @@
 using Elastic.Markdown.Helpers;
 using Elastic.Markdown.Myst.CodeBlocks;
 using Elastic.Markdown.Myst.Directives;
-using Elastic.Markdown.Myst.Directives.Admonition;
 using Elastic.Markdown.Myst.Directives.Image;
 using Elastic.Markdown.Myst.Directives.Include;
-using Elastic.Markdown.Myst.Directives.Tabs;
 using Markdig.Extensions.DefinitionLists;
 using Markdig.Extensions.Tables;
 using Markdig.Extensions.Yaml;
@@ -382,18 +380,8 @@ public class LlmDirectiveRenderer : MarkdownObjectRenderer<LlmMarkdownRenderer, 
 		renderer.Writer.Write("<");
 		renderer.Writer.Write(obj.Directive);
 
-		switch (obj)
-		{
-			case DropdownBlock dropdown:
-				renderer.Writer.Write($" title=\"{dropdown.Title}\"");
-				break;
-			case TabItemBlock tabItem:
-				renderer.Writer.Write($" title=\"{tabItem.Title}\"");
-				break;
-			case AdmonitionBlock admonition when obj.Directive is "admonition":
-				renderer.Writer.Write($" title=\"{admonition.Title}\"");
-				break;
-		}
+		if (obj is ITitledBlock titledBlock)
+			renderer.Writer.Write($" title=\"{titledBlock.Title}\"");
 
 		renderer.WriteLine(">");
 		renderer.EnsureLine();

--- a/src/Elastic.Markdown/Myst/Renderers/LlmMarkdown/LlmBlockRenderers.cs
+++ b/src/Elastic.Markdown/Myst/Renderers/LlmMarkdown/LlmBlockRenderers.cs
@@ -393,14 +393,6 @@ public class LlmDirectiveRenderer : MarkdownObjectRenderer<LlmMarkdownRenderer, 
 				break;
 		}
 
-		// if (obj is ITitledBlock titledBlock
-		// 	&& obj.Directive != "note"
-		// 	&& obj.Directive != "warning"
-		// 	&& obj.Directive != "tip"
-		// 	&& obj.Directive != "important"
-		// )
-		// 	renderer.Writer.Write($" title=\"{titledBlock.Title}\"");
-
 		renderer.WriteLine(">");
 		renderer.EnsureLine();
 

--- a/src/Elastic.Markdown/Myst/Renderers/LlmMarkdown/LlmBlockRenderers.cs
+++ b/src/Elastic.Markdown/Myst/Renderers/LlmMarkdown/LlmBlockRenderers.cs
@@ -388,7 +388,7 @@ public class LlmDirectiveRenderer : MarkdownObjectRenderer<LlmMarkdownRenderer, 
 				// skip for these directives
 				// otherwise it will render as <note title="Note">
 				break;
-			case ITitledBlock titledBlock:
+			case IBlockTitle titledBlock:
 				renderer.Writer.Write($" title=\"{titledBlock.Title}\"");
 				break;
 		}

--- a/src/Elastic.Markdown/Myst/Renderers/LlmMarkdown/LlmBlockRenderers.cs
+++ b/src/Elastic.Markdown/Myst/Renderers/LlmMarkdown/LlmBlockRenderers.cs
@@ -5,6 +5,7 @@
 using Elastic.Markdown.Helpers;
 using Elastic.Markdown.Myst.CodeBlocks;
 using Elastic.Markdown.Myst.Directives;
+using Elastic.Markdown.Myst.Directives.Admonition;
 using Elastic.Markdown.Myst.Directives.Image;
 using Elastic.Markdown.Myst.Directives.Include;
 using Markdig.Extensions.DefinitionLists;
@@ -380,8 +381,25 @@ public class LlmDirectiveRenderer : MarkdownObjectRenderer<LlmMarkdownRenderer, 
 		renderer.Writer.Write("<");
 		renderer.Writer.Write(obj.Directive);
 
-		if (obj is ITitledBlock titledBlock)
-			renderer.Writer.Write($" title=\"{titledBlock.Title}\"");
+		switch (obj)
+		{
+			case AdmonitionBlock when obj.Directive
+				is "note" or "tip" or "warning" or "important":
+				// skip for these directives
+				// otherwise it will render as <note title="Note">
+				break;
+			case ITitledBlock titledBlock:
+				renderer.Writer.Write($" title=\"{titledBlock.Title}\"");
+				break;
+		}
+
+		// if (obj is ITitledBlock titledBlock
+		// 	&& obj.Directive != "note"
+		// 	&& obj.Directive != "warning"
+		// 	&& obj.Directive != "tip"
+		// 	&& obj.Directive != "important"
+		// )
+		// 	renderer.Writer.Write($" title=\"{titledBlock.Title}\"");
 
 		renderer.WriteLine(">");
 		renderer.EnsureLine();


### PR DESCRIPTION
## Changes

- Set missing title for Stepper StepBlock.
- Refactor how the LlmDirectiveRenderer determines if it needs to render a title attribute