### PR TITLE
Add SemVer filter for EDOT Collector (Elastic Agent) version detection in UpdateCLI

### DIFF
--- a/.github/updatecli/updatecli.d/versions.yml
+++ b/.github/updatecli/updatecli.d/versions.yml
@@ -58,8 +58,8 @@ sources:
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       versionfilter:
-        kind: regex
-        pattern: "v9.(\\d*).(\\d*)$"
+        kind: semver
+        pattern: ">=9.0.0 <10.0.0"
 
   latest-edot-dotnet-version:
     name: Get latest release version for the elastic-otel-dotnet


### PR DESCRIPTION
This adds SemVer detection to the UpdateCLI script that retrieves EDOT Collector (Elastic Agent) versions, to avoid situations in which versions like `8.20` coming after, say, `9.3` could trigger a wrong update for the latest version.

See an example of the issue in https://github.com/elastic/docs-builder/pull/1896#discussion_r2356680575