### PR TITLE
Redirect fixes

### DIFF
--- a/src/Elastic.Documentation/Diagnostics/DiagnosticsCollector.cs
+++ b/src/Elastic.Documentation/Diagnostics/DiagnosticsCollector.cs
@@ -111,6 +111,8 @@ public class DiagnosticsCollector(IReadOnlyCollection<IDiagnosticsOutput> output
 			Message = message
 		});
 
+	public void EmitError(string file, string message, string specificErrorMessage) => Emit(Severity.Error, file, $"{message}{Environment.NewLine}{specificErrorMessage}");
+
 	public void EmitError(string file, string message, Exception? e = null)
 	{
 		message = message

--- a/src/Elastic.Documentation/Diagnostics/IDiagnosticsCollector.cs
+++ b/src/Elastic.Documentation/Diagnostics/IDiagnosticsCollector.cs
@@ -23,6 +23,7 @@ public interface IDiagnosticsCollector : IAsyncDisposable, IHostedService
 
 	void Emit(Severity severity, string file, string message);
 	void EmitError(string file, string message, Exception? e = null);
+	void EmitError(string file, string message, string specificErrorMessage);
 	void EmitWarning(string file, string message);
 	void EmitHint(string file, string message);
 	void Write(Diagnostic diagnostic);

--- a/src/services/Elastic.Documentation.Assembler/Building/AssemblerBuilder.cs
+++ b/src/services/Elastic.Documentation.Assembler/Building/AssemblerBuilder.cs
@@ -116,7 +116,7 @@ public class AssemblerBuilder(
 			if (Uri.IsWellFormedUriString(path, UriKind.Absolute)) // Cross-repo links
 			{
 				_ = linkResolver.TryResolve(
-					e => context.Collector.EmitError(path, $"An error occurred while resolving cross-link {path}", e),
+					specificErrorMessage => context.Collector.EmitError(path, $"An error occurred while resolving cross-link {path}", specificErrorMessage),
 					new Uri(path),
 					out uri);
 			}


### PR DESCRIPTION
Closes #2264 

This PR fixes the following scenario involving redirect sanitization:

### Empty redirect targets

An incorrect input for the redirect target (such as a cross-link not registered in the link index) output an error, but didn't properly register one at the collector. This caused docs-builder to proceed, yielding an empty string as a resolved path.

At a later point in the assemble process, during key-value store updates, the redirect was being set as an empty string.