### PR TITLE
Update ECK version to 3.2.0

### DIFF
--- a/config/versions.yml
+++ b/config/versions.yml
@@ -19,7 +19,7 @@ versioning_systems:
   ech: *all
   eck:
     base: 3.0
-    current: 3.1.0
+    current: 3.2.0
   ess: *all
   ecs:
     base: 9.0


### PR DESCRIPTION
Updating eck current to 3.2.0.

To be merged only on the day of ECK 3.2.0 release!

Release is currently planned for October 30, 2025.