### PR TITLE
Update current version for eck to 3.3.0

### DIFF
--- a/config/versions.yml
+++ b/config/versions.yml
@@ -19,7 +19,7 @@ versioning_systems:
   ech: *all
   eck:
     base: 3.0
-    current: 3.2.0
+    current: 3.3.0
   ess: *all
   ecs:
     base: 9.0


### PR DESCRIPTION
To be merged only on the day of ECK 3.3.0 release!

Release is currently planned for Jan 27, 2026.