### PR TITLE
Fix AskAI chat persistence and use well-known `idb-keyval` library

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/web-components/AskAi/Chat.test.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/AskAi/Chat.test.tsx
@@ -6,13 +6,12 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import * as React from 'react'
 
-// Mock zustand-indexeddb (IndexedDB not available in Node.js test environment)
-jest.mock('zustand-indexeddb', () => ({
-    createIndexedDBStorage: () => ({
-        getItem: jest.fn().mockResolvedValue(null),
-        setItem: jest.fn().mockResolvedValue(undefined),
-        removeItem: jest.fn().mockResolvedValue(undefined),
-    }),
+// Mock idb-keyval (IndexedDB not available in Node.js test environment)
+jest.mock('idb-keyval', () => ({
+    get: jest.fn().mockResolvedValue(null),
+    set: jest.fn().mockResolvedValue(undefined),
+    del: jest.fn().mockResolvedValue(undefined),
+    createStore: jest.fn().mockReturnValue({}),
 }))
 
 // Create a fresh QueryClient for each test

--- a/src/Elastic.Documentation.Site/Assets/web-components/AskAi/ChatMessage.test.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/AskAi/ChatMessage.test.tsx
@@ -6,13 +6,12 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
 import * as React from 'react'
 
-// Mock zustand-indexeddb (IndexedDB not available in Node.js test environment)
-jest.mock('zustand-indexeddb', () => ({
-    createIndexedDBStorage: () => ({
-        getItem: jest.fn().mockResolvedValue(null),
-        setItem: jest.fn().mockResolvedValue(undefined),
-        removeItem: jest.fn().mockResolvedValue(undefined),
-    }),
+// Mock idb-keyval (IndexedDB not available in Node.js test environment)
+jest.mock('idb-keyval', () => ({
+    get: jest.fn().mockResolvedValue(null),
+    set: jest.fn().mockResolvedValue(undefined),
+    del: jest.fn().mockResolvedValue(undefined),
+    createStore: jest.fn().mockReturnValue({}),
 }))
 
 // Create a fresh QueryClient for each test

--- a/src/Elastic.Documentation.Site/package-lock.json
+++ b/src/Elastic.Documentation.Site/package-lock.json
@@ -34,6 +34,7 @@
         "htmx-ext-head-support": "2.0.4",
         "htmx-ext-preload": "2.1.2",
         "htmx.org": "2.0.8",
+        "idb-keyval": "^6.2.2",
         "katex": "^0.16.25",
         "lodash": "^4.17.21",
         "marked": "17.0.1",
@@ -43,8 +44,7 @@
         "ua-parser-js": "2.0.6",
         "uuid": "11.1.0",
         "zod": "4.1.12",
-        "zustand": "5.0.8",
-        "zustand-indexeddb": "^0.1.1"
+        "zustand": "5.0.8"
       },
       "devDependencies": {
         "@babel/core": "7.28.4",
@@ -27335,6 +27335,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/idb-keyval": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
+      "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/identity-obj-proxy": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
@@ -33413,15 +33419,6 @@
         "use-sync-external-store": {
           "optional": true
         }
-      }
-    },
-    "node_modules/zustand-indexeddb": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/zustand-indexeddb/-/zustand-indexeddb-0.1.1.tgz",
-      "integrity": "sha512-2IErbvNdzxHkPLRep53e2dRcX0TtDmc940aPyEjzLxAYWVxNY9crrtkufrE/k/jkvfxybuu8xN+emSdWFMVP6w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "zustand": "^5.0.0"
       }
     },
     "node_modules/zwitch": {

--- a/src/Elastic.Documentation.Site/package.json
+++ b/src/Elastic.Documentation.Site/package.json
@@ -111,6 +111,7 @@
     "htmx-ext-head-support": "2.0.4",
     "htmx-ext-preload": "2.1.2",
     "htmx.org": "2.0.8",
+    "idb-keyval": "6.2.2",
     "katex": "^0.16.25",
     "lodash": "^4.17.21",
     "marked": "17.0.1",
@@ -120,7 +121,6 @@
     "ua-parser-js": "2.0.6",
     "uuid": "11.1.0",
     "zod": "4.1.12",
-    "zustand": "5.0.8",
-    "zustand-indexeddb": "^0.1.1"
+    "zustand": "5.0.8"
   }
 }


### PR DESCRIPTION
### Problem
Users on the edge environment encountered this error when using Ask AI:
```
NotFoundError: Failed to execute 'transaction' on 'IDBDatabase': One of the specified object stores was not found
```

### Root Cause
The `zustand-indexeddb` library hardcodes IndexedDB version to 1. When the code tried to create new object stores for conversation data, the database was already at version 1, so no `upgradeneeded` event fired and the stores were never created.

### Solution
Replace `zustand-indexeddb` with `idb-keyval`:
- Uses a simple key-value pattern (no object store/version management)
- Leverages IndexedDB's native structured cloning (no JSON serialization)
- Custom database name: `elastic-docs-keyval-store`
- Namespaced keys: `ask-ai/conversations-index`, `ask-ai/conversation-{id}`

### Other Changes
- Moved `aiProvider` from index to per-conversation storage
- Added `MAX_CONVERSATIONS = 2` limit (temporary until UI supports multiple)
- Simplified storage structure for extensibility