### PR TITLE
Update speculative build logic

### DIFF
--- a/config/products.yml
+++ b/config/products.yml
@@ -141,6 +141,9 @@ products:
   fleet:
     display: 'Fleet'
     versioning: 'stack'
+  fleet-server:
+    display: 'Fleet Server'
+    versioning: 'stack'
   heartbeat:
     display: 'Heartbeat'
     versioning: 'stack'

--- a/src/Elastic.Documentation.Configuration/Assembler/AssemblyConfiguration.cs
+++ b/src/Elastic.Documentation.Configuration/Assembler/AssemblyConfiguration.cs
@@ -221,7 +221,7 @@ public record AssemblyConfiguration
 				logger.LogInformation("Current is not using versioned branches checking product info");
 				var productVersion = versioningSystem.Current;
 				var previousMinorVersion = new SemVersion(productVersion.Major, Math.Max(productVersion.Minor - 1, 0), 0);
-				if (v >= productVersion)
+				if (v.Minor >= productVersion.Minor)
 				{
 					logger.LogInformation("Speculative build {Branch} is gte product current '{ProductCurrent}'", branchOrTag, productVersion);
 					match = match with

--- a/src/Elastic.Documentation.Configuration/Assembler/AssemblyConfiguration.cs
+++ b/src/Elastic.Documentation.Configuration/Assembler/AssemblyConfiguration.cs
@@ -220,10 +220,11 @@ public record AssemblyConfiguration
 			{
 				logger.LogInformation("Current is not using versioned branches checking product info");
 				var productVersion = versioningSystem.Current;
+				var anchoredProductVersion = new SemVersion(productVersion.Major, productVersion.Minor, 0);
 				var previousMinorVersion = new SemVersion(productVersion.Major, Math.Max(productVersion.Minor - 1, 0), 0);
-				if (v.Minor >= productVersion.Minor)
+				if (v >= anchoredProductVersion)
 				{
-					logger.LogInformation("Speculative build {Branch} is gte product current '{ProductCurrent}'", branchOrTag, productVersion);
+					logger.LogInformation("Speculative build {Branch} is gte product current '{ProductCurrent}' anchored at {ProductAnchored}", branchOrTag, productVersion, anchoredProductVersion);
 					match = match with
 					{
 						Speculative = true


### PR DESCRIPTION
In https://github.com/elastic/docs-builder/pull/2177, @Mpdreamz updated the logic to support speculative builds for the previous minor version. However, I think this resulted in losing support for speculative builds for the _current_ minor version. 

I'm seeing this in PRs like https://github.com/elastic/elastic-agent/pull/11069 where before https://github.com/elastic/docs-builder/pull/2177 was merged [the preview build worked as expected](https://github.com/elastic/elastic-agent/actions/runs/19148991015/job/54734053923), but after it [did not](https://github.com/elastic/elastic-agent/actions/runs/19267668839/job/55087437814).

For the case of elastic/elastic-agent, today when the current version is `9.2.1` I'd expect PR previews to build for `9.1` and `9.2`, but not for `9.0`. Before making the changes in this PR, I ran `assembler content-source match` for each minor version:

<details>
<summary>✅  <code>9.0</code>: Worked as expected (NO speculative build)</summary>
Results:

```
$ .artifacts/publish/docs-builder/release/docs-builder assembler content-source match elastic/elastic-agent 9.0
info ::e.d.c.tionFileProvider:: ConfigurationSource.Local: located /Users/colleenmcginnis/GitHub/docs-builder/config
info ::m.h.Lifetime          :: Application started. Press Ctrl+C to shut down.
info ::m.h.Lifetime          :: Hosting environment: Production
info ::m.h.Lifetime          :: Content root path: /Users/colleenmcginnis/GitHub/docs-builder
info ::d.b.f.InfoLoggerFilter:: Configuration source: Local
info ::d.b.f.InfoLoggerFilter:: Version: 0.85.1-canary.0.1+dea2e731f5deb4fb046984fd5426fd558c52e844
info ::d.b.f.StopwatchFilter :: assembler content-source match :: Starting...
info ::e.d.a.c.atchingService::  Validating 'elastic/elastic-agent' '9.0' 
info ::e.d.c.a.a.tSourceMatch:: Active content-sources for elastic/elastic-agent. current: main, next: main, edge: main' 
info ::e.d.c.a.a.tSourceMatch:: Branch or tag 9.0 is a versioned branch
info ::e.d.c.a.a.tSourceMatch:: Current is not using versioned branches checking product info
info ::e.d.c.a.a.tSourceMatch:: NO speculative build 9.0 is lte product current '9.2.1'
info ::e.d.a.c.atchingService:: 'elastic/elastic-agent' '9.0' combination not found in configuration.
```
</details>

<details>
<summary>✅  <code>9.1</code>: Worked as expected (speculative build)</summary>
Results:

```
$ .artifacts/publish/docs-builder/release/docs-builder assembler content-source match elastic/elastic-agent 9.1 
info ::e.d.c.tionFileProvider:: ConfigurationSource.Local: located /Users/colleenmcginnis/GitHub/docs-builder/config
info ::m.h.Lifetime          :: Application started. Press Ctrl+C to shut down.
info ::m.h.Lifetime          :: Hosting environment: Production
info ::m.h.Lifetime          :: Content root path: /Users/colleenmcginnis/GitHub/docs-builder
info ::d.b.f.InfoLoggerFilter:: Configuration source: Local
info ::d.b.f.InfoLoggerFilter:: Version: 0.85.1-canary.0.1+dea2e731f5deb4fb046984fd5426fd558c52e844
info ::d.b.f.StopwatchFilter :: assembler content-source match :: Starting...
info ::e.d.a.c.atchingService::  Validating 'elastic/elastic-agent' '9.1' 
info ::e.d.c.a.a.tSourceMatch:: Active content-sources for elastic/elastic-agent. current: main, next: main, edge: main' 
info ::e.d.c.a.a.tSourceMatch:: Branch or tag 9.1 is a versioned branch
info ::e.d.c.a.a.tSourceMatch:: Current is not using versioned branches checking product info
info ::e.d.c.a.a.tSourceMatch:: Speculative build 9.1 is gte product current previous minor '9.1.0'
```
</details>

<details>
<summary>❌  <code>9.2</code>: Did NOT work as expected  (NO speculative build)</summary>
Results:

```
$ .artifacts/publish/docs-builder/release/docs-builder assembler content-source match elastic/elastic-agent 9.2 
info ::e.d.c.tionFileProvider:: ConfigurationSource.Local: located /Users/colleenmcginnis/GitHub/docs-builder/config
info ::m.h.Lifetime          :: Application started. Press Ctrl+C to shut down.
info ::m.h.Lifetime          :: Hosting environment: Production
info ::m.h.Lifetime          :: Content root path: /Users/colleenmcginnis/GitHub/docs-builder
info ::d.b.f.InfoLoggerFilter:: Configuration source: Local
info ::d.b.f.InfoLoggerFilter:: Version: 0.85.1-canary.0.1+dea2e731f5deb4fb046984fd5426fd558c52e844
info ::d.b.f.StopwatchFilter :: assembler content-source match :: Starting...
info ::e.d.a.c.atchingService::  Validating 'elastic/elastic-agent' '9.2' 
info ::e.d.c.a.a.tSourceMatch:: Active content-sources for elastic/elastic-agent. current: main, next: main, edge: main' 
info ::e.d.c.a.a.tSourceMatch:: Branch or tag 9.2 is a versioned branch
info ::e.d.c.a.a.tSourceMatch:: Current is not using versioned branches checking product info
info ::e.d.c.a.a.tSourceMatch:: NO speculative build 9.2 is lte product current '9.2.1'
info ::e.d.a.c.atchingService:: 'elastic/elastic-agent' '9.2' combination not found in configuration.
```
</details>

I think this is because in `if (v >= productVersion)` we're comparing `9.2.0` to `9.2.1` when we should be checking that the branch (`9.2`) is greater than or equal to the latest _minor_ (`9.2.1` ➡️  `9.2`).

After adding the changes in this PR I reran `assembler content-source match` for each minor version again and got the results I'd expect. 

I also added `fleet-server` to the product list so this logic will also work on PRs in elastic/fleet-server ([example](https://github.com/elastic/fleet-server/pull/5908)).