### PR TITLE
Detect deployment.environment in frontend

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/telemetry/instrumentation.ts
+++ b/src/Elastic.Documentation.Site/Assets/telemetry/instrumentation.ts
@@ -290,7 +290,6 @@ class EuidSpanProcessor implements SpanProcessor {
 
 /**
  * Detects the deployment environment from the hostname at runtime.
- * This is called when deploymentEnvironment is not explicitly provided to initializeOtel().
  *
  * Since the JavaScript is pre-built and bundled into docs-builder CLI,
  * we detect the environment purely from the runtime hostname in the browser.


### PR DESCRIPTION
## Context

I tried adding it to the collector as resource processor. But that didn't work because the ADOT collector lambda layer doesn't have this component.

We cannot add it at build time as well, since we are building the JS artifacts only once for all environments.

Hence, we need to determine it at runtime.