### PR TITLE
Fix changelog render with multiple input

### DIFF
--- a/docs/cli/release/changelog-render.md
+++ b/docs/cli/release/changelog-render.md
@@ -16,11 +16,12 @@ docs-builder changelog render [options...] [-h|--help]
 
 `--input <string[]>`
 :   One or more bundle input files.
-:   Each bundle is specified as "bundle-file-path|changelog-file-path|repo" using pipe (`|`) as delimiter.
-:   To merge multiple bundles, separate them with commas: `--input "bundle1|dir1|repo1,bundle2|dir2|repo2"`.
-:   For example, `--input "/path/to/changelog-bundle.yaml|/path/to/changelogs|elasticsearch"`.
+:   Each bundle is specified as "bundle-file-path|changelog-file-path|repo|link-visibility" using pipe (`|`) as delimiter.
+:   To merge multiple bundles, separate them with commas: `--input "bundle1|dir1|repo1|keep-links,bundle2|dir2|repo2|hide-links"`.
+:   For example, `--input "/path/to/changelog-bundle.yaml|/path/to/changelogs|elasticsearch|keep-links"`.
 :   Only `bundle-file-path` is required for each bundle.
 :   Use `repo` if your changelogs do not contain full URLs for the pull requests or issues; otherwise they will be incorrectly derived with "elastic/elastic" in the URL by default.
+:   Use `link-visibility` to control whether PR/issue links are shown or hidden for entries from this bundle. Valid values are `keep-links` (default) or `hide-links`. Use `hide-links` for bundles from private repositories.
 :   **Important**: Paths must be absolute or use environment variables. Tilde (`~`) expansion is not supported.
 
 `--output <string?>`
@@ -34,11 +35,6 @@ docs-builder changelog render [options...] [-h|--help]
 
 `--subsections`
 :   Optional: Group entries by area in subsections.
-:   Defaults to false.
-
-`--hide-private-links`
-:   Optional: Hide private links by commenting them out in the markdown output.
-:   This option is useful when rendering changelog bundles in private repositories.
 :   Defaults to false.
 
 `--hide-features <string[]?>`

--- a/docs/contribute/changelog.md
+++ b/docs/contribute/changelog.md
@@ -341,11 +341,10 @@ For up-to-date details, use the `-h` command option:
 Render bundled changelog(s) to markdown files
 
 Options:
-  --input <string[]>             Required: Bundle input(s) in format "bundle-file-path|changelog-file-path|repo" (use pipe as delimiter). To merge multiple bundles, separate them with commas: "bundle1|dir1|repo1,bundle2|dir2|repo2". Only bundle-file-path is required. Paths must be absolute or use environment variables; tilde (~) expansion is not supported. [Required]
+  --input <string[]>             Required: Bundle input(s) in format "bundle-file-path|changelog-file-path|repo|link-visibility" (use pipe as delimiter). To merge multiple bundles, separate them with commas. Only bundle-file-path is required. link-visibility can be "hide-links" or "keep-links" (default). Paths must be absolute or use environment variables; tilde (~) expansion is not supported. [Required]
   --output <string?>             Optional: Output directory for rendered markdown files. Defaults to current directory [Default: null]
   --title <string?>              Optional: Title to use for section headers in output markdown files. Defaults to version from first bundle [Default: null]
   --subsections                  Optional: Group entries by area/component in subsections. For breaking changes with a subtype, groups by subtype instead of area. Defaults to false
-  --hide-private-links           Optional: Hide private links by commenting them out in the markdown output. Defaults to false
   --hide-features <string[]?>    Filter by feature IDs (comma-separated), or a path to a newline-delimited file containing feature IDs. Can be specified multiple times. Entries with matching feature-id values will be commented out in the markdown output. [Default: null]
   --config <string?>             Optional: Path to the changelog.yml configuration file. Defaults to 'docs/changelog.yml' [Default: null]
 ```
@@ -373,13 +372,13 @@ To create markdown files from this bundle, run the `docs-builder changelog rende
 
 ```sh
 docs-builder changelog render \
-  --input "/path/to/changelog-bundle.yaml|/path/to/changelogs|elasticsearch,/path/to/other-bundle.yaml|/path/to/other-changelogs|kibana" \ <1>
+  --input "/path/to/changelog-bundle.yaml|/path/to/changelogs|elasticsearch|keep-links,/path/to/other-bundle.yaml|/path/to/other-changelogs|kibana|hide-links" \ <1>
   --title 9.2.2 \ <2>
   --output /path/to/release-notes \ <3>
   --subsections <4>
 ```
 
