### PR TITLE
Raise size of dropdown titles

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/markdown/dropdown.css
+++ b/src/Elastic.Documentation.Site/Assets/markdown/dropdown.css
@@ -7,7 +7,7 @@
 		details.dropdown {
 			@apply border-grey-20 mt-4 block rounded-sm border-1 shadow-xs;
 			summary.dropdown-title {
-				@apply text-ink-dark flex cursor-pointer items-stretch justify-between font-sans font-bold;
+				@apply text-ink-dark flex cursor-pointer items-stretch justify-between font-sans font-bold text-xl;
 			}
 
 			&[open] .dropdown-title {


### PR DESCRIPTION
Fixes https://github.com/elastic/docs-builder/issues/1919 by raising the size of dropdown titles to the size we use for H4 headings.

+CC @karenzone 