### PR TITLE
Bumps the docs version to 9.2.5

### DIFF
--- a/config/versions.yml
+++ b/config/versions.yml
@@ -3,7 +3,7 @@ versioning_systems:
   # Updates for Stack versions are manual
   stack: &stack
     base: 9.0
-    current: 9.2.4
+    current: 9.2.5
 
   # Using an unlikely high version
   # So that our logic that would display "planned" doesn't trigger


### PR DESCRIPTION
DO NOT MERGE UNTIL RELEASE DAY

Docs release issue: https://github.com/elastic/dev/issues/3429