### PR TITLE
Warn when a heading contains an inline `applies_to`

### DIFF
--- a/src/Elastic.Markdown/Myst/InlineParsers/HeadingBlockWithSlugParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/HeadingBlockWithSlugParser.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System.Text.RegularExpressions;
+using Elastic.Markdown.Diagnostics;
 using Elastic.Markdown.Myst.Roles.Icons;
 using Markdig;
 using Markdig.Helpers;
@@ -29,7 +30,7 @@ public class HeadingBlockWithSlugBuilderExtension : IMarkdownExtension
 	public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer) { }
 }
 
-public partial class HeadingBlockWithSlugParser : HeadingBlockParser
+public class HeadingBlockWithSlugParser : HeadingBlockParser
 {
 	private static readonly Regex IconSyntax = IconParser.IconRegex();
 	private static readonly Regex AppliesToSyntax = HeadingAppliesToParser.AppliesToSyntaxRegex();
@@ -40,8 +41,9 @@ public partial class HeadingBlockWithSlugParser : HeadingBlockParser
 			return base.Close(processor, block);
 
 		var text = headingBlock.Lines.Lines[0].Slice.AsSpan();
+
 		if (AppliesToSyntax.IsMatch(text))
-			processor.GetContext().Build.Collector.EmitWarning(processor.GetContext().MarkdownSourcePath, "Do not use inline 'applies_to' annotations with headings. Use a section 'applies_to' annotation instead.");
+			processor.EmitWarning("Do not use inline 'applies_to' annotations with headings. Use a section 'applies_to' annotation instead.");
 
 		// Remove icon syntax from the heading text
 		var cleanText = IconSyntax.Replace(text.ToString(), "").Trim();


### PR DESCRIPTION
Warns when a heading contains an inline `applies_to`.

@theletterf and I paired today on adding a warning when we detect inline `applies_to` syntax in the heading text. We tried a couple different approaches. This one works, but I'm not sure if it's the best place to check for this.

Open questions for @elastic/docs-engineering:

* Is this an appropriate place to check for `applies_to` syntax in a heading?
* Does it make sense to use regex to check?
* Is there a way to add more context (like the line number and highlighting the text that's causing the error) to the warning message? Right now it just looks like this:
  <img width="725" height="155" alt="Screenshot 2025-08-25 at 12 34 10 PM" src="https://github.com/user-attachments/assets/36b48975-2fc6-48d0-b0a0-94865435cb4d" />
