### PR TITLE
Updates `current` stack version to 9.2

### DIFF
--- a/config/assembler.yml
+++ b/config/assembler.yml
@@ -39,8 +39,8 @@ environments:
 
 shared_configuration:
   stack: &stack
-    current:  9.1
-    next: 9.2
+    current:  9.2
+    next: main
     edge: main
 
   master: &master

--- a/config/versions.yml
+++ b/config/versions.yml
@@ -3,7 +3,7 @@ versioning_systems:
   # Updates for Stack versions are manual
   stack: &stack
     base: 9.0
-    current: 9.1.5
+    current: 9.2.0
 
   # Using an unlikely high version
   # So that our logic that would display "planned" doesn't trigger


### PR DESCRIPTION
⚠️ DO NOT MERGE UNTIL RELEASE DATE ⚠️

Bumps the `current` stack version to `9.2`. 