### PR TITLE
Sort areas alphabetically in changelog render output

### DIFF
--- a/src/services/Elastic.Documentation.Services/ChangelogService.cs
+++ b/src/services/Elastic.Documentation.Services/ChangelogService.cs
@@ -2436,7 +2436,7 @@ public partial class ChangelogService(
 		{
 			// Group by subtype if subsections is enabled, otherwise group by area
 			var groupedEntries = subsections
-				? breakingChanges.GroupBy(e => string.IsNullOrWhiteSpace(e.Subtype) ? string.Empty : e.Subtype).ToList()
+				? breakingChanges.GroupBy(e => string.IsNullOrWhiteSpace(e.Subtype) ? string.Empty : e.Subtype).OrderBy(g => g.Key).ToList()
 				: breakingChanges.GroupBy(e => GetComponent(e)).ToList();
 
 			foreach (var group in groupedEntries)
@@ -2573,7 +2573,9 @@ public partial class ChangelogService(
 
 		if (deprecations.Count > 0)
 		{
-			var groupedByArea = deprecations.GroupBy(e => GetComponent(e)).ToList();
+			var groupedByArea = subsections
+				? deprecations.GroupBy(e => GetComponent(e)).OrderBy(g => g.Key).ToList()
+				: deprecations.GroupBy(e => GetComponent(e)).ToList();
 			foreach (var areaGroup in groupedByArea)
 			{
 				if (subsections && !string.IsNullOrWhiteSpace(areaGroup.Key))
@@ -2708,7 +2710,9 @@ public partial class ChangelogService(
 
 		if (knownIssues.Count > 0)
 		{
-			var groupedByArea = knownIssues.GroupBy(e => GetComponent(e)).ToList();
+			var groupedByArea = subsections
+				? knownIssues.GroupBy(e => GetComponent(e)).OrderBy(g => g.Key).ToList()
+				: knownIssues.GroupBy(e => GetComponent(e)).ToList();
 			foreach (var areaGroup in groupedByArea)
 			{
 				if (subsections && !string.IsNullOrWhiteSpace(areaGroup.Key))
@@ -2820,7 +2824,9 @@ public partial class ChangelogService(
 	[System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0058:Expression value is never used", Justification = "StringBuilder methods return builder for chaining")]
 	private void RenderEntriesByArea(StringBuilder sb, List<ChangelogData> entries, bool subsections, HashSet<string> featureIdsToHide, Dictionary<string, RenderBlockersEntry>? renderBlockers, Dictionary<ChangelogData, HashSet<string>> entryToBundleProducts, Dictionary<ChangelogData, string> entryToRepo, Dictionary<ChangelogData, bool> entryToHideLinks)
 	{
-		var groupedByArea = entries.GroupBy(e => GetComponent(e)).ToList();
+		var groupedByArea = subsections
+			? entries.GroupBy(e => GetComponent(e)).OrderBy(g => g.Key).ToList()
+			: entries.GroupBy(e => GetComponent(e)).ToList();
 		foreach (var areaGroup in groupedByArea)
 		{
 			if (subsections && !string.IsNullOrWhiteSpace(areaGroup.Key))
@@ -3396,7 +3402,9 @@ public partial class ChangelogService(
 	[System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Parameter matches interface pattern for consistency")]
 	private void RenderEntriesByAreaAsciidoc(StringBuilder sb, List<ChangelogData> entries, string repo, bool subsections, HashSet<string> featureIdsToHide, Dictionary<string, RenderBlockersEntry>? renderBlockers, Dictionary<ChangelogData, HashSet<string>> entryToBundleProducts, Dictionary<ChangelogData, string> entryToRepo, Dictionary<ChangelogData, bool> entryToHideLinks)
 	{
-		var groupedByArea = entries.GroupBy(e => GetComponent(e)).ToList();
+		var groupedByArea = subsections
+			? entries.GroupBy(e => GetComponent(e)).OrderBy(g => g.Key).ToList()
+			: entries.GroupBy(e => GetComponent(e)).ToList();
 		foreach (var areaGroup in groupedByArea)
 		{
 			var componentName = !string.IsNullOrWhiteSpace(areaGroup.Key) ? areaGroup.Key : "General";
@@ -3472,7 +3480,7 @@ public partial class ChangelogService(
 	{
 		// Group by subtype if subsections is enabled, otherwise group by area
 		var groupedEntries = subsections
-			? breakingChanges.GroupBy(e => string.IsNullOrWhiteSpace(e.Subtype) ? string.Empty : e.Subtype).ToList()
+			? breakingChanges.GroupBy(e => string.IsNullOrWhiteSpace(e.Subtype) ? string.Empty : e.Subtype).OrderBy(g => g.Key).ToList()
 			: breakingChanges.GroupBy(e => GetComponent(e)).ToList();
 
 		foreach (var group in groupedEntries)
@@ -3560,7 +3568,7 @@ public partial class ChangelogService(
 	[System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Parameter matches interface pattern for consistency")]
 	private void RenderDeprecationsAsciidoc(StringBuilder sb, List<ChangelogData> deprecations, string repo, bool subsections, HashSet<string> featureIdsToHide, Dictionary<string, RenderBlockersEntry>? renderBlockers, Dictionary<ChangelogData, HashSet<string>> entryToBundleProducts, Dictionary<ChangelogData, string> entryToRepo, Dictionary<ChangelogData, bool> entryToHideLinks)
 	{
-		var groupedByArea = deprecations.GroupBy(e => GetComponent(e)).ToList();
+		var groupedByArea = deprecations.GroupBy(e => GetComponent(e)).OrderBy(g => g.Key).ToList();
 		foreach (var areaGroup in groupedByArea)
 		{
 			var componentName = !string.IsNullOrWhiteSpace(areaGroup.Key) ? areaGroup.Key : "General";
@@ -3645,7 +3653,7 @@ public partial class ChangelogService(
 	[System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Parameter matches interface pattern for consistency")]
 	private void RenderKnownIssuesAsciidoc(StringBuilder sb, List<ChangelogData> knownIssues, string repo, bool subsections, HashSet<string> featureIdsToHide, Dictionary<string, RenderBlockersEntry>? renderBlockers, Dictionary<ChangelogData, HashSet<string>> entryToBundleProducts, Dictionary<ChangelogData, string> entryToRepo, Dictionary<ChangelogData, bool> entryToHideLinks)
 	{
-		var groupedByArea = knownIssues.GroupBy(e => GetComponent(e)).ToList();
+		var groupedByArea = knownIssues.GroupBy(e => GetComponent(e)).OrderBy(g => g.Key).ToList();
 		foreach (var areaGroup in groupedByArea)
 		{
 			var componentName = !string.IsNullOrWhiteSpace(areaGroup.Key) ? areaGroup.Key : "General";


### PR DESCRIPTION
## Impetus

@florent-leborgne pointed out that when the "docs-builder changelog render" command is run with "--subsections", there's currently no obvious sort order. For example, see https://github.com/elastic/elasticsearch/pull/140795

In the old `.gradlew generateReleaseNotes` tooling, they were sorted alphabetically.

## Summary

Updated the `docs-builder changelog render` command to sort area subsections alphabetically when `--subsections` is used. This matches the behavior of the Gradle `generateReleaseNotes` tool, which uses `TreeMap` for automatic alphabetical sorting.

NOTE: Any changelogs that don't have areas appear at the beginning of the list.

### Changes Made

Updated 8 locations in `ChangelogService.cs` to sort grouped entries alphabetically:

1. **Breaking Changes (Markdown)** - Sorts by subtype when `subsections` is enabled
2. **Deprecations (Markdown)** - Sorts by area when `subsections` is enabled
3. **Known Issues (Markdown)** - Sorts by area when `subsections` is enabled
4. **Regular Entries (Markdown)** - Sorts by area when `subsections` is enabled
5. **Regular Entries (Asciidoc)** - Sorts by area when `subsections` is enabled
6. **Breaking Changes (Asciidoc)** - Sorts by subtype when `subsections` is enabled
7. **Deprecations (Asciidoc)** - Always sorts by area (always shows subsections)
8. **Known Issues (Asciidoc)** - Always sorts by area (always shows subsections)

### Implementation

Added `.OrderBy(g => g.Key)` after the `GroupBy` operations when subsections are enabled, ensuring alphabetical sorting by the group key (area or subtype). This matches the Java implementation's use of `TreeMap` for automatic sorting.

The build completed successfully with no errors. All changes maintain backward compatibility and only affect the ordering when `--subsections` is used.

## Screenshots

### Before

No obvious or consistent sort order:

<img width="2339" height="1331" alt="image" src="https://github.com/user-attachments/assets/3c784ab7-4a2e-442a-b520-1de9f76a7837" />

### After

Sections in `index.md` are sorted alphabetically:

<img width="2129" height="1441" alt="image" src="https://github.com/user-attachments/assets/1298d1c0-e69e-4ce2-a5e8-c72920ab1031" />

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  

4. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: composer-1
