### PR TITLE
Change table width in csv include directive

### DIFF
--- a/docs/_snippets/sample-data-12-columns.csv
+++ b/docs/_snippets/sample-data-12-columns.csv
@@ -1,0 +1,6 @@
+Product,SKU,Category,Brand,Price,Stock,Weight,Rating,Reviews,Color,Size,Material
+Laptop Pro,LP-001,Electronics,TechCorp,1299.99,45,2.3kg,4.5,1250,Silver,15 inch,Aluminum
+Wireless Mouse,WM-002,Accessories,ClickMaster,49.99,230,0.1kg,4.2,890,Black,Standard,Plastic
+USB-C Hub,UH-003,Accessories,ConnectAll,79.99,180,0.2kg,4.7,654,Gray,Compact,Metal
+Mechanical Keyboard,MK-004,Accessories,TypeFast,159.99,92,0.8kg,4.8,2100,White,Full,ABS Plastic
+Monitor Stand,MS-005,Furniture,DeskPro,89.99,67,1.5kg,4.1,445,Black,Large,Steel

--- a/docs/syntax/csv-include.md
+++ b/docs/syntax/csv-include.md
@@ -49,12 +49,38 @@ Specify a custom field separator (default is comma):
 :::
 ```
 
+### Wide tables
+
+CSV files with many columns are rendered as scrollable tables:
+
+:::::{tab-set}
+
+::::{tab-item} Output
+
+:::{csv-include} ../_snippets/sample-data-12-columns.csv
+:caption: Product inventory with 12 columns
+:::
+
+::::
+
+::::{tab-item} Markdown
+
+```markdown
+:::{csv-include} _snippets/sample-data-12-columns.csv
+:caption: Product inventory with 12 columns
+:::
+```
+
+::::
+
+:::::
+
 ### Performance limits
 
 The directive includes built-in performance limits to handle large files efficiently:
 
 - **Row limit**: Maximum of 25,000 rows will be displayed
-- **Column limit**: Maximum of 10 columns will be displayed  
+- **Column limit**: Maximum of 15 columns will be displayed  
 - **File size limit**: Maximum file size of 10MB
 
 ## Performance considerations

--- a/src/Elastic.Markdown/Myst/Directives/CsvInclude/CsvIncludeBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/CsvInclude/CsvIncludeBlock.cs
@@ -17,7 +17,7 @@ public class CsvIncludeBlock(DirectiveBlockParser parser, ParserContext context)
 	public string Separator { get; private set; } = ",";
 	public int MaxRows { get; private set; } = 25000;
 	public long MaxFileSizeBytes { get; private set; } = 10 * 1024 * 1024; // 10MB
-	public int MaxColumns { get; private set; } = 10;
+	public int MaxColumns { get; private set; } = 15;
 
 	public override void FinalizeAndValidate(ParserContext context)
 	{


### PR DESCRIPTION
This increases the columns' limit from 10 to 15.