### PR TITLE
Hide stepper line after last step

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/markdown/stepper.css
+++ b/src/Elastic.Documentation.Site/Assets/markdown/stepper.css
@@ -40,9 +40,9 @@
 				content: '';
 				left: calc(var(--spacing) * 4 - 1px);
 			}
-		&:last-child::before {
-			@apply hidden;
-		}
+			&:last-child::before {
+				@apply hidden;
+			}
 			&::after {
 				@apply border-grey-20 bg-grey-10 absolute top-0 left-0 flex size-8 items-center justify-center rounded-full border-1 text-sm text-black;
 				content: counter(stepper);


### PR DESCRIPTION
Maybe subjective: I think that having the line completely stop at the last step number in stepper components (and not continue until the end of the associated text block) makes it clearer that this is the last step.

CC @itsalexcm if you feel different about this.

For example, on this example the line would stop at 3 instead of continuing like in the screenshot
<img width="861" height="487" alt="image" src="https://github.com/user-attachments/assets/f5be4104-bb01-44d2-aec4-f0eda23d0e99" />
