### PR TITLE
Update ECK current version to 3.1.0

### DIFF
--- a/config/versions.yml
+++ b/config/versions.yml
@@ -19,7 +19,7 @@ versioning_systems:
   ech: *all
   eck:
     base: 3.0
-    current: 3.0.0
+    current: 3.1.0
   ess: *all
   self: *stack
   ecctl:

--- a/config/versions.yml
+++ b/config/versions.yml
@@ -82,7 +82,7 @@ versioning_systems:
     current: 1.5.0
   edot_node:
     base: 1.0
-    current: 1.1.1
+    current: 1.2.0
   edot_php:
     base: 1.0
     current: 1.1.1


### PR DESCRIPTION
Updating eck current to 3.1.0

@barkbay , we should merge this as soon as you want to bump the ECK version to 3.1.0.