### PR TITLE
Set Dependabot cooldown to 14 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
   - package-ecosystem: npm
     directories:
       - '**/*'
+    cooldown:
+      days: 14
     schedule:
       interval: 'weekly'
       day: 'monday'


### PR DESCRIPTION
 Dependabot is configured per repo so we need your help to ensure that when “npm” is the package ecosystem that we set a cooldown to 14 days. See https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown- 