-1. Provide information about the changelog bundle(s). The format for each bundle is `"<bundle-file-path>|<changelog-file-path>|<repository>"` using pipe (`|`) as delimiter. To merge multiple bundles, separate them with commas (`,`). Only the `<bundle-file-path>` is required for each bundle. The `<changelog-file-path>` is useful if the changelogs are not in the default directory and are not resolved within the bundle. The `<repository>` is necessary if your changelogs do not contain full URLs for the pull requests or issues.
+1. Provide information about the changelog bundle(s). The format for each bundle is `"<bundle-file-path>|<changelog-file-path>|<repository>|<link-visibility>"` using pipe (`|`) as delimiter. To merge multiple bundles, separate them with commas (`,`). Only the `<bundle-file-path>` is required for each bundle. The `<changelog-file-path>` is useful if the changelogs are not in the default directory and are not resolved within the bundle. The `<repository>` is necessary if your changelogs do not contain full URLs for the pull requests or issues. The `<link-visibility>` can be `hide-links` or `keep-links` (default) to control whether PR/issue links are hidden for entries from private repositories.
 2. The `--title` value is used for an output folder name and for section titles in the markdown files. If you omit `--title` and the first bundle contains a product `target` value, that value is used. Otherwise, if none of the bundles have product `target` fields, the title defaults to "unknown".
 3. By default the command creates the output files in the current directory.
 4. By default the changelog areas are not displayed in the output. Add `--subsections` to group changelog details by their `areas`. For breaking changes that have a `subtype` value, the subsections will be grouped by subtype instead of area.
