### PR TITLE
Add concurrency config to deploy-api-lambda workflow

### DIFF
--- a/.github/workflows/deploy-api-lambda.yml
+++ b/.github/workflows/deploy-api-lambda.yml
@@ -15,6 +15,7 @@ jobs:
     uses: ./.github/workflows/build-api-lambda.yml
     
   deploy:
+    concurrency: ${{ github.workflow }}
     permissions: 
       contents: read
       id-token: write


### PR DESCRIPTION
There should not be simultaneous running deployments to aws lambda