### PR TITLE
Revert applies_to in directives design for recognition value

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/markdown/applies-switch.css
+++ b/src/Elastic.Documentation.Site/Assets/markdown/applies-switch.css
@@ -13,22 +13,18 @@
 			}
 		}
 
-		.applies-item {
+		&>.applies-switch-label>.applies-item {
 			@apply cursor-pointer text-inherit;
 
 			&:hover {
 				@apply text-inherit;
 			}
 			.applicable-info {
-				@apply cursor-pointer border-none bg-transparent p-0;
-
-				&:not(:last-child):after {
-					content: ',';
-				}
+				@apply cursor-pointer;
 			}
 			.applicable-name,
 			.applicable-meta {
-				@apply text-base;
+				@apply text-xs;
 			}
 		}
 

--- a/src/Elastic.Documentation.Site/Assets/markdown/applies-switch.css
+++ b/src/Elastic.Documentation.Site/Assets/markdown/applies-switch.css
@@ -13,7 +13,7 @@
 			}
 		}
 
-		&>.applies-switch-label>.applies-item {
+		& > .applies-switch-label > .applies-item {
 			@apply cursor-pointer text-inherit;
 
 			&:hover {

--- a/src/Elastic.Documentation.Site/Assets/markdown/applies-to.css
+++ b/src/Elastic.Documentation.Site/Assets/markdown/applies-to.css
@@ -22,7 +22,7 @@
 		}
 
 		.applicable-separator {
-			@apply self-stretch bg-grey-20 mx-2;
+			@apply bg-grey-20 mx-2 self-stretch;
 			mix-blend-mode: multiply;
 			width: 1px;
 		}

--- a/src/Elastic.Documentation.Site/Assets/markdown/applies-to.css
+++ b/src/Elastic.Documentation.Site/Assets/markdown/applies-to.css
@@ -9,7 +9,7 @@
 		}
 
 		.applicable-info {
-			@apply border-grey-20 inline-grid cursor-default grid-cols-[auto_1fr_auto] rounded-full border-[1px] bg-white pt-1.5 pr-3 pb-1.5 pl-3;
+			@apply border-grey-20 inline-flex cursor-default rounded-full border-[1px] bg-white pt-1.5 pr-3 pb-1.5 pl-3;
 		}
 
 		.applicable-meta {
@@ -22,11 +22,9 @@
 		}
 
 		.applicable-separator {
+			@apply self-stretch bg-grey-20 mx-2;
+			mix-blend-mode: multiply;
 			width: 1px;
-			height: 100%;
-			background-color: var(--color-grey-20);
-			margin-left: calc(var(--spacing) * 2);
-			margin-right: calc(var(--spacing) * 2);
 		}
 	}
 

--- a/src/Elastic.Documentation.Site/Assets/markdown/dropdown.css
+++ b/src/Elastic.Documentation.Site/Assets/markdown/dropdown.css
@@ -38,17 +38,13 @@
 			}
 
 			.applies-dropdown {
-				@apply flex cursor-pointer items-center gap-1 p-2 px-4 font-normal;
+				@apply flex cursor-pointer items-center gap-1 p-2 px-2 font-normal;
 				.applicable-info {
-					@apply cursor-pointer border-none bg-transparent p-0;
-					&:not(:last-child):after {
-						@apply text-sm;
-						content: ',';
-					}
+					@apply cursor-pointer;
 				}
 				.applicable-name,
 				.applicable-meta {
-					@apply text-sm;
+					@apply text-xs;
 				}
 			}
 		}

