### PR TITLE
Add Search/AI Assistant to dev enviroment.

### DIFF
--- a/config/assembler.yml
+++ b/config/assembler.yml
@@ -30,6 +30,8 @@ environments:
     uri: http://localhost:4000
     content_source: current
     path_prefix: docs
+    feature_flags:
+      SEARCH_OR_ASK_AI: true
 
 shared_configuration:
   stack: &stack

--- a/src/tooling/docs-builder/Http/DocumentationWebHost.cs
+++ b/src/tooling/docs-builder/Http/DocumentationWebHost.cs
@@ -144,7 +144,6 @@ public class DocumentationWebHost
 		_ = _webApplication.MapGet("/api/{**slug}", (string slug, ReloadableGeneratorState holder, Cancel ctx) =>
 			ServeApiFile(holder, slug, ctx));
 
-
 		var apiV1 = _webApplication.MapGroup("/docs/_api/v1");
 		apiV1.MapElasticDocsApiEndpoints();
 

--- a/src/tooling/docs-builder/Http/StaticWebHost.cs
+++ b/src/tooling/docs-builder/Http/StaticWebHost.cs
@@ -2,9 +2,9 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using Elastic.Documentation.Api.Infrastructure;
 using Elastic.Documentation.Configuration;
 using Elastic.Documentation.ServiceDefaults;
-using Elastic.Documentation.Tooling;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -27,6 +27,8 @@ public class StaticWebHost
 		});
 
 		_ = builder.AddDocumentationServiceDefaults();
+
+		builder.Services.AddElasticDocsApiUsecases("dev");
 
 		_ = builder.Logging
 			.AddFilter("Microsoft.AspNetCore.Hosting.Diagnostics", LogLevel.Error)
@@ -51,6 +53,10 @@ public class StaticWebHost
 		_ = WebApplication.MapGet("/", (Cancel _) => Results.Redirect("docs"));
 
 		_ = WebApplication.MapGet("{**slug}", ServeDocumentationFile);
+
+		var apiV1 = WebApplication.MapGroup("/docs/_api/v1");
+		apiV1.MapElasticDocsApiEndpoints();
+
 	}
 
 	private async Task<IResult> ServeDocumentationFile(string slug, Cancel _)

--- a/tests-integration/Elastic.Assembler.IntegrationTests/AssembleFixture.cs
+++ b/tests-integration/Elastic.Assembler.IntegrationTests/AssembleFixture.cs
@@ -34,6 +34,9 @@ public class DocumentationFixture : IAsyncLifetime
 		_ = builder.Services.AddElasticDocumentationLogging(LogLevel.Information);
 		_ = builder.Services.AddLogging(c => c.AddXUnit());
 		_ = builder.Services.AddLogging(c => c.AddInMemory());
+		// TODO expose this as secrets for now not needed integration tests
+		_ = builder.AddParameter("LlmGatewayUrl", "");
+		_ = builder.AddParameter("LlmGatewayServiceAccountPath", "");
 		DistributedApplication = await builder.BuildAsync();
 		InMemoryLogger = DistributedApplication.Services.GetService<InMemoryLogger>()!;
 		await DistributedApplication.StartAsync();

--- a/tests-integration/Elastic.Documentation.Aspire/AppHost.cs
+++ b/tests-integration/Elastic.Documentation.Aspire/AppHost.cs
@@ -19,19 +19,39 @@ if (logLevel != LogLevel.Information)
 
 var builder = DistributedApplication.CreateBuilder(args);
 
+// Add a secret parameter named "secret"
+var llmUrl = builder.AddParameter("LlmGatewayUrl", secret: true);
+var llmServiceAccountPath = builder.AddParameter("LlmGatewayServiceAccountPath", secret: true);
+
 var cloneAll = builder.AddProject<Projects.docs_assembler>("DocsAssemblerCloneAll").WithArgs(["repo", "clone-all", .. globalArguments]);
 
 var buildAll = builder.AddProject<Projects.docs_assembler>("DocsAssemblerBuildAll").WithArgs(["repo", "build-all", .. globalArguments])
 	.WaitForCompletion(cloneAll);
 
