### PR TITLE
Reduce published binary size from 223MB to 40MB

### DIFF
--- a/src/Elastic.Documentation.Site/Elastic.Documentation.Site.csproj
+++ b/src/Elastic.Documentation.Site/Elastic.Documentation.Site.csproj
@@ -71,12 +71,23 @@
     <Touch Files="_static/.build-stamp" AlwaysCreate="true" />
   </Target>
 
+  <!-- Clean old hashed assets during publish to avoid accumulating stale files -->
+  <Target Name="CleanOldHashedAssets" BeforeTargets="NpmRunBuild" Condition="'$(PublishDir)' != ''">
+    <ItemGroup>
+      <OldHashedFiles Include="_static/*.????????*.js" />
+      <OldHashedFiles Include="_static/*.????????*.css" />
+      <OldHashedFiles Include="_static/*.????????*.js.map" />
+      <OldHashedFiles Include="_static/*.????????*.css.map" />
+    </ItemGroup>
+    <Delete Files="@(OldHashedFiles)" ContinueOnError="true" />
+  </Target>
+
   <Target Name="EmbedGeneratedAssets" AfterTargets="NpmRunBuild">
     <ItemGroup>
       <EmbeddedResource Include="_static/*.js" Watch="false" />
-      <EmbeddedResource Include="_static/*.js.map" Watch="false" />
+      <EmbeddedResource Include="_static/*.js.map" Watch="false" Condition="'$(Configuration)' == 'Debug'" />
       <EmbeddedResource Include="_static/*.css" Watch="false" />
-      <EmbeddedResource Include="_static/*.css.map" Watch="false" />
+      <EmbeddedResource Include="_static/*.css.map" Watch="false" Condition="'$(Configuration)' == 'Debug'" />
       <EmbeddedResource Include="_static/*.svg" Watch="false" />
       <EmbeddedResource Include="_static/*.png" Watch="false" />
       <EmbeddedResource Include="_static/*.ttf" Watch="false" />


### PR DESCRIPTION
The AOT-compiled docs-builder binary was bloated due to embedded static assets:

- Old hashed JS/CSS files accumulated in `_static/` across builds (98 versions of some files)
- Source map files (146MB) were being embedded in release builds

Changes:
- Clean old hashed assets during publish to remove stale versioned files
- Only embed `.map` files in Debug builds (not needed in production)

| Metric | Before | After | Reduction |
|--------|--------|-------|-----------|
| Binary size | 223 MB | 40 MB | 82% |
| `_static/` folder | 187 MB | 18 MB | 90% |

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
