### PR TITLE
Add telemetry for "Find in Docs" component

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/telemetry/semconv.ts
+++ b/src/Elastic.Documentation.Site/Assets/telemetry/semconv.ts
@@ -15,6 +15,7 @@ export {
     ATTR_SERVICE_VERSION,
     ATTR_HTTP_RESPONSE_STATUS_CODE,
     ATTR_ERROR_TYPE,
+    ATTR_EXCEPTION_MESSAGE,
 } from '@opentelemetry/semantic-conventions'
 
 // ============================================================================
@@ -103,6 +104,92 @@ export const ATTR_SEARCH_RESULT_POSITION_ON_PAGE =
  * @example 0.85
  */
 export const ATTR_SEARCH_RESULT_SCORE = 'search.result.score'
+
+// ============================================================================
+// FIND IN DOCS ATTRIBUTES (Custom)
+// These are for the navigation "Find in Docs" feature (quick search in sidebar).
+// Separate from the advanced Search page telemetry.
+// ============================================================================
+
+/**
+ * The query string entered by the user in Find in Docs
+ * @example "elasticsearch aggregations"
+ */
+export const ATTR_FIND_IN_DOCS_QUERY = 'find_in_docs.query'
+
+/**
+ * Length of the query string
+ * @example 25
+ */
+export const ATTR_FIND_IN_DOCS_QUERY_LENGTH = 'find_in_docs.query.length'
+
+/**
+ * Total number of results found
+ * @example 142
+ */
+export const ATTR_FIND_IN_DOCS_RESULTS_TOTAL = 'find_in_docs.results.total'
+
+/**
+ * How the Find in Docs was initiated
+ * @example "keyboard_shortcut" | "focus" | "click"
+ */
+export const ATTR_FIND_IN_DOCS_TRIGGER = 'find_in_docs.trigger'
+
+/**
+ * Reason the Find in Docs was closed
+ * @example "escape" | "blur" | "navigate" | "clear"
+ */
+export const ATTR_FIND_IN_DOCS_CLOSE_REASON = 'find_in_docs.close_reason'
+
+/**
+ * Whether Find in Docs had results when closed
+ * @example true
+ */
+export const ATTR_FIND_IN_DOCS_HAD_RESULTS = 'find_in_docs.had_results'
+
+/**
+ * Whether a result was selected when Find in Docs closed
+ * @example true
+ */
+export const ATTR_FIND_IN_DOCS_HAD_SELECTION = 'find_in_docs.had_selection'
+
+/**
+ * Navigation method used (keyboard or mouse)
+ * @example "keyboard" | "mouse"
+ */
+export const ATTR_FIND_IN_DOCS_NAVIGATION_METHOD =
+    'find_in_docs.navigation.method'
+
+/**
+ * Navigation direction
+ * @example "up" | "down"
+ */
+export const ATTR_FIND_IN_DOCS_NAVIGATION_DIRECTION =
+    'find_in_docs.navigation.direction'
+
+/**
+ * URL of the clicked result
+ * @example "/docs/elasticsearch/reference/current/search-aggregations.html"
+ */
+export const ATTR_FIND_IN_DOCS_RESULT_URL = 'find_in_docs.result.url'
+
+/**
+ * Position of the clicked result (0-based)
+ * @example 3
+ */
+export const ATTR_FIND_IN_DOCS_RESULT_POSITION = 'find_in_docs.result.position'
+
+/**
+ * Relevance score of the clicked result
+ * @example 0.85
+ */
+export const ATTR_FIND_IN_DOCS_RESULT_SCORE = 'find_in_docs.result.score'
+
+/**
+ * Retry-After header value in seconds (for rate limiting)
+ * @example 30
+ */
+export const ATTR_FIND_IN_DOCS_RETRY_AFTER = 'find_in_docs.retry_after'
 
 // ============================================================================
 // EVENT ATTRIBUTES (Custom)

