### PR TITLE
Remove applies to glitch from ToC when using inline applies to in headings

### DIFF
--- a/docs/syntax/applies.md
+++ b/docs/syntax/applies.md
@@ -268,7 +268,7 @@ observability: deprecated 9.0.0
 
 ### Inline
 
-#### In text
+#### In text {applies_to}`serverless: `
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas ut libero diam. Mauris sed eleifend erat,
 sit amet auctor odio. Donec ac placerat nunc. {applies_to}`stack: preview` Aenean scelerisque viverra lectus

--- a/src/Elastic.Markdown/Myst/InlineParsers/HeadingBlockWithSlugParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/HeadingBlockWithSlugParser.cs
@@ -34,11 +34,9 @@ public partial class HeadingBlockWithSlugParser : HeadingBlockParser
 	private static readonly Regex IconSyntax = IconParser.IconRegex();
 	private static readonly Regex AppliesToSyntax = AppliesToSyntaxRegex();
 
-	private static string StripAppliesToAnnotations(string text)
-	{
+	private static string StripAppliesToAnnotations(string text) =>
 		// Remove applies_to inline annotations from the text
-		return AppliesToSyntax.Replace(text, "").Trim();
-	}
+		AppliesToSyntax.Replace(text, "").Trim();
 
 	[GeneratedRegex(@"\{applies_to\}`[^`]*`", RegexOptions.Compiled)]
 	private static partial Regex AppliesToSyntaxRegex();

--- a/tests/authoring/Inline/AppliesToRole.fs
+++ b/tests/authoring/Inline/AppliesToRole.fs
@@ -162,3 +162,26 @@ If this functionality is unavailable or behaves differently when deployed on ECH
 	</span>
 	element.</p>
 """
+
+type ``strips applies_to annotations from headings in table of contents`` () =
+    static let markdown = Setup.Markdown """
+# Main Title
+
+## Section with applies_to {applies_to}`stack: preview 9.1`
+
+### Another section {applies_to}`serverless: beta`
+
+Some content here.
+"""
+
+    [<Fact>]
+    let ``heading text is stripped of applies_to annotations`` () =
+        let document = markdown |> converts "index.md"
+        let tocItems = document.File.PageTableOfContent.Values |> Seq.toList
+        
+        // Verify that the heading text doesn't contain the applies_to annotations
+        let sectionHeading = tocItems |> List.find (fun item -> item.Heading = "Section with applies_to")
+        let anotherSectionHeading = tocItems |> List.find (fun item -> item.Heading = "Another section")
+        
+        test <@ sectionHeading.Heading = "Section with applies_to" @>
+        test <@ anotherSectionHeading.Heading = "Another section" @>


### PR DESCRIPTION
Fixes https://github.com/elastic/docs-builder/issues/1574