### PR TITLE
docs: Document navigation patterns and suppress diagnostics

### DIFF
--- a/docs/configure/content-set/navigation.md
+++ b/docs/configure/content-set/navigation.md
@@ -8,10 +8,6 @@ Example:
 
 ```yaml
 project: 'PROJECT_NAME'
-soft_line_endings: true
-
-external_hosts:
-  - EXTERNAL_LINKS_HERE
 
 exclude:
   - 'EXCLUDED_FILES'
@@ -40,23 +36,6 @@ Example:
 
 ```yaml
 project: 'APM Java agent reference'
-```
-
-### `soft_line_endings`
-
-Optional key. Defaults to `false`. When enabled turns soft line endings in the markdown to hard HTML breaks `<br />`.
-
-
-### `external_hosts`
-
-All links to external hosts must be declared in this section of `docset.yml`.
-
-Example:
-
-```yaml
-external_hosts:
-  - google.com
-  - github.com
 ```
 
 ### `cross_links`
@@ -198,10 +177,196 @@ subs:
 
 See [Attributes](./attributes.md) to learn more.
 
-## `toc.yml`
+### `suppress`
 
-As a rule, each `docset.yml` file can only be included once in the assembler. This prevents us from accidentally duplicating pages in the docs. However, there are times when you want to split content sets and include them partially in different areas of the TOC. That's what `toc.yml` files are for. These files split one documentation set into multiple “sub-TOCs,” each mapped to a different navigation node.
+Optional list of diagnostic hint types to suppress for this navigation file. Available in both `docset.yml` and `toc.yml` files.
 
-A `toc.yml` file may only declare a nested [TOC](#toc), other options are ignored. 
+Valid suppression values:
 
-A `toc.yml` may not link to further nested `toc.yml` files. Doing so will result in an error
+- `DeepLinkingVirtualFile`
+- `FolderFileNameMismatch`
+
+Example:
+
+```yaml
+suppress:
+  - DeepLinkingVirtualFile
+  - FolderFileNameMismatch
+```
+
+#### `DeepLinkingVirtualFile`
+
+Suppresses hints about files with children that use deep-linking (path contains `/`).
+
+By default, the builder emits a hint when a file reference includes a path separator and has children:
+
+```yaml
+toc:
+  - file: a/b/c/getting-started.md
+    children:
+      - file: a/b/c/setup.md
+      - file: a/b/c/install.md
+```
+
+**Hint message**: "File 'a/b/c/getting-started.md' uses deep-linking with children. Consider using 'folder' instead of 'file' for better navigation structure. Virtual files are primarily intended to group sibling files together."
+
+**Why this is discouraged**: Virtual files (files with children) are intended to group sibling files together, not to create deep navigation hierarchies. Using `folder` structures provides clearer organization.
+
+**Preferred alternative**:
+
+```yaml
+toc:
+  - folder: a
+    children:
+      - folder: b
+        children:
+          - folder: c
+            children:
+              - file: index.md
+              - file: getting-started.md
+                children:
+                  - file: setup.md
+                  - file: install.md
+```
+
+Or use nested `toc.yml` files for better maintainability.
+
+#### `FolderFileNameMismatch`
+
+Suppresses hints about file names not matching folder names in folder+file combinations.
+
+By default, when using the folder+file pattern, the builder emits a hint if the file name doesn't match the folder name:
+
+```yaml
+toc:
+  - folder: getting-started
+    file: overview.md
+```
+
+**Hint message**: "File name 'overview.md' does not match folder name 'getting-started'. Best practice is to name the file the same as the folder (e.g., 'folder: getting-started, file: getting-started.md')."
+
+**Why this is discouraged**: Mismatched names can cause confusion about which file represents the folder's main content. Consistent naming makes navigation structure more predictable.
+
+**Preferred alternatives**:
+
+```yaml
+# Option 1: Match file name to folder name
+toc:
+  - folder: getting-started
+    file: getting-started.md
+
+# Option 2: Use index.md (always allowed)
+toc:
+  - folder: getting-started
+    file: index.md
+
+# Option 3: Use folder only with children
+toc:
+  - folder: getting-started
+    children:
+      - file: index.md
+```
+
+## Navigation configuration patterns
+
+### Single file reference
+
+Reference a standalone file:
+
+```yaml
+toc:
+  - file: index.md
+  - file: getting-started.md
+  - file: api-reference.md
+```
+
+### File with children (virtual grouping)
+
+Group related sibling files under a parent file without creating a folder on disk:
+
+```yaml
+toc:
+  - file: getting-started.md
+    children:
+      - file: installation.md
+      - file: configuration.md
+      - file: first-steps.md
+```
+
+All children must be siblings of the parent file (in the same directory). The parent file may not select files outside its own subtree.
+
+### Folder without explicit children
+
+Include all markdown files in a folder automatically:
+
+```yaml
+toc:
+  - folder: api
+```
+
+All `.md` files in the `api/` folder will be included automatically. This is useful during development when the structure is still evolving.
+
+### Folder with explicit children
+
+Define exact files and their order within a folder:
+
+```yaml
+toc:
+  - folder: api
+    children:
+      - file: index.md
+      - file: authentication.md
+      - file: endpoints.md
+      - file: errors.md
+```
+
+When `children` is defined, all markdown files in the folder must be listed. The builder will error on dangling documentation files.
+
+### Folder and file combination
+
+Specify both a folder and a file to create a folder with a non-index entry point:
+
+```yaml
+toc:
+  - folder: getting-started
+    file: overview.md
+    children:
+      - file: installation.md
+      - file: configuration.md
+```
+
+Best practice: Use `index.md` or match the file name to the folder name to avoid `FolderFileNameMismatch` hints.
+
+### Nested toc reference
+
+Include a dedicated `toc.yml` file for large sections:
+
+```yaml
+toc:
+  - file: index.md
+  - toc: api-reference
+  - toc: tutorials
+  - toc: guides
+```
+
+Each `toc` reference loads the corresponding `toc.yml` file from that directory (e.g., `api-reference/toc.yml`).
+
+### Mixed patterns
+
+Combine different patterns as needed:
+
+```yaml
+toc:
+  - file: index.md
+  - file: quick-start.md
+  - folder: guides
+    children:
+      - file: index.md
+      - folder: installation
+        file: installation.md
+        children:
+          - file: prerequisites.md
+          - file: steps.md
+  - toc: api-reference
+  - folder: troubleshooting
+```


### PR DESCRIPTION
Extend navigation documentation with comprehensive best practices and
diagnostic suppression features:

- Add navigation configuration patterns (file, folder, nested toc)
- Document `suppress` field for docset.yml and toc.yml
- Explain DeepLinkingVirtualFile and FolderFileNameMismatch hints
- Describe anti-patterns each suppression addresses
- Add when-to-use guidance for each navigation pattern

The configure/content-set/navigation.md provides dry reference material
with complete YAML examples, while building-blocks/documentation-set-
navigation.md offers narrative-driven guidance with real-world scenarios
and progressive examples showing how to evolve documentation structure.
