### PR TITLE
Fix case for self-managed badges

### DIFF
--- a/docs/syntax/applies.md
+++ b/docs/syntax/applies.md
@@ -323,7 +323,7 @@ nec dignissim. Vestibulum ut felis nec massa auctor placerat. Maecenas vel dictu
 
 1. **Stack** - Elastic Stack
 2. **Serverless** - Elastic Cloud Serverless offerings
-3. **Deployment** - Deployment options (ECH, ECK, ECE, Self-Managed)
+3. **Deployment** - Deployment options (ECH, ECK, ECE, Self-managed)
 4. **ProductApplicability** - Specialized tools and agents (ECCTL, Curator, EDOT, APM Agents)
 5. **Product (generic)** - Generic product applicability
 

--- a/src/Elastic.Markdown/Myst/Components/ApplicabilityMappings.cs
+++ b/src/Elastic.Markdown/Myst/Components/ApplicabilityMappings.cs
@@ -23,7 +23,7 @@ public static class ApplicabilityMappings
 	public static readonly ApplicabilityDefinition Ech = new("ECH", "Elastic&nbsp;Cloud&nbsp;Hosted", VersioningSystemId.Ess);
 	public static readonly ApplicabilityDefinition Eck = new("ECK", "Elastic&nbsp;Cloud&nbsp;on&nbsp;Kubernetes", VersioningSystemId.Eck);
 	public static readonly ApplicabilityDefinition Ece = new("ECE", "Elastic&nbsp;Cloud&nbsp;Enterprise", VersioningSystemId.Ece);
-	public static readonly ApplicabilityDefinition Self = new("Self-Managed", "Self-managed Elastic&nbsp;deployments", VersioningSystemId.Self);
+	public static readonly ApplicabilityDefinition Self = new("Self-managed", "Self-managed Elastic&nbsp;deployments", VersioningSystemId.Self);
 
 	// Product Applicability
 	public static readonly ApplicabilityDefinition Ecctl = new("ECCTL", "Elastic&nbsp;Cloud&nbsp;Control", VersioningSystemId.Ecctl);

--- a/tests/authoring/Applicability/ApplicableToComponent.fs
+++ b/tests/authoring/Applicability/ApplicableToComponent.fs
@@ -300,7 +300,7 @@ deployment:
         markdown |> convertsToHtml """
 <p class="applies applies-block">
 	<span class="applicable-info" data-tippy-content="We plan to add this functionality in a future Self-managed Elastic&nbsp;deployments update. Subject to change.">
-		<span class="applicable-name">Self-Managed</span>
+		<span class="applicable-name">Self-managed</span>
 		<span class="applicable-separator"></span>
 		<span class="applicable-meta applicable-meta-ga">
 			Planned
@@ -761,7 +761,7 @@ If this functionality is unavailable or behaves differently when deployed on ECH
 		</span>
 	</span>
 	<span class="applicable-info" data-tippy-content="We plan to add this functionality in a future Self-managed Elastic&nbsp;deployments update. Subject to change.">
-		<span class="applicable-name">Self-Managed</span>
+		<span class="applicable-name">Self-managed</span>
 		<span class="applicable-separator"></span>
 		<span class="applicable-meta applicable-meta-ga">
 			Planned


### PR DESCRIPTION
@vishaangelova noticed that the self-managed badges are showing some kind of title case `Self-Managed` instead of regular case.