### PR TITLE
Improve search relevance and ensure less janky 'as you type' results

### DIFF
--- a/config/search.yml
+++ b/config/search.yml
@@ -1,40 +1,14 @@
-synonyms:
-  - [ ".net", "c#", "csharp", "dotnet", "net" ]
-  - [ "esql", "es|ql => esql" ]
-  - [ "data-stream", "data stream", "datastream => data-streams"]
-  - [ "data-streams", "data streams", "datastreams"]
-  - [ "motlp", "managed otlp" ]
-  - [ "s3", "aws s3", "amazon s3" ]
-  - [ "es", "elasticsearch" ]
-  - [ "elastic learned sparse encoder", "elser" ]
-  - [ "ccs", "cross cluster search", "cross-cluster search", "spaghetti" ]
-  - [ "cps", "cross project search", "cross-project search" ]
-  - [ "apm", "application performance monitoring" ]
-  - [ "ecctl", "elastic cloud control" ]
-  - [ "opentelemetry", "otel" ]
-  - [ "elastic distributions of opentelemetry", "edot" ]
-  - [ "eck", "elastic cloud on kubernetes" ]
-  - [ "ece", "elastic cloud enterprise" ]
-  - [ "elv2", "elastic license v2" ]
-  - [ "kql", "kibana query language" ]
-  - [ "ccr", "cross-cluster replication", "cross cluster replication" ]
-  - [ "esaas", "elastic stack as a service" ]
-  - [ "knn", "k-nearest neighbors" ]
-  - [ "ech", "elastic cloud hosted", "ess" ]
-  - [ "elasticsearch service", "elastic cloud" ]
-  - [ "aws", "amazon" ]
-  - [ "gcp", "google cloud platform" ]
-  - [ "ilm", "index lifecycle management" ]
-  - [ "javascript", "js", "node", "nodejs", "node.js" ]
-  - [ "edot", "elastic distribution of opentelemetry" ]
-  - [ "k8s", "kubernetes" ]
-  - [ "ecs", "elastic common schema" ]
-  - [ "machine-learning", "machine learning", "ml => machine learning" ]
-  - [ "eis", "elastic inference service" ]
-  - [ "traffic filter", "network security" ]
-  - [ "sso", "single sign-on" ]
-  - [ "querydsl", "query dsl", "query dsl"]
+# Dampen the impact of search results that contain these terms.
+# Use sparingly, in general our query relevance should be good enough.
+diminish_terms:
+  - plugin
+  - client
+  - integration
+  - curator
+  - hadoop
+  - glossary
 
+# Query rules, to promote certain results over others.
 # Use sparingly, in general our query relevance should be good enough.
 rules:
   # datastreams require this special handling because `datastream` is really unique vs the other spellings. 
@@ -65,8 +39,47 @@ rules:
       ids:
         - /docs/reference/logstash
 
-diminish_terms:
-  - plugin
-  - client
-  - integration
-  - glossary
+
+synonyms:
+  - [ ".net", "c#", "csharp", "dotnet", "net" ]
+  - [ "apm", "application performance monitoring" ]
+  - [ "aws", "amazon" ]
+  - [ "ccr", "cross-cluster replication", "cross cluster replication" ]
+  - [ "ccs", "cross cluster search", "cross-cluster search", "spaghetti" ]
+  - [ "cps", "cross project search", "cross-project search" ]
+  - [ "data-stream", "data stream", "datastream => data-streams"]
+  - [ "data-streams", "data streams", "datastreams"]
+  - [ "ecctl", "elastic cloud control" ]
+  - [ "ece", "elastic cloud enterprise" ]
+  - [ "ech", "elastic cloud hosted", "ess" ]
+  - [ "eck", "elastic cloud on kubernetes" ]
+  - [ "ecs", "elastic common schema" ]
+  - [ "edot", "elastic distribution of opentelemetry" ]
+  - [ "edr", "endpoint detection response" ]
+  - [ "eis", "elastic inference service" ]
+  - [ "eks", "elastic kubernetes service" ]
+  - [ "elastic distributions of opentelemetry", "edot" ]
+  - [ "elastic learned sparse encoder", "elser" ]
+  - [ "elasticsearch service", "elastic cloud" ]
+  - [ "elv2", "elastic license v2" ]
+  - [ "es", "elasticsearch" ]
+  - [ "esaas", "elastic stack as a service" ]
+  - [ "esql", "es|ql => esql" ]
+  - [ "gcp", "google cloud platform" ]
+  - [ "ilm", "index lifecycle management" ]
+  - [ "javascript", "js", "node", "nodejs", "node.js" ]
+  - [ "k8s", "kubernetes" ]
+  - [ "knn", "k-nearest neighbors" ]
+  - [ "kpi", "key performance indicator" ]
+  - [ "kql", "kibana query language" ]
+  - [ "logsdb", "logs datastream", "logs data stream" ]
+  - [ "machine-learning", "machine learning", "ml => machine learning" ]
+  - [ "motlp", "managed otlp" ]
+  - [ "opentelemetry", "otel" ]
+  - [ "querydsl", "query dsl", "query dsl"]
+  - [ "rag", "retrieval augmented generation" ]
+  - [ "s3", "aws s3", "amazon s3" ]
+  - [ "sso", "single sign-on" ]
+  - [ "traffic filter", "network security" ]
+  - [ "tsvb", "time series visual builder" ]
+

