### PR TITLE
#1552 Title in HTML head

### DIFF
--- a/src/Elastic.Documentation/Exporter.cs
+++ b/src/Elastic.Documentation/Exporter.cs
@@ -16,6 +16,7 @@ public enum Exporter
 	DocumentationState,
 	LinkMetadata,
 	Redirects,
+	MarkdownValidation
 }
 public static class ExportOptions
 {

--- a/src/Elastic.Markdown/Exporters/ExporterExtensions.cs
+++ b/src/Elastic.Markdown/Exporters/ExporterExtensions.cs
@@ -27,6 +27,7 @@ public static class ExporterExtensions
 			markdownExporters.Add(new ElasticsearchMarkdownSemanticExporter(logFactory, context.Collector, indexNamespace, context.Endpoints));
 		if (exportOptions.Contains(Exporter.ElasticsearchNoSemantic))
 			markdownExporters.Add(new ElasticsearchMarkdownExporter(logFactory, context.Collector, indexNamespace, context.Endpoints));
+		markdownExporters.Add(new MarkdownValidationExporter());
 		return markdownExporters;
 	}
 }

--- a/src/Elastic.Markdown/Exporters/MarkdownValidationExporter.cs
+++ b/src/Elastic.Markdown/Exporters/MarkdownValidationExporter.cs
@@ -1,0 +1,57 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions;
+using Elastic.Markdown.Exporters;
+using Elastic.Markdown.IO;
+
+namespace Elastic.Markdown.Exporters;
+
+public class MarkdownValidationExporter : IMarkdownExporter
+{
+	private readonly List<MarkdownFile> _files = [];
+
+	/// <inheritdoc />
+	public ValueTask StartAsync(Cancel ctx = default) => default;
+
+	/// <inheritdoc />
+	public ValueTask StopAsync(Cancel ctx = default)
+	{
+		var titleMap = new Dictionary<string, List<MarkdownFile>>(StringComparer.OrdinalIgnoreCase);
+		foreach (var file in _files)
+		{
+			if (string.IsNullOrWhiteSpace(file.Title))
+			{
+				Console.WriteLine($"Error: File {file.FilePath} has no title");
+				continue;
+			}
+			if (!titleMap.TryGetValue(file.Title, out var list))
+				titleMap[file.Title] = [];
+			titleMap[file.Title].Add(file);
+		}
+		foreach (var kv in titleMap)
+		{
+			var files = kv.Value;
+			if (files.Count > 1)
+			{
+				var title = kv.Key;
+				var filePaths = string.Join(", ", files.Select(f => f.FilePath));
+				Console.WriteLine($"Error: Title '{title}' is used in multiple files: {filePaths}");
+			}
+		}
+		return default;
+	}
+
+	/// <inheritdoc />
+	public ValueTask<bool> ExportAsync(MarkdownExportFileContext fileContext, Cancel ctx)
+	{
+		var markdownFile = fileContext.SourceFile;
+		_files.Add(markdownFile);
+		Console.WriteLine($"+++ MarkdownValidationExporter: document.Title: {markdownFile.Title}");
+		return ValueTask.FromResult(true);
+	}
+
+	/// <inheritdoc />
+	public ValueTask<bool> FinishExportAsync(IDirectoryInfo outputFolder, Cancel ctx) => ValueTask.FromResult(true);
+}


### PR DESCRIPTION
Added a Markdown validation exporter. It collects the document titles and at the end of the build reports the repeated document titles.

This PR is not complete. It currently reports the repeated document titles by writing to the console. The StopAsync() method of an exporter doesn't have access to a build context to report the errors to the build.