### PR TITLE
Adding an allowlist for EPR links for the image directive

### DIFF
--- a/src/Elastic.Markdown/Myst/Directives/Image/ImageBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Image/ImageBlock.cs
@@ -68,6 +68,8 @@ public class ImageBlock(DirectiveBlockParser parser, ParserContext context)
 
 	public string? Label { get; private set; }
 
+	private static readonly string[] AllowedUriList = ["epr.elastic.co"];
+
 	public override void FinalizeAndValidate(ParserContext context)
 	{
 		Label = Prop("label", "name");
@@ -98,7 +100,9 @@ public class ImageBlock(DirectiveBlockParser parser, ParserContext context)
 
 		if (Uri.TryCreate(imageUrl, UriKind.Absolute, out var uri) && uri.Scheme.StartsWith("http"))
 		{
-			this.EmitWarning($"{Directive} is using an external URI: {uri} ");
+			if (!AllowedUriList.Any(host => uri.Host.Contains(host)))
+				this.EmitWarning($"{Directive} is using an external URI: {uri} ");
+
 			Found = true;
 			ImageUrl = imageUrl;
 			return;

--- a/src/Elastic.Markdown/Myst/Directives/Image/ImageBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Image/ImageBlock.cs
@@ -68,7 +68,7 @@ public class ImageBlock(DirectiveBlockParser parser, ParserContext context)
 
 	public string? Label { get; private set; }
 
-	private static readonly string[] AllowedUriList = ["epr.elastic.co"];
+	private static readonly HashSet<string> AllowedUriHosts = ["epr.elastic.co"];
 
 	public override void FinalizeAndValidate(ParserContext context)
 	{
@@ -100,7 +100,7 @@ public class ImageBlock(DirectiveBlockParser parser, ParserContext context)
 
 		if (Uri.TryCreate(imageUrl, UriKind.Absolute, out var uri) && uri.Scheme.StartsWith("http"))
 		{
-			if (!AllowedUriList.Any(host => uri.Host.Contains(host)))
+			if (!AllowedUriHosts.Contains(uri.Host))
 				this.EmitWarning($"{Directive} is using an external URI: {uri} ");
 
 			Found = true;


### PR DESCRIPTION
Adding an allowlist to the image directive URI check for links to the elastic package registry so that we can easily utilize integration images in the docs

Relates https://github.com/elastic/integration-docs/pull/827

I manually verified this by checking that changing the [line](https://github.com/elastic/docs-builder/blob/main/docs/syntax/images.md?plain=1#L48) to 
`:::{image} https://epr.elastic.co/package/system_audit/1.11.0/img/system-audit-package-dashboard.png` 
and saw no build warnings.