### PR TITLE
Bump EDOT versions in versions.yml for 9.1

### DIFF
--- a/config/versions.yml
+++ b/config/versions.yml
@@ -66,7 +66,7 @@ versioning_systems:
   # EDOTs
   edot_collector:
     base: 9.0
-    current: 9.0.3
+    current: 9.1.0
   edot_ios:
     base: 1.0
     current: 1.2.1
@@ -78,16 +78,16 @@ versioning_systems:
     current: 1.0.2
   edot_java:
     base: 1.0
-    current: 1.4.1
+    current: 1.5.0
   edot_node:
     base: 1.0
-    current: 1.1.1
+    current: 1.2.0
   edot_php:
     base: 1.0
-    current: 1.0.0
+    current: 1.1.0
   edot_python:
     base: 1.0
-    current: 1.3.0
+    current: 1.4.0
   edot_cf_aws:
     base: 0.1
     current: 0.1.6


### PR DESCRIPTION
This bumps selected EDOT versions for 9.1 release. Others to be updated by UpdateCLI once it's up (#1602).

* DO NOT MERGE TILL ALL VERSIONS ARE RELEASED *