### PR TITLE
Fix release

### DIFF
--- a/build/Targets.fs
+++ b/build/Targets.fs
@@ -70,7 +70,6 @@ let private publishZip _ =
                 $".artifacts/publish/{tool}/release/NOTICE.txt"
             ]
     zip "docs-builder"
-    zip "docs-assembler"
     
 let private prNumber () =
     match Environment.environVarOrNone "GITHUB_REF_NAME" with


### PR DESCRIPTION
## Context

The release is failing because it's trying to zip docs-assembler. Which doesn't exist anymore.

## Changes

Remove instructions to zip docs-assembler artifacts.