### PR TITLE
Fix breadcrumbs

### DIFF
--- a/src/Elastic.Markdown/Layout/_Breadcrumbs.cshtml
+++ b/src/Elastic.Markdown/Layout/_Breadcrumbs.cshtml
@@ -15,6 +15,7 @@
 			<a
 				itemprop="item"
 				href="@item.Url"
+				@(i == 0 ? "hx-disable=true" : "")
 				@Htmx.GetHxAttributes(Model.CurrentNavigationItem?.NavigationRoot.Id == item.NavigationRoot.Id)
 			>
 				<span class="hover:text-black">@item.NavigationTitle</span>


### PR DESCRIPTION
## Context

The first link to `/docs` in the breadcrumbs only changes the URL to `/docs`, but does not actually change the content because HTMX can't find an appropriate container to swap.

## Changes

Disable the first element with `hx-disable="true"` so it acts as a normal link.