--- a/src/Elastic.Documentation.Site/Assets/web-components/NavigationSearch/FindInDocsTelemetry.test.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/NavigationSearch/FindInDocsTelemetry.test.tsx
@@ -1,0 +1,319 @@
+import * as logging from '../../telemetry/logging'
+import { cooldownStore } from '../shared/cooldown.store'
+import { NavigationSearch } from './NavigationSearch'
+import { SearchResultsList } from './SearchResultsList'
+import { navigationSearchStore } from './navigationSearch.store'
+import * as queryHook from './useNavigationSearchQuery'
+import { EuiProvider } from '@elastic/eui'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import * as React from 'react'
+
+// Mock htmx - it uses XPath which jsdom doesn't support properly
+jest.mock('htmx.org', () => ({
+    on: jest.fn(),
+    off: jest.fn(),
+    process: jest.fn(),
+    ajax: jest.fn(),
+}))
+
+// Mock the telemetry logging functions
+jest.mock('../../telemetry/logging', () => ({
+    logInfo: jest.fn(),
+    logWarn: jest.fn(),
+}))
+
+// Mock search results for result click tests
+const mockSearchResults = {
+    results: [
+        {
+            url: '/docs/elasticsearch/guide',
+            title: 'Elasticsearch Guide',
+            description: 'Learn about Elasticsearch',
+            score: 0.95,
+            type: 'doc' as const,
+            parents: [{ title: 'Docs' }, { title: 'Elasticsearch' }],
+        },
+        {
+            url: '/docs/kibana/dashboard',
+            title: 'Kibana Dashboard',
+            description: 'Create dashboards',
+            score: 0.85,
+            type: 'doc' as const,
+            parents: [{ title: 'Docs' }, { title: 'Kibana' }],
+        },
+    ],
+    totalResults: 2,
+    pageCount: 1,
+}
+
+// Create a fresh QueryClient for each test
+const createTestQueryClient = () =>
+    new QueryClient({
+        defaultOptions: {
+            queries: { retry: false },
+            mutations: { retry: false },
+        },
+    })
+
+// Wrapper component for tests
+const renderWithProviders = (ui: React.ReactElement) => {
+    const testQueryClient = createTestQueryClient()
+    return render(
+        <EuiProvider
+            colorMode="light"
+            globalStyles={false}
+            utilityClasses={false}
+        >
+            <QueryClientProvider client={testQueryClient}>
+                {ui}
+            </QueryClientProvider>
+        </EuiProvider>
+    )
+}
+
+// Helper to reset all stores
+const resetStores = () => {
+    navigationSearchStore.getState().actions.clearSearchTerm()
+    cooldownStore.setState({
+        cooldowns: {
+            search: { cooldown: null, awaitingNewInput: false },
+            askAi: { cooldown: null, awaitingNewInput: false },
+        },
+    })
+}
+
+describe('Find in Docs Telemetry Integration', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        resetStores()
+    })
+
+    afterEach(() => {
+        jest.restoreAllMocks()
+    })
+
+    describe('Opening Find in Docs', () => {
+        it('should track find_in_docs_opened when input is focused', async () => {
+            // Arrange
+            renderWithProviders(<NavigationSearch />)
+            const input = screen.getByPlaceholderText(/find in docs/i)
+
+            // Act
+            await userEvent.click(input)
+
+            // Assert
+            expect(logging.logInfo).toHaveBeenCalledWith(
+                'find_in_docs_opened',
+                {
+                    'find_in_docs.trigger': 'focus',
+                }
+            )
+        })
+
+        it('should track keyboard_shortcut trigger when opened via Cmd+K', async () => {
+            // Arrange
+            renderWithProviders(<NavigationSearch />)
+
+            // Act - simulate Cmd+K
+            await userEvent.keyboard('{Meta>}k{/Meta}')
+
+            // Assert
+            expect(logging.logInfo).toHaveBeenCalledWith(
+                'find_in_docs_opened',
+                {
+                    'find_in_docs.trigger': 'keyboard_shortcut',
+                }
+            )
+        })
+    })
+
+    describe('Closing Find in Docs', () => {
+        it('should track find_in_docs_closed with escape reason when pressing Escape', async () => {
+            // Arrange
+            renderWithProviders(<NavigationSearch />)
+            const input = screen.getByPlaceholderText(/find in docs/i)
+
+            // Act - focus and type, then escape
+            await userEvent.click(input)
+            await userEvent.type(input, 'elasticsearch')
+            jest.clearAllMocks() // Clear the opened event
+
+            await userEvent.keyboard('{Escape}')
+
+            // Assert
+            expect(logging.logInfo).toHaveBeenCalledWith(
+                'find_in_docs_closed',
+                expect.objectContaining({
+                    'find_in_docs.close_reason': 'escape',
+                    'find_in_docs.query': 'elasticsearch',
+                })
+            )
+        })
+
+        it('should track find_in_docs_closed with blur reason when clicking outside', async () => {
+            // Arrange
+            renderWithProviders(
+                <div>
+                    <NavigationSearch />
+                    <button data-testid="outside">Outside</button>
+                </div>
+            )
+            const input = screen.getByPlaceholderText(/find in docs/i)
+
+            // Act - focus, type, then click outside
+            await userEvent.click(input)
+            await userEvent.type(input, 'test')
+            jest.clearAllMocks()
+
+            await userEvent.click(screen.getByTestId('outside'))
+
+            // Assert
+            expect(logging.logInfo).toHaveBeenCalledWith(
+                'find_in_docs_closed',
+                expect.objectContaining({
+                    'find_in_docs.close_reason': 'blur',
+                })
+            )
+        })
+
+        it('should include hadResults and hadSelection in close event', async () => {
+            // Arrange
+            renderWithProviders(<NavigationSearch />)
+            const input = screen.getByPlaceholderText(/find in docs/i)
+
+            // Act - focus, type, then escape without results
+            await userEvent.click(input)
+            await userEvent.type(input, 'test')
+            jest.clearAllMocks()
+
+            await userEvent.keyboard('{Escape}')
+
+            // Assert - should have hadResults and hadSelection fields
+            expect(logging.logInfo).toHaveBeenCalledWith(
+                'find_in_docs_closed',
+                expect.objectContaining({
+                    'find_in_docs.had_results': expect.any(Boolean),
+                    'find_in_docs.had_selection': expect.any(Boolean),
+                })
+            )
+        })
+    })
+
+    describe('Error Tracking', () => {
+        it('should track find_in_docs_rate_limited on 429 response', async () => {
+            // Arrange - mock 429 response
+            global.fetch = jest.fn().mockResolvedValue({
+                ok: false,
+                status: 429,
+                headers: {
+                    get: (name: string) =>
+                        name === 'Retry-After' ? '30' : null,
+                },
+                json: () => Promise.resolve({ error: 'Rate limited' }),
+            })
+
+            renderWithProviders(<NavigationSearch />)
+            const input = screen.getByPlaceholderText(/find in docs/i)
+
+            // Act
+            await userEvent.click(input)
+            await userEvent.type(input, 'test query')
+
+            // Assert - wait for rate limit warning
+            await waitFor(() => {
+                expect(logging.logWarn).toHaveBeenCalledWith(
+                    'find_in_docs_rate_limited',
+                    expect.objectContaining({
+                        'find_in_docs.query': expect.any(String),
+                    })
+                )
+            })
+        })
+    })
+})
+
+describe('Find in Docs Result Click Tracking', () => {
+    // Shared props for SearchResultsList - reduces duplication
+    const createResultsListProps = () => ({
+        isKeyboardNavigating: { current: false },
+        onMouseMove: jest.fn(),
+        onResultClick: jest.fn(),
+    })
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        resetStores()
+        // Set up the store with a search term
+        navigationSearchStore.getState().actions.setSearchTerm('elasticsearch')
+
+        // Mock the query hook to return results
+        jest.spyOn(queryHook, 'useNavigationSearchQuery').mockReturnValue({
+            isLoading: false,
+            isFetching: false,
+            data: mockSearchResults,
+            error: null,
+        } as ReturnType<typeof queryHook.useNavigationSearchQuery>)
+    })
+
+    afterEach(() => {
+        jest.restoreAllMocks()
+    })
+
+    it('should track result click with query, position, url, and score', async () => {
+        // Arrange
+        const props = createResultsListProps()
+        renderWithProviders(<SearchResultsList {...props} />)
+
+        // Act
+        await userEvent.click(screen.getByText('Elasticsearch Guide'))
+
+        // Assert - verify all required telemetry fields
+        expect(logging.logInfo).toHaveBeenCalledWith(
+            'find_in_docs_result_clicked',
+            {
+                'find_in_docs.query': 'elasticsearch',
+                'find_in_docs.result.position': 0,
+                'find_in_docs.result.url': '/docs/elasticsearch/guide',
+                'find_in_docs.result.score': 0.95,
+            }
+        )
+        expect(props.onResultClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('should track correct position for each result (0-indexed)', async () => {
+        // Arrange
+        const props = createResultsListProps()
+        renderWithProviders(<SearchResultsList {...props} />)
+
+        // Act - click second result
+        await userEvent.click(screen.getByText('Kibana Dashboard'))
+
+        // Assert
+        expect(logging.logInfo).toHaveBeenCalledWith(
+            'find_in_docs_result_clicked',
+            expect.objectContaining({
+                'find_in_docs.result.position': 1,
+            })
+        )
+    })
+
+    it('should use current search term from store in telemetry', async () => {
+        // Arrange - change the search term after initial setup
+        navigationSearchStore.getState().actions.setSearchTerm('updated query')
+        const props = createResultsListProps()
+        renderWithProviders(<SearchResultsList {...props} />)
+
+        // Act
+        await userEvent.click(screen.getByText('Elasticsearch Guide'))
+
+        // Assert - query should reflect the updated store value
+        expect(logging.logInfo).toHaveBeenCalledWith(
+            'find_in_docs_result_clicked',
+            expect.objectContaining({
+                'find_in_docs.query': 'updated query',
+            })
+        )
+    })
+})

--- a/src/Elastic.Documentation.Site/Assets/web-components/NavigationSearch/SearchResultsList.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/NavigationSearch/SearchResultsList.tsx
@@ -1,6 +1,7 @@
 import { SanitizedHtmlContent } from './SanitizedHtmlContent'
 import { useSelectedIndex, useSearchActions } from './navigationSearch.store'
 import { useSearchTerm } from './navigationSearch.store'
+import { useFindInDocsTelemetry } from './useFindInDocsTelemetry'
 import {
     useNavigationSearchQuery,
     SearchResultItem,
@@ -84,6 +85,7 @@ export const SearchResultsList = ({
     const { isLoading, data } = useNavigationSearchQuery()
     const containerRef = useRef<HTMLDivElement>(null)
     const searchTerm = useSearchTerm()
+    const { trackResultClicked } = useFindInDocsTelemetry()
 
     const results = data?.results ?? []
     const isInitialLoading = isLoading && !data
@@ -146,6 +148,16 @@ export const SearchResultsList = ({
         }
     }
 
+    const handleResultClick = (result: SearchResultItem, index: number) => {
+        trackResultClicked({
+            query: searchTerm,
+            position: index,
+            url: result.url,
+            score: result.score,
+        })
+        onResultClick()
+    }
+
     return (
         <div ref={containerRef} css={containerStyles}>
             {results.map((result, index) => (
@@ -157,7 +169,7 @@ export const SearchResultsList = ({
                     isKeyboardNavigating={isKeyboardNavigating.current}
                     onMouseEnter={() => handleMouseEnter(index)}
                     onMouseMove={() => handleItemMouseMove(index)}
-                    onClick={onResultClick}
+                    onClick={() => handleResultClick(result, index)}
                 />
             ))}
         </div>

--- a/src/Elastic.Documentation.Site/Assets/web-components/NavigationSearch/useFindInDocsTelemetry.ts
+++ b/src/Elastic.Documentation.Site/Assets/web-components/NavigationSearch/useFindInDocsTelemetry.ts
@@ -1,0 +1,164 @@
+/**
+ * Centralized telemetry hook for the "Find in Docs" component.
+ * Provides functions to track quality, performance, user behavior, and errors.
+ *
+ * Uses "find_in_docs" naming to distinguish from the advanced Search page.
+ */
+import { logInfo, logWarn } from '../../telemetry/logging'
+import {
+    ATTR_FIND_IN_DOCS_QUERY,
+    ATTR_FIND_IN_DOCS_QUERY_LENGTH,
+    ATTR_FIND_IN_DOCS_RESULTS_TOTAL,
+    ATTR_FIND_IN_DOCS_RESULT_URL,
+    ATTR_FIND_IN_DOCS_RESULT_POSITION,
+    ATTR_FIND_IN_DOCS_RESULT_SCORE,
+    ATTR_FIND_IN_DOCS_TRIGGER,
+    ATTR_FIND_IN_DOCS_CLOSE_REASON,
+    ATTR_FIND_IN_DOCS_HAD_RESULTS,
+    ATTR_FIND_IN_DOCS_HAD_SELECTION,
+    ATTR_FIND_IN_DOCS_NAVIGATION_METHOD,
+    ATTR_FIND_IN_DOCS_NAVIGATION_DIRECTION,
+    ATTR_FIND_IN_DOCS_RETRY_AFTER,
+    ATTR_ERROR_TYPE,
+    ATTR_EXCEPTION_MESSAGE,
+} from '../../telemetry/semconv'
+import { useCallback } from 'react'
+
+export type FindInDocsTrigger = 'keyboard_shortcut' | 'focus' | 'click'
+export type FindInDocsCloseReason = 'escape' | 'blur' | 'navigate' | 'clear'
+export type NavigationMethod = 'keyboard' | 'mouse'
+export type NavigationDirection = 'up' | 'down'
+
+interface ResultClickParams {
+    query: string
+    position: number
+    url: string
+    score: number
+}
+
+interface ClosedParams {
+    reason: FindInDocsCloseReason
+    query: string
+    hadResults: boolean
+    hadSelection: boolean
+}
+
+interface NavigationParams {
+    method: NavigationMethod
+    direction: NavigationDirection
+    query: string
+}
+
+interface RateLimitedParams {
+    query: string
+    retryAfter: number
+}
+
+interface ErrorParams {
+    query: string
+    errorType: string
+    errorMessage: string
+}
+
+export const useFindInDocsTelemetry = () => {
+    /**
+     * Track when user opens Find in Docs (focus or keyboard shortcut)
+     */
+    const trackOpened = useCallback((trigger: FindInDocsTrigger) => {
+        logInfo('find_in_docs_opened', {
+            [ATTR_FIND_IN_DOCS_TRIGGER]: trigger,
+        })
+    }, [])
+
+    /**
+     * Track when Find in Docs is closed
+     */
+    const trackClosed = useCallback(
+        ({ reason, query, hadResults, hadSelection }: ClosedParams) => {
+            logInfo('find_in_docs_closed', {
+                [ATTR_FIND_IN_DOCS_CLOSE_REASON]: reason,
+                [ATTR_FIND_IN_DOCS_QUERY]: query,
+                [ATTR_FIND_IN_DOCS_HAD_RESULTS]: hadResults,
+                [ATTR_FIND_IN_DOCS_HAD_SELECTION]: hadSelection,
+            })
+        },
+        []
+    )
+
+    /**
+     * Track when user clicks on a result
+     */
+    const trackResultClicked = useCallback(
+        ({ query, position, url, score }: ResultClickParams) => {
+            logInfo('find_in_docs_result_clicked', {
+                [ATTR_FIND_IN_DOCS_QUERY]: query,
+                [ATTR_FIND_IN_DOCS_RESULT_POSITION]: position,
+                [ATTR_FIND_IN_DOCS_RESULT_URL]: url,
+                [ATTR_FIND_IN_DOCS_RESULT_SCORE]: score,
+            })
+        },
+        []
+    )
+
+    /**
+     * Track when Find in Docs returns zero results
+     */
+    const trackZeroResults = useCallback((query: string) => {
+        logInfo('find_in_docs_zero_results', {
+            [ATTR_FIND_IN_DOCS_QUERY]: query,
+            [ATTR_FIND_IN_DOCS_QUERY_LENGTH]: query.length,
+            [ATTR_FIND_IN_DOCS_RESULTS_TOTAL]: 0,
+        })
+    }, [])
+
+    /**
+     * Track keyboard/mouse navigation through results
+     */
+    const trackNavigation = useCallback(
+        ({ method, direction, query }: NavigationParams) => {
+            logInfo('find_in_docs_navigation', {
+                [ATTR_FIND_IN_DOCS_NAVIGATION_METHOD]: method,
+                [ATTR_FIND_IN_DOCS_NAVIGATION_DIRECTION]: direction,
+                [ATTR_FIND_IN_DOCS_QUERY]: query,
+            })
+        },
+        []
+    )
+
+    /**
+     * Track rate limit errors (429)
+     */
+    const trackRateLimited = useCallback(
+        ({ query, retryAfter }: RateLimitedParams) => {
+            logWarn('find_in_docs_rate_limited', {
+                [ATTR_FIND_IN_DOCS_QUERY]: query,
+                [ATTR_FIND_IN_DOCS_RETRY_AFTER]: retryAfter,
+            })
+        },
+        []
+    )
+
+    /**
+     * Track errors
+     */
+    const trackError = useCallback(
+        ({ query, errorType, errorMessage }: ErrorParams) => {
+            logWarn('find_in_docs_error', {
+                [ATTR_FIND_IN_DOCS_QUERY]: query,
+                [ATTR_ERROR_TYPE]: errorType,
+                [ATTR_EXCEPTION_MESSAGE]: errorMessage,
+            })
+        },
+        []
+    )
+
+    return {
+        trackOpened,
+        trackClosed,
+        trackResultClicked,
+        trackZeroResults,
+        trackNavigation,
+        trackRateLimited,
+        trackError,
+    }
+}

--- a/src/Elastic.Documentation.Site/Assets/web-components/NavigationSearch/useNavigationSearchKeyboardNavigation.ts
+++ b/src/Elastic.Documentation.Site/Assets/web-components/NavigationSearch/useNavigationSearchKeyboardNavigation.ts
@@ -1,4 +1,9 @@
-import { useSelectedIndex, useSearchActions } from './navigationSearch.store'
+import {
+    useSelectedIndex,
+    useSearchActions,
+    useSearchTerm,
+} from './navigationSearch.store'
+import { useFindInDocsTelemetry } from './useFindInDocsTelemetry'
 import { useRef, useCallback } from 'react'
 
 interface Options {
@@ -24,7 +29,9 @@ export const useNavigationSearchKeyboardNavigation = ({
     const inputRef = useRef<HTMLInputElement>(null)
     const isKeyboardNavigating = useRef(false)
     const selectedIndex = useSelectedIndex()
+    const searchTerm = useSearchTerm()
     const { setSelectedIndex } = useSearchActions()
+    const { trackNavigation } = useFindInDocsTelemetry()
 
     const handleMouseMove = useCallback(() => {
         isKeyboardNavigating.current = false
@@ -73,6 +80,11 @@ export const useNavigationSearchKeyboardNavigation = ({
                                 : Math.min(selectedIndex + 1, resultsCount - 1)
                         setSelectedIndex(nextIndex)
                         scrollToItem(nextIndex)
+                        trackNavigation({
+                            method: 'keyboard',
+                            direction: 'down',
+                            query: searchTerm,
+                        })
                     }
                     break
 
@@ -83,6 +95,11 @@ export const useNavigationSearchKeyboardNavigation = ({
                         const prevIndex = selectedIndex - 1
                         setSelectedIndex(prevIndex)
                         scrollToItem(prevIndex)
+                        trackNavigation({
+                            method: 'keyboard',
+                            direction: 'up',
+                            query: searchTerm,
+                        })
                     }
                     break
             }
@@ -91,9 +108,11 @@ export const useNavigationSearchKeyboardNavigation = ({
             resultsCount,
             isLoading,
             selectedIndex,
+            searchTerm,
             setSelectedIndex,
             onClose,
             onNavigate,
+            trackNavigation,
         ]
     )
 

--- a/src/Elastic.Documentation.Site/Assets/web-components/NavigationSearch/useNavigationSearchQuery.ts
+++ b/src/Elastic.Documentation.Site/Assets/web-components/NavigationSearch/useNavigationSearchQuery.ts
@@ -1,14 +1,17 @@
+import { logInfo, logWarn } from '../../telemetry/logging'
 import {
-    ATTR_SEARCH_QUERY,
-    ATTR_SEARCH_PAGE,
-    ATTR_SEARCH_RESULTS_TOTAL,
-    ATTR_SEARCH_RESULTS_COUNT,
-    ATTR_SEARCH_PAGE_COUNT,
+    ATTR_FIND_IN_DOCS_QUERY,
+    ATTR_FIND_IN_DOCS_QUERY_LENGTH,
+    ATTR_FIND_IN_DOCS_RESULTS_TOTAL,
+    ATTR_FIND_IN_DOCS_RETRY_AFTER,
+    ATTR_ERROR_TYPE,
 } from '../../telemetry/semconv'
 import { traceSpan } from '../../telemetry/tracing'
 import {
     createApiErrorFromResponse,
     shouldRetry,
+    isApiError,
+    isRateLimitError,
 } from '../shared/errorHandling'
 import { ApiError } from '../shared/errorHandling'
 import {
@@ -106,10 +109,10 @@ export const useNavigationSearchQuery = () => {
                 })
             }
 
-            return traceSpan('execute navigation search', async (span) => {
-                // Track frontend search (even if backend response is cached by CloudFront)
-                span.setAttribute(ATTR_SEARCH_QUERY, debouncedSearchTerm)
-                span.setAttribute(ATTR_SEARCH_PAGE, pageNumber)
+            return traceSpan('find_in_docs', async (span) => {
+                // Track Find in Docs query (even if backend response is cached by CloudFront)
+                span.setAttribute(ATTR_FIND_IN_DOCS_QUERY, debouncedSearchTerm)
+                span.setAttribute('find_in_docs.page', pageNumber)
 
                 const params = new URLSearchParams({
                     q: debouncedSearchTerm,
@@ -133,17 +136,27 @@ export const useNavigationSearchQuery = () => {
 
                 // Add result metrics to span
                 span.setAttribute(
-                    ATTR_SEARCH_RESULTS_TOTAL,
+                    ATTR_FIND_IN_DOCS_RESULTS_TOTAL,
                     searchResponse.totalResults
                 )
                 span.setAttribute(
-                    ATTR_SEARCH_RESULTS_COUNT,
+                    'find_in_docs.results.count',
                     searchResponse.results.length
                 )
                 span.setAttribute(
-                    ATTR_SEARCH_PAGE_COUNT,
+                    'find_in_docs.page.count',
                     searchResponse.pageCount
                 )
+
+                // Track zero results for quality analysis
+                if (searchResponse.totalResults === 0) {
+                    logInfo('find_in_docs_zero_results', {
+                        [ATTR_FIND_IN_DOCS_QUERY]: debouncedSearchTerm,
+                        [ATTR_FIND_IN_DOCS_QUERY_LENGTH]:
+                            debouncedSearchTerm.length,
+                        [ATTR_FIND_IN_DOCS_RESULTS_TOTAL]: 0,
+                    })
+                }
 
                 return searchResponse
             })
@@ -168,6 +181,25 @@ export const useNavigationSearchQuery = () => {
             ],
         })
     }, [queryClient, debouncedSearchTerm, pageNumber, typeFilter])
+
+    // Track errors for observability
+    useEffect(() => {
+        if (query.error && isApiError(query.error)) {
+            if (isRateLimitError(query.error)) {
+                logWarn('find_in_docs_rate_limited', {
+                    [ATTR_FIND_IN_DOCS_QUERY]: debouncedSearchTerm,
+                    [ATTR_FIND_IN_DOCS_RETRY_AFTER]:
+                        query.error.retryAfter ?? 0,
+                })
+            } else {
+                logWarn('find_in_docs_error', {
+                    [ATTR_FIND_IN_DOCS_QUERY]: debouncedSearchTerm,
+                    [ATTR_ERROR_TYPE]: `${query.error.statusCode}`,
+                    'error.message': query.error.message,
+                })
+            }
+        }
+    }, [query.error, debouncedSearchTerm])
 
     return {
         ...query,


### PR DESCRIPTION
### Summary
Adds observability to understand how users search and interact with results.

### Events tracked

| Event | Description | Key data included |
|-------|-------------|-------------------|
| `find_in_docs_opened` | User opens search | trigger (focus/keyboard) |
| `find_in_docs_closed` | User closes search | reason, query, had_results |
| `find_in_docs_result_clicked` | User clicks result | query, position, url, score |
| `find_in_docs_zero_results` | No results found | query |
| `find_in_docs_navigation` | Arrow key navigation | direction (up/down) |
| `find_in_docs_rate_limited` | 429 error | retry_after |
| `find_in_docs_error` | API error | error_type, message |