### PR TITLE
prerelease.yml deploy to github pages needs concurrency control

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -19,6 +19,8 @@ jobs:
       full-version: ${{ steps.bootstrap.outputs.full-version }}
       major-version: ${{ steps.bootstrap.outputs.major-version }}
     needs: [build]
+    concurrency: 
+      group: deploy-to-github-pages
 
     environment:
       name: github-pages


### PR DESCRIPTION
```
Error: Creating Pages deployment failed
Error: HttpError: Deployment request failed for edcefbe842e776cf2af323246575599a442fed88 due to in progress deployment. Please cancel 31ea516eecc3815e2060e13dc0d3eadb1b41f8ec first or wait for it to complete.
    at /home/runner/work/_actions/actions/deploy-pages/v4.0.5/node_modules/@octokit/request/dist-node/index.js:124:1
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at createPagesDeployment (/home/runner/work/_actions/actions/deploy-pages/v4.0.5/src/internal/api-client.js:125:1)
    at Deployment.create (/home/runner/work/_actions/actions/deploy-pages/v4.0.5/src/internal/deployment.js:74:1)
    at main (/home/runner/work/_actions/actions/deploy-pages/v4.0.5/src/index.js:30:1)
```

Spotted here: https://github.com/elastic/docs-builder/actions/runs/17976545930/job/51131715777#step:8:27