### PR TITLE
Fix cross-link validation

### DIFF
--- a/src/Elastic.Documentation.Links/CrossLinks/CrossLinkResolver.cs
+++ b/src/Elastic.Documentation.Links/CrossLinks/CrossLinkResolver.cs
@@ -89,16 +89,6 @@ public class CrossLinkResolver(FetchedCrossLinks crossLinks, IUriEnvironmentReso
 		if (sourceLinkReference.Links.TryGetValue(originalLookupPath, out var directLinkMetadata))
 			return ResolveDirectLink(errorEmitter, uriResolver, crossLinkUri, originalLookupPath, directLinkMetadata, out resolvedUri);
 
-		// For development docs or known repositories, allow links even if they don't exist in the link index
-		if (isDeclaredRepo)
-		{
-			// Create a synthesized URL for development purposes
-			var path = ToTargetUrlPath(originalLookupPath);
-			resolvedUri = uriResolver.Resolve(crossLinkUri, path);
-			return true;
-		}
-
-
 		var linksJson = $"https://elastic-docs-link-index.s3.us-east-2.amazonaws.com/elastic/{crossLinkUri.Scheme}/main/links.json";
 		if (fetchedCrossLinks.LinkIndexEntries.TryGetValue(crossLinkUri.Scheme, out var indexEntry))
 			linksJson = $"https://elastic-docs-link-index.s3.us-east-2.amazonaws.com/{indexEntry.Path}";

--- a/tests/authoring/Inline/CrossLinks.fs
+++ b/tests/authoring/Inline/CrossLinks.fs
@@ -101,6 +101,30 @@ type ``link to repository that does not resolve yet`` () =
     [<Fact>]
     let ``has no warning`` () = markdown |> hasNoWarnings
 
+type ``error when linking to non-existent file in declared repository`` () =
+
+    static let markdown = Setup.Markdown """
+[Non-existent file](docs-content://non-existent-file.md)
+"""
+    
+    [<Fact>]
+    let ``validate HTML`` () =
+        // This link cannot be resolved, so we just output the link as-is
+        markdown |> convertsToHtml """
+            <p><a
+                href="docs-content://non-existent-file.md">
+                Non-existent file
+                </a>
+            </p>
+        """
+
+    [<Fact>]
+    let ``error when file not found in links.json`` () = 
+        markdown |> hasError("'non-existent-file.md' is not a valid link in the 'docs-content' cross link index")
+
+    [<Fact>]
+    let ``has no warning`` () = markdown |> hasNoWarnings
+
 type ``Using double forward slashes`` () =
 
     static let markdown = Setup.Markdown """


### PR DESCRIPTION
## Context

The build did not error in https://github.com/elastic/elasticsearch/pull/135837/commits/4b0dfd16309900c8281ddf6a649d1e7b67da9ae8#r2398182955.

Reported by @leemthompo 

## Changes

- Remove the resolving logic based on "declared repos".
- Add test



