### PR TITLE
Explicitly check for CTLR+C during exception filter

### DIFF
--- a/src/tooling/Elastic.Documentation.Tooling/Filters/CatchExceptionFilter.cs
+++ b/src/tooling/Elastic.Documentation.Tooling/Filters/CatchExceptionFilter.cs
@@ -10,15 +10,21 @@ namespace Elastic.Documentation.Tooling.Filters;
 public sealed class CatchExceptionFilter(ConsoleAppFilter next, ILogger<CatchExceptionFilter> logger)
 	: ConsoleAppFilter(next)
 {
+	private bool _cancelKeyPressed;
 	public override async Task InvokeAsync(ConsoleAppContext context, Cancel cancellationToken)
 	{
+		Console.CancelKeyPress += (sender, e) =>
+		{
+			logger.LogInformation("Received CTRL+C cancelling");
+			_cancelKeyPressed = true;
+		};
 		try
 		{
 			await Next.InvokeAsync(context, cancellationToken);
 		}
 		catch (Exception ex)
 		{
-			if (ex is OperationCanceledException)
+			if (ex is OperationCanceledException && cancellationToken.IsCancellationRequested && _cancelKeyPressed)
 			{
 				logger.LogInformation("Cancellation requested, exiting.");
 				return;


### PR DESCRIPTION
Since `TaskCancelledException` extends `OperationCancelledException` we need to add more safe guards to ensure this operation was requested interactively by a CLI user through `CTRL+C`. 

This handling was hiding genuine failures such as HttpClient timeouts.
