### PR TITLE
Disable HTMX history cache

### DIFF
--- a/src/Elastic.Documentation.Site/_GlobalLayout.cshtml
+++ b/src/Elastic.Documentation.Site/_GlobalLayout.cshtml
@@ -7,6 +7,7 @@
 </head>
 
 <body
+	hx-history="false"
 	class="group/body text-ink has-[#primary-nav-hamburger:checked]:overflow-hidden"
 	hx-ext="preload, head-support"
 	data-docs-builder-version="@Model.DocsBuilderVersion"


### PR DESCRIPTION
Sorry @cotti, I unintentionally removed the fix in https://github.com/elastic/docs-builder/pull/2463/changes#diff-4775366fa68d71f1347785cd909a002df5f3d32414285672b7efa3c0aed935a4.

I tried `hx-history="false"` as discussed in Slack, and this works too.