### PR TITLE
Add "View as markdown" link

### DIFF
--- a/src/Elastic.Markdown/HtmlWriter.cs
+++ b/src/Elastic.Markdown/HtmlWriter.cs
@@ -138,6 +138,7 @@ public class HtmlWriter(
 			UrlPathPrefix = markdown.UrlPathPrefix,
 			AppliesTo = markdown.YamlFrontMatter?.AppliesTo,
 			GithubEditUrl = editUrl,
+			MarkdownUrl = markdown.Url.TrimEnd('/') + ".md",
 			AllowIndexing = DocumentationSet.Context.AllowIndexing && (markdown.CrossLink.Equals("docs-content://index.md", StringComparison.OrdinalIgnoreCase) || markdown is DetectionRuleFile || !current.Hidden),
 			CanonicalBaseUrl = DocumentationSet.Context.CanonicalBaseUrl,
 			GoogleTagManager = DocumentationSet.Context.GoogleTagManager,

--- a/src/Elastic.Markdown/Layout/_TableOfContents.cshtml
+++ b/src/Elastic.Markdown/Layout/_TableOfContents.cshtml
@@ -7,6 +7,14 @@
 			</version-dropdown>
 		</div>
 		<ul class="mt-6 hidden md:flex items-center lg:block gap-4">
+			<li class="view-as-markdown lg:not-first:mt-1">
+				<a href="@Model.MarkdownUrl" class="link text-sm" target="_blank">
+					<svg class="link-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 -1 24 24">
+						<path fill="currentColor" d="M22.131725 19.247H1.9386225C1.0239525 19.247 0.25 18.47305 0.25 17.558375v-11.11675c0 -0.914675 0.7739525 -1.688625 1.6886225 -1.688625H22.061375c0.914675 0 1.688625 0.77395 1.688625 1.688625v11.11675c0 0.914675 -0.7036 1.688625 -1.618275 1.688625ZM1.9386225 5.87875c-0.2814375 0 -0.562875 0.281425 -0.562875 0.562875v11.11675c0 0.3518 0.2814375 0.562875 0.562875 0.562875H22.061375c0.3518 0 0.562875 -0.281425 0.562875 -0.562875v-11.11675c0 -0.3518 -0.281425 -0.562875 -0.562875 -0.562875l-20.1227525 0ZM3.62725 15.86975V8.130225h2.2515l2.2515 2.814375 2.251475 -2.814375h2.2515V15.86975h-2.2515V11.437125L8.13025 14.2515l-2.2515 -2.814375V15.86975h-2.2515Zm14.1422 0L14.392225 12.140725h2.251475v-4.0105h2.2515v3.940125h2.2515L17.76945 15.86975Z" stroke-width="0.25"></path>
+					</svg>
+					View as markdown
+				</a>
+			</li>
 			@if (!string.IsNullOrEmpty(Model.GithubEditUrl))
 			{
 				<li class="edit-this-page lg:not-first:mt-1 @(Model.HideEditThisPage ? "hidden" : string.Empty)">

--- a/src/Elastic.Markdown/MarkdownLayoutViewModel.cs
+++ b/src/Elastic.Markdown/MarkdownLayoutViewModel.cs
@@ -12,6 +12,8 @@ public record MarkdownLayoutViewModel : GlobalLayoutViewModel
 {
 	public required string? GithubEditUrl { get; init; }
 
+	public required string MarkdownUrl { get; init; }
+
 	public required bool HideEditThisPage { get; init; }
 	public required string? ReportIssueUrl { get; init; }
 

--- a/src/Elastic.Markdown/Page/Index.cshtml
+++ b/src/Elastic.Markdown/Page/Index.cshtml
@@ -29,6 +29,7 @@
 		NavigationFileName = Model.NavigationFileName,
 		UrlPathPrefix = Model.UrlPathPrefix,
 		GithubEditUrl = Model.GithubEditUrl,
+		MarkdownUrl = Model.MarkdownUrl,
 		HideEditThisPage = Model.Features.DisableGitHubEditLink && Model.IsAssemblerBuild,
 		AllowIndexing = Model.AllowIndexing,
 		CanonicalBaseUrl = Model.CanonicalBaseUrl,

--- a/src/Elastic.Markdown/Page/Index.cshtml
+++ b/src/Elastic.Markdown/Page/Index.cshtml
@@ -49,6 +49,7 @@
 		{
 			<meta class="elastic" name="product_version" content="@(new HtmlString(Model.CurrentVersion))"/>
 			<meta name="DC.identifier" content="@(new HtmlString(Model.CurrentVersion))"/>
+			<link rel="alternate" type="text/markdown" href="@(Model.MarkdownUrl)" title="Markdown export"/>
 		}
 		if (name == GlobalSections.Head && Model.Products is { Count: > 0 })
 		{

--- a/src/Elastic.Markdown/Page/IndexViewModel.cs
+++ b/src/Elastic.Markdown/Page/IndexViewModel.cs
@@ -43,6 +43,7 @@ public class IndexViewModel
 	public required VersionDrownDownItemViewModel[]? VersionDropdownItems { get; init; }
 	public required string? UrlPathPrefix { get; init; }
 	public required string? GithubEditUrl { get; init; }
+	public required string MarkdownUrl { get; init; }
 	public required string? ReportIssueUrl { get; init; }
 	public required ApplicableTo? AppliesTo { get; init; }
 	public required bool AllowIndexing { get; init; }


### PR DESCRIPTION
Part of https://github.com/elastic/docs-builder/issues/1591

## Changes

- Add "View as markdown" link to other CTA links.
- `<link rel="alternate" type="text/markdown" href="@(Model.MarkdownUrl)" title="Markdown export"/>`

## Screenshot

<img width="440" height="466" alt="image" src="https://github.com/user-attachments/assets/e4ae417c-50f2-42ca-9332-bcc6122aabdb" />
