### PR TITLE
Clean-up certain components before htmx navigation save

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/main.ts
+++ b/src/Elastic.Documentation.Site/Assets/main.ts
@@ -228,11 +228,11 @@ document.body.addEventListener(
 // Clean up web component content before htmx saves to history cache.
 document.body.addEventListener('htmx:beforeHistorySave', function () {
     // connectedCallback() re-renders
-    $$(
-        'applies-to-popover, version-dropdown, search-or-ask-ai'
-    ).forEach((el) => {
-        el.innerHTML = ''
-    })
+    $$('applies-to-popover, version-dropdown, search-or-ask-ai').forEach(
+        (el) => {
+            el.innerHTML = ''
+        }
+    )
 
     // EUI portal containers getting orphaned during navigation
     $$('[data-euiportal="true"]').forEach((el) => {


### PR DESCRIPTION
Fixes #2440 

## Summary

This pull request adds a cleanup routine to ensure that certain web components and portal containers are properly reset before htmx saves the page state to its history cache in localStorage. This prevents issues with stale or orphaned DOM elements during client-side navigation.

### Frontend cleanup improvements:

* Added an event listener for `htmx:beforeHistorySave` in `main.ts` to clear the inner HTML of `applies-to-popover`, `version-dropdown`, and `search-or-ask-ai` web components before htmx caches the page.
* Removed orphaned EUI portal containers (elements with `data-euiportal="true"`) before htmx history caching to prevent DOM clutter during navigation.

