### PR TITLE
Update ecs version per 9.3 release

### DIFF
--- a/config/assembler.yml
+++ b/config/assembler.yml
@@ -89,7 +89,7 @@ references:
   apm-aws-lambda:
   apm-k8s-attacher:
   ecs:
-    current: 9.2 # releases do not always align with the Stack version
+    current: 9.3 # releases do not always align with the Stack version
     next: main
   ecs-dotnet:
   ecs-logging-go-logrus:

--- a/config/versions.yml
+++ b/config/versions.yml
@@ -23,7 +23,7 @@ versioning_systems:
   ess: *all
   ecs:
     base: 9.0
-    current: 9.2.0
+    current: 9.3.0
   self: *stack
   ecctl:
     base: 1.0


### PR DESCRIPTION
In preparation for the ECS 9.3.0 release, bumping the versions for docs-builder. 

(I referenced this [PR](https://github.com/elastic/docs-builder/pull/2108) from 9.2 for the exact changes to be made)

Do not merge automatically, will merge on release day. 