### PR TITLE
Add warnings for semver in appliesto

### DIFF
--- a/docs/syntax/applies.md
+++ b/docs/syntax/applies.md
@@ -245,17 +245,17 @@ applies_to:
 :::::{dropdown} Block examples
 
 ```{applies_to}
-stack: preview 9.1
+stack: preview >=9.1
 serverless: ga
 
-apm_agent_dotnet: ga 1.0.0
+apm_agent_dotnet: ga 1.0.0`
 apm_agent_java: beta 1.0.0
 edot_dotnet: preview 1.0.0
 edot_python:
 edot_node: ga 1.0.0
-elasticsearch: preview 9.0.0
+elasticsearch: preview 9.0.0a
 security: removed 9.0.0
-observability: deprecated 9.0.0
+observability: deprecated 9.0.0beta
 ```
 :::::
 

--- a/docs/syntax/applies.md
+++ b/docs/syntax/applies.md
@@ -245,17 +245,17 @@ applies_to:
 :::::{dropdown} Block examples
 
 ```{applies_to}
-stack: preview >=9.1
+stack: preview 9.1
 serverless: ga
 
-apm_agent_dotnet: ga 1.0.0`
+apm_agent_dotnet: ga 1.0.0
 apm_agent_java: beta 1.0.0
 edot_dotnet: preview 1.0.0
 edot_python:
 edot_node: ga 1.0.0
-elasticsearch: preview 9.0.0a
+elasticsearch: preview 9.0.0
 security: removed 9.0.0
-observability: deprecated 9.0.0beta
+observability: deprecated 9.0.0
 ```
 :::::
 

--- a/src/Elastic.Documentation/AppliesTo/Applicability.cs
+++ b/src/Elastic.Documentation/AppliesTo/Applicability.cs
@@ -227,7 +227,7 @@ public record Applicability : IComparable<Applicability>, IComparable
 				null => AllVersions.Instance,
 				"all" => AllVersions.Instance,
 				"" => AllVersions.Instance,
-				var t => SemVersionConverter.TryParse(t, out var v) ? v : null
+				var t => SemVersionConverter.TryParse(t, diagnostics, out var v) ? v : null
 			};
 		availability = new Applicability { Version = version, Lifecycle = lifecycle };
 		return true;

