### PR TITLE
Add MCP server scaffolding and basic structure

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -64,6 +64,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
     <PackageVersion Include="Markdig" Version="0.41.1" />
+    <PackageVersion Include="ModelContextProtocol" Version="0.2.0-preview.1" />
     <PackageVersion Include="NetEscapades.EnumGenerators" Version="1.0.0-beta12" PrivateAssets="all" ExcludeAssets="runtime" />
     <PackageVersion Include="Proc" Version="0.9.1" />
     <PackageVersion Include="RazorSlices" Version="0.9.4" />
@@ -72,6 +73,7 @@
     <PackageVersion Include="Slugify.Core" Version="4.0.1" />
     <PackageVersion Include="SoftCircuits.IniFileParser" Version="2.7.0" />
     <PackageVersion Include="System.IO.Abstractions" Version="22.1.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
     <PackageVersion Include="Utf8StreamReader" Version="1.3.2" />
     <PackageVersion Include="Vecc.YamlDotNet.Analyzers.StaticGenerator" Version="16.1.3" PrivateAssets="All" />

--- a/docs-builder.slnx
+++ b/docs-builder.slnx
@@ -53,6 +53,7 @@
     <Project Path="src/Elastic.Documentation.Site/Elastic.Documentation.Site.csproj" />
     <Project Path="src/Elastic.Documentation/Elastic.Documentation.csproj" />
     <Project Path="src/Elastic.Markdown/Elastic.Markdown.csproj" />
+    <Project Path="src/Elastic.Documentation.Mcp/Elastic.Documentation.Mcp.csproj" />
   </Folder>
   <Folder Name="/src/api/">
     <Project Path="src/api/Elastic.Documentation.Api.Core/Elastic.Documentation.Api.Core.csproj" />

--- a/docs/_docset.yml
+++ b/docs/_docset.yml
@@ -157,6 +157,9 @@ toc:
         children:
           - file: index.md
           - file: changelog-add.md
+  - folder: mcp
+    children:
+      - file: index.md
   - folder: migration
     children:
       - file: index.md

--- a/docs/mcp/index.md
+++ b/docs/mcp/index.md
@@ -1,0 +1,65 @@
+# MCP server
+
+{{dbuild}} includes an [MCP (Model Context Protocol)](https://modelcontextprotocol.io/introduction) server that allows AI assistants to interact with the documentation tooling directly.
+
+## Available tools
+
+The MCP server currently exposes the following tools:
+
+| Tool | Description |
+|------|-------------|
+| `Echo` | Echoes a greeting message back to the client. |
+
+## Configuration
+
+To use the {{dbuild}} MCP server, add it to your IDE's MCP configuration.
+
+::::{tab-set}
+
+:::{tab-item} Cursor
+Create or edit `.cursor/mcp.json` in your workspace:
+
+```json
+{
+  "mcpServers": {
+    "docs-builder": {
+      "command": "docs-builder",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+Then restart Cursor or reload the window. The tools will be available in **Agent mode**.
+:::
+
+:::{tab-item} VS Code
+Create or edit `.vscode/mcp.json` in your workspace:
+
+```json
+{
+  "servers": {
+    "docs-builder": {
+      "type": "stdio",
+      "command": "docs-builder",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+Requires GitHub Copilot with MCP support enabled.
+:::
+
+::::
+
+## Testing with MCP Inspector
+
+You can test the MCP server using the [MCP Inspector](https://github.com/modelcontextprotocol/inspector):
+
+```bash
+npx @modelcontextprotocol/inspector docs-builder mcp
+```
+
+This opens a web UI where you can browse all available tools and invoke them manually.
+

--- a/src/Elastic.Documentation.Mcp/EchoTool.cs
+++ b/src/Elastic.Documentation.Mcp/EchoTool.cs
@@ -1,0 +1,16 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+
+namespace Elastic.Documentation.Mcp;
+
+[McpServerToolType]
+public static class EchoTool
+{
+	[McpServerTool, Description("Echoes a greeting message back to the client.")]
+	public static string Echo(string message) => $"Hello from docs-builder: {message}";
+}
+

--- a/src/Elastic.Documentation.Mcp/Elastic.Documentation.Mcp.csproj
+++ b/src/Elastic.Documentation.Mcp/Elastic.Documentation.Mcp.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ModelContextProtocol" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+  </ItemGroup>
+
+</Project>
+

--- a/src/Elastic.Documentation.Mcp/Program.cs
+++ b/src/Elastic.Documentation.Mcp/Program.cs
@@ -1,0 +1,19 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+var builder = Host.CreateApplicationBuilder(args);
+builder.Logging.AddConsole(options =>
+	options.LogToStandardErrorThreshold = LogLevel.Trace);
+
+builder.Services
+	.AddMcpServer()
+	.WithStdioServerTransport()
+	.WithToolsFromAssembly();
+
+await builder.Build().RunAsync();
+


### PR DESCRIPTION
This adds the basic scaffolding for a `docs-builder` MCP server running locally (stdio mode).

For now it just contains an `echo` tool that echoes messages. The implementation is based on https://devblogs.microsoft.com/dotnet/build-a-model-context-protocol-mcp-server-in-csharp/, which keeps the code pretty clean!

To test locally, add this MCP snippet to the Cursor's configuration:

```
      "docs-builder-mcp": {
         "command": "dotnet",
         "args": [
            "run",
            "--project",
            "/Users/fabri/repos/docs-builder/src/Elastic.Documentation.Mcp/Elastic.Documentation.Mcp.csproj"
         ]
      },
```

What could we add next? Some ideas:

- Commands so that agents know how to use docs-builder and debug errors.
- Semantic search commands.
- Check if a markdown file is valid according to docs-builder syntax.
- Look up what a substitution variable (like {{stack}}) resolves to.
— Get the syntax and examples for a specific directive.
— Check if all links in a document are valid.
— Look up where a cross-link resolves to.
— Scan a file or folder for broken links.
— Move a documentation file and automatically handle redirects.
— Create a redirect from one URL to another.
— Trigger a documentation build and return errors/warnings.
— Start a local preview server.

--- 
LLM usage disclosure: I used Claude Opus 4.5 in Cursor 2 to create this PR.