### PR TITLE
[DOCS] Add nested definition list syntax

### DIFF
--- a/docs/syntax/definition-lists.md
+++ b/docs/syntax/definition-lists.md
@@ -47,3 +47,22 @@ Legume
 :::
 
 ::::
+
+
+## Nested definition list
+
+Definition lists can be also be nested by indenting the child definition list.
+
+```markdown
+Vegetable
+:   Any edible part of a plant that is used in savory dishes. This includes roots, stems, leaves, flowers, and sometimes fruits that are used as vegetables.
+
+Fruit
+:   A sweet and fleshy product of a tree or other plant that contains seed and can be eaten as food. Common examples include apples, oranges, and bananas. Most fruits are rich in vitamins, minerals and fiber.
+    
+    Citrus
+    :   Fruits with a leathery rind and segmented pulp, such as oranges, lemons, and grapefruits. High in vitamin C.  Common examples include oranges, lemons, and grapefruits.
+
+    Stone fruit
+    :   Fruits with a fleshy outer part surrounding a hard pit, such as peaches, plums, and cherries. Common examples include peaches, plums, and cherries.
+```


### PR DESCRIPTION
## Notes for reviewers

- Yesterday I learned this worked
- I tried to do a tab set for the docs, but _trust me_ it didn't render properly!
- The syntax does actually work though and folks just need raw syntax example anyways 🚤 

## Example output

<img width="899" height="523" alt="Screenshot 2026-01-15 at 12 02 07" src="https://github.com/user-attachments/assets/17018e8e-c1a9-471f-9806-7c359940ac0c" />
