### PR TITLE
Update shared_configuration.stack.next to 9.3.0

### DIFF
--- a/config/assembler.yml
+++ b/config/assembler.yml
@@ -48,7 +48,7 @@ environments:
 shared_configuration:
   stack: &stack
     current:  9.2
-    next: main
+    next: 9.3.0
     edge: main
 
   master: &master

--- a/config/assembler.yml
+++ b/config/assembler.yml
@@ -48,7 +48,7 @@ environments:
 shared_configuration:
   stack: &stack
     current:  9.2
-    next: 9.3.0
+    next: 9.3
     edge: main
 
   master: &master


### PR DESCRIPTION
Updating the Assembler config to start publishing the upcoming minor version (9.3.0) to our staging site as per the instructions [here](https://stunning-adventure-qrvr1k2.pages.github.io/releases/elastic-stack-v9/).

Merge and release the day of or morning of 9.3 release.