### PR TITLE
Rename "Elastic products" section to "Solutions and use cases"

### DIFF
--- a/src/Elastic.Markdown/Layout/_LandingPage.cshtml
+++ b/src/Elastic.Markdown/Layout/_LandingPage.cshtml
@@ -43,9 +43,9 @@
 
 	<section class="w-full px-8 lg:px-6 bg-grey-10">
 		<div class="container mx-auto py-10">
-			<div class="heading-wrapper" id="elastic-products">
+			<div class="heading-wrapper" id="solutions-use-cases">
 				<h2 class="font-bold font-sans text-3xl text-ink-dark">
-					<a href="#elastic-products">Elastic products</a>
+					<a href="#solutions-use-cases">Solutions and use cases</a>
 				</h2>
 			</div>
 			<div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6 mt-6">


### PR DESCRIPTION
- We renamed this section to "products" because we received some guidance that that was the term for solutions going forward
- However, this is not materializing and surfaces like elastic.co still use the term "solutions"
- To reduce some confusion about the Elasticsearch solution vs. the Elasticsearch engine, we're making this small change to make it clear that "Elasticsearch" card reflects the solution, not the engine
- Including "and use cases" to reflect that Elasticsearch is less of a complete solution than the others (open to feedback on this)
- Carves a tiny chunk off of https://github.com/elastic/docs-content-internal/issues/311 (internal) while we wait for design resources
- full context is in [this internal doc](https://docs.google.com/document/d/1o4UxQzNNk3QPtfRHjPl5-slOJtNyNsfyRB2mjAYnVfM/edit?tab=t.0#heading=h.scpop4uzmkx3)

<img width="1135" height="526" alt="image" src="https://github.com/user-attachments/assets/53cdfcfe-09ff-4a99-a35d-1c3044ccb348" />

old copy is [here](https://www.elastic.co/docs)