### PR TITLE
/_search now fullscreen, no header(s) and footers

### DIFF
--- a/src/Elastic.Documentation.Site/_GlobalLayout.cshtml
+++ b/src/Elastic.Documentation.Site/_GlobalLayout.cshtml
@@ -19,11 +19,17 @@
 	<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=@(Model.GoogleTagManager.Id)@(new HtmlString(Model.GoogleTagManager.QueryString()))"
 	                  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 }
-@(await RenderPartialAsync(_Header.Create(Model)))
-<div id="main-container" class="flex flex-col items-center border-t-1 border-grey-20">
+@if (Model.RenderHeaders)
+{
+	@(await RenderPartialAsync(_Header.Create(Model)))
+}
+<div id="main-container" class="flex flex-col items-center @(Model.RenderHeaders ? "border-t-1 border-grey-20" : "")">
 	@(await RenderBodyAsync())
 </div>
-@await RenderPartialAsync(_Footer.Create(Model))
+@if (Model.RenderHeaders)
+{
+	@await RenderPartialAsync(_Footer.Create(Model))
+}
 @await RenderSectionAsync(GlobalSections.Footer)
 </body>
 </html>

--- a/src/Elastic.Documentation.Site/_ViewModels.cs
+++ b/src/Elastic.Documentation.Site/_ViewModels.cs
@@ -41,6 +41,8 @@ public record GlobalLayoutViewModel
 
 	public bool RenderHamburgerIcon { get; init; } = true;
 
+	public bool RenderHeaders { get; init; } = true;
+
 	public string Static(string path)
 	{
 		var staticPath = $"_static/{path.TrimStart('/')}";

--- a/src/Elastic.Markdown/Layout/_FullSearch.cshtml
+++ b/src/Elastic.Markdown/Layout/_FullSearch.cshtml
@@ -1,5 +1,5 @@
 @inherits RazorSlice<Elastic.Markdown.MarkdownLayoutViewModel>
 
-<div class="max-w-(--max-layout-width) w-full h-full mx-auto">
+<div class="max-w-(--max-layout-width) w-full h-full mx-auto" style="--offset-top: 0;">
 	<full-page-search></full-page-search>
 </div>

--- a/src/Elastic.Markdown/Page/Index.cshtml
+++ b/src/Elastic.Markdown/Page/Index.cshtml
@@ -13,6 +13,7 @@
 		DocsBuilderVersion = ShortId.Create(BuildContext.Version),
 		Layout = Model.CurrentDocument.YamlFrontMatter?.Layout,
 		RenderHamburgerIcon = Model.CurrentDocument.YamlFrontMatter?.Layout != MarkdownPageLayout.LandingPage,
+		RenderHeaders = Model.CurrentDocument.YamlFrontMatter?.Layout != MarkdownPageLayout.FullSearch,
 		DocSetName = Model.DocSetName,
 		Title = $"{Model.Title} | {Model.SiteName}",
 		Description = Model.Description,


### PR DESCRIPTION

https://github.com/user-attachments/assets/e49ed5e1-7aa0-4415-ad28-0399a051111d

