### PR TITLE
Use Elastic Inference Service (EIS) during indexing by default

### DIFF
--- a/src/Elastic.Documentation.Configuration/DocumentationEndpoints.cs
+++ b/src/Elastic.Documentation.Configuration/DocumentationEndpoints.cs
@@ -23,6 +23,7 @@ public class ElasticsearchEndpoint
 	// inference options
 	public int SearchNumThreads { get; set; } = 8;
 	public int IndexNumThreads { get; set; } = 8;
+	public bool NoElasticInferenceService { get; set; }
 
 	// index options
 	public string IndexNamePrefix { get; set; } = "semantic-docs";
@@ -30,7 +31,6 @@ public class ElasticsearchEndpoint
 	// channel buffer options
 	public int BufferSize { get; set; } = 100;
 	public int MaxRetries { get; set; } = 3;
-
 
 	// connection options
 	public bool DebugMode { get; set; }

--- a/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchExporter.cs
+++ b/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchExporter.cs
@@ -56,7 +56,10 @@ public class ElasticsearchSemanticExporter(
 		ActiveSearchAlias = $"{endpoint.IndexNamePrefix}-{indexNamespace.ToLowerInvariant()}",
 		IndexNumThreads = endpoint.IndexNumThreads,
 		SearchNumThreads = endpoint.SearchNumThreads,
-		InferenceCreateTimeout = TimeSpan.FromMinutes(endpoint.BootstrapTimeout ?? 4)
+		InferenceCreateTimeout = TimeSpan.FromMinutes(endpoint.BootstrapTimeout ?? 4),
+		UsePreexistingInferenceIds = !endpoint.NoElasticInferenceService,
+		InferenceId = endpoint.NoElasticInferenceService ? null : ".elser-2-elastic",
+		SearchInferenceId = endpoint.NoElasticInferenceService ? null : ".elser-2-elastic"
 	});
 
 
@@ -250,15 +253,13 @@ public abstract class ElasticsearchExporter<TChannelOptions, TChannel> : IDispos
 
 	private static string AbstractMapping() =>
 		"""
-		, "abstract": {
-			"type": "text"
-		}
+		, "abstract": { "type": "text" }
 		""";
 
-	private static string InferenceMapping(string _) =>
+	private static string InferenceMapping(string inferenceId) =>
 		$"""
 		 	"type": "semantic_text",
-		 	"inference_id": ".elser-2-elastic"
+		 	"inference_id": "{inferenceId}"
 		 """;
 
 	private static string AbstractInferenceMapping(string inferenceId) =>

