### PR TITLE
Support mutation M.M-1

### DIFF
--- a/docs/syntax/substitutions.md
+++ b/docs/syntax/substitutions.md
@@ -77,6 +77,7 @@ For variables declaring a semantic version or `Major.Minor` the following operat
 | `M.x`    | Display major component followed by '.x' |
 | `M.M`    | Display only the major and the minor     |
 | `M+1`    | The next major version                   |
+| `M-1`    | The previous major version (returns original value if major is 0) |
 | `M.M+1`  | The next minor version                   |
 | `M.M-1`  | The previous minor version (returns original value if minor is 0) |
 
@@ -108,6 +109,7 @@ sub:
 * M.M: {{version.stack | M.M }}
 * M: {{version.stack | M }}
 * M+1: {{version.stack | M+1 }}
+* M-1: {{version.stack | M-1 }}
 * M+1 | M.M: {{version.stack | M+1 | M.M }}
 * M.M+1: {{version.stack | M.M+1 }}
 * M.M-1: {{version.stack | M.M-1 }}
@@ -130,6 +132,7 @@ sub:
 * M.M: {{version.stack | M.M }}
 * M: {{version.stack | M }}
 * M+1: {{version.stack | M+1 }}
+* M-1: {{version.stack | M-1 }}
 * M+1 | M.M: {{version.stack | M+1 | M.M }}
 * M.M+1: {{version.stack | M.M+1 }}
 * M.M-1: {{version.stack | M.M-1 }}

--- a/docs/syntax/version-variables.md
+++ b/docs/syntax/version-variables.md
@@ -24,6 +24,7 @@ can be printed in any kind of ways.
 | `{{version.stack| M.M}}`    |  {{version.stack|M.M}} |
 | `{{version.stack.base | M }}`     | {{version.stack.base | M }} |
 | `{{version.stack | M+1       | M }}` | {{version.stack | M+1 | M }} |
+| `{{version.stack | M-1 }}` | {{version.stack | M-1 }} |
 | `{{version.stack.base | M.M+1 }}` | {{version.stack.base | M.M+1 }} |
 | `{{version.stack | M.M-1 }}` | {{version.stack | M.M-1 }} |
 

--- a/src/Elastic.Markdown/Myst/InlineParsers/Substitution/SubstitutionMutationHelper.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/Substitution/SubstitutionMutationHelper.cs
@@ -73,6 +73,7 @@ public static class SubstitutionMutationHelper
 			SubstitutionMutation.MajorX => TryGetVersion(value, v => $"{v.Major}.x"),
 			SubstitutionMutation.MajorMinor => TryGetVersion(value, v => $"{v.Major}.{v.Minor}"),
 			SubstitutionMutation.IncreaseMajor => TryGetVersion(value, v => $"{v.Major + 1}.0.0"),
+			SubstitutionMutation.DecreaseMajor => TryGetVersion(value, v => v.Major == 0 ? value : $"{v.Major - 1}.0.0"),
 			SubstitutionMutation.IncreaseMinor => TryGetVersion(value, v => $"{v.Major}.{v.Minor + 1}.0"),
 			SubstitutionMutation.DecreaseMinor => TryGetVersion(value, v => v.Minor == 0 ? value : $"{v.Major}.{v.Minor - 1}.0"),
 			SubstitutionMutation.LowerCase => (true, value.ToLowerInvariant()),

--- a/src/Elastic.Markdown/Myst/InlineParsers/Substitution/SubstitutionParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/Substitution/SubstitutionParser.cs
@@ -33,6 +33,7 @@ public enum SubstitutionMutation
 	[Display(Name = "M.x")] MajorX,
 	[Display(Name = "M.M")] MajorMinor,
 	[Display(Name = "M+1")] IncreaseMajor,
+	[Display(Name = "M-1")] DecreaseMajor,
 	[Display(Name = "M.M+1")] IncreaseMinor,
 	[Display(Name = "M.M-1")] DecreaseMinor,
 	[Display(Name = "lc")] LowerCase,

