### PR TITLE
Fix RootNavigation on MarkdownFile

### DIFF
--- a/src/tooling/docs-assembler/Cli/RepositoryCommands.cs
+++ b/src/tooling/docs-assembler/Cli/RepositoryCommands.cs
@@ -169,7 +169,7 @@ internal sealed class RepositoryCommands(
 		var navigation = new GlobalNavigation(assembleSources, navigationFile);
 
 		var pathProvider = new GlobalNavigationPathProvider(navigationFile, assembleSources, assembleContext);
-		var htmlWriter = new GlobalNavigationHtmlWriter(logFactory, navigation);
+		var htmlWriter = new GlobalNavigationHtmlWriter(logFactory, navigation, collector);
 		var legacyPageChecker = new LegacyPageChecker();
 		var historyMapper = new PageLegacyUrlMapper(legacyPageChecker, assembleSources.HistoryMappings);
 

--- a/src/tooling/docs-assembler/Navigation/GlobalNavigation.cs
+++ b/src/tooling/docs-assembler/Navigation/GlobalNavigation.cs
@@ -47,7 +47,7 @@ public record GlobalNavigation : IPositionalNavigation
 
 		var navigationIndex = 0;
 		var allNavigationItems = new HashSet<INavigationItem>();
-		UpdateParent(allNavigationItems, NavigationItems, null);
+		UpdateParent(allNavigationItems, NavigationItems, null, null);
 		UpdateNavigationIndex(NavigationItems, ref navigationIndex);
 		TopLevelItems = NavigationItems.OfType<TableOfContentsTree>().Where(t => !t.Hidden).ToList();
 		NavigationLookup = TopLevelItems.ToDictionary(kv => kv.Source, kv => kv);
@@ -64,9 +64,12 @@ public record GlobalNavigation : IPositionalNavigation
 	private void UpdateParent(
 		HashSet<INavigationItem> allNavigationItems,
 		IReadOnlyCollection<INavigationItem> navigationItems,
-		INodeNavigationItem<INavigationModel, INavigationItem>? parent
+		INodeNavigationItem<INavigationModel, INavigationItem>? parent,
+		IRootNavigationItem<INavigationModel, INavigationItem>? topLevelNavigation
 	)
 	{
+		if (parent is IRootNavigationItem<INavigationModel, INavigationItem> tree)
+			topLevelNavigation ??= tree;
 		foreach (var item in navigationItems)
 		{
 			switch (item)
@@ -74,13 +77,17 @@ public record GlobalNavigation : IPositionalNavigation
 				case FileNavigationItem fileNavigationItem:
 					if (parent is not null)
 						fileNavigationItem.Parent = parent;
+					if (topLevelNavigation is not null)
+						fileNavigationItem.Model.NavigationRoot = topLevelNavigation;
 					_ = allNavigationItems.Add(fileNavigationItem);
 					break;
 				case DocumentationGroup documentationGroup:
 					if (parent is not null)
 						documentationGroup.Parent = parent;
+					if (topLevelNavigation is not null)
+						documentationGroup.Index.NavigationRoot = topLevelNavigation;
 					_ = allNavigationItems.Add(documentationGroup);
-					UpdateParent(allNavigationItems, documentationGroup.NavigationItems, documentationGroup);
+					UpdateParent(allNavigationItems, documentationGroup.NavigationItems, documentationGroup, topLevelNavigation);
 					break;
 				default:
 					_navigationFile.EmitError($"Unhandled navigation item type: {item.GetType()}");

--- a/src/tooling/docs-assembler/Navigation/GlobalNavigationHtmlWriter.cs
+++ b/src/tooling/docs-assembler/Navigation/GlobalNavigationHtmlWriter.cs
@@ -19,7 +19,7 @@ public class GlobalNavigationHtmlWriter(ILoggerFactory logFactory, GlobalNavigat
 	public async Task<NavigationRenderResult> RenderNavigation(IRootNavigationItem<INavigationModel, INavigationItem> currentRootNavigation, int maxLevel, Cancel ctx = default)
 	{
 		if (currentRootNavigation.Parent is not null && currentRootNavigation.Parent.Depth != 0)
-			collector.EmitGlobalError($"Passed root is not actually a root {currentRootNavigation.NavigationTitle} ({currentRootNavigation.Id}) in {currentRootNavigation.Url}");
+			collector.EmitGlobalError($"Passed root is not actually a top level navigation item {currentRootNavigation.NavigationTitle} ({currentRootNavigation.Id}) in {currentRootNavigation.Url}");
 
 		if (_renderedNavigationCache.TryGetValue((currentRootNavigation.Id, maxLevel), out var html))
 		{

--- a/src/tooling/docs-assembler/Navigation/GlobalNavigationHtmlWriter.cs
+++ b/src/tooling/docs-assembler/Navigation/GlobalNavigationHtmlWriter.cs
@@ -3,13 +3,14 @@
 // See the LICENSE file in the project root for more information
 
 using System.Collections.Concurrent;
+using Elastic.Documentation.Diagnostics;
 using Elastic.Documentation.Site.Navigation;
 using Elastic.Markdown.IO.Navigation;
 using Microsoft.Extensions.Logging;
 
 namespace Documentation.Assembler.Navigation;
 
-public class GlobalNavigationHtmlWriter(ILoggerFactory logFactory, GlobalNavigation globalNavigation) : INavigationHtmlWriter
+public class GlobalNavigationHtmlWriter(ILoggerFactory logFactory, GlobalNavigation globalNavigation, DiagnosticsCollector collector) : INavigationHtmlWriter
 {
 	private readonly ILogger<Program> _logger = logFactory.CreateLogger<Program>();
 
@@ -17,34 +18,30 @@ public class GlobalNavigationHtmlWriter(ILoggerFactory logFactory, GlobalNavigat
 
 	public async Task<NavigationRenderResult> RenderNavigation(IRootNavigationItem<INavigationModel, INavigationItem> currentRootNavigation, int maxLevel, Cancel ctx = default)
 	{
-		INodeNavigationItem<INavigationModel, INavigationItem> lastParentBeforeRoot = currentRootNavigation;
-		INodeNavigationItem<INavigationModel, INavigationItem> parent = currentRootNavigation;
-		while (parent.Parent is not null)
-		{
-			lastParentBeforeRoot = parent;
-			parent = parent.Parent;
-		}
-		if (_renderedNavigationCache.TryGetValue((lastParentBeforeRoot.Id, maxLevel), out var html))
+		if (currentRootNavigation.Parent is not null && currentRootNavigation.Parent.Depth != 0)
+			collector.EmitGlobalError($"Passed root is not actually a root {currentRootNavigation.NavigationTitle} ({currentRootNavigation.Id}) in {currentRootNavigation.Url}");
+
+		if (_renderedNavigationCache.TryGetValue((currentRootNavigation.Id, maxLevel), out var html))
 		{
 			return new NavigationRenderResult
 			{
 				Html = html,
-				Id = lastParentBeforeRoot.Id
+				Id = currentRootNavigation.Id
 			};
 		}
 
-		_logger.LogInformation("Rendering navigation for {NavigationTitle} ({Id})", lastParentBeforeRoot.NavigationTitle, lastParentBeforeRoot.Id);
+		_logger.LogInformation("Rendering navigation for {NavigationTitle} ({Id})", currentRootNavigation.NavigationTitle, currentRootNavigation.Id);
 
-		if (lastParentBeforeRoot is not DocumentationGroup group)
+		if (currentRootNavigation is not DocumentationGroup group)
 			return NavigationRenderResult.Empty;
 
 		var model = CreateNavigationModel(group, maxLevel);
 		html = await ((INavigationHtmlWriter)this).Render(model, ctx);
-		_renderedNavigationCache[(lastParentBeforeRoot.Id, maxLevel)] = html;
+		_renderedNavigationCache[(currentRootNavigation.Id, maxLevel)] = html;
 		return new NavigationRenderResult
 		{
 			Html = html,
-			Id = lastParentBeforeRoot.Id
+			Id = currentRootNavigation.Id
 		};
 	}
 


### PR DESCRIPTION
Updates the `RootNavigation` on `MarkdownFile` during assembler builds.

For documentation sets where the root is a phantom the old logic to grab the root could yield bad results because those phantom roots are not part of the navigation. 

Now all file's in the navigation are explicitly re-rooted during composition.


Further more we now fail the assembler build if a `MarkdownFile` want's the render a navigation from a content root that is not really a top level item.

This should prevent this from happening again.

