### PR TITLE
Fix hljs highlighting in AI answer

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/hljs.ts
+++ b/src/Elastic.Documentation.Site/Assets/hljs.ts
@@ -176,3 +176,6 @@ export function initHighlight() {
         hljs.highlightElement
     )
 }
+
+// Export the configured hljs instance for reuse
+export { hljs }

--- a/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/AskAi/ChatMessage.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/AskAi/ChatMessage.tsx
@@ -1,4 +1,5 @@
 import { initCopyButton } from '../../../copybutton'
+import { hljs } from '../../../hljs'
 import { GeneratingStatus } from './GeneratingStatus'
 import { References } from './RelatedResources'
 import { ChatMessage as ChatMessageType } from './chat.store'
@@ -19,7 +20,6 @@ import {
 } from '@elastic/eui'
 import { css } from '@emotion/react'
 import DOMPurify from 'dompurify'
-import hljs from 'highlight.js/lib/core'
 import { Marked, RendererObject, Tokens } from 'marked'
 import * as React from 'react'
 import { useEffect, useMemo } from 'react'


### PR DESCRIPTION
## Changes

- Add `hljs.highlightAuto` as fallback if `hljs.highlight` fails to render because of a non-existing language.
- Use existing hljs instance in ChatMessage.tsx

## Context

`hljs.highlight` fails if you specify a language that we did not install.