### PR TITLE
Skip IDE0032 warning in synthetics CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
   
   synthetics:
     runs-on: ubuntu-latest
+    env:
+      MSBuildNoWarn: IDE0032
     steps:
       - uses: actions/checkout@v5
         


### PR DESCRIPTION
Fix https://github.com/elastic/docs-builder/actions/runs/19364044721/job/55402636155?pr=2205

```bash
Error: /home/runner/work/docs-builder/docs-builder/src/Elastic.Documentation.Configuration/Assembler/GoogleTagManager.cs(14,2): error IDE0032: Use auto property (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0032) [/home/runner/work/docs-builder/docs-builder/src/Elastic.Documentation.Configuration/Elastic.Documentation.Configuration.csproj]
Error: /home/runner/work/docs-builder/docs-builder/src/Elastic.Documentation.Configuration/BuildContext.cs(61,2): error IDE0032: Use auto property (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0032) [/home/runner/work/docs-builder/docs-builder/src/Elastic.Documentation.Configuration/Elastic.Documentation.Configuration.csproj]
Error: /home/runner/work/docs-builder/docs-builder/src/Elastic.Documentation.Configuration/Builder/ConfigurationFile.cs(39,2): error IDE0032: Use auto property (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0032) [/home/runner/work/docs-builder/docs-builder/src/Elastic.Documentation.Configuration/Elastic.Documentation.Configuration.csproj]
```