### PR TITLE
Add a little timeout on the required-labels check if the PR was just opened

### DIFF
--- a/.github/workflows/required-labels.yml
+++ b/.github/workflows/required-labels.yml
@@ -19,6 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      - name: Wait for PR to be ready (if just opened)
+        if: github.event_name == 'pull_request_target' && github.event.action == 'opened'
+        run: sleep 30
       - id: get-labels
         run: |
           labels=$(yq '[.categories[].labels] + .exclude-labels | flatten | unique | sort | @tsv' .github/release-drafter.yml | tr '\t' ',')


### PR DESCRIPTION
## Context

When you open a PR, you instantly get a comment that the label is missing.

With this timeout, the author has some time until that happens.

This is just to reduce some noise.