### PR TITLE
Improve our PR match logic

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -93,7 +93,7 @@ jobs:
           echo "base_ref=${BASE_BRANCH}" >> $GITHUB_OUTPUT
       - name: Match for merge-group events
         id: merge-group-check
-        if: contains(fromJSON('["pull_request", "pull_request_target"]'), github.event_name)
+        if: contains(fromJSON('["merge_group"]'), github.event_name)
         uses: elastic/docs-builder/actions/assembler-match@main
         with:
           ref_name: ${{ steps.merge-group-base-branch.outputs.base_ref }}


### PR DESCRIPTION
Run `elastic/docs-builder/actions/assembler-match@main` against the base branch of pr's and merge groups too. 

PR checks should only run against active branches.