### PR TITLE
Set `DOCKER_NO_PUBLISH` env variable to conditionally skip container publishing.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,8 @@ jobs:
         
       - name: Publish Containers
         if: ${{ matrix.os == 'ubuntu-latest' }} 
+        env:
+          DOCKER_NO_PUBLISH: true
         run: dotnet run --project build -c release -- publishcontainers
         
       - name: Run Container

--- a/build/Targets.fs
+++ b/build/Targets.fs
@@ -104,13 +104,14 @@ let private publishContainers _ =
                 "-p"; $"ContainerImageTags=\"%s{labels};%s{Software.Version.Normalize()}\""
                 "-p"; $"ContainerRepository=elastic/%s{project}"
             ]
+        let noPublish = Environment.environVarOrNone "DOCKER_NO_PUBLISH"
         let registry =
-            match (ci, pr) with
-            | Some _, None -> [
+            match (ci, pr, noPublish) with
+            | Some _, None, None -> [
                     "-p"; "ContainerRegistry=ghcr.io"
                     "-p"; "ContainerUser=1001:1001";
                 ]
-            | _, _ -> []
+            | _ -> []
         exec { run "dotnet" (args @ registry) }
     createImage "docs-builder"
     createImage "docs-assembler"


### PR DESCRIPTION
We do not want to publish from our `ci > build` step. `prerelease > build` already does this.
