### PR TITLE
Force to use KubernetesClient 17.0.14

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,12 +17,12 @@
     <PackageVersion Include="Amazon.Lambda.S3Events" Version="3.1.0" />
     <PackageVersion Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4" />
     <PackageVersion Include="Amazon.Lambda.SQSEvents" Version="2.2.0" />
-    <PackageVersion Include="Aspire.Hosting" Version="9.4.0" />
-    <PackageVersion Include="Aspire.Hosting.Testing" Version="9.4.0" />
+    <PackageVersion Include="Aspire.Hosting" Version="9.4.2" />
+    <PackageVersion Include="Aspire.Hosting.Testing" Version="9.4.2" />
     <PackageVersion Include="AWSSDK.Core" Version="4.0.0.2" />
     <PackageVersion Include="AWSSDK.SQS" Version="4.0.0.1" />
     <PackageVersion Include="AWSSDK.S3" Version="4.0.0.1" />
-    <PackageVersion Include="Elastic.Aspire.Hosting.Elasticsearch" Version="9.3.0" />
+    <PackageVersion Include="Elastic.Aspire.Hosting.Elasticsearch" Version="9.4.1" />
     <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="9.1.4" />
     <PackageVersion Include="FakeItEasy" Version="8.3.0" />
     <PackageVersion Include="Elastic.Ingest.Elasticsearch" Version="0.14.0" />
@@ -79,7 +79,7 @@
   </ItemGroup>
   <!-- Test packages -->
   <ItemGroup>
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.4.0" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.4.2" />
     <PackageVersion Include="AngleSharp.Diffing" Version="1.0.0" />
     <PackageVersion Include="DiffPlex" Version="1.7.2" />
     <PackageVersion Include="FluentAssertions" Version="7.2.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageVersion Include="Amazon.Lambda.AspNetCoreServer.Hosting" Version="1.9.0" />
     <PackageVersion Include="Amazon.Lambda.RuntimeSupport" Version="1.13.0" />
-    <PackageVersion Include="Amazon.Lambda.Core" Version="2.5.1" />
+    <PackageVersion Include="Amazon.Lambda.Core" Version="2.7.0" />
     <PackageVersion Include="Amazon.Lambda.S3Events" Version="3.1.0" />
     <PackageVersion Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4" />
     <PackageVersion Include="Amazon.Lambda.SQSEvents" Version="2.2.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="AWSSDK.Core" Version="4.0.0.2" />
     <PackageVersion Include="AWSSDK.SQS" Version="4.0.0.1" />
     <PackageVersion Include="AWSSDK.S3" Version="4.0.0.1" />
-    <PackageVersion Include="Elastic.Aspire.Hosting.Elasticsearch" Version="9.4.1" />
+    <PackageVersion Include="Elastic.Aspire.Hosting.Elasticsearch" Version="9.3.0" />
     <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="9.1.4" />
     <PackageVersion Include="FakeItEasy" Version="8.3.0" />
     <PackageVersion Include="Elastic.Ingest.Elasticsearch" Version="0.14.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,7 +30,7 @@
     <PackageVersion Include="Elastic.Ingest.Elasticsearch" Version="0.14.0" />
     <PackageVersion Include="InMemoryLogger" Version="1.0.66" />
     <PackageVersion Include="MartinCostello.Logging.XUnit.v3" Version="0.6.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.4" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.7" />
     <PackageVersion Include="Microsoft.OpenApi" Version="2.0.0-preview9" />
     <PackageVersion Include="System.Text.Json" Version="9.0.5" />
     <PackageVersion Include="TUnit" Version="0.25.21" />
@@ -63,7 +63,7 @@
     <PackageVersion Include="Slugify.Core" Version="4.0.1" />
     <PackageVersion Include="SoftCircuits.IniFileParser" Version="2.7.0" />
     <PackageVersion Include="System.IO.Abstractions" Version="22.0.16" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.4" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.7" />
     <PackageVersion Include="Utf8StreamReader" Version="1.3.2" />
     <PackageVersion Include="Vecc.YamlDotNet.Analyzers.StaticGenerator" Version="16.1.3" PrivateAssets="All" />
     <PackageVersion Include="Westwind.AspNetCore.LiveReload" Version="0.5.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
   <!-- AWS -->
   <ItemGroup>
     <PackageVersion Include="Amazon.Lambda.AspNetCoreServer.Hosting" Version="1.9.0" />
-    <PackageVersion Include="Amazon.Lambda.RuntimeSupport" Version="1.13.0" />
+    <PackageVersion Include="Amazon.Lambda.RuntimeSupport" Version="1.13.1" />
     <PackageVersion Include="Amazon.Lambda.Core" Version="2.7.0" />
     <PackageVersion Include="Amazon.Lambda.S3Events" Version="3.1.0" />
     <PackageVersion Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,6 +22,7 @@
     <PackageVersion Include="AWSSDK.Core" Version="4.0.0.2" />
     <PackageVersion Include="AWSSDK.SQS" Version="4.0.0.1" />
     <PackageVersion Include="AWSSDK.S3" Version="4.0.0.1" />
+    <PackageVersion Include="KubernetesClient" Version="17.0.14" />
     <PackageVersion Include="Elastic.Aspire.Hosting.Elasticsearch" Version="9.3.0" />
     <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="9.1.4" />
     <PackageVersion Include="FakeItEasy" Version="8.3.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,7 @@
     <MinVerSkip Condition="'$(Configuration)' == 'Debug'">true</MinVerSkip>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
     <GlobalPackageReference Include="MinVer" Version="6.0.0" PrivateAssets="All" />


### PR DESCRIPTION
## Context

workflows are currently failing with

```
  /home/runner/work/docs-builder/docs-builder/src/tooling/docs-assembler/docs-assembler.csproj : error NU1902: Warning As Error: Package 'KubernetesClient' 17.0.4 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-w7r3-mgwf-4mqq [/home/runner/work/docs-builder/docs-builder/docs-builder.sln]
    Failed to restore /home/runner/work/docs-builder/docs-builder/src/tooling/docs-assembler/docs-assembler.csproj (in 3.76 sec).
  
  Build FAILED.
  
  /home/runner/work/docs-builder/docs-builder/src/tooling/docs-assembler/docs-assembler.csproj : error NU1902: Warning As Error: Package 'KubernetesClient' 17.0.4 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-w7r3-mgwf-4mqq [/home/runner/work/docs-builder/docs-builder/docs-builder.sln]
      0 Warning(s)
      1 Error(s)
```

using `dotnet list package --include-transitive` I identified that the cause are the "Aspire.Hosting.*" dependencies.

Also see: https://github.com/advisories/GHSA-w7r3-mgwf-4mqq


## Changes

- Use `<CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>`
- And add KubernetesClient 17.0.14
- This required updates to other packages as well.