### PR TITLE
Fix navigation dropdown

### DIFF
--- a/src/Elastic.Documentation.Navigation/Isolated/Node/TableOfContentsNavigation.cs
+++ b/src/Elastic.Documentation.Navigation/Isolated/Node/TableOfContentsNavigation.cs
@@ -84,7 +84,7 @@ public class TableOfContentsNavigation<TModel> : IRootNavigationItem<TModel, INa
 	public string ParentPath { get; }
 
 	/// <inheritdoc cref="INodeNavigationItem{TIndex,TChildNavigation}.Id" />
-	public string Id { get; }
+	public string Id { get; private set; }
 
 	/// <inheritdoc />
 	public ILeafNavigationItem<TModel> Index { get; private set; }
@@ -103,6 +103,7 @@ public class TableOfContentsNavigation<TModel> : IRootNavigationItem<TModel, INa
 	{
 		var indexNavigation = navigationItems.QueryIndex<TModel>(this, $"{ParentPath}/index.md", out navigationItems);
 		Index = indexNavigation;
+		Id = ShortId.Create(indexNavigation.Url);
 		NavigationItems = navigationItems;
 	}
 }


### PR DESCRIPTION
## Context

The current navigation dropdown is not working in certain cases.

I realized that the Id of toc navigations is not truly unique, which causes the navigation items to have duplicate IDs, thus the dropdown cannot identify the container.

## Changes

Use the url of the file to generate an ID.