### PR TITLE
Dimensions docs-builder edition

### DIFF
--- a/docs/syntax/applies.md
+++ b/docs/syntax/applies.md
@@ -48,7 +48,6 @@ applies_to:
 ```
 
 
-For more examples, refer to [Page level examples](#examples).
 
 ### Section level
 


### PR DESCRIPTION
Sibling PR to https://github.com/elastic/docs-content/pull/4819

Specified that we should only use one dimension, fixed the two examples where we use two dimensions (and bad version numbers, on top of that)