### PR TITLE
Add render_blockers to changelog config

### DIFF
--- a/config/changelog.yml.example
+++ b/config/changelog.yml.example
@@ -4,16 +4,16 @@
 
 # Available types for changelog entries
 available_types:
-  - feature
-  - enhancement
-  - bug-fix
-  - known-issue
   - breaking-change
+  - bug-fix
   - deprecation
   - docs
+  - enhancement
+  - feature
+  - known-issue
+  - other
   - regression
   - security
-  - other
 
 # Available subtypes for breaking changes
 available_subtypes:
@@ -34,24 +34,23 @@ available_lifecycles:
 
 # Available areas (optional - if not specified, all areas are allowed)
 available_areas:
-  - search
-  - security
-  - machine-learning
-  - observability
-  - index-management
+  # - Autoscaling
+  # - Search
+  # - Security
+  # - Watcher
   # Add more areas as needed
 
 # Available products (optional - if not specified, all products are allowed)
 available_products:
-  - elasticsearch
-  - kibana
-  - apm
-  - beats
-  - elastic-agent
-  - fleet
-  - cloud-hosted
-  - cloud-serverless
-  - cloud-enterprise
+  # - elasticsearch
+  # - kibana
+  # - apm
+  # - beats
+  # - elastic-agent
+  # - fleet
+  # - cloud-hosted
+  # - cloud-serverless
+  # - cloud-enterprise
   # Add more products as needed
 
 # GitHub label mappings (optional - used when --pr option is specified)
@@ -59,20 +58,36 @@ available_products:
 # When a PR has a label that matches a key, the corresponding type value is used
 label_to_type:
   # Example mappings - customize based on your label naming conventions
-  # "type:feature": feature
-  # "type:bug": bug-fix
-  # "type:enhancement": enhancement
-  # "type:breaking": breaking-change
-  # "type:security": security
+  # ">breaking": breaking-change
+  # ">bug": bug-fix
+  # ">docs": docs
+  # ">enhancement": enhancement
+  # ">feature": feature
 
 # Maps GitHub PR labels to changelog area values
 # Multiple labels can map to the same area, and a single label can map to multiple areas (comma-separated)
 label_to_areas:
   # Example mappings - customize based on your label naming conventions
-  # "area:search": search
-  # "area:security": security
-  # "area:ml": machine-learning
-  # "area:observability": observability
-  # "area:index": index-management
-  # "area:multiple": "search, security"  # Multiple areas comma-separated
+  # ":Distributed Coordination/Autoscaling": Autoscaling
+  # ":Search/Search": Search
+  # ":Security/Security": Security
+  # ":Data Management/Watcher": Watcher
+  # "area:multiple": "Search, Security"  # Multiple areas comma-separated
+
+# Render blockers (optional - used by the "docs-builder changelog render" command)
+# Changelogs matching the specified products and areas/types will be commented out in rendered output files
+# Dictionary key can be a single product ID or comma-separated product IDs (e.g., "elasticsearch, cloud-serverless")
+# Dictionary value contains areas and/or types that should be blocked for those products
+render_blockers:
+  # Multiple products (comma-separated) with areas and types that should be blocked
+  "cloud-hosted, cloud-serverless":
+    areas: # List of area values that should be blocked (commented out) during render
+      - Autoscaling
+      - Watcher
+    types: # List of type values that should be blocked (commented out) during render
+      - docs
+  # Single product with areas that should be blocked
+  elasticsearch:
+    areas:
+      - Security
 

--- a/docs/cli/release/changelog-render.md
+++ b/docs/cli/release/changelog-render.md
@@ -45,3 +45,6 @@ docs-builder changelog render [options...] [-h|--help]
 :   When specifying feature IDs directly, provide comma-separated values.
 :   When specifying a file path, provide a single value that points to a newline-delimited file. The file should contain one feature ID per line.
 :   Entries with matching `feature-id` values will be commented out in the markdown output and a warning will be emitted.
