### PR TITLE
Update changelog to pull from PR

### DIFF
--- a/config/changelog.yml.example
+++ b/config/changelog.yml.example
@@ -54,3 +54,25 @@ available_products:
   - cloud-enterprise
   # Add more products as needed
 
+# GitHub label mappings (optional - used when --pr option is specified)
+# Maps GitHub PR labels to changelog type values
+# When a PR has a label that matches a key, the corresponding type value is used
+label_to_type:
+  # Example mappings - customize based on your label naming conventions
+  # "type:feature": feature
+  # "type:bug": bug-fix
+  # "type:enhancement": enhancement
+  # "type:breaking": breaking-change
+  # "type:security": security
+
+# Maps GitHub PR labels to changelog area values
+# Multiple labels can map to the same area, and a single label can map to multiple areas (comma-separated)
+label_to_areas:
+  # Example mappings - customize based on your label naming conventions
+  # "area:search": search
+  # "area:security": security
+  # "area:ml": machine-learning
+  # "area:observability": observability
+  # "area:index": index-management
+  # "area:multiple": "search, security"  # Multiple areas comma-separated
+

--- a/docs/cli/release/changelog-add.md
+++ b/docs/cli/release/changelog-add.md
@@ -38,20 +38,30 @@ docs-builder changelog add [options...] [-h|--help]
 `--output <string?>`
 :   Optional: Output directory for the changelog fragment. Defaults to current directory.
 
