### PR TITLE
Bumps the docs version to 9.2.3

### DIFF
--- a/config/versions.yml
+++ b/config/versions.yml
@@ -3,7 +3,7 @@ versioning_systems:
   # Updates for Stack versions are manual
   stack: &stack
     base: 9.0
-    current: 9.2.2
+    current: 9.2.3
 
   # Using an unlikely high version
   # So that our logic that would display "planned" doesn't trigger


### PR DESCRIPTION
DO NOT MERGE UNTIL RELEASE DAY

docs release issues:

- [9.2.3](https://github.com/elastic/dev/issues/3398)
- [9.1.9](https://github.com/elastic/dev/issues/3396)