### PR TITLE
Continuing tweaking search relevance

### DIFF
--- a/config/synonyms.yml
+++ b/config/synonyms.yml
@@ -1,6 +1,8 @@
 synonyms:
   - [ ".net", "c#", "csharp", "dotnet", "net" ]
-  - [ "esql", "es|ql" ]
+  - [ "esql", "es|ql => esql" ]
+  - [ "data-stream", "data stream", "datastream => data-streams"]
+  - [ "data-streams", "data streams", "datastreams"]
   - [ "motlp", "managed otlp" ]
   - [ "s3", "aws s3", "amazon s3" ]
   - [ "es", "elasticsearch" ]
@@ -27,7 +29,7 @@ synonyms:
   - [ "edot", "elastic distribution of opentelemetry" ]
   - [ "k8s", "kubernetes" ]
   - [ "ecs", "elastic common schema" ]
-  - [ "ml", "machine learning" ]
+  - [ "machine-learning", "machine learning", "ml => machine learning" ]
   - [ "eis", "elastic inference service" ]
   - [ "traffic filter", "network security" ]
   - [ "sso", "single sign-on" ]

--- a/src/Elastic.Documentation.Site/package-lock.json
+++ b/src/Elastic.Documentation.Site/package-lock.json
@@ -149,7 +149,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1998,7 +1997,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2022,7 +2020,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2328,7 +2325,6 @@
       "version": "11.13.5",
       "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
       "integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
-      "peer": true,
       "dependencies": {
         "@emotion/babel-plugin": "^11.13.5",
         "@emotion/cache": "^11.13.5",
@@ -2351,7 +2347,6 @@
       "version": "11.14.0",
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -4479,7 +4474,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4873,7 +4867,6 @@
       "integrity": "sha512-erH9GdLe8Boie0mCO8hXn8Qt/pCACsOFlKp8UHNMlPaizUtCDkCOQqwmSi+VyrJ3dMMCOc/qBwTSGAJaJE8/Kw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.1",
         "@parcel/cache": "2.16.0",
@@ -7380,7 +7373,6 @@
       "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-5.2.2.tgz",
       "integrity": "sha512-fYDQA9e6yTNmA13TLVSA+WMQRc5Bn/c0EUBditUHNfMMxN7M82c38b1kEggVE3pLpZ0FwkwJkUEKMiOi52JXFA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/generator": "^7.26.5",
         "@babel/parser": "^7.26.7",
@@ -7433,7 +7425,8 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -7648,7 +7641,6 @@
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -7780,7 +7772,6 @@
       "integrity": "sha512-tK3GPFWbirvNgsNKto+UmB/cRtn6TZfyw0D6IKrW55n6Vbs7KJoZtI//kpTKzE/DUmmnAFD8/Ca46s7Obs92/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.4",
         "@typescript-eslint/types": "8.46.4",
@@ -8310,7 +8301,6 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8837,7 +8827,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -9458,7 +9447,8 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/dompurify": {
       "version": "3.2.7",
@@ -9716,7 +9706,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -12338,7 +12327,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -12895,6 +12883,7 @@
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -13141,7 +13130,6 @@
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -13754,7 +13742,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -13801,7 +13788,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -13896,6 +13882,7 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -13910,6 +13897,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -14059,7 +14047,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -14082,7 +14069,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -14419,7 +14405,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
       "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }
@@ -15479,7 +15464,8 @@
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "peer": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -15526,7 +15512,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16372,8 +16357,7 @@
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
       "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/zustand": {
       "version": "5.0.8",

--- a/src/Elastic.Documentation/Search/DocumentationDocument.cs
+++ b/src/Elastic.Documentation/Search/DocumentationDocument.cs
@@ -25,6 +25,15 @@ public record DocumentationDocument
 	[JsonPropertyName("url")]
 	public string Url { get; set; } = string.Empty;
 
+	[JsonPropertyName("navigation_depth")]
+	public int NavigationDepth { get; set; } = 50; //default to a high number so that omission gets penalized.
+
+	[JsonPropertyName("navigation_table_of_contents")]
+	public int NavigationTableOfContents { get; set; } = 50; //default to a high number so that omission gets penalized.
+
+	[JsonPropertyName("navigation_section")]
+	public string? NavigationSection { get; set; }
+
 	/// The date of the batch update this document was part of last.
 	/// This date could be higher than the date_last_updated.
 	[JsonPropertyName("batch_index_date")]

--- a/src/Elastic.Markdown/Exporters/IMarkdownExporter.cs
+++ b/src/Elastic.Markdown/Exporters/IMarkdownExporter.cs
@@ -20,6 +20,7 @@ public record MarkdownExportFileContext
 	public required IFileInfo DefaultOutputFile { get; init; }
 	public required DocumentationSet DocumentationSet { get; init; }
 	public required INavigationItem NavigationItem { get; init; }
+	public required INavigationTraversable PositionaNavigation { get; init; }
 }
 
 public interface IMarkdownExporter

--- a/tests-integration/Elastic.Assembler.IntegrationTests/Search/SearchBootstrapFixture.cs
+++ b/tests-integration/Elastic.Assembler.IntegrationTests/Search/SearchBootstrapFixture.cs
@@ -181,7 +181,8 @@ public class SearchBootstrapFixture(DocumentationFixture fixture) : IAsyncLifeti
 				collector,
 				endpoint,
 				"dev", // index namespace
-				transport
+				transport,
+				[]
 			);
 
 			// Get the current hash from Elasticsearch index template

