### PR TITLE
Add Collector back to applicability badges

### DIFF
--- a/src/Elastic.Documentation/AppliesTo/ApplicableToYamlConverter.cs
+++ b/src/Elastic.Documentation/AppliesTo/ApplicableToYamlConverter.cs
@@ -221,6 +221,7 @@ public class ApplicableToYamlConverter(IReadOnlyCollection<string> productKeys) 
 			{ "apm_agent_rum_js", a => productAvailability.ApmAgentRumJs = a },
 			{ "edot_ios", a => productAvailability.EdotIos = a },
 			{ "edot_android", a => productAvailability.EdotAndroid = a },
+			{ "edot_collector", a => productAvailability.EdotCollector = a },
 			{ "edot_dotnet", a => productAvailability.EdotDotnet = a },
 			{ "edot_java", a => productAvailability.EdotJava = a },
 			{ "edot_node", a => productAvailability.EdotNode = a },


### PR DESCRIPTION
For some reason, the `edot_collector` product, while accepted, wasn't rendering badges anywhere. Turns out it was missing from https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/AppliesTo/ApplicableToYamlConverter.cs, so I'm adding it back.