### PR TITLE
Fix preview builds

### DIFF
--- a/src/Elastic.Documentation.Configuration/ConfigurationFileProvider.cs
+++ b/src/Elastic.Documentation.Configuration/ConfigurationFileProvider.cs
@@ -32,10 +32,16 @@ public partial class ConfigurationFileProvider
 		SkipPrivateRepositories = skipPrivateRepositories;
 		TemporaryDirectory = fileSystem.Directory.CreateTempSubdirectory("docs-builder-config");
 
-		ConfigurationSource = configurationSource ?? (
-			fileSystem.Directory.Exists(LocalConfigurationDirectory)
-				? ConfigurationSource.Local : ConfigurationSource.Embedded
-			);
+		// TODO: This doesn't work as expected if a github actions consumer repo has a `config` directory.
+		// ConfigurationSource = configurationSource ?? (
+		// 	fileSystem.Directory.Exists(LocalConfigurationDirectory)
+		// 		? ConfigurationSource.Local : ConfigurationSource.Embedded
+		// 	);
+
+
+		// Using Embedded as default for now
+		ConfigurationSource = configurationSource ?? ConfigurationSource.Embedded;
+
 
 		if (ConfigurationSource == ConfigurationSource.Local && !fileSystem.Directory.Exists(LocalConfigurationDirectory))
 			throw new Exception($"Required directory form {nameof(ConfigurationSource)}.{nameof(ConfigurationSource.Local)} directory {LocalConfigurationDirectory} does not exist.");


### PR DESCRIPTION
## Changes

Use embedded configuration by default.

## Context

preview builds are failing in https://github.com/elastic/elasticsearch-java/actions/runs/17989803792/job/51177024669?pr=1071, because elastic/elasticsearch-java has  a `config` folder.