@@ -405,7 +404,7 @@ For example, the `index.md` output file contains information derived from the ch
 * Break on FieldData when building global ordinals. [#108875](https://github.com/elastic/elastic/pull/108875) 
 ```
 
-To comment out the pull request and issue links, for example if they relate to a private repository, use the `--hide-private-links` option.
+To comment out the pull request and issue links, for example if they relate to a private repository, add `hide-links` to the `--input` option for that bundle. This allows you to selectively hide links per bundle when merging changelogs from multiple repositories.
 
 If you have changelogs with `feature-id` values and you want them to be omitted from the output, use the `--hide-features` option.
 For more information, refer to [](/cli/release/changelog-render.md).

--- a/src/services/Elastic.Documentation.Services/Changelog/BundleInput.cs
+++ b/src/services/Elastic.Documentation.Services/Changelog/BundleInput.cs
@@ -5,12 +5,18 @@
 namespace Elastic.Documentation.Services.Changelog;
 
 /// <summary>
-/// Input for a single bundle file with optional directory and repo
+/// Input for a single bundle file with optional directory, repo, and link visibility
 /// </summary>
 public class BundleInput
 {
 	public string BundleFile { get; set; } = string.Empty;
 	public string? Directory { get; set; }
 	public string? Repo { get; set; }
+	/// <summary>
+	/// Whether to hide PR/issue links for entries from this bundle.
+	/// When true, links are commented out in the markdown output.
+	/// Defaults to false (links are shown).
+	/// </summary>
+	public bool HideLinks { get; set; }
 }
 

--- a/src/services/Elastic.Documentation.Services/Changelog/ChangelogRenderInput.cs
+++ b/src/services/Elastic.Documentation.Services/Changelog/ChangelogRenderInput.cs
@@ -13,7 +13,6 @@ public class ChangelogRenderInput
 	public string? Output { get; set; }
 	public string? Title { get; set; }
 	public bool Subsections { get; set; }
-	public bool HidePrivateLinks { get; set; }
 	public string[]? HideFeatures { get; set; }
 	public string? Config { get; set; }
 }

--- a/src/services/Elastic.Documentation.Services/ChangelogService.cs
+++ b/src/services/Elastic.Documentation.Services/ChangelogService.cs
@@ -1592,7 +1592,7 @@ public partial class ChangelogService(
 			}
 
 			// Merge phase: Now that validation passed, load and merge all bundles
-			var allResolvedEntries = new List<(ChangelogData entry, string repo, HashSet<string> bundleProductIds)>();
+			var allResolvedEntries = new List<(ChangelogData entry, string repo, HashSet<string> bundleProductIds, bool hideLinks)>();
 			var allProducts = new HashSet<(string product, string target)>();
 
 			foreach (var (bundledData, bundleInput, bundleDirectory) in bundleDataList)
@@ -1653,7 +1653,7 @@ public partial class ChangelogService(
 
 					if (entryData != null)
 					{
-						allResolvedEntries.Add((entryData, repo, bundleProductIds));
+						allResolvedEntries.Add((entryData, repo, bundleProductIds, bundleInput.HideLinks));
 					}
 				}
 			}
@@ -1806,7 +1806,7 @@ public partial class ChangelogService(
 
 			// Track hidden entries for warnings
 			var hiddenEntries = new List<(string title, string featureId)>();
-			foreach (var (entry, _, _) in allResolvedEntries)
+			foreach (var (entry, _, _, _) in allResolvedEntries)
 			{
 				if (!string.IsNullOrWhiteSpace(entry.FeatureId) && featureIdsToHide.Contains(entry.FeatureId))
 				{
@@ -1826,7 +1826,7 @@ public partial class ChangelogService(
 			// Check entries against render blockers and track blocked entries
 			// render_blockers matches against bundle products, not individual entry products
 			var blockedEntries = new List<(string title, List<string> reasons)>();
-			foreach (var (entry, _, bundleProductIds) in allResolvedEntries)
+			foreach (var (entry, _, bundleProductIds, _) in allResolvedEntries)
 			{
 				var isBlocked = ShouldBlockEntry(entry, bundleProductIds, renderBlockers, out var blockReasons);
 				if (isBlocked)
@@ -1874,32 +1874,39 @@ public partial class ChangelogService(
 			// Create mapping from entries to their bundle product IDs for render_blockers checking
 			// Use a custom comparer for reference equality since entries are objects
 			var entryToBundleProducts = new Dictionary<ChangelogData, HashSet<string>>();
-			foreach (var (entry, _, bundleProductIds) in allResolvedEntries)
+			foreach (var (entry, _, bundleProductIds, _) in allResolvedEntries)
 			{
 				entryToBundleProducts[entry] = bundleProductIds;
 			}
 
 			// Create mapping from entries to their repo for PR link formatting
 			var entryToRepo = new Dictionary<ChangelogData, string>();
-			foreach (var (entry, repo, _) in allResolvedEntries)
+			foreach (var (entry, repo, _, _) in allResolvedEntries)
 			{
 				entryToRepo[entry] = repo;
+			}
+
+			// Create mapping from entries to their hideLinks setting for per-bundle link visibility
+			var entryToHideLinks = new Dictionary<ChangelogData, bool>();
+			foreach (var (entry, _, _, hideLinks) in allResolvedEntries)
+			{
+				entryToHideLinks[entry] = hideLinks;
 			}
 
 			// Render markdown files (use first repo found for section anchors, or default)
 			var repoForAnchors = allResolvedEntries.Count > 0 ? allResolvedEntries[0].repo : defaultRepo;
 
 			// Render index.md (features, enhancements, bug fixes, security, docs, regression, other)
-			await RenderIndexMarkdown(collector, outputDir, title, titleSlug, repoForAnchors, allResolvedEntries.Select(e => e.entry).ToList(), entriesByType, input.Subsections, input.HidePrivateLinks, featureIdsToHide, renderBlockers, entryToBundleProducts, entryToRepo, ctx);
+			await RenderIndexMarkdown(collector, outputDir, title, titleSlug, repoForAnchors, allResolvedEntries.Select(e => e.entry).ToList(), entriesByType, input.Subsections, featureIdsToHide, renderBlockers, entryToBundleProducts, entryToRepo, entryToHideLinks, ctx);
 
 			// Render breaking-changes.md
-			await RenderBreakingChangesMarkdown(collector, outputDir, title, titleSlug, repoForAnchors, allResolvedEntries.Select(e => e.entry).ToList(), entriesByType, input.Subsections, input.HidePrivateLinks, featureIdsToHide, renderBlockers, entryToBundleProducts, entryToRepo, ctx);
+			await RenderBreakingChangesMarkdown(collector, outputDir, title, titleSlug, repoForAnchors, allResolvedEntries.Select(e => e.entry).ToList(), entriesByType, input.Subsections, featureIdsToHide, renderBlockers, entryToBundleProducts, entryToRepo, entryToHideLinks, ctx);
 
 			// Render deprecations.md
-			await RenderDeprecationsMarkdown(collector, outputDir, title, titleSlug, repoForAnchors, allResolvedEntries.Select(e => e.entry).ToList(), entriesByType, input.Subsections, input.HidePrivateLinks, featureIdsToHide, renderBlockers, entryToBundleProducts, entryToRepo, ctx);
+			await RenderDeprecationsMarkdown(collector, outputDir, title, titleSlug, repoForAnchors, allResolvedEntries.Select(e => e.entry).ToList(), entriesByType, input.Subsections, featureIdsToHide, renderBlockers, entryToBundleProducts, entryToRepo, entryToHideLinks, ctx);
 
 			// Render known-issues.md
-			await RenderKnownIssuesMarkdown(collector, outputDir, title, titleSlug, repoForAnchors, allResolvedEntries.Select(e => e.entry).ToList(), entriesByType, input.Subsections, input.HidePrivateLinks, featureIdsToHide, renderBlockers, entryToBundleProducts, entryToRepo, ctx);
+			await RenderKnownIssuesMarkdown(collector, outputDir, title, titleSlug, repoForAnchors, allResolvedEntries.Select(e => e.entry).ToList(), entriesByType, input.Subsections, featureIdsToHide, renderBlockers, entryToBundleProducts, entryToRepo, entryToHideLinks, ctx);
 
 			_logger.LogInformation("Rendered changelog markdown files to {OutputDir}", outputDir);
 
@@ -1937,11 +1944,11 @@ public partial class ChangelogService(
 		List<ChangelogData> entries,
 		Dictionary<string, List<ChangelogData>> entriesByType,
 		bool subsections,
-		bool hidePrivateLinks,
 		HashSet<string> featureIdsToHide,
 		Dictionary<string, RenderBlockersEntry>? renderBlockers,
 		Dictionary<ChangelogData, HashSet<string>> entryToBundleProducts,
 		Dictionary<ChangelogData, string> entryToRepo,
+		Dictionary<ChangelogData, bool> entryToHideLinks,
 		Cancel ctx
 	)
 	{
@@ -1989,7 +1996,7 @@ public partial class ChangelogService(
 			{
 				sb.AppendLine(CultureInfo.InvariantCulture, $"### Features and enhancements [{repo}-{titleSlug}-features-enhancements]");
 				var combined = features.Concat(enhancements).ToList();
-				RenderEntriesByArea(sb, combined, subsections, hidePrivateLinks, featureIdsToHide, renderBlockers, entryToBundleProducts, entryToRepo);
+				RenderEntriesByArea(sb, combined, subsections, featureIdsToHide, renderBlockers, entryToBundleProducts, entryToRepo, entryToHideLinks);
 			}
 
 			if (security.Count > 0 || bugFixes.Count > 0)
@@ -1997,28 +2004,28 @@ public partial class ChangelogService(
 				sb.AppendLine();
 				sb.AppendLine(CultureInfo.InvariantCulture, $"### Fixes [{repo}-{titleSlug}-fixes]");
 				var combined = security.Concat(bugFixes).ToList();
-				RenderEntriesByArea(sb, combined, subsections, hidePrivateLinks, featureIdsToHide, renderBlockers, entryToBundleProducts, entryToRepo);
+				RenderEntriesByArea(sb, combined, subsections, featureIdsToHide, renderBlockers, entryToBundleProducts, entryToRepo, entryToHideLinks);
 			}
 
 			if (docs.Count > 0)
 			{
 				sb.AppendLine();
 				sb.AppendLine(CultureInfo.InvariantCulture, $"### Documentation [{repo}-{titleSlug}-docs]");
-				RenderEntriesByArea(sb, docs, subsections, hidePrivateLinks, featureIdsToHide, renderBlockers, entryToBundleProducts, entryToRepo);
+				RenderEntriesByArea(sb, docs, subsections, featureIdsToHide, renderBlockers, entryToBundleProducts, entryToRepo, entryToHideLinks);
 			}
 
 			if (regressions.Count > 0)
 			{
 				sb.AppendLine();
 				sb.AppendLine(CultureInfo.InvariantCulture, $"### Regressions [{repo}-{titleSlug}-regressions]");
-				RenderEntriesByArea(sb, regressions, subsections, hidePrivateLinks, featureIdsToHide, renderBlockers, entryToBundleProducts, entryToRepo);
+				RenderEntriesByArea(sb, regressions, subsections, featureIdsToHide, renderBlockers, entryToBundleProducts, entryToRepo, entryToHideLinks);
 			}
 
 			if (other.Count > 0)
 			{
 				sb.AppendLine();
 				sb.AppendLine(CultureInfo.InvariantCulture, $"### Other changes [{repo}-{titleSlug}-other]");
-				RenderEntriesByArea(sb, other, subsections, hidePrivateLinks, featureIdsToHide, renderBlockers, entryToBundleProducts, entryToRepo);
+				RenderEntriesByArea(sb, other, subsections, featureIdsToHide, renderBlockers, entryToBundleProducts, entryToRepo, entryToHideLinks);
 			}
 		}
 		else
@@ -2047,11 +2054,11 @@ public partial class ChangelogService(
 		List<ChangelogData> entries,
 		Dictionary<string, List<ChangelogData>> entriesByType,
 		bool subsections,
-		bool hidePrivateLinks,
 		HashSet<string> featureIdsToHide,
 		Dictionary<string, RenderBlockersEntry>? renderBlockers,
 		Dictionary<ChangelogData, HashSet<string>> entryToBundleProducts,
 		Dictionary<ChangelogData, string> entryToRepo,
+		Dictionary<ChangelogData, bool> entryToHideLinks,
 		Cancel ctx
 	)
 	{
@@ -2080,6 +2087,7 @@ public partial class ChangelogService(
 				{
 					var bundleProductIds = entryToBundleProducts.GetValueOrDefault(entry, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
 					var entryRepo = entryToRepo.GetValueOrDefault(entry, repo);
+					var entryHideLinks = entryToHideLinks.GetValueOrDefault(entry, false);
 					var shouldHide = (!string.IsNullOrWhiteSpace(entry.FeatureId) && featureIdsToHide.Contains(entry.FeatureId)) ||
 						ShouldBlockEntry(entry, bundleProductIds, renderBlockers, out _);
 
@@ -2095,18 +2103,18 @@ public partial class ChangelogService(
 					var hasIssues = entry.Issues != null && entry.Issues.Count > 0;
 					if (hasPr || hasIssues)
 					{
-						if (hidePrivateLinks)
+						if (entryHideLinks)
 						{
 							// When hiding private links, put them on separate lines as comments
 							if (hasPr)
 							{
-								sb.AppendLine(FormatPrLink(entry.Pr!, entryRepo, hidePrivateLinks));
+								sb.AppendLine(FormatPrLink(entry.Pr!, entryRepo, entryHideLinks));
 							}
 							if (hasIssues)
 							{
 								foreach (var issue in entry.Issues!)
 								{
-									sb.AppendLine(FormatIssueLink(issue, entryRepo, hidePrivateLinks));
+									sb.AppendLine(FormatIssueLink(issue, entryRepo, entryHideLinks));
 								}
 							}
 							sb.AppendLine("For more information, check the pull request or issue above.");
@@ -2116,14 +2124,14 @@ public partial class ChangelogService(
 							sb.Append("For more information, check ");
 							if (hasPr)
 							{
-								sb.Append(FormatPrLink(entry.Pr!, entryRepo, hidePrivateLinks));
+								sb.Append(FormatPrLink(entry.Pr!, entryRepo, entryHideLinks));
 							}
 							if (hasIssues)
 							{
 								foreach (var issue in entry.Issues!)
 								{
 									sb.Append(' ');
-									sb.Append(FormatIssueLink(issue, entryRepo, hidePrivateLinks));
+									sb.Append(FormatIssueLink(issue, entryRepo, entryHideLinks));
 								}
 							}
 							sb.AppendLine(".");
@@ -2185,11 +2193,11 @@ public partial class ChangelogService(
 		List<ChangelogData> entries,
 		Dictionary<string, List<ChangelogData>> entriesByType,
 		bool subsections,
-		bool hidePrivateLinks,
 		HashSet<string> featureIdsToHide,
 		Dictionary<string, RenderBlockersEntry>? renderBlockers,
 		Dictionary<ChangelogData, HashSet<string>> entryToBundleProducts,
 		Dictionary<ChangelogData, string> entryToRepo,
+		Dictionary<ChangelogData, bool> entryToHideLinks,
 		Cancel ctx
 	)
 	{
@@ -2214,6 +2222,7 @@ public partial class ChangelogService(
 				{
 					var bundleProductIds = entryToBundleProducts.GetValueOrDefault(entry, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
 					var entryRepo = entryToRepo.GetValueOrDefault(entry, repo);
+					var entryHideLinks = entryToHideLinks.GetValueOrDefault(entry, false);
 					var shouldHide = (!string.IsNullOrWhiteSpace(entry.FeatureId) && featureIdsToHide.Contains(entry.FeatureId)) ||
 						ShouldBlockEntry(entry, bundleProductIds, renderBlockers, out _);
 
@@ -2229,18 +2238,18 @@ public partial class ChangelogService(
 					var hasIssues = entry.Issues != null && entry.Issues.Count > 0;
 					if (hasPr || hasIssues)
 					{
-						if (hidePrivateLinks)
+						if (entryHideLinks)
 						{
 							// When hiding private links, put them on separate lines as comments
 							if (hasPr)
 							{
-								sb.AppendLine(FormatPrLink(entry.Pr!, entryRepo, hidePrivateLinks));
+								sb.AppendLine(FormatPrLink(entry.Pr!, entryRepo, entryHideLinks));
 							}
 							if (hasIssues)
 							{
 								foreach (var issue in entry.Issues!)
 								{
-									sb.AppendLine(FormatIssueLink(issue, entryRepo, hidePrivateLinks));
+									sb.AppendLine(FormatIssueLink(issue, entryRepo, entryHideLinks));
 								}
 							}
 							sb.AppendLine("For more information, check the pull request or issue above.");
@@ -2250,14 +2259,14 @@ public partial class ChangelogService(
 							sb.Append("For more information, check ");
 							if (hasPr)
 							{
-								sb.Append(FormatPrLink(entry.Pr!, entryRepo, hidePrivateLinks));
+								sb.Append(FormatPrLink(entry.Pr!, entryRepo, entryHideLinks));
 							}
 							if (hasIssues)
 							{
 								foreach (var issue in entry.Issues!)
 								{
 									sb.Append(' ');
-									sb.Append(FormatIssueLink(issue, entryRepo, hidePrivateLinks));
+									sb.Append(FormatIssueLink(issue, entryRepo, entryHideLinks));
 								}
 							}
 							sb.AppendLine(".");
@@ -2319,11 +2328,11 @@ public partial class ChangelogService(
 		List<ChangelogData> entries,
 		Dictionary<string, List<ChangelogData>> entriesByType,
 		bool subsections,
-		bool hidePrivateLinks,
 		HashSet<string> featureIdsToHide,
 		Dictionary<string, RenderBlockersEntry>? renderBlockers,
 		Dictionary<ChangelogData, HashSet<string>> entryToBundleProducts,
 		Dictionary<ChangelogData, string> entryToRepo,
+		Dictionary<ChangelogData, bool> entryToHideLinks,
 		Cancel ctx
 	)
 	{
@@ -2348,6 +2357,7 @@ public partial class ChangelogService(
 				{
 					var bundleProductIds = entryToBundleProducts.GetValueOrDefault(entry, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
 					var entryRepo = entryToRepo.GetValueOrDefault(entry, repo);
+					var entryHideLinks = entryToHideLinks.GetValueOrDefault(entry, false);
 					var shouldHide = (!string.IsNullOrWhiteSpace(entry.FeatureId) && featureIdsToHide.Contains(entry.FeatureId)) ||
 						ShouldBlockEntry(entry, bundleProductIds, renderBlockers, out _);
 
@@ -2363,18 +2373,18 @@ public partial class ChangelogService(
 					var hasIssues = entry.Issues != null && entry.Issues.Count > 0;
 					if (hasPr || hasIssues)
 					{
-						if (hidePrivateLinks)
+						if (entryHideLinks)
 						{
 							// When hiding private links, put them on separate lines as comments
 							if (hasPr)
 							{
-								sb.AppendLine(FormatPrLink(entry.Pr!, entryRepo, hidePrivateLinks));
+								sb.AppendLine(FormatPrLink(entry.Pr!, entryRepo, entryHideLinks));
 							}
 							if (hasIssues)
 							{
 								foreach (var issue in entry.Issues!)
 								{
-									sb.AppendLine(FormatIssueLink(issue, entryRepo, hidePrivateLinks));
+									sb.AppendLine(FormatIssueLink(issue, entryRepo, entryHideLinks));
 								}
 							}
 							sb.AppendLine("For more information, check the pull request or issue above.");
@@ -2384,14 +2394,14 @@ public partial class ChangelogService(
 							sb.Append("For more information, check ");
 							if (hasPr)
 							{
-								sb.Append(FormatPrLink(entry.Pr!, entryRepo, hidePrivateLinks));
+								sb.Append(FormatPrLink(entry.Pr!, entryRepo, entryHideLinks));
 							}
 							if (hasIssues)
 							{
 								foreach (var issue in entry.Issues!)
 								{
 									sb.Append(' ');
-									sb.Append(FormatIssueLink(issue, entryRepo, hidePrivateLinks));
+									sb.Append(FormatIssueLink(issue, entryRepo, entryHideLinks));
 								}
 							}
 							sb.AppendLine(".");
@@ -2443,7 +2453,7 @@ public partial class ChangelogService(
 	}
 
 	[System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0058:Expression value is never used", Justification = "StringBuilder methods return builder for chaining")]
-	private void RenderEntriesByArea(StringBuilder sb, List<ChangelogData> entries, bool subsections, bool hidePrivateLinks, HashSet<string> featureIdsToHide, Dictionary<string, RenderBlockersEntry>? renderBlockers, Dictionary<ChangelogData, HashSet<string>> entryToBundleProducts, Dictionary<ChangelogData, string> entryToRepo)
+	private void RenderEntriesByArea(StringBuilder sb, List<ChangelogData> entries, bool subsections, HashSet<string> featureIdsToHide, Dictionary<string, RenderBlockersEntry>? renderBlockers, Dictionary<ChangelogData, HashSet<string>> entryToBundleProducts, Dictionary<ChangelogData, string> entryToRepo, Dictionary<ChangelogData, bool> entryToHideLinks)
 	{
 		var groupedByArea = entries.GroupBy(e => GetComponent(e)).ToList();
 		foreach (var areaGroup in groupedByArea)
@@ -2459,6 +2469,7 @@ public partial class ChangelogService(
 			{
 				var bundleProductIds = entryToBundleProducts.GetValueOrDefault(entry, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
 				var entryRepo = entryToRepo.GetValueOrDefault(entry, "elastic");
+				var entryHideLinks = entryToHideLinks.GetValueOrDefault(entry, false);
 				var shouldHide = (!string.IsNullOrWhiteSpace(entry.FeatureId) && featureIdsToHide.Contains(entry.FeatureId)) ||
 					ShouldBlockEntry(entry, bundleProductIds, renderBlockers, out _);
 
@@ -2470,7 +2481,7 @@ public partial class ChangelogService(
 				sb.Append(Beautify(entry.Title));
 
 				var hasCommentedLinks = false;
-				if (hidePrivateLinks)
+				if (entryHideLinks)
 				{
 					// When hiding private links, put them on separate lines as comments with proper indentation
 					if (!string.IsNullOrWhiteSpace(entry.Pr))
@@ -2481,7 +2492,7 @@ public partial class ChangelogService(
 							sb.Append("% ");
 						}
 						sb.Append("  ");
-						sb.Append(FormatPrLink(entry.Pr, entryRepo, hidePrivateLinks));
+						sb.Append(FormatPrLink(entry.Pr, entryRepo, entryHideLinks));
 						hasCommentedLinks = true;
 					}
 
@@ -2495,7 +2506,7 @@ public partial class ChangelogService(
 								sb.Append("% ");
 							}
 							sb.Append("  ");
-							sb.Append(FormatIssueLink(issue, entryRepo, hidePrivateLinks));
+							sb.Append(FormatIssueLink(issue, entryRepo, entryHideLinks));
 							hasCommentedLinks = true;
 						}
 					}
@@ -2511,7 +2522,7 @@ public partial class ChangelogService(
 					sb.Append(' ');
 					if (!string.IsNullOrWhiteSpace(entry.Pr))
 					{
-						sb.Append(FormatPrLink(entry.Pr, entryRepo, hidePrivateLinks));
+						sb.Append(FormatPrLink(entry.Pr, entryRepo, entryHideLinks));
 						sb.Append(' ');
 					}
 
@@ -2519,7 +2530,7 @@ public partial class ChangelogService(
 					{
 						foreach (var issue in entry.Issues)
 						{
-							sb.Append(FormatIssueLink(issue, entryRepo, hidePrivateLinks));
+							sb.Append(FormatIssueLink(issue, entryRepo, entryHideLinks));
 							sb.Append(' ');
 						}
 					}
@@ -2528,8 +2539,8 @@ public partial class ChangelogService(
 				if (!string.IsNullOrWhiteSpace(entry.Description))
 				{
 					// Add blank line before description
-					// When hidePrivateLinks is true and links exist, add an indented blank line
-					if (hidePrivateLinks && hasCommentedLinks)
+					// When hiding links, add an indented blank line if there are commented links
+					if (entryHideLinks && hasCommentedLinks)
 					{
 						sb.AppendLine("  ");
 					}

--- a/src/tooling/docs-builder/Arguments/BundleInputParser.cs
+++ b/src/tooling/docs-builder/Arguments/BundleInputParser.cs
@@ -7,7 +7,7 @@ using Elastic.Documentation.Services.Changelog;
 namespace Documentation.Builder.Arguments;
 
 /// <summary>
-/// Utility class for parsing bundle input format: "bundle-file-path|changelog-file-path|repo"
+/// Utility class for parsing bundle input format: "bundle-file-path|changelog-file-path|repo|link-visibility"
 /// Uses pipe (|) as delimiter since ConsoleAppFramework auto-splits string[] by comma.
 /// Only bundle-file-path is required.
 /// </summary>
@@ -15,8 +15,9 @@ public static class BundleInputParser
 {
 	/// <summary>
 	/// Parses a single input string into a BundleInput object.
-	/// Format: "bundle-file-path|changelog-file-path|repo" (only bundle-file-path is required)
+	/// Format: "bundle-file-path|changelog-file-path|repo|link-visibility" (only bundle-file-path is required)
 	/// Uses pipe (|) as delimiter since ConsoleAppFramework auto-splits string[] by comma.
+	/// link-visibility can be "hide-links" or "keep-links" (default is keep-links if omitted).
 	/// </summary>
 	public static BundleInput? Parse(string input)
 	{
@@ -46,14 +47,21 @@ public static class BundleInputParser
 			bundleInput.Repo = parts[2];
 		}
 
+		// Link visibility is optional (fourth part) - "hide-links" or "keep-links"
+		if (parts.Length > 3 && !string.IsNullOrWhiteSpace(parts[3]))
+		{
+			bundleInput.HideLinks = parts[3].Equals("hide-links", StringComparison.OrdinalIgnoreCase);
+		}
+
 		return bundleInput;
 	}
 
 	/// <summary>
 	/// Parses multiple input strings into a list of BundleInput objects.
-	/// Each input is in format: "bundle-file-path|changelog-file-path|repo" (only bundle-file-path is required)
+	/// Each input is in format: "bundle-file-path|changelog-file-path|repo|link-visibility" (only bundle-file-path is required)
 	/// Uses pipe (|) as delimiter since ConsoleAppFramework auto-splits string[] by comma.
 	/// Multiple bundles can be specified by comma-separating them in a single --input option.
+	/// link-visibility can be "hide-links" or "keep-links" (default is keep-links if omitted).
 	/// </summary>
 	public static List<BundleInput> ParseAll(string[]? inputs)
 	{

--- a/src/tooling/docs-builder/Commands/ChangelogCommand.cs
+++ b/src/tooling/docs-builder/Commands/ChangelogCommand.cs
@@ -286,11 +286,10 @@ internal sealed class ChangelogCommand(
 	/// <summary>
 	/// Render bundled changelog(s) to markdown files
 	/// </summary>
-	/// <param name="input">Required: Bundle input(s) in format "bundle-file-path|changelog-file-path|repo" (use pipe as delimiter). To merge multiple bundles, separate them with commas: "bundle1|dir1|repo1,bundle2|dir2|repo2". Only bundle-file-path is required. Paths must be absolute or use environment variables; tilde (~) expansion is not supported.</param>
+	/// <param name="input">Required: Bundle input(s) in format "bundle-file-path|changelog-file-path|repo|link-visibility" (use pipe as delimiter). To merge multiple bundles, separate them with commas. Only bundle-file-path is required. link-visibility can be "hide-links" or "keep-links" (default). Paths must be absolute or use environment variables; tilde (~) expansion is not supported.</param>
 	/// <param name="output">Optional: Output directory for rendered markdown files. Defaults to current directory</param>
 	/// <param name="title">Optional: Title to use for section headers in output markdown files. Defaults to version from first bundle</param>
 	/// <param name="subsections">Optional: Group entries by area/component in subsections. For breaking changes with a subtype, groups by subtype instead of area. Defaults to false</param>
-	/// <param name="hidePrivateLinks">Optional: Hide private links by commenting them out in the markdown output. Defaults to false</param>
 	/// <param name="hideFeatures">Filter by feature IDs (comma-separated), or a path to a newline-delimited file containing feature IDs. Can be specified multiple times. Entries with matching feature-id values will be commented out in the markdown output.</param>
 	/// <param name="ctx"></param>
 	[Command("render")]
@@ -299,7 +298,6 @@ internal sealed class ChangelogCommand(
 		string? output = null,
 		string? title = null,
 		bool subsections = false,
-		bool hidePrivateLinks = false,
 		string[]? hideFeatures = null,
 		string? config = null,
 		Cancel ctx = default
@@ -340,7 +338,6 @@ internal sealed class ChangelogCommand(
 			Output = output,
 			Title = title,
 			Subsections = subsections,
-			HidePrivateLinks = hidePrivateLinks,
 			HideFeatures = allFeatureIds.Count > 0 ? allFeatureIds.ToArray() : null,
 			Config = config
 		};


### PR DESCRIPTION
## Summary

This PR fixes an issue with the "docs-builder changelog render" command as it's implemented in  https://github.com/elastic/docs-builder/pull/2341

When rendering multiple bundles in a single command, the full set of information was not being rendered successfully.

## Changes

### 1. Multiple `--input` option support
- Problem: Only the last `--input` was processed when multiple were provided.
- Solution:
  - Changed `input` parameter from `[BundleInputParser] List<BundleInput>` to `string[]` in `ChangelogCommand.cs`
  - Moved parsing logic from `BundleInputParserAttribute` to manual parsing using `BundleInputParser.ParseAll(input)`
  - ConsoleAppFramework now accumulates all `--input` values into the array

### 2. Delimiter change for bundle input format
- Problem: ConsoleAppFramework auto-splits `string[]` parameters by comma, causing conflicts with comma-separated bundle parts.
- Solution:
  - Changed internal delimiter from comma (`,`) to pipe (`|`) in `BundleInputParser.cs`
  - Format: `"bundle-file-path|changelog-file-path|repo"` (parts separated by `|`)
  - Multiple bundles still separated by commas: `"bundle1|dir1|repo1,bundle2|dir2|repo2"`

### 3. Per-entry PR URL resolution
- Problem: PR URLs were resolved using the first bundle's repository instead of each entry's repository.
- Solution:
  - Created `entryToRepo` dictionary mapping each `ChangelogData` entry to its repository
  - Updated rendering methods (`RenderIndexMarkdown`, `RenderBreakingChangesMarkdown`, `RenderDeprecationsMarkdown`, `RenderKnownIssuesMarkdown`, `RenderEntriesByArea`) to accept and use `entryToRepo`
  - Each PR/issue link now uses the correct repository context

### 4. Per-bundle link visibility control
- Problem: `--hide-private-links` was global, but bundles can come from different repositories (some private, some public).
- Solution:
  - Removed global `--hide-private-links` command-line option
  - Added `HideLinks` property to `BundleInput` class
  - Extended bundle input format to include link visibility: `"bundle-file-path|changelog-file-path|repo|link-visibility"`
  - `link-visibility` accepts `hide-links` or `keep-links` (default)
  - Created `entryToHideLinks` dictionary to track per-entry link visibility
  - Updated rendering methods to use per-entry link visibility settings

## Files Modified

### Core Implementation
- `src/services/Elastic.Documentation.Services/Changelog/BundleInput.cs` - Added `HideLinks` property
- `src/tooling/docs-builder/Arguments/BundleInputParser.cs` - Updated to parse 4-part format with link visibility
- `src/tooling/docs-builder/Commands/ChangelogCommand.cs` - Removed `--hide-private-links`, updated `--input` parsing
- `src/services/Elastic.Documentation.Services/Changelog/ChangelogRenderInput.cs` - Removed `HidePrivateLinks` property
- `src/services/Elastic.Documentation.Services/ChangelogService.cs` - Updated rendering logic for per-entry repo and link visibility

### Documentation
- `docs/contribute/changelog.md` - Updated `--input` format documentation, removed `--hide-private-links` references
- `docs/cli/release/changelog-render.md` - Updated option descriptions and examples

## Usage Example

```sh
docs-builder changelog render \
  --input "/path/to/elasticsearch-serverless/bundle.yaml|/path/to/changelogs|elasticsearch-serverless|hide-links,/path/to/elasticsearch/bundle.yaml|/path/to/changelogs|elasticsearch|keep-links,/path/to/kibana/bundle.yaml|/path/to/changelogs|kibana|keep-links" \
  --output /path/to/output \
  --title "2025-01-13"
```

## Testing
- All unit tests pass (987 tests)
- Build succeeds with no errors
- Binaries published successfully

## Breaking Changes
- The `--hide-private-links` global option has been removed. Use `hide-links` in the `--input` format instead.
- Bundle input format changed from comma-delimited to pipe-delimited: `bundle|dir|repo` → `bundle|dir|repo|link-visibility`

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  

4. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: claude-4.5-opus-high