### PR TITLE
Optimize local development build times for dotnet run

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,11 +2,23 @@
   <PropertyGroup>
     <!-- Enable central package management, https://learn.microsoft.com/en-us/nuget/consume-packages/Central-Package-Management -->
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <MinVerSkip Condition="'$(Configuration)' == 'Debug'">true</MinVerSkip>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
+  <!-- MinVer: only run in CI or Release builds to speed up local development -->
+  <Choose>
+    <When Condition="'$(CI)' == 'true' OR '$(Configuration)' == 'Release'">
+      <PropertyGroup>
+        <MinVerSkip>false</MinVerSkip>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <MinVerSkip>true</MinVerSkip>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
   <ItemGroup>
     <GlobalPackageReference Include="MinVer" Version="6.0.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,13 +2,33 @@
 <Project>
   <!-- Src Directory Build Properties -->
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+  <!-- Build optimizations: disable expensive tasks locally, enable in CI/Release -->
+  <Choose>
+    <When Condition="'$(CI)' == 'true' OR '$(Configuration)' == 'Release'">
+      <PropertyGroup>
+        <!-- NuGet audit -->
+        <NuGetAudit>true</NuGetAudit>
+        <NuGetAuditMode>all</NuGetAuditMode>
+        <NuGetAuditLevel>low</NuGetAuditLevel>
+        <!-- SourceLink for debugging published packages -->
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <EnableSourceLink>true</EnableSourceLink>
+        <EnableSourceControlManagerQueries>true</EnableSourceControlManagerQueries>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <!-- Disable for faster local builds -->
+        <NuGetAudit>false</NuGetAudit>
+        <EnableSourceLink>false</EnableSourceLink>
+        <EnableSourceControlManagerQueries>false</EnableSourceControlManagerQueries>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
   <PropertyGroup>
-    <NuGetAuditMode>all</NuGetAuditMode>
-    <NuGetAuditLevel>low</NuGetAuditLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <!-- TODO ENABLE to document our code properly <GenerateDocumentationFile>true</GenerateDocumentationFile> -->
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <StartupHookSupport Condition="'$(Configuration)' == 'Debug'">true</StartupHookSupport>
   </PropertyGroup>
 </Project>

--- a/src/Elastic.Documentation.Site/.gitignore
+++ b/src/Elastic.Documentation.Site/.gitignore
@@ -7,3 +7,4 @@ _static/*.woff
 _static/*.woff2
 _static/*.js
 _static/*.js.map
+_static/.build-stamp

--- a/src/Elastic.Documentation.Site/Elastic.Documentation.Site.csproj
+++ b/src/Elastic.Documentation.Site/Elastic.Documentation.Site.csproj
@@ -41,15 +41,34 @@
       2. Run npm run build before building the .NET project.
       MSBuild runs NpmInstall before this task because of the DependsOnTargets attribute.
       DependsOnTargets ensures MinVer runs first so $(MinVerVersion) is available.
+
+      Inputs/Outputs enable incremental builds - the target only runs when source files change.
    -->
-  <Target Name="NpmRunBuild" DependsOnTargets="NpmInstall;MinVer" BeforeTargets="BeforeBuild">
+  <ItemGroup>
+    <NpmBuildInputFiles Include="Assets/**/*.ts" />
+    <NpmBuildInputFiles Include="Assets/**/*.tsx" />
+    <NpmBuildInputFiles Include="Assets/**/*.css" />
+    <NpmBuildInputFiles Include="package.json" />
+    <NpmBuildInputFiles Include="package-lock.json" />
+    <NpmBuildInputFiles Include="tsconfig.json" />
+    <NpmBuildInputFiles Include="tailwind.config.js" />
+    <NpmBuildInputFiles Include=".parcelrc" />
+    <NpmBuildInputFiles Include=".postcssrc" />
+  </ItemGroup>
+  <Target Name="NpmRunBuild"
+          DependsOnTargets="NpmInstall;MinVer"
+          BeforeTargets="BeforeBuild"
+          Inputs="@(NpmBuildInputFiles)"
+          Outputs="_static/.build-stamp">
     <Message Text="Building frontend with version: $(MinVerVersion)" Importance="high" />
-    <Exec Command="npm run build" 
-          WorkingDirectory="$(MSBuildThisFileDirectory)" 
+    <Exec Command="npm run build"
+          WorkingDirectory="$(MSBuildThisFileDirectory)"
           ConsoleToMsBuild="true"
           EnvironmentVariables="DOCS_BUILDER_VERSION=$(MinVerVersion)">
       <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
     </Exec>
+    <!-- Write the stamp file, so incremental builds work -->
+    <Touch Files="_static/.build-stamp" AlwaysCreate="true" />
   </Target>
 
   <Target Name="EmbedGeneratedAssets" AfterTargets="NpmRunBuild">

--- a/src/tooling/Directory.Build.props
+++ b/src/tooling/Directory.Build.props
@@ -3,8 +3,6 @@
   <!-- Src Directory Build Properties -->
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   <PropertyGroup>
-    <NuGetAuditMode>all</NuGetAuditMode>
-    <NuGetAuditLevel>low</NuGetAuditLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <!-- TODO ENABLE to document our code properly <GenerateDocumentationFile>true</GenerateDocumentationFile> -->


### PR DESCRIPTION
Reduces `dotnet run --project src/tooling/docs-builder -- --help` from ~7s to ~2.9s (60% faster) by disabling expensive build tasks that are only needed in CI or Release builds.

## Performance Results

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Full run (warm cache) | ~7.0s | ~2.9s | **~60% faster** |
| Build only (no restore) | ~5.5s | ~2.9s | ~47% faster |

## Changes

### Disable expensive tasks locally (enabled in CI/Release)

- **MinVer**: Skip version calculation locally (`Directory.Packages.props`)
- **NuGet Audit**: Skip vulnerability scanning locally (`src/Directory.Build.props`)
- **SourceLink**: Skip git repository queries locally (`src/Directory.Build.props`)

All features automatically re-enable when `CI=true` or `Configuration=Release`.

### Fix npm incremental builds

- Add `Inputs`/`Outputs` to `NpmRunBuild` target in `Elastic.Documentation.Site.csproj`
- npm build now skips when source files (*.ts, *.tsx, *.css) haven't changed
- Saves ~2s per build when frontend is unchanged

### Cleanup

- Remove duplicate NuGet audit settings from `src/tooling/Directory.Build.props`
- Add `_static/.build-stamp` to `.gitignore`

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
