### PR TITLE
Fix duplicate stream requests on tab switch

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/AskAi/useFetchEventSource.ts
+++ b/src/Elastic.Documentation.Site/Assets/web-components/SearchOrAskAi/AskAi/useFetchEventSource.ts
@@ -85,6 +85,7 @@ export function useFetchEventSource<TPayload>({
                     },
                     body: bodyString,
                     signal: controller.signal, // Use local controller, not ref
+                    openWhenHidden: true, // Keep connection alive when tab is hidden
                     onopen: async (response: Response) => {
                         if (
                             response.ok &&


### PR DESCRIPTION
## Changes

Switching browser tabs while streaming caused @microsoft/fetch-event-source to close the connection and reconnect, creating duplicate requests. Adding openWhenHidden: true keeps the connection alive when the tab is hidden, allowing streaming to continue in the background without reconnection.