### PR TITLE
Change base version for edot-cf-aws

### DIFF
--- a/config/versions.yml
+++ b/config/versions.yml
@@ -96,7 +96,7 @@ versioning_systems:
     base: 1.0
     current: 1.11.0
   edot-cf-aws:
-    base: 0.1
+    base: 1.0
     current: 1.2.0
   edot-cf-azure:
     base: 0.1


### PR DESCRIPTION
Ups the base version of edot-cf-aws to 1.0 (was 0.1)