### PR TITLE
Fix synonyms config for indexing

### DIFF
--- a/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchExporter.cs
+++ b/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchExporter.cs
@@ -164,8 +164,9 @@ public abstract class ElasticsearchExporter<TChannelOptions, TChannel> : IDispos
 		    "filter": {
 		      "synonyms_filter": {
 				  "type": "synonym_graph",
-				  "synonyms_set": "{{synonymSetName}}"
-				  },
+				  "synonyms_set": "{{synonymSetName}}",
+				  "updateable": true
+			  },
 		      "english_stop": {
 		        "type": "stop",
 		        "stopwords": "_english_"


### PR DESCRIPTION
Fix synonyms config.

using `"updateable": true` makes sure it's using search time synonyms. 

According to https://www.elastic.co/docs/solutions/search/full-text/search-with-synonyms#synonyms-apply-synonyms we can only use search time synonyms.

I'm not sure why this was working before.

