### PR TITLE
Improve changelog bundle --output

### DIFF
--- a/docs/cli/release/changelog-bundle.md
+++ b/docs/cli/release/changelog-bundle.md
@@ -35,7 +35,8 @@ docs-builder changelog bundle [options...] [-h|--help]
 - `"* * *"` - match all changelogs (equivalent to `--all`)
 
 `--output <string?>`
-:   Optional: The output file path for the bundle.
+:   Optional: The output path for the bundle.
+:   Can be either (1) a directory path, in which case `changelog-bundle.yaml` is created in that directory, or (2) a file path ending in `.yml` or `.yaml`.
 :   Defaults to `changelog-bundle.yaml` in the input directory.
 
 `--output-products <List<ProductInfo>?>`

--- a/docs/contribute/changelog.md
+++ b/docs/contribute/changelog.md
@@ -147,7 +147,7 @@ Bundle changelogs
 
 Options:
   --directory <string?>                     Optional: Directory containing changelog YAML files. Defaults to current directory [Default: null]
-  --output <string?>                        Optional: Output file path for the bundled changelog. Defaults to 'changelog-bundle.yaml' in the input directory [Default: null]
+  --output <string?>                        Optional: Output path for the bundled changelog. Can be either (1) a directory path, in which case 'changelog-bundle.yaml' is created in that directory, or (2) a file path ending in .yml or .yaml. Defaults to 'changelog-bundle.yaml' in the input directory [Default: null]
   --all                                     Include all changelogs in the directory. Only one filter option can be specified: `--all`, `--input-products`, or `--prs`.
   --input-products <List<ProductInfo>?>     Filter by products in format "product target lifecycle, ..." (e.g., "cloud-serverless 2025-12-02 ga, cloud-serverless 2025-12-06 beta"). When specified, all three parts (product, target, lifecycle) are required but can be wildcards (*). Examples: "elasticsearch * *" matches all elasticsearch changelogs, "cloud-serverless 2025-12-02 *" matches cloud-serverless 2025-12-02 with any lifecycle, "* 9.3.* *" matches any product with target starting with "9.3.", "* * *" matches all changelogs (equivalent to --all). Only one filter option can be specified: `--all`, `--input-products`, or `--prs`. [Default: null]
   --output-products <List<ProductInfo>?>    Optional: Explicitly set the products array in the output file in format "product target lifecycle, ...". Overrides any values from changelogs. [Default: null]
@@ -311,6 +311,26 @@ entries:
 :::{note}
 When a changelog matches multiple `--input-products` filters, it appears only once in the bundle. This deduplication applies even when using `--all` or `--prs`.
 :::
+
+### Output file location
+
+The `--output` option supports two formats:
+
+1. **Directory path**: If you specify a directory path (without a filename), the command creates `changelog-bundle.yaml` in that directory:
+
+   ```sh
+   docs-builder changelog bundle --all --output /path/to/output/dir
+   # Creates /path/to/output/dir/changelog-bundle.yaml
+   ```
+
+2. **File path**: If you specify a file path ending in `.yml` or `.yaml`, the command uses that exact path:
+
+   ```sh
+   docs-builder changelog bundle --all --output /path/to/custom-bundle.yaml
+   # Creates /path/to/custom-bundle.yaml
+   ```
+
+If you specify a file path with a different extension (not `.yml` or `.yaml`), the command returns an error.
 
 ## Create documentation [render-changelogs]
 


### PR DESCRIPTION
## Summary

Updated the `docs-builder changelog bundle` command's `--output` option and updated documentation and tests.

## Impetus

While testing https://github.com/elastic/docs-builder/pull/2452 I encountered problems specifying an output directory for the bundle since it was interpreting part of the output path as a filename.

## Changes Made:

- Command Implementation (`src/tooling/docs-builder/Commands/ChangelogCommand.cs`):
  - Updated `--output` to accept:
     - Directory path: creates `changelog-bundle.yaml` in that directory
     - File path ending in `.yml` or `.yaml`: uses that exact path
   - Added validation: if a filename is provided, it must end in `.yml` or `.yaml`
   - Updated XML documentation comment
- Documentation (`docs/contribute/changelog.md` and `docs/cli/release/changelog-bundle.md`):
    - Updated the `--output` option description
    - Added "Output file location" section with examples for both formats
   - Fixed code fence formatting
- Tests (`tests/Elastic.Documentation.Services.Tests/ChangelogServiceTests.cs`):
  - Added `BundleChangelogs_WithDirectoryOutputPath_CreatesDefaultFilename` to verify directory-only output paths work correctly

All 31 bundle-related tests pass

## Behavior

- `--output /path/to/dir` → creates `/path/to/dir/changelog-bundle.yaml`
- `--output /path/to/file.yaml` → `creates /path/to/file.yaml`
- `--output /path/to/file.txt` → error (must end in `.yml` or `.yaml`)

The implementation is backward compatible: existing tests continue to pass, and the service layer already handles directory creation.

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  

4. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: composer-1 agent 