+
+You can configure `render_blockers` in your `changelog.yml` configuration file to automatically block changelog entries from being rendered based on their products, areas, and/or types.
+For more information, refer to [](/contribute/changelog.md#render-blockers).

--- a/docs/cli/release/changelog-render.md
+++ b/docs/cli/release/changelog-render.md
@@ -46,5 +46,10 @@ docs-builder changelog render [options...] [-h|--help]
 :   When specifying a file path, provide a single value that points to a newline-delimited file. The file should contain one feature ID per line.
 :   Entries with matching `feature-id` values will be commented out in the markdown output and a warning will be emitted.
 
+`--config <string?>`
+:   Optional: Path to the changelog.yml configuration file.
+:   Defaults to `docs/changelog.yml`.
+:   This configuration file is where the command looks for `render_blockers` details.
+
 You can configure `render_blockers` in your `changelog.yml` configuration file to automatically block changelog entries from being rendered based on their products, areas, and/or types.
 For more information, refer to [](/contribute/changelog.md#render-blockers).

--- a/docs/contribute/changelog.md
+++ b/docs/contribute/changelog.md
@@ -85,10 +85,52 @@ If a configuration file exists, the command validates all its values before gene
 - If the configuration file contains `lifecycle`, `product`, `subtype`, or `type` values that don't match the values in `products.yml` and `ChangelogConfiguration.cs`, validation fails. The changelog file is not created.
 - If the configuration file contains `areas` values and they don't match what you specify in the `--areas` command option, validation fails. The changelog file is not created.
 
+The `available_types`, `available_subtypes`, and `available_lifecycles` fields are optional in the configuration file.
+If not specified, all default values from `ChangelogConfiguration.cs` are used.
+
 ### GitHub label mappings
 
 You can optionally add `label_to_type` and `label_to_areas` mappings in your changelog configuration.
 When you run the command with the `--pr` option, it can use these mappings to fill in the `type` and `areas` in your changelog based on your pull request labels.
+
+Refer to [changelog.yml.example](https://github.com/elastic/docs-builder/blob/main/config/changelog.yml.example).
+
+### Render blockers [render-blockers]
+
+You can optionally add `render_blockers` in your changelog configuration to block specific changelog entries from being rendered in markdown output files.
+When you run the `docs-builder changelog render` command, changelog entries that match the specified products and areas/types will be commented out in the markdown output.
+
+The `render_blockers` configuration uses a dictionary format where:
+
+- The key can be a single product ID or comma-separated product IDs (e.g., `"elasticsearch, cloud-serverless"`)
+- The value contains `areas` and/or `types` that should be blocked for those products
+
+An entry is blocked if any product in the changelog entry matches any product key in `render_blockers` AND (any area matches OR any type matches).
+If a changelog entry has multiple products, all matching products in `render_blockers` are checked.
+
+The `types` values in `render_blockers` must exist in the `available_types` list (or in the default types if `available_types` is not specified).
+
+Example configuration:
+
+```yaml
+render_blockers:
+  "cloud-hosted, cloud-serverless":
+    areas: # List of area values that should be blocked (commented out) during render
+      - Autoscaling
+      - Watcher
+    types: # List of type values that should be blocked (commented out) during render
+      - docs
+  elasticsearch: # Another single product case
+    areas:
+      - Security
+```
+
+When rendering, entries with:
+
+- Product `cloud-hosted` or `cloud-serverless` AND (area `Autoscaling` or `Watcher` OR type `docs`) will be commented out
+- Product `elasticsearch` AND area `Security` will be commented out
+
+The command will emit warnings indicating which changelog entries were commented out and why.
 
 Refer to [changelog.yml.example](https://github.com/elastic/docs-builder/blob/main/config/changelog.yml.example).
 

--- a/docs/contribute/changelog.md
+++ b/docs/contribute/changelog.md
@@ -100,6 +100,9 @@ Refer to [changelog.yml.example](https://github.com/elastic/docs-builder/blob/ma
 You can optionally add `render_blockers` in your changelog configuration to block specific changelog entries from being rendered in markdown output files.
 When you run the `docs-builder changelog render` command, changelog entries that match the specified products and areas/types will be commented out in the markdown output.
 
+By default, the `docs-builder changelog render` command checks the following path: `docs/changelog.yml`.
+You can specify a different path with the `--config` command option.
+
 The `render_blockers` configuration uses a dictionary format where:
 
 - The key can be a single product ID or comma-separated product IDs (e.g., `"elasticsearch, cloud-serverless"`)
@@ -303,6 +306,7 @@ Options:
   --subsections                  Optional: Group entries by area/component in subsections. Defaults to false
   --hide-private-links           Optional: Hide private links by commenting them out in the markdown output. Defaults to false
   --hide-features <string[]?>    Filter by feature IDs (comma-separated), or a path to a newline-delimited file containing feature IDs. Can be specified multiple times. Entries with matching feature-id values will be commented out in the markdown output. [Default: null]
+  --config <string?>             Optional: Path to the changelog.yml configuration file. Defaults to 'docs/changelog.yml' [Default: null]
 ```
 
 Before you can use this command you must create changelog files and collect them into bundles.

--- a/src/services/Elastic.Documentation.Services/Changelog/ChangelogConfiguration.cs
+++ b/src/services/Elastic.Documentation.Services/Changelog/ChangelogConfiguration.cs
@@ -57,6 +57,31 @@ public class ChangelogConfiguration
 	/// </summary>
 	public Dictionary<string, string>? LabelToAreas { get; set; }
 
+	/// <summary>
+	/// Configuration for blocking changelogs from being rendered (commented out in markdown output)
+	/// Dictionary key can be a single product ID or comma-separated product IDs (e.g., "elasticsearch, cloud-serverless")
+	/// Dictionary value contains areas and/or types that should be blocked for those products
+	/// Changelogs matching any product key and any area/type in the corresponding entry will be commented out
+	/// </summary>
+	public Dictionary<string, RenderBlockersEntry>? RenderBlockers { get; set; }
+
 	public static ChangelogConfiguration Default => new();
+}
+
+/// <summary>
+/// Configuration entry for blocking changelogs during render
+/// </summary>
+public class RenderBlockersEntry
+{
+	/// <summary>
+	/// List of area values that should be blocked (commented out) during render
+	/// </summary>
+	public List<string>? Areas { get; set; }
+
+	/// <summary>
+	/// List of type values that should be blocked (commented out) during render
+	/// Types must exist in the available_types list (or default AvailableTypes if not specified)
+	/// </summary>
+	public List<string>? Types { get; set; }
 }
 

--- a/src/services/Elastic.Documentation.Services/Changelog/ChangelogRenderInput.cs
+++ b/src/services/Elastic.Documentation.Services/Changelog/ChangelogRenderInput.cs
@@ -15,5 +15,6 @@ public class ChangelogRenderInput
 	public bool Subsections { get; set; }
 	public bool HidePrivateLinks { get; set; }
 	public string[]? HideFeatures { get; set; }
+	public string? Config { get; set; }
 }
 

--- a/src/services/Elastic.Documentation.Services/Changelog/ChangelogYamlStaticContext.cs
+++ b/src/services/Elastic.Documentation.Services/Changelog/ChangelogYamlStaticContext.cs
@@ -10,6 +10,7 @@ namespace Elastic.Documentation.Services.Changelog;
 [YamlSerializable(typeof(ChangelogData))]
 [YamlSerializable(typeof(ProductInfo))]
 [YamlSerializable(typeof(ChangelogConfiguration))]
+[YamlSerializable(typeof(RenderBlockersEntry))]
 [YamlSerializable(typeof(BundledChangelogData))]
 [YamlSerializable(typeof(BundledProduct))]
 [YamlSerializable(typeof(BundledEntry))]

--- a/src/services/Elastic.Documentation.Services/ChangelogService.cs
+++ b/src/services/Elastic.Documentation.Services/ChangelogService.cs
@@ -1620,7 +1620,7 @@ public partial class ChangelogService(
 			var titleSlug = TitleToSlug(title);
 
 			// Load changelog configuration to check for render_blockers
-			var config = await LoadChangelogConfiguration(collector, null, ctx);
+			var config = await LoadChangelogConfiguration(collector, input.Config, ctx);
 			if (config == null)
 			{
 				collector.EmitError(string.Empty, "Failed to load changelog configuration");

--- a/src/services/Elastic.Documentation.Services/Elastic.Documentation.Services.csproj
+++ b/src/services/Elastic.Documentation.Services/Elastic.Documentation.Services.csproj
@@ -7,6 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Elastic.Documentation.Services.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Vecc.YamlDotNet.Analyzers.StaticGenerator" />
     <PackageReference Include="YamlDotNet" />
     <PackageReference Include="System.IO.Abstractions" />

--- a/src/tooling/docs-builder/Commands/ChangelogCommand.cs
+++ b/src/tooling/docs-builder/Commands/ChangelogCommand.cs
@@ -193,6 +193,7 @@ internal sealed class ChangelogCommand(
 		bool subsections = false,
 		bool hidePrivateLinks = false,
 		string[]? hideFeatures = null,
+		string? config = null,
 		Cancel ctx = default
 	)
 	{
@@ -229,7 +230,8 @@ internal sealed class ChangelogCommand(
 			Title = title,
 			Subsections = subsections,
 			HidePrivateLinks = hidePrivateLinks,
-			HideFeatures = allFeatureIds.Count > 0 ? allFeatureIds.ToArray() : null
+			HideFeatures = allFeatureIds.Count > 0 ? allFeatureIds.ToArray() : null,
+			Config = config
 		};
 
 		serviceInvoker.AddCommand(service, renderInput,

--- a/tests/Elastic.Documentation.Services.Tests/ChangelogServiceTests.cs
+++ b/tests/Elastic.Documentation.Services.Tests/ChangelogServiceTests.cs
@@ -2908,6 +2908,769 @@ public class ChangelogServiceTests : IDisposable
 		indexContent.Should().Contain("% * Hidden feature");
 	}
 
+	[Fact]
+	public async Task RenderChangelogs_WithRenderBlockers_CommentsOutMatchingEntries()
+	{
+		// Arrange
+		var service = new ChangelogService(_loggerFactory, _configurationContext, null);
+		var fileSystem = new FileSystem();
+		var changelogDir = fileSystem.Path.Combine(fileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		fileSystem.Directory.CreateDirectory(changelogDir);
+
+		// Create changelog that should be blocked (elasticsearch + search area)
+		var changelog1 = """
+			title: Blocked feature
+			type: feature
+			products:
+			  - product: elasticsearch
+			    target: 9.2.0
+			areas:
+			  - search
+			pr: https://github.com/elastic/elasticsearch/pull/100
+			description: This feature should be blocked
+			""";
+
+		// Create changelog that should NOT be blocked (elasticsearch but different area)
+		var changelog2 = """
+			title: Visible feature
+			type: feature
+			products:
+			  - product: elasticsearch
+			    target: 9.2.0
+			areas:
+			  - observability
+			pr: https://github.com/elastic/elasticsearch/pull/101
+			description: This feature should be visible
+			""";
+
+		var changelogFile1 = fileSystem.Path.Combine(changelogDir, "1755268130-blocked.yaml");
+		var changelogFile2 = fileSystem.Path.Combine(changelogDir, "1755268140-visible.yaml");
+		await fileSystem.File.WriteAllTextAsync(changelogFile1, changelog1, TestContext.Current.CancellationToken);
+		await fileSystem.File.WriteAllTextAsync(changelogFile2, changelog2, TestContext.Current.CancellationToken);
+
+		// Create config file with render_blockers in docs/ subdirectory
+		var configDir = fileSystem.Path.Combine(fileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		var docsDir = fileSystem.Path.Combine(configDir, "docs");
+		fileSystem.Directory.CreateDirectory(docsDir);
+		var configPath = fileSystem.Path.Combine(docsDir, "changelog.yml");
+		var configContent = """
+			available_types:
+			  - feature
+			available_subtypes: []
+			available_lifecycles:
+			  - ga
+			render_blockers:
+			  elasticsearch:
+			    areas:
+			      - search
+			""";
+		await fileSystem.File.WriteAllTextAsync(configPath, configContent, TestContext.Current.CancellationToken);
+
+		// Create bundle file
+		var bundleDir = fileSystem.Path.Combine(fileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		fileSystem.Directory.CreateDirectory(bundleDir);
+
+		var bundleFile = fileSystem.Path.Combine(bundleDir, "bundle.yaml");
+		var bundleContent = $"""
+			products:
+			  - product: elasticsearch
+			    target: 9.2.0
+			entries:
+			  - file:
+			      name: 1755268130-blocked.yaml
+			      checksum: {ComputeSha1(changelog1)}
+			  - file:
+			      name: 1755268140-visible.yaml
+			      checksum: {ComputeSha1(changelog2)}
+			""";
+		await fileSystem.File.WriteAllTextAsync(bundleFile, bundleContent, TestContext.Current.CancellationToken);
+
+		// Set current directory to where config file is located so it can be found
+		var originalDir = Directory.GetCurrentDirectory();
+		try
+		{
+			Directory.SetCurrentDirectory(configDir);
+
+			var outputDir = fileSystem.Path.Combine(fileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+
+			var input = new ChangelogRenderInput
+			{
+				Bundles = [new BundleInput { BundleFile = bundleFile, Directory = changelogDir }],
+				Output = outputDir,
+				Title = "9.2.0"
+			};
+
+			// Act
+			var result = await service.RenderChangelogs(_collector, input, TestContext.Current.CancellationToken);
+
+			// Assert
+			result.Should().BeTrue();
+			_collector.Errors.Should().Be(0);
+			_collector.Warnings.Should().BeGreaterThan(0);
+			_collector.Diagnostics.Should().Contain(d =>
+				d.Severity == Severity.Warning &&
+				d.Message.Contains("Blocked feature") &&
+				d.Message.Contains("render_blockers") &&
+				d.Message.Contains("product 'elasticsearch'") &&
+				d.Message.Contains("area 'search'"));
+
+			var indexFile = fileSystem.Path.Combine(outputDir, "9.2.0", "index.md");
+			fileSystem.File.Exists(indexFile).Should().BeTrue();
+
+			var indexContent = await fileSystem.File.ReadAllTextAsync(indexFile, TestContext.Current.CancellationToken);
+			// Blocked entry should be commented out with % prefix
+			indexContent.Should().Contain("% * Blocked feature");
+			// Visible entry should not be commented
+			indexContent.Should().Contain("* Visible feature");
+			indexContent.Should().NotContain("% * Visible feature");
+		}
+		finally
+		{
+			Directory.SetCurrentDirectory(originalDir);
+		}
+	}
+
+	[Fact]
+	public async Task RenderChangelogs_WithRenderBlockers_CommaSeparatedProducts_CommentsOutMatchingEntries()
+	{
+		// Arrange
+		var service = new ChangelogService(_loggerFactory, _configurationContext, null);
+		var fileSystem = new FileSystem();
+		var changelogDir = fileSystem.Path.Combine(fileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		fileSystem.Directory.CreateDirectory(changelogDir);
+
+		// Create changelog with cloud-serverless product that should be blocked
+		var changelog1 = """
+			title: Blocked cloud feature
+			type: feature
+			products:
+			  - product: cloud-serverless
+			    target: 2025-12-02
+			areas:
+			  - security
+			pr: https://github.com/elastic/cloud-serverless/pull/100
+			description: This feature should be blocked
+			""";
+
+		// Create changelog with elasticsearch product that should also be blocked
+		var changelog2 = """
+			title: Blocked elasticsearch feature
+			type: feature
+			products:
+			  - product: elasticsearch
+			    target: 9.2.0
+			areas:
+			  - security
+			pr: https://github.com/elastic/elasticsearch/pull/101
+			description: This feature should also be blocked
+			""";
+
+		var changelogFile1 = fileSystem.Path.Combine(changelogDir, "1755268130-cloud-blocked.yaml");
+		var changelogFile2 = fileSystem.Path.Combine(changelogDir, "1755268140-es-blocked.yaml");
+		await fileSystem.File.WriteAllTextAsync(changelogFile1, changelog1, TestContext.Current.CancellationToken);
+		await fileSystem.File.WriteAllTextAsync(changelogFile2, changelog2, TestContext.Current.CancellationToken);
+
+		// Create config file with render_blockers using comma-separated products in docs/ subdirectory
+		var configDir = fileSystem.Path.Combine(fileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		var docsDir = fileSystem.Path.Combine(configDir, "docs");
+		fileSystem.Directory.CreateDirectory(docsDir);
+		var configPath = fileSystem.Path.Combine(docsDir, "changelog.yml");
+		var configContent = """
+			available_types:
+			  - feature
+			available_subtypes: []
+			available_lifecycles:
+			  - ga
+			render_blockers:
+			  "elasticsearch, cloud-serverless":
+			    areas:
+			      - security
+			""";
+		await fileSystem.File.WriteAllTextAsync(configPath, configContent, TestContext.Current.CancellationToken);
+
+		// Create bundle file
+		var bundleDir = fileSystem.Path.Combine(fileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		fileSystem.Directory.CreateDirectory(bundleDir);
+
+		var bundleFile = fileSystem.Path.Combine(bundleDir, "bundle.yaml");
+		var bundleContent = $"""
+			products:
+			  - product: elasticsearch
+			    target: 9.2.0
+			  - product: cloud-serverless
+			    target: 2025-12-02
+			entries:
+			  - file:
+			      name: 1755268130-cloud-blocked.yaml
+			      checksum: {ComputeSha1(changelog1)}
+			  - file:
+			      name: 1755268140-es-blocked.yaml
+			      checksum: {ComputeSha1(changelog2)}
+			""";
+		await fileSystem.File.WriteAllTextAsync(bundleFile, bundleContent, TestContext.Current.CancellationToken);
+
+		// Set current directory to where config file is located so it can be found
+		var originalDir = Directory.GetCurrentDirectory();
+		try
+		{
+			Directory.SetCurrentDirectory(configDir);
+
+			var outputDir = fileSystem.Path.Combine(fileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+
+			var input = new ChangelogRenderInput
+			{
+				Bundles = [new BundleInput { BundleFile = bundleFile, Directory = changelogDir }],
+				Output = outputDir,
+				Title = "9.2.0"
+			};
+
+			// Act
+			var result = await service.RenderChangelogs(_collector, input, TestContext.Current.CancellationToken);
+
+			// Assert
+			result.Should().BeTrue();
+			_collector.Errors.Should().Be(0);
+			_collector.Warnings.Should().BeGreaterThan(0);
+
+			var indexFile = fileSystem.Path.Combine(outputDir, "9.2.0", "index.md");
+			fileSystem.File.Exists(indexFile).Should().BeTrue();
+
+			var indexContent = await fileSystem.File.ReadAllTextAsync(indexFile, TestContext.Current.CancellationToken);
+			// Both entries should be commented out
+			indexContent.Should().Contain("% * Blocked cloud feature");
+			indexContent.Should().Contain("% * Blocked elasticsearch feature");
+		}
+		finally
+		{
+			Directory.SetCurrentDirectory(originalDir);
+		}
+	}
+
+	[Fact]
+	public async Task RenderChangelogs_WithRenderBlockers_MultipleProductsInEntry_ChecksAllProducts()
+	{
+		// Arrange
+		var service = new ChangelogService(_loggerFactory, _configurationContext, null);
+		var fileSystem = new FileSystem();
+		var changelogDir = fileSystem.Path.Combine(fileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		fileSystem.Directory.CreateDirectory(changelogDir);
+
+		// Create changelog with multiple products - one matches render_blockers
+		var changelog = """
+			title: Multi-product feature
+			type: feature
+			products:
+			  - product: elasticsearch
+			    target: 9.2.0
+			  - product: kibana
+			    target: 9.2.0
+			areas:
+			  - search
+			pr: https://github.com/elastic/elasticsearch/pull/100
+			description: This feature should be blocked because elasticsearch matches
+			""";
+
+		var changelogFile = fileSystem.Path.Combine(changelogDir, "1755268130-multi-product.yaml");
+		await fileSystem.File.WriteAllTextAsync(changelogFile, changelog, TestContext.Current.CancellationToken);
+
+		// Create config file with render_blockers for elasticsearch only in docs/ subdirectory
+		var configDir = fileSystem.Path.Combine(fileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		var docsDir = fileSystem.Path.Combine(configDir, "docs");
+		fileSystem.Directory.CreateDirectory(docsDir);
+		var configPath = fileSystem.Path.Combine(docsDir, "changelog.yml");
+		var configContent = """
+			available_types:
+			  - feature
+			available_subtypes: []
+			available_lifecycles:
+			  - ga
+			render_blockers:
+			  elasticsearch:
+			    areas:
+			      - search
+			""";
+		await fileSystem.File.WriteAllTextAsync(configPath, configContent, TestContext.Current.CancellationToken);
+
+		// Create bundle file
+		var bundleDir = fileSystem.Path.Combine(fileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		fileSystem.Directory.CreateDirectory(bundleDir);
+
+		var bundleFile = fileSystem.Path.Combine(bundleDir, "bundle.yaml");
+		var bundleContent = $"""
+			products:
+			  - product: elasticsearch
+			    target: 9.2.0
+			  - product: kibana
+			    target: 9.2.0
+			entries:
+			  - file:
+			      name: 1755268130-multi-product.yaml
+			      checksum: {ComputeSha1(changelog)}
+			""";
+		await fileSystem.File.WriteAllTextAsync(bundleFile, bundleContent, TestContext.Current.CancellationToken);
+
+		// Set current directory to where config file is located so it can be found
+		var originalDir = Directory.GetCurrentDirectory();
+		try
+		{
+			Directory.SetCurrentDirectory(configDir);
+
+			var outputDir = fileSystem.Path.Combine(fileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+
+			var input = new ChangelogRenderInput
+			{
+				Bundles = [new BundleInput { BundleFile = bundleFile, Directory = changelogDir }],
+				Output = outputDir,
+				Title = "9.2.0"
+			};
+
+			// Act
+			var result = await service.RenderChangelogs(_collector, input, TestContext.Current.CancellationToken);
+
+			// Assert
+			result.Should().BeTrue();
+			_collector.Errors.Should().Be(0);
+			_collector.Warnings.Should().BeGreaterThan(0);
+			_collector.Diagnostics.Should().Contain(d =>
+				d.Severity == Severity.Warning &&
+				d.Message.Contains("Multi-product feature") &&
+				d.Message.Contains("product 'elasticsearch'"));
+
+			var indexFile = fileSystem.Path.Combine(outputDir, "9.2.0", "index.md");
+			fileSystem.File.Exists(indexFile).Should().BeTrue();
+
+			var indexContent = await fileSystem.File.ReadAllTextAsync(indexFile, TestContext.Current.CancellationToken);
+			// Should be blocked because elasticsearch matches, even though kibana doesn't
+			indexContent.Should().Contain("% * Multi-product feature");
+		}
+		finally
+		{
+			Directory.SetCurrentDirectory(originalDir);
+		}
+	}
+
+	[Fact]
+	public async Task RenderChangelogs_WithRenderBlockers_TypeBlocking_CommentsOutMatchingEntries()
+	{
+		// Arrange
+		var service = new ChangelogService(_loggerFactory, _configurationContext, null);
+		var fileSystem = new FileSystem();
+		var changelogDir = fileSystem.Path.Combine(fileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		fileSystem.Directory.CreateDirectory(changelogDir);
+
+		// Create changelog that should be blocked (elasticsearch + feature type, blocked by type)
+		var changelog1 = """
+			title: Blocked feature by type
+			type: feature
+			products:
+			  - product: elasticsearch
+			    target: 9.2.0
+			pr: https://github.com/elastic/elasticsearch/pull/100
+			description: This feature should be blocked by type
+			""";
+
+		// Create changelog that should NOT be blocked (elasticsearch but different type)
+		var changelog2 = """
+			title: Visible enhancement
+			type: enhancement
+			products:
+			  - product: elasticsearch
+			    target: 9.2.0
+			pr: https://github.com/elastic/elasticsearch/pull/101
+			description: This enhancement should be visible
+			""";
+
+		var changelogFile1 = fileSystem.Path.Combine(changelogDir, "1755268130-blocked.yaml");
+		var changelogFile2 = fileSystem.Path.Combine(changelogDir, "1755268140-visible.yaml");
+		await fileSystem.File.WriteAllTextAsync(changelogFile1, changelog1, TestContext.Current.CancellationToken);
+		await fileSystem.File.WriteAllTextAsync(changelogFile2, changelog2, TestContext.Current.CancellationToken);
+
+		// Create config file with render_blockers blocking docs type
+		var configDir = fileSystem.Path.Combine(fileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		var docsDir = fileSystem.Path.Combine(configDir, "docs");
+		fileSystem.Directory.CreateDirectory(docsDir);
+		var configPath = fileSystem.Path.Combine(docsDir, "changelog.yml");
+		var configContent = """
+			available_types:
+			  - feature
+			  - enhancement
+			available_subtypes: []
+			available_lifecycles:
+			  - ga
+			render_blockers:
+			  elasticsearch:
+			    types:
+			      - feature
+			""";
+		await fileSystem.File.WriteAllTextAsync(configPath, configContent, TestContext.Current.CancellationToken);
+
+		// Create bundle file
+		var bundleDir = fileSystem.Path.Combine(fileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		fileSystem.Directory.CreateDirectory(bundleDir);
+
+		var bundleFile = fileSystem.Path.Combine(bundleDir, "bundle.yaml");
+		var bundleContent = $"""
+			products:
+			  - product: elasticsearch
+			    target: 9.2.0
+			entries:
+			  - file:
+			      name: 1755268130-blocked.yaml
+			      checksum: {ComputeSha1(changelog1)}
+			  - file:
+			      name: 1755268140-visible.yaml
+			      checksum: {ComputeSha1(changelog2)}
+			""";
+		await fileSystem.File.WriteAllTextAsync(bundleFile, bundleContent, TestContext.Current.CancellationToken);
+
+		// Set current directory to where config file is located so it can be found
+		var originalDir = Directory.GetCurrentDirectory();
+		try
+		{
+			Directory.SetCurrentDirectory(configDir);
+
+			var outputDir = fileSystem.Path.Combine(fileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+
+			var input = new ChangelogRenderInput
+			{
+				Bundles = [new BundleInput { BundleFile = bundleFile, Directory = changelogDir }],
+				Output = outputDir,
+				Title = "9.2.0"
+			};
+
+			// Act
+			var result = await service.RenderChangelogs(_collector, input, TestContext.Current.CancellationToken);
+
+			// Assert
+			result.Should().BeTrue();
+			_collector.Errors.Should().Be(0);
+			_collector.Warnings.Should().BeGreaterThan(0);
+			_collector.Diagnostics.Should().Contain(d =>
+				d.Severity == Severity.Warning &&
+				d.Message.Contains("Blocked feature by type") &&
+				d.Message.Contains("render_blockers") &&
+				d.Message.Contains("product 'elasticsearch'") &&
+				d.Message.Contains("type 'feature'"));
+
+			var indexFile = fileSystem.Path.Combine(outputDir, "9.2.0", "index.md");
+			fileSystem.File.Exists(indexFile).Should().BeTrue();
+
+			var indexContent = await fileSystem.File.ReadAllTextAsync(indexFile, TestContext.Current.CancellationToken);
+			// Blocked entry should be commented out with % prefix
+			indexContent.Should().Contain("% * Blocked feature by type");
+			// Visible entry should not be commented
+			indexContent.Should().Contain("* Visible enhancement");
+			indexContent.Should().NotContain("% * Visible enhancement");
+		}
+		finally
+		{
+			Directory.SetCurrentDirectory(originalDir);
+		}
+	}
+
+	[Fact]
+	public async Task RenderChangelogs_WithRenderBlockers_AreasAndTypes_CommentsOutMatchingEntries()
+	{
+		// Arrange
+		var service = new ChangelogService(_loggerFactory, _configurationContext, null);
+		var fileSystem = new FileSystem();
+		var changelogDir = fileSystem.Path.Combine(fileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		fileSystem.Directory.CreateDirectory(changelogDir);
+
+		// Create changelog that should be blocked by area (elasticsearch + search area)
+		var changelog1 = """
+			title: Blocked by area
+			type: feature
+			products:
+			  - product: elasticsearch
+			    target: 9.2.0
+			areas:
+			  - search
+			pr: https://github.com/elastic/elasticsearch/pull/100
+			description: This should be blocked by area
+			""";
+
+		// Create changelog that should be blocked by type (elasticsearch + enhancement type, blocked by type)
+		var changelog2 = """
+			title: Blocked by type
+			type: enhancement
+			products:
+			  - product: elasticsearch
+			    target: 9.2.0
+			pr: https://github.com/elastic/elasticsearch/pull/101
+			description: This should be blocked by type
+			""";
+
+		// Create changelog that should NOT be blocked
+		var changelog3 = """
+			title: Visible feature
+			type: feature
+			products:
+			  - product: elasticsearch
+			    target: 9.2.0
+			areas:
+			  - observability
+			pr: https://github.com/elastic/elasticsearch/pull/102
+			description: This should be visible
+			""";
+
+		var changelogFile1 = fileSystem.Path.Combine(changelogDir, "1755268130-area-blocked.yaml");
+		var changelogFile2 = fileSystem.Path.Combine(changelogDir, "1755268140-type-blocked.yaml");
+		var changelogFile3 = fileSystem.Path.Combine(changelogDir, "1755268150-visible.yaml");
+		await fileSystem.File.WriteAllTextAsync(changelogFile1, changelog1, TestContext.Current.CancellationToken);
+		await fileSystem.File.WriteAllTextAsync(changelogFile2, changelog2, TestContext.Current.CancellationToken);
+		await fileSystem.File.WriteAllTextAsync(changelogFile3, changelog3, TestContext.Current.CancellationToken);
+
+		// Create config file with render_blockers blocking both areas and types
+		var configDir = fileSystem.Path.Combine(fileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		var docsDir = fileSystem.Path.Combine(configDir, "docs");
+		fileSystem.Directory.CreateDirectory(docsDir);
+		var configPath = fileSystem.Path.Combine(docsDir, "changelog.yml");
+		var configContent = """
+			available_types:
+			  - feature
+			  - enhancement
+			available_subtypes: []
+			available_lifecycles:
+			  - ga
+			render_blockers:
+			  elasticsearch:
+			    areas:
+			      - search
+			    types:
+			      - enhancement
+			""";
+		await fileSystem.File.WriteAllTextAsync(configPath, configContent, TestContext.Current.CancellationToken);
+
+		// Create bundle file
+		var bundleDir = fileSystem.Path.Combine(fileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		fileSystem.Directory.CreateDirectory(bundleDir);
+
+		var bundleFile = fileSystem.Path.Combine(bundleDir, "bundle.yaml");
+		var bundleContent = $"""
+			products:
+			  - product: elasticsearch
+			    target: 9.2.0
+			entries:
+			  - file:
+			      name: 1755268130-area-blocked.yaml
+			      checksum: {ComputeSha1(changelog1)}
+			  - file:
+			      name: 1755268140-type-blocked.yaml
+			      checksum: {ComputeSha1(changelog2)}
+			  - file:
+			      name: 1755268150-visible.yaml
+			      checksum: {ComputeSha1(changelog3)}
+			""";
+		await fileSystem.File.WriteAllTextAsync(bundleFile, bundleContent, TestContext.Current.CancellationToken);
+
+		// Set current directory to where config file is located so it can be found
+		var originalDir = Directory.GetCurrentDirectory();
+		try
+		{
+			Directory.SetCurrentDirectory(configDir);
+
+			var outputDir = fileSystem.Path.Combine(fileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+
+			var input = new ChangelogRenderInput
+			{
+				Bundles = [new BundleInput { BundleFile = bundleFile, Directory = changelogDir }],
+				Output = outputDir,
+				Title = "9.2.0"
+			};
+
+			// Act
+			var result = await service.RenderChangelogs(_collector, input, TestContext.Current.CancellationToken);
+
+			// Assert
+			result.Should().BeTrue();
+			_collector.Errors.Should().Be(0);
+			_collector.Warnings.Should().BeGreaterThan(0);
+
+			var indexFile = fileSystem.Path.Combine(outputDir, "9.2.0", "index.md");
+			fileSystem.File.Exists(indexFile).Should().BeTrue();
+
+			var indexContent = await fileSystem.File.ReadAllTextAsync(indexFile, TestContext.Current.CancellationToken);
+			// Both blocked entries should be commented out
+			indexContent.Should().Contain("% * Blocked by area");
+			indexContent.Should().Contain("% * Blocked by type");
+			// Visible entry should not be commented
+			indexContent.Should().Contain("* Visible feature");
+			indexContent.Should().NotContain("% * Visible feature");
+		}
+		finally
+		{
+			Directory.SetCurrentDirectory(originalDir);
+		}
+	}
+
+	[Fact]
+	public async Task LoadChangelogConfiguration_WithoutAvailableTypes_UsesDefaults()
+	{
+		// Arrange
+		var service = new ChangelogService(_loggerFactory, _configurationContext, null);
+		var fileSystem = new FileSystem();
+		var configDir = fileSystem.Path.Combine(fileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		var docsDir = fileSystem.Path.Combine(configDir, "docs");
+		fileSystem.Directory.CreateDirectory(docsDir);
+		var configPath = fileSystem.Path.Combine(docsDir, "changelog.yml");
+		// Config without available_types - should use defaults
+		var configContent = """
+			available_subtypes: []
+			available_lifecycles:
+			  - ga
+			""";
+		await fileSystem.File.WriteAllTextAsync(configPath, configContent, TestContext.Current.CancellationToken);
+
+		var originalDir = Directory.GetCurrentDirectory();
+		try
+		{
+			Directory.SetCurrentDirectory(configDir);
+
+			// Act
+			var config = await service.LoadChangelogConfiguration(_collector, null, TestContext.Current.CancellationToken);
+
+			// Assert
+			config.Should().NotBeNull();
+			_collector.Errors.Should().Be(0);
+			// Should have default types
+			config!.AvailableTypes.Should().Contain("feature");
+			config.AvailableTypes.Should().Contain("bug-fix");
+			config.AvailableTypes.Should().Contain("docs");
+		}
+		finally
+		{
+			Directory.SetCurrentDirectory(originalDir);
+		}
+	}
+
+	[Fact]
+	public async Task LoadChangelogConfiguration_WithoutAvailableSubtypes_UsesDefaults()
+	{
+		// Arrange
+		var service = new ChangelogService(_loggerFactory, _configurationContext, null);
+		var fileSystem = new FileSystem();
+		var configDir = fileSystem.Path.Combine(fileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		var docsDir = fileSystem.Path.Combine(configDir, "docs");
+		fileSystem.Directory.CreateDirectory(docsDir);
+		var configPath = fileSystem.Path.Combine(docsDir, "changelog.yml");
+		// Config without available_subtypes - should use defaults
+		var configContent = """
+			available_types:
+			  - feature
+			available_lifecycles:
+			  - ga
+			""";
+		await fileSystem.File.WriteAllTextAsync(configPath, configContent, TestContext.Current.CancellationToken);
+
+		var originalDir = Directory.GetCurrentDirectory();
+		try
+		{
+			Directory.SetCurrentDirectory(configDir);
+
+			// Act
+			var config = await service.LoadChangelogConfiguration(_collector, null, TestContext.Current.CancellationToken);
+
+			// Assert
+			config.Should().NotBeNull();
+			_collector.Errors.Should().Be(0);
+			// Should have default subtypes
+			config!.AvailableSubtypes.Should().Contain("api");
+			config.AvailableSubtypes.Should().Contain("behavioral");
+		}
+		finally
+		{
+			Directory.SetCurrentDirectory(originalDir);
+		}
+	}
+
+	[Fact]
+	public async Task LoadChangelogConfiguration_WithoutAvailableLifecycles_UsesDefaults()
+	{
+		// Arrange
+		var service = new ChangelogService(_loggerFactory, _configurationContext, null);
+		var fileSystem = new FileSystem();
+		var configDir = fileSystem.Path.Combine(fileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		var docsDir = fileSystem.Path.Combine(configDir, "docs");
+		fileSystem.Directory.CreateDirectory(docsDir);
+		var configPath = fileSystem.Path.Combine(docsDir, "changelog.yml");
+		// Config without available_lifecycles - should use defaults
+		var configContent = """
+			available_types:
+			  - feature
+			available_subtypes: []
+			""";
+		await fileSystem.File.WriteAllTextAsync(configPath, configContent, TestContext.Current.CancellationToken);
+
+		var originalDir = Directory.GetCurrentDirectory();
+		try
+		{
+			Directory.SetCurrentDirectory(configDir);
+
+			// Act
+			var config = await service.LoadChangelogConfiguration(_collector, null, TestContext.Current.CancellationToken);
+
+			// Assert
+			config.Should().NotBeNull();
+			_collector.Errors.Should().Be(0);
+			// Should have default lifecycles
+			config!.AvailableLifecycles.Should().Contain("preview");
+			config.AvailableLifecycles.Should().Contain("beta");
+			config.AvailableLifecycles.Should().Contain("ga");
+		}
+		finally
+		{
+			Directory.SetCurrentDirectory(originalDir);
+		}
+	}
+
+	[Fact]
+	public async Task LoadChangelogConfiguration_WithInvalidRenderBlockersType_ReturnsError()
+	{
+		// Arrange
+		var service = new ChangelogService(_loggerFactory, _configurationContext, null);
+		var fileSystem = new FileSystem();
+		var configDir = fileSystem.Path.Combine(fileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		var docsDir = fileSystem.Path.Combine(configDir, "docs");
+		fileSystem.Directory.CreateDirectory(docsDir);
+		var configPath = fileSystem.Path.Combine(docsDir, "changelog.yml");
+		// Config with invalid type in render_blockers
+		var configContent = """
+			available_types:
+			  - feature
+			  - docs
+			available_subtypes: []
+			available_lifecycles:
+			  - ga
+			render_blockers:
+			  elasticsearch:
+			    types:
+			      - invalid-type
+			""";
+		await fileSystem.File.WriteAllTextAsync(configPath, configContent, TestContext.Current.CancellationToken);
+
+		var originalDir = Directory.GetCurrentDirectory();
+		try
+		{
+			Directory.SetCurrentDirectory(configDir);
+
+			// Act
+			var config = await service.LoadChangelogConfiguration(_collector, null, TestContext.Current.CancellationToken);
+
+			// Assert
+			config.Should().BeNull();
+			_collector.Errors.Should().BeGreaterThan(0);
+			_collector.Diagnostics.Should().Contain(d =>
+				d.Severity == Severity.Error &&
+				d.Message.Contains("Type 'invalid-type' in render_blockers") &&
+				d.Message.Contains("is not in the list of available types"));
+		}
+		finally
+		{
+			Directory.SetCurrentDirectory(originalDir);
+		}
+	}
+
 	private static string ComputeSha1(string content)
 	{
 		var bytes = System.Text.Encoding.UTF8.GetBytes(content);


### PR DESCRIPTION
This PR augments the `docs-builder changelog render` functionality implemented in https://github.com/elastic/docs-builder/pull/2341
It relates to `add_blockers` functionality in https://github.com/elastic/docs-builder/pull/2350

## Impetus

The need for this functionality arose when I was working on testing the workflow in elasticsearch and elasticsearch-serverless repos (see draft config files in https://github.com/elastic/elasticsearch/pull/140141 and https://github.com/elastic/elasticsearch-serverless/pull/5156). In the case of the elasticsearch repo in particular, there will be changelogs created for PRs that technically apply to and are delivered in both stack and serverless releases (and thus reasonably end up in the bundles if we're generating them based on the official list of PRs in a release or even if we're generating the bundles based on the "products" info in the changelogs).  However, the Elasticsearch stakeholders have provided a list of "areas" that should not be included in the serverless release docs (since they're not something users need to care about e.g. ILM, Watcher, monitoring, etc). Right now we're filtering those out via a spreadsheet that keys off  the PR labels so we need to be able to continue to do something along that line with this tooling.

After I got the "areas" filtering working, I realized we ought to do the same for "types" since we've added some types (e.g. docs) that we don't have anywhere to publish yet but that would be nice to start collecting changelogs for nonetheless.

NOTE: For now I've commented the changelogs out instead of removing them entirely, so that we can double-check with PMs or stakeholders until we're absolutely confident in the exclusions. In the long term if we want to remove instead of comment, that's fine with me.

## Summary 

- Adds the `render_blockers` feature to the changelog configuration system to optionally comment out certain changelog entries from the markdown output

An entry is blocked if:

- Any product in the bundle matches any product key in `render_blockers` AND
- (Any area in the entry matches OR any type in the entry matches)

NOTE: The products in the `render_blockers` definition are intentionally matched against the bundle's `products` rather than against the individual changelogs' `products`.

## Examples

1. Check out the PR and generate the binaries per [README.md](https://github.com/elastic/docs-builder/blob/main/README.md):
    ```sh
    ./build.sh clean
    ./build.sh publishbinaries
    cd .artifacts/publish/docs-builder/release
    ```
2. Create some changelogs with various types and areas, for example:
    ```sh
     ./docs-builder changelog add --pr 108759 --repo elasticsearch --owner elastic \
       --products "elasticsearch" --type bug-fix --areas "autoscaling,Infra/REST API" \
       --output test-1/   --feature-id test-feature

    ./docs-builder changelog add --title 'test deprecation' --impact 'Describe the impact' \
      --action 'Describe next steps' --description 'A more detailed description'
      --repo elasticsearch --owner elastic --products "elasticsearch" \
      --type deprecation --areas watcher --output test-1/

     ./docs-builder changelog add --title 'test breaking' \
       --description 'A more detailed description' --repo elasticsearch --owner elastic \
       --products "elasticsearch" --type breaking-change --areas search --output test-1/

    ./docs-builder changelog add --title 'Awesome new docs were added' \
      --products "elasticsearch" --type docs --areas "search" --output test-1/ \
      --feature-id awesome
    ```
3. Create changelog bundles:
     ```sh
     ./docs-builder changelog bundle --all --directory ./test-1 \
       --output-products "elasticsearch 1.2.3" \
       --output ./bundles/changelog-bundle-es.yml
     
     ./docs-builder changelog bundle --all --directory ./test-1 \
       --output-products "cloud-serverless 2026-01-01" \
       --output ./bundles/changelog-bundle-ess.yml
     ```
4. Add a changelog configuration file with a `render_blockers` section. For example, create a `changelog.yml` file that contains:
    ```yml
     render_blockers:
       # Multiple products (comma-separated) with areas and types that should be blocked
       cloud-serverless:
         areas: # List of area values that should be blocked (commented out) during render
           - Autoscaling
           - Watcher
         types: # List of type values that should be blocked (commented out) during render
           - docs
       # Single product with areas and types that should be blocked
       elasticsearch:
         types:
           - docs
     ```
5. Render the serverless bundle and check whether the `render_blockers` are heeded. 
    ```sh
    ./docs-builder changelog render  \
      --config "./changelog.yml" \
      --input "./bundles/changelog-bundle-ess.yml,./test-1,elasticsearch" \
      --output ./out-ess
    ```
    This command returns the following warning messages:
    ```
    The following errors and warnings were found in the documentation
    
    Warning: Changelog entry 'Awesome new docs were added' will be commented out in markdown output because it matches render_blockers: product 'cloud-serverless' with type 'docs'
    
    Warning: Changelog entry 'test deprecation' will be commented out in markdown output because it matches render_blockers: product 'cloud-serverless' with area 'watcher'
    
    Warning: Changelog entry 'Expose `?master_timeout` in autoscaling APIs' will be commented out in markdown output because it matches render_blockers: product 'cloud-serverless' with area 'autoscaling'
    ```
6. Render the Elasticsearch bundle but add some feature filtering too:
     ```sh
    ./docs-builder changelog render \
      --config "./changelog.yml" \
      --input "./bundles/changelog-bundle-es.yml,./test-1,elasticsearch" \
      --output ./out-es
      --hide-features awesome,test-feature
    ```
    
    This command generates the following warnings:
    ```sh
    Warning: Changelog entry 'Awesome new docs were added' with feature-id 'awesome' will be commented out in markdown output
    
    Warning: Changelog entry 'Expose `?master_timeout` in autoscaling APIs' with feature-id 'test-feature' will be commented out in markdown output
    
    Warning: Changelog entry 'Awesome new docs were added' will be commented out in markdown output because it matches render_blockers: product 'elasticsearch' with type 'docs'
    ```

## Changes made

- Configuration Structure (`ChangelogConfiguration.cs`)
    - Added `RenderBlockers` property to `ChangelogConfiguration` as `Dictionary<string, RenderBlockersEntry>`
    - Added `RenderBlockersEntry` with Areas and Types properties
    - Keys can be a single product ID or comma-separated product IDs (e.g., "elasticsearch, cloud-serverless")
- Configuration File (`changelog.yml.example`)
    - Added `render_blockers` section with commented examples for products and areas
- Render Logic (`ChangelogService.cs`)
    - Updated `LoadChangelogConfiguration` to:
      - Default `available_types`, `available_subtypes`, and `available_lifecycles` if not specified
      - Validate `render_blockers` types against `available_types`   
    - Loads changelog configuration in `RenderChangelogs`
    - Extracts `render_blockers`
    - Parses comma-separated product keys
    - Modifies the entry tracking to include bundle product IDs with each entry: (`ChangelogData entry, string repo, HashSet<string> bundleProductIds`)
    - Updates `ShouldBlockEntry` to accept `HashSet<string> bundleProductIds` and check those instead of `entry.Products`
    - Creates a mapping `entryToBundleProducts` to track which bundle products belong to each entry
    - Updates all rendering methods (RenderIndexMarkdown, RenderBreakingChangesMarkdown, RenderDeprecationsMarkdown, RenderEntriesByArea) to accept and use the `entryToBundleProducts` mapping
    - Updates all call sites to pass bundle product IDs when checking if an entry should be blocked
    - The configuration file is now loaded from the specified path (or defaults to `docs/changelog.yml`)
 - Updated `ChangelogCommand.cs`:
   - Added config parameter to the `Render` method signature
   - Added XML documentation for the `--config` parameter
   - Passed the config value to `ChangelogRenderInput`
 - Updated `ChangelogRenderInput.cs`:
   - Added `Config` property to store the configuration file path
 - Tests (`ChangelogServiceTests.cs`)
    - Added tests:
      - `RenderChangelogs_WithRenderBlockers_CommentsOutMatchingEntries` - Tests basic blocking with single product
      - `RenderChangelogs_WithRenderBlockers_CommaSeparatedProducts_CommentsOutMatchingEntries` - Tests comma-separated product keys
      - `RenderChangelogs_WithRenderBlockers_MultipleProductsInEntry_ChecksAllProducts` - Tests entries with multiple products
      - `RenderChangelogs_WithRenderBlockers_UsesBundleProductsNotEntryProducts` to verify that bundle products are used, not entry products
      - `RenderChangelogs_WithCustomConfigPath_UsesSpecifiedConfigFile`- Tests a config file in a custom location (not in `docs/ subdirectory)
      - Added tests for type blocking
      - Added tests for combined areas and types blocking
      - Added tests to verify default values for `available_types`, `available_subtypes`, and `available_lifecycles`
      - Added test to verify validation of invalid types in `render_blockers`
- Made `LoadChangelogConfiguration` internal:
   - Added `InternalsVisibleTo` attribute to allow test access
- Documentation
  - Updated `docs/contribute/changelog.md` with the render `--config` option and a new "Render blockers" section explaining the format
  - Updated `docs/cli/release/changelog-render.md` with the new option, and a short blurb and link

The implementation follows the same pattern [for commenting out changelog entries] as `hideFeatures` but checks products, areas, and types from the configuration instead of feature IDs from command-line arguments. When a changelog entry matches any values in `render_blockers`, it is commented out in the markdown output and a warning is emitted explaining why.

All tests pass and the build succeeds. The feature now supports blocking changelog entries by both areas and types, with proper validation and default handling.

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  

3. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: composer-1 agent 