### PR TITLE
Add diff-validate action and minor fixes

### DIFF
--- a/actions/diff-validate/action.yml
+++ b/actions/diff-validate/action.yml
@@ -1,0 +1,10 @@
+name: 'Validate Redirect Rules'
+description: 'Validates consistency of the documentation changes in relation to redirect rules'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate Redirect Rules
+      uses: elastic/docs-builder@main
+      with:
+        command: "diff validate"

--- a/docs-builder.sln
+++ b/docs-builder.sln
@@ -141,6 +141,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elastic.Documentation.Api.I
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elastic.Documentation.Api.Lambda", "src\api\Elastic.Documentation.Api.Lambda\Elastic.Documentation.Api.Lambda.csproj", "{C6A121C5-DEB1-4FCE-9140-AF144EA98EEE}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "diff-validate", "diff-validate", "{E7C7A02B-9AB4-455A-9A64-3D326ED1A95A}"
+	ProjectSection(SolutionItems) = preProject
+		actions\diff-validate\action.yml = actions\diff-validate\action.yml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -287,5 +292,6 @@ Global
 		{F30B90AD-1A01-4A6F-9699-809FA6875B22} = {B042CC78-5060-4091-B95A-79C71BA3908A}
 		{AE3FC78E-167F-4B6E-88EC-84743EB748B7} = {B042CC78-5060-4091-B95A-79C71BA3908A}
 		{C6A121C5-DEB1-4FCE-9140-AF144EA98EEE} = {B042CC78-5060-4091-B95A-79C71BA3908A}
+		{E7C7A02B-9AB4-455A-9A64-3D326ED1A95A} = {245023D2-D3CA-47B9-831D-DAB91A2FFDC7}
 	EndGlobalSection
 EndGlobal

--- a/src/tooling/docs-builder/Tracking/IntegrationGitRepositoryTracker.cs
+++ b/src/tooling/docs-builder/Tracking/IntegrationGitRepositoryTracker.cs
@@ -33,8 +33,12 @@ public class IntegrationGitRepositoryTracker(string lookupPath) : IRepositoryTra
 		var renamedFiles = Environment.GetEnvironmentVariable("RENAMED_FILES");
 		if (!string.IsNullOrEmpty(renamedFiles))
 		{
-			foreach (var file in renamedFiles.Split(' ', StringSplitOptions.RemoveEmptyEntries).Where(f => f.StartsWith(LookupPath)))
-				yield return new RenamedGitChange(string.Empty, file, GitChangeType.Renamed);
+			foreach (var pair in renamedFiles.Split(' ', StringSplitOptions.RemoveEmptyEntries).Where(f => f.StartsWith(LookupPath)))
+			{
+				var parts = pair.Split(':');
+				if (parts.Length == 2)
+					yield return new RenamedGitChange(parts[0], parts[1], GitChangeType.Renamed);
+			}
 		}
 	}
 }


### PR DESCRIPTION
In order to get redirect rule validation working on all CIs using preview-build, we need to run `docs-builder diff validate` as an Action.

This PR introduces the action and provides smaller fixes in preparation for a follow-up to re-enable the workflow step.