### PR TITLE
Update `config/versions.yml` for Elastic Stack release 9.0.4

### DIFF
--- a/config/versions.yml
+++ b/config/versions.yml
@@ -1,7 +1,7 @@
 versioning_systems:
   stack: &stack
     base: 9.0
-    current: 9.0.3
+    current: 9.0.4
   
   # Using an unlikely high version
   # So that our logic that would display "planned" doesn't trigger


### PR DESCRIPTION
Updates `config/versions.yml` for Elastic Stack release 9.0.4, which was released today.