### PR TITLE
Enable edot-cf-gcp in updatecli

### DIFF
--- a/.github/updatecli/updatecli.d/versions.yml
+++ b/.github/updatecli/updatecli.d/versions.yml
@@ -73,7 +73,7 @@ sources:
       versionfilter:
         kind: latest
 
-  latest-edot-cf-gcp-version:
+  latest-docker-edot-cf-gcp-version:
     name: Get latest release version for the edot-cf-gcp
     kind: githubrelease
     transformers:
@@ -81,6 +81,19 @@ sources:
     spec:
       owner: elastic
       repository: edot-cloud-forwarder-gcp
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      versionfilter:
+        kind: latest
+
+  latest-terraform-google-edot-cf-version:
+    name: Get latest release version for the terraform-google-edot-cloud-forwarder
+    kind: githubrelease
+    transformers:
+      - trimprefix: v
+    spec:
+      owner: elastic
+      repository: terraform-google-edot-cloud-forwarder
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       versionfilter:
@@ -473,13 +486,22 @@ targets:
       key: versioning_systems.edot-cf-azure.current
 
   update-docs-docset-cf-gcp:
-    name: 'Update config/versions.yml edot-cf-gcp {{ source "latest-edot-cf-gcp-version" }}'
+    name: 'Update config/versions.yml edot-cf-gcp {{ source "latest-docker-edot-cf-gcp-version" }}'
     scmid: githubConfig
-    sourceid: latest-edot-cf-gcp-version
+    sourceid: latest-docker-edot-cf-gcp-version
     kind: yaml
     spec:
       file: config/versions.yml
       key: versioning_systems.edot-cf-gcp.current
+
+  update-docs-docset-terraform-google-edot-cf:
+    name: 'Update config/versions.yml terraform-google-edot-cf {{ source "latest-terraform-google-edot-cf-version" }}'
+    scmid: githubConfig
+    sourceid: latest-terraform-google-edot-cf-version
+    kind: yaml
+    spec:
+      file: config/versions.yml
+      key: versioning_systems.terraform-google-edot-cf.current
 
   update-docs-docset-collector:
     name: 'Update config/versions.yml edot-collector {{ source "latest-edot-collector-version" }}'

--- a/.github/updatecli/updatecli.d/versions.yml
+++ b/.github/updatecli/updatecli.d/versions.yml
@@ -73,18 +73,18 @@ sources:
       versionfilter:
         kind: latest
 
-  # latest-edot-cf-gcp-version:
-  #   name: Get latest release version for the edot-cf-gcp
-  #   kind: githubrelease
-  #   transformers:
-  #     - trimprefix: v
-  #   spec:
-  #     owner: elastic
-  #     repository: edot-cloud-forwarder-gcp
-  #     token: '{{ requiredEnv "GITHUB_TOKEN" }}'
-  #     username: '{{ requiredEnv "GITHUB_ACTOR" }}'
-  #     versionfilter:
-  #       kind: latest
+  latest-edot-cf-gcp-version:
+    name: Get latest release version for the edot-cf-gcp
+    kind: githubrelease
+    transformers:
+      - trimprefix: v
+    spec:
+      owner: elastic
+      repository: edot-cloud-forwarder-gcp
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      versionfilter:
+        kind: latest
 
   latest-edot-collector-version:
     name: Get latest major release version for the elastic-agent
@@ -472,14 +472,14 @@ targets:
       file: config/versions.yml
       key: versioning_systems.edot-cf-azure.current
 
-  # update-docs-docset-cf-gcp:
-  #   name: 'Update config/versions.yml edot-cf-gcp {{ source "latest-edot-cf-gcp-version" }}'
-  #   scmid: githubConfig
-  #   sourceid: latest-edot-cf-gcp-version
-  #   kind: yaml
-  #   spec:
-  #     file: config/versions.yml
-  #     key: versioning_systems.edot-cf-gcp.current
+  update-docs-docset-cf-gcp:
+    name: 'Update config/versions.yml edot-cf-gcp {{ source "latest-edot-cf-gcp-version" }}'
+    scmid: githubConfig
+    sourceid: latest-edot-cf-gcp-version
+    kind: yaml
+    spec:
+      file: config/versions.yml
+      key: versioning_systems.edot-cf-gcp.current
 
   update-docs-docset-collector:
     name: 'Update config/versions.yml edot-collector {{ source "latest-edot-collector-version" }}'

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -30,6 +30,7 @@ jobs:
             docs-builder
             edot-cloud-forwarder-aws
             edot-cloud-forwarder-azure
+            edot-cloud-forwarder-gcp
 
       - uses: elastic/oblt-actions/updatecli/run@v1
         with:

--- a/config/products.yml
+++ b/config/products.yml
@@ -54,6 +54,9 @@ products:
   cloud-terraform:
     display: 'Elastic Cloud Terraform Provider'
     versioning: 'cloud-terraform'
+  terraform-google-edot-cf:
+    display: 'Terraform Google EDOT CF'
+    versioning: 'terraform-google-edot-cf'
   curator:
     display: 'Elasticsearch Curator'
   ecs:

--- a/config/versions.yml
+++ b/config/versions.yml
@@ -104,6 +104,9 @@ versioning_systems:
   edot-cf-gcp:
     base: 0.1
     current: 0.1.0
+  terraform-google-edot-cf:
+    base: 0.1
+    current: 0.1.0
 
   # Logging
   ecs-logging-dotnet:

--- a/src/Elastic.Documentation.Configuration/Versions/VersionConfiguration.cs
+++ b/src/Elastic.Documentation.Configuration/Versions/VersionConfiguration.cs
@@ -115,6 +115,8 @@ public enum VersioningSystemId
 	EdotCfAzure,
 	[Display(Name = "edot-cf-gcp")]
 	EdotCfGcp,
+	[Display(Name = "terraform-google-edot-cf")]
+	TerraformGoogleEdotCf,
 	[Display(Name = "edot-collector")]
 	EdotCollector,
 	[Display(Name = "search-ui")]


### PR DESCRIPTION
With the first release of edot-cf-gcp happening, we can uncomment the updatecli logic for the repo.

+CC @constanca-m 