### PR TITLE
Use retrievers in search query

### DIFF
--- a/src/api/Elastic.Documentation.Api.Infrastructure/Adapters/Search/ElasticsearchGateway.cs
+++ b/src/api/Elastic.Documentation.Api.Infrastructure/Adapters/Search/ElasticsearchGateway.cs
@@ -117,9 +117,7 @@ public class ElasticsearchGateway : ISearchGateway
 					response.ElasticsearchServerError?.Error?.Reason ?? "Unknown");
 			}
 			else
-			{
 				_logger.LogInformation("RRF search completed for '{Query}'. Total hits: {TotalHits}", query, response.Total);
-			}
 
 			return ProcessSearchResponse(response);
 		}


### PR DESCRIPTION
As explained in https://www.elastic.co/docs/solutions/search/hybrid-semantic-text for a truly hybrid search