### PR TITLE
Center images when not using 100% width

### DIFF
--- a/docs/syntax/images.md
+++ b/docs/syntax/images.md
@@ -19,7 +19,6 @@ If a page uses an image that exists outside the folder that contains the `toc.ym
 
 ![APM](/syntax/images/apm.png)
 
-
 Or, use the `image` directive.
 
 ```markdown
@@ -57,10 +56,10 @@ Note that images nested within other content (like lists or admonitions) are not
 - First item in the list
 - Second item with an image:
 
-    :::{image} /syntax/images/apm.png
-    :alt: APM Logo in list
-    :width: 400px
-    :::
+  :::{image} /syntax/images/apm.png
+  :alt: APM Logo in list
+  :width: 400px
+  :::
 
 - Third item in the list
 
@@ -69,7 +68,6 @@ Note that images nested within other content (like lists or admonitions) are not
 Screenshots are images displayed with a box-shadow. Define a screenshot by adding the `:screenshot:` attribute to a block-level image directive.
 
 ```markdown
-
 :::{image} /syntax/images/apm.png
 :screenshot:
 :::
@@ -87,7 +85,6 @@ Here is the same image used inline ![Elasticsearch](/syntax/images/observability
 
 Here is the same image used inline ![Elasticsearch](/syntax/images/observability.png "elasticsearch =50%x50%")
 
-
 ### Inline image titles
 
 Titles are optional making this the minimal syntax required:
@@ -103,7 +100,6 @@ For inline images, the alt text always overrides any title specified in the Mark
 ```
 
 ![Elasticsearch](/syntax/images/observability.png "Different title =50%x50%")
-
 
 ### Inline image sizing
 
@@ -129,17 +125,16 @@ If `H` is omitted `W` is used as the height as well.
 When specifying just the size without a title, no space is required before the `=` sign. When combining a title with sizing, a space is required before the `=`:
 
 ```markdown
-![alt](img.png "=50%")              <!-- Just size, no space needed -->
-![alt](img.png "My Title =50%")    <!-- With title, space required -->
+![alt](img.png "=50%") <!-- Just size, no space needed -->
+![alt](img.png "My Title =50%") <!-- With title, space required -->
 ```
 
-
-
-### SVG 
+### SVG
 
 ```markdown
 ![Elasticsearch](/syntax/images/alerts.svg)
 ```
+
 ![Elasticsearch](/syntax/images/alerts.svg)
 
 ### GIF
@@ -147,6 +142,7 @@ When specifying just the size without a title, no space is required before the `
 ```markdown
 ![Elasticsearch](/syntax/images/timeslider.gif)
 ```
+
 ![Elasticsearch](/syntax/images/timeslider.gif)
 
 ## Asciidoc syntax
@@ -177,11 +173,14 @@ The image carousel directive builds upon the image directive.
 
 :::{image} images/applies.png
 :alt: Second image description
+
 ### Title is optional - alt text will be used as title if not specified
+
 :::
 
 ::::
 ```
+
 ::::{carousel}
 
 :id: nested-carousel-example

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "docs-builder",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/src/Elastic.Documentation.Site/Assets/markdown/images.css
+++ b/src/Elastic.Documentation.Site/Assets/markdown/images.css
@@ -8,7 +8,7 @@
 		}
 		/* Override centering for images in lists */
 		li a.image-reference > img {
-			@apply ml-0 mr-0;
+			@apply mr-0 ml-0;
 		}
 		/*
 		 * tailwind reset makes all images `display: block`


### PR DESCRIPTION
This PR tweaks our CSS so that images not taking the whole width of the container will be centered, as it happens in the Elastic Blog, for example.

— 

I used Claude Sonnet 4.5 with Claude CLI 2.0 to author this pull request.