### PR TITLE
Enable SEARCH_OR_ASK_AI feature flag on prod

### DIFF
--- a/config/assembler.yml
+++ b/config/assembler.yml
@@ -7,6 +7,8 @@ environments:
     google_tag_manager:
       enabled: true
       id: GTM-KNJMG2M
+    feature_flags:
+      SEARCH_OR_ASK_AI: true
   staging:
     uri: https://staging-website.elastic.co
     path_prefix: docs


### PR DESCRIPTION
This will not show the SearchOrAskAI bar in prod to the public.

The feature is still hidden by a VPN allowed list.