### PR TITLE
Fix "unavailable" tooltip text missing in applicability badges

### DIFF
--- a/src/Elastic.Markdown/Myst/Components/ApplicableToComponent.cshtml
+++ b/src/Elastic.Markdown/Myst/Components/ApplicableToComponent.cshtml
@@ -235,6 +235,7 @@
 				ProductLifecycle.TechnicalPreview => "Available in technical preview",
 				ProductLifecycle.Deprecated => "Deprecated",
 				ProductLifecycle.Removed => "Removed",
+				ProductLifecycle.Unavailable => "Not available",
 				_ => ""
 			};
 			


### PR DESCRIPTION
This adds the missing `unavailable` ProductLifecycle value, mapped to `Not available`.

Fixes https://github.com/elastic/docs-builder/issues/1751