### PR TITLE
Add crosslinks to toc: in docset.yml

### DIFF
--- a/docs/_docset.yml
+++ b/docs/_docset.yml
@@ -149,5 +149,7 @@ toc:
           - folder: baz
             children:
               - file: qux.md
-  - title: "Getting Started Guide"
-    crosslink: docs-content://get-started/introduction.md
+      - title: "Getting Started Guide"
+        crosslink: docs-content://get-started/introduction.md
+      - title: "Test title"
+        crosslink: docs-content://solutions/search/elasticsearch-basics-quickstart.md

--- a/docs/_docset.yml
+++ b/docs/_docset.yml
@@ -149,3 +149,5 @@ toc:
           - folder: baz
             children:
               - file: qux.md
+  - title: "Getting Started Guide"
+    crosslink: docs-content://get-started/introduction.md

--- a/docs/configure/content-set/navigation.md
+++ b/docs/configure/content-set/navigation.md
@@ -72,11 +72,37 @@ cross_links:
   - docs-content
 ```
 
+#### Adding cross-links in Markdown content
+
 To link to a document in the `docs-content` repository, you would write the link as follows:
 
-```
+```markdown
 [Link to docs-content doc](docs-content://directory/another-directory/file.md)
 ```
+
+You can also link to specific anchors within the document:
+
+```markdown
+[Link to specific section](docs-content://directory/file.md#section-id)
+```
+
+#### Adding cross-links in navigation
+
+Cross-links can also be included in navigation structures. When creating a `toc.yml` file or defining navigation in `docset.yml`, you can add cross-links as follows:
+
+```yaml
+toc:
+  - file: index.md
+  - title: External Documentation
+    cross_link: docs-content://directory/file.md
+  - folder: local-section
+    children:
+      - file: index.md
+      - title: API Reference
+        cross_link: elasticsearch://api/index.html
+```
+
+Cross-links in navigation will be automatically resolved during the build process, maintaining consistent linking between related documentation across repositories.
 
 ### `exclude`
 

--- a/docs/configure/content-set/navigation.md
+++ b/docs/configure/content-set/navigation.md
@@ -94,12 +94,12 @@ Cross-links can also be included in navigation structures. When creating a `toc.
 toc:
   - file: index.md
   - title: External Documentation
-    cross_link: docs-content://directory/file.md
+    crosslink: docs-content://directory/file.md
   - folder: local-section
     children:
       - file: index.md
       - title: API Reference
-        cross_link: elasticsearch://api/index.html
+        crosslink: elasticsearch://api/index.html
 ```
 
 Cross-links in navigation will be automatically resolved during the build process, maintaining consistent linking between related documentation across repositories.

--- a/src/Elastic.Documentation.Configuration/Builder/TableOfContentsConfiguration.cs
+++ b/src/Elastic.Documentation.Configuration/Builder/TableOfContentsConfiguration.cs
@@ -129,6 +129,8 @@ public record TableOfContentsConfiguration : ITableOfContentsScope
 	private IEnumerable<ITocItem>? ReadChild(YamlStreamReader reader, YamlMappingNode tocEntry, string parentPath)
 	{
 		string? file = null;
+		string? crossLink = null;
+		string? title = null;
 		string? folder = null;
 		string[]? detectionRules = null;
 		TableOfContentsConfiguration? toc = null;
@@ -147,6 +149,13 @@ public record TableOfContentsConfiguration : ITableOfContentsScope
 				case "file":
 					hiddenFile = key == "hidden";
 					file = ReadFile(reader, entry, parentPath);
+					break;
+				case "title":
+					title = reader.ReadString(entry);
+					break;
+				case "crosslink":
+					hiddenFile = false;
+					crossLink = reader.ReadString(entry);
 					break;
 				case "folder":
 					folder = ReadFolder(reader, entry, parentPath);
@@ -197,6 +206,12 @@ public record TableOfContentsConfiguration : ITableOfContentsScope
 
 			var path = $"{parentPath}{Path.DirectorySeparatorChar}{file}".TrimStart(Path.DirectorySeparatorChar);
 			return [new FileReference(this, path, hiddenFile, children ?? [])];
+		}
+
+		if (crossLink is not null)
+		{
+			// No validation here - we'll validate cross-links separately
+			return [new CrossLinkReference(this, crossLink, title, hiddenFile, children ?? [])];
 		}
 
 		if (folder is not null)

--- a/src/Elastic.Documentation.Configuration/TableOfContents/ITocItem.cs
+++ b/src/Elastic.Documentation.Configuration/TableOfContents/ITocItem.cs
@@ -14,6 +14,9 @@ public interface ITocItem
 public record FileReference(ITableOfContentsScope TableOfContentsScope, string RelativePath, bool Hidden, IReadOnlyCollection<ITocItem> Children)
 	: ITocItem;
 
