### PR TITLE
Add initial stub of agents file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ The repository is self-documenting:
 
 - `/docs/` contains comprehensive documentation
 
-You MUST update the documentation when making changes.
+You MUST update the documentation when there are changes in the markdown syntax or rendering behaviour.
 
 ## Useful file locations
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,105 @@
+# AI Assistant Guide for docs-builder
+
+This file contains instructions and guidance for AIs when working with the docs-builder repository.
+
+## Repository overview
+
+This is Elastic's distributed documentation tooling system built on .NET 9, consisting of:
+
+- **docs-builder**: CLI tool for building single documentation sets
+- **docs-assembler**: CLI tool for assembling multiple doc sets
+- Written in C# and F# with extensive Markdown processing capabilities
+
+## Essential commands
+
+### Development
+```bash
+# Build the project
+dotnet build
+
+# Simulates a full release -- run this to confirm the absence of build errors
+dotnet run --project build -c release
+
+# Runs all tests
+dotnet test
+
+# Run docs-builder locally
+./build.sh run -- serve
+
+# Clean build artifacts
+dotnet clean
+```
+
+### Linting and Code Quality
+
+```bash
+# Format code. Always run this when output contains formatting errors.
+dotnet format
+
+# Run specific test project
+dotnet test tests/Elastic.Markdown.Tests/
+
+# Run tests with verbose output
+dotnet test --logger "console;verbosity=detailed"
+```
+
+## Key architecture Points
+
+### Main Projects
+
+- `src/Elastic.Markdown/` - Core Markdown processing engine
+- `src/tooling/docs-builder/` - Main CLI application
+- `src/tooling/docs-assembler/` - Assembly tool
+- `src/Elastic.Documentation.Site/` - Web rendering components
+
+### Testing Structure
+
+- `tests/` - C# unit tests
+- `tests/authoring/` - F# authoring tests
+- `tests-integration/` - Integration tests
+
+### Configuration
+
+- `config/` - YAML configuration files
+- `Directory.Build.props` - MSBuild properties
+- `Directory.Packages.props` - Centralized package management
+
+## Development guidelines
+
+### Adding New Features
+
+1. **Markdown Extensions**: Add to `src/Elastic.Markdown/Myst/`
+2. **CLI Commands**: Extend `src/tooling/docs-builder/Cli/` or `docs-assembler/Cli/`
+3. **Web Components**: Add to `src/Elastic.Documentation.Site/`
+4. **Configuration**: Modify `src/Elastic.Documentation.Configuration/`
+
+### Code style
+
+- Follow existing C# and F# conventions in the codebase
+- ...
+
+### Testing requirements
+
+- Add unit tests for new functionality
+- Use F# for authoring/documentation-specific tests
+- ...
+
+### Common patterns
+
+- ...
+
+## Documentation
+
+The repository is self-documenting:
+
+- `/docs/` contains comprehensive documentation
+
+You MUST update the documentation when making changes.
+
+## Useful file locations
+
+- Entry points: `src/tooling/docs-builder/Program.cs`, `src/tooling/docs-assembler/Program.cs`
+- Markdown processing: `src/Elastic.Markdown/Myst/`
+- Web assets: `src/Elastic.Documentation.Site/Assets/`
+- Configuration schemas: `src/Elastic.Documentation.Configuration/`
+- Test helpers: `tests/Elastic.Markdown.Tests/TestHelpers.cs`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,20 +14,21 @@ This is Elastic's distributed documentation tooling system built on .NET 9, cons
 
 ### Development
 ```bash
-# Build the project
+# Ensure no compilation failures -- run this to confirm the absence of build errors.
 dotnet build
 
-# Simulates a full release -- run this to confirm the absence of build errors
-dotnet run --project build -c release
-
-# Runs all tests
-dotnet test
-
 # Run docs-builder locally
-./build.sh run -- serve
+dotnet run --project src/tooling/docs-builder 
 
-# Clean build artifacts
-dotnet clean
+# Run all the unit tests which complete fast.
+./build.sh unit-test
+
+# Clean all the build artifacts located in .artifacts folder
+./build.sh clean
+
+# Produce native binaries -- only call this if a change touches serialization and you are committing on behalf of the developer.
+ ./build.sh publishbinaries
+
 ```
 
 ### Linting and Code Quality


### PR DESCRIPTION
This adds an AGENTS.md file we can use for AI-drive development in Copilot, Claude Code, Cursor, and other IDEs.

We need to complete it all together. It's customer to use pretty peremptory language in these files, like "You MUST", etc.