### PR TITLE
Use POST request to check if the API is available

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/SearchOrAskAiButton.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/SearchOrAskAiButton.tsx
@@ -33,10 +33,10 @@ export const SearchOrAskAiButton = () => {
     const { data: isApiAvailable } = useQuery({
         queryKey: ['api-health'],
         queryFn: async () => {
-            const response = await fetch('/docs/_api/v1/')
+            const response = await fetch('/docs/_api/v1/', { method: 'POST' })
             return response.ok
         },
-        staleTime: 5 * 60 * 1000, // 5 minutes
+        staleTime: 60 * 60 * 1000, // 60 minutes
         retry: false,
     })
 

--- a/src/api/Elastic.Documentation.Api.Infrastructure/MappingsExtensions.cs
+++ b/src/api/Elastic.Documentation.Api.Infrastructure/MappingsExtensions.cs
@@ -16,6 +16,7 @@ public static class MappingsExtension
 	public static void MapElasticDocsApiEndpoints(this IEndpointRouteBuilder group)
 	{
 		_ = group.MapGet("/", () => Results.Empty);
+		_ = group.MapPost("/", () => Results.Empty);
 		MapAskAiEndpoint(group);
 		MapSearchEndpoint(group);
 	}


### PR DESCRIPTION
GET requests are cached on the edge. which means, once a user with VPN gets a 200 OK, all users in the region get a 200 OK, which is not the intended behaviour

POST requests are not cached
