### PR TITLE
Add highlighted body text to search results

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/Search/SearchResults.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/Search/SearchResults.tsx
@@ -2,7 +2,6 @@ import { useSearchTerm } from '../search.store'
 import { SearchResultItem, useSearchQuery } from './useSearchQuery'
 import {
     useEuiFontSize,
-    EuiHighlight,
     EuiLink,
     EuiLoadingSpinner,
     EuiSpacer,

--- a/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/Search/SearchResults.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/Search/SearchResults.tsx
@@ -152,7 +152,6 @@ function SearchResultListItem({ item: result }: SearchResultListItemProps) {
                         <div
                             css={css`
                                 font-family: ${euiTheme.font.family};
-                                // color: ${euiTheme.colors.textSubdued};
                                 position: relative;
 
                                 /* 2 lines with ellipsis */

--- a/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/Search/SearchResults.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/Search/SearchResults.tsx
@@ -245,7 +245,7 @@ const SanitizedHtmlContent = memo(
             const sanitized = DOMPurify.sanitize(htmlContent, {
                 ALLOWED_TAGS: ['mark'],
                 ALLOWED_ATTR: [],
-                KEEP_CONTENT: true
+                KEEP_CONTENT: true,
             })
 
             // Check if text starts mid-sentence (lowercase first letter)

--- a/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/Search/SearchResults.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/Search/SearchResults.tsx
@@ -14,8 +14,8 @@ import {
 } from '@elastic/eui'
 import { css } from '@emotion/react'
 import { useDebounce } from '@uidotdev/usehooks'
-import * as React from 'react'
-import { useEffect, useMemo, useState } from 'react'
+import DOMPurify from 'dompurify'
+import { useEffect, useMemo, useState, memo } from 'react'
 
 export const SearchResults = () => {
     const searchTerm = useSearchTerm()
@@ -103,25 +103,15 @@ interface SearchResultListItemProps {
 
 function SearchResultListItem({ item: result }: SearchResultListItemProps) {
     const { euiTheme } = useEuiTheme()
-    const searchTerm = useSearchTerm()
-    const highlightSearchTerms = useMemo(
-        () =>
-            searchTerm
-                .toLowerCase()
-                .split(' ')
-                .filter((i) => i.length > 1),
-        [searchTerm]
-    )
-
-    if (highlightSearchTerms.includes('esql')) {
-        highlightSearchTerms.push('es|ql')
-    }
-
-    if (highlightSearchTerms.includes('dotnet')) {
-        highlightSearchTerms.push('.net')
-    }
+    const titleFontSize = useEuiFontSize('m')
     return (
-        <li>
+        <li
+            css={css`
+                :not(:first-child) {
+                    border-top: 1px dotted ${euiTheme.colors.borderBasePrimary};
+                }
+            `}
+        >
             <div
                 tabIndex={0}
                 css={css`
@@ -129,8 +119,7 @@ function SearchResultListItem({ item: result }: SearchResultListItemProps) {
                             align-items: flex-start;
                             gap: ${euiTheme.size.s};
                             padding-inline: ${euiTheme.size.s};
-                            padding-block: ${euiTheme.size.xs};
-                            border-radius: ${euiTheme.border.radius.small};
+                            padding-block: ${euiTheme.size.m};
                             :hover {
                                 background-color: ${euiTheme.colors.backgroundTransparentSubdued};
                         `}
@@ -148,41 +137,56 @@ function SearchResultListItem({ item: result }: SearchResultListItemProps) {
                         text-align: left;
                     `}
                 >
-                    <EuiLink
-                        tabIndex={-1}
-                        href={result.url}
+                    <Breadcrumbs parents={result.parents} />
+                    <div
                         css={css`
-                            .euiMark {
-                                background-color: ${euiTheme.colors
-                                    .backgroundLightWarning};
-                                font-weight: inherit;
-                            }
+                            padding-block: ${euiTheme.size.xs};
+                            font-size: ${titleFontSize.fontSize};
                         `}
                     >
-                        <EuiHighlight
-                            search={highlightSearchTerms}
-                            highlightAll={true}
+                        <EuiLink tabIndex={-1} href={result.url}>
+                            <span>{result.title}</span>
+                        </EuiLink>
+                    </div>
+
+                    <EuiText size="xs">
+                        <div
+                            css={css`
+                                font-family: ${euiTheme.font.family};
+                                // color: ${euiTheme.colors.textSubdued};
+                                position: relative;
+
+                                /* 2 lines with ellipsis */
+                                display: -webkit-box;
+                                -webkit-line-clamp: 2;
+                                -webkit-box-orient: vertical;
+                                overflow: hidden;
+
+                                width: 90%;
+
+                                mark {
+                                    background-color: transparent;
+                                    font-weight: ${euiTheme.font.weight.bold};
+                                    color: ${euiTheme.colors.ink};
+                                }
+                            `}
                         >
-                            {result.title}
-                        </EuiHighlight>
-                    </EuiLink>
-                    <Breadcrumbs
-                        parents={result.parents}
-                        highlightSearchTerms={highlightSearchTerms}
-                    />
+                            {result.highlightedBody ? (
+                                <SanitizedHtmlContent
+                                    htmlContent={result.highlightedBody}
+                                />
+                            ) : (
+                                <span>{result.description}</span>
+                            )}
+                        </div>
+                    </EuiText>
                 </div>
             </div>
         </li>
     )
 }
 
-function Breadcrumbs({
-    parents,
-    highlightSearchTerms,
-}: {
-    parents: SearchResultItem['parents']
-    highlightSearchTerms: string[]
-}) {
+function Breadcrumbs({ parents }: { parents: SearchResultItem['parents'] }) {
     const { euiTheme } = useEuiTheme()
     const { fontSize: smallFontsize } = useEuiFontSize('xs')
     return (
@@ -224,12 +228,7 @@ function Breadcrumbs({
                                     }
                                 `}
                             >
-                                <EuiHighlight
-                                    search={highlightSearchTerms}
-                                    highlightAll={true}
-                                >
-                                    {parent.title}
-                                </EuiHighlight>
+                                {parent.title}
                             </EuiText>
                         </EuiLink>
                     </li>
@@ -237,3 +236,32 @@ function Breadcrumbs({
         </ul>
     )
 }
+
+const SanitizedHtmlContent = memo(
+    ({ htmlContent }: { htmlContent: string }) => {
+        const processed = useMemo(() => {
+            if (!htmlContent) return ''
+
+            const sanitized = DOMPurify.sanitize(htmlContent, {
+                ALLOWED_TAGS: ['mark'],
+                ALLOWED_ATTR: [],
+                KEEP_CONTENT: true
+            })
+
+            // Check if text starts mid-sentence (lowercase first letter)
+            const temp = document.createElement('div')
+            temp.innerHTML = sanitized
+            const text = temp.textContent || ''
+            const firstChar = text.trim()[0]
+
+            // Add leading ellipsis if starts with lowercase
+            if (firstChar && /[a-z]/.test(firstChar)) {
+                return '… ' + sanitized
+            }
+
+            return sanitized
+        }, [htmlContent])
+
+        return <div dangerouslySetInnerHTML={{ __html: processed }} />
+    }
+)

--- a/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/Search/useSearchQuery.ts
+++ b/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/Search/useSearchQuery.ts
@@ -13,6 +13,7 @@ const SearchResultItem = z.object({
     description: z.string(),
     score: z.number(),
     parents: z.array(SearchResultItemParent),
+    highlightedBody: z.string().nullish(),
 })
 
 export type SearchResultItem = z.infer<typeof SearchResultItem>

--- a/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/SearchOrAskAiModal.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/SearchOrAskAiModal.tsx
@@ -48,7 +48,7 @@ export const SearchOrAskAiModal = () => {
                 css={css`
                     flex-grow: 1;
                     overflow-y: scroll;
-                    max-height: 80vh;
+                    max-height: 70vh;
                     ${useEuiOverflowScroll('y')}
                 `}
             >

--- a/src/Elastic.Documentation.Site/package-lock.json
+++ b/src/Elastic.Documentation.Site/package-lock.json
@@ -17,6 +17,7 @@
         "@tanstack/react-query": "^5.87.4",
         "@uidotdev/usehooks": "2.4.1",
         "clipboard": "2.0.11",
+        "dompurify": "3.2.7",
         "highlight.js": "11.11.1",
         "htmx-ext-head-support": "2.0.4",
         "htmx-ext-preload": "2.1.1",
@@ -7268,6 +7269,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "optional": true
+    },
     "node_modules/@types/unist": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
@@ -9031,6 +9038,14 @@
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dotenv": {
       "version": "16.6.1",

--- a/src/Elastic.Documentation.Site/package.json
+++ b/src/Elastic.Documentation.Site/package.json
@@ -89,6 +89,7 @@
     "@tanstack/react-query": "^5.87.4",
     "@uidotdev/usehooks": "2.4.1",
     "clipboard": "2.0.11",
+    "dompurify": "3.2.7",
     "highlight.js": "11.11.1",
     "htmx-ext-head-support": "2.0.4",
     "htmx-ext-preload": "2.1.1",

--- a/src/Elastic.Documentation/Search/DocumentationDocument.cs
+++ b/src/Elastic.Documentation/Search/DocumentationDocument.cs
@@ -39,6 +39,10 @@ public record DocumentationDocument
 	[JsonPropertyName("body")]
 	public string? Body { get; set; }
 
+	// Stripped body is the body with markdown removed, suitable for search indexing
+	[JsonPropertyName("stripped_body")]
+	public string? StrippedBody { get; set; }
+
 	[JsonPropertyName("url_segment_count")]
 	public int? UrlSegmentCount { get; set; }
 

--- a/src/Elastic.Markdown/Exporters/ElasticsearchMarkdownExporter.cs
+++ b/src/Elastic.Markdown/Exporters/ElasticsearchMarkdownExporter.cs
@@ -293,7 +293,7 @@ public abstract class ElasticsearchMarkdownExporterBase<TChannelOptions, TChanne
 		var body = LlmMarkdownExporter.ConvertToLlmMarkdown(fileContext.Document, fileContext.BuildContext);
 
 		var headings = fileContext.Document.Descendants<HeadingBlock>()
-			.Select(h => h.GetData("header") as string ?? string.Empty) // TODO: this
+			.Select(h => h.GetData("header") as string ?? string.Empty) // TODO: Confirm that 'header' data is correctly set for all HeadingBlock instances and that this extraction is reliable.
 			.Where(text => !string.IsNullOrEmpty(text))
 			.ToArray();
 

--- a/src/Elastic.Markdown/Exporters/IMarkdownExporter.cs
+++ b/src/Elastic.Markdown/Exporters/IMarkdownExporter.cs
@@ -17,7 +17,6 @@ public record MarkdownExportFileContext
 	public required MarkdownDocument Document { get; init; }
 	public required MarkdownFile SourceFile { get; init; }
 	public required IFileInfo DefaultOutputFile { get; init; }
-	public string? LLMText { get; set; }
 	public required DocumentationSet DocumentationSet { get; init; }
 }
 

--- a/src/Elastic.Markdown/Exporters/LlmMarkdownExporter.cs
+++ b/src/Elastic.Markdown/Exporters/LlmMarkdownExporter.cs
@@ -19,26 +19,26 @@ public class LlmMarkdownExporter : IMarkdownExporter
 {
 	private const string LlmsTxtTemplate = """
 		# Elastic Documentation
-		
+
 		> Elastic provides an open source search, analytics, and AI platform, and out-of-the-box solutions for observability and security. The Search AI platform combines the power of search and generative AI to provide near real-time search and analysis with relevance to reduce your time to value.
 		>
 		>Elastic offers the following solutions or types of projects:
 		>
-		>* [Elasticsearch](https://www.elastic.co/docs/solutions/search): Build powerful search and RAG applications using Elasticsearch's vector database, AI toolkit, and advanced retrieval capabilities.  
+		>* [Elasticsearch](https://www.elastic.co/docs/solutions/search): Build powerful search and RAG applications using Elasticsearch's vector database, AI toolkit, and advanced retrieval capabilities.
 		>* [Elastic Observability](https://www.elastic.co/docs/solutions/observability): Gain comprehensive visibility into applications, infrastructure, and user experience through logs, metrics, traces, and other telemetry data, all in a single interface.
 		>* [Elastic Security](https://www.elastic.co/docs/solutions/security): Combine SIEM, endpoint security, and cloud security to provide comprehensive tools for threat detection and prevention, investigation, and response.
-		
+
 		The documentation is organized to guide you through your journey with Elastic, from learning the basics to deploying and managing complex solutions. Here is a detailed breakdown of the documentation structure:
-		
-		* [**Elastic fundamentals**](https://www.elastic.co/docs/get-started): Understand the basics about the deployment options, platform, and solutions, and features of the documentation.  
-		* [**Solutions and use cases**](https://www.elastic.co/docs/solutions): Learn use cases, evaluate, and implement Elastic's solutions: Observability, Search, and Security.  
-		* [**Manage data**](https://www.elastic.co/docs/manage-data): Learn about data store primitives, ingestion and enrichment, managing the data lifecycle, and migrating data.  
-		* [**Explore and analyze**](https://www.elastic.co/docs/explore-analyze): Get value from data through querying, visualization, machine learning, and alerting.  
-		* [**Deploy and manage**](https://www.elastic.co/docs/deploy-manage): Deploy and manage production-ready clusters. Covers deployment options and maintenance tasks.  
-		* [**Manage your Cloud account**](https://www.elastic.co/docs/cloud-account): A dedicated section for user-facing cloud account tasks like resetting passwords.  
-		* [**Troubleshoot**](https://www.elastic.co/docs/troubleshoot): Identify and resolve problems.  
-		* [**Extend and contribute**](https://www.elastic.co/docs/extend): How to contribute to or integrate with Elastic, from open source to plugins to integrations.  
-		* [**Release notes**](https://www.elastic.co/docs/release-notes): Contains release notes and changelogs for each new release.  
+
+		* [**Elastic fundamentals**](https://www.elastic.co/docs/get-started): Understand the basics about the deployment options, platform, and solutions, and features of the documentation.
+		* [**Solutions and use cases**](https://www.elastic.co/docs/solutions): Learn use cases, evaluate, and implement Elastic's solutions: Observability, Search, and Security.
+		* [**Manage data**](https://www.elastic.co/docs/manage-data): Learn about data store primitives, ingestion and enrichment, managing the data lifecycle, and migrating data.
+		* [**Explore and analyze**](https://www.elastic.co/docs/explore-analyze): Get value from data through querying, visualization, machine learning, and alerting.
+		* [**Deploy and manage**](https://www.elastic.co/docs/deploy-manage): Deploy and manage production-ready clusters. Covers deployment options and maintenance tasks.
+		* [**Manage your Cloud account**](https://www.elastic.co/docs/cloud-account): A dedicated section for user-facing cloud account tasks like resetting passwords.
+		* [**Troubleshoot**](https://www.elastic.co/docs/troubleshoot): Identify and resolve problems.
+		* [**Extend and contribute**](https://www.elastic.co/docs/extend): How to contribute to or integrate with Elastic, from open source to plugins to integrations.
+		* [**Release notes**](https://www.elastic.co/docs/release-notes): Contains release notes and changelogs for each new release.
 		* [**Reference**](https://www.elastic.co/docs/reference): Reference material for core tasks and manuals for optional products.
 		""";
 

--- a/src/Elastic.Markdown/Helpers/Markdown.cs
+++ b/src/Elastic.Markdown/Helpers/Markdown.cs
@@ -2,9 +2,11 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Text.RegularExpressions;
+
 namespace Elastic.Markdown.Helpers;
 
-public static class MarkdownStringExtensions
+public static partial class MarkdownStringExtensions
 {
 	public static string StripMarkdown(this string markdown)
 	{

--- a/src/Elastic.Markdown/Helpers/Markdown.cs
+++ b/src/Elastic.Markdown/Helpers/Markdown.cs
@@ -2,11 +2,9 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-using System.Text.RegularExpressions;
-
 namespace Elastic.Markdown.Helpers;
 
-public static partial class MarkdownStringExtensions
+public static class MarkdownStringExtensions
 {
 	public static string StripMarkdown(this string markdown)
 	{

--- a/src/api/Elastic.Documentation.Api.Core/Search/SearchUsecase.cs
+++ b/src/api/Elastic.Documentation.Api.Core/Search/SearchUsecase.cs
@@ -62,4 +62,5 @@ public record SearchResultItem
 	public required string Description { get; init; }
 	public required SearchResultItemParent[] Parents { get; init; }
 	public float Score { get; init; }
+	public string? HighlightedBody { get; init; }
 }

--- a/src/api/Elastic.Documentation.Api.Infrastructure/Adapters/Search/ElasticsearchGateway.cs
+++ b/src/api/Elastic.Documentation.Api.Infrastructure/Adapters/Search/ElasticsearchGateway.cs
@@ -69,8 +69,7 @@ public partial class ElasticsearchGateway : ISearchGateway
 				sourceSerializer: (_, settings) => new DefaultSourceSerializer(settings, EsJsonContext.Default)
 			)
 			.DefaultIndex(elasticsearchOptions.IndexName)
-			.Authentication(new ApiKey(elasticsearchOptions.ApiKey))
-			.DisableDirectStreaming(); // Captures request/response bodies for debugging
+			.Authentication(new ApiKey(elasticsearchOptions.ApiKey));
 
 		_client = new ElasticsearchClient(clientSettings);
 	}

--- a/src/api/Elastic.Documentation.Api.Infrastructure/Adapters/Search/ElasticsearchGateway.cs
+++ b/src/api/Elastic.Documentation.Api.Infrastructure/Adapters/Search/ElasticsearchGateway.cs
@@ -4,9 +4,11 @@
 
 using System.Text.Json.Serialization;
 using Elastic.Clients.Elasticsearch;
+using Elastic.Clients.Elasticsearch.Core.Search;
 using Elastic.Clients.Elasticsearch.QueryDsl;
 using Elastic.Clients.Elasticsearch.Serialization;
 using Elastic.Documentation.Api.Core.Search;
+using Elastic.Documentation.AppliesTo;
 using Elastic.Transport;
 using Microsoft.Extensions.Logging;
 
@@ -26,14 +28,20 @@ internal sealed record DocumentDto
 	[JsonPropertyName("body")]
 	public string? Body { get; init; }
 
+	[JsonPropertyName("stripped_body")]
+	public string? StrippedBody { get; init; }
+
 	[JsonPropertyName("abstract")]
-	public required string Abstract { get; init; }
+	public string? Abstract { get; init; }
 
 	[JsonPropertyName("url_segment_count")]
 	public int UrlSegmentCount { get; init; }
 
 	[JsonPropertyName("parents")]
 	public ParentDocumentDto[] Parents { get; init; } = [];
+
+	[JsonPropertyName("applies_to")]
+	public ApplicableTo? Applies { get; init; }
 }
 
 internal sealed record ParentDocumentDto
@@ -45,7 +53,7 @@ internal sealed record ParentDocumentDto
 	public required string Url { get; init; }
 }
 
-public class ElasticsearchGateway : ISearchGateway
+public partial class ElasticsearchGateway : ISearchGateway
 {
 	private readonly ElasticsearchClient _client;
 	private readonly ElasticsearchOptions _elasticsearchOptions;
@@ -61,7 +69,8 @@ public class ElasticsearchGateway : ISearchGateway
 				sourceSerializer: (_, settings) => new DefaultSourceSerializer(settings, EsJsonContext.Default)
 			)
 			.DefaultIndex(elasticsearchOptions.IndexName)
-			.Authentication(new ApiKey(elasticsearchOptions.ApiKey));
+			.Authentication(new ApiKey(elasticsearchOptions.ApiKey))
+			.DisableDirectStreaming(); // Captures request/response bodies for debugging
 
 		_client = new ElasticsearchClient(clientSettings);
 	}
@@ -73,6 +82,9 @@ public class ElasticsearchGateway : ISearchGateway
 	{
 		_logger.LogInformation("Starting RRF hybrid search for '{Query}' with pageNumber={PageNumber}, pageSize={PageSize}", query, pageNumber, pageSize);
 
+		const string preTag = "<mark>";
+		const string postTag = "</mark>";
+
 		var searchQuery = query.Replace("dotnet", "net", StringComparison.InvariantCultureIgnoreCase);
 
 		var lexicalSearchRetriever =
@@ -80,6 +92,7 @@ public class ElasticsearchGateway : ISearchGateway
 				|| new MatchQuery(Infer.Field<DocumentDto>(f => f.Title), searchQuery) { Operator = Operator.And, Boost = 8.0f }
 				|| new MatchBoolPrefixQuery(Infer.Field<DocumentDto>(f => f.Title), searchQuery) { Boost = 6.0f }
 				|| new MatchQuery(Infer.Field<DocumentDto>(f => f.Abstract), searchQuery) { Boost = 4.0f }
+				|| new MatchQuery(Infer.Field<DocumentDto>(f => f.StrippedBody), searchQuery) { Boost = 3.0f }
 				|| new MatchQuery(Infer.Field<DocumentDto>(f => f.Parents.First().Title), searchQuery) { Boost = 2.0f }
 				|| new MatchQuery(Infer.Field<DocumentDto>(f => f.Title), searchQuery) { Fuzziness = 1, Boost = 1.0f }
 			)
@@ -87,7 +100,7 @@ public class ElasticsearchGateway : ISearchGateway
 			;
 		var semanticSearchRetriever =
 				((Query)new SemanticQuery("title.semantic_text", searchQuery) { Boost = 5.0f }
-				 || new SemanticQuery("abstract", searchQuery) { Boost = 3.0f }
+				 || new SemanticQuery("abstract.semantic_text", searchQuery) { Boost = 3.0f }
 				)
 				&& !(Query)new TermsQuery(Infer.Field<DocumentDto>(f => f.Url.Suffix("keyword")),
 					new TermsQueryField(["/docs", "/docs/", "/docs/404", "/docs/404/"]))
@@ -106,10 +119,41 @@ public class ElasticsearchGateway : ISearchGateway
 							ret => ret.Standard(std => std.Query(semanticSearchRetriever))
 						)
 						.RankConstant(60) // Controls how much weight is given to document ranking
+						.RankWindowSize(100)
 					)
 				)
-				.From((pageNumber - 1) * pageSize)
-				.Size(pageSize), ctx);
+		.From((pageNumber - 1) * pageSize)
+		.Size(pageSize)
+		.Source(sf => sf
+			.Filter(f => f
+				.Includes(
+					e => e.Title,
+					e => e.Url,
+					e => e.Description,
+					e => e.Parents
+				)
+			)
+		)
+		.Highlight(h => h
+				.RequireFieldMatch(true)
+				.Fields(f => f
+				.Add(Infer.Field<DocumentDto>(d => d.StrippedBody), hf => hf
+					.FragmentSize(150)
+					.NumberOfFragments(3)
+					.NoMatchSize(150)
+					.BoundaryChars(":.!?\t\n")
+					.BoundaryScanner(BoundaryScanner.Sentence)
+					.BoundaryMaxScan(15)
+					.FragmentOffset(0)
+					.HighlightQuery(q => q.Match(m => m
+						.Field(d => d.StrippedBody)
+						.Query(searchQuery)
+						.Analyzer("highlight_analyzer")
+					))
+					.PreTags(preTag)
+					.PostTags(postTag))
+				)
+			), ctx);
 
 			if (!response.IsValidResponse)
 			{
@@ -128,122 +172,36 @@ public class ElasticsearchGateway : ISearchGateway
 		}
 	}
 
-	public async Task<(int TotalHits, List<SearchResultItem> Results)> ExactSearchAsync(string query, int pageNumber, int pageSize, Cancel ctx = default)
-	{
-		_logger.LogInformation("Starting search for '{Query}' with pageNumber={PageNumber}, pageSize={PageSize}", query, pageNumber, pageSize);
-
-		var searchQuery = query.Replace("dotnet", "net", StringComparison.InvariantCultureIgnoreCase);
-
-		try
-		{
-			var response = await _client.SearchAsync<DocumentDto>(s => s
-				.Indices(_elasticsearchOptions.IndexName)
-				.Query(q => q
-					.Bool(b => b
-						.Should(
-							// Tier 1: Exact/Prefix matches (highest boost)
-							sh => sh.Prefix(p => p
-								.Field("title.keyword")
-								.Value(searchQuery)
-								.CaseInsensitive(true)
-								.Boost(300.0f)
-							),
-
-							// Tier 2: Semantic search (combined into one clause)
-							sh => sh.DisMax(dm => dm
-								.Queries(
-									dq => dq.Semantic(sem => sem
-										.Field("title.semantic_text")
-										.Query(searchQuery)
-									),
-									dq => dq.Semantic(sem => sem
-										.Field("abstract")
-										.Query(searchQuery)
-									)
-								)
-								.Boost(200.0f)
-							),
-
-							// Tier 3: Standard text matching
-							sh => sh.DisMax(dm => dm
-								.Queries(
-									dq => dq.MatchBoolPrefix(m => m
-										.Field(f => f.Title)
-										.Query(searchQuery)
-									),
-									dq => dq.Match(m => m
-										.Field(f => f.Title)
-										.Query(searchQuery)
-										.Operator(Operator.And)
-									),
-									dq => dq.Match(m => m
-										.Field(f => f.Abstract)
-										.Query(searchQuery)
-									)
-								)
-								.Boost(100.0f)
-							),
-
-							// Tier 4: Parent matching
-							sh => sh.Match(m => m
-								.Field("parents.title")
-								.Query(searchQuery)
-								.Boost(75.0f)
-							),
-
-							// Tier 5: Fuzzy fallback
-							sh => sh.Match(m => m
-								.Field(f => f.Title)
-								.Query(searchQuery)
-								.Fuzziness(1) // Reduced from 2
-								.Boost(25.0f)
-							)
-						)
-						.MustNot(mn => mn.Terms(t => t
-							.Field("url.keyword")
-							.Terms(factory => factory.Value("/docs", "/docs/", "/docs/404", "/docs/404/"))
-						))
-						.MinimumShouldMatch(1)
-					)
-				)
-				.From((pageNumber - 1) * pageSize)
-				.Size(pageSize), ctx);
-
-			if (!response.IsValidResponse)
-			{
-				_logger.LogWarning("Elasticsearch search response was not valid. Reason: {Reason}",
-					response.ElasticsearchServerError?.Error?.Reason ?? "Unknown");
-			}
-			else
-			{
-				_logger.LogInformation("Search completed for '{Query}'. Total hits: {TotalHits}", query, response.Total);
-			}
-
-			return ProcessSearchResponse(response);
-		}
-		catch (Exception ex)
-		{
-			_logger.LogError(ex, "Error occurred during Elasticsearch search for '{Query}'", query);
-			throw;
-		}
-	}
-
-
 	private static (int TotalHits, List<SearchResultItem> Results) ProcessSearchResponse(SearchResponse<DocumentDto> response)
 	{
 		var totalHits = (int)response.Total;
 
-		var results = response.Documents.Select((doc, index) => new SearchResultItem
+		var results = response.Documents.Select((doc, index) =>
 		{
-			Url = doc.Url,
-			Title = doc.Title,
-			Description = doc.Description ?? string.Empty,
-			Parents = doc.Parents.Select(parent => new SearchResultItemParent
+			var hit = response.Hits.ElementAtOrDefault(index);
+			var highlights = hit?.Highlight;
+
+			string? highlightedBody = null;
+
+			if (highlights != null)
 			{
-				Title = parent.Title,
-				Url = parent.Url
-			}).ToArray(),
-			Score = (float)(response.Hits.ElementAtOrDefault(index)?.Score ?? 0.0)
+				if (highlights.TryGetValue("stripped_body", out var bodyHighlights) && bodyHighlights.Count > 0)
+					highlightedBody = string.Join(". ", bodyHighlights.Select(h => h.TrimEnd('.')));
+			}
+
+			return new SearchResultItem
+			{
+				Url = doc.Url,
+				Title = doc.Title,
+				Description = doc.Description ?? string.Empty,
+				Parents = doc.Parents.Select(parent => new SearchResultItemParent
+				{
+					Title = parent.Title,
+					Url = parent.Url
+				}).ToArray(),
+				Score = (float)(hit?.Score ?? 0.0),
+				HighlightedBody = highlightedBody
+			};
 		}).ToList();
 
 		return (totalHits, results);

--- a/src/api/Elastic.Documentation.Api.Infrastructure/Aws/LocalParameterProvider.cs
+++ b/src/api/Elastic.Documentation.Api.Infrastructure/Aws/LocalParameterProvider.cs
@@ -32,7 +32,7 @@ public class LocalParameterProvider : IParameterProvider
 				}
 			case "docs-elasticsearch-index":
 				{
-					return "semantic-documentation-latest";
+					return GetEnv("DOCUMENTATION_ELASTIC_INDEX", "semantic-docs-dev-latest");
 				}
 			default:
 				{
@@ -41,11 +41,13 @@ public class LocalParameterProvider : IParameterProvider
 		}
 	}
 
-	private static string GetEnv(string name)
+	private static string GetEnv(string name, string? defaultValue = null)
 	{
 		var value = Environment.GetEnvironmentVariable(name);
-		if (string.IsNullOrEmpty(value))
-			throw new ArgumentException($"Environment variable '{name}' not found.");
-		return value;
+		if (!string.IsNullOrEmpty(value))
+			return value;
+		if (defaultValue != null)
+			return defaultValue;
+		throw new ArgumentException($"Environment variable '{name}' not found.");
 	}
 }

--- a/src/api/Elastic.Documentation.Api.Infrastructure/Elastic.Documentation.Api.Infrastructure.csproj
+++ b/src/api/Elastic.Documentation.Api.Infrastructure/Elastic.Documentation.Api.Infrastructure.csproj
@@ -11,6 +11,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\..\Elastic.Documentation\Elastic.Documentation.csproj" />
       <ProjectReference Include="..\Elastic.Documentation.Api.Core\Elastic.Documentation.Api.Core.csproj" />
     </ItemGroup>
 


### PR DESCRIPTION
Part of https://github.com/elastic/docs-eng-team/issues/266
Closes https://github.com/elastic/docs-eng-team/issues/181
Closes https://github.com/elastic/docs-eng-team/issues/196
Closes https://github.com/elastic/docs-eng-team/issues/195

## Changes

- Use Elasticsearch's highlighting feature instead of EUI highlighting
- Add highlighted body to search results
- Simplify design: 
  - Use bold instead of yellow highlighting.
  - Don't highlight title and breadcrumbs
- Fix pagination

## Screenshot

<img width="886" height="789" alt="image" src="https://github.com/user-attachments/assets/61ed19bc-cdc8-4f51-b8f8-2c502fdc2c89" />
