### PR TITLE
Change API root endpoint to GET method

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/SearchOrAskAiButton.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/SearchOrAskAiButton.tsx
@@ -33,7 +33,7 @@ export const SearchOrAskAiButton = () => {
     const { data: isApiAvailable } = useQuery({
         queryKey: ['api-health'],
         queryFn: async () => {
-            const response = await fetch('/docs/_api/v1/', { method: 'HEAD' })
+            const response = await fetch('/docs/_api/v1/')
             return response.ok
         },
         staleTime: 5 * 60 * 1000, // 5 minutes

--- a/src/api/Elastic.Documentation.Api.Infrastructure/MappingsExstension.cs
+++ b/src/api/Elastic.Documentation.Api.Infrastructure/MappingsExstension.cs
@@ -15,7 +15,7 @@ public static class MappingsExtension
 {
 	public static void MapElasticDocsApiEndpoints(this IEndpointRouteBuilder group)
 	{
-		_ = group.MapMethods("/", [HttpMethods.Head], () => Results.Empty);
+		_ = group.MapGet("/", () => Results.Empty);
 		MapAskAiEndpoint(group);
 		MapSearchEndpoint(group);
 	}


### PR DESCRIPTION
It seems like fastly is changed the request from `HEAD` to `GET`.

Not sure why. For now just use `GET`.