--- a/src/Elastic.ApiExplorer/Elasticsearch/OpenApiDocumentExporter.cs
+++ b/src/Elastic.ApiExplorer/Elasticsearch/OpenApiDocumentExporter.cs
@@ -165,6 +165,7 @@ public partial class OpenApiDocumentExporter(VersionsConfiguration versionsConfi
 					Type = "api",
 					Url = url,
 					Title = title,
+					SearchTitle = title,
 					Description = description,
 					Body = body,
 					StrippedBody = body,

--- a/src/Elastic.Documentation/Search/DocumentationDocument.cs
+++ b/src/Elastic.Documentation/Search/DocumentationDocument.cs
@@ -10,20 +10,32 @@ namespace Elastic.Documentation.Search;
 public record ParentDocument
 {
 	[JsonPropertyName("title")]
-	public string? Title { get; set; }
+	public required string Title { get; set; }
 
 	[JsonPropertyName("url")]
-	public string? Url { get; set; }
+	public required string Url { get; set; }
 }
 
 public record DocumentationDocument
 {
-	[JsonPropertyName("type")]
-	public string Type { get; set; } = "doc";
+	[JsonPropertyName("title")]
+	public required string Title { get; set; }
 
-	// TODO make this required once all doc_sets have published again
+	/// <summary>
+	/// Search title is a combination of the title and the url components.
+	/// This is used for querying to not reward documents with short titles contributing to heavily to scoring
+	/// </summary>
+	[JsonPropertyName("search_title")]
+	public required string SearchTitle { get; set; }
+
+	[JsonPropertyName("type")]
+	public required string Type { get; set; } = "doc";
+
 	[JsonPropertyName("url")]
-	public string Url { get; set; } = string.Empty;
+	public required string Url { get; set; } = string.Empty;
+
+	[JsonPropertyName("hash")]
+	public string Hash { get; set; } = string.Empty;
 
 	[JsonPropertyName("navigation_depth")]
 	public int NavigationDepth { get; set; } = 50; //default to a high number so that omission gets penalized.
@@ -43,20 +55,6 @@ public record DocumentationDocument
 	[JsonPropertyName("last_updated")]
 	public DateTimeOffset LastUpdated { get; set; }
 
-	// TODO make this required once all doc_sets have published again
-	[JsonPropertyName("hash")]
-	public string Hash { get; set; } = string.Empty;
-
-	/// <summary>
-	/// Search title is a combination of the title and the url components.
-	/// This is used for querying to not reward documents with short titles contributing to heavily to scoring
-	/// </summary>
-	[JsonPropertyName("search_title")]
-	public string? SearchTitle { get; set; }
-
-	[JsonPropertyName("title")]
-	public string? Title { get; set; }
-
 	[JsonPropertyName("description")]
 	public string? Description { get; set; }
 
@@ -72,7 +70,7 @@ public record DocumentationDocument
 	[JsonPropertyName("body")]
 	public string? Body { get; set; }
 
-	// Stripped body is the body with Markdown removed, suitable for search indexing
+	/// Stripped body is the body with Markdown removed, suitable for search indexing
 	[JsonPropertyName("stripped_body")]
 	public string? StrippedBody { get; set; }
 

--- a/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchIngestChannel.Mapping.cs
+++ b/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchIngestChannel.Mapping.cs
@@ -2,153 +2,15 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-using Elastic.Channels;
-using Elastic.Documentation.Configuration;
-using Elastic.Documentation.Diagnostics;
 using Elastic.Documentation.Search;
-using Elastic.Documentation.Serialization;
 using Elastic.Ingest.Elasticsearch.Catalog;
-using Elastic.Ingest.Elasticsearch.Indices;
-using Elastic.Ingest.Elasticsearch.Semantic;
-using Elastic.Transport;
-using Microsoft.Extensions.Logging;
 
 namespace Elastic.Markdown.Exporters.Elasticsearch;
 
-public class ElasticsearchLexicalExporter(
-	ILoggerFactory logFactory,
-	IDiagnosticsCollector collector,
-	ElasticsearchEndpoint endpoint,
-	string indexNamespace,
-	DistributedTransport transport,
-	string[] indexTimeSynonyms
-)
-	: ElasticsearchExporter<CatalogIndexChannelOptions<DocumentationDocument>, CatalogIndexChannel<DocumentationDocument>>
-	(logFactory, collector, endpoint, transport, o => new(o), t => new(t)
-	{
-		BulkOperationIdLookup = d => d.Url,
-		// hash, last_updated and batch_index_date are all set before the docs are written to the channel
-		ScriptedHashBulkUpsertLookup = (d, _) => new HashedBulkUpdate("hash", d.Hash, "ctx._source.batch_index_date = params.batch_index_date",
-			new Dictionary<string, string>
-			{
-				{ "batch_index_date", d.BatchIndexDate.ToString("o") }
-			}),
-		GetMapping = () => CreateMapping(null),
-		GetMappingSettings = () => CreateMappingSetting($"docs-{indexNamespace}", indexTimeSynonyms),
-		IndexFormat =
-			$"{endpoint.IndexNamePrefix.Replace("semantic", "lexical").ToLowerInvariant()}-{indexNamespace.ToLowerInvariant()}-{{0:yyyy.MM.dd.HHmmss}}",
-		ActiveSearchAlias = $"{endpoint.IndexNamePrefix.Replace("semantic", "lexical").ToLowerInvariant()}-{indexNamespace.ToLowerInvariant()}"
-	});
-
-public class ElasticsearchSemanticExporter(
-	ILoggerFactory logFactory,
-	IDiagnosticsCollector collector,
-	ElasticsearchEndpoint endpoint,
-	string indexNamespace,
-	DistributedTransport transport,
-	string[] indexTimeSynonyms
-)
-	: ElasticsearchExporter<SemanticIndexChannelOptions<DocumentationDocument>, SemanticIndexChannel<DocumentationDocument>>
-	(logFactory, collector, endpoint, transport, o => new(o), t => new(t)
-	{
-		BulkOperationIdLookup = d => d.Url,
-		GetMapping = (inferenceId, _) => CreateMapping(inferenceId),
-		GetMappingSettings = (_, _) => CreateMappingSetting($"docs-{indexNamespace}", indexTimeSynonyms),
-		IndexFormat = $"{endpoint.IndexNamePrefix.ToLowerInvariant()}-{indexNamespace.ToLowerInvariant()}-{{0:yyyy.MM.dd.HHmmss}}",
-		ActiveSearchAlias = $"{endpoint.IndexNamePrefix}-{indexNamespace.ToLowerInvariant()}",
-		IndexNumThreads = endpoint.IndexNumThreads,
-		SearchNumThreads = endpoint.SearchNumThreads,
-		InferenceCreateTimeout = TimeSpan.FromMinutes(endpoint.BootstrapTimeout ?? 4),
-		UsePreexistingInferenceIds = !endpoint.NoElasticInferenceService,
-		InferenceId = endpoint.NoElasticInferenceService ? null : ".elser-2-elastic",
-		SearchInferenceId = endpoint.NoElasticInferenceService ? null : ".elser-2-elastic"
-	});
-
-public abstract class ElasticsearchExporter<TChannelOptions, TChannel> : IDisposable
+public abstract partial class ElasticsearchIngestChannel<TChannelOptions, TChannel>
 	where TChannelOptions : CatalogIndexChannelOptionsBase<DocumentationDocument>
 	where TChannel : CatalogIndexChannel<DocumentationDocument, TChannelOptions>
 {
-	private readonly IDiagnosticsCollector _collector;
-	public TChannel Channel { get; }
-	private readonly ILogger _logger;
-
-	protected ElasticsearchExporter(
-		ILoggerFactory logFactory,
-		IDiagnosticsCollector collector,
-		ElasticsearchEndpoint endpoint,
-		DistributedTransport transport,
-		Func<TChannelOptions, TChannel> createChannel,
-		Func<DistributedTransport, TChannelOptions> createOptions
-	)
-	{
-		_collector = collector;
-		_logger = logFactory.CreateLogger<ElasticsearchExporter<TChannelOptions, TChannel>>();
-		//The max num threads per allocated node, from testing its best to limit our max concurrency
-		//producing to this number as well
-		var options = createOptions(transport);
-		var i = 0;
-		options.BufferOptions = new BufferOptions
-		{
-			OutboundBufferMaxSize = endpoint.BufferSize,
-			ExportMaxConcurrency = endpoint.IndexNumThreads,
-			ExportMaxRetries = endpoint.MaxRetries
-		};
-		options.SerializerContext = SourceGenerationContext.Default;
-		options.ExportBufferCallback = () =>
-		{
-			var count = Interlocked.Increment(ref i);
-			_logger.LogInformation("Exported {Count} documents to Elasticsearch index {IndexName}",
-				count * endpoint.BufferSize, Channel?.IndexName ?? string.Format(options.IndexFormat, "latest"));
-		};
-		options.ExportExceptionCallback = e =>
-		{
-			_logger.LogError(e, "Failed to export document");
-			_collector.EmitGlobalError("Elasticsearch export: failed to export document", e);
-		};
-		options.ServerRejectionCallback = items =>
-		{
-			foreach (var (doc, responseItem) in items)
-			{
-				_collector.EmitGlobalError(
-					$"Server rejection: {responseItem.Status} {responseItem.Error?.Type} {responseItem.Error?.Reason} for document {doc.Url}");
-			}
-		};
-		Channel = createChannel(options);
-		_logger.LogInformation("Created {Channel} Elasticsearch target for indexing", typeof(TChannel).Name);
-	}
-
-	public async ValueTask<bool> StopAsync(Cancel ctx = default)
-	{
-		_logger.LogInformation("Waiting to drain all inflight exports to Elasticsearch");
-		var drained = await Channel.WaitForDrainAsync(null, ctx);
-		if (!drained)
-			_collector.EmitGlobalError("Elasticsearch export: failed to complete indexing in a timely fashion while shutting down");
-
-		_logger.LogInformation("Refreshing target index {Index}", Channel.IndexName);
-		var refreshed = await Channel.RefreshAsync(ctx);
-		if (!refreshed)
-			_collector.EmitGlobalError($"Refreshing target index {Channel.IndexName} did not complete successfully");
-
-		_logger.LogInformation("Applying aliases to {Index}", Channel.IndexName);
-		var swapped = await Channel.ApplyAliasesAsync(ctx);
-		if (!swapped)
-			_collector.EmitGlobalError($"${nameof(ElasticsearchMarkdownExporter)} failed to apply aliases to index {Channel.IndexName}");
-
-		return drained && refreshed && swapped;
-	}
-
-	public async ValueTask<bool> RefreshAsync(Cancel ctx = default) => await Channel.RefreshAsync(ctx);
-
-	public async ValueTask<bool> TryWrite(DocumentationDocument document, Cancel ctx = default)
-	{
-		if (Channel.TryWrite(document))
-			return true;
-
-		if (await Channel.WaitToWriteAsync(ctx))
-			return Channel.TryWrite(document);
-		return false;
-	}
-
 	protected static string CreateMappingSetting(string synonymSetName, string[] synonyms)
 	{
 		var indexTimeSynonyms = $"[{string.Join(",", synonyms.Select(r => $"\"{r}\""))}]";
