### PR TITLE
Fix math init logic

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/main.ts
+++ b/src/Elastic.Documentation.Site/Assets/main.ts
@@ -23,7 +23,7 @@ const isLazyLoadNavigationEnabled =
  * Initialize KaTeX math rendering for elements with class 'math'
  */
 function initMath() {
-    const mathElements = $$('.math')
+    const mathElements = $$('.math:not([data-katex-processed])')
     mathElements.forEach((element) => {
         try {
             const content = element.textContent?.trim()
@@ -56,6 +56,9 @@ function initMath() {
                     // Add common macros if needed
                 },
             })
+
+            // Mark as processed to prevent double processing
+            element.setAttribute('data-katex-processed', 'true')
         } catch (error) {
             console.warn('KaTeX rendering error:', error)
             // Fallback: keep the original content
@@ -63,6 +66,11 @@ function initMath() {
         }
     })
 }
+
+// Initialize math on initial page load
+document.addEventListener('DOMContentLoaded', function () {
+    initMath()
+})
 
 document.addEventListener('htmx:load', function (event) {
     initTocNav()


### PR DESCRIPTION
Math formulas were duplicated on initial page load due to a race condition between server-side HTML rendering and client-side KaTeX initialization (at least according to Claude).

Added DOMContentLoaded event listener for initial page load while preventing double processing with data attributes.

Test: https://docs-v3-preview.elastic.dev/elastic/docs-builder/pull/2106/syntax/math