+public record CrossLinkReference(ITableOfContentsScope TableOfContentsScope, string CrossLinkUri, string? Title, bool Hidden, IReadOnlyCollection<ITocItem> Children)
+	: ITocItem;
+
 public record FolderReference(ITableOfContentsScope TableOfContentsScope, string RelativePath, IReadOnlyCollection<ITocItem> Children)
 	: ITocItem;
 

--- a/src/Elastic.Markdown/IO/Navigation/CrossLinkNavigationItem.cs
+++ b/src/Elastic.Markdown/IO/Navigation/CrossLinkNavigationItem.cs
@@ -1,0 +1,67 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using Elastic.Documentation.Site.Navigation;
+
+namespace Elastic.Markdown.IO.Navigation;
+
+[DebuggerDisplay("CrossLink: {Url}")]
+public record CrossLinkNavigationItem : ILeafNavigationItem<INavigationModel>
+{
+	// Override Url accessor to use ResolvedUrl if available
+	string INavigationItem.Url => ResolvedUrl ?? Url;
+	public CrossLinkNavigationItem(string url, string? title, DocumentationGroup group, bool hidden = false)
+	{
+		_url = url;
+		NavigationTitle = title ?? GetNavigationTitleFromUrl(url);
+		Parent = group;
+		NavigationRoot = group.NavigationRoot;
+		Hidden = hidden;
+	}
+
+	private string GetNavigationTitleFromUrl(string url)
+	{
+		// Extract a decent title from the URL
+		try
+		{
+			if (Uri.TryCreate(url, UriKind.Absolute, out var uri))
+			{
+				// Get the last segment of the path and remove extension
+				var lastSegment = uri.AbsolutePath.Split('/').Last();
+				lastSegment = Path.GetFileNameWithoutExtension(lastSegment);
+
+				// Convert to title case (simple version)
+				if (!string.IsNullOrEmpty(lastSegment))
+				{
+					var words = lastSegment.Replace('-', ' ').Replace('_', ' ').Split(' ');
+					var titleCase = string.Join(" ", words.Select(w =>
+						string.IsNullOrEmpty(w) ? "" : char.ToUpper(w[0]) + w[1..].ToLowerInvariant()));
+					return titleCase;
+				}
+			}
+		}
+		catch
+		{
+			// Fall back to URL if parsing fails
+		}
+
+		return url;
+	}
+
+	public INodeNavigationItem<INavigationModel, INavigationItem>? Parent { get; set; }
+	public IRootNavigationItem<INavigationModel, INavigationItem> NavigationRoot { get; }
+	// Original URL from the cross-link
+	private readonly string _url;
+
+	// Store resolved URL for rendering
+	public string? ResolvedUrl { get; set; }
+
+	// Implement the INavigationItem.Url property to use ResolvedUrl if available
+	public string Url => ResolvedUrl ?? _url; public string NavigationTitle { get; }
+	public int NavigationIndex { get; set; }
+	public bool Hidden { get; }
+	public INavigationModel Model => null!; // Cross-link has no local model
+}