+`--owner <string?>`
+:   Optional: GitHub repository owner (used when `--pr` is just a number).
+
 `--products <List<ProductInfo>>`
 :   Required: Products affected in format "product target lifecycle, ..." (for example, `"elasticsearch 9.2.0 ga, cloud-serverless 2025-08-05"`).
 :   The valid product identifiers are listed in [products.yml](https://github.com/elastic/docs-builder/blob/main/config/products.yml).
 :   The valid lifecycles are listed in [ChangelogConfiguration.cs](https://github.com/elastic/docs-builder/blob/main/src/services/Elastic.Documentation.Services/Changelog/ChangelogConfiguration.cs).
 
 `--pr <string?>`
-:   Optional: Pull request number.
+:   Optional: Pull request URL or number (if `--owner` and `--repo` are provided).
+:   If specified, `--title` can be derived from the PR.
+:   If mappings are configured, `--areas` and `--type` can also be derived from the PR.
+
+`--repo <string?>`
+:   Optional: GitHub repository name (used when `--pr` is just a number).
 
 `--subtype <string?>`
 :   Optional: Subtype for breaking changes (for example, `api`, `behavioral`, or `configuration`).
 :   The valid subtypes are listed in [ChangelogConfiguration.cs](https://github.com/elastic/docs-builder/blob/main/src/services/Elastic.Documentation.Services/Changelog/ChangelogConfiguration.cs).
 
 `--title <string>`
-:    Required: A short, user-facing title (max 80 characters)
+:    A short, user-facing title (max 80 characters)
+:    Required if `--pr` is not specified.
+:    If both `--pr` and `--title` are specified, the latter value is used instead of what exists in the PR.
 
 `--type <string>`
 :   Required: Type of change (for example, `feature`, `enhancement`, `bug-fix`, or `breaking-change`).

--- a/docs/contribute/changelog.md
+++ b/docs/contribute/changelog.md
@@ -25,20 +25,22 @@ Usage: changelog add [options...] [-h|--help] [--version]
 Add a new changelog fragment from command-line input
 
 Options:
-  --title <string>                  Required: A short, user-facing title (max 80 characters) (Required)
-  --type <string>                   Required: Type of change (feature, enhancement, bug-fix, breaking-change, etc.) (Required)
-  --products <List<ProductInfo>>    Required: Products affected in format "product target lifecycle, ..." (e.g., "elasticsearch 9.2.0 ga, cloud-serverless 2025-08-05") (Required)
-  --subtype <string?>               Optional: Subtype for breaking changes (api, behavioral, configuration, etc.) (Default: null)
-  --areas <string[]?>               Optional: Area(s) affected (comma-separated or specify multiple times) (Default: null)
-  --pr <string?>                    Optional: Pull request URL (Default: null)
-  --issues <string[]?>              Optional: Issue URL(s) (comma-separated or specify multiple times) (Default: null)
-  --description <string?>           Optional: Additional information about the change (max 600 characters) (Default: null)
-  --impact <string?>                Optional: How the user's environment is affected (Default: null)
-  --action <string?>                Optional: What users must do to mitigate (Default: null)
-  --feature-id <string?>            Optional: Feature flag ID (Default: null)
-  --highlight <bool?>               Optional: Include in release highlights (Default: null)
-  --output <string?>                Optional: Output directory for the changelog fragment. Defaults to current directory (Default: null)
-  --config <string?>                Optional: Path to the changelog.yml configuration file. Defaults to 'docs/changelog.yml' (Default: null)
+  --products <List<ProductInfo>>    Required: Products affected in format "product target lifecycle, ..." (e.g., "elasticsearch 9.2.0 ga, cloud-serverless 2025-08-05") [Required]
+  --title <string?>                 Optional: A short, user-facing title (max 80 characters). Required if --pr is not specified. If --pr is specified, will be derived from PR title if not provided. [Default: null]
+  --type <string?>                  Optional: Type of change (feature, enhancement, bug-fix, breaking-change, etc.). Required if --pr is not specified. If --pr is specified, will be derived from PR labels if not provided. [Default: null]
+  --subtype <string?>               Optional: Subtype for breaking changes (api, behavioral, configuration, etc.) [Default: null]
+  --areas <string[]?>               Optional: Area(s) affected (comma-separated or specify multiple times) [Default: null]
+  --pr <string?>                    Optional: Pull request URL or PR number (if --owner and --repo are provided). If specified, --title and --type can be derived from the PR. [Default: null]
+  --owner <string?>                 Optional: GitHub repository owner (used when --pr is just a number) [Default: null]
+  --repo <string?>                  Optional: GitHub repository name (used when --pr is just a number) [Default: null]
+  --issues <string[]?>              Optional: Issue URL(s) (comma-separated or specify multiple times) [Default: null]
+  --description <string?>           Optional: Additional information about the change (max 600 characters) [Default: null]
+  --impact <string?>                Optional: How the user's environment is affected [Default: null]
+  --action <string?>                Optional: What users must do to mitigate [Default: null]
+  --feature-id <string?>            Optional: Feature flag ID [Default: null]
+  --highlight <bool?>               Optional: Include in release highlights [Default: null]
+  --output <string?>                Optional: Output directory for the changelog fragment. Defaults to current directory [Default: null]
+  --config <string?>                Optional: Path to the changelog.yml configuration file. Defaults to 'docs/changelog.yml' [Default: null]
 ```
 
 ### Product format
@@ -82,16 +84,17 @@ The following command creates a changelog for a bug fix that applies to two prod
 
 ```sh
 docs-builder changelog add \
-  --title "Fixes enrich and lookup join resolution based on minimum transport version" \
-  --type bug-fix \ <1>
-  --products "elasticsearch 9.2.3, cloud-serverless 2025-12-02" \ <2>
+  --title "Fixes enrich and lookup join resolution based on minimum transport version" \ <1>
+  --type bug-fix \ <2>
+  --products "elasticsearch 9.2.3, cloud-serverless 2025-12-02" \ <3>
   --areas "ES|QL"
-  --pr "https://github.com/elastic/elasticsearch/pull/137431" <3>
+  --pr "https://github.com/elastic/elasticsearch/pull/137431" <4>
 ```
 
-1. The type values are defined in [ChangelogConfiguration.cs](https://github.com/elastic/docs-builder/blob/main/src/services/Elastic.Documentation.Services/Changelog/ChangelogConfiguration.cs).
-2. The product values are defined in [products.yml](https://github.com/elastic/docs-builder/blob/main/config/products.yml).
-3. At this time, the PR value can be a number or a URL; it is not validated.
+1. This option is required only if you want to override what's derived from the PR title.
+2. The type values are defined in [ChangelogConfiguration.cs](https://github.com/elastic/docs-builder/blob/main/src/services/Elastic.Documentation.Services/Changelog/ChangelogConfiguration.cs).
+3. The product values are defined in [products.yml](https://github.com/elastic/docs-builder/blob/main/config/products.yml).
+4. The `--pr` value can be a full URL (such as `https://github.com/owner/repo/pull/123`, a short format (such as `owner/repo#123`) or just a number (in which case you must also provide `--owner` and `--repo` options).
 
 The output file has the following format:
 

--- a/docs/contribute/changelog.md
+++ b/docs/contribute/changelog.md
@@ -26,11 +26,11 @@ Add a new changelog fragment from command-line input
 
 Options:
   --products <List<ProductInfo>>    Required: Products affected in format "product target lifecycle, ..." (e.g., "elasticsearch 9.2.0 ga, cloud-serverless 2025-08-05") [Required]
-  --title <string?>                 Optional: A short, user-facing title (max 80 characters). Required if --pr is not specified. If --pr is specified, will be derived from PR title if not provided. [Default: null]
-  --type <string?>                  Optional: Type of change (feature, enhancement, bug-fix, breaking-change, etc.). Required if --pr is not specified. If --pr is specified, will be derived from PR labels if not provided. [Default: null]
+  --title <string?>                 Optional: A short, user-facing title (max 80 characters). Required if --pr is not specified. If --pr and --title are specified, the latter value is used instead of what exists in the PR. [Default: null]
+  --type <string?>                  Optional: Type of change (feature, enhancement, bug-fix, breaking-change, etc.). Required if --pr is not specified. If mappings are configured, type can be derived from the PR. [Default: null]
   --subtype <string?>               Optional: Subtype for breaking changes (api, behavioral, configuration, etc.) [Default: null]
   --areas <string[]?>               Optional: Area(s) affected (comma-separated or specify multiple times) [Default: null]
-  --pr <string?>                    Optional: Pull request URL or PR number (if --owner and --repo are provided). If specified, --title and --type can be derived from the PR. [Default: null]
+  --pr <string?>                    Optional: Pull request URL or PR number (if --owner and --repo are provided). If specified, --title can be derived from the PR. If mappings are configured, --areas and --type can also be derived from the PR. [Default: null]
   --owner <string?>                 Optional: GitHub repository owner (used when --pr is just a number) [Default: null]
   --repo <string?>                  Optional: GitHub repository name (used when --pr is just a number) [Default: null]
   --issues <string[]?>              Optional: Issue URL(s) (comma-separated or specify multiple times) [Default: null]

--- a/docs/contribute/changelog.md
+++ b/docs/contribute/changelog.md
@@ -78,7 +78,16 @@ If a configuration file exists, the command validates all its values before gene
 - If the configuration file contains `lifecycle`, `product`, `subtype`, or `type` values that don't match the values in `products.yml` and `ChangelogConfiguration.cs`, validation fails. The changelog file is not created.
 - If the configuration file contains `areas` values and they don't match what you specify in the `--areas` command option, validation fails. The changelog file is not created.
 
+### GitHub label mappings
+
+You can optionally add `label_to_type` and `label_to_areas` mappings in your changelog configuration.
+When you run the command with the `--pr` option, it can use these mappings to fill in the `type` and `areas` in your changelog based on your pull request labels.
+
+Refer to [changelog.yml.example](https://github.com/elastic/docs-builder/blob/main/config/changelog.yml.example).
+
 ## Examples
+
+### Multiple products
 
 The following command creates a changelog for a bug fix that applies to two products:
 
@@ -109,4 +118,53 @@ products:
 title: Fixes enrich and lookup join resolution based on minimum transport version
 areas:
 - ES|QL
+```
+
+### PR label mappings
+
+You can update your changelog configuration file to contain GitHub label mappings, for example:
+
+```yaml
+# Available areas (optional - if not specified, all areas are allowed)
+available_areas:
+  - search
+  - security
+  - machine-learning
+  - observability
+  - index-management
+  - ES|QL
+  # Add more areas as needed
+
+# GitHub label mappings (optional - used when --pr option is specified)
+# Maps GitHub PR labels to changelog type values
+# When a PR has a label that matches a key, the corresponding type value is used
+label_to_type:
+  # Example mappings - customize based on your label naming conventions
+  ">enhancement": enhancement
+  ">breaking": breaking-change
+
+# Maps GitHub PR labels to changelog area values
+# Multiple labels can map to the same area, and a single label can map to multiple areas (comma-separated)
+label_to_areas:
+  # Example mappings - customize based on your label naming conventions
+  ":Search Relevance/ES|QL": "ES|QL"
+```
+
+When you use the `--pr` option to derive information from a pull request, it can make use of those mappings:
+
+```sh
+docs-builder changelog add --pr https://github.com/elastic/elasticsearch/pull/139272 --products "elasticsearch 9.3.0" --config test/changelog.yml
+```
+
+In this case, the changelog file derives the title, type, and areas:
+
+```yaml
+pr: https://github.com/elastic/elasticsearch/pull/139272
+type: enhancement
+products:
+- product: elasticsearch
+  target: 9.3.0
+areas:
+- ES|QL
+title: '[ES|QL] Take TOP_SNIPPETS out of snapshot'
 ```

--- a/src/services/Elastic.Documentation.Services/Changelog/ChangelogConfiguration.cs
+++ b/src/services/Elastic.Documentation.Services/Changelog/ChangelogConfiguration.cs
@@ -46,6 +46,17 @@ public class ChangelogConfiguration
 
 	public List<string>? AvailableProducts { get; set; }
 
+	/// <summary>
+	/// Mapping from GitHub label names to changelog type values
+	/// </summary>
+	public Dictionary<string, string>? LabelToType { get; set; }
+
+	/// <summary>
+	/// Mapping from GitHub label names to changelog area values
+	/// Multiple labels can map to the same area, and a single label can map to multiple areas (comma-separated)
+	/// </summary>
+	public Dictionary<string, string>? LabelToAreas { get; set; }
+
 	public static ChangelogConfiguration Default => new();
 }
 

--- a/src/services/Elastic.Documentation.Services/Changelog/ChangelogInput.cs
+++ b/src/services/Elastic.Documentation.Services/Changelog/ChangelogInput.cs
@@ -9,12 +9,14 @@ namespace Elastic.Documentation.Services.Changelog;
 /// </summary>
 public class ChangelogInput
 {
-	public required string Title { get; set; }
-	public required string Type { get; set; }
+	public string? Title { get; set; }
+	public string? Type { get; set; }
 	public required List<ProductInfo> Products { get; set; }
 	public string? Subtype { get; set; }
 	public string[] Areas { get; set; } = [];
 	public string? Pr { get; set; }
+	public string? Owner { get; set; }
+	public string? Repo { get; set; }
 	public string[] Issues { get; set; } = [];
 	public string? Description { get; set; }
 	public string? Impact { get; set; }

--- a/src/services/Elastic.Documentation.Services/Changelog/GitHubPrService.cs
+++ b/src/services/Elastic.Documentation.Services/Changelog/GitHubPrService.cs
@@ -128,12 +128,10 @@ public partial class GitHubPrService(ILoggerFactory loggerFactory)
 		}
 
 		// Handle just a PR number when owner/repo are provided
-		if (int.TryParse(prUrl, out var prNumber))
+		if (int.TryParse(prUrl, out var prNumber) &&
+			!string.IsNullOrWhiteSpace(defaultOwner) && !string.IsNullOrWhiteSpace(defaultRepo))
 		{
-			if (!string.IsNullOrWhiteSpace(defaultOwner) && !string.IsNullOrWhiteSpace(defaultRepo))
-			{
-				return (defaultOwner, defaultRepo, prNumber);
-			}
+			return (defaultOwner, defaultRepo, prNumber);
 		}
 
 		return (null, null, null);

--- a/src/services/Elastic.Documentation.Services/Changelog/GitHubPrService.cs
+++ b/src/services/Elastic.Documentation.Services/Changelog/GitHubPrService.cs
@@ -84,7 +84,7 @@ public partial class GitHubPrService(ILoggerFactory loggerFactory)
 			_logger.LogWarning("Request timeout fetching PR info from GitHub");
 			return null;
 		}
-		catch (Exception ex)
+		catch (Exception ex) when (ex is not OutOfMemoryException && ex is not StackOverflowException && ex is not ThreadAbortException)
 		{
 			_logger.LogWarning(ex, "Unexpected error fetching PR info from GitHub");
 			return null;

--- a/src/services/Elastic.Documentation.Services/Changelog/GitHubPrService.cs
+++ b/src/services/Elastic.Documentation.Services/Changelog/GitHubPrService.cs
@@ -1,0 +1,154 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace Elastic.Documentation.Services.Changelog;
+
+/// <summary>
+/// Service for fetching pull request information from GitHub
+/// </summary>
+public class GitHubPrService(ILoggerFactory loggerFactory)
+{
+	private readonly ILogger<GitHubPrService> _logger = loggerFactory.CreateLogger<GitHubPrService>();
+	private static readonly HttpClient HttpClient = new();
+	private static readonly JsonSerializerOptions JsonOptions = new()
+	{
+		PropertyNameCaseInsensitive = true
+	};
+
+	static GitHubPrService()
+	{
+		HttpClient.DefaultRequestHeaders.Add("User-Agent", "docs-builder");
+		HttpClient.DefaultRequestHeaders.Add("Accept", "application/vnd.github.v3+json");
+	}
+
+	/// <summary>
+	/// Fetches pull request information from GitHub
+	/// </summary>
+	/// <param name="prUrl">The PR URL (e.g., https://github.com/owner/repo/pull/123 or owner/repo#123)</param>
+	/// <param name="ctx">Cancellation token</param>
+	/// <returns>PR information or null if fetch fails</returns>
+	public async Task<GitHubPrInfo?> FetchPrInfoAsync(string prUrl, CancellationToken ctx = default)
+	{
+		try
+		{
+			var (owner, repo, prNumber) = ParsePrUrl(prUrl);
+			if (owner == null || repo == null || prNumber == null)
+			{
+				_logger.LogWarning("Unable to parse PR URL: {PrUrl}", prUrl);
+				return null;
+			}
+
+			// Add GitHub token if available (for rate limiting and private repos)
+			var githubToken = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
+			using var request = new HttpRequestMessage(HttpMethod.Get, $"https://api.github.com/repos/{owner}/{repo}/pulls/{prNumber}");
+			if (!string.IsNullOrEmpty(githubToken))
+			{
+				request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", githubToken);
+			}
+
+			_logger.LogDebug("Fetching PR info from: {ApiUrl}", request.RequestUri);
+
+			var response = await HttpClient.SendAsync(request, ctx);
+			if (!response.IsSuccessStatusCode)
+			{
+				_logger.LogWarning("Failed to fetch PR info. Status: {StatusCode}, Reason: {ReasonPhrase}", response.StatusCode, response.ReasonPhrase);
+				return null;
+			}
+
+			var jsonContent = await response.Content.ReadAsStringAsync(ctx);
+			var prData = JsonSerializer.Deserialize<GitHubPrResponse>(jsonContent, JsonOptions);
+
+			if (prData == null)
+			{
+				_logger.LogWarning("Failed to deserialize PR response");
+				return null;
+			}
+
+			return new GitHubPrInfo
+			{
+				Title = prData.Title,
+				Labels = prData.Labels?.Select(l => l.Name).ToArray() ?? []
+			};
+		}
+		catch (HttpRequestException ex)
+		{
+			_logger.LogWarning(ex, "HTTP error fetching PR info from GitHub");
+			return null;
+		}
+		catch (TaskCanceledException)
+		{
+			_logger.LogWarning("Request timeout fetching PR info from GitHub");
+			return null;
+		}
+		catch (Exception ex)
+		{
+			_logger.LogWarning(ex, "Unexpected error fetching PR info from GitHub");
+			return null;
+		}
+	}
+
+	private static (string? owner, string? repo, int? prNumber) ParsePrUrl(string prUrl)
+	{
+		// Handle full URL: https://github.com/owner/repo/pull/123
+		if (prUrl.StartsWith("https://github.com/", StringComparison.OrdinalIgnoreCase) ||
+			prUrl.StartsWith("http://github.com/", StringComparison.OrdinalIgnoreCase))
+		{
+			var uri = new Uri(prUrl);
+			var segments = uri.Segments;
+			// segments[0] is "/", segments[1] is "owner/", segments[2] is "repo/", segments[3] is "pull/", segments[4] is "123"
+			if (segments.Length >= 5 && segments[3].Equals("pull/", StringComparison.OrdinalIgnoreCase))
+			{
+				var owner = segments[1].TrimEnd('/');
+				var repo = segments[2].TrimEnd('/');
+				if (int.TryParse(segments[4], out var prNum))
+				{
+					return (owner, repo, prNum);
+				}
+			}
+		}
+
+		// Handle short format: owner/repo#123
+		var hashIndex = prUrl.LastIndexOf('#');
+		if (hashIndex > 0 && hashIndex < prUrl.Length - 1)
+		{
+			var repoPart = prUrl[..hashIndex];
+			var prPart = prUrl[(hashIndex + 1)..];
+			if (int.TryParse(prPart, out var prNum))
+			{
+				var repoParts = repoPart.Split('/');
+				if (repoParts.Length == 2)
+				{
+					return (repoParts[0], repoParts[1], prNum);
+				}
+			}
+		}
+
+		return (null, null, null);
+	}
+
+	private sealed class GitHubPrResponse
+	{
+		public string Title { get; set; } = string.Empty;
+		public List<GitHubLabel>? Labels { get; set; }
+	}
+
+	private sealed class GitHubLabel
+	{
+		public string Name { get; set; } = string.Empty;
+	}
+}
+
+/// <summary>
+/// Information about a GitHub pull request
+/// </summary>
+public class GitHubPrInfo
+{
+	public string Title { get; set; } = string.Empty;
+	public string[] Labels { get; set; } = [];
+}
+

--- a/src/services/Elastic.Documentation.Services/Changelog/GitHubPrService.cs
+++ b/src/services/Elastic.Documentation.Services/Changelog/GitHubPrService.cs
@@ -84,7 +84,7 @@ public partial class GitHubPrService(ILoggerFactory loggerFactory)
 			_logger.LogWarning("Request timeout fetching PR info from GitHub");
 			return null;
 		}
-		catch (Exception ex) when (ex is not OutOfMemoryException && ex is not StackOverflowException && ex is not ThreadAbortException)
+		catch (Exception ex) when (ex is not (OutOfMemoryException or StackOverflowException or ThreadAbortException))
 		{
 			_logger.LogWarning(ex, "Unexpected error fetching PR info from GitHub");
 			return null;

--- a/src/services/Elastic.Documentation.Services/Changelog/GitHubPrService.cs
+++ b/src/services/Elastic.Documentation.Services/Changelog/GitHubPrService.cs
@@ -4,6 +4,7 @@
 
 using System.Net.Http.Headers;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
 
 namespace Elastic.Documentation.Services.Changelog;
@@ -11,14 +12,10 @@ namespace Elastic.Documentation.Services.Changelog;
 /// <summary>
 /// Service for fetching pull request information from GitHub
 /// </summary>
-public class GitHubPrService(ILoggerFactory loggerFactory)
+public partial class GitHubPrService(ILoggerFactory loggerFactory)
 {
 	private readonly ILogger<GitHubPrService> _logger = loggerFactory.CreateLogger<GitHubPrService>();
 	private static readonly HttpClient HttpClient = new();
-	private static readonly JsonSerializerOptions JsonOptions = new()
-	{
-		PropertyNameCaseInsensitive = true
-	};
 
 	static GitHubPrService()
 	{
@@ -63,7 +60,7 @@ public class GitHubPrService(ILoggerFactory loggerFactory)
 			}
 
 			var jsonContent = await response.Content.ReadAsStringAsync(ctx);
-			var prData = JsonSerializer.Deserialize<GitHubPrResponse>(jsonContent, JsonOptions);
+			var prData = JsonSerializer.Deserialize(jsonContent, GitHubPrJsonContext.Default.GitHubPrResponse);
 
 			if (prData == null)
 			{
@@ -152,6 +149,12 @@ public class GitHubPrService(ILoggerFactory loggerFactory)
 	{
 		public string Name { get; set; } = string.Empty;
 	}
+
+	[JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
+	[JsonSerializable(typeof(GitHubPrResponse))]
+	[JsonSerializable(typeof(GitHubLabel))]
+	[JsonSerializable(typeof(List<GitHubLabel>))]
+	private sealed partial class GitHubPrJsonContext : JsonSerializerContext;
 }
 
 /// <summary>

--- a/src/services/Elastic.Documentation.Services/Changelog/GitHubPrService.cs
+++ b/src/services/Elastic.Documentation.Services/Changelog/GitHubPrService.cs
@@ -12,7 +12,7 @@ namespace Elastic.Documentation.Services.Changelog;
 /// <summary>
 /// Service for fetching pull request information from GitHub
 /// </summary>
-public partial class GitHubPrService(ILoggerFactory loggerFactory)
+public partial class GitHubPrService(ILoggerFactory loggerFactory) : IGitHubPrService
 {
 	private readonly ILogger<GitHubPrService> _logger = loggerFactory.CreateLogger<GitHubPrService>();
 	private static readonly HttpClient HttpClient = new();

--- a/src/services/Elastic.Documentation.Services/Changelog/IGitHubPrService.cs
+++ b/src/services/Elastic.Documentation.Services/Changelog/IGitHubPrService.cs
@@ -1,0 +1,22 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic.Documentation.Services.Changelog;
+
+/// <summary>
+/// Service interface for fetching pull request information from GitHub
+/// </summary>
+public interface IGitHubPrService
+{
+	/// <summary>
+	/// Fetches pull request information from GitHub
+	/// </summary>
+	/// <param name="prUrl">The PR URL (e.g., https://github.com/owner/repo/pull/123, owner/repo#123, or just a number if owner/repo are provided)</param>
+	/// <param name="owner">Optional: GitHub repository owner (used when prUrl is just a number)</param>
+	/// <param name="repo">Optional: GitHub repository name (used when prUrl is just a number)</param>
+	/// <param name="ctx">Cancellation token</param>
+	/// <returns>PR information or null if fetch fails</returns>
+	Task<GitHubPrInfo?> FetchPrInfoAsync(string prUrl, string? owner = null, string? repo = null, CancellationToken ctx = default);
+}
+

--- a/src/services/Elastic.Documentation.Services/ChangelogService.cs
+++ b/src/services/Elastic.Documentation.Services/ChangelogService.cs
@@ -17,12 +17,12 @@ namespace Elastic.Documentation.Services;
 public class ChangelogService(
 	ILoggerFactory logFactory,
 	IConfigurationContext configurationContext,
-	GitHubPrService? githubPrService = null
+	IGitHubPrService? githubPrService = null
 ) : IService
 {
 	private readonly ILogger _logger = logFactory.CreateLogger<ChangelogService>();
 	private readonly IFileSystem _fileSystem = new FileSystem();
-	private readonly GitHubPrService? _githubPrService = githubPrService;
+	private readonly IGitHubPrService? _githubPrService = githubPrService;
 
 	public async Task<bool> CreateChangelog(
 		IDiagnosticsCollector collector,

--- a/src/services/Elastic.Documentation.Services/ChangelogService.cs
+++ b/src/services/Elastic.Documentation.Services/ChangelogService.cs
@@ -41,8 +41,8 @@ public class ChangelogService(
 			}
 
 			// Validate that if PR is just a number, owner and repo must be provided
-			if (!string.IsNullOrWhiteSpace(input.Pr) 
-				&& int.TryParse(input.Pr, out _) 
+			if (!string.IsNullOrWhiteSpace(input.Pr)
+				&& int.TryParse(input.Pr, out _)
 				&& (string.IsNullOrWhiteSpace(input.Owner) || string.IsNullOrWhiteSpace(input.Repo)))
 			{
 				collector.EmitError(string.Empty, "When --pr is specified as just a number, both --owner and --repo must be provided");
@@ -473,10 +473,10 @@ public class ChangelogService(
 		}
 		catch (Exception ex)
 		{
-			if (ex is OutOfMemoryException ||
-			    ex is StackOverflowException ||
-			    ex is AccessViolationException ||
-			    ex is ThreadAbortException)
+			if (ex is OutOfMemoryException or
+				StackOverflowException or
+				AccessViolationException or
+				ThreadAbortException)
 			{
 				throw;
 			}

--- a/src/services/Elastic.Documentation.Services/ChangelogService.cs
+++ b/src/services/Elastic.Documentation.Services/ChangelogService.cs
@@ -41,13 +41,12 @@ public class ChangelogService(
 			}
 
 			// Validate that if PR is just a number, owner and repo must be provided
-			if (!string.IsNullOrWhiteSpace(input.Pr) && int.TryParse(input.Pr, out _))
+			if (!string.IsNullOrWhiteSpace(input.Pr) 
+				&& int.TryParse(input.Pr, out _) 
+				&& (string.IsNullOrWhiteSpace(input.Owner) || string.IsNullOrWhiteSpace(input.Repo)))
 			{
-				if (string.IsNullOrWhiteSpace(input.Owner) || string.IsNullOrWhiteSpace(input.Repo))
-				{
-					collector.EmitError(string.Empty, "When --pr is specified as just a number, both --owner and --repo must be provided");
-					return false;
-				}
+				collector.EmitError(string.Empty, "When --pr is specified as just a number, both --owner and --repo must be provided");
+				return false;
 			}
 
 			// If PR is specified, try to fetch PR information and derive title/type

--- a/src/services/Elastic.Documentation.Services/ChangelogService.cs
+++ b/src/services/Elastic.Documentation.Services/ChangelogService.cs
@@ -474,6 +474,13 @@ public class ChangelogService(
 		}
 		catch (Exception ex)
 		{
+			if (ex is OutOfMemoryException ||
+			    ex is StackOverflowException ||
+			    ex is AccessViolationException ||
+			    ex is ThreadAbortException)
+			{
+				throw;
+			}
 			_logger.LogWarning(ex, "Error fetching PR information from GitHub. Continuing with provided values.");
 			return null;
 		}

--- a/src/services/Elastic.Documentation.Services/ChangelogService.cs
+++ b/src/services/Elastic.Documentation.Services/ChangelogService.cs
@@ -495,16 +495,14 @@ public class ChangelogService(
 	private static List<string> MapLabelsToAreas(string[] labels, Dictionary<string, string> labelToAreasMapping)
 	{
 		var areas = new HashSet<string>();
-		foreach (var label in labels)
+		foreach (var label in labels.Where(label => labelToAreasMapping.ContainsKey(label)))
 		{
-			if (labelToAreasMapping.TryGetValue(label, out var mappedAreas))
+			var mappedAreas = labelToAreasMapping[label];
+			// Support comma-separated areas
+			var areaList = mappedAreas.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+			foreach (var area in areaList)
 			{
-				// Support comma-separated areas
-				var areaList = mappedAreas.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-				foreach (var area in areaList)
-				{
-					_ = areas.Add(area);
-				}
+				_ = areas.Add(area);
 			}
 		}
 		return areas.ToList();

--- a/src/services/Elastic.Documentation.Services/ChangelogService.cs
+++ b/src/services/Elastic.Documentation.Services/ChangelogService.cs
@@ -485,12 +485,9 @@ public class ChangelogService(
 		}
 	}
 
-	private static string? MapLabelsToType(string[] labels, Dictionary<string, string> labelToTypeMapping)
-	{
-		return labels
+	private static string? MapLabelsToType(string[] labels, Dictionary<string, string> labelToTypeMapping) => labels
 			.Select(label => labelToTypeMapping.TryGetValue(label, out var mappedType) ? mappedType : null)
 			.FirstOrDefault(mappedType => mappedType != null);
-	}
 
 	private static List<string> MapLabelsToAreas(string[] labels, Dictionary<string, string> labelToAreasMapping)
 	{

--- a/src/services/Elastic.Documentation.Services/ChangelogService.cs
+++ b/src/services/Elastic.Documentation.Services/ChangelogService.cs
@@ -495,15 +495,13 @@ public class ChangelogService(
 	private static List<string> MapLabelsToAreas(string[] labels, Dictionary<string, string> labelToAreasMapping)
 	{
 		var areas = new HashSet<string>();
-		foreach (var label in labels.Where(label => labelToAreasMapping.ContainsKey(label)))
+		var areaList = labels
+			.Where(label => labelToAreasMapping.ContainsKey(label))
+			.SelectMany(label => labelToAreasMapping[label]
+				.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+		foreach (var area in areaList)
 		{
-			var mappedAreas = labelToAreasMapping[label];
-			// Support comma-separated areas
-			var areaList = mappedAreas.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-			foreach (var area in areaList)
-			{
-				_ = areas.Add(area);
-			}
+			_ = areas.Add(area);
 		}
 		return areas.ToList();
 	}

--- a/src/services/Elastic.Documentation.Services/ChangelogService.cs
+++ b/src/services/Elastic.Documentation.Services/ChangelogService.cs
@@ -487,14 +487,9 @@ public class ChangelogService(
 
 	private static string? MapLabelsToType(string[] labels, Dictionary<string, string> labelToTypeMapping)
 	{
-		foreach (var label in labels)
-		{
-			if (labelToTypeMapping.TryGetValue(label, out var mappedType))
-			{
-				return mappedType;
-			}
-		}
-		return null;
+		return labels
+			.Select(label => labelToTypeMapping.TryGetValue(label, out var mappedType) ? mappedType : null)
+			.FirstOrDefault(mappedType => mappedType != null);
 	}
 
 	private static List<string> MapLabelsToAreas(string[] labels, Dictionary<string, string> labelToAreasMapping)

--- a/src/tooling/docs-builder/Commands/ChangelogCommand.cs
+++ b/src/tooling/docs-builder/Commands/ChangelogCommand.cs
@@ -31,12 +31,14 @@ internal sealed class ChangelogCommand(
 	/// <summary>
 	/// Add a new changelog fragment from command-line input
 	/// </summary>
-	/// <param name="title">Required: A short, user-facing title (max 80 characters)</param>
-	/// <param name="type">Required: Type of change (feature, enhancement, bug-fix, breaking-change, etc.)</param>
+	/// <param name="title">Optional: A short, user-facing title (max 80 characters). Required if --pr is not specified. If --pr is specified, will be derived from PR title if not provided.</param>
+	/// <param name="type">Optional: Type of change (feature, enhancement, bug-fix, breaking-change, etc.). Required if --pr is not specified. If --pr is specified, will be derived from PR labels if not provided.</param>
 	/// <param name="products">Required: Products affected in format "product target lifecycle, ..." (e.g., "elasticsearch 9.2.0 ga, cloud-serverless 2025-08-05")</param>
 	/// <param name="subtype">Optional: Subtype for breaking changes (api, behavioral, configuration, etc.)</param>
 	/// <param name="areas">Optional: Area(s) affected (comma-separated or specify multiple times)</param>
-	/// <param name="pr">Optional: Pull request URL</param>
+	/// <param name="pr">Optional: Pull request URL or PR number (if --owner and --repo are provided). If specified, --title and --type can be derived from the PR.</param>
+	/// <param name="owner">Optional: GitHub repository owner (used when --pr is just a number)</param>
+	/// <param name="repo">Optional: GitHub repository name (used when --pr is just a number)</param>
 	/// <param name="issues">Optional: Issue URL(s) (comma-separated or specify multiple times)</param>
 	/// <param name="description">Optional: Additional information about the change (max 600 characters)</param>
 	/// <param name="impact">Optional: How the user's environment is affected</param>
@@ -48,12 +50,14 @@ internal sealed class ChangelogCommand(
 	/// <param name="ctx"></param>
 	[Command("add")]
 	public async Task<int> Create(
-		string title,
-		string type,
 		[ProductInfoParser] List<ProductInfo> products,
+		string? title = null,
+		string? type = null,
 		string? subtype = null,
 		string[]? areas = null,
 		string? pr = null,
+		string? owner = null,
+		string? repo = null,
 		string[]? issues = null,
 		string? description = null,
 		string? impact = null,
@@ -78,6 +82,8 @@ internal sealed class ChangelogCommand(
 			Subtype = subtype,
 			Areas = areas ?? [],
 			Pr = pr,
+			Owner = owner,
+			Repo = repo,
 			Issues = issues ?? [],
 			Description = description,
 			Impact = impact,

--- a/src/tooling/docs-builder/Commands/ChangelogCommand.cs
+++ b/src/tooling/docs-builder/Commands/ChangelogCommand.cs
@@ -31,12 +31,12 @@ internal sealed class ChangelogCommand(
 	/// <summary>
 	/// Add a new changelog fragment from command-line input
 	/// </summary>
-	/// <param name="title">Optional: A short, user-facing title (max 80 characters). Required if --pr is not specified. If --pr is specified, will be derived from PR title if not provided.</param>
+	/// <param name="title">Optional: A short, user-facing title (max 80 characters). Required if --pr is not specified. If --pr and --title are specified, the latter value is used instead of what exists in the PR.</param>
 	/// <param name="type">Optional: Type of change (feature, enhancement, bug-fix, breaking-change, etc.). Required if --pr is not specified. If --pr is specified, will be derived from PR labels if not provided.</param>
 	/// <param name="products">Required: Products affected in format "product target lifecycle, ..." (e.g., "elasticsearch 9.2.0 ga, cloud-serverless 2025-08-05")</param>
 	/// <param name="subtype">Optional: Subtype for breaking changes (api, behavioral, configuration, etc.)</param>
 	/// <param name="areas">Optional: Area(s) affected (comma-separated or specify multiple times)</param>
-	/// <param name="pr">Optional: Pull request URL or PR number (if --owner and --repo are provided). If specified, --title and --type can be derived from the PR.</param>
+	/// <param name="pr">Optional: Pull request URL or PR number (if --owner and --repo are provided). If specified, --title can be derived from the PR. If mappings are configured, --areas and --type can also be derived from the PR.</param>
 	/// <param name="owner">Optional: GitHub repository owner (used when --pr is just a number)</param>
 	/// <param name="repo">Optional: GitHub repository name (used when --pr is just a number)</param>
 	/// <param name="issues">Optional: Issue URL(s) (comma-separated or specify multiple times)</param>

--- a/src/tooling/docs-builder/Commands/ChangelogCommand.cs
+++ b/src/tooling/docs-builder/Commands/ChangelogCommand.cs
@@ -71,7 +71,7 @@ internal sealed class ChangelogCommand(
 	{
 		await using var serviceInvoker = new ServiceInvoker(collector);
 
-		var githubPrService = new GitHubPrService(logFactory);
+		IGitHubPrService githubPrService = new GitHubPrService(logFactory);
 		var service = new ChangelogService(logFactory, configurationContext, githubPrService);
 
 		var input = new ChangelogInput

--- a/src/tooling/docs-builder/Commands/ChangelogCommand.cs
+++ b/src/tooling/docs-builder/Commands/ChangelogCommand.cs
@@ -67,7 +67,8 @@ internal sealed class ChangelogCommand(
 	{
 		await using var serviceInvoker = new ServiceInvoker(collector);
 
-		var service = new ChangelogService(logFactory, configurationContext);
+		var githubPrService = new GitHubPrService(logFactory);
+		var service = new ChangelogService(logFactory, configurationContext, githubPrService);
 
 		var input = new ChangelogInput
 		{

--- a/src/tooling/docs-builder/Commands/ChangelogCommand.cs
+++ b/src/tooling/docs-builder/Commands/ChangelogCommand.cs
@@ -32,7 +32,7 @@ internal sealed class ChangelogCommand(
 	/// Add a new changelog fragment from command-line input
 	/// </summary>
 	/// <param name="title">Optional: A short, user-facing title (max 80 characters). Required if --pr is not specified. If --pr and --title are specified, the latter value is used instead of what exists in the PR.</param>
-	/// <param name="type">Optional: Type of change (feature, enhancement, bug-fix, breaking-change, etc.). Required if --pr is not specified. If --pr is specified, will be derived from PR labels if not provided.</param>
+	/// <param name="type">Optional: Type of change (feature, enhancement, bug-fix, breaking-change, etc.). Required if --pr is not specified. If mappings are configured, type can be derived from the PR.</param>
 	/// <param name="products">Required: Products affected in format "product target lifecycle, ..." (e.g., "elasticsearch 9.2.0 ga, cloud-serverless 2025-08-05")</param>
 	/// <param name="subtype">Optional: Subtype for breaking changes (api, behavioral, configuration, etc.)</param>
 	/// <param name="areas">Optional: Area(s) affected (comma-separated or specify multiple times)</param>

--- a/tests/Elastic.Documentation.Services.Tests/ChangelogServiceTests.cs
+++ b/tests/Elastic.Documentation.Services.Tests/ChangelogServiceTests.cs
@@ -562,7 +562,7 @@ public class ChangelogServiceTests
 				"https://github.com/elastic/elasticsearch/issues/123",
 				"https://github.com/elastic/elasticsearch/issues/456"
 			],
-			Output = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())
+			Output = new FileSystem().Path.Combine(new FileSystem().Path.GetTempPath(), Guid.NewGuid().ToString())
 		};
 
 		// Act

--- a/tests/Elastic.Documentation.Services.Tests/ChangelogServiceTests.cs
+++ b/tests/Elastic.Documentation.Services.Tests/ChangelogServiceTests.cs
@@ -663,7 +663,7 @@ public class ChangelogServiceTests
 		{
 			Pr = "https://github.com/elastic/elasticsearch/pull/12345",
 			Products = [new ProductInfo { Product = "elasticsearch", Target = "9.2.0" }],
-			Output = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())
+			Output = _fileSystem.Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())
 		};
 
 		// Act
@@ -687,7 +687,7 @@ public class ChangelogServiceTests
 			Title = "Test",
 			Type = "feature",
 			Products = [new ProductInfo { Product = "invalid-product", Target = "9.2.0" }],
-			Output = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())
+			Output = _fileSystem.Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())
 		};
 
 		// Act
@@ -711,7 +711,7 @@ public class ChangelogServiceTests
 			Title = "Test",
 			Type = "invalid-type",
 			Products = [new ProductInfo { Product = "elasticsearch", Target = "9.2.0" }],
-			Output = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())
+			Output = _fileSystem.Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())
 		};
 
 		// Act

--- a/tests/Elastic.Documentation.Services.Tests/ChangelogServiceTests.cs
+++ b/tests/Elastic.Documentation.Services.Tests/ChangelogServiceTests.cs
@@ -737,7 +737,7 @@ public class ChangelogServiceTests
 			Type = "feature",
 			Products = [new ProductInfo { Product = "elasticsearch", Target = "9.2.0" }],
 			Highlight = true,
-			Output = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())
+			Output = new FileSystem().Path.Combine(new FileSystem().Path.GetTempPath(), Guid.NewGuid().ToString())
 		};
 
 		// Act
@@ -776,7 +776,7 @@ public class ChangelogServiceTests
 			Type = "feature",
 			Products = [new ProductInfo { Product = "elasticsearch", Target = "9.2.0" }],
 			FeatureId = "feature:new-search-api",
-			Output = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())
+			Output = new FileSystem().Path.Combine(new FileSystem().Path.GetTempPath(), Guid.NewGuid().ToString())
 		};
 
 		// Act

--- a/tests/Elastic.Documentation.Services.Tests/ChangelogServiceTests.cs
+++ b/tests/Elastic.Documentation.Services.Tests/ChangelogServiceTests.cs
@@ -609,9 +609,10 @@ public class ChangelogServiceTests
 			.Returns(prInfo);
 
 		// Config without label_to_type mapping
-		var configDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+		var fileSystem = new FileSystem();
+		var configDir = fileSystem.Path.Combine(fileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
 		Directory.CreateDirectory(configDir);
-		var configPath = Path.Combine(configDir, "changelog.yml");
+		var configPath = fileSystem.Path.Combine(configDir, "changelog.yml");
 		var configContent = """
 			available_types:
 			  - feature
@@ -631,7 +632,7 @@ public class ChangelogServiceTests
 			Pr = "https://github.com/elastic/elasticsearch/pull/12345",
 			Products = [new ProductInfo { Product = "elasticsearch", Target = "9.2.0" }],
 			Config = configPath,
-			Output = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())
+			Output = fileSystem.Path.Combine(fileSystem.Path.GetTempPath(), Guid.NewGuid().ToString())
 		};
 
 		// Act

--- a/tests/Elastic.Documentation.Services.Tests/ChangelogServiceTests.cs
+++ b/tests/Elastic.Documentation.Services.Tests/ChangelogServiceTests.cs
@@ -107,7 +107,7 @@ public class ChangelogServiceTests
 			Type = "feature",
 			Products = [new ProductInfo { Product = "elasticsearch", Target = "9.2.0", Lifecycle = "ga" }],
 			Description = "This is a new search feature",
-			Output = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())
+			Output = _fileSystem.Path.Combine(_fileSystem.Path.GetTempPath(), Guid.NewGuid().ToString())
 		};
 
 		// Act

--- a/tests/Elastic.Documentation.Services.Tests/ChangelogServiceTests.cs
+++ b/tests/Elastic.Documentation.Services.Tests/ChangelogServiceTests.cs
@@ -231,9 +231,10 @@ public class ChangelogServiceTests
 			A<CancellationToken>._))
 			.Returns(prInfo);
 
-		var configDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+		var fs = new FileSystem();
+		var configDir = fs.Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
 		Directory.CreateDirectory(configDir);
-		var configPath = Path.Combine(configDir, "changelog.yml");
+		var configPath = fs.Path.Combine(configDir, "changelog.yml");
 		var configContent = """
 			available_types:
 			  - feature
@@ -257,7 +258,7 @@ public class ChangelogServiceTests
 			Pr = "https://github.com/elastic/elasticsearch/pull/12345",
 			Products = [new ProductInfo { Product = "elasticsearch", Target = "9.2.0" }],
 			Config = configPath,
-			Output = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())
+			Output = fs.Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())
 		};
 
 		// Act

--- a/tests/Elastic.Documentation.Services.Tests/ChangelogServiceTests.cs
+++ b/tests/Elastic.Documentation.Services.Tests/ChangelogServiceTests.cs
@@ -302,9 +302,10 @@ public class ChangelogServiceTests
 			A<CancellationToken>._))
 			.Returns(prInfo);
 
-		var configDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-		Directory.CreateDirectory(configDir);
-		var configPath = Path.Combine(configDir, "changelog.yml");
+		var fileSystem = new FileSystem();
+		var configDir = fileSystem.Path.Combine(fileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		fileSystem.Directory.CreateDirectory(configDir);
+		var configPath = fileSystem.Path.Combine(configDir, "changelog.yml");
 		var configContent = """
 			available_types:
 			  - feature
@@ -320,7 +321,7 @@ public class ChangelogServiceTests
 			  "area:security": security
 			  "area:search": search
 			""";
-		await File.WriteAllTextAsync(configPath, configContent);
+		await fileSystem.File.WriteAllTextAsync(configPath, configContent);
 
 		var service = new ChangelogService(_loggerFactory, _configurationContext, mockGitHubService);
 
@@ -329,7 +330,7 @@ public class ChangelogServiceTests
 			Pr = "https://github.com/elastic/elasticsearch/pull/12345",
 			Products = [new ProductInfo { Product = "elasticsearch", Target = "9.2.0" }],
 			Config = configPath,
-			Output = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())
+			Output = fileSystem.Path.Combine(fileSystem.Path.GetTempPath(), Guid.NewGuid().ToString())
 		};
 
 		// Act

--- a/tests/Elastic.Documentation.Services.Tests/Elastic.Documentation.Services.Tests.csproj
+++ b/tests/Elastic.Documentation.Services.Tests/Elastic.Documentation.Services.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\services\Elastic.Documentation.Services\Elastic.Documentation.Services.csproj" />
+    <ProjectReference Include="..\..\src\Elastic.Documentation.Configuration\Elastic.Documentation.Configuration.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FakeItEasy" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Elastic.Documentation.Services.Tests/TestHelpers.cs
+++ b/tests/Elastic.Documentation.Services.Tests/TestHelpers.cs
@@ -1,0 +1,72 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Documentation.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Elastic.Documentation.Services.Tests;
+
+public class TestDiagnosticsOutput(ITestOutputHelper output) : IDiagnosticsOutput
+{
+	public void Write(Diagnostic diagnostic)
+	{
+		if (diagnostic.Severity == Severity.Error)
+			output.WriteLine($"Error: {diagnostic.Message} ({diagnostic.File}:{diagnostic.Line})");
+		else
+			output.WriteLine($"Warn : {diagnostic.Message} ({diagnostic.File}:{diagnostic.Line})");
+	}
+}
+
+public class TestDiagnosticsCollector(ITestOutputHelper output)
+	: DiagnosticsCollector([new TestDiagnosticsOutput(output)])
+{
+	private readonly List<Diagnostic> _diagnostics = [];
+
+	public IReadOnlyCollection<Diagnostic> Diagnostics => _diagnostics;
+
+	/// <inheritdoc />
+	public override void Write(Diagnostic diagnostic)
+	{
+		IncrementSeverityCount(diagnostic);
+		_diagnostics.Add(diagnostic);
+	}
+
+	/// <inheritdoc />
+	public override DiagnosticsCollector StartAsync(Cancel ctx) => this;
+
+	/// <inheritdoc />
+	public override Task StopAsync(Cancel cancellationToken) => Task.CompletedTask;
+}
+
+public class TestLogger(ITestOutputHelper? output) : ILogger
+{
+	private sealed class NullScope : IDisposable
+	{
+		public void Dispose() { }
+	}
+
+	public IDisposable BeginScope<TState>(TState state) where TState : notnull => new NullScope();
+
+	public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Trace;
+
+	public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) =>
+		output?.WriteLine(formatter(state, exception));
+}
+
+public class TestLoggerProvider(ITestOutputHelper? output) : ILoggerProvider
+{
+	public void Dispose() => GC.SuppressFinalize(this);
+
+	public ILogger CreateLogger(string categoryName) => new TestLogger(output);
+}
+
+public class TestLoggerFactory(ITestOutputHelper? output) : ILoggerFactory
+{
+	public void Dispose() => GC.SuppressFinalize(this);
+
+	public void AddProvider(ILoggerProvider provider) { }
+
+	public ILogger CreateLogger(string categoryName) => new TestLogger(output);
+}
+


### PR DESCRIPTION
## Summary

1. Updated the `docs-builder changelog add` command to support the `--pr` option with GitHub integration.
2. Added `--repo` and `--owner` options to resolve GitHub URLs when only a PR number is provided (based on the use of those options in the `elastic-agent-changelog-tool build` command per https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md)
3. Updated the `docs-builder changelog add` command to make `--title` and `--type` optional when `--pr` is specified.
4. Created tests for the command with mocked GitHub PR responses using FakeItEasy.

### Features:

- Automatic PR title extraction when --pr is specified
- Label-based type and area mapping via configuration
- Graceful fallback if GitHub is inaccessible
- Respects explicit command-line overrides (`--title`, `--type`, `--areas`)
- Supports GitHub token authentication via GITHUB_TOKEN environment variable
- When `--pr` is specified:
   - `--title` and `--type` are optional
       - Title is derived from PR title if not provided
       - Type is derived from PR labels (via `label_to_type` mapping) if not provided
       - Areas are derived from PR labels (via `label_to_areas` mapping) if not provided
       - Fails if PR info cannot be fetched or title/type cannot be derived
   - `--owner` and `--repo` are required if only a PR number is provided
- When `--pr` is not specified:
    - `--title` and `--type` are required (validation error if missing)
- Tests are run via `dotnet test tests/Elastic.Documentation.Services.Tests` command 

## Usage examples

If I provide a `changelog.yml` that contains type and area mappings, for example:

```yaml
# Available areas (optional - if not specified, all areas are allowed)
available_areas:
  - search
  - security
  - machine-learning
  - observability
  - index-management
  - ES|QL
  # Add more areas as needed

# GitHub label mappings (optional - used when --pr option is specified)
# Maps GitHub PR labels to changelog type values
# When a PR has a label that matches a key, the corresponding type value is used
label_to_type:
  # Example mappings - customize based on your label naming conventions
  ">enhancement": enhancement
  ">breaking": breaking-change

# Maps GitHub PR labels to changelog area values
# Multiple labels can map to the same area, and a single label can map to multiple areas (comma-separated)
label_to_areas:
  # Example mappings - customize based on your label naming conventions
  ":Search Relevance/ES|QL": "ES|QL"
```

I can then use these mappings to grab details from the pull request:

```sh
./docs-builder changelog add --pr https://github.com/elastic/elasticsearch/pull/139272 --products "elasticsearch 9.3.0" --config blah/changelog.yml
```

The generated `1765415340-[es|ql]-take-top_snippets-out-of-snapshot.yaml` file has successfully derived the title, type, and area:

```yaml
pr: https://github.com/elastic/elasticsearch/pull/139272
type: enhancement
products:
- product: elasticsearch
  target: 9.3.0
areas:
- ES|QL
title: '[ES|QL] Take TOP_SNIPPETS out of snapshot'
```


You can also provide just a PR number with owner and repo (with and without overriding title and type):

```sh
docs-builder changelog add  --pr 123 --owner elastic --repo elasticsearch --products "elasticsearch 9.2.0 ga"

docs-builder changelog add --title "Fix bug" --type bug-fix --products "elasticsearch 9.2.0 ga" --pr 123 --owner elastic --repo docs-builder
```

Here's an example of an error message for the new behaviour in a situation where I haven't created type mappings:

```sh
 ./docs-builder changelog add --pr https://github.com/elastic/elasticsearch/pull/139272 --products "elasticsearch 9.3.0"

...

Error: Cannot derive type from PR https://github.com/elastic/elasticsearch/pull/139272 labels: no label-to-type mapping configured in changelog.yml. Please provide --type or configure label_to_type in changelog.yml.
```

## AI summaries of changes made

Since I made these updates in four iterations, here are the individual summaries...

### Related to --pr github integration changes

- `ChangelogConfiguration` (`src/services/Elastic.Documentation.Services/Changelog/ChangelogConfiguration.cs`):
    - Added LabelToType dictionary for mapping GitHub labels to changelog types
    - Added LabelToAreas dictionary for mapping GitHub labels to changelog areas
- `GitHubPrService` (`src/services/Elastic.Documentation.Services/Changelog/GitHubPrService.cs`):
    - New service to fetch PR information from GitHub API
    - Parses PR URLs (full URLs and short format like owner/repo#123)
    - Handles authentication via GITHUB_TOKEN environment variable
    - Returns PR title and labels
- `ChangelogService` (`src/services/Elastic.Documentation.Services/ChangelogService.cs`):
    - Integrated GitHub PR fetching when `--pr` is provided
    - Uses PR title for changelog title (unless `--title` is explicitly provided)
    - Maps PR labels to type and areas based on configuration
    - Falls back gracefully if GitHub access fails with informational messages
- `ChangelogCommand` (`src/tooling/docs-builder/Commands/ChangelogCommand.cs`):
    - Updated to create and pass `GitHubPrService` to `ChangelogService`
- `changelog.yml.example` (`config/changelog.yml.example`):
    - Added example configuration for label_to_type and label_to_areas mappings

The implementation is complete and builds successfully. The command will now automatically populate changelog fields from GitHub PRs when the `--pr` option is used, while still allowing manual overrides.

### Related to addition of --owner and --repo

* `ChangelogCommand` (`src/tooling/docs-builder/Commands/ChangelogCommand.cs`):
    * Added `--owner` and `--repo` optional parameters
    * Updated documentation to indicate they're used when `--pr` is just a number
    * Passed these values to `ChangelogInput`
* `ChangelogInput` (`src/services/Elastic.Documentation.Services/Changelog/ChangelogInput.cs`):
    * Added `Owner` and `Repo` properties
* `GitHubPrService` (`src/services/Elastic.Documentation.Services/Changelog/GitHubPrService.cs`):
    * Updated `FetchPrInfoAsync` to accept optional `owner` and `repo` parameters
    * Updated `ParsePrUrl` to use provided owner/repo when prUrl is just a number
    * Supports:
        - Full URLs: `https://github.com/owner/repo/pull/123`
        - Short format: `owner/repo#123`
        -Just a number: `123` (requires `--owner` and `--repo`)
* `ChangelogService` (`src/services/Elastic.Documentation.Services/ChangelogService.cs`):
    * Updated to pass owner and repo to the GitHub service
    * Added validation: if `--pr` is just a number, both `--owner` and `--repo` must be provided

The implementation is complete and builds successfully. The command now supports resolving GitHub PRs using just a number when `--owner` and `--repo` are provided.

### Related to required command options

- `ChangelogCommand` (`src/tooling/docs-builder/Commands/ChangelogCommand.cs`):
    - Made title and type optional parameters (nullable)
    - Reordered parameters so required products comes first
    - Updated documentation to indicate they're optional when `--pr` is specified
- `ChangelogInput` (`src/services/Elastic.Documentation.Services/Changelog/ChangelogInput.cs`):
    - Changed Title and Type from required to nullable properties
- `ChangelogService` (`src/services/Elastic.Documentation.Services/ChangelogService.cs`):
    - Updated validation logic:
      - If `--pr` is specified, fetch PR info first
      - If PR fetch fails, fail with an error
      - If PR fetch succeeds but title/type can't be derived, fail with specific error messages:
          - Title: fails if PR has no title
          - Type: fails if no label-to-type mapping is configured or no matching label is found
      - Final validation ensures title/type are present (either from PR or explicitly provided)
      - Added null-forgiving operators in BuildChangelogData since values are validated before use

The implementation is complete and builds successfully. The command now supports deriving title and type from PRs when `--pr` is specified, and fails with clear error messages if they cannot be derived.

### Related to added tests

- Created `IGitHubPrService` interface (`src/services/Elastic.Documentation.Services/Changelog/IGitHubPrService.cs`)
    - Enables mocking GitHub API calls
- Updated `GitHubPrService` to implement `IGitHubPrService`
    - Maintains backward compatibility
- Updated `ChangelogService` to use `IGitHubPrService` instead of the concrete class
    - Enables dependency injection and mocking
- Updated `ChangelogCommand` to use the interface
- Created test project (`tests/Elastic.Documentation.Services.Tests/`)
    - Includes test helpers (`TestHelpers.cs`) with `TestDiagnosticsCollector` and `TestLoggerFactory`
- Created tests (`ChangelogServiceTests.cs`) covering:
    - Basic changelog creation with YAML validation
    - PR option with title derivation from GitHub
    - Label-to-type mapping from PR labels
    - Label-to-areas mapping from PR labels
    - PR number with owner/repo parameters
    - Explicit title override of PR title
    - Multiple products
    - Breaking changes with subtypes
    - Issues array
    - Feature ID and highlight flags
    - Error cases (invalid product, invalid type, PR fetch failures, missing label mappings)

All 15 tests pass, validating the changelog add command's input handling and YAML output generation with mocked GitHub PR responses.

## Outstanding questions

- Do we need a way to configure default `owner` and `repo` values?

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  

2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: composer-1 agent 
