### PR TITLE
Add --strip-title-prefix option to changelog add command

### DIFF
--- a/docs/cli/release/changelog-add.md
+++ b/docs/cli/release/changelog-add.md
@@ -38,10 +38,6 @@ docs-builder changelog add [options...] [-h|--help]
 `--output <string?>`
 :   Optional: Output directory for the changelog fragment. Defaults to current directory.
 
-`--use-pr-number`
-:   Optional: Use the PR number as the filename instead of generating it from a unique ID and title.
-:   When using this option, you must also provide the `--pr` option.
-
 `--owner <string?>`
 :   Optional: GitHub repository owner (used when `--pr` is just a number).
 
@@ -64,6 +60,11 @@ docs-builder changelog add [options...] [-h|--help]
 `--repo <string?>`
 :   Optional: GitHub repository name (used when `--pr` is just a number).
 
+`--strip-title-prefix`
+:   Optional: When used with `--prs`, remove square brackets and text within them from the beginning of PR titles.
+:   For example, if a PR title is `"[Attack discovery] Improves Attack discovery hallucination detection"`, the changelog title will be `"Improves Attack discovery hallucination detection"`.
+:   This option applies only when the title is derived from the PR (when `--title` is not explicitly provided).
+
 `--subtype <string?>`
 :   Optional: Subtype for breaking changes (for example, `api`, `behavioral`, or `configuration`).
 :   The valid subtypes are listed in [ChangelogConfiguration.cs](https://github.com/elastic/docs-builder/blob/main/src/services/Elastic.Documentation.Services/Changelog/ChangelogConfiguration.cs).
@@ -76,3 +77,7 @@ docs-builder changelog add [options...] [-h|--help]
 `--type <string>`
 :   Required: Type of change (for example, `feature`, `enhancement`, `bug-fix`, or `breaking-change`).
 :   The valid types are listed in [ChangelogConfiguration.cs](https://github.com/elastic/docs-builder/blob/main/src/services/Elastic.Documentation.Services/Changelog/ChangelogConfiguration.cs).
+
+`--use-pr-number`
+:   Optional: Use the PR number as the filename instead of generating it from a unique ID and title.
+:   When using this option, you must also provide the `--pr` option.

--- a/docs/contribute/changelog.md
+++ b/docs/contribute/changelog.md
@@ -140,6 +140,7 @@ Options:
   --output <string?>                Optional: Output directory for the changelog. Defaults to current directory [Default: null]
   --config <string?>                Optional: Path to the changelog.yml configuration file. Defaults to 'docs/changelog.yml' [Default: null]
   --use-pr-number                   Optional: Use the PR number as the filename instead of generating it from a unique ID and title
+  --strip-title-prefix              Optional: When used with --prs, remove square brackets and text within them from the beginning of PR titles
 ```
 
 ### Authorization
@@ -242,10 +243,17 @@ When you use the `--prs` option to derive information from a pull request, it ca
 docs-builder changelog add \
   --prs https://github.com/elastic/elasticsearch/pull/139272 \
   --products "elasticsearch 9.3.0" \
-  --config test/changelog.yml
+  --config test/changelog.yml \
+  --strip-title-prefix
 ```
 
 In this case, the changelog file derives the title, type, and areas from the pull request.
+
+The `--strip-title-prefix` option in this example means that if the PR title has a prefix in square brackets (such as `[ES|QL]` or `[Security]`), it is automatically removed from the changelog title.
+
+:::{note}
+The `--strip-title-prefix` option only applies when the title is derived from the PR (when `--title` is not explicitly provided). If you specify `--title` explicitly, that title is used as-is without any prefix stripping.
+:::
 
 #### Block changelog creation with PR labels [example-block-label]
 

--- a/src/services/Elastic.Documentation.Services/Changelog/ChangelogInput.cs
+++ b/src/services/Elastic.Documentation.Services/Changelog/ChangelogInput.cs
@@ -26,5 +26,6 @@ public class ChangelogInput
 	public string? Output { get; set; }
 	public string? Config { get; set; }
 	public bool UsePrNumber { get; set; }
+	public bool StripTitlePrefix { get; set; }
 }
 

--- a/src/tooling/docs-builder/Commands/ChangelogCommand.cs
+++ b/src/tooling/docs-builder/Commands/ChangelogCommand.cs
@@ -51,6 +51,7 @@ internal sealed class ChangelogCommand(
 	/// <param name="output">Optional: Output directory for the changelog. Defaults to current directory</param>
 	/// <param name="config">Optional: Path to the changelog.yml configuration file. Defaults to 'docs/changelog.yml'</param>
 	/// <param name="usePrNumber">Optional: Use the PR number as the filename instead of generating it from a unique ID and title</param>
+	/// <param name="stripTitlePrefix">Optional: When used with --prs, remove square brackets and text within them from the beginning of PR titles (e.g., "[Inference API] Title" becomes "Title")</param>
 	/// <param name="ctx"></param>
 	[Command("add")]
 	public async Task<int> Create(
@@ -71,6 +72,7 @@ internal sealed class ChangelogCommand(
 		string? output = null,
 		string? config = null,
 		bool usePrNumber = false,
+		bool stripTitlePrefix = false,
 		Cancel ctx = default
 	)
 	{
@@ -136,7 +138,8 @@ internal sealed class ChangelogCommand(
 			Highlight = highlight,
 			Output = output,
 			Config = config,
-			UsePrNumber = usePrNumber
+			UsePrNumber = usePrNumber,
+			StripTitlePrefix = stripTitlePrefix
 		};
 
 		serviceInvoker.AddCommand(service, input,


### PR DESCRIPTION
## Impetus

In https://github.com/elastic/docs-content/pull/4627 it becomes obvious that a lot of PR titles have prefixes that we've been automatically or manually removing from release notes. We should have an option for cleaning this up when the changelogs are created.

## Overview

Added a new `--strip-title-prefix` option to the `docs-builder changelog add` command that automatically removes square bracket prefixes from PR titles when creating changelogs.

## Changes Made

### 1. Core Implementation

#### ChangelogInput Class
- **File**: `src/services/Elastic.Documentation.Services/Changelog/ChangelogInput.cs`
- **Change**: Added `StripTitlePrefix` boolean property to track whether prefix stripping should be applied

#### ChangelogCommand Class
- **File**: `src/tooling/docs-builder/Commands/ChangelogCommand.cs`
- **Changes**:
  - Added `--strip-title-prefix` parameter to the `Create` method
  - Added XML documentation describing the option
  - Passed the parameter value to `ChangelogInput.StripTitlePrefix`

#### ChangelogService Class
- **File**: `src/services/Elastic.Documentation.Services/ChangelogService.cs`
- **Changes**:
  - Added `StripSquareBracketPrefix()` helper method that:
    - Checks if title starts with `[`
    - Finds the matching `]`
    - Removes the brackets and content within them
    - Trims leading whitespace from the result
  - Applied prefix stripping logic when PR title is used (line ~251)
  - Ensured `StripTitlePrefix` property is copied when processing multiple PRs

### 2. Functionality

The `--strip-title-prefix` option:
- Works only with the `--prs` option
- Only applies when the title is derived from the PR (when `--title` is not explicitly provided)
- Removes square brackets and text within them from the beginning of PR titles
- Example transformation:
  - Input: `"[Inference API] Include rerank in supported tasks for IBM watsonx integration"`
  - Output: `"Include rerank in supported tasks for IBM watsonx integration"`

### 3. Documentation Updates

Updated `docs/cli/release/changelog-add.md` and `docs/contribute/changelog.md`.

## Usage Example

```sh
./docs-builder changelog add \
  --prs https://github.com/elastic/kibana/pull/247965 \
  --products "kibana 9.3.0" \
  --config /path/to/kibana/docs/changelog.yml \
  --strip-title-prefix
```

The PR title is `"[Attack discovery] Improves Attack discovery hallucination detection"` but the changelog contains the following information:

```yml
pr: https://github.com/elastic/kibana/pull/247965
type: enhancement
products:
- product: kibana
  target: 9.3.0
areas:
- Elastic Security solution
title: Improves Attack discovery hallucination detection
```

## Technical Details

### Implementation Logic

The `StripSquareBracketPrefix()` method:
1. Returns the title unchanged if it's null or whitespace
2. Returns the title unchanged if it doesn't start with `[`
3. Searches for the matching `]` character starting from position 1
4. If no matching `]` is found, returns the title unchanged
5. Extracts everything after the closing bracket and trims leading whitespace

### Edge Cases Handled

- Titles without square brackets: returned unchanged
- Titles with unmatched brackets: returned unchanged (no `]` found)
- Empty titles: returned unchanged
- Titles with multiple bracket pairs: only the first prefix is removed

## Testing

- Build verification: All changes compile successfully with no errors or warnings
- Code analysis: Fixed CA1865 warning by using `StartsWith('[')` instead of `StartsWith("[", StringComparison.Ordinal)`

## Files Modified

1. `src/services/Elastic.Documentation.Services/Changelog/ChangelogInput.cs`
2. `src/tooling/docs-builder/Commands/ChangelogCommand.cs`
3. `src/services/Elastic.Documentation.Services/ChangelogService.cs`
4. `docs/cli/release/changelog-add.md`
5. `docs/contribute/changelog.md`

## Backward Compatibility

This change is fully backward compatible:
- The option defaults to `false` if not specified
- Existing workflows continue to work without modification
- Only affects behavior when explicitly enabled with `--strip-title-prefix`

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  

4. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: composer-1
