### PR TITLE
Updating ECK version to 3.1

### DIFF
--- a/config/versions.yml
+++ b/config/versions.yml
@@ -16,7 +16,7 @@ versioning_systems:
   ech: *all
   eck:
     base: 3.0
-    current: 3.2
+    current: 3.1
   ess: *all
   self: *stack
 


### PR DESCRIPTION
ECK currently shows `current` as `3.2` but according to the official schedule that release isn't due until a few months from now. This will update to `3.1`, which GAs next week. 

(I'm intentionally being vague about the exact release dates since these can change.)