--- a/src/Elastic.Markdown/Myst/Components/ApplicableToViewModel.cs
+++ b/src/Elastic.Markdown/Myst/Components/ApplicableToViewModel.cs
@@ -64,15 +64,15 @@ public class ApplicableToViewModel
 	{
 		var items = new List<ApplicabilityItem>();
 
-		if (AppliesTo.Stack is not null)
-			items.AddRange(ProcessSingleCollection(AppliesTo.Stack, ApplicabilityMappings.Stack));
-
 		if (AppliesTo.Serverless is not null)
 		{
 			items.AddRange(AppliesTo.Serverless.AllProjects is not null
 				? ProcessSingleCollection(AppliesTo.Serverless.AllProjects, ApplicabilityMappings.Serverless)
 				: ProcessMappedCollections(AppliesTo.Serverless, ServerlessMappings));
 		}
+
+		if (AppliesTo.Stack is not null)
+			items.AddRange(ProcessSingleCollection(AppliesTo.Stack, ApplicabilityMappings.Stack));
 
 		if (AppliesTo.Deployment is not null)
 			items.AddRange(ProcessMappedCollections(AppliesTo.Deployment, DeploymentMappings));

--- a/tests/authoring/Applicability/ApplicableToComponent.fs
+++ b/tests/authoring/Applicability/ApplicableToComponent.fs
@@ -554,15 +554,6 @@ apm_agent_java: beta 9.1.0
     let ``renders complex mixed scenario`` () =
         markdown |> convertsToHtml """
 <p class="applies applies-block">
-	<span class="applicable-info" data-tippy-content="We plan to add this functionality in a future Elastic&nbsp;Stack update. Subject to change.
-
-If this functionality is unavailable or behaves differently when deployed on ECH, ECE, ECK, or a self-managed installation, it will be indicated on the page.">
-		<span class="applicable-name">Stack</span>
-		<span class="applicable-separator"></span>
-		<span class="applicable-meta applicable-meta-ga">
-			Planned
-		</span>
-	</span>
 	<span class="applicable-info" data-tippy-content="We plan to add this functionality in a future Serverless&nbsp;Elasticsearch projects update. Subject to change.
 
 Beta features are subject to change. The design and code is less mature than official GA features and is being provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features.">
@@ -578,6 +569,15 @@ This functionality may be changed or removed in a future release. Elastic will w
 		<span class="applicable-name">Serverless Observability</span>
 		<span class="applicable-separator"></span>
 		<span class="applicable-meta applicable-meta-preview">
+			Planned
+		</span>
+	</span>
+	<span class="applicable-info" data-tippy-content="We plan to add this functionality in a future Elastic&nbsp;Stack update. Subject to change.
+
+If this functionality is unavailable or behaves differently when deployed on ECH, ECE, ECK, or a self-managed installation, it will be indicated on the page.">
+		<span class="applicable-name">Stack</span>
+		<span class="applicable-separator"></span>
+		<span class="applicable-meta applicable-meta-ga">
 			Planned
 		</span>
 	</span>
@@ -723,17 +723,17 @@ product: ga 9.0.0
     let ``renders missing VersioningSystemId coverage`` () =
         markdown |> convertsToHtml """
 <p class="applies applies-block">
-	<span class="applicable-info" data-tippy-content="We plan to add this functionality in a future Elastic&nbsp;Stack update. Subject to change.
-
-If this functionality is unavailable or behaves differently when deployed on ECH, ECE, ECK, or a self-managed installation, it will be indicated on the page.">
-		<span class="applicable-name">Stack</span>
+	<span class="applicable-info" data-tippy-content="We plan to add this functionality in a future Elastic&nbsp;Cloud&nbsp;Serverless update. Subject to change.">
+		<span class="applicable-name">Serverless</span>
 		<span class="applicable-separator"></span>
 		<span class="applicable-meta applicable-meta-ga">
 			Planned
 		</span>
 	</span>
-	<span class="applicable-info" data-tippy-content="We plan to add this functionality in a future Elastic&nbsp;Cloud&nbsp;Serverless update. Subject to change.">
-		<span class="applicable-name">Serverless</span>
+	<span class="applicable-info" data-tippy-content="We plan to add this functionality in a future Elastic&nbsp;Stack update. Subject to change.
+
+If this functionality is unavailable or behaves differently when deployed on ECH, ECE, ECK, or a self-managed installation, it will be indicated on the page.">
+		<span class="applicable-name">Stack</span>
 		<span class="applicable-separator"></span>
 		<span class="applicable-meta applicable-meta-ga">
 			Planned


### PR DESCRIPTION
Closes https://github.com/elastic/docs-builder/issues/1976

## Changes

- Make applies_to in directives more recognizeable by reverting to the original design.
- Render Serverless before Stack in applies_to

## Screenshots

<img width="49%" height="588" alt="image" src="https://github.com/user-attachments/assets/378e0ab3-086b-461a-ac5a-66000bde4d64" />

<img width="49%" height="681" alt="image" src="https://github.com/user-attachments/assets/58633d15-5cf2-4528-aaa6-3d7e987b05a1" />