-var elasticsearch = builder.AddElasticsearch("elasticsearch");
+var elasticsearch = builder.AddElasticsearch("elasticsearch")
+	.WithEnvironment("LICENSE", "trial");
 
 var api = builder.AddProject<Projects.Elastic_Documentation_Api_Lambda>("ApiLambda").WithArgs(globalArguments)
+	.WithEnvironment("ENVIRONMENT", "dev")
+	.WithEnvironment("LLM_GATEWAY_FUNCTION_URL", llmUrl)
+	.WithEnvironment("LLM_GATEWAY_SERVICE_ACCOUNT_KEY_PATH", llmServiceAccountPath)
 	.WaitFor(elasticsearch)
 	.WithReference(elasticsearch);
 
 var indexElasticsearch = builder.AddProject<Projects.docs_assembler>("DocsAssemblerElasticsearch")
-	.WithArgs(["repo", "build-all", "--exporters", "html,elasticsearch", .. globalArguments])
+	.WithArgs(["repo", "build-all", "--exporters", "elasticsearch", .. globalArguments])
+	.WithEnvironment("DOCUMENTATION_ELASTIC_URL", elasticsearch.GetEndpoint("http"))
+	.WithEnvironment(context =>
+	{
+		context.EnvironmentVariables["DOCUMENTATION_ELASTIC_PASSWORD"] = elasticsearch.Resource.PasswordParameter;
+	})
+	.WithReference(elasticsearch)
+	.WithExplicitStart()
+	.WaitFor(elasticsearch)
+	.WaitForCompletion(cloneAll);
+
+var indexElasticsearchSemantic = builder.AddProject<Projects.docs_assembler>("DocsAssemblerElasticsearchSemantic")
+	.WithArgs(["repo", "build-all", "--exporters", "semantic", .. globalArguments])
 	.WithEnvironment("DOCUMENTATION_ELASTIC_URL", elasticsearch.GetEndpoint("http"))
 	.WithEnvironment(context =>
 	{
@@ -44,11 +64,17 @@ var indexElasticsearch = builder.AddProject<Projects.docs_assembler>("DocsAssemb
 
 var serveStatic = builder.AddProject<Projects.docs_builder>("DocsBuilderServeStatic")
 	.WithReference(elasticsearch)
+	.WithEnvironment("LLM_GATEWAY_FUNCTION_URL", llmUrl)
+	.WithEnvironment("LLM_GATEWAY_SERVICE_ACCOUNT_KEY_PATH", llmServiceAccountPath)
+	.WithEnvironment("DOCUMENTATION_ELASTIC_URL", elasticsearch.GetEndpoint("http"))
+	.WithEnvironment(context =>
+	{
+		context.EnvironmentVariables["DOCUMENTATION_ELASTIC_PASSWORD"] = elasticsearch.Resource.PasswordParameter;
+	})
 	.WithHttpEndpoint(port: 4000, isProxied: false)
 	.WithArgs(["serve-static", .. globalArguments])
 	.WithHttpHealthCheck("/", 200)
+	.WaitFor(elasticsearch)
 	.WaitForCompletion(buildAll);
-
-
 
 builder.Build().Run();


### PR DESCRIPTION
This also exposes the proxy to `docs-builder serve-static`.

It now also wires up the configuration for our dotnet aspire project.

If the secrets have not been configured yet aspire will prompt to provide them

<img width="1141" height="95" alt="image" src="https://github.com/user-attachments/assets/b50812bc-8b2c-4c65-85e5-e8c4762a3fa1" />

Make sure `Save to user secrets` is checked:

<img width="516" height="405" alt="image" src="https://github.com/user-attachments/assets/b6ea0fd2-f4ca-4a78-8bc7-53f67ddb838c" />

After which you'll need to restart the aspire application again. 

Once `DocsBuilderServeStatic` is started (it waits for clone-all and build-all) it will have the experimental documentation search bar enabled. 

The search is still static (pending #1731) but now the AI responses are real.

<img width="878" height="476" alt="image" src="https://github.com/user-attachments/assets/3fe58500-9aaa-4e7f-8556-24901062a45c" />