@@ -246,6 +108,7 @@ public abstract class ElasticsearchExporter<TChannelOptions, TChannel> : IDispos
 			""";
 	}
 
+	// language=json
 	protected static string CreateMapping(string? inferenceId) =>
 		$$"""
 		  {
@@ -347,13 +210,4 @@ public abstract class ElasticsearchExporter<TChannelOptions, TChannel> : IDispos
 		 	"type": "semantic_text",
 		 	"inference_id": "{inferenceId}"
 		 """;
-
-
-	public void Dispose()
-	{
-		Channel.Complete();
-		Channel.Dispose();
-
-		GC.SuppressFinalize(this);
-	}
 }

--- a/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchIngestChannel.cs
+++ b/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchIngestChannel.cs
@@ -1,0 +1,159 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Channels;
+using Elastic.Documentation.Configuration;
+using Elastic.Documentation.Diagnostics;
+using Elastic.Documentation.Search;
+using Elastic.Documentation.Serialization;
+using Elastic.Ingest.Elasticsearch.Catalog;
+using Elastic.Ingest.Elasticsearch.Indices;
+using Elastic.Ingest.Elasticsearch.Semantic;
+using Elastic.Transport;
+using Microsoft.Extensions.Logging;
+
+namespace Elastic.Markdown.Exporters.Elasticsearch;
+
+public class ElasticsearchLexicalIngestChannel(
+	ILoggerFactory logFactory,
+	IDiagnosticsCollector collector,
+	ElasticsearchEndpoint endpoint,
+	string indexNamespace,
+	DistributedTransport transport,
+	string[] indexTimeSynonyms
+)
+	: ElasticsearchIngestChannel<CatalogIndexChannelOptions<DocumentationDocument>, CatalogIndexChannel<DocumentationDocument>>
+	(logFactory, collector, endpoint, transport, o => new(o), t => new(t)
+	{
+		BulkOperationIdLookup = d => d.Url,
+		// hash, last_updated and batch_index_date are all set before the docs are written to the channel
+		ScriptedHashBulkUpsertLookup = (d, _) => new HashedBulkUpdate("hash", d.Hash, "ctx._source.batch_index_date = params.batch_index_date",
+			new Dictionary<string, string>
+			{
+				{ "batch_index_date", d.BatchIndexDate.ToString("o") }
+			}),
+		GetMapping = () => CreateMapping(null),
+		GetMappingSettings = () => CreateMappingSetting($"docs-{indexNamespace}", indexTimeSynonyms),
+		IndexFormat =
+			$"{endpoint.IndexNamePrefix.Replace("semantic", "lexical").ToLowerInvariant()}-{indexNamespace.ToLowerInvariant()}-{{0:yyyy.MM.dd.HHmmss}}",
+		ActiveSearchAlias = $"{endpoint.IndexNamePrefix.Replace("semantic", "lexical").ToLowerInvariant()}-{indexNamespace.ToLowerInvariant()}"
+	});
+
+public class ElasticsearchSemanticIngestChannel(
+	ILoggerFactory logFactory,
+	IDiagnosticsCollector collector,
+	ElasticsearchEndpoint endpoint,
+	string indexNamespace,
+	DistributedTransport transport,
+	string[] indexTimeSynonyms
+)
+	: ElasticsearchIngestChannel<SemanticIndexChannelOptions<DocumentationDocument>, SemanticIndexChannel<DocumentationDocument>>
+	(logFactory, collector, endpoint, transport, o => new(o), t => new(t)
+	{
+		BulkOperationIdLookup = d => d.Url,
+		GetMapping = (inferenceId, _) => CreateMapping(inferenceId),
+		GetMappingSettings = (_, _) => CreateMappingSetting($"docs-{indexNamespace}", indexTimeSynonyms),
+		IndexFormat = $"{endpoint.IndexNamePrefix.ToLowerInvariant()}-{indexNamespace.ToLowerInvariant()}-{{0:yyyy.MM.dd.HHmmss}}",
+		ActiveSearchAlias = $"{endpoint.IndexNamePrefix}-{indexNamespace.ToLowerInvariant()}",
+		IndexNumThreads = endpoint.IndexNumThreads,
+		SearchNumThreads = endpoint.SearchNumThreads,
+		InferenceCreateTimeout = TimeSpan.FromMinutes(endpoint.BootstrapTimeout ?? 4),
+		UsePreexistingInferenceIds = !endpoint.NoElasticInferenceService,
+		InferenceId = endpoint.NoElasticInferenceService ? null : ".elser-2-elastic",
+		SearchInferenceId = endpoint.NoElasticInferenceService ? null : ".elser-2-elastic"
+	});
+
+public abstract partial class ElasticsearchIngestChannel<TChannelOptions, TChannel> : IDisposable
+	where TChannelOptions : CatalogIndexChannelOptionsBase<DocumentationDocument>
+	where TChannel : CatalogIndexChannel<DocumentationDocument, TChannelOptions>
+{
+	private readonly IDiagnosticsCollector _collector;
+	public TChannel Channel { get; }
+	private readonly ILogger _logger;
+
+	protected ElasticsearchIngestChannel(
+		ILoggerFactory logFactory,
+		IDiagnosticsCollector collector,
+		ElasticsearchEndpoint endpoint,
+		DistributedTransport transport,
+		Func<TChannelOptions, TChannel> createChannel,
+		Func<DistributedTransport, TChannelOptions> createOptions
+	)
+	{
+		_collector = collector;
+		_logger = logFactory.CreateLogger<ElasticsearchIngestChannel<TChannelOptions, TChannel>>();
+		//The max num threads per allocated node, from testing its best to limit our max concurrency
+		//producing to this number as well
+		var options = createOptions(transport);
+		var i = 0;
+		options.BufferOptions = new BufferOptions
+		{
+			OutboundBufferMaxSize = endpoint.BufferSize,
+			ExportMaxConcurrency = endpoint.IndexNumThreads,
+			ExportMaxRetries = endpoint.MaxRetries
+		};
+		options.SerializerContext = SourceGenerationContext.Default;
+		options.ExportBufferCallback = () =>
+		{
+			var count = Interlocked.Increment(ref i);
+			_logger.LogInformation("Exported {Count} documents to Elasticsearch index {IndexName}",
+				count * endpoint.BufferSize, Channel?.IndexName ?? string.Format(options.IndexFormat, "latest"));
+		};
+		options.ExportExceptionCallback = e =>
+		{
+			_logger.LogError(e, "Failed to export document");
+			_collector.EmitGlobalError("Elasticsearch export: failed to export document", e);
+		};
+		options.ServerRejectionCallback = items =>
+		{
+			foreach (var (doc, responseItem) in items)
+			{
+				_collector.EmitGlobalError(
+					$"Server rejection: {responseItem.Status} {responseItem.Error?.Type} {responseItem.Error?.Reason} for document {doc.Url}");
+			}
+		};
+		Channel = createChannel(options);
+		_logger.LogInformation("Created {Channel} Elasticsearch target for indexing", typeof(TChannel).Name);
+	}
+
+	public async ValueTask<bool> StopAsync(Cancel ctx = default)
+	{
+		_logger.LogInformation("Waiting to drain all inflight exports to Elasticsearch");
+		var drained = await Channel.WaitForDrainAsync(null, ctx);
+		if (!drained)
+			_collector.EmitGlobalError("Elasticsearch export: failed to complete indexing in a timely fashion while shutting down");
+
+		_logger.LogInformation("Refreshing target index {Index}", Channel.IndexName);
+		var refreshed = await Channel.RefreshAsync(ctx);
+		if (!refreshed)
+			_collector.EmitGlobalError($"Refreshing target index {Channel.IndexName} did not complete successfully");
+
+		_logger.LogInformation("Applying aliases to {Index}", Channel.IndexName);
+		var swapped = await Channel.ApplyAliasesAsync(ctx);
+		if (!swapped)
+			_collector.EmitGlobalError($"${nameof(ElasticsearchMarkdownExporter)} failed to apply aliases to index {Channel.IndexName}");
+
+		return drained && refreshed && swapped;
+	}
+
+	public async ValueTask<bool> RefreshAsync(Cancel ctx = default) => await Channel.RefreshAsync(ctx);
+
+	public async ValueTask<bool> TryWrite(DocumentationDocument document, Cancel ctx = default)
+	{
+		if (Channel.TryWrite(document))
+			return true;
+
+		if (await Channel.WaitToWriteAsync(ctx))
+			return Channel.TryWrite(document);
+		return false;
+	}
+
+	public void Dispose()
+	{
+		Channel.Complete();
+		Channel.Dispose();
+
+		GC.SuppressFinalize(this);
+	}
+}

--- a/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchMarkdownExporter.Export.cs
+++ b/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchMarkdownExporter.Export.cs
@@ -1,0 +1,194 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions;
+using Elastic.ApiExplorer.Elasticsearch;
+using Elastic.Documentation.AppliesTo;
+using Elastic.Documentation.Navigation;
+using Elastic.Documentation.Search;
+using Elastic.Ingest.Elasticsearch.Indices;
+using Elastic.Markdown.Helpers;
+using Markdig.Syntax;
+using Microsoft.Extensions.Logging;
+using static System.StringSplitOptions;
+using MarkdownParser = Markdig.Parsers.MarkdownParser;
+
+namespace Elastic.Markdown.Exporters.Elasticsearch;
+
+public partial class ElasticsearchMarkdownExporter
+{
+	/// <summary>
+	/// Assigns hash, last updated, and batch index date to a documentation document.
+	/// </summary>
+	private void AssignDocumentMetadata(DocumentationDocument doc)
+	{
+		var semanticHash = _semanticChannel.Channel.ChannelHash;
+		var lexicalHash = _lexicalChannel.Channel.ChannelHash;
+		var hash = HashedBulkUpdate.CreateHash(semanticHash, lexicalHash,
+			doc.Url, doc.Type, doc.StrippedBody ?? string.Empty, string.Join(",", doc.Headings.OrderBy(h => h)),
+			doc.SearchTitle ?? string.Empty,
+			doc.NavigationSection ?? string.Empty, doc.NavigationDepth.ToString("N0"),
+			doc.NavigationTableOfContents.ToString("N0"),
+			_fixedSynonymsHash
+		);
+		doc.Hash = hash;
+		doc.LastUpdated = _batchIndexDate;
+		doc.BatchIndexDate = _batchIndexDate;
+	}
+
+	private static void CommonEnrichments(DocumentationDocument doc, INavigationItem? navigationItem)
+	{
+		doc.SearchTitle = CreateSearchTitle();
+		// if we have no navigation, initialize to 20 since rank_feature would score 0 too high
+		doc.NavigationDepth = navigationItem?.NavigationDepth ?? 20;
+		doc.NavigationTableOfContents = navigationItem switch
+		{
+			// release-notes get effectively flattened by product, so we to dampen its effect slightly
+			IRootNavigationItem<INavigationModel, INavigationItem> when navigationItem.NavigationSection == "release notes" =>
+				Math.Min(4 * doc.NavigationDepth, 48),
+			IRootNavigationItem<INavigationModel, INavigationItem> => Math.Min(2 * doc.NavigationDepth, 48),
+			INodeNavigationItem<INavigationModel, INavigationItem> => 50,
+			_ => 100
+		};
+		doc.NavigationSection = navigationItem?.NavigationSection;
+		if (doc.Type == "api")
+			doc.NavigationSection = "api";
+
+		// this section gets promoted in the navigation we don't want it to be promoted in the search results
+		// e.g. `Use high-contrast mode in Kibana - ( docs cloud-account high contrast`
+		if (doc.NavigationSection == "manage your cloud account and preferences")
+			doc.NavigationDepth *= 2;
+
+		string CreateSearchTitle()
+		{
+			// skip doc and the section
+			var split = new[] { '/', ' ', '-', '.', '_' };
+			var urlComponents = new HashSet<string>(
+				doc.Url.Split('/', RemoveEmptyEntries).Skip(2)
+					.SelectMany(c => c.Split(split, RemoveEmptyEntries)).ToArray()
+			);
+			var title = doc.Title;
+			//skip tokens already part of the title we don't want to influence TF/IDF
+			var tokensInTitle = new HashSet<string>(title.Split(split, RemoveEmptyEntries).Select(t => t.ToLowerInvariant()));
+			return $"{doc.Title} - {string.Join(" ", urlComponents.Where(c => !tokensInTitle.Contains(c.ToLowerInvariant())))}";
+		}
+	}
+	public async ValueTask<bool> ExportAsync(MarkdownExportFileContext fileContext, Cancel ctx)
+	{
+		var file = fileContext.SourceFile;
+		var navigation = fileContext.PositionaNavigation;
+		var currentNavigation = navigation.GetNavigationFor(file);
+		var url = currentNavigation.Url;
+
+		if (url is "/docs" or "/docs/404")
+		{
+			// Skip the root and 404 pages
+			_logger.LogInformation("Skipping export for {Url}", url);
+			return true;
+		}
+
+		// Remove the first h1 because we already have the title
+		// and we don't want it to appear in the body
+		var h1 = fileContext.Document.Descendants<HeadingBlock>().FirstOrDefault(h => h.Level == 1);
+		if (h1 is not null)
+			_ = fileContext.Document.Remove(h1);
+
+		var body = LlmMarkdownExporter.ConvertToLlmMarkdown(fileContext.Document, fileContext.BuildContext);
+
+		var headings = fileContext.Document.Descendants<HeadingBlock>()
+			.Select(h => h.GetData("header") as string ?? string.Empty) // TODO: Confirm that 'header' data is correctly set for all HeadingBlock instances and that this extraction is reliable.
+			.Where(text => !string.IsNullOrEmpty(text))
+			.ToArray();
+
+		var strippedBody = body.StripMarkdown();
+		var @abstract = !string.IsNullOrEmpty(strippedBody)
+			? strippedBody[..Math.Min(strippedBody.Length, 400)] + " " + string.Join(" \n- ", headings)
+			: string.Empty;
+
+		// this is temporary until https://github.com/elastic/docs-builder/pull/2070 lands
+		// this PR will add a service for us to resolve to a versioning scheme.
+		var appliesTo = fileContext.SourceFile.YamlFrontMatter?.AppliesTo ?? ApplicableTo.Default;
+
+		var doc = new DocumentationDocument
+		{
+			Url = url,
+			Title = file.Title,
+			Type = "doc",
+			SearchTitle = file.Title, //updated in CommonEnrichments
+			Body = body,
+			StrippedBody = strippedBody,
+			Description = fileContext.SourceFile.YamlFrontMatter?.Description,
+			Abstract = @abstract,
+			Applies = appliesTo,
+			Parents = navigation.GetParentsOfMarkdownFile(file).Select(i => new ParentDocument
+			{
+				Title = i.NavigationTitle,
+				Url = i.Url
+			}).Reverse().ToArray(),
+			Headings = headings,
+			Hidden = fileContext.NavigationItem.Hidden
+		};
+
+		CommonEnrichments(doc, currentNavigation);
+		AssignDocumentMetadata(doc);
+
+		if (_indexStrategy == IngestStrategy.Multiplex)
+			return await _lexicalChannel.TryWrite(doc, ctx) && await _semanticChannel.TryWrite(doc, ctx);
+		return await _lexicalChannel.TryWrite(doc, ctx);
+	}
+
+	/// <inheritdoc />
+	public async ValueTask<bool> FinishExportAsync(IDirectoryInfo outputFolder, Cancel ctx)
+	{
+
+		// this is temporary; once we implement Elastic.ApiExplorer, this should flow through
+		// we'll rename IMarkdownExporter to IDocumentationFileExporter at that point
+		_logger.LogInformation("Exporting OpenAPI documentation to Elasticsearch");
+
+		var exporter = new OpenApiDocumentExporter(_versionsConfiguration);
+
+		await foreach (var doc in exporter.ExportDocuments(limitPerSource: null, ctx))
+		{
+			var document = MarkdownParser.Parse(doc.Body ?? string.Empty);
+
+			doc.Body = LlmMarkdownExporter.ConvertToLlmMarkdown(document, _context);
+
+			var headings = document.Descendants<HeadingBlock>()
+				.Select(h => h.GetData("header") as string ?? string.Empty) // TODO: Confirm that 'header' data is correctly set for all HeadingBlock instances and that this extraction is reliable.
+				.Where(text => !string.IsNullOrEmpty(text))
+				.ToArray();
+
+			doc.StrippedBody = doc.Body.StripMarkdown();
+			var @abstract = !string.IsNullOrEmpty(doc.StrippedBody)
+				? doc.Body[..Math.Min(doc.StrippedBody.Length, 400)] + " " + string.Join(" \n- ", doc.Headings)
+				: string.Empty;
+			doc.Abstract = @abstract;
+			doc.Headings = headings;
+			CommonEnrichments(doc, null);
+			AssignDocumentMetadata(doc);
+
+			// Write to channels following the multiplex or reindex strategy
+			if (_indexStrategy == IngestStrategy.Multiplex)
+			{
+				if (!await _lexicalChannel.TryWrite(doc, ctx) || !await _semanticChannel.TryWrite(doc, ctx))
+				{
+					_logger.LogError("Failed to write OpenAPI document {Url}", doc.Url);
+					return false;
+				}
+			}
+			else
+			{
+				if (!await _lexicalChannel.TryWrite(doc, ctx))
+				{
+					_logger.LogError("Failed to write OpenAPI document {Url}", doc.Url);
+					return false;
+				}
+			}
+		}
+
+		_logger.LogInformation("Finished exporting OpenAPI documentation");
+		return true;
+	}
+
+}

--- a/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchMarkdownExporter.cs
+++ b/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchMarkdownExporter.cs
@@ -2,40 +2,31 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-using System.IO.Abstractions;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Elastic.ApiExplorer.Elasticsearch;
-using Elastic.Documentation.AppliesTo;
 using Elastic.Documentation.Configuration;
 using Elastic.Documentation.Configuration.Search;
 using Elastic.Documentation.Configuration.Versions;
 using Elastic.Documentation.Diagnostics;
-using Elastic.Documentation.Navigation;
-using Elastic.Documentation.Search;
 using Elastic.Ingest.Elasticsearch;
 using Elastic.Ingest.Elasticsearch.Indices;
-using Elastic.Markdown.Helpers;
 using Elastic.Transport;
 using Elastic.Transport.Products.Elasticsearch;
-using Markdig.Syntax;
 using Microsoft.Extensions.Logging;
 using NetEscapades.EnumGenerators;
-using static System.StringSplitOptions;
-using MarkdownParser = Markdig.Parsers.MarkdownParser;
 
 namespace Elastic.Markdown.Exporters.Elasticsearch;
 
 [EnumExtensions]
 public enum IngestStrategy { Reindex, Multiplex }
 
-public class ElasticsearchMarkdownExporter : IMarkdownExporter, IDisposable
+public partial class ElasticsearchMarkdownExporter : IMarkdownExporter, IDisposable
 {
 	private readonly IDiagnosticsCollector _collector;
 	private readonly IDocumentationConfigurationContext _context;
 	private readonly ILogger _logger;
-	private readonly ElasticsearchLexicalExporter _lexicalChannel;
-	private readonly ElasticsearchSemanticExporter _semanticChannel;
+	private readonly ElasticsearchLexicalIngestChannel _lexicalChannel;
+	private readonly ElasticsearchSemanticIngestChannel _semanticChannel;
 
 	private readonly ElasticsearchEndpoint _endpoint;
 
@@ -104,8 +95,8 @@ public class ElasticsearchMarkdownExporter : IMarkdownExporter, IDisposable
 		}).Where(r => fixedSynonyms.Contains(r.Id)).Select(r => r.Synonyms).ToArray();
 		_fixedSynonymsHash = HashedBulkUpdate.CreateHash(string.Join(",", indexTimeSynonyms));
 
-		_lexicalChannel = new ElasticsearchLexicalExporter(logFactory, collector, es, indexNamespace, _transport, indexTimeSynonyms);
-		_semanticChannel = new ElasticsearchSemanticExporter(logFactory, collector, es, indexNamespace, _transport, indexTimeSynonyms);
+		_lexicalChannel = new ElasticsearchLexicalIngestChannel(logFactory, collector, es, indexNamespace, _transport, indexTimeSynonyms);
+		_semanticChannel = new ElasticsearchSemanticIngestChannel(logFactory, collector, es, indexNamespace, _transport, indexTimeSynonyms);
 	}
 
 	/// <inheritdoc />
@@ -438,178 +429,6 @@ public class ElasticsearchMarkdownExporter : IMarkdownExporter, IDisposable
 				await Task.Delay(TimeSpan.FromSeconds(5), ctx);
 
 		} while (!completed);
-	}
-
-	/// <summary>
-	/// Assigns hash, last updated, and batch index date to a documentation document.
-	/// </summary>
-	private void AssignDocumentMetadata(DocumentationDocument doc)
-	{
-		var semanticHash = _semanticChannel.Channel.ChannelHash;
-		var lexicalHash = _lexicalChannel.Channel.ChannelHash;
-		var hash = HashedBulkUpdate.CreateHash(semanticHash, lexicalHash,
-			doc.Url, doc.Type, doc.StrippedBody ?? string.Empty, string.Join(",", doc.Headings.OrderBy(h => h)),
-			doc.SearchTitle ?? string.Empty,
-			doc.NavigationSection ?? string.Empty, doc.NavigationDepth.ToString("N0"),
-			doc.NavigationTableOfContents.ToString("N0"),
-			_fixedSynonymsHash
-		);
-		doc.Hash = hash;
-		doc.LastUpdated = _batchIndexDate;
-		doc.BatchIndexDate = _batchIndexDate;
-	}
-
-	private void CommonEnrichments(DocumentationDocument doc, INavigationItem? navigationItem)
-	{
-		doc.SearchTitle = CreateSearchTitle();
-		// if we have no navigation, initialize to 20 since rank_feature would score 0 too high
-		doc.NavigationDepth = navigationItem?.NavigationDepth ?? 20;
-		doc.NavigationTableOfContents = navigationItem switch
-		{
-			// release-notes get effectively flattened by product, so we to dampen its effect slightly
-			IRootNavigationItem<INavigationModel, INavigationItem> when navigationItem.NavigationSection == "release notes" =>
-				Math.Min(4 * doc.NavigationDepth, 48),
-			IRootNavigationItem<INavigationModel, INavigationItem> => Math.Min(2 * doc.NavigationDepth, 48),
-			INodeNavigationItem<INavigationModel, INavigationItem> => 50,
-			_ => 100
-		};
-		doc.NavigationSection = navigationItem?.NavigationSection;
-		if (doc.Type == "api")
-			doc.NavigationSection = "api";
-
-		// this section gets promoted in the navigation we don't want it to be promoted in the search results
-		// e.g. `Use high-contrast mode in Kibana - ( docs cloud-account high contrast`
-		if (doc.NavigationSection == "manage your cloud account and preferences")
-			doc.NavigationDepth *= 2;
-
-		string CreateSearchTitle()
-		{
-			// skip doc and the section
-			var split = new[] { '/', ' ', '-', '.', '_' };
-			var urlComponents = new HashSet<string>(
-				doc.Url.Split('/', RemoveEmptyEntries).Skip(2)
-					.SelectMany(c => c.Split(split, RemoveEmptyEntries)).ToArray()
-			);
-			var title = doc.Title ?? string.Empty;
-			//skip tokens already part of the title we don't want to influence TF/IDF
-			var tokensInTitle = new HashSet<string>(title.Split(split, RemoveEmptyEntries).Select(t => t.ToLowerInvariant()));
-			return $"{doc.Title} - {string.Join(" ", urlComponents.Where(c => !tokensInTitle.Contains(c.ToLowerInvariant())))}";
-		}
-	}
-
-	public async ValueTask<bool> ExportAsync(MarkdownExportFileContext fileContext, Cancel ctx)
-	{
-		var file = fileContext.SourceFile;
-		var navigation = fileContext.PositionaNavigation;
-		var currentNavigation = navigation.GetNavigationFor(file);
-		var url = currentNavigation.Url;
-
-		if (url is "/docs" or "/docs/404")
-		{
-			// Skip the root and 404 pages
-			_logger.LogInformation("Skipping export for {Url}", url);
-			return true;
-		}
-
-		// Remove the first h1 because we already have the title
-		// and we don't want it to appear in the body
-		var h1 = fileContext.Document.Descendants<HeadingBlock>().FirstOrDefault(h => h.Level == 1);
-		if (h1 is not null)
-			_ = fileContext.Document.Remove(h1);
-
-		var body = LlmMarkdownExporter.ConvertToLlmMarkdown(fileContext.Document, fileContext.BuildContext);
-
-		var headings = fileContext.Document.Descendants<HeadingBlock>()
-			.Select(h => h.GetData("header") as string ?? string.Empty) // TODO: Confirm that 'header' data is correctly set for all HeadingBlock instances and that this extraction is reliable.
-			.Where(text => !string.IsNullOrEmpty(text))
-			.ToArray();
-
-		var strippedBody = body.StripMarkdown();
-		var @abstract = !string.IsNullOrEmpty(strippedBody)
-			? strippedBody[..Math.Min(strippedBody.Length, 400)] + " " + string.Join(" \n- ", headings)
-			: string.Empty;
-
-		// this is temporary until https://github.com/elastic/docs-builder/pull/2070 lands
-		// this PR will add a service for us to resolve to a versioning scheme.
-		var appliesTo = fileContext.SourceFile.YamlFrontMatter?.AppliesTo ?? ApplicableTo.Default;
-
-		var doc = new DocumentationDocument
-		{
-			Url = url,
-			Title = file.Title,
-			Body = body,
-			StrippedBody = strippedBody,
-			Description = fileContext.SourceFile.YamlFrontMatter?.Description,
-			Abstract = @abstract,
-			Applies = appliesTo,
-			Parents = navigation.GetParentsOfMarkdownFile(file).Select(i => new ParentDocument
-			{
-				Title = i.NavigationTitle,
-				Url = i.Url
-			}).Reverse().ToArray(),
-			Headings = headings,
-			Hidden = fileContext.NavigationItem.Hidden
-		};
-
-		CommonEnrichments(doc, currentNavigation);
-		AssignDocumentMetadata(doc);
-
-		if (_indexStrategy == IngestStrategy.Multiplex)
-			return await _lexicalChannel.TryWrite(doc, ctx) && await _semanticChannel.TryWrite(doc, ctx);
-		return await _lexicalChannel.TryWrite(doc, ctx);
-	}
-
-	/// <inheritdoc />
-	public async ValueTask<bool> FinishExportAsync(IDirectoryInfo outputFolder, Cancel ctx)
-	{
-
-		// this is temporary; once we implement Elastic.ApiExplorer, this should flow through
-		// we'll rename IMarkdownExporter to IDocumentationFileExporter at that point
-		_logger.LogInformation("Exporting OpenAPI documentation to Elasticsearch");
-
-		var exporter = new OpenApiDocumentExporter(_versionsConfiguration);
-
-		await foreach (var doc in exporter.ExportDocuments(limitPerSource: null, ctx))
-		{
-			var document = MarkdownParser.Parse(doc.Body ?? string.Empty);
-
-			doc.Body = LlmMarkdownExporter.ConvertToLlmMarkdown(document, _context);
-
-			var headings = document.Descendants<HeadingBlock>()
-				.Select(h => h.GetData("header") as string ?? string.Empty) // TODO: Confirm that 'header' data is correctly set for all HeadingBlock instances and that this extraction is reliable.
-				.Where(text => !string.IsNullOrEmpty(text))
-				.ToArray();
-
-			doc.StrippedBody = doc.Body.StripMarkdown();
-			var @abstract = !string.IsNullOrEmpty(doc.StrippedBody)
-				? doc.Body[..Math.Min(doc.StrippedBody.Length, 400)] + " " + string.Join(" \n- ", doc.Headings)
-				: string.Empty;
-			doc.Abstract = @abstract;
-			doc.Headings = headings;
-			CommonEnrichments(doc, null);
-			AssignDocumentMetadata(doc);
-
-			// Write to channels following the multiplex or reindex strategy
-			if (_indexStrategy == IngestStrategy.Multiplex)
-			{
-				if (!await _lexicalChannel.TryWrite(doc, ctx) || !await _semanticChannel.TryWrite(doc, ctx))
-				{
-					_logger.LogError("Failed to write OpenAPI document {Url}", doc.Url);
-					return false;
-				}
-			}
-			else
-			{
-				if (!await _lexicalChannel.TryWrite(doc, ctx))
-				{
-					_logger.LogError("Failed to write OpenAPI document {Url}", doc.Url);
-					return false;
-				}
-			}
-		}
-
-		_logger.LogInformation("Finished exporting OpenAPI documentation");
-		return true;
 	}
 
 	/// <inheritdoc />

--- a/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchMarkdownExporter.cs
+++ b/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchMarkdownExporter.cs
@@ -46,7 +46,7 @@ public class ElasticsearchMarkdownExporter : IMarkdownExporter, IDisposable
 	private string _currentLexicalHash = string.Empty;
 	private string _currentSemanticHash = string.Empty;
 
-	private readonly IReadOnlyCollection<string> _synonyms;
+	private readonly IReadOnlyDictionary<string, string[]> _synonyms;
 	private readonly IReadOnlyCollection<QueryRule> _rules;
 	private readonly VersionsConfiguration _versionsConfiguration;
 	private readonly string _fixedSynonymsHash;
@@ -98,8 +98,8 @@ public class ElasticsearchMarkdownExporter : IMarkdownExporter, IDisposable
 		string[] fixedSynonyms = ["esql", "data-stream", "data-streams", "machine-learning"];
 		var indexTimeSynonyms = _synonyms.Aggregate(new List<SynonymRule>(), (acc, synonym) =>
 		{
-			var id = synonym.Split(",", RemoveEmptyEntries)[0].Trim();
-			acc.Add(new SynonymRule { Id = id, Synonyms = synonym });
+			var id = synonym.Key;
+			acc.Add(new SynonymRule { Id = id, Synonyms = string.Join(", ", synonym.Value) });
 			return acc;
 		}).Where(r => fixedSynonyms.Contains(r.Id)).Select(r => r.Synonyms).ToArray();
 		_fixedSynonymsHash = HashedBulkUpdate.CreateHash(string.Join(",", indexTimeSynonyms));
@@ -169,8 +169,8 @@ public class ElasticsearchMarkdownExporter : IMarkdownExporter, IDisposable
 
 		var synonymRules = _synonyms.Aggregate(new List<SynonymRule>(), (acc, synonym) =>
 		{
-			var id = synonym.Split(",", RemoveEmptyEntries)[0].Trim();
-			acc.Add(new SynonymRule { Id = id, Synonyms = synonym });
+			var id = synonym.Key;
+			acc.Add(new SynonymRule { Id = id, Synonyms = string.Join(", ", synonym.Value) });
 			return acc;
 		});
 

--- a/src/Elastic.Markdown/IO/MarkdownFile.cs
+++ b/src/Elastic.Markdown/IO/MarkdownFile.cs
@@ -47,7 +47,7 @@ public record MarkdownFile : DocumentationFile, ITableOfContentsScope, IDocument
 		//todo refactor mutability of MarkdownFile as a whole
 		ScopeDirectory = build.Configuration.ScopeDirectory;
 		Products = build.ProductsConfiguration;
-		Title = FileName.StripMarkdown();
+		Title = RelativePath;
 	}
 
 	public ProductsConfiguration Products { get; }
@@ -165,11 +165,8 @@ public record MarkdownFile : DocumentationFile, ITableOfContentsScope, IDocument
 				NavigationTitle = replacement;
 		}
 
-		if (string.IsNullOrEmpty(Title))
-		{
-			Title = RelativePath;
+		if (Title == RelativePath)
 			Collector.EmitWarning(FilePath, "Document has no title, using file name as title.");
-		}
 		else if (Title.AsSpan().ReplaceSubstitutions(subs, Collector, out var replacement))
 			Title = replacement;
 

--- a/src/Elastic.Markdown/IO/MarkdownFile.cs
+++ b/src/Elastic.Markdown/IO/MarkdownFile.cs
@@ -47,7 +47,7 @@ public record MarkdownFile : DocumentationFile, ITableOfContentsScope, IDocument
 		//todo refactor mutability of MarkdownFile as a whole
 		ScopeDirectory = build.Configuration.ScopeDirectory;
 		Products = build.ProductsConfiguration;
-
+		Title = FileName.StripMarkdown();
 	}
 
 	public ProductsConfiguration Products { get; }
@@ -61,12 +61,12 @@ public record MarkdownFile : DocumentationFile, ITableOfContentsScope, IDocument
 	public YamlFrontMatter? YamlFrontMatter { get; private set; }
 	public string? TitleRaw { get; protected set; }
 
-	public string? Title
+	public string Title
 	{
 		get;
 		protected set
 		{
-			field = value?.StripMarkdown();
+			field = value.StripMarkdown();
 			TitleRaw = value;
 		}
 	}
@@ -148,9 +148,9 @@ public record MarkdownFile : DocumentationFile, ITableOfContentsScope, IDocument
 
 	protected void ReadDocumentInstructions(MarkdownDocument document, Func<string, DocumentationFile?> documentationFileLookup)
 	{
-		Title ??= document
+		Title = document
 			.FirstOrDefault(block => block is HeadingBlock { Level: 1 })?
-			.GetData("header") as string;
+			.GetData("header") as string ?? Title;
 
 		var yamlFrontMatter = ProcessYamlFrontMatter(document);
 		YamlFrontMatter = yamlFrontMatter;

--- a/src/api/Elastic.Documentation.Api.Infrastructure/Adapters/Search/ElasticsearchGateway.cs
+++ b/src/api/Elastic.Documentation.Api.Infrastructure/Adapters/Search/ElasticsearchGateway.cs
@@ -12,67 +12,11 @@ using Elastic.Clients.Elasticsearch.Serialization;
 using Elastic.Documentation.Api.Core.Search;
 using Elastic.Documentation.AppliesTo;
 using Elastic.Documentation.Configuration.Search;
+using Elastic.Documentation.Search;
 using Elastic.Transport;
 using Microsoft.Extensions.Logging;
 
 namespace Elastic.Documentation.Api.Infrastructure.Adapters.Search;
-
-internal sealed record DocumentDto
-{
-	[JsonPropertyName("title")]
-	public required string Title { get; init; }
-
-	[JsonPropertyName("search_title")]
-	public required string SearchTitle { get; init; }
-
-	[JsonPropertyName("url")]
-	public required string Url { get; init; }
-
-	[JsonPropertyName("navigation_depth")]
-	public int NavigationDepth { get; init; }
-
-	[JsonPropertyName("navigation_table_of_contents")]
-	public int NavigationTableOfContents { get; init; }
-
-	[JsonPropertyName("navigation_section")]
-	public string? NavigationSection { get; init; }
-
-	[JsonPropertyName("description")]
-	public string? Description { get; init; }
-
-	[JsonPropertyName("type")]
-	public string Type { get; init; } = "doc";
-
-	[JsonPropertyName("body")]
-	public string? Body { get; init; }
-
-	[JsonPropertyName("stripped_body")]
-	public string? StrippedBody { get; init; }
-
-	[JsonPropertyName("abstract")]
-	public string? Abstract { get; init; }
-
-	[JsonPropertyName("headings")]
-	public string[] Headings { get; init; } = [];
-
-	[JsonPropertyName("parents")]
-	public ParentDocumentDto[] Parents { get; init; } = [];
-
-	[JsonPropertyName("applies_to")]
-	public ApplicableTo? Applies { get; init; }
-
-	[JsonPropertyName("hidden")]
-	public bool Hidden { get; init; } = false;
-}
-
-internal sealed record ParentDocumentDto
-{
-	[JsonPropertyName("title")]
-	public required string Title { get; init; }
-
-	[JsonPropertyName("url")]
-	public required string Url { get; init; }
-}
 
 public partial class ElasticsearchGateway : ISearchGateway
 {
@@ -88,7 +32,6 @@ public partial class ElasticsearchGateway : ISearchGateway
 		_logger = logger;
 		_elasticsearchOptions = elasticsearchOptions;
 		_searchConfiguration = searchConfiguration;
-		_diminishTerms = searchConfiguration.DiminishTerms;
 		_rulesetName = searchConfiguration.Rules.Count > 0 ? ExtractRulesetName(elasticsearchOptions.IndexName) : null;
 		var nodePool = new SingleNodePool(new Uri(elasticsearchOptions.Url.Trim()));
 		var clientSettings = new ElasticsearchClientSettings(
@@ -99,6 +42,14 @@ public partial class ElasticsearchGateway : ISearchGateway
 			.Authentication(new ApiKey(elasticsearchOptions.ApiKey));
 
 		_client = new ElasticsearchClient(clientSettings);
+
+		_diminishTerms = searchConfiguration.DiminishTerms;
+		DiminishTermsQuery = new MultiMatchQuery
+		{
+			Query = string.Join(' ', _diminishTerms),
+			Operator = Operator.Or,
+			Fields = new[] { "search_title", "url.match" }
+		};
 	}
 
 	public async Task<bool> CanConnect(Cancel ctx) => (await _client.PingAsync(ctx)).IsValidResponse;
@@ -114,7 +65,7 @@ public partial class ElasticsearchGateway : ISearchGateway
 	{
 		// Index name format: semantic-docs-{namespace}-latest
 		var parts = indexName.Split('-');
-		if (parts.Length >= 3 && parts[0] == "semantic" && parts[1] == "docs")
+		if (parts is ["semantic", "docs", _, ..])
 			return $"docs-ruleset-{parts[2]}";
 		return null;
 	}
@@ -160,7 +111,7 @@ public partial class ElasticsearchGateway : ISearchGateway
 	/// </summary>
 	private Query BuildLexicalQuery(string searchQuery)
 	{
-		var tokens = searchQuery.Split(Array.Empty<char>(), StringSplitOptions.RemoveEmptyEntries);
+		var tokens = searchQuery.Split(' ', StringSplitOptions.RemoveEmptyEntries);
 
 		var query =
 			(Query)new ConstantScoreQuery
@@ -220,7 +171,7 @@ public partial class ElasticsearchGateway : ISearchGateway
 			{
 				Filter = new MatchQuery
 				{
-					Field = Infer.Field<DocumentDto>(f => f.Url.Suffix("match")),
+					Field = Infer.Field<DocumentationDocument>(f => f.Url.Suffix("match")),
 					Query = searchQuery
 				},
 				Boost = 0.3f
@@ -242,18 +193,7 @@ public partial class ElasticsearchGateway : ISearchGateway
 		{
 			Must = [query],
 			Filter = [DocumentFilter],
-			Should = [
-				new RankFeatureQuery {
-					Field = Infer.Field<DocumentDto>(f => f.NavigationDepth),
-					Boost = 0.8f
-				},
-				new RankFeatureQuery {
-					Field = Infer.Field<DocumentDto>(f => f.NavigationTableOfContents),
-					Boost = 0.8f
-				},
-				new TermQuery { Field = Infer.Field<DocumentDto>(f => f.NavigationSection ), Value = "reference", Boost = 0.15f },
-				new TermQuery { Field = Infer.Field<DocumentDto>(f => f.NavigationSection ), Value = "getting-started", Boost = 0.1f }
-			]
+			Should = ScoringQueries
 		};
 
 		Query baseQuery = _diminishTerms.Count == 0
@@ -262,12 +202,7 @@ public partial class ElasticsearchGateway : ISearchGateway
 			{
 				Positive = positiveQuery,
 				NegativeBoost = 0.8,
-				Negative = new MultiMatchQuery
-				{
-					Query = string.Join(' ', _diminishTerms),
-					Operator = Operator.Or,
-					Fields = new[] { "search_title", "url.match" }
-				}
+				Negative = DiminishTermsQuery
 			};
 
 		return WrapWithRuleQuery(baseQuery, searchQuery);
@@ -280,9 +215,27 @@ public partial class ElasticsearchGateway : ISearchGateway
 		(Query)new SemanticQuery("title.semantic_text", searchQuery) { Boost = 5.0f }
 		|| new SemanticQuery("abstract.semantic_text", searchQuery) { Boost = 3.0f };
 
-	private static Query DocumentFilter { get; } = !(Query)new TermsQuery(Infer.Field<DocumentDto>(f => f.Url.Suffix("keyword")),
+	private Query DiminishTermsQuery { get; }
+
+	private static Query[] ScoringQueries { get; } =
+	[
+		new RankFeatureQuery
+		{
+			Field = Infer.Field<DocumentationDocument>(f => f.NavigationDepth),
+			Boost = 0.8f
+		},
+		new RankFeatureQuery
+		{
+			Field = Infer.Field<DocumentationDocument>(f => f.NavigationTableOfContents),
+			Boost = 0.8f
+		},
+		new TermQuery { Field = Infer.Field<DocumentationDocument>(f => f.NavigationSection), Value = "reference", Boost = 0.15f },
+		new TermQuery { Field = Infer.Field<DocumentationDocument>(f => f.NavigationSection), Value = "getting-started", Boost = 0.1f }
+	];
+
+	private static Query DocumentFilter { get; } = !(Query)new TermsQuery(Infer.Field<DocumentationDocument>(f => f.Url.Suffix("keyword")),
 		new TermsQueryField(["/docs", "/docs/", "/docs/404", "/docs/404/"]))
-		&& !(Query)new TermQuery { Field = Infer.Field<DocumentDto>(f => f.Hidden), Value = true };
+		&& !(Query)new TermQuery { Field = Infer.Field<DocumentationDocument>(f => f.Hidden), Value = true };
 
 	public async Task<(int TotalHits, List<SearchResultItem> Results)> HybridSearchWithRrfAsync(string query, int pageNumber, int pageSize,
 		Cancel ctx = default)
@@ -293,16 +246,15 @@ public partial class ElasticsearchGateway : ISearchGateway
 		const string postTag = "</mark>";
 
 		var searchQuery = query;
-		var lexicalSearchRetriever = BuildLexicalQuery(searchQuery);
-		var semanticSearchRetriever = BuildSemanticQuery(searchQuery);
+		var lexicalQuery = BuildLexicalQuery(searchQuery);
 
 		try
 		{
-			var response = await _client.SearchAsync<DocumentDto>(s => s
+			var response = await _client.SearchAsync<DocumentationDocument>(s => s
 				.Indices(_elasticsearchOptions.IndexName)
 				.From(Math.Max(pageNumber - 1, 0) * pageSize)
 				.Size(pageSize)
-				.Query(BuildLexicalQuery(query))
+				.Query(lexicalQuery)
 				// .Retriever(r => r
 				// 	.Rrf(rrf => rrf
 				// 		.Filter(BuildFilter())
@@ -332,7 +284,7 @@ public partial class ElasticsearchGateway : ISearchGateway
 				.Highlight(h => h
 					.RequireFieldMatch(true)
 					.Fields(f => f
-						.Add(Infer.Field<DocumentDto>(d => d.SearchTitle.Suffix("completion")), hf => hf
+						.Add(Infer.Field<DocumentationDocument>(d => d.SearchTitle.Suffix("completion")), hf => hf
 							.FragmentSize(150)
 							.NumberOfFragments(3)
 							.NoMatchSize(150)
@@ -347,7 +299,7 @@ public partial class ElasticsearchGateway : ISearchGateway
 							))
 							.PreTags(preTag)
 							.PostTags(postTag))
-						.Add(Infer.Field<DocumentDto>(d => d.StrippedBody), hf => hf
+						.Add(Infer.Field<DocumentationDocument>(d => d.StrippedBody), hf => hf
 							.FragmentSize(150)
 							.NumberOfFragments(3)
 							.NoMatchSize(150)
@@ -382,7 +334,7 @@ public partial class ElasticsearchGateway : ISearchGateway
 		}
 	}
 
-	private static (int TotalHits, List<SearchResultItem> Results) ProcessSearchResponse(SearchResponse<DocumentDto> response)
+	private static (int TotalHits, List<SearchResultItem> Results) ProcessSearchResponse(SearchResponse<DocumentationDocument> response)
 	{
 		var totalHits = (int)response.Total;
 
@@ -432,7 +384,6 @@ public partial class ElasticsearchGateway : ISearchGateway
 	{
 		var searchQuery = query;
 		var lexicalQuery = BuildLexicalQuery(searchQuery);
-		//var semanticQuery = BuildSemanticQuery(searchQuery);
 
 		// Combine queries with bool should to match RRF behavior
 		var combinedQuery = (Query)new BoolQuery
@@ -444,7 +395,7 @@ public partial class ElasticsearchGateway : ISearchGateway
 		try
 		{
 			// First, find the document by URL
-			var getDocResponse = await _client.SearchAsync<DocumentDto>(s => s
+			var getDocResponse = await _client.SearchAsync<DocumentationDocument>(s => s
 				.Indices(_elasticsearchOptions.IndexName)
 				.Query(q => q.Term(t => t.Field(f => f.Url).Value(documentUrl)))
 				.Size(1), ctx);
@@ -463,7 +414,7 @@ public partial class ElasticsearchGateway : ISearchGateway
 			var documentId = getDocResponse.Hits.First().Id;
 
 			// Now explain why this document matches (or doesn't match) the query
-			var explainResponse = await _client.ExplainAsync<DocumentDto>(_elasticsearchOptions.IndexName, documentId, e => e
+			var explainResponse = await _client.ExplainAsync<DocumentationDocument>(_elasticsearchOptions.IndexName, documentId, e => e
 				.Query(combinedQuery), ctx);
 
 			if (!explainResponse.IsValidResponse)
@@ -569,8 +520,8 @@ public sealed record ExplainResult
 	public string Explanation { get; init; } = string.Empty;
 }
 
-[JsonSerializable(typeof(DocumentDto))]
-[JsonSerializable(typeof(ParentDocumentDto))]
+[JsonSerializable(typeof(DocumentationDocument))]
+[JsonSerializable(typeof(ParentDocument))]
 [JsonSerializable(typeof(RuleQueryMatchCriteria))]
 internal sealed partial class EsJsonContext : JsonSerializerContext;
 

--- a/tests-integration/Elastic.Assembler.IntegrationTests/Search/SearchBootstrapFixture.cs
+++ b/tests-integration/Elastic.Assembler.IntegrationTests/Search/SearchBootstrapFixture.cs
@@ -176,7 +176,7 @@ public class SearchBootstrapFixture(DocumentationFixture fixture) : IAsyncLifeti
 			var collector = new ConsoleDiagnosticsCollector(loggerFactory);
 
 			// Create semantic exporter to check channel hash (index namespace is 'dev' for tests)
-			using var semanticExporter = new ElasticsearchSemanticExporter(
+			using var semanticExporter = new ElasticsearchSemanticIngestChannel(
 				loggerFactory,
 				collector,
 				endpoint,

--- a/tests-integration/Elastic.Assembler.IntegrationTests/TestHelpers.cs
+++ b/tests-integration/Elastic.Assembler.IntegrationTests/TestHelpers.cs
@@ -52,7 +52,7 @@ public static class TestHelpers
 				}
 			}.ToFrozenDictionary()
 		};
-		var search = new SearchConfiguration { Synonyms = [], Rules = [], DiminishTerms = [] };
+		var search = new SearchConfiguration { Synonyms = new Dictionary<string, string[]>(), Rules = [], DiminishTerms = [] };
 		return new ConfigurationContext
 		{
 			Endpoints = new DocumentationEndpoints

--- a/tests-integration/Search.IntegrationTests/SearchRelevanceTests.cs
+++ b/tests-integration/Search.IntegrationTests/SearchRelevanceTests.cs
@@ -31,15 +31,16 @@ public class SearchRelevanceTests(ITestOutputHelper output)
 		{ "elasticsearch getting started", "/docs/solutions/search/get-started", null },
 		{ "elastic common schema", "/docs/reference/ecs", null },
 		{ "ecs", "/docs/reference/ecs", null },
-		{ "c# client", "/docs/reference/elasticsearch/clients/dotnet", null },
-		{ "dotnet client", "/docs/reference/elasticsearch/clients/dotnet", null },
+		{ "c# client", "/docs/reference/elasticsearch/clients/dotnet/installation", ["/docs/reference/elasticsearch/clients/dotnet"] },
+		{ "dotnet client", "/docs/reference/elasticsearch/clients/dotnet/installation", ["/docs/reference/elasticsearch/clients/dotnet"] },
 		{ "runscript", "/docs/api/doc/kibana/operation/operation-runscriptaction", [ "/docs/solutions/security/endpoint-response-actions" ] },
 		{ "data-streams", "/docs/manage-data/data-store/data-streams", null },
 		{ "datastream", "/docs/manage-data/data-store/data-streams", null },
 		{ "data stream", "/docs/manage-data/data-store/data-streams", null },
 		{ "saml sso", "/docs/deploy-manage/users-roles/cloud-organization/configure-saml-authentication", ["/docs/deploy-manage/users-roles/cloud-organization/configure-saml-authentication"] },
 		{ "templates", "/docs/manage-data/data-store/templates", null},
-		{ "query dsl", "/docs/reference/query-languages/querydsl", ["/docs/explore-analyze/query-filter/languages/querydsl"]},
+		// different results because of the exact match on title, QueryDSL needs to be normalized in the content
+		{ "query dsl", "/docs/explore-analyze/query-filter/languages/querydsl", ["/docs/explore-analyze/query-filter/languages/querydsl"]},
 		{ "querydsl", "/docs/reference/query-languages/querydsl", ["/docs/explore-analyze/query-filter/languages/querydsl"]},
 		{ "Agent policy", "/docs/reference/fleet/agent-policy", null},
 		{ "aliases", "/docs/manage-data/data-store/aliases", null},
@@ -56,7 +57,14 @@ public class SearchRelevanceTests(ITestOutputHelper output)
 		{ "esql", "/docs/reference/query-languages/esql", null},
 		{ "ES|QL", "/docs/reference/query-languages/esql", null},
 		{ "Output plugins for Logstash", "/docs/reference/logstash/plugins/output-plugins", null},
-		{ "Sending data to Elastic Cloud Hosted", "/docs/solutions/observability/get-started/quickstart-elastic-cloud-otel-endpoint", ["/docs/reference/logstash/connecting-to-cloud"]},
+		// exact match on title wins but with variations we prefer the more general topic page
+		{ "Sending data to Elastic Cloud Hosted", "/docs/reference/logstash/connecting-to-cloud", ["/docs/solutions/observability/get-started/quickstart-elastic-cloud-otel-endpoint"]},
+		{ "Send data to Elastic Cloud Hosted", "/docs/solutions/observability/get-started/quickstart-elastic-cloud-otel-endpoint", ["/docs/reference/logstash/connecting-to-cloud"]},
+
+		{ "universal profiling", "/docs/solutions/observability/infra-and-hosts/universal-profiling", null},
+		{ "agg", "/docs/explore-analyze/query-filter/aggregations", null},
+		{ "a", "/docs/reference/apm/observability/apm", null},
+		//universal profiling
 	};
 
 	[Theory]
@@ -232,7 +240,7 @@ See test output above for detailed scoring breakdowns from Elasticsearch's _expl
 		var options = new ElasticsearchOptions(parameterProvider);
 		var searchConfig = new SearchConfiguration
 		{
-			Synonyms = [],
+			Synonyms = new Dictionary<string, string[]>(),
 			Rules =
 			[
 				new QueryRule

--- a/tests/Elastic.ApiExplorer.Tests/TestHelpers.cs
+++ b/tests/Elastic.ApiExplorer.Tests/TestHelpers.cs
@@ -46,7 +46,7 @@ public static class TestHelpers
 				}
 			}.ToFrozenDictionary()
 		};
-		var search = new SearchConfiguration { Synonyms = [], Rules = [], DiminishTerms = [] };
+		var search = new SearchConfiguration { Synonyms = new Dictionary<string, string[]>(), Rules = [], DiminishTerms = [] };
 		return new ConfigurationContext
 		{
 			Endpoints = new DocumentationEndpoints

--- a/tests/Elastic.Markdown.Tests/Inline/FootnotesTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/FootnotesTests.cs
@@ -302,6 +302,8 @@ public partial class FootnotesCodeBlockInDirectiveTests(ITestOutputHelper output
 	[^2]: This is the second footnote.
 	""")
 {
+	private readonly ITestOutputHelper _output = output;
+
 	[Fact]
 	public void CodeBlockRendered()
 	{
@@ -314,9 +316,9 @@ public partial class FootnotesCodeBlockInDirectiveTests(ITestOutputHelper output
 		// Should have exactly 2 back-references (one for [^1] and one for [^2])
 		// If code block content is being parsed, we'd see 4 back-references
 		var count = BackRefRegex().Count(Html);
-		output.WriteLine("=== HTML ===");
-		output.WriteLine(Html);
-		output.WriteLine("=== END ===");
+		_output.WriteLine("=== HTML ===");
+		_output.WriteLine(Html);
+		_output.WriteLine("=== END ===");
 		count.Should().Be(2, $"Expected 2 back-refs (one per footnote), got {count}. Code block content may be parsed incorrectly.");
 	}
 

--- a/tests/Elastic.Markdown.Tests/Search/DocumentationDocumentSerializationTests.cs
+++ b/tests/Elastic.Markdown.Tests/Search/DocumentationDocumentSerializationTests.cs
@@ -21,8 +21,10 @@ public class DocumentationDocumentSerializationTests
 	{
 		var doc = new DocumentationDocument
 		{
+			Type = "doc",
 			Url = "/test/page",
 			Title = "Test Page",
+			SearchTitle = "Test Page",
 			Applies = new ApplicableTo
 			{
 				Stack = AppliesCollection.GenerallyAvailable
@@ -53,8 +55,10 @@ public class DocumentationDocumentSerializationTests
 	{
 		var doc = new DocumentationDocument
 		{
+			Type = "doc",
 			Url = "/test/deployment",
 			Title = "Deployment Test",
+			SearchTitle = "Deployment Test",
 			Applies = new ApplicableTo
 			{
 				Deployment = new DeploymentApplicability
@@ -93,8 +97,10 @@ public class DocumentationDocumentSerializationTests
 	{
 		var doc = new DocumentationDocument
 		{
+			Type = "doc",
 			Url = "/test/serverless",
 			Title = "Serverless Test",
+			SearchTitle = "Serverless Test",
 			Applies = new ApplicableTo
 			{
 				Serverless = new ServerlessProjectApplicability
@@ -133,8 +139,10 @@ public class DocumentationDocumentSerializationTests
 	{
 		var doc = new DocumentationDocument
 		{
+			Type = "doc",
 			Url = "/test/product",
 			Title = "Product Test",
+			SearchTitle = "Product Test",
 			Applies = new ApplicableTo
 			{
 				Product = new AppliesCollection([new Applicability { Lifecycle = ProductLifecycle.Beta, Version = (SemVersion)"2.0.0" }])
@@ -161,8 +169,10 @@ public class DocumentationDocumentSerializationTests
 	{
 		var doc = new DocumentationDocument
 		{
+			Type = "doc",
 			Url = "/test/apm",
 			Title = "APM Test",
+			SearchTitle = "APM Test",
 			Applies = new ApplicableTo
 			{
 				ProductApplicability = new ProductApplicability
@@ -201,8 +211,10 @@ public class DocumentationDocumentSerializationTests
 	{
 		var doc = new DocumentationDocument
 		{
+			Type = "doc",
 			Url = "/test/complex",
 			Title = "Complex Test",
+			SearchTitle = "Complex Test",
 			Applies = new ApplicableTo
 			{
 				Stack = new AppliesCollection([new Applicability { Lifecycle = ProductLifecycle.GenerallyAvailable, Version = (SemVersion)"8.0.0" }]),
@@ -236,8 +248,10 @@ public class DocumentationDocumentSerializationTests
 	{
 		var doc = new DocumentationDocument
 		{
+			Type = "doc",
 			Url = "/test/no-applies",
 			Title = "No Applies Test",
+			SearchTitle = "No Applies Test",
 			Applies = null
 		};
 
@@ -261,8 +275,10 @@ public class DocumentationDocumentSerializationTests
 	{
 		var doc = new DocumentationDocument
 		{
+			Type = "doc",
 			Url = "/test/empty-applies",
 			Title = "Empty Applies Test",
+			SearchTitle = "Empty Applies Test",
 			Applies = new ApplicableTo()
 		};
 
@@ -280,8 +296,10 @@ public class DocumentationDocumentSerializationTests
 	{
 		var original = new DocumentationDocument
 		{
+			Type = "doc",
 			Url = "/test/roundtrip",
 			Title = "Round Trip Test",
+			SearchTitle = "Round Trip Test",
 			Hash = "abc123",
 			BatchIndexDate = DateTimeOffset.Parse("2024-01-15T10:00:00Z", CultureInfo.InvariantCulture),
 			LastUpdated = DateTimeOffset.Parse("2024-01-15T09:00:00Z", CultureInfo.InvariantCulture),
@@ -317,8 +335,10 @@ public class DocumentationDocumentSerializationTests
 	{
 		var doc = new DocumentationDocument
 		{
+			Type = "doc",
 			Url = "/test/multiple",
 			Title = "Multiple Test",
+			SearchTitle = "Multiple Test",
 			Applies = new ApplicableTo
 			{
 				Stack = new AppliesCollection(

--- a/tests/Elastic.Markdown.Tests/TestHelpers.cs
+++ b/tests/Elastic.Markdown.Tests/TestHelpers.cs
@@ -61,7 +61,7 @@ public static class TestHelpers
 				}
 			}.ToFrozenDictionary()
 		};
-		var search = new SearchConfiguration { Synonyms = [], Rules = [], DiminishTerms = [] };
+		var search = new SearchConfiguration { Synonyms = new Dictionary<string, string[]>(), Rules = [], DiminishTerms = [] };
 		return new ConfigurationContext
 		{
 			Endpoints = new DocumentationEndpoints

--- a/tests/authoring/Framework/Setup.fs
+++ b/tests/authoring/Framework/Setup.fs
@@ -288,7 +288,7 @@ type Setup =
             Endpoints=DocumentationEndpoints(Elasticsearch = ElasticsearchEndpoint.Default),
             ProductsConfiguration = ProductsConfiguration(Products = productDict.ToFrozenDictionary()),
             LegacyUrlMappings = LegacyUrlMappingConfiguration(Mappings = []),
-            SearchConfiguration = SearchConfiguration(Synonyms = [], Rules = [], DiminishTerms = [])
+            SearchConfiguration = SearchConfiguration(Synonyms = Dictionary<string, string[]>(), Rules = [], DiminishTerms = [])
         )
         let context = BuildContext(
             collector,


### PR DESCRIPTION
  - Improve search relevance with exact title matching
   and prefix search capabilities
  - Add title prefix boosting for smoother
  autocomplete behavior:
    - Single character queries (e.g., "A") get high
  boost (100x) to show only titles starting with that
  letter
    - Two character queries get medium boost (4x)
    - Up to 10 characters uses a term query with no
  additional boost
    - This creates a less janky autocomplete
  experience where results don't shift dramatically as
   you type
  - Add bidirectional synonym expansion for query-time
   boosting
    - Ensures both .NET and dotnet score high when the
   page title is just .NET
    - Synonyms are expanded in both directions so
  searching either term finds the relevant page
  - Apply keyword normalizer to all keyword fields for
   consistent case-insensitive matching
  - Reorganize and expand config/search.yml with new
  synonyms (edr, eks, kpi, logsdb, rag, tsvb) and
  diminish terms (curator, hadoop, glossary)
  - Remove unused url_segment_count field from
  document mapping

  Test plan

  - Verify all search relevance tests pass with
  updated expected results
  - Test prefix searches with short queries (1-2
  characters) return sensible results with titles
  starting with those characters
  - Verify typing progressively longer queries
  produces stable results without excessive shifting
  - Verify synonym expansion works bidirectionally
  (searching "dotnet" finds ".NET" pages and vice
  versa)
  - Confirm exact title matches are properly boosted
  in search results
