### PR TITLE
Add Hadoop and clients to products.yml

### DIFF
--- a/config/products.yml
+++ b/config/products.yml
@@ -134,6 +134,34 @@ products:
   elasticsearch-client:
     display: 'Elasticsearch Client'
     versioning: 'stack'
+  elasticsearch-client-go:
+    display: 'Elasticsearch Go Client'
+    repository: 'go-elasticsearch'
+  elasticsearch-client-java:
+    display: 'Elasticsearch Java Client'
+    repository: 'elasticsearch-java'
+  elasticsearch-client-javascript:
+    display: 'Elasticsearch JavaScript Client'
+    repository: 'elasticsearch-js'
+  elasticsearch-client-dotnet:
+    display: 'Elasticsearch .NET Client'
+    repository: 'elasticsearch-net'
+  elasticsearch-client-php:
+    display: 'Elasticsearch PHP Client'
+    repository: 'elasticsearch-php'
+  elasticsearch-client-python:
+    display: 'Elasticsearch Python Client'
+    repository: 'elasticsearch-py'
+  elasticsearch-client-ruby:
+    display: 'Elasticsearch Ruby Client'
+    repository: 'elasticsearch-ruby'
+  elasticsearch-client-rust:
+    display: 'Elasticsearch Rust Client'
+    repository: 'elasticsearch-rs'
+  elasticsearch-hadoop:
+    display: 'Elasticsearch for Apache Hadoop'
+    repository: 'elasticsearch-hadoop'
+    versioning: 'stack'
   ess:
     display: 'Elastic Cloud Hosted'
     versioning: 'all'

--- a/config/products.yml
+++ b/config/products.yml
@@ -137,27 +137,35 @@ products:
   elasticsearch-client-go:
     display: 'Elasticsearch Go Client'
     repository: 'go-elasticsearch'
+    versioning: 'elasticsearch-client-go'
   elasticsearch-client-java:
     display: 'Elasticsearch Java Client'
     repository: 'elasticsearch-java'
+    versioning: 'elasticsearch-client-java'
   elasticsearch-client-javascript:
     display: 'Elasticsearch JavaScript Client'
     repository: 'elasticsearch-js'
+    versioning: 'elasticsearch-client-javascript'
   elasticsearch-client-dotnet:
     display: 'Elasticsearch .NET Client'
     repository: 'elasticsearch-net'
+    versioning: 'elasticsearch-client-dotnet'
   elasticsearch-client-php:
     display: 'Elasticsearch PHP Client'
     repository: 'elasticsearch-php'
+    versioning: 'elasticsearch-client-php'
   elasticsearch-client-python:
     display: 'Elasticsearch Python Client'
     repository: 'elasticsearch-py'
+    versioning: 'elasticsearch-client-python'
   elasticsearch-client-ruby:
     display: 'Elasticsearch Ruby Client'
     repository: 'elasticsearch-ruby'
+    versioning: 'elasticsearch-client-ruby'
   elasticsearch-client-rust:
     display: 'Elasticsearch Rust Client'
     repository: 'elasticsearch-rs'
+    versioning: 'elasticsearch-client-rust'
   elasticsearch-hadoop:
     display: 'Elasticsearch for Apache Hadoop'
     repository: 'elasticsearch-hadoop'

--- a/config/versions.yml
+++ b/config/versions.yml
@@ -140,6 +140,31 @@ versioning_systems:
     base: 1.0
     current: 1.24.2
 
+  # Elasticsearch clients (separate from Elasticsearch)
+  elasticsearch-client-go:
+    base: 9.0
+    current: 9.2.0
+  elasticsearch-client-java:
+    base: 9.0
+    current: 9.2.1
+  elasticsearch-client-javascript:
+    base: 9.0
+    current: 9.2.0
+  elasticsearch-client-dotnet:
+    base: 9.0
+    current: 9.2.2
+  elasticsearch-client-php:
+    base: 9.0
+    current: 9.2.0
+  elasticsearch-client-python:
+    base: 9.0
+    current: 9.2.0
+  elasticsearch-client-ruby:
+    base: 9.0
+    current: 9.2.0
+  elasticsearch-client-rust:
+    base: 9.0
+    current: 9.1.0
   # Other
   cloud-terraform:
     base: 0.11

--- a/src/Elastic.Documentation.Configuration/Versions/VersionConfiguration.cs
+++ b/src/Elastic.Documentation.Configuration/Versions/VersionConfiguration.cs
@@ -121,6 +121,22 @@ public enum VersioningSystemId
 	SearchUI,
 	[Display(Name = "cloud-terraform")]
 	CloudTerraform,
+	[Display(Name = "elasticsearch-client-go")]
+	ElasticsearchClientGo,
+	[Display(Name = "elasticsearch-client-java")]
+	ElasticsearchClientJava,
+	[Display(Name = "elasticsearch-client-javascript")]
+	ElasticsearchClientJavascript,
+	[Display(Name = "elasticsearch-client-dotnet")]
+	ElasticsearchClientDotnet,
+	[Display(Name = "elasticsearch-client-php")]
+	ElasticsearchClientPhp,
+	[Display(Name = "elasticsearch-client-python")]
+	ElasticsearchClientPython,
+	[Display(Name = "elasticsearch-client-ruby")]
+	ElasticsearchClientRuby,
+	[Display(Name = "elasticsearch-client-rust")]
+	ElasticsearchClientRust,
 }
 
 [YamlSerializable]


### PR DESCRIPTION
Relates to https://github.com/elastic/docs-builder/pull/2298#discussion_r2588111222

This PR updates the `products.yml` to include identifiers that we'll need for the following release notes:

- https://www.elastic.co/docs/release-notes/elasticsearch/clients/java
- https://www.elastic.co/docs/release-notes/elasticsearch/clients/javascript
- https://www.elastic.co/docs/release-notes/elasticsearch/clients/dotnet
- https://www.elastic.co/docs/release-notes/elasticsearch/clients/php
- https://www.elastic.co/docs/release-notes/elasticsearch/clients/python
- https://www.elastic.co/docs/release-notes/elasticsearch/clients/ruby
- https://www.elastic.co/docs/release-notes/elasticsearch-hadoop

I also added the Go and Rust clients too.
For the `current` client versions, I based it on the latest release in each of the relevant repos.