--- a/tests/Elastic.Markdown.Tests/Inline/SubstitutionTest.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/SubstitutionTest.cs
@@ -223,6 +223,8 @@ Major.x: {{version|M.x}}
 Major.x with space: {{version | M.x}}
 Increase major: {{version|M+1}}
 Increase major with space: {{version | M+1}}
+Decrease major: {{version|M-1}}
+Decrease major with space: {{version | M-1}}
 Increase minor: {{version|M.M+1}}
 Increase minor with space: {{version | M.M+1}}
 Decrease minor: {{version|M.M-1}}
@@ -242,6 +244,8 @@ Decrease minor with space: {{version | M.M-1}}
 			.And.Contain("Major.x with space: 9.x")
 			.And.Contain("Increase major: 10.0.0")
 			.And.Contain("Increase major with space: 10.0.0")
+			.And.Contain("Decrease major: 8.0.0")
+			.And.Contain("Decrease major with space: 8.0.0")
 			.And.Contain("Increase minor: 9.1.0")
 			.And.Contain("Increase minor with space: 9.1.0")
 			.And.Contain("Decrease minor: 9.0.4")
@@ -276,6 +280,36 @@ Version with minor 0: {{version-with-zero-minor|M.M-1}}
 			.And.Contain("Version with minor greater than 0 and M.M: 9.1")
 			// When minor = 0, should return original value
 			.And.Contain("Version with minor 0: 9.0.4");
+	}
+
+	[Fact]
+	public void HasNoErrors() => Collector.Diagnostics.Should().HaveCount(0);
+}
+
+public class DecreaseMajorMutationTest(ITestOutputHelper output) : InlineTest(output,
+"""
+---
+sub:
+  version-with-major: "9.2.3"
+  version-with-zero-major: "0.5.2"
+---
+
+# Testing Decrease Major Mutation
+
+Version with major greater than 0: {{version-with-major|M-1}}
+Version with major greater than 0 and M.M: {{version-with-major|M-1|M.M}}
+Version with major 0: {{version-with-zero-major|M-1}}
+"""
+)
+{
+	[Fact]
+	public void DecreaseMajorWorksCorrectly()
+	{
+		// When major > 0, should decrease major and set minor/patch to 0
+		Html.Should().Contain("Version with major greater than 0: 8.0.0")
+			.And.Contain("Version with major greater than 0 and M.M: 8.0")
+			// When major = 0, should return original value
+			.And.Contain("Version with major 0: 0.5.2");
 	}
 
 	[Fact]

--- a/tests/authoring/Inline/SubstitutionMutations.fs
+++ b/tests/authoring/Inline/SubstitutionMutations.fs
@@ -26,6 +26,7 @@ sub:
 * M.M: {{versions.stack | M.M }}
 * M: {{versions.stack | M }}
 * M+1: {{versions.stack | M+1 }}
+* M-1: {{versions.stack | M-1 }}
 * M+1 | M.M: {{versions.stack | M+1 | M.M }}
 * M.M+1: {{versions.stack | M.M+1 }}
 * M.M-1: {{versions.stack | M.M-1 }}
@@ -47,6 +48,7 @@ sub:
  	<li>M.M: 9.1</li>
  	<li>M: 9</li>
  	<li>M+1: 10.0.0</li>
+ 	<li>M-1: 8.0.0</li>
  	<li>M+1 | M.M: 10.0</li>
  	<li>M.M+1: 9.2.0</li>
  	<li>M.M-1: 9.0.0</li>


### PR DESCRIPTION
We need this functionality to keep track of the versions supported by default on Elastic Cloud Hosted, which are:

* The two latest minor versions of the latest major version
* The latest minor version of the previous major version

This PR focuses on the first item.

I'd like {{version.stack | M.M-1 | M.M }} to render to 9.1 if version.stack is for example 9.2.3.

If minor version is 0 we return the original value without deducing anything, to avoid a negative number.

PS - I've used cursor to implement this.

This functionality would be required by https://github.com/elastic/docs-content/pull/4607