### PR TITLE
Remove products from the hint for unused substitution keys

### DIFF
--- a/src/Elastic.Markdown/DocumentationGenerator.cs
+++ b/src/Elastic.Markdown/DocumentationGenerator.cs
@@ -184,6 +184,9 @@ public class DocumentationGenerator
 		var keysNotInUse = definedKeys.Except(inUse)
 				// versions keys are injected
 				.Where(key => !key.StartsWith("version."))
+				// product keys are injected
+				.Where(key => !key.StartsWith("product."))
+				.Where(key => !key.StartsWith('.'))
 				// reserving context namespace
 				.Where(key => !key.StartsWith("context."))
 				.ToArray();


### PR DESCRIPTION
Fixes https://github.com/elastic/docs-builder/issues/1996

Exclude product variables (similar to how we exclude version variables) from the hint for unused substitution keys. (This is the outcome of a pairing session with @cotti. 🍐)