### PR TITLE
Improve error message when deleting a file locally to add redirects and update call sites

### DIFF
--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -258,7 +258,7 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 					 ? $"one of: {string.Join(", ", redirect.Many.Select(m => m.To))}"
 					 : "unknown"
 					);
-				processor.EmitError(link, $"Local file `{url}` has a redirect, please update this reference to: {name}");
+				processor.EmitWarning(link, $"Local file `{url}` has a redirect, please update this reference to: {name}");
 			}
 			else
 				processor.EmitError(link, $"`{url}` does not exist. If it was recently removed add a redirect. resolved to `{pathOnDisk}");


### PR DESCRIPTION
<img width="1256" height="154" alt="image" src="https://github.com/user-attachments/assets/2e8250da-41eb-4045-870d-56914511159a" />

(Updated ⬆️ to be a warning instead).

If a local link does not exist:

* Update error to say it doesn't exist and if it was removed recently to add a redirect.
* If the redirect exist but the callsites have not been updated add an error to update the local links.


cc @florent-leborgne 


