### PR TITLE
Adjust delete threshold logic in `AwsS3SyncPlanStrategy`

### DIFF
--- a/src/tooling/docs-assembler/Deploying/AwsS3SyncPlanStrategy.cs
+++ b/src/tooling/docs-assembler/Deploying/AwsS3SyncPlanStrategy.cs
@@ -158,6 +158,7 @@ public class AwsS3SyncPlanStrategy(
 
 		return new SyncPlan
 		{
+			TotalRemoteFiles = remoteObjects.Count,
 			TotalSourceFiles = localObjects.Length,
 			DeleteRequests = deleteRequests.ToList(),
 			AddRequests = addRequests.ToList(),
@@ -176,15 +177,20 @@ public class AwsS3SyncPlanStrategy(
 			return new(false, 1.0f, deleteThreshold);
 		}
 
-		var deleteRatio = (float)plan.DeleteRequests.Count / plan.TotalSyncRequests;
-		// if the total sync requests are less than 100, we enforce a higher ratio of 0.8
+		var deleteRatio = (float)plan.DeleteRequests.Count / plan.TotalRemoteFiles;
+		if (plan.TotalRemoteFiles == 0)
+		{
+			_logger.LogInformation("No files discovered in S3, assuming a clean bucket resetting delete threshold to `0.0' as our plan should not have ANY deletions");
+			deleteThreshold = 0.0f;
+		}
+		// if the total remote files are less than or equal to 100, we enforce a higher ratio of 0.8
 		// this allows newer assembled documentation to be in a higher state of flux
-		if (plan.TotalSyncRequests <= 100)
+		if (plan.TotalRemoteFiles <= 100)
 			deleteThreshold = Math.Max(deleteThreshold, 0.8f);
 
-		// if the total sync requests are less than 1000, we enforce a higher ratio of 0.5
+		// if the total remote files are less than or equal to 1000, we enforce a higher ratio of 0.5
 		// this allows newer assembled documentation to be in a higher state of flux
-		else if (plan.TotalSyncRequests <= 1000)
+		else if (plan.TotalRemoteFiles <= 1000)
 			deleteThreshold = Math.Max(deleteThreshold, 0.5f);
 
 		if (deleteRatio > deleteThreshold)

--- a/src/tooling/docs-assembler/Deploying/DocsSync.cs
+++ b/src/tooling/docs-assembler/Deploying/DocsSync.cs
@@ -52,9 +52,15 @@ public record SkipRequest : SyncRequest
 
 public record SyncPlan
 {
+	/// The total number of source files that were located in the build output
 	[JsonPropertyName("total_source_files")]
 	public required int TotalSourceFiles { get; init; }
 
+	/// The total number of remote files that were located in the remote location
+	[JsonPropertyName("total_remote_files")]
+	public required int TotalRemoteFiles { get; init; }
+
+	/// The total number of sync requests that were generated (sum of <see cref="AddRequests"/>, <see cref="UpdateRequests"/>, <see cref="DeleteRequests"/>)
 	[JsonPropertyName("total_sync_requests")]
 	public required int TotalSyncRequests { get; init; }
 

--- a/tests/docs-assembler.Tests/src/docs-assembler.Tests/DocsSyncTests.cs
+++ b/tests/docs-assembler.Tests/src/docs-assembler.Tests/DocsSyncTests.cs
@@ -66,6 +66,8 @@ public class DocsSyncTests
 
 		// Assert
 
+		plan.TotalRemoteFiles.Should().Be(3);
+
 		plan.TotalSourceFiles.Should().Be(5);
 		plan.TotalSyncRequests.Should().Be(6); //including skip on server
 
@@ -231,6 +233,7 @@ public class DocsSyncTests
 		var context = new AssembleContext(config, configurationContext, "dev", collector, fileSystem, fileSystem, null, checkoutDirectory);
 		var plan = new SyncPlan
 		{
+			TotalRemoteFiles = 0,
 			TotalSourceFiles = 5,
 			TotalSyncRequests = 6,
 			AddRequests = [


### PR DESCRIPTION
- Update delete ratio calculation to use `TotalRemoteFiles` instead of `TotalSyncRequests`.
- Add logging and reset delete threshold to `0.0` when no S3 remote files are discovered. Ensuring our plan only contains additions.

Emit `plan-valid` as github actions output.