--- a/tests/Elastic.Markdown.Tests/AppliesTo/VersionWarningTests.cs
+++ b/tests/Elastic.Markdown.Tests/AppliesTo/VersionWarningTests.cs
@@ -1,0 +1,113 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Collections.Generic;
+using Elastic.Documentation;
+using Elastic.Documentation.AppliesTo;
+using Elastic.Documentation.Diagnostics;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Markdown.Tests.AppliesTo;
+
+public class VersionWarningTests
+{
+	[Fact]
+	public void ValidVersion_NoWarning()
+	{
+		var diagnostics = new List<(Severity, string)>();
+		var success = SemVersionConverter.TryParse("9.1.0", diagnostics, out var version);
+
+		success.Should().BeTrue();
+		version.Should().NotBeNull();
+		version!.ToString().Should().Be("9.1.0");
+		diagnostics.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void ValidVersionWithFallback_NoWarning()
+	{
+		var diagnostics = new List<(Severity, string)>();
+		var success = SemVersionConverter.TryParse("9.1", diagnostics, out var version);
+
+		success.Should().BeTrue();
+		version.Should().NotBeNull();
+		version!.ToString().Should().Be("9.1.0");
+		diagnostics.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void InvalidVersionWithOperator_WarningEmitted()
+	{
+		var diagnostics = new List<(Severity, string)>();
+		var success = SemVersionConverter.TryParse(">=9.1.0", diagnostics, out var version);
+
+		success.Should().BeFalse();
+		version.Should().BeNull();
+		diagnostics.Should().HaveCount(1);
+		diagnostics[0].Item1.Should().Be(Severity.Warning);
+		diagnostics[0].Item2.Should().Contain("Invalid version format '>=9.1.0'");
+		diagnostics[0].Item2.Should().Contain("Expected semantic version format");
+	}
+
+	[Fact]
+	public void InvalidVersionWithBacktick_WarningEmitted()
+	{
+		var diagnostics = new List<(Severity, string)>();
+		var success = SemVersionConverter.TryParse("9.1`", diagnostics, out var version);
+
+		success.Should().BeFalse();
+		version.Should().BeNull();
+		diagnostics.Should().HaveCount(1);
+		diagnostics[0].Item1.Should().Be(Severity.Warning);
+		diagnostics[0].Item2.Should().Contain("Invalid version format '9.1`'");
+		diagnostics[0].Item2.Should().Contain("Expected semantic version format");
+	}
+
+	[Fact]
+	public void InvalidVersionFormat_WarningEmitted()
+	{
+		var diagnostics = new List<(Severity, string)>();
+		var success = SemVersionConverter.TryParse("invalid-version", diagnostics, out var version);
+
+		success.Should().BeFalse();
+		version.Should().BeNull();
+		diagnostics.Should().HaveCount(1);
+		diagnostics[0].Item1.Should().Be(Severity.Warning);
+		diagnostics[0].Item2.Should().Contain("Invalid version format 'invalid-version'");
+	}
+
+	[Fact]
+	public void EmptyVersion_NoWarning()
+	{
+		var diagnostics = new List<(Severity, string)>();
+		var success = SemVersionConverter.TryParse("", diagnostics, out var version);
+
+		success.Should().BeTrue();
+		version.Should().Be(AllVersions.Instance);
+		diagnostics.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void AllVersion_NoWarning()
+	{
+		var diagnostics = new List<(Severity, string)>();
+		var success = SemVersionConverter.TryParse("all", diagnostics, out var version);
+
+		success.Should().BeTrue();
+		version.Should().Be(AllVersions.Instance);
+		diagnostics.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void NullVersion_NoWarning()
+	{
+		var diagnostics = new List<(Severity, string)>();
+		var success = SemVersionConverter.TryParse(null, diagnostics, out var version);
+
+		success.Should().BeTrue();
+		version.Should().Be(AllVersions.Instance);
+		diagnostics.Should().BeEmpty();
+	}
+}

--- a/tests/Elastic.Markdown.Tests/AppliesTo/VersionWarningTests.cs
+++ b/tests/Elastic.Markdown.Tests/AppliesTo/VersionWarningTests.cs
@@ -14,7 +14,7 @@ namespace Elastic.Markdown.Tests.AppliesTo;
 public class VersionWarningTests
 {
 	[Fact]
-	public void ValidVersion_NoWarning()
+	public void ValidVersionNoWarning()
 	{
 		var diagnostics = new List<(Severity, string)>();
 		var success = SemVersionConverter.TryParse("9.1.0", diagnostics, out var version);
@@ -26,7 +26,7 @@ public class VersionWarningTests
 	}
 
 	[Fact]
-	public void ValidVersionWithFallback_NoWarning()
+	public void ValidVersionWithFallbackNoWarning()
 	{
 		var diagnostics = new List<(Severity, string)>();
 		var success = SemVersionConverter.TryParse("9.1", diagnostics, out var version);
@@ -38,7 +38,7 @@ public class VersionWarningTests
 	}
 
 	[Fact]
-	public void InvalidVersionWithOperator_WarningEmitted()
+	public void InvalidVersionWithOperatorWarningEmitted()
 	{
 		var diagnostics = new List<(Severity, string)>();
 		var success = SemVersionConverter.TryParse(">=9.1.0", diagnostics, out var version);
@@ -52,7 +52,7 @@ public class VersionWarningTests
 	}
 
 	[Fact]
-	public void InvalidVersionWithBacktick_WarningEmitted()
+	public void InvalidVersionWithBacktickWarningEmitted()
 	{
 		var diagnostics = new List<(Severity, string)>();
 		var success = SemVersionConverter.TryParse("9.1`", diagnostics, out var version);
@@ -66,7 +66,7 @@ public class VersionWarningTests
 	}
 
 	[Fact]
-	public void InvalidVersionFormat_WarningEmitted()
+	public void InvalidVersionFormatWarningEmitted()
 	{
 		var diagnostics = new List<(Severity, string)>();
 		var success = SemVersionConverter.TryParse("invalid-version", diagnostics, out var version);
@@ -79,7 +79,7 @@ public class VersionWarningTests
 	}
 
 	[Fact]
-	public void EmptyVersion_NoWarning()
+	public void EmptyVersionNoWarning()
 	{
 		var diagnostics = new List<(Severity, string)>();
 		var success = SemVersionConverter.TryParse("", diagnostics, out var version);
@@ -90,7 +90,7 @@ public class VersionWarningTests
 	}
 
 	[Fact]
-	public void AllVersion_NoWarning()
+	public void AllVersionNoWarning()
 	{
 		var diagnostics = new List<(Severity, string)>();
 		var success = SemVersionConverter.TryParse("all", diagnostics, out var version);
@@ -101,7 +101,7 @@ public class VersionWarningTests
 	}
 
 	[Fact]
-	public void NullVersion_NoWarning()
+	public void NullVersionNoWarning()
 	{
 		var diagnostics = new List<(Severity, string)>();
 		var success = SemVersionConverter.TryParse(null, diagnostics, out var version);


### PR DESCRIPTION
Fixes https://github.com/elastic/docs-builder/issues/2094

This is just a draft / test.

For example, when entering this:

````
```{applies_to}
stack: preview >=9.1
apm_agent_dotnet: ga 1.0.0`
elasticsearch: preview 9.0.0a
observability: deprecated 9.0.0beta
```
````

Docs-builder emits these warnings:

```
        The following errors and warnings were found in the documentation

Warning: Invalid version format '>=9.1'. Expected semantic version format (e.g., '9.1.0' or '9.1'). Version will be ignored.
     ┌─[/Users/fabri/repos/docs-builder/docs/syntax/applies.md]
     │
     │
     └─
 
Warning: Invalid version format '9.0.0a'. Expected semantic version format (e.g., '9.1.0' or '9.1'). Version will be ignored.
     ┌─[/Users/fabri/repos/docs-builder/docs/syntax/applies.md]
     │
     │
     └─
 
Warning: Invalid version format '9.0.0beta'. Expected semantic version format (e.g., '9.1.0' or '9.1'). Version will be ignored.
     ┌─[/Users/fabri/repos/docs-builder/docs/syntax/applies.md]
     │
     │
     └─
 
Warning: Invalid version format '1.0.0`'. Expected semantic version format (e.g., '9.1.0' or '9.1'). Version will be ignored.
     ┌─[/Users/fabri/repos/docs-builder/docs/syntax/applies.md]
     │
     │
     └─
```

--- 

Co-authored using Cursor in automatic rotation model.