### PR TITLE
Add link to internal feedback issue template

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/SearchOrAskAiModal.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/SearchOrAskAiModal.tsx
@@ -8,8 +8,8 @@ import {
     EuiBetaBadge,
     EuiText,
     EuiHorizontalRule,
-    useEuiOverflowScroll,
-} from '@elastic/eui'
+    useEuiOverflowScroll, EuiLink
+} from "@elastic/eui";
 import { css } from '@emotion/react'
 import * as React from 'react'
 
@@ -89,7 +89,7 @@ export const SearchOrAskAiModal = () => {
                 />
 
                 <EuiText color="subdued" size="xs">
-                    This feature is in beta. Got feedback? We'd love to hear it!
+                    This feature is in beta. <EuiLink target="_blank" rel="noopener noreferrer"  href="https://github.com/elastic/docs-eng-team/issues/new?template=search-or-ask-ai-feedback.yml">Got feedback? We'd love to hear it!</EuiLink>
                 </EuiText>
             </div>
         </div>

--- a/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/SearchOrAskAiModal.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/SearchOrAskAiModal.tsx
@@ -86,7 +86,7 @@ export const SearchOrAskAiModal = () => {
                     `}
                     label="Beta"
                     color="accent"
-                    tooltipContent="This feature is in beta. Got feedback? We'd love to hear it!"
+                    tooltipContent="This feature is in beta. It's only enabled if you are in Elastic's Global VPN."
                 />
 
                 <EuiText color="subdued" size="xs">

--- a/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/SearchOrAskAiModal.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/SearchOrAskAiModal.tsx
@@ -8,8 +8,9 @@ import {
     EuiBetaBadge,
     EuiText,
     EuiHorizontalRule,
-    useEuiOverflowScroll, EuiLink
-} from "@elastic/eui";
+    useEuiOverflowScroll,
+    EuiLink,
+} from '@elastic/eui'
 import { css } from '@emotion/react'
 import * as React from 'react'
 
@@ -89,7 +90,14 @@ export const SearchOrAskAiModal = () => {
                 />
 
                 <EuiText color="subdued" size="xs">
-                    This feature is in beta. <EuiLink target="_blank" rel="noopener noreferrer"  href="https://github.com/elastic/docs-eng-team/issues/new?template=search-or-ask-ai-feedback.yml">Got feedback? We'd love to hear it!</EuiLink>
+                    This feature is in beta.{' '}
+                    <EuiLink
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        href="https://github.com/elastic/docs-eng-team/issues/new?template=search-or-ask-ai-feedback.yml"
+                    >
+                        Got feedback? We'd love to hear it!
+                    </EuiLink>
                 </EuiText>
             </div>
         </div>


### PR DESCRIPTION
## Changes

Add a link to the new issue template https://github.com/elastic/docs-eng-team/issues/new?template=search-or-ask-ai-feedback.yml

## Screenshot

<img width="911" height="344" alt="image" src="https://github.com/user-attachments/assets/5bc8e519-6bb4-4591-8aa2-46dee7d28804" />