--- a/src/services/Elastic.Documentation.Assembler/Indexing/AssemblerIndexService.cs
+++ b/src/services/Elastic.Documentation.Assembler/Indexing/AssemblerIndexService.cs
@@ -36,6 +36,7 @@ public class AssemblerIndexService(
 	/// <param name="noSemantic">Index without semantic fields</param>
 	/// <param name="searchNumThreads">The number of search threads the inference endpoint should use. Defaults: 8</param>
 	/// <param name="indexNumThreads">The number of index threads the inference endpoint should use. Defaults: 8</param>
+	/// <param name="noEis">Do not use the Elastic Inference Service, bootstrap inference endpoint</param>
 	/// <param name="bootstrapTimeout">Timeout in minutes for the inference endpoint creation. Defaults: 4</param>
 	/// <param name="indexNamePrefix">The prefix for the computed index/alias names. Defaults: semantic-docs</param>
 	/// <param name="forceReindex">Force reindex strategy to semantic index</param>
@@ -62,6 +63,7 @@ public class AssemblerIndexService(
 		bool? noSemantic = null,
 		int? searchNumThreads = null,
 		int? indexNumThreads = null,
+		bool? noEis = null,
 		int? bootstrapTimeout = null,
 		// index options
 		string? indexNamePrefix = null,
@@ -101,6 +103,8 @@ public class AssemblerIndexService(
 			cfg.SearchNumThreads = searchNumThreads.Value;
 		if (indexNumThreads.HasValue)
 			cfg.IndexNumThreads = indexNumThreads.Value;
+		if (noEis.HasValue)
+			cfg.NoElasticInferenceService = noEis.Value;
 		if (!string.IsNullOrEmpty(indexNamePrefix))
 			cfg.IndexNamePrefix = indexNamePrefix;
 		if (bufferSize.HasValue)

--- a/src/services/Elastic.Documentation.Isolated/IsolatedIndexService.cs
+++ b/src/services/Elastic.Documentation.Isolated/IsolatedIndexService.cs
@@ -33,6 +33,7 @@ public class IsolatedIndexService(
 	/// <param name="noSemantic">Index without semantic fields</param>
 	/// <param name="searchNumThreads">The number of search threads the inference endpoint should use. Defaults: 8</param>
 	/// <param name="indexNumThreads">The number of index threads the inference endpoint should use. Defaults: 8</param>
+	/// <param name="noEis">Do not use the Elastic Inference Service, bootstrap inference endpoint</param>
 	/// <param name="bootstrapTimeout">Timeout in minutes for the inference endpoint creation. Defaults: 4</param>
 	/// <param name="indexNamePrefix">The prefix for the computed index/alias names. Defaults: semantic-docs</param>
 	/// <param name="forceReindex">Force reindex strategy to semantic index</param>
@@ -59,6 +60,7 @@ public class IsolatedIndexService(
 		bool? noSemantic = null,
 		int? searchNumThreads = null,
 		int? indexNumThreads = null,
+		bool? noEis = null,
 		int? bootstrapTimeout = null,
 		// index options
 		string? indexNamePrefix = null,
@@ -98,6 +100,8 @@ public class IsolatedIndexService(
 			cfg.SearchNumThreads = searchNumThreads.Value;
 		if (indexNumThreads.HasValue)
 			cfg.IndexNumThreads = indexNumThreads.Value;
+		if (noEis.HasValue)
+			cfg.NoElasticInferenceService = noEis.Value;
 		if (!string.IsNullOrEmpty(indexNamePrefix))
 			cfg.IndexNamePrefix = indexNamePrefix;
 		if (bufferSize.HasValue)

--- a/src/tooling/docs-builder/Commands/Assembler/AssemblerIndexCommand.cs
+++ b/src/tooling/docs-builder/Commands/Assembler/AssemblerIndexCommand.cs
@@ -33,6 +33,7 @@ internal sealed class AssemblerIndexCommand(
 	/// <param name="noSemantic">Index without semantic fields</param>
 	/// <param name="searchNumThreads">The number of search threads the inference endpoint should use. Defaults: 8</param>
 	/// <param name="indexNumThreads">The number of index threads the inference endpoint should use. Defaults: 8</param>
+	/// <param name="noEis">Do not use the Elastic Inference Service, bootstrap inference endpoint</param>
 	/// <param name="indexNamePrefix">The prefix for the computed index/alias names. Defaults: semantic-docs</param>
 	/// <param name="forceReindex">Force reindex strategy to semantic index</param>
 	/// <param name="bootstrapTimeout">Timeout in minutes for the inference endpoint creation. Defaults: 4</param>
@@ -60,6 +61,7 @@ internal sealed class AssemblerIndexCommand(
 		bool? noSemantic = null,
 		int? searchNumThreads = null,
 		int? indexNumThreads = null,
+		bool? noEis = null,
 		int? bootstrapTimeout = null,
 
 		// index options
@@ -93,7 +95,7 @@ internal sealed class AssemblerIndexCommand(
 				// endpoint options
 				endpoint, environment, apiKey, username, password,
 				// inference options
-				noSemantic, indexNumThreads, searchNumThreads, bootstrapTimeout,
+				noSemantic, indexNumThreads, searchNumThreads, noEis, bootstrapTimeout,
 				// channel and connection options
 				indexNamePrefix, forceReindex, bufferSize, maxRetries, debugMode,
 				// proxy options
@@ -106,7 +108,7 @@ internal sealed class AssemblerIndexCommand(
 				// endpoint options
 				state.endpoint, state.environment, state.apiKey, state.username, state.password,
 				// inference options
-				state.noSemantic, state.searchNumThreads, state.indexNumThreads, state.bootstrapTimeout,
+				state.noSemantic, state.searchNumThreads, state.indexNumThreads, state.noEis, state.bootstrapTimeout,
 				// channel and connection options
 				state.indexNamePrefix, state.forceReindex, state.bufferSize, state.maxRetries, state.debugMode,
 				// proxy options

--- a/src/tooling/docs-builder/Commands/IndexCommand.cs
+++ b/src/tooling/docs-builder/Commands/IndexCommand.cs
@@ -32,6 +32,7 @@ internal sealed class IndexCommand(
 	/// <param name="searchNumThreads">The number of search threads the inference endpoint should use. Defaults: 8</param>
 	/// <param name="indexNumThreads">The number of index threads the inference endpoint should use. Defaults: 8</param>
 	/// <param name="indexNamePrefix">The prefix for the computed index/alias names. Defaults: semantic-docs</param>
+	/// <param name="noEis">Do not use the Elastic Inference Service, bootstrap inference endpoint</param>
 	/// <param name="forceReindex">Force reindex strategy to semantic index</param>
 	/// <param name="bootstrapTimeout">Timeout in minutes for the inference endpoint creation. Defaults: 4</param>
 	/// <param name="bufferSize">The number of documents to send to ES as part of the bulk. Defaults: 100</param>
@@ -58,6 +59,7 @@ internal sealed class IndexCommand(
 		bool? noSemantic = null,
 		int? searchNumThreads = null,
 		int? indexNumThreads = null,
+		bool? noEis = null,
 		int? bootstrapTimeout = null,
 
 		// index options
@@ -91,7 +93,7 @@ internal sealed class IndexCommand(
 				// endpoint options
 				endpoint, apiKey, username, password,
 				// inference options
-				noSemantic, indexNumThreads, searchNumThreads, bootstrapTimeout,
+				noSemantic, indexNumThreads, noEis, searchNumThreads, bootstrapTimeout,
 				// channel and connection options
 				indexNamePrefix, forceReindex, bufferSize, maxRetries, debugMode,
 				// proxy options
@@ -104,7 +106,7 @@ internal sealed class IndexCommand(
 				// endpoint options
 				state.endpoint, state.apiKey, state.username, state.password,
 				// inference options
-				state.noSemantic, state.searchNumThreads, state.indexNumThreads, state.bootstrapTimeout,
+				state.noSemantic, state.searchNumThreads, state.indexNumThreads, state.noEis, state.bootstrapTimeout,
 				// channel and connection options
 				state.indexNamePrefix, state.forceReindex, state.bufferSize, state.maxRetries, state.debugMode,
 				// proxy options


### PR DESCRIPTION
- Introduced `--no-eis` parameter to control EIS usage.
- Updated `AssemblerIndexService` configuration and inference options.
- Adjusted `ElasticsearchExporter` to handle `InferenceId` and `SearchInferenceId` based on `noEis`.
- Enhanced mappings to support dynamic `inference_id`.
