### PR TITLE
LLM Markdown: Fix duplicate content in table cells 

### DIFF
--- a/src/Elastic.Markdown/Myst/Renderers/LlmMarkdown/LlmBlockRenderers.cs
+++ b/src/Elastic.Markdown/Myst/Renderers/LlmMarkdown/LlmBlockRenderers.cs
@@ -382,12 +382,13 @@ public class LlmTableRenderer : MarkdownObjectRenderer<LlmMarkdownRenderer, Tabl
 	private static string RenderTableCellContent(LlmMarkdownRenderer renderer, TableCell cell) =>
 		DocumentationObjectPoolProvider.UseLlmMarkdownRenderer(
 			renderer.BuildContext,
-			cell.Descendants().OfType<Inline>(),
-			static (tmpRenderer, obj) =>
+			cell,
+			static (tmpRenderer, c) =>
 			{
-				foreach (var inline in obj)
-					tmpRenderer.Write(inline);
-			});
+				// Render the cell's child blocks (e.g., ParagraphBlock) which properly
+				// handles the inline hierarchy without duplicating nested inline content
+				tmpRenderer.WriteChildren(c);
+			}).Trim();
 }
 
 public class LlmDirectiveRenderer : MarkdownObjectRenderer<LlmMarkdownRenderer, DirectiveBlock>

--- a/tests/authoring/LlmMarkdown/LlmMarkdownOutput.fs
+++ b/tests/authoring/LlmMarkdown/LlmMarkdownOutput.fs
@@ -641,3 +641,113 @@ Another setting description.
 
 An advanced option.
 """
+
+type ``links in paragraphs`` () =
+    static let markdown = Setup.Document """
+This is a paragraph with a [link to docs](https://www.elastic.co/docs/deploy-manage/security) in it.
+"""
+
+    [<Fact>]
+    let ``renders links without duplication`` () =
+        markdown |> convertsToNewLLM """This is a paragraph with a [link to docs](https://www.elastic.co/docs/deploy-manage/security) in it.
+"""
+
+type ``links in tables`` () =
+    static let markdown = Setup.Document """
+| Feature | Availability |
+|---------|--------------|
+| [Security configurations](https://www.elastic.co/docs/deploy-manage/security) | Full control |
+| [Authentication realms](https://www.elastic.co/docs/deploy-manage/users-roles) | Available |
+"""
+
+    [<Fact>]
+    let ``renders links in table cells without duplication`` () =
+        markdown |> convertsToNewLLM """
+| Feature                                                                        | Availability |
+|--------------------------------------------------------------------------------|--------------|
+| [Security configurations](https://www.elastic.co/docs/deploy-manage/security)  | Full control |
+| [Authentication realms](https://www.elastic.co/docs/deploy-manage/users-roles) | Available    |
+"""
+
+type ``multiple links in table cells`` () =
+    static let markdown = Setup.Document """
+| Feature | Links |
+|---------|-------|
+| Security | [Config](https://example.com/config) and [Auth](https://example.com/auth) |
+"""
+
+    [<Fact>]
+    let ``renders multiple links in same cell without duplication`` () =
+        markdown |> convertsToNewLLM """
+| Feature  | Links                                                                     |
+|----------|---------------------------------------------------------------------------|
+| Security | [Config](https://example.com/config) and [Auth](https://example.com/auth) |
+"""
+
+type ``links with formatting in tables`` () =
+    static let markdown = Setup.Document """
+| Feature | Description |
+|---------|-------------|
+| [**Bold link**](https://example.com) | Description |
+| [*Italic link*](https://example.com/italic) | Another |
+"""
+
+    [<Fact>]
+    let ``renders formatted links in table cells correctly`` () =
+        markdown |> convertsToNewLLM """
+| Feature                                     | Description |
+|---------------------------------------------|-------------|
+| [**Bold link**](https://example.com)        | Description |
+| [*Italic link*](https://example.com/italic) | Another     |
+"""
+
+type ``bold and italic in tables`` () =
+    static let markdown = Setup.Document """
+| Format | Example |
+|--------|---------|
+| Bold | This is **bold text** here |
+| Italic | This is *italic text* here |
+| Both | This is **bold** and *italic* |
+"""
+
+    [<Fact>]
+    let ``renders bold and italic in table cells without duplication`` () =
+        markdown |> convertsToNewLLM """
+| Format | Example                       |
+|--------|-------------------------------|
+| Bold   | This is **bold text** here    |
+| Italic | This is *italic text* here    |
+| Both   | This is **bold** and *italic* |
+"""
+
+type ``code inline in tables`` () =
+    static let markdown = Setup.Document """
+| Command | Description |
+|---------|-------------|
+| `git status` | Shows status |
+| `git commit` | Commits changes |
+"""
+
+    [<Fact>]
+    let ``renders code inline in table cells correctly`` () =
+        markdown |> convertsToNewLLM """
+| Command      | Description     |
+|--------------|-----------------|
+| `git status` | Shows status    |
+| `git commit` | Commits changes |
+"""
+
+type ``images in tables`` () =
+    static let markdown = Setup.Document """
+| Icon | Name |
+|------|------|
+| ![logo](https://example.com/logo.png) | Logo |
+"""
+
+    [<Fact>]
+    let ``renders images in table cells without duplication`` () =
+        markdown |> convertsToNewLLM """
+| Icon                                  | Name |
+|---------------------------------------|------|
+| ![logo](https://example.com/logo.png) | Logo |
+"""


### PR DESCRIPTION
Closes https://github.com/elastic/docs-builder/issues/2316

### Problem
When rendering markdown tables for LLM consumption, link labels and formatted text were duplicated.

**Example of the bug:**
```
| [Security configurations](https://...security)Security configurations | Full control |
```

### Cause
The `RenderTableCellContent` method used `cell.Descendants().OfType<Inline>()` which returns all nested inline elements. This caused container inlines (links, bold, italic) and their child text to be rendered separately.

### Solution
Changed to render the cell's child blocks directly using `WriteChildren(cell)`. This properly handles the inline hierarchy without duplication.

### Testing
Added 7 new tests covering:
- Links in tables and paragraphs
- Multiple links in same cell
- Bold and italic text in tables
- Images in tables
- Code inline in tables

All 35 LLM markdown tests pass.