### PR TITLE
Improve configuration initialization

### DIFF
--- a/aspire/AppHost.cs
+++ b/aspire/AppHost.cs
@@ -13,10 +13,16 @@ using static Elastic.Documentation.Aspire.ResourceNames;
 // ReSharper disable NotAccessedVariable
 
 var logLevel = LogLevel.Information;
-GlobalCommandLine.Process(ref args, ref logLevel, out var skipPrivateRepositories, out _);
+GlobalCommandLine.Process(ref args, ref logLevel, out var skipPrivateRepositories, out var configurationSource, out _);
 var globalArguments = new List<string>();
 if (skipPrivateRepositories)
 	globalArguments.Add("--skip-private-repositories");
+
+if (configurationSource is { } cs)
+{
+	globalArguments.Add("--config-source");
+	globalArguments.Add(cs.ToStringFast(true));
+}
 
 if (logLevel != LogLevel.Information)
 {

--- a/aspire/AppHost.cs
+++ b/aspire/AppHost.cs
@@ -5,30 +5,9 @@
 
 using ConsoleAppFramework;
 using Elastic.Documentation;
-using Microsoft.Extensions.Logging;
 using static Elastic.Documentation.Aspire.ResourceNames;
 
-// ReSharper disable UnusedVariable
-// ReSharper disable RedundantAssignment
-// ReSharper disable NotAccessedVariable
-
-var logLevel = LogLevel.Information;
-GlobalCommandLine.Process(ref args, ref logLevel, out var skipPrivateRepositories, out var configurationSource, out _);
-var globalArguments = new List<string>();
-if (skipPrivateRepositories)
-	globalArguments.Add("--skip-private-repositories");
-
-if (configurationSource is { } cs)
-{
-	globalArguments.Add("--config-source");
-	globalArguments.Add(cs.ToStringFast(true));
-}
-
-if (logLevel != LogLevel.Information)
-{
-	globalArguments.Add("--log-level");
-	globalArguments.Add(logLevel.ToString());
-}
+GlobalCli.Process(ref args, out _, out var globalArguments);
 
 await ConsoleApp.RunAsync(args, BuildAspireHost);
 return;
@@ -38,7 +17,6 @@ return;
 async Task BuildAspireHost(bool startElasticsearch, bool assumeCloned, bool skipPrivateRepositories, Cancel ctx)
 {
 	var builder = DistributedApplication.CreateBuilder(args);
-	skipPrivateRepositories = globalArguments.Contains("--skip-private-repositories");
 
 	var llmUrl = builder.AddParameter("LlmGatewayUrl", secret: true);
 	var llmServiceAccountPath = builder.AddParameter("LlmGatewayServiceAccountPath", secret: true);
@@ -69,6 +47,7 @@ async Task BuildAspireHost(bool startElasticsearch, bool assumeCloned, bool skip
 		.WithEnvironment("LLM_GATEWAY_SERVICE_ACCOUNT_KEY_PATH", llmServiceAccountPath)
 		.WithExplicitStart();
 
+	// ReSharper disable once RedundantAssignment
 	api = startElasticsearch
 		? api
 			.WithReference(elasticsearchLocal)
@@ -84,6 +63,8 @@ async Task BuildAspireHost(bool startElasticsearch, bool assumeCloned, bool skip
 		.WithArgs(["assembler", "build", "--exporters", "elasticsearch", .. globalArguments])
 		.WithExplicitStart()
 		.WaitForCompletion(cloneAll);
+
+	// ReSharper disable once RedundantAssignment
 	indexElasticsearch = startElasticsearch
 		? indexElasticsearch
 			.WaitFor(elasticsearchLocal)
@@ -103,6 +84,8 @@ async Task BuildAspireHost(bool startElasticsearch, bool assumeCloned, bool skip
 		.WithEnvironment(context => context.EnvironmentVariables["DOCUMENTATION_ELASTIC_PASSWORD"] = elasticsearchLocal.Resource.PasswordParameter)
 		.WithExplicitStart()
 		.WaitForCompletion(cloneAll);
+
+	// ReSharper disable once RedundantAssignment
 	indexElasticsearchSemantic = startElasticsearch
 		? indexElasticsearchSemantic
 			.WaitFor(elasticsearchLocal)
@@ -136,6 +119,7 @@ async Task BuildAspireHost(bool startElasticsearch, bool assumeCloned, bool skip
 			.WithEnvironment("DOCUMENTATION_ELASTIC_APIKEY", elasticsearchApiKey);
 
 
+	// ReSharper disable once RedundantAssignment
 	serveStatic = startElasticsearch ? serveStatic.WaitFor(elasticsearchLocal) : serveStatic.WaitFor(buildAll);
 
 	await builder.Build().RunAsync(ctx);

--- a/src/Elastic.Documentation.Configuration/ConfigurationFileProvider.cs
+++ b/src/Elastic.Documentation.Configuration/ConfigurationFileProvider.cs
@@ -6,40 +6,73 @@ using System.IO.Abstractions;
 using System.Text.RegularExpressions;
 using Elastic.Documentation.Configuration.Assembler;
 using Microsoft.Extensions.DependencyInjection;
-using NetEscapades.EnumGenerators;
+using Microsoft.Extensions.Logging;
 
 namespace Elastic.Documentation.Configuration;
-
-[EnumExtensions]
-public enum ConfigurationSource
-{
-	Local,
-	Checkout,
-	Embedded
-}
 
 public partial class ConfigurationFileProvider
 {
 	private readonly IFileSystem _fileSystem;
 	private readonly string _assemblyName;
+	private readonly ILogger<ConfigurationFileProvider> _logger;
 
-	public ConfigurationSource ConfigurationSource { get; private set; } = ConfigurationSource.Embedded;
+	public ConfigurationSource ConfigurationSource { get; }
 	public string? GitReference { get; }
 
-	public ConfigurationFileProvider(IFileSystem fileSystem, bool skipPrivateRepositories = false)
+	public ConfigurationFileProvider(
+		ILoggerFactory logFactory,
+		IFileSystem fileSystem,
+		bool skipPrivateRepositories = false,
+		ConfigurationSource? configurationSource = null
+	)
 	{
+		_logger = logFactory.CreateLogger<ConfigurationFileProvider>();
 		_fileSystem = fileSystem;
 		_assemblyName = typeof(ConfigurationFileProvider).Assembly.GetName().Name!;
 		SkipPrivateRepositories = skipPrivateRepositories;
 		TemporaryDirectory = fileSystem.Directory.CreateTempSubdirectory("docs-builder-config");
 
+		ConfigurationSource = configurationSource ?? (
+			fileSystem.Directory.Exists(LocalConfigurationDirectory)
+				? ConfigurationSource.Local
+				: fileSystem.Directory.Exists(LocalConfigurationDirectory)
+					? ConfigurationSource.Init
+					: ConfigurationSource.Embedded
+			);
+
+		if (ConfigurationSource == ConfigurationSource.Local && !fileSystem.Directory.Exists(LocalConfigurationDirectory))
+			throw new Exception($"Required directory form {nameof(ConfigurationSource)}.{nameof(ConfigurationSource.Local)} directory {LocalConfigurationDirectory} does not exist.");
+
+		if (ConfigurationSource == ConfigurationSource.Init && !fileSystem.Directory.Exists(AppDataConfigurationDirectory))
+			throw new Exception($"Required directory form {nameof(ConfigurationSource)}.{nameof(ConfigurationSource.Init)} directory {AppDataConfigurationDirectory} does not exist.");
+
+		var path = GetAppDataPath("git-ref.txt");
+		if (_fileSystem.File.Exists(path))
+			GitReference = _fileSystem.File.ReadAllText(path);
+		else if (ConfigurationSource == ConfigurationSource.Init)
+			throw new Exception($"Can not read git-ref.txt in directory {LocalConfigurationDirectory}");
+
+		if (ConfigurationSource == ConfigurationSource.Init)
+		{
+			_logger.LogInformation("{ConfigurationSource}: git ref '{GitReference}', in {Directory}",
+				$"{nameof(ConfigurationSource)}.{nameof(ConfigurationSource.Init)}", GitReference, AppDataConfigurationDirectory);
+		}
+
+		if (ConfigurationSource == ConfigurationSource.Local)
+		{
+			_logger.LogInformation("{ConfigurationSource}: located {Directory}",
+				$"{nameof(ConfigurationSource)}.{nameof(ConfigurationSource.Local)}", AppDataConfigurationDirectory);
+		}
+		if (ConfigurationSource == ConfigurationSource.Embedded)
+		{
+			_logger.LogInformation("{ConfigurationSource} using embedded in binary configuration",
+				$"{nameof(ConfigurationSource)}.{nameof(ConfigurationSource.Embedded)}");
+		}
+
 		VersionFile = CreateTemporaryConfigurationFile("versions.yml");
 		AssemblerFile = CreateTemporaryConfigurationFile("assembler.yml");
 		NavigationFile = CreateTemporaryConfigurationFile("navigation.yml");
 		LegacyUrlMappingsFile = CreateTemporaryConfigurationFile("legacy-url-mappings.yml");
-		var path = GetAppDataPath("git-ref.txt");
-		if (ConfigurationSource == ConfigurationSource.Checkout && _fileSystem.File.Exists(path))
-			GitReference = _fileSystem.File.ReadAllText(path);
 	}
 
 	public bool SkipPrivateRepositories { get; }
@@ -65,6 +98,8 @@ public partial class ConfigurationFileProvider
 		var tempFile = Path.Combine(TemporaryDirectory.FullName, "navigation.filtered.yml");
 		if (_fileSystem.File.Exists(tempFile))
 			return NavigationFile;
+
+		_logger.LogInformation("Filtering navigation file to remove private repositories");
 
 		// This routine removes `toc: `'s linking to private repositories and reindents any later lines if needed.
 		// This will make any public children in the nav move up one place.
@@ -139,19 +174,22 @@ public partial class ConfigurationFileProvider
 	private StreamReader GetLocalOrEmbedded(string fileName)
 	{
 		var localPath = GetLocalPath(fileName);
-		var appDataPath = GetAppDataPath(fileName);
-		if (_fileSystem.File.Exists(localPath))
+		if (ConfigurationSource == ConfigurationSource.Local && _fileSystem.File.Exists(localPath))
 		{
-			ConfigurationSource = ConfigurationSource.Local;
 			var reader = _fileSystem.File.OpenText(localPath);
 			return reader;
 		}
-		if (_fileSystem.File.Exists(appDataPath))
+		if (ConfigurationSource == ConfigurationSource.Local)
+			throw new Exception($"Can not read {fileName} in directory {LocalConfigurationDirectory}");
+
+		var appDataPath = GetAppDataPath(fileName);
+		if (ConfigurationSource == ConfigurationSource.Init && _fileSystem.File.Exists(appDataPath))
 		{
-			ConfigurationSource = ConfigurationSource.Checkout;
 			var reader = _fileSystem.File.OpenText(appDataPath);
 			return reader;
 		}
+		if (ConfigurationSource == ConfigurationSource.Init)
+			throw new Exception($"Can not read {fileName} in directory {AppDataConfigurationDirectory}");
 		return GetEmbeddedStream(fileName);
 	}
 
@@ -168,19 +206,21 @@ public partial class ConfigurationFileProvider
 
 	private static string GetLocalPath(string file) => Path.Combine(LocalConfigurationDirectory, file);
 	private static string GetAppDataPath(string file) => Path.Combine(AppDataConfigurationDirectory, file);
+
 	[GeneratedRegex(@"^\s+-?\s?toc:\s?")]
 	private static partial Regex TocPrefixRegex();
 }
 
 public static class ConfigurationFileProviderServiceCollectionExtensions
 {
-	public static IServiceCollection AddConfigurationFileProvider(
-		this IServiceCollection services,
+	public static IServiceCollection AddConfigurationFileProvider(this IServiceCollection services,
 		bool skipPrivateRepositories,
-		Action<IServiceCollection, ConfigurationFileProvider> configure
-	)
+		Documentation.ConfigurationSource? configurationSource,
+		Action<IServiceCollection, ConfigurationFileProvider> configure)
 	{
-		var provider = new ConfigurationFileProvider(new FileSystem(), skipPrivateRepositories);
+		using var sp = services.BuildServiceProvider();
+		var logFactory = sp.GetRequiredService<ILoggerFactory>();
+		var provider = new ConfigurationFileProvider(logFactory, new FileSystem(), skipPrivateRepositories, configurationSource);
 		_ = services.AddSingleton(provider);
 		configure(services, provider);
 		return services;

--- a/src/Elastic.Documentation.Configuration/ConfigurationFileProvider.cs
+++ b/src/Elastic.Documentation.Configuration/ConfigurationFileProvider.cs
@@ -34,10 +34,7 @@ public partial class ConfigurationFileProvider
 
 		ConfigurationSource = configurationSource ?? (
 			fileSystem.Directory.Exists(LocalConfigurationDirectory)
-				? ConfigurationSource.Local
-				: fileSystem.Directory.Exists(LocalConfigurationDirectory)
-					? ConfigurationSource.Init
-					: ConfigurationSource.Embedded
+				? ConfigurationSource.Local : ConfigurationSource.Embedded
 			);
 
 		if (ConfigurationSource == ConfigurationSource.Local && !fileSystem.Directory.Exists(LocalConfigurationDirectory))

--- a/src/Elastic.Documentation.Configuration/ConfigurationFileProvider.cs
+++ b/src/Elastic.Documentation.Configuration/ConfigurationFileProvider.cs
@@ -40,25 +40,25 @@ public partial class ConfigurationFileProvider
 		if (ConfigurationSource == ConfigurationSource.Local && !fileSystem.Directory.Exists(LocalConfigurationDirectory))
 			throw new Exception($"Required directory form {nameof(ConfigurationSource)}.{nameof(ConfigurationSource.Local)} directory {LocalConfigurationDirectory} does not exist.");
 
-		if (ConfigurationSource == ConfigurationSource.Init && !fileSystem.Directory.Exists(AppDataConfigurationDirectory))
-			throw new Exception($"Required directory form {nameof(ConfigurationSource)}.{nameof(ConfigurationSource.Init)} directory {AppDataConfigurationDirectory} does not exist.");
+		if (ConfigurationSource == ConfigurationSource.Remote && !fileSystem.Directory.Exists(AppDataConfigurationDirectory))
+			throw new Exception($"Required directory form {nameof(ConfigurationSource)}.{nameof(ConfigurationSource.Remote)} directory {AppDataConfigurationDirectory} does not exist.");
 
 		var path = GetAppDataPath("git-ref.txt");
 		if (_fileSystem.File.Exists(path))
 			GitReference = _fileSystem.File.ReadAllText(path);
-		else if (ConfigurationSource == ConfigurationSource.Init)
+		else if (ConfigurationSource == ConfigurationSource.Remote)
 			throw new Exception($"Can not read git-ref.txt in directory {LocalConfigurationDirectory}");
 
-		if (ConfigurationSource == ConfigurationSource.Init)
+		if (ConfigurationSource == ConfigurationSource.Remote)
 		{
 			_logger.LogInformation("{ConfigurationSource}: git ref '{GitReference}', in {Directory}",
-				$"{nameof(ConfigurationSource)}.{nameof(ConfigurationSource.Init)}", GitReference, AppDataConfigurationDirectory);
+				$"{nameof(ConfigurationSource)}.{nameof(ConfigurationSource.Remote)}", GitReference, AppDataConfigurationDirectory);
 		}
 
 		if (ConfigurationSource == ConfigurationSource.Local)
 		{
 			_logger.LogInformation("{ConfigurationSource}: located {Directory}",
-				$"{nameof(ConfigurationSource)}.{nameof(ConfigurationSource.Local)}", AppDataConfigurationDirectory);
+				$"{nameof(ConfigurationSource)}.{nameof(ConfigurationSource.Local)}", LocalConfigurationDirectory);
 		}
 		if (ConfigurationSource == ConfigurationSource.Embedded)
 		{
@@ -180,12 +180,12 @@ public partial class ConfigurationFileProvider
 			throw new Exception($"Can not read {fileName} in directory {LocalConfigurationDirectory}");
 
 		var appDataPath = GetAppDataPath(fileName);
-		if (ConfigurationSource == ConfigurationSource.Init && _fileSystem.File.Exists(appDataPath))
+		if (ConfigurationSource == ConfigurationSource.Remote && _fileSystem.File.Exists(appDataPath))
 		{
 			var reader = _fileSystem.File.OpenText(appDataPath);
 			return reader;
 		}
-		if (ConfigurationSource == ConfigurationSource.Init)
+		if (ConfigurationSource == ConfigurationSource.Remote)
 			throw new Exception($"Can not read {fileName} in directory {AppDataConfigurationDirectory}");
 		return GetEmbeddedStream(fileName);
 	}
@@ -198,8 +198,8 @@ public partial class ConfigurationFileProvider
 		return reader;
 	}
 
-	private static string AppDataConfigurationDirectory { get; } = Path.Combine(Paths.ApplicationData.FullName, "config-clone", "config");
-	private static string LocalConfigurationDirectory { get; } = Path.Combine(Paths.WorkingDirectoryRoot.FullName, "config");
+	public static string AppDataConfigurationDirectory { get; } = Path.Combine(Paths.ApplicationData.FullName, "config-clone", "config");
+	public static string LocalConfigurationDirectory { get; } = Path.Combine(Paths.WorkingDirectoryRoot.FullName, "config");
 
 	private static string GetLocalPath(string file) => Path.Combine(LocalConfigurationDirectory, file);
 	private static string GetAppDataPath(string file) => Path.Combine(AppDataConfigurationDirectory, file);
@@ -212,7 +212,7 @@ public static class ConfigurationFileProviderServiceCollectionExtensions
 {
 	public static IServiceCollection AddConfigurationFileProvider(this IServiceCollection services,
 		bool skipPrivateRepositories,
-		Documentation.ConfigurationSource? configurationSource,
+		ConfigurationSource? configurationSource,
 		Action<IServiceCollection, ConfigurationFileProvider> configure)
 	{
 		using var sp = services.BuildServiceProvider();

--- a/src/Elastic.Documentation.ServiceDefaults/AppDefaultsExtensions.cs
+++ b/src/Elastic.Documentation.ServiceDefaults/AppDefaultsExtensions.cs
@@ -13,8 +13,6 @@ using Microsoft.Extensions.Logging.Console;
 
 namespace Elastic.Documentation.ServiceDefaults;
 
-public record CliInvocation(bool IsHelpOrVersion);
-
 public static class AppDefaultsExtensions
 {
 	public static TBuilder AddDocumentationServiceDefaults<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
@@ -22,25 +20,21 @@ public static class AppDefaultsExtensions
 		var args = Array.Empty<string>();
 		return builder.AddDocumentationServiceDefaults(ref args);
 	}
-	public static TBuilder AddDocumentationServiceDefaults<TBuilder>(this TBuilder builder, ref string[] args, Action<IServiceCollection, ConfigurationFileProvider> configure) where TBuilder : IHostApplicationBuilder =>
-		builder.AddDocumentationServiceDefaults(ref args, null, configure);
-
-	public static TBuilder AddDocumentationServiceDefaults<TBuilder>(this TBuilder builder, ref string[] args, LogLevel? defaultLogLevel = null, Action<IServiceCollection, ConfigurationFileProvider>? configure = null)
+	public static TBuilder AddDocumentationServiceDefaults<TBuilder>(this TBuilder builder, ref string[] args, Action<IServiceCollection, ConfigurationFileProvider>? configure = null)
 		where TBuilder : IHostApplicationBuilder
 	{
-		var logLevel = defaultLogLevel ?? LogLevel.Information;
-		GlobalCommandLine.Process(ref args, ref logLevel, out var skipPrivateRepositories, out var configurationSource, out var isHelpOrVersion);
+		GlobalCli.Process(ref args, out var globalArgs);
 
 		var services = builder.Services;
-		_ = builder.Services.AddElasticDocumentationLogging(logLevel);
+		_ = builder.Services.AddElasticDocumentationLogging(globalArgs.LogLevel);
 		_ = services
-			.AddConfigurationFileProvider(skipPrivateRepositories, configurationSource, (s, p) =>
+			.AddConfigurationFileProvider(globalArgs.SkipPrivateRepositories, globalArgs.ConfigurationSource, (s, p) =>
 			{
 				_ = s.AddSingleton(p.CreateVersionConfiguration());
 				configure?.Invoke(s, p);
 			});
-		_ = builder.Services.AddElasticDocumentationLogging(logLevel);
-		_ = services.AddSingleton(new CliInvocation(isHelpOrVersion));
+		_ = builder.Services.AddElasticDocumentationLogging(globalArgs.LogLevel);
+		_ = services.AddSingleton(globalArgs);
 
 		return builder.AddServiceDefaults();
 	}

--- a/src/Elastic.Documentation.ServiceDefaults/AppDefaultsExtensions.cs
+++ b/src/Elastic.Documentation.ServiceDefaults/AppDefaultsExtensions.cs
@@ -25,14 +25,16 @@ public static class AppDefaultsExtensions
 	public static TBuilder AddDocumentationServiceDefaults<TBuilder>(this TBuilder builder, ref string[] args, Action<IServiceCollection, ConfigurationFileProvider> configure) where TBuilder : IHostApplicationBuilder =>
 		builder.AddDocumentationServiceDefaults(ref args, null, configure);
 
-	public static TBuilder AddDocumentationServiceDefaults<TBuilder>(this TBuilder builder, ref string[] args, LogLevel? defaultLogLevel = null, Action<IServiceCollection, ConfigurationFileProvider>? configure = null) where TBuilder : IHostApplicationBuilder
+	public static TBuilder AddDocumentationServiceDefaults<TBuilder>(this TBuilder builder, ref string[] args, LogLevel? defaultLogLevel = null, Action<IServiceCollection, ConfigurationFileProvider>? configure = null)
+		where TBuilder : IHostApplicationBuilder
 	{
 		var logLevel = defaultLogLevel ?? LogLevel.Information;
-		GlobalCommandLine.Process(ref args, ref logLevel, out var skipPrivateRepositories, out var isHelpOrVersion);
+		GlobalCommandLine.Process(ref args, ref logLevel, out var skipPrivateRepositories, out var configurationSource, out var isHelpOrVersion);
 
 		var services = builder.Services;
+		_ = builder.Services.AddElasticDocumentationLogging(logLevel);
 		_ = services
-			.AddConfigurationFileProvider(skipPrivateRepositories, (s, p) =>
+			.AddConfigurationFileProvider(skipPrivateRepositories, configurationSource, (s, p) =>
 			{
 				_ = s.AddSingleton(p.CreateVersionConfiguration());
 				configure?.Invoke(s, p);

--- a/src/Elastic.Documentation/ConfigurationSource.cs
+++ b/src/Elastic.Documentation/ConfigurationSource.cs
@@ -10,6 +10,6 @@ namespace Elastic.Documentation;
 public enum ConfigurationSource
 {
 	Local,
-	Init,
+	Remote,
 	Embedded
 }

--- a/src/Elastic.Documentation/ConfigurationSource.cs
+++ b/src/Elastic.Documentation/ConfigurationSource.cs
@@ -1,0 +1,15 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using NetEscapades.EnumGenerators;
+
+namespace Elastic.Documentation;
+
+[EnumExtensions]
+public enum ConfigurationSource
+{
+	Local,
+	Init,
+	Embedded
+}

--- a/src/Elastic.Documentation/GlobalCommandLine.cs
+++ b/src/Elastic.Documentation/GlobalCommandLine.cs
@@ -6,46 +6,61 @@ using Microsoft.Extensions.Logging;
 
 namespace Elastic.Documentation;
 
-public static class GlobalCommandLine
+public record GlobalCliArgs
 {
-	public static void Process(
-		ref string[] args,
-		ref LogLevel defaultLogLevel,
-		out bool skipPrivateRepositories,
-		out ConfigurationSource? configurationSource,
-		out bool isHelpOrVersion
-	)
+	public LogLevel LogLevel { get; init; } = LogLevel.Information;
+	public ConfigurationSource? ConfigurationSource { get; init; }
+	public bool SkipPrivateRepositories { get; init; }
+	public bool IsHelpOrVersion { get; init; }
+}
+public static class GlobalCli
+{
+	public static void Process(ref string[] args, out GlobalCliArgs cli) => Process(ref args, out cli, out _);
+	public static void Process(ref string[] args, out GlobalCliArgs cli, out string[] globalArguments)
 	{
-		configurationSource = null;
-		skipPrivateRepositories = false;
-		isHelpOrVersion = false;
-		var newArgs = new List<string>();
+		cli = new GlobalCliArgs();
+		globalArguments = [];
+		var globalArgs = new List<string>();
+		var filteredArguments = new List<string>();
 		for (var i = 0; i < args.Length; i++)
 		{
 			if (args[i] == "--log-level")
 			{
 				if (args.Length > i + 1)
-					defaultLogLevel = GetLogLevel(args[i + 1]);
+				{
+					cli = cli with { LogLevel = GetLogLevel(args[i + 1]) };
+					globalArgs.Add("--log-level");
+					globalArgs.Add(args[i + 1]);
+				}
 				i++;
 			}
-			else if (args[i] == "--config-source")
+			else if (args[i] is "--config-source" or "--configuration-source" or "-c")
 			{
 				if (args.Length > i + 1 && ConfigurationSourceExtensions.TryParse(args[i + 1], out var cs, true, true))
-					configurationSource = cs;
+				{
+					cli = cli with { ConfigurationSource = cs };
+					globalArgs.Add("--config-source");
+					globalArgs.Add(args[i + 1]);
+				}
 				i++;
 			}
 			else if (args[i] == "--skip-private-repositories")
-				skipPrivateRepositories = true;
+			{
+				cli = cli with { SkipPrivateRepositories = true };
+				globalArgs.Add("--skip-private-repositories");
+			}
 			else if (args[i] is "--help" or "--version")
 			{
-				isHelpOrVersion = true;
-				newArgs.Add(args[i]);
+				cli = cli with { IsHelpOrVersion = true };
+				globalArgs.Add(args[i]);
+				filteredArguments.Add(args[i]);
 			}
 			else
-				newArgs.Add(args[i]);
+				filteredArguments.Add(args[i]);
 		}
 
-		args = [.. newArgs];
+		args = [.. filteredArguments];
+		globalArguments = [.. globalArgs];
 	}
 
 	private static LogLevel GetLogLevel(string? logLevel) => logLevel switch

--- a/src/Elastic.Documentation/GlobalCommandLine.cs
+++ b/src/Elastic.Documentation/GlobalCommandLine.cs
@@ -12,9 +12,11 @@ public static class GlobalCommandLine
 		ref string[] args,
 		ref LogLevel defaultLogLevel,
 		out bool skipPrivateRepositories,
+		out ConfigurationSource? configurationSource,
 		out bool isHelpOrVersion
 	)
 	{
+		configurationSource = null;
 		skipPrivateRepositories = false;
 		isHelpOrVersion = false;
 		var newArgs = new List<string>();
@@ -24,6 +26,12 @@ public static class GlobalCommandLine
 			{
 				if (args.Length > i + 1)
 					defaultLogLevel = GetLogLevel(args[i + 1]);
+				i++;
+			}
+			else if (args[i] == "--config-source")
+			{
+				if (args.Length > i + 1 && ConfigurationSourceExtensions.TryParse(args[i + 1], out var cs, true, true))
+					configurationSource = cs;
 				i++;
 			}
 			else if (args[i] == "--skip-private-repositories")

--- a/src/services/Elastic.Documentation.Assembler/Sourcing/GitFacade.cs
+++ b/src/services/Elastic.Documentation.Assembler/Sourcing/GitFacade.cs
@@ -39,7 +39,8 @@ public class SingleCommitOptimizedGitRepository(IDiagnosticsCollector collector,
 	public bool IsInitialized() => Directory.Exists(Path.Combine(WorkingDirectory.FullName, ".git"));
 	public void Pull(string branch) => ExecIn(EnvironmentVars, "git", "pull", "--depth", "1", "--allow-unrelated-histories", "--no-ff", "origin", branch);
 	public void Fetch(string reference) => ExecIn(EnvironmentVars, "git", "fetch", "--no-tags", "--prune", "--no-recurse-submodules", "--depth", "1", "origin", reference);
-	public void EnableSparseCheckout(string[] folders) => ExecIn(EnvironmentVars, "git", ["sparse-checkout", "set", .. folders]);
+	public void EnableSparseCheckout(string[] folders) => ExecIn(EnvironmentVars, "git", ["sparse-checkout", "set", "--no-cone", .. folders]);
+
 	public void DisableSparseCheckout() => ExecIn(EnvironmentVars, "git", "sparse-checkout", "disable");
 	public void Checkout(string reference) => ExecIn(EnvironmentVars, "git", "checkout", "--force", reference);
 

--- a/src/services/Elastic.Documentation.Assembler/Sourcing/RepositorySourcesFetcher.cs
+++ b/src/services/Elastic.Documentation.Assembler/Sourcing/RepositorySourcesFetcher.cs
@@ -204,7 +204,7 @@ public class RepositorySourcer(ILoggerFactory logFactory, IDirectoryInfo checkou
 				return new Checkout
 				{
 					Directory = checkoutFolder,
-					HeadReference = gitRef,
+					HeadReference = git.GetCurrentCommit(),
 					Repository = repository,
 				};
 			}
@@ -225,7 +225,7 @@ public class RepositorySourcer(ILoggerFactory logFactory, IDirectoryInfo checkou
 		return new Checkout
 		{
 			Directory = checkoutFolder,
-			HeadReference = gitRef,
+			HeadReference = git.GetCurrentCommit(),
 			Repository = repository,
 		};
 	}

--- a/src/tooling/Elastic.Documentation.Tooling/DocumentationTooling.cs
+++ b/src/tooling/Elastic.Documentation.Tooling/DocumentationTooling.cs
@@ -34,8 +34,8 @@ public static class DocumentationTooling
 			{
 				var logFactory = sp.GetRequiredService<ILoggerFactory>();
 				var githubActionsService = sp.GetRequiredService<ICoreService>();
-				var isHelp = sp.GetRequiredService<CliInvocation>();
-				if (isHelp.IsHelpOrVersion)
+				var globalArgs = sp.GetRequiredService<GlobalCliArgs>();
+				if (globalArgs.IsHelpOrVersion)
 					return new DiagnosticsCollector([]);
 				return new ConsoleDiagnosticsCollector(logFactory, githubActionsService);
 			})
@@ -101,8 +101,6 @@ public static class DocumentationTooling
 		}
 		return null;
 	}
-
-	[SuppressMessage("Reliability", "CA2012:Use ValueTasks correctly")]
 
 	[SuppressMessage("Reliability", "CA2012:Use ValueTasks correctly")]
 	private static Uri ResolveServiceEndpoint(ServiceEndpointResolver resolver, Func<string> fallback)

--- a/src/tooling/Elastic.Documentation.Tooling/Filters/InfoLoggerFilter.cs
+++ b/src/tooling/Elastic.Documentation.Tooling/Filters/InfoLoggerFilter.cs
@@ -28,7 +28,7 @@ public class InfoLoggerFilter(
 			return;
 		}
 		logger.LogInformation("Configuration source: {ConfigurationSource}", fileProvider.ConfigurationSource.ToStringFast(true));
-		if (fileProvider.ConfigurationSource == ConfigurationSource.Checkout)
+		if (fileProvider.ConfigurationSource == ConfigurationSource.Init)
 			logger.LogInformation("Configuration source git reference: {ConfigurationSourceGitReference}", fileProvider.GitReference);
 		logger.LogInformation("Version: {Version}", assemblyVersion);
 		await Next.InvokeAsync(context, cancellationToken);

--- a/src/tooling/Elastic.Documentation.Tooling/Filters/InfoLoggerFilter.cs
+++ b/src/tooling/Elastic.Documentation.Tooling/Filters/InfoLoggerFilter.cs
@@ -5,7 +5,6 @@
 using System.Reflection;
 using ConsoleAppFramework;
 using Elastic.Documentation.Configuration;
-using Elastic.Documentation.ServiceDefaults;
 using Microsoft.Extensions.Logging;
 
 namespace Elastic.Documentation.Tooling.Filters;
@@ -14,7 +13,7 @@ public class InfoLoggerFilter(
 	ConsoleAppFilter next,
 	ILogger<InfoLoggerFilter> logger,
 	ConfigurationFileProvider fileProvider,
-	CliInvocation cliInvocation
+	GlobalCliArgs cli
 )
 	: ConsoleAppFilter(next)
 {
@@ -22,13 +21,13 @@ public class InfoLoggerFilter(
 	{
 		var assemblyVersion = Assembly.GetExecutingAssembly().GetCustomAttributes<AssemblyInformationalVersionAttribute>()
 			.FirstOrDefault()?.InformationalVersion;
-		if (cliInvocation.IsHelpOrVersion)
+		if (cli.IsHelpOrVersion)
 		{
 			await Next.InvokeAsync(context, cancellationToken);
 			return;
 		}
 		logger.LogInformation("Configuration source: {ConfigurationSource}", fileProvider.ConfigurationSource.ToStringFast(true));
-		if (fileProvider.ConfigurationSource == ConfigurationSource.Init)
+		if (fileProvider.ConfigurationSource == ConfigurationSource.Remote)
 			logger.LogInformation("Configuration source git reference: {ConfigurationSourceGitReference}", fileProvider.GitReference);
 		logger.LogInformation("Version: {Version}", assemblyVersion);
 		await Next.InvokeAsync(context, cancellationToken);

--- a/src/tooling/docs-assembler/Cli/RepositoryCommands.cs
+++ b/src/tooling/docs-assembler/Cli/RepositoryCommands.cs
@@ -29,15 +29,17 @@ internal sealed class RepositoryCommands(
 {
 	/// <summary> Clone the configuration folder </summary>
 	/// <param name="gitRef">The git reference of the config, defaults to 'main'</param>
+	/// <param name="local">Save the remote configuration locally in the pwd so later commands can pick it up as local</param>
 	/// <param name="ctx"></param>
 	[Command("init-config")]
-	public async Task<int> CloneConfigurationFolder(string? gitRef = null, Cancel ctx = default)
+	public async Task<int> CloneConfigurationFolder(string? gitRef = null, bool local = false, Cancel ctx = default)
 	{
 		await using var serviceInvoker = new ServiceInvoker(collector);
 
 		var fs = new FileSystem();
 		var service = new ConfigurationCloneService(logFactory, assemblyConfiguration, fs);
-		serviceInvoker.AddCommand(service, gitRef, static async (s, collector, gitRef, ctx) => await s.InitConfigurationToApplicationData(collector, gitRef, ctx));
+		serviceInvoker.AddCommand(service, (gitRef, local), static async (s, collector, state, ctx) =>
+			await s.InitConfigurationToApplicationData(collector, state.gitRef, state.local, ctx));
 		return await serviceInvoker.InvokeAsync(ctx);
 	}
 

--- a/src/tooling/docs-assembler/Program.cs
+++ b/src/tooling/docs-assembler/Program.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using Actions.Core.Services;
 using ConsoleAppFramework;
 using Documentation.Assembler.Cli;
+using Elastic.Documentation;
 using Elastic.Documentation.Configuration.Assembler;
 using Elastic.Documentation.ServiceDefaults;
 using Elastic.Documentation.Tooling;
@@ -46,7 +47,7 @@ if (!string.IsNullOrEmpty(command))
 
 await app.RunAsync(args);
 
-internal sealed class ReplaceLogFilter(ConsoleAppFilter next, ILogger<Program> logger, CliInvocation cli)
+internal sealed class ReplaceLogFilter(ConsoleAppFilter next, ILogger<Program> logger, GlobalCliArgs cli)
 	: ConsoleAppFilter(next)
 {
 	[SuppressMessage("Usage", "CA2254:Template should be a static expression")]

--- a/src/tooling/docs-builder/Filters/CheckForUpdatesFilter.cs
+++ b/src/tooling/docs-builder/Filters/CheckForUpdatesFilter.cs
@@ -10,7 +10,7 @@ using Elastic.Documentation.ServiceDefaults;
 
 namespace Documentation.Builder.Filters;
 
-internal sealed class CheckForUpdatesFilter(ConsoleAppFilter next, CliInvocation cliInvocation) : ConsoleAppFilter(next)
+internal sealed class CheckForUpdatesFilter(ConsoleAppFilter next, GlobalCliArgs cli) : ConsoleAppFilter(next)
 {
 	private readonly FileInfo _stateFile = new(Path.Combine(Paths.ApplicationData.FullName, "docs-build-check.state"));
 
@@ -19,7 +19,7 @@ internal sealed class CheckForUpdatesFilter(ConsoleAppFilter next, CliInvocation
 		await Next.InvokeAsync(context, ctx);
 		if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CI")))
 			return;
-		if (cliInvocation.IsHelpOrVersion)
+		if (cli.IsHelpOrVersion)
 			return;
 
 		var latestVersionUrl = await GetLatestVersion(ctx);

--- a/src/tooling/docs-builder/Filters/ReplaceLogFilter.cs
+++ b/src/tooling/docs-builder/Filters/ReplaceLogFilter.cs
@@ -4,12 +4,12 @@
 
 using System.Diagnostics.CodeAnalysis;
 using ConsoleAppFramework;
-using Elastic.Documentation.ServiceDefaults;
+using Elastic.Documentation;
 using Microsoft.Extensions.Logging;
 
 namespace Documentation.Builder.Filters;
 
-internal sealed class ReplaceLogFilter(ConsoleAppFilter next, ILogger<Program> logger, CliInvocation cli)
+internal sealed class ReplaceLogFilter(ConsoleAppFilter next, ILogger<Program> logger, GlobalCliArgs cli)
 	: ConsoleAppFilter(next)
 {
 	[SuppressMessage("Usage", "CA2254:Template should be a static expression")]

--- a/src/tooling/docs-builder/Program.cs
+++ b/src/tooling/docs-builder/Program.cs
@@ -26,7 +26,6 @@ var app = builder.ToConsoleAppBuilder((s) =>
 	return ConsoleApp.Create();
 });
 
-
 app.UseFilter<ReplaceLogFilter>();
 app.UseFilter<InfoLoggerFilter>();
 app.UseFilter<StopwatchFilter>();

--- a/tests/Elastic.ApiExplorer.Tests/Elastic.ApiExplorer.Tests.csproj
+++ b/tests/Elastic.ApiExplorer.Tests/Elastic.ApiExplorer.Tests.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Elastic.ApiExplorer\Elastic.ApiExplorer.csproj"/>
+    <ProjectReference Include="..\authoring\authoring.fsproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Elastic.ApiExplorer.Tests/TestHelpers.cs
+++ b/tests/Elastic.ApiExplorer.Tests/TestHelpers.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System.IO.Abstractions;
+using authoring;
 using Elastic.Documentation;
 using Elastic.Documentation.Configuration;
 using Elastic.Documentation.Configuration.Versions;
@@ -33,7 +34,7 @@ public static class TestHelpers
 			{
 				Elasticsearch = ElasticsearchEndpoint.Default,
 			},
-			ConfigurationFileProvider = new ConfigurationFileProvider(fileSystem),
+			ConfigurationFileProvider = new ConfigurationFileProvider(new TestLoggerFactory(), fileSystem),
 			VersionsConfiguration = versionsConfiguration
 		};
 	}

--- a/tests/Elastic.ApiExplorer.Tests/TestHelpers.cs
+++ b/tests/Elastic.ApiExplorer.Tests/TestHelpers.cs
@@ -3,10 +3,10 @@
 // See the LICENSE file in the project root for more information
 
 using System.IO.Abstractions;
-using authoring;
 using Elastic.Documentation;
 using Elastic.Documentation.Configuration;
 using Elastic.Documentation.Configuration.Versions;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Elastic.ApiExplorer.Tests;
 
@@ -34,7 +34,7 @@ public static class TestHelpers
 			{
 				Elasticsearch = ElasticsearchEndpoint.Default,
 			},
-			ConfigurationFileProvider = new ConfigurationFileProvider(new TestLoggerFactory(), fileSystem),
+			ConfigurationFileProvider = new ConfigurationFileProvider(NullLoggerFactory.Instance, fileSystem),
 			VersionsConfiguration = versionsConfiguration
 		};
 	}

--- a/tests/Elastic.Markdown.Tests/TestHelpers.cs
+++ b/tests/Elastic.Markdown.Tests/TestHelpers.cs
@@ -33,7 +33,7 @@ public static class TestHelpers
 			{
 				Elasticsearch = ElasticsearchEndpoint.Default,
 			},
-			ConfigurationFileProvider = new ConfigurationFileProvider(fileSystem),
+			ConfigurationFileProvider = new ConfigurationFileProvider(new TestLoggerFactory(TestContext.Current.TestOutputHelper), fileSystem),
 			VersionsConfiguration = versionsConfiguration
 		};
 	}

--- a/tests/Elastic.Markdown.Tests/TestLogger.cs
+++ b/tests/Elastic.Markdown.Tests/TestLogger.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Elastic.Markdown.Tests;
 
-public class TestLogger(ITestOutputHelper output) : ILogger
+public class TestLogger(ITestOutputHelper? output) : ILogger
 {
 	private sealed class NullScope : IDisposable
 	{
@@ -18,17 +18,17 @@ public class TestLogger(ITestOutputHelper output) : ILogger
 	public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Trace;
 
 	public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) =>
-		output.WriteLine(formatter(state, exception));
+		output?.WriteLine(formatter(state, exception));
 }
 
-public class TestLoggerProvider(ITestOutputHelper output) : ILoggerProvider
+public class TestLoggerProvider(ITestOutputHelper? output) : ILoggerProvider
 {
 	public void Dispose() => GC.SuppressFinalize(this);
 
 	public ILogger CreateLogger(string categoryName) => new TestLogger(output);
 }
 
-public class TestLoggerFactory(ITestOutputHelper output) : ILoggerFactory
+public class TestLoggerFactory(ITestOutputHelper? output) : ILoggerFactory
 {
 	public void Dispose() => GC.SuppressFinalize(this);
 

--- a/tests/authoring/Framework/Setup.fs
+++ b/tests/authoring/Framework/Setup.fs
@@ -260,7 +260,7 @@ type Setup =
         )
        
         let versionConfig = VersionsConfiguration(VersioningSystems = versioningSystems)
-        let configurationFileProvider = ConfigurationFileProvider(fileSystem)
+        let configurationFileProvider = ConfigurationFileProvider(new TestLoggerFactory(), fileSystem)
         let configurationContext = ConfigurationContext(
             VersionsConfiguration = versionConfig,
             ConfigurationFileProvider = configurationFileProvider,

--- a/tests/docs-assembler.Tests/src/docs-assembler.Tests/AssemblerConfigurationTests.cs
+++ b/tests/docs-assembler.Tests/src/docs-assembler.Tests/AssemblerConfigurationTests.cs
@@ -8,6 +8,7 @@ using Elastic.Documentation.Configuration;
 using Elastic.Documentation.Configuration.Assembler;
 using Elastic.Documentation.Diagnostics;
 using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Documentation.Assembler.Tests;
 
@@ -24,7 +25,7 @@ public class PublicOnlyAssemblerConfigurationTests
 			FileSystem.Path.Combine(Paths.GetSolutionDirectory()!.FullName, ".artifacts", "checkouts")
 		);
 		Collector = new DiagnosticsCollector([]);
-		var configurationFileProvider = new ConfigurationFileProvider(FileSystem, skipPrivateRepositories: true);
+		var configurationFileProvider = new ConfigurationFileProvider(NullLoggerFactory.Instance, FileSystem, skipPrivateRepositories: true);
 		var configurationContext = TestHelpers.CreateConfigurationContext(FileSystem, configurationFileProvider: configurationFileProvider);
 		var config = AssemblyConfiguration.Create(configurationContext.ConfigurationFileProvider);
 		Context = new AssembleContext(config, configurationContext, "dev", Collector, FileSystem, FileSystem, CheckoutDirectory.FullName, null);

--- a/tests/docs-assembler.Tests/src/docs-assembler.Tests/TestHelpers.cs
+++ b/tests/docs-assembler.Tests/src/docs-assembler.Tests/TestHelpers.cs
@@ -6,6 +6,7 @@ using System.IO.Abstractions;
 using Elastic.Documentation;
 using Elastic.Documentation.Configuration;
 using Elastic.Documentation.Configuration.Versions;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Documentation.Assembler.Tests;
 
@@ -17,7 +18,7 @@ public static class TestHelpers
 		ConfigurationFileProvider? configurationFileProvider = null
 	)
 	{
-		configurationFileProvider ??= new ConfigurationFileProvider(fileSystem);
+		configurationFileProvider ??= new ConfigurationFileProvider(NullLoggerFactory.Instance, fileSystem);
 		versionsConfiguration ??= new VersionsConfiguration
 		{
 			VersioningSystems = new Dictionary<VersioningSystemId, VersioningSystem>


### PR DESCRIPTION
Updates the `init-config` target to validate the passed `--git-ref` is actually the one that is checked out.

```bash
docs-builder assembler config init --git-ref 2c41839a928e4fbb1f838ec46a05c81cbe346144
```

If you just want the latest/edge you can omit `--git-ref`

```bash
docs-builder assembler config init
```

Then you can force `remote` as a configuration source.

```
docs-builder assembler clone --config-source remote
docs-builder assembler build -c remote
```

`--config-source` and `-c` can be used interchangeably. 

If the application folder `docs-builder assembler config init` writes to is not available both of these will exit with an error code. 

Every invocation of `docs-builder` and `docs-assembler` will indicate what config source is being used:

```
info ::e.d.c.tionFileProvider:: ConfigurationSource.Remote: git ref '2c41839a928e4fbb1f838ec46a05c81cbe346144', in /Users/mpdreamz/Library/Application Support/elastic/docs-builder/config-clone/config
```

### Defaults if none are provided

If `--config-source` is not provided it will default to `ConfigurationSource.Local` if `config` exists in the `pwd`, this is the default during development.

Otherwise `ConfigurationSource.Embedded` will use the configuration files embedded in the binary.



### Create assembler workspaces

In an empty folder you can `config init --local` to clone the repository to the current working directory (`pwd`) instead. This makes it a lot easier to create a local assemble workspace to validate changes. 

```bash
docs-builder assembler config init --local
docs-builder assembler clone -c local # (-c 'local' is default and can be omitted) 
docs-builder assembler build -c local # (-c 'local' is default and can be omitted) 
```

In a follow up we will add commands to build to pick up different checkouts more easily.


