### PR TITLE
Update APM .NET agent legacy URL mapping versions for 1.34.0

### DIFF
--- a/config/legacy-url-mappings.yml
+++ b/config/legacy-url-mappings.yml
@@ -8,7 +8,7 @@ stack: &stack [ '9.0+', '8.19', '8.18', '8.17', '8.16', '8.15', '8.14', '8.13', 
 
 mappings:
   en/apm/agent/android/: [ '1.2.0' , '0.x' ]
-  en/apm/agent/dotnet/: [ '1.33.0' ]
+  en/apm/agent/dotnet/: [ '1.34.0' ]
   en/apm/agent/go/: [ '2.7.1', '1.x', '0.5' ]
   en/apm/agent/java/: ['1.54.0', '0.7', '0.6']
   en/apm/agent/nodejs/: [ '4.x', '3.x', '2.x', '1.x' ]


### PR DESCRIPTION
Fixes https://github.com/elastic/docs-content/issues/2771
Builds on https://github.com/elastic/docs-builder/pull/1792

Updates APM .NET agent legacy URL mapping versions for 1.34.0. The `current` version was updated via automation in https://github.com/elastic/docs-builder/pull/1792, but the version dropdown is still showing 1.33.0. 