### PR TITLE
Update ECE current version in versions.yml

### DIFF
--- a/config/versions.yml
+++ b/config/versions.yml
@@ -15,7 +15,7 @@ versioning_systems:
   # Ece version updates are manual
   ece:
     base: 4.0
-    current: 4.1
+    current: 4.0.1
   ech: *all
   eck:
     base: 3.0


### PR DESCRIPTION
Not sure if nobody had taken a look at this after having migrated to the docs-builder versioning variables, but I believe ECE version 4.1.0 hasn't been released yet, and our docs should mention 4.0.1 as the current latest release.

cc: @shainaraskas , please validate.

@alexandra5000 , FYI, related with https://github.com/elastic/docs-content/pull/2420
