### PR TITLE
Update versions.yml for 9.1.3

### DIFF
--- a/config/versions.yml
+++ b/config/versions.yml
@@ -3,7 +3,7 @@ versioning_systems:
   # Updates for Stack versions are manual
   stack: &stack
     base: 9.0
-    current: 9.1.2
+    current: 9.1.3
 
   # Using an unlikely high version
   # So that our logic that would display "planned" doesn't trigger


### PR DESCRIPTION
This PR updates the versions config file changing `versioning_systems.stack.current` to the minor version about to be released.

9.1.3 docs release issue: https://github.com/elastic/dev/issues/3264
9.1.3 dev issue: https://github.com/elastic/dev/issues/3262