### PR TITLE
Lazyload `SearchOrAskAiModal`

### DIFF
--- a/src/Elastic.Documentation.Site/.gitignore
+++ b/src/Elastic.Documentation.Site/.gitignore
@@ -1,11 +1,7 @@
 .parcel-cache/
 node_modules/
-_static/main.js
-_static/main.js.map
-_static/custom-elements.js
-_static/custom-elements.js.map
-_static/pages-nav.js
-_static/pages-nav.js.map
 _static/styles.css
 _static/styles.css.map
 _static/*.woff2
+_static/*.js
+_static/*.js.map

--- a/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/SearchOrAskAiButton.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/SearchOrAskAiButton.tsx
@@ -1,5 +1,5 @@
+/** @jsxImportSource @emotion/react */
 import '../../eui-icons-cache'
-import { SearchOrAskAiModal } from './SearchOrAskAiModal'
 import { useModalActions, useModalIsOpen } from './modal.store'
 import { useSearchActions, useSearchTerm } from './search.store'
 import {
@@ -10,10 +10,14 @@ import {
     EuiPanel,
     EuiTextTruncate,
     EuiText,
+    EuiLoadingSpinner,
 } from '@elastic/eui'
 import { css } from '@emotion/react'
 import * as React from 'react'
-import { useEffect } from 'react'
+import { useEffect, Suspense, lazy } from 'react'
+
+// Lazy load the modal component
+const SearchOrAskAiModal = lazy(() => import('./SearchOrAskAiModal').then(module => ({ default: module.SearchOrAskAiModal })))
 
 export const SearchOrAskAiButton = () => {
     const searchTerm = useSearchTerm()
@@ -28,6 +32,13 @@ export const SearchOrAskAiButton = () => {
         top: 48px;
         width: 90ch;
         max-width: 100%;
+    `
+
+    const loadingCss = css`
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        padding: 2rem;
     `
 
     useEffect(() => {
@@ -81,7 +92,13 @@ export const SearchOrAskAiButton = () => {
                     <EuiOverlayMask>
                         <EuiFocusTrap onClickOutside={closeModal}>
                             <EuiPanel role="dialog" css={positionCss}>
-                                <SearchOrAskAiModal />
+                                <Suspense fallback={
+                                    <div css={loadingCss}>
+                                        <EuiLoadingSpinner size="xl"  />
+                                    </div>
+                                }>
+                                    <SearchOrAskAiModal />
+                                </Suspense>
                             </EuiPanel>
                         </EuiFocusTrap>
                     </EuiOverlayMask>

--- a/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/SearchOrAskAiButton.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/SearchOrAskAiButton.tsx
@@ -17,7 +17,11 @@ import * as React from 'react'
 import { useEffect, Suspense, lazy } from 'react'
 
 // Lazy load the modal component
-const SearchOrAskAiModal = lazy(() => import('./SearchOrAskAiModal').then(module => ({ default: module.SearchOrAskAiModal })))
+const SearchOrAskAiModal = lazy(() =>
+    import('./SearchOrAskAiModal').then((module) => ({
+        default: module.SearchOrAskAiModal,
+    }))
+)
 
 export const SearchOrAskAiButton = () => {
     const searchTerm = useSearchTerm()
@@ -92,11 +96,13 @@ export const SearchOrAskAiButton = () => {
                     <EuiOverlayMask>
                         <EuiFocusTrap onClickOutside={closeModal}>
                             <EuiPanel role="dialog" css={positionCss}>
-                                <Suspense fallback={
-                                    <div css={loadingCss}>
-                                        <EuiLoadingSpinner size="xl"  />
-                                    </div>
-                                }>
+                                <Suspense
+                                    fallback={
+                                        <div css={loadingCss}>
+                                            <EuiLoadingSpinner size="xl" />
+                                        </div>
+                                    }
+                                >
                                     <SearchOrAskAiModal />
                                 </Suspense>
                             </EuiPanel>

--- a/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/SearchOrAskAiModal.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/SearchOrAskAiModal.tsx
@@ -20,12 +20,7 @@ export const SearchOrAskAiModal = () => {
     const { setSearchTerm, submitAskAiTerm } = useSearchActions()
 
     return (
-        <EuiPanel
-            css={css`
-                max-height: 80vh;
-                overflow: hidden;
-            `}
-        >
+        <>
             <EuiFieldSearch
                 fullWidth
                 placeholder="Search the docs or ask Elastic Docs AI Assistant"
@@ -61,6 +56,6 @@ export const SearchOrAskAiModal = () => {
                     This feature is in beta. Got feedback? We'd love to hear it!
                 </EuiText>
             </div>
-        </EuiPanel>
+        </>
     )
 }

--- a/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/SearchOrAskAiModal.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/SearchOrAskAiModal.tsx
@@ -3,7 +3,6 @@ import { Suggestions } from './Suggestions'
 import { useAskAiTerm, useSearchActions, useSearchTerm } from './search.store'
 import {
     EuiFieldSearch,
-    EuiPanel,
     EuiSpacer,
     EuiBetaBadge,
     EuiText,


### PR DESCRIPTION
## Changes

Lazyload the `SearchOrAskAiModal`

This leads to a significat reduction in the initial JS asset size.

| Before | After |
| --- | ---|
| <img width="513" height="177" alt="image" src="https://github.com/user-attachments/assets/bfca252e-0ad8-4567-9a0c-2dfa17ee61a8" /> | <img width="513" height="203" alt="image" src="https://github.com/user-attachments/assets/1c5ae287-2bdf-4b10-8e13-0f7da87bba6f" /> |

Hence, initially the site loads 840kb instead of 2mb.