--- a/src/Elastic.Markdown/IO/Navigation/DocumentationGroup.cs
+++ b/src/Elastic.Markdown/IO/Navigation/DocumentationGroup.cs
@@ -119,7 +119,13 @@ public class DocumentationGroup : INodeNavigationItem<MarkdownFile, INavigationI
 
 		foreach (var tocItem in lookups.TableOfContents)
 		{
-			if (tocItem is FileReference file)
+			if (tocItem is CrossLinkReference crossLink)
+			{
+				// Create a special navigation item for cross-repository links
+				var crossLinkItem = new CrossLinkNavigationItem(crossLink.CrossLinkUri, crossLink.Title, this, crossLink.Hidden);
+				AddToNavigationItems(crossLinkItem, ref fileIndex);
+			}
+			else if (tocItem is FileReference file)
 			{
 				if (!lookups.FlatMappedFiles.TryGetValue(file.RelativePath, out var d))
 				{

--- a/src/Elastic.Markdown/IO/Navigation/NavigationCrossLinkValidator.cs
+++ b/src/Elastic.Markdown/IO/Navigation/NavigationCrossLinkValidator.cs
@@ -1,0 +1,94 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Elastic.Documentation.Site.Navigation;
+using Elastic.Markdown.Links.CrossLinks;
+
+namespace Elastic.Markdown.IO.Navigation;
+
+public static class NavigationCrossLinkValidator
+{
+	public static async Task ValidateNavigationCrossLinksAsync(
+		INavigationItem root,
+		ICrossLinkResolver crossLinkResolver,
+		Action<string> errorEmitter)
+	{
+		// Ensure cross-links are fetched before validation
+		_ = await crossLinkResolver.FetchLinks(new Cancel());
+
+		// Collect all navigation items that contain cross-repo links
+		var itemsWithCrossLinks = FindNavigationItemsWithCrossLinks(root);
+
+		foreach (var item in itemsWithCrossLinks)
+		{
+			if (item is CrossLinkNavigationItem crossLinkItem)
+			{
+				var url = crossLinkItem.Url;
+				if (url != null && Uri.TryCreate(url, UriKind.Absolute, out var crossUri) &&
+					crossUri.Scheme != "http" && crossUri.Scheme != "https")
+				{
+					// Try to resolve the cross-link URL
+					if (crossLinkResolver.TryResolve(errorEmitter, crossUri, out var resolvedUri))
+					{
+						// If resolved successfully, set the resolved URL
+						crossLinkItem.ResolvedUrl = resolvedUri.ToString();
+					}
+					else
+					{
+						// Error already emitted by CrossLinkResolver
+						// But we won't fail the build - just display the original URL
+					}
+				}
+			}
+			else if (item is FileNavigationItem fileItem &&
+					fileItem.Url != null &&
+					Uri.TryCreate(fileItem.Url, UriKind.Absolute, out var fileUri) &&
+					fileUri.Scheme != "http" &&
+					fileUri.Scheme != "https")
+			{
+				// Cross-link URL detected in a FileNavigationItem, but we're not validating it yet
+			}
+		}
+
+		return;
+	}
+
+	private static List<INavigationItem> FindNavigationItemsWithCrossLinks(INavigationItem item)
+	{
+		var results = new List<INavigationItem>();
+
+		// Check if this item has a cross-link
+		if (item is CrossLinkNavigationItem crossLinkItem)
+		{
+			var url = crossLinkItem.Url;
+			if (url != null &&
+				Uri.TryCreate(url, UriKind.Absolute, out var uri) &&
+				uri.Scheme != "http" &&
+				uri.Scheme != "https")
+			{
+				results.Add(item);
+			}
+		}
+		else if (item is FileNavigationItem fileItem &&
+				fileItem.Url != null &&
+				Uri.TryCreate(fileItem.Url, UriKind.Absolute, out var fileUri) &&
+				fileUri.Scheme != "http" &&
+				fileUri.Scheme != "https")
+		{
+			results.Add(item);
+		}       // Recursively check children if this is a container
+		if (item is INodeNavigationItem<INavigationModel, INavigationItem> containerItem)
+		{
+			foreach (var child in containerItem.NavigationItems)
+			{
+				results.AddRange(FindNavigationItemsWithCrossLinks(child));
+			}
+		}
+
+		return results;
+	}
+}

--- a/tests/Elastic.Markdown.Tests/TestCrossLinkResolver.cs
+++ b/tests/Elastic.Markdown.Tests/TestCrossLinkResolver.cs
@@ -19,6 +19,10 @@ public class TestCrossLinkResolver : ICrossLinkResolver
 
 	public Task<FetchedCrossLinks> FetchLinks(Cancel ctx)
 	{
+		// Clear existing entries to prevent duplicate key errors when called multiple times
+		LinkReferences.Clear();
+		DeclaredRepositories.Clear();
+
 		// language=json
 		var json = """
 		           {
@@ -47,7 +51,7 @@ public class TestCrossLinkResolver : ICrossLinkResolver
 		var reference = CrossLinkFetcher.Deserialize(json);
 		LinkReferences.Add("docs-content", reference);
 		LinkReferences.Add("kibana", reference);
-		DeclaredRepositories.AddRange(["docs-content", "kibana", "elasticsearch"]);
+		DeclaredRepositories.AddRange(["docs-content", "kibana"]);
 
 		var indexEntries = LinkReferences.ToDictionary(e => e.Key, e => new LinkRegistryEntry
 		{

--- a/tests/authoring/Framework/TestCrossLinkResolver.fs
+++ b/tests/authoring/Framework/TestCrossLinkResolver.fs
@@ -28,6 +28,10 @@ type TestCrossLinkResolver (config: ConfigurationFile) =
         member this.UriResolver = uriResolver
 
         member this.FetchLinks(ctx) =
+            // Clear existing entries to prevent duplicate key errors when called multiple times
+            this.LinkReferences.Clear()
+            this.DeclaredRepositories.Clear()
+            
             let redirects = RepositoryLinks.SerializeRedirects config.Redirects
             // language=json
             let json = $$"""{
@@ -66,7 +70,6 @@ type TestCrossLinkResolver (config: ConfigurationFile) =
             this.LinkReferences.Add("kibana", reference)
             this.DeclaredRepositories.Add("docs-content") |> ignore;
             this.DeclaredRepositories.Add("kibana") |> ignore;
-            this.DeclaredRepositories.Add("elasticsearch") |> ignore
 
             let indexEntries =
                 this.LinkReferences.ToDictionary(_.Key, fun (e : KeyValuePair<string, RepositoryLinks>) -> LinkRegistryEntry(


### PR DESCRIPTION
This PR adds crosslinks as accepted item types in docset.yml toc directives.

For example:

```yaml
toc:
  - file: index.md
  - title: External Documentation
    crosslink: docs-content://directory/file.md
```