### PR TITLE
Add image path tests

### DIFF
--- a/tests/Elastic.Markdown.Tests/Inline/ImagePathResolutionTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/ImagePathResolutionTests.cs
@@ -96,8 +96,10 @@ public class ImagePathResolutionTests(ITestOutputHelper output)
 
 		await documentationSet.ResolveDirectoryTree(TestContext.Current.CancellationToken);
 
-		if (documentationSet.TryFindDocumentByRelativePath(guideRelativePath) is not MarkdownFile markdownFile)
-			throw new InvalidOperationException("Failed to resolve markdown file for test.");
+		// Normalize path for cross-platform compatibility (Windows uses backslashes)
+		var normalizedPath = guideRelativePath.Replace('/', Path.DirectorySeparatorChar);
+		if (documentationSet.TryFindDocumentByRelativePath(normalizedPath) is not MarkdownFile markdownFile)
+			throw new InvalidOperationException($"Failed to resolve markdown file for test. Tried path: {normalizedPath}");
 
 		// For assembler builds DocumentationSetNavigation seeds MarkdownNavigationLookup with navigation items whose Url already
 		// includes the computed path_prefix. To exercise the same branch in isolation, inject a stub navigation entry with the


### PR DESCRIPTION
## What
Added `ImagePathResolutionTests.cs` to verify `DiagnosticLinkInlineParser.UpdateRelativeUrl` correctly resolves image paths in both assembler and non-assembler builds.
Why: In assembler builds, documentation from multiple repos is combined with each section getting a `path_prefix` from navigation.yml (e.g., platform, reference/elasticsearch). Image URLs must include this prefix: `images/pic.png` → `/docs/platform/setup/images/pic.png`. Non-assembler builds skip the prefix: `/docs/setup/images/pic.png`.

## How it works
Mock a minimal doc set with a markdown file at `setup/guide.md` referencing `images/pic.png`
Seed navigation metadata by injecting a stub INavigationItem into MarkdownNavigationLookup with the expected URL (e.g., `/platform/setup/guide`).. this mimics what DocumentationSetNavigation produces in real assembler builds
Call UpdateRelativeUrl which reads the stub's URL, extracts the directory path, and resolves the image relative to it
Assert the result includes (or excludes) the `path_prefix` based on AssemblerBuild flag

## Why
By stubbing navigation metadata instead of building the full navigation tree, the test stays fast, isolated, and focused on UpdateRelativeUrl behavior. The stub recreates the exact state the production code sees.