### PR TITLE
Bumping stack version to 9.1.1 in versions.yml

### DIFF
--- a/config/versions.yml
+++ b/config/versions.yml
@@ -3,7 +3,7 @@ versioning_systems:
   # Updates for Stack versions are manual
   stack: &stack
     base: 9.0
-    current: 9.1.0
+    current: 9.1.1
 
   # Using an unlikely high version
   # So that our logic that would display "planned" doesn't trigger


### PR DESCRIPTION
To be merged by docs engineering team on August 6th (day before release).

Docs release issue: https://github.com/elastic/dev/issues/3242
