### PR TITLE
Fix running authoring tests in CI

### DIFF
--- a/build/Targets.fs
+++ b/build/Targets.fs
@@ -134,7 +134,7 @@ let private runTests (testSuite: TestSuite) _ =
     let testFilter =
         match testSuite with
         | All -> []
-        | Unit -> ["--filter"; "FullyQualifiedName~.Tests"]
+        | Unit -> ["--filter"; "FullyQualifiedName~.Tests|FullyQualifiedName~AuthoringTests"]
         | Integration -> ["--filter"; "FullyQualifiedName~.IntegrationTests"]
 
     exec {

--- a/tests/authoring/Applicability/ApplicableToComponent.fs
+++ b/tests/authoring/Applicability/ApplicableToComponent.fs
@@ -2,7 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-module ``product availability``.``applicable to component``
+module ``AuthoringTests``.``product availability``.``applicable to component``
 
 open Elastic.Documentation.AppliesTo
 open Elastic.Markdown.Myst.Directives.AppliesTo

--- a/tests/authoring/Applicability/AppliesToDirective.fs
+++ b/tests/authoring/Applicability/AppliesToDirective.fs
@@ -2,7 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-module ``product availability``.``yaml directive``
+module ``AuthoringTests``.``product availability``.``yaml directive``
 
 open Elastic.Documentation.AppliesTo
 open Elastic.Markdown.Myst.Directives.AppliesTo

--- a/tests/authoring/Applicability/AppliesToFrontMatter.fs
+++ b/tests/authoring/Applicability/AppliesToFrontMatter.fs
@@ -2,7 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-module ``product availability``.``yaml frontmatter``
+module ``AuthoringTests``.``product availability``.``yaml frontmatter``
 
 open Elastic.Documentation.AppliesTo
 open JetBrains.Annotations

--- a/tests/authoring/Blocks/Admonitions.fs
+++ b/tests/authoring/Blocks/Admonitions.fs
@@ -1,7 +1,7 @@
 // Licensed to Elasticsearch B.V under one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
-module ``block elements``.``admonition elements``
+module ``AuthoringTests``.``block elements``.``admonition elements``
 
 open Xunit
 open authoring

--- a/tests/authoring/Blocks/CodeBlocks/CodeBlocks.fs
+++ b/tests/authoring/Blocks/CodeBlocks/CodeBlocks.fs
@@ -2,7 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-module ``block elements``.``code blocks``
+module ``AuthoringTests``.``block elements``.``code blocks``
 
 open Elastic.Markdown.Myst.CodeBlocks
 open Swensen.Unquote

--- a/tests/authoring/Blocks/ImageBlocks.fs
+++ b/tests/authoring/Blocks/ImageBlocks.fs
@@ -1,7 +1,7 @@
 // Licensed to Elasticsearch B.V under one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
-module ``block elements``.``image blocks``
+module ``AuthoringTests``.``block elements``.``image blocks``
 
 open Xunit
 open authoring

--- a/tests/authoring/Blocks/Lists.fs
+++ b/tests/authoring/Blocks/Lists.fs
@@ -1,7 +1,7 @@
 // Licensed to Elasticsearch B.V under one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
-module ``block elements``.``list elements``
+module ``AuthoringTests``.``block elements``.``list elements``
 
 open Xunit
 open authoring

--- a/tests/authoring/Container/DefinitionLists.fs
+++ b/tests/authoring/Container/DefinitionLists.fs
@@ -2,7 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-module ``container elements``.``vertical definition lists``
+module ``AuthoringTests``.``container elements``.``vertical definition lists``
 
 open Xunit
 open authoring

--- a/tests/authoring/Directives/IncludeBlocks.fs
+++ b/tests/authoring/Directives/IncludeBlocks.fs
@@ -2,7 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-module ``directive elements``.``include directive``
+module ``AuthoringTests``.``directive elements``.``include directive``
 
 open Swensen.Unquote
 open Xunit

--- a/tests/authoring/Framework/MarkdownDocumentAssertions.fs
+++ b/tests/authoring/Framework/MarkdownDocumentAssertions.fs
@@ -31,9 +31,10 @@ module MarkdownDocumentAssertions =
         let actual = actual.Value
         let result = actual.MarkdownResults |> Seq.find (fun r -> r.File.RelativePath = "index.md")
         let matter = result.File.YamlFrontMatter
-        matter.AppliesTo.Diagnostics <- expectedAvailability.Diagnostics
         match matter with
         | NonNull m ->
+            if expectedAvailability <> null then
+                m.AppliesTo.Diagnostics <- expectedAvailability.Diagnostics
             let apply = m.AppliesTo
             test <@ apply = expectedAvailability @>
         | _ -> failwithf "%s has no yamlfront matter" result.File.RelativePath

--- a/tests/authoring/Generator/LinkReferenceFile.fs
+++ b/tests/authoring/Generator/LinkReferenceFile.fs
@@ -2,7 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-module ``documentation generator``.``links json artifact``
+module ``AuthoringTests``.``documentation generator``.``links json artifact``
 
 open Xunit
 open authoring

--- a/tests/authoring/Inline/AppliesToRole.fs
+++ b/tests/authoring/Inline/AppliesToRole.fs
@@ -2,7 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-module ``inline elements``.``applies_to role``
+module ``AuthoringTests``.``inline elements``.``applies_to role``
 
 open Elastic.Documentation.AppliesTo
 open Elastic.Markdown.Myst.Roles.AppliesTo

--- a/tests/authoring/Inline/Comments.fs
+++ b/tests/authoring/Inline/Comments.fs
@@ -2,7 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-module ``inline elements``.``comment block``
+module ``AuthoringTests``.``inline elements``.``comment block``
 
 open Xunit
 open authoring
@@ -17,4 +17,3 @@ not a comment
     [<Fact>]
     let ``validate HTML: commented line should not be emitted`` () =
         markdown |> convertsToHtml """<p>not a comment</p>"""
-

--- a/tests/authoring/Inline/CrossLinkRedirectAnchors.fs
+++ b/tests/authoring/Inline/CrossLinkRedirectAnchors.fs
@@ -2,7 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-module ``inline elements``.``complex anchors``
+module ``AuthoringTests``.``inline elements``.``complex anchors``
 
 open Xunit
 open authoring.CrossLinkResolverAssertions

--- a/tests/authoring/Inline/CrossLinks.fs
+++ b/tests/authoring/Inline/CrossLinks.fs
@@ -2,7 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-module ``inline elements``.``cross links``
+module ``AuthoringTests``.``inline elements``.``cross links``
 
 open Xunit
 open authoring

--- a/tests/authoring/Inline/CrossLinksRedirects.fs
+++ b/tests/authoring/Inline/CrossLinksRedirects.fs
@@ -2,7 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-module ``inline elements``.``cross links redirects``
+module ``AuthoringTests``.``inline elements``.``cross links redirects``
 
 open Xunit
 open authoring
@@ -164,4 +164,3 @@ type ``Scenario 5: Deleting an entire page`` () =
         markdown |> convertsToHtml $"""
             <p><a href="{urlPrefix}/">Scenario 5</a></p>
         """
-

--- a/tests/authoring/Inline/InlineAnchors.fs
+++ b/tests/authoring/Inline/InlineAnchors.fs
@@ -2,7 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-module ``inline elements``.``anchors DEPRECATED``
+module ``AuthoringTests``.``inline elements``.``anchors DEPRECATED``
 
 open Elastic.Markdown.Myst.InlineParsers
 open Markdig.Syntax

--- a/tests/authoring/Inline/InlineAppliesTo.fs
+++ b/tests/authoring/Inline/InlineAppliesTo.fs
@@ -2,7 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-module ``inline elements``.``image``
+module ``AuthoringTests``.``inline elements``.``image``
 
 open Xunit
 open authoring

--- a/tests/authoring/Inline/InlineLinks.fs
+++ b/tests/authoring/Inline/InlineLinks.fs
@@ -2,7 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-module ``inline elements``.``links``
+module ``AuthoringTests``.``inline elements``.``links``
 
 open Xunit
 open authoring

--- a/tests/authoring/Inline/KbdRole.fs
+++ b/tests/authoring/Inline/KbdRole.fs
@@ -2,7 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-module ``inline elements``.``kbd role``
+module ``AuthoringTests``.``inline elements``.``kbd role``
 
 open Xunit
 open authoring

--- a/tests/authoring/Inline/RelativeLinks.fs
+++ b/tests/authoring/Inline/RelativeLinks.fs
@@ -2,7 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-module ``inline elements``.``relative links``
+module ``AuthoringTests``.``inline elements``.``relative links``
 
 open Xunit
 open authoring
@@ -54,5 +54,3 @@ Through various means $$$including-this-inline-syntax$$$
 
     [<Fact>]
     let ``has no errors`` () = generator |> hasNoErrors
-
-

--- a/tests/authoring/Inline/SubstitutionMutations.fs
+++ b/tests/authoring/Inline/SubstitutionMutations.fs
@@ -2,7 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-module ``inline elements``.``substitution mutations``
+module ``AuthoringTests``.``inline elements``.``substitution mutations``
 
 open Xunit
 open authoring

--- a/tests/authoring/Inline/Substitutions.fs
+++ b/tests/authoring/Inline/Substitutions.fs
@@ -2,7 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-module ``inline elements``.``substitutions``
+module ``AuthoringTests``.``inline elements``.``substitutions``
 
 open Xunit
 open authoring

--- a/tests/authoring/Linters/WhiteSpaceNormalizers.fs
+++ b/tests/authoring/Linters/WhiteSpaceNormalizers.fs
@@ -2,7 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-module ``linters``.``white space normalizers``
+module ``AuthoringTests``.``linters``.``white space normalizers``
 
 open Xunit
 open authoring

--- a/tests/authoring/LlmMarkdown/LlmMarkdownOutput.fs
+++ b/tests/authoring/LlmMarkdown/LlmMarkdownOutput.fs
@@ -2,7 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-module ``llm markdown``.``output tests``
+module ``AuthoringTests``.``llm markdown``.``output tests``
 
 open Swensen.Unquote
 open Xunit


### PR DESCRIPTION
## Changes
- prefix all authoring tests with `AuthoringTests`.
- Add prefix filter
- Fix failing applies_to tests.