### PR TITLE
Add AI/LLM files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -397,3 +397,11 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# Add LLM/AI related files
+AGENTS.md
+.github/copilot-instructions.md
+.github/instructions/**.instructions.md
+CLAUDE.md
+GEMINI.md
+.cursor


### PR DESCRIPTION
This adds common AI agent context / instructions files to .gitignore, so they can be used in AI-powered tools / IDEs.