### PR TITLE
Fix "Contribute and extend" link

### DIFF
--- a/src/Elastic.Markdown/Layout/_LandingPage.cshtml
+++ b/src/Elastic.Markdown/Layout/_LandingPage.cshtml
@@ -252,7 +252,7 @@
 					<h3 class="font-sans font-bold text-2xl">Contribute and extend</h3>
 					<p class="grow mt-4">Learn how to contribute to Elastic products and extend capabilities.</p>
 					<div class="mt-6">
-						<a href="@Model.Link("extend/kibana")" class="link text-white wrap-break-word">
+						<a href="@Model.Link("extend/")" class="link text-white wrap-break-word">
 							<span class="wrap-break-word">
 								View contribute and extend docs
 							</span>


### PR DESCRIPTION
I don't think it should link to the Kibana section?

I was confused by the link in https://www.elastic.co/docs#product-resources when reviewing https://github.com/elastic/docs-content/pull/2229