### PR TITLE
Change feature_id to feature-id in changelogs

### DIFF
--- a/src/services/Elastic.Documentation.Services/Changelog/ChangelogData.cs
+++ b/src/services/Elastic.Documentation.Services/Changelog/ChangelogData.cs
@@ -2,6 +2,8 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using YamlDotNet.Serialization;
+
 namespace Elastic.Documentation.Services.Changelog;
 
 /// <summary>
@@ -22,6 +24,7 @@ public class ChangelogData
 	public string? Description { get; set; }
 	public string? Impact { get; set; }
 	public string? Action { get; set; }
+	[YamlMember(Alias = "feature-id", ApplyNamingConventions = false)]
 	public string? FeatureId { get; set; }
 	public bool? Highlight { get; set; }
 }

--- a/tests/Elastic.Documentation.Services.Tests/ChangelogServiceTests.cs
+++ b/tests/Elastic.Documentation.Services.Tests/ChangelogServiceTests.cs
@@ -820,7 +820,7 @@ public class ChangelogServiceTests : IDisposable
 			Directory.CreateDirectory(outputDir);
 		var files = Directory.GetFiles(outputDir, "*.yaml");
 		var yamlContent = await File.ReadAllTextAsync(files[0], TestContext.Current.CancellationToken);
-		yamlContent.Should().Contain("feature_id: feature:new-search-api");
+		yamlContent.Should().Contain("feature-id: feature:new-search-api");
 	}
 }
 


### PR DESCRIPTION
## Background

While working on https://github.com/elastic/docs-builder/pull/2412, I encountered this error on the `docs-builder changelog bundle" command:

```sh
../docs-builder/.artifacts/publish/docs-builder/release/docs-builder changelog bundle --all --directory ./docs/changelog/
...
Error: Failed to parse YAML: Property 'feature-id' not found on type 'Elastic.Documentation.Services.Changelog.ChangelogData'.
```

The command worked when I updated the changelog files to use `feature_id: xxx` but that does not align with the schema in https://docs-v3-preview.elastic.dev/elastic/docs-builder/tree/main/contribute/changelog and AFAICT there was no conscious choice to use underscore and IMO it's less confusing to keep the command option and the schema in sync.

## Summary

Updated the `docs-builder changelog add` command and related code to use `feature-id` instead of `feature_id`.

## Changes Made:

- `ChangelogData.cs`: Added `[YamlMember(Alias = "feature-id", ApplyNamingConventions = false)]` to the `FeatureId` property to ensure YAML serialization uses `feature-id` instead of `feature_id`.
- `ChangelogServiceTests.cs`: Updated the test assertion to check for `feature-id` instead of `feature_id`.
- Documentation: Already uses `feature-id` correctly:
    - Command help shows `--feature-id`
    - Schema documentation shows `feature-id:`
    - Generated YAML comments show `# feature-id:`

The C# parameter name `featureId` remains camelCase (standard), and `ConsoleAppFramework` converts it to `--feature-id` for the CLI. The YAML output now uses feature-id with a hyphen as required.

## Tests

- All 15 changelog tests pass
- Build succeeds with no errors

## Alternatives

If it's preferrable to stick with `feature_id` in the changelog files, IMO we should change the command option to `--feature` or `--feature_id` to avoid confusion.

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  

2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: composer-1 agent 