### PR TITLE
Revert "ECE version bumped to 4.0.3"

### DIFF
--- a/config/versions.yml
+++ b/config/versions.yml
@@ -15,7 +15,7 @@ versioning_systems:
   # Ece version updates are manual
   ece:
     base: 4.0
-    current: 4.0.3
+    current: 4.0.2
   ech: *all
   eck:
     base: 3.0


### PR DESCRIPTION
Reverts elastic/docs-builder#2139 - this is blocking ECK 3.2 