--- a/tests-integration/Search.IntegrationTests/SearchRelevanceTests.cs
+++ b/tests-integration/Search.IntegrationTests/SearchRelevanceTests.cs
@@ -44,7 +44,7 @@ public class SearchRelevanceTests(ITestOutputHelper output)
 		{ "aliases", "/docs/manage-data/data-store/aliases", null},
 		{ "Kibana privilege", "/docs/deploy-manage/users-roles/cluster-or-deployment-auth/kibana-privileges", null},
 		{ "lens", "/docs/explore-analyze/visualize/lens", null},
-		{ "machine learning node", "/docs/deploy-manage/autoscaling/autoscaling-in-ece-and-ech", ["/docs/deploy-manage/distributed-architecture/clusters-nodes-shards/node-roles"]},
+		{ "machine learning node", "/docs/deploy-manage/autoscaling/autoscaling-in-ece-and-ech", null },
 		{ "machine learning", "/docs/reference/machine-learning", null},
 		{ "ml", "/docs/reference/machine-learning", null},
 		{ "elasticsearch", "/docs/reference/elasticsearch", null},

--- a/tests-integration/Search.IntegrationTests/SearchRelevanceTests.cs
+++ b/tests-integration/Search.IntegrationTests/SearchRelevanceTests.cs
@@ -36,10 +36,25 @@ public class SearchRelevanceTests(ITestOutputHelper output)
 		{ "data-streams", "/docs/manage-data/data-store/data-streams", null },
 		{ "datastream", "/docs/manage-data/data-store/data-streams", null },
 		{ "data stream", "/docs/manage-data/data-store/data-streams", null },
-		{ "saml sso", "/docs/deploy-manage/users-roles/cloud-organization/register-elastic-cloud-saml-in-okta", ["/docs/deploy-manage/users-roles/cloud-organization/configure-saml-authentication"] },
+		{ "saml sso", "/docs/deploy-manage/users-roles/cloud-organization/configure-saml-authentication", ["/docs/deploy-manage/users-roles/cloud-organization/configure-saml-authentication"] },
 		{ "templates", "/docs/manage-data/data-store/templates", null},
-		{ "query dsl", "/docs/explore-analyze/query-filter/languages/querydsl", null},
-		{ "querydsl", "/docs/explore-analyze/query-filter/languages/querydsl", null}
+		{ "query dsl", "/docs/reference/query-languages/querydsl", ["/docs/explore-analyze/query-filter/languages/querydsl"]},
+		{ "querydsl", "/docs/reference/query-languages/querydsl", ["/docs/explore-analyze/query-filter/languages/querydsl"]},
+		{ "Agent policy", "/docs/reference/fleet/agent-policy", null},
+		{ "aliases", "/docs/manage-data/data-store/aliases", null},
+		{ "Kibana privilege", "/docs/deploy-manage/users-roles/cluster-or-deployment-auth/kibana-privileges", null},
+		{ "lens", "/docs/explore-analyze/visualize/lens", null},
+		{ "machine learning node", "/docs/deploy-manage/autoscaling/autoscaling-in-ece-and-ech", ["/docs/deploy-manage/distributed-architecture/clusters-nodes-shards/node-roles"]},
+		{ "machine learning", "/docs/reference/machine-learning", null},
+		{ "ml", "/docs/reference/machine-learning", null},
+		{ "elasticsearch", "/docs/reference/elasticsearch", null},
+		{ "kibana", "/docs/reference/kibana", null},
+		{ "cloud", "/docs/reference/cloud", null},
+		{ "logstash", "/docs/reference/logstash", null},
+		{ "esql", "/docs/reference/query-languages/esql", null},
+		{ "ES|QL", "/docs/reference/query-languages/esql", null},
+		{ "Output plugins for Logstash", "/docs/reference/logstash/plugins/output-plugins", null},
+		{ "Sending data to Elastic Cloud Hosted", "/docs/solutions/observability/get-started/quickstart-elastic-cloud-otel-endpoint", ["/docs/reference/logstash/connecting-to-cloud"]},
 	};
 
 	[Theory]


### PR DESCRIPTION
  Summary

  - Add rank_feature scoring for navigation structure - Landing/overview pages now score better based on their navigation depth and position. navigation_depth and
  navigation_table_of_contents fields are indexed as rank_feature with negative impact (shallower = better). Reference and getting-started sections get slight boosts.
  - Improve synonym handling - Split synonyms into index-time and search-time. Key terms like esql, data-streams, and machine-learning now use explicit contraction rules (e.g.,
  es|ql => esql, data stream => data-streams) applied at index time for consistent matching.
  - Tune lexical query scoring - Wrap title completion match in ConstantScoreQuery to prevent high TF/IDF from dominating. Reduce body match boost. Add phrase matching for 3+
  token queries. Remove redundant title tokens from search_title to avoid inflating TF.

  Test plan

  - Run existing search relevance tests - 14 new test cases added covering single-term product searches (elasticsearch, kibana, logstash, etc.), synonyms (ml, esql), and longer
  queries
  - Verify landing pages like /docs/reference/elasticsearch rank first for "elasticsearch"
  - Verify synonym searches like "ml" and "machine learning" return same top result
  - Confirm deeper nested pages don't outrank overview pages for generic terms


----

This is not complete but ready to be merged, this is a another step closer to increase relevance in continutation of #2279 

Not all relevance test pass yet:


## q=datastreams

```
Expected: /docs/manage-data/data-store/data-streams
  - Score: 7.5496
  - Matched: True

Actual: /docs/manage-data/lifecycle/data-stream
  - Score: 7.5838
  - Matched: True
```

It's close but the top result is not quite what I want.


## q=logstash

```
Expected: /docs/reference/logstash
  - Score: 7.8765
  - Matched: True

Actual: /docs/release-notes/logstash
  - Score: 7.9206
  - Matched: True
```

Similar its close but because logstash reference is nested deeper than its release-notes its not at in the number 1 spot. 

Will continue to follow up with this.
