### PR TITLE
Fix console escaping of placeholder values

### DIFF
--- a/docs/syntax/code.md
+++ b/docs/syntax/code.md
@@ -135,12 +135,9 @@ render(input2);
 
 ::::
 
+#### Automatic callouts
 
-
-
-#### Magic Callouts
-
-If a code block contains code comments in the form of `//` or `#`, callouts will be magically created 🪄.
+If a code block contains code comments in the form of `//` or `#`, callouts are automatically created.
 
 
 ::::{tab-set}
@@ -231,9 +228,9 @@ bazbazbaz: 3 <3>
 
 ::::
 
-#### Disable callouts
+#### Turn off callouts
 
-You can disable callouts by adding a code block argument `callouts=false`.
+You can turn off callouts by adding a code block argument `callouts=false`.
 
 ::::{tab-set}
 
@@ -276,14 +273,27 @@ In a console code block, the first line is highlighted as a dev console string a
 :::{tab-item} Output
 
 ```console
-GET /mydocuments/_search
+POST _reindex
 {
-    "from": 1,
+  "source": {
+    "remote": {
+      "host": "<OTHER_HOST_URL>",
+      "username": "user",
+      "password": "pass"
+    },
+    "index": "my-index-000001",
     "query": {
-        "match_all" {}
+      "match": {
+        "test": "data"
+      }
     }
+  },
+  "dest": {
+    "index": "my-new-index-000001"
+  }
 }
 ```
+
 
 :::
 
@@ -291,12 +301,24 @@ GET /mydocuments/_search
 
 ````markdown
 ```console
-GET /mydocuments/_search
+POST _reindex
 {
-    "from": 1,
+  "source": {
+    "remote": {
+      "host": "<OTHER_HOST_URL>",
+      "username": "user",
+      "password": "pass"
+    },
+    "index": "my-index-000001",
     "query": {
-        "match_all" {}
+      "match": {
+        "test": "data"
+      }
     }
+  },
+  "dest": {
+    "index": "my-new-index-000001"
+  }
 }
 ```
 ````
@@ -402,7 +424,7 @@ This `code` is inline.
 
 ::::
 
-## Supported Languages
+## Supported languages
 
-Please refer to [hljs.ts](https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation.Site/Assets/hljs.ts)
+Refer to [hljs.ts](https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation.Site/Assets/hljs.ts)
 for a complete list of supported languages.

--- a/src/Elastic.Markdown/Myst/CodeBlocks/CodeViewModel.cs
+++ b/src/Elastic.Markdown/Myst/CodeBlocks/CodeViewModel.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Net;
 using Elastic.Markdown.Helpers;
 using Microsoft.AspNetCore.Html;
 
@@ -33,11 +34,11 @@ public class CodeViewModel
 	public HtmlString RenderLineWithCallouts(string content, int lineNumber)
 	{
 		if (EnhancedCodeBlock?.CallOuts == null)
-			return new HtmlString(content);
+			return new HtmlString(WebUtility.HtmlEncode(content));
 
 		var callouts = EnhancedCodeBlock.CallOuts.Where(c => c.Line == lineNumber);
 		if (!callouts.Any())
-			return new HtmlString(content);
+			return new HtmlString(WebUtility.HtmlEncode(content));
 
 		var line = content;
 		var html = new System.Text.StringBuilder();
@@ -50,7 +51,7 @@ public class CodeViewModel
 		}
 		line = line.TrimEnd();
 
-		_ = html.Append(line);
+		_ = html.Append(WebUtility.HtmlEncode(line));
 
 		// Add callout HTML after the line
 		foreach (var callout in callouts)


### PR DESCRIPTION
Fixes https://github.com/elastic/docs-builder/issues/2007

Claude's diagnosis:

> When you use console syntax highlighting, the text fragments like <password> don't render because:
> 
>   1. Console blocks use a different rendering path: In Code.cshtml (lines 12-21), console blocks render through ApiSegments using RenderLineWithCallouts() instead of the standard RenderCodeBlockLines() method.
>   2. No HTML escaping in console rendering: The RenderLineWithCallouts() method in CodeViewModel.cs (lines 33-62) directly appends the content to the HTML string without escaping HTML entities (line 53):
>   _ = html.Append(line);  // No HTML escaping!
>   3. Standard code blocks ARE escaped: When using any other language, the rendering goes through EnhancedCodeBlockHtmlRenderer.RenderCodeBlockLines() which calls renderer.WriteEscape(slice) (line 61), properly
>   escaping HTML entities like < and >.
> 
>   So when you write <password> in a console block, the browser interprets it as an HTML tag (which doesn't exist), so it doesn't render. In other languages, it gets escaped to &lt;password&gt; and displays
>   correctly.

Which makes sense if Console blocks were created differently or before we had callouts

---

Authored using Claude 4.5 in Claude CLI 2.0 with some human intervention