### PR TITLE
Add x-amz-content-sha256 header to AskAi stream requests

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/AskAi/useFetchEventSource.ts
+++ b/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/AskAi/useFetchEventSource.ts
@@ -62,7 +62,7 @@ export function useFetchEventSource<TPayload>({
             try {
                 // Stringify payload once to ensure hash matches the exact body sent
                 const bodyString = JSON.stringify(payload)
-                
+
                 // Compute SHA256 hash for CloudFront + Lambda Function URL with OAC
                 // This proves body integrity from client to CloudFront
                 const contentHash = await computeSHA256(bodyString)


### PR DESCRIPTION
## Problem
 When using CloudFront with Origin Access Control (OAC) to secure Lambda Function URLs, POST requests require the x-amz-content-sha256 header for body integrity validation.

## Solution

Added SHA256 hash computation in useFetchEventSource.ts for request body
Included x-amz-content-sha256 header in all POST requests to /ask-ai/stream
Used ES5-compatible hex formatting (avoiding padStart for broader browser support)

## Why

Required by AWS CloudFront OAC to prove request body integrity from client to CloudFront. CloudFront handles the SigV4 signing; client only needs to compute the hash.
Impact: Enables secure streaming through CloudFront with OAC enabled, supporting the hybrid architecture for Lambda Function URLs.