### PR TITLE
Add automatic `applies_to` version sorting

### DIFF
--- a/docs/syntax/applies.md
+++ b/docs/syntax/applies.md
@@ -70,6 +70,10 @@ Where:
 - The [version](#version) is optional
 - You can specify multiple states by separating them with a comma. For example: `stack: preview 9.1, ga 9.4`
 
+:::{note}
+**Automatic Version Sorting**: When you specify multiple versions for the same product, the build system automatically sorts them in descending order (highest version first) regardless of the order you write them in the source file. For example, `stack: ga 8.18.6, ga 9.1.2, ga 8.19.2, ga 9.0.6` will be displayed as `stack: ga 9.1.2, ga 9.0.6, ga 8.19.2, ga 8.18.6`. Items without versions (like `ga` without a version or `all`) are sorted last.
+:::
+
 Note that a key without any value doesn't show any badge in the output.
 
 ### Lifecycle

--- a/tests/authoring/Applicability/AppliesToFrontMatter.fs
+++ b/tests/authoring/Applicability/AppliesToFrontMatter.fs
@@ -163,8 +163,8 @@ applies_to:
     let ``apply matches expected`` () =
         markdown |> appliesTo (ApplicableTo(
             Product=AppliesCollection([
-                Applicability.op_Explicit "preview 9.5";
-                Applicability.op_Explicit "removed 9.7"
+                Applicability.op_Explicit "removed 9.7";
+                Applicability.op_Explicit "preview 9.5"
             ] |> Array.ofList)
         ))
 
@@ -212,3 +212,69 @@ applies_to:
     [<Fact>]
     let ``does not render label`` () =
         markdown |> appliesTo (Unchecked.defaultof<ApplicableTo>)
+
+type ``sorts applies_to versions in descending order`` () =
+    static let markdown = frontMatter """
+applies_to:
+   stack: ga 8.18.6, ga 9.1.2, ga 8.19.2, ga 9.0.6
+"""
+    [<Fact>]
+    let ``versions are sorted highest to lowest`` () =
+        let expectedVersions = [
+            Applicability.op_Explicit "ga 9.1.2"
+            Applicability.op_Explicit "ga 9.0.6"
+            Applicability.op_Explicit "ga 8.19.2"
+            Applicability.op_Explicit "ga 8.18.6"
+        ]
+        markdown |> appliesTo (ApplicableTo(
+            Stack=AppliesCollection(expectedVersions |> Array.ofList)
+        ))
+
+type ``sorts applies_to with mixed versioned and non-versioned items`` () =
+    static let markdown = frontMatter """
+applies_to:
+   stack: ga 8.18.6, ga, ga 9.1.2, all, ga 8.19.2
+"""
+    [<Fact>]
+    let ``versioned items are sorted first, non-versioned items last`` () =
+        let expectedVersions = [
+            Applicability.op_Explicit "ga 9.1.2"
+            Applicability.op_Explicit "ga 8.19.2"
+            Applicability.op_Explicit "ga 8.18.6"
+            Applicability.op_Explicit "ga"
+            Applicability.op_Explicit "all"
+        ]
+        markdown |> appliesTo (ApplicableTo(
+            Stack=AppliesCollection(expectedVersions |> Array.ofList)
+        ))
+
+type ``sorts applies_to with patch versions correctly`` () =
+    static let markdown = frontMatter """
+applies_to:
+   stack: ga 9.1, ga 9.1.1, ga 9.0.5
+"""
+    [<Fact>]
+    let ``patch versions are sorted correctly`` () =
+        let expectedVersions = [
+            Applicability.op_Explicit "ga 9.1.1"
+            Applicability.op_Explicit "ga 9.1"
+            Applicability.op_Explicit "ga 9.0.5"
+        ]
+        markdown |> appliesTo (ApplicableTo(
+            Stack=AppliesCollection(expectedVersions |> Array.ofList)
+        ))
+
+type ``sorts applies_to with major versions correctly`` () =
+    static let markdown = frontMatter """
+applies_to:
+   stack: ga 3.x, ga 5.x
+"""
+    [<Fact>]
+    let ``major versions are sorted correctly`` () =
+        let expectedVersions = [
+            Applicability.op_Explicit "ga 5.x"
+            Applicability.op_Explicit "ga 3.x"
+        ]
+        markdown |> appliesTo (ApplicableTo(
+            Stack=AppliesCollection(expectedVersions |> Array.ofList)
+        ))

--- a/tests/authoring/Inline/AppliesToRole.fs
+++ b/tests/authoring/Inline/AppliesToRole.fs
@@ -133,7 +133,7 @@ This is an inline {applies_to}`stack: preview 9.0, ga 9.1` element.
         let directives = markdown |> converts "index.md" |> parses<AppliesToRole>
         test <@ directives.Length = 1 @>
         directives |> appliesToDirective (ApplicableTo(
-            Stack=AppliesCollection.op_Explicit "preview 9.0, ga 9.1"
+            Stack=AppliesCollection.op_Explicit "ga 9.1, preview 9.0"
         ))
 
     [<Fact>]
@@ -143,20 +143,20 @@ This is an inline {applies_to}`stack: preview 9.0, ga 9.1` element.
 	<span class="applies applies-inline">
 		<span class="applicable-info" data-tippy-content="We plan to add this functionality in a future Elastic&nbsp;Stack update. Subject to change.
 
-This functionality may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.">
-			<span class="applicable-name">Stack</span>
-			<span class="applicable-separator"></span>
-			<span class="applicable-meta applicable-meta-preview">
-				Planned
-			</span>
-		</span>
-		<span class="applicable-info" data-tippy-content="We plan to add this functionality in a future Elastic&nbsp;Stack update. Subject to change.
-
 If this functionality is unavailable or behaves differently when deployed on ECH, ECE, ECK, or a self-managed installation, it will be indicated on the page.">
 			<span class="applicable-name">Stack</span>
 			<span class="applicable-separator"></span>
 			<span class="applicable-meta applicable-meta-ga">
 				GA planned
+			</span>
+		</span>
+		<span class="applicable-info" data-tippy-content="We plan to add this functionality in a future Elastic&nbsp;Stack update. Subject to change.
+
+This functionality may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.">
+			<span class="applicable-name">Stack</span>
+			<span class="applicable-separator"></span>
+			<span class="applicable-meta applicable-meta-preview">
+				Planned
 			</span>
 		</span>
 	</span>


### PR DESCRIPTION
## Summary

Adds automatic version sorting. Partially implements https://github.com/elastic/docs-builder/issues/1435.

### Problem
Currently, users must manually ensure `applies_to` badges are written in the correct version order in source files. This requires manual effort and is error-prone.

### Solution
This PR automatically sorts `applies_to` badges by version in descending order (highest version first), regardless of the order they appear in the source file.

### Changes Made

#### Core Implementation
- **Modified `AppliesCollection.TryParse`** in `src/Elastic.Documentation/AppliesTo/Applicability.cs`:
  - Added automatic sorting of applicability items by version in descending order
  - Items without versions (like "all" or no version specified) are sorted last

- **Created `SemVersionComparer` class**:
  - Handles comparison of SemVersion objects for sorting
  - Treats both `null` and `AllVersions.Instance` as non-versioned items (lowest priority)
  - Uses proper null-safe comparison to avoid conflicts with SemVersion operator overloads

#### Test Updates
- **Updated existing tests** to reflect new sorting behavior:
  - Modified `parses product multiple` test to expect sorted order
  - Updated inline test to expect sorted order in HTML output
- **Added comprehensive test coverage**:
  - Basic version sorting (9.1.2, 9.0.6, 8.19.2, 8.18.6)
  - Mixed versioned and non-versioned items (ga 8.18.6, ga, ga 9.1.2, all, ga 8.19.2)
  - Patch version sorting (9.1, 9.1.1, 9.0.5)
  - Major version sorting (3.x, 5.x)

#### Documentation
- **Added documentation** to `docs/syntax/applies.md` explaining the automatic sorting behavior
- **Included example** showing before/after ordering

### Related

https://github.com/elastic/beats/pull/45810#discussion_r2268179314