### PR TITLE
Add landing page changes from #1827

### DIFF
--- a/src/Elastic.Markdown/Layout/_LandingPage.cshtml
+++ b/src/Elastic.Markdown/Layout/_LandingPage.cshtml
@@ -14,7 +14,7 @@
 					For easy reference, changes in 9.1.0 are marked inline. For details, check <a href="https://www.elastic.co/docs/get-started/versioning-availability" class="link">Understanding versioning and availability.</a></p>
 				<div class="flex md:inline-flex gap-3 mt-6">
 					<a href="@Model.Link("/get-started/")" class="grow select-none cursor-pointer text-white text-nowrap bg-blue-elastic hover:bg-blue-elastic-110 focus:ring-4 focus:ring-blue-elastic-50 font-semibold font-sans rounded-sm px-6 py-2 focus:outline-none h-10 flex items-center justify-center">
-						Get started
+						Elastic Fundamentals
 					</a>
 					<a href="@Model.Link("/deploy-manage/upgrade")" class="grow cursor-pointer text-blue-elastic hover:text-blue-elastic-100 text-nowrap border-2 border-blue-elastic hover:border-blue-elastic-100 focus:ring-4 focus:outline-none focus:ring-blue-elastic-50 font-semibold font-sans rounded-sm px-6 py-2 text-center h-10 flex items-center justify-center">
 						Upgrade versions
@@ -252,12 +252,12 @@
 					</div>
 				</div>
 				<div class="flex flex-col p-6">
-					<h3 class="font-sans font-bold text-2xl">Contribute and extend</h3>
+					<h3 class="font-sans font-bold text-2xl">Extend and contribute</h3>
 					<p class="grow mt-4">Learn how to contribute to Elastic products and extend capabilities.</p>
 					<div class="mt-6">
 						<a href="@Model.Link("extend/")" class="link text-white wrap-break-word">
 							<span class="wrap-break-word">
-								View contribute and extend docs
+								View extend and contribute docs
 							</span>
 							<svg class="link-arrow"
 							     xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">


### PR DESCRIPTION
We reverted https://github.com/elastic/docs-builder/pull/1894 because the new Glossary secondary nav item would break the layout.

This reintroduces the changes without the new Glossary button.