### PR TITLE
Reuse streaming AI client on frontend

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/web-components/AskAi/chat.store.ts
+++ b/src/Elastic.Documentation.Site/Assets/web-components/AskAi/chat.store.ts
@@ -1,14 +1,7 @@
 import { logError } from '../../telemetry/logging'
+import { startAskAiStream, AiProvider } from '../shared/askAiStreamClient'
 import { cooldownStore } from '../shared/cooldown.store'
-import {
-    ApiError,
-    isApiError,
-    isRateLimitError,
-} from '../shared/errorHandling'
-import {
-    startAskAiStream,
-    AiProvider,
-} from '../shared/askAiStreamClient'
+import { ApiError, isApiError, isRateLimitError } from '../shared/errorHandling'
 import { AskAiEvent } from './AskAiEvent'
 import { MessageThrottler } from './MessageThrottler'
 import { v4 as uuidv4 } from 'uuid'

--- a/src/Elastic.Documentation.Site/Assets/web-components/FullPageSearch/AIAnswerPanel.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/FullPageSearch/AIAnswerPanel.tsx
@@ -209,7 +209,10 @@ export const AIAnswerPanel = ({
                 })
 
                 // Stream completed successfully (normal close)
-                if (mountedRef.current && streamingQueryRef.current === currentQuery) {
+                if (
+                    mountedRef.current &&
+                    streamingQueryRef.current === currentQuery
+                ) {
                     answeredQueryRef.current = currentQuery
                     streamingQueryRef.current = null
                     setStreaming(false)

--- a/src/Elastic.Documentation.Site/Assets/web-components/shared/askAiStreamClient.ts
+++ b/src/Elastic.Documentation.Site/Assets/web-components/shared/askAiStreamClient.ts
@@ -2,12 +2,6 @@
  * Shared streaming client for AskAI Lambda communication.
  * Handles AWS CloudFront + Lambda Function URL with OAC authentication.
  */
-
-import {
-    fetchEventSource,
-    EventSourceMessage,
-    EventStreamContentType,
-} from '@microsoft/fetch-event-source'
 import { logWarn } from '../../telemetry/logging'
 import { AskAiEvent, AskAiEventSchema } from '../AskAi/AskAiEvent'
 import {
@@ -15,6 +9,11 @@ import {
     createApiErrorFromResponse,
     isApiError,
 } from './errorHandling'
+import {
+    fetchEventSource,
+    EventSourceMessage,
+    EventStreamContentType,
+} from '@microsoft/fetch-event-source'
 
 export type AiProvider = 'AgentBuilder' | 'LlmGateway'
 


### PR DESCRIPTION
## Summary

- Extracts streaming Lambda communication logic into a shared `askAiStreamClient.ts` module
- Updates `AIAnswerPanel.tsx` to use the shared client, fixing missing AWS headers (`x-amz-content-sha256`, `X-AI-Provider`) that were causing authentication issues
- Refactors `chat.store.ts` to use the shared client, reducing code duplication

## Changes

**New shared client** (`shared/askAiStreamClient.ts`):
- SHA256 hash computation for CloudFront + Lambda Function URL with OAC
- Proper SSE handling via `@microsoft/fetch-event-source`
- Zod schema validation for all events
- Callback-based interface for event handling

**AIAnswerPanel.tsx**:
- Replaced manual fetch/SSE parsing with shared client
- Now correctly authenticates with AWS (was missing required headers)

**chat.store.ts**:
- Simplified streaming logic from ~110 lines to ~25 lines
- Retains MessageThrottler for UI update buffering

## Test plan

- [ ] Verify AskAI chat panel streams responses correctly
- [ ] Verify full-page search AI answer panel streams responses correctly
- [ ] Confirm no console errors related to authentication or SSE parsing

🤖 Generated with [Claude Code](https://claude.ai/code)
