### PR TITLE
[DOCS] Fix broken links, clarify minimal changelog types

### DIFF
--- a/config/changelog.example.yml
+++ b/config/changelog.example.yml
@@ -34,6 +34,7 @@ lifecycles:
 # Labels are specified in a "label -> value" format
 pivot:
   # Type definitions with optional labels
+  # At a minimum, feature, bug-fix, and breaking-change must be configured.
   # Keys are type names, values can be:
   #   - simple string: comma-separated label list (e.g., ">bug, >fix")
   #   - empty/null: no labels for this type

--- a/docs/contribute/_snippets/changelog-fields.md
+++ b/docs/contribute/_snippets/changelog-fields.md
@@ -9,8 +9,7 @@ title:
 type: 
 
 # A required string that contains the type of change.
-# For the acceptable values, refer to https://github.com/elastic/docs-builder/blob/main/src/services/Elastic.Changelog/Configuration/ChangelogConfiguration.cs
-
+# For the acceptable values, refer to https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ChangelogEntryType.cs
 products:
 
 # A required array of objects that denote the affected products and their target release.
@@ -31,7 +30,7 @@ products:
       lifecycle:
 
       # An optional string for new features and enhancements that have a specific availability.
-      # For the acceptable values, refer to https://github.com/elastic/docs-builder/blob/main/src/services/Elastic.Changelog/Configuration/ChangelogConfiguration.cs
+      # For the acceptable values, refer to https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/Lifecycle.cs
 
 ##### Optional fields #####
 action:
@@ -79,5 +78,5 @@ pr:
 subtype:
 
 # An optional string that applies only to breaking changes and further subdivides that type.
-# For the acceptable values, refer to https://github.com/elastic/docs-builder/blob/main/src/services/Elastic.Changelog/Configuration/ChangelogConfiguration.cs
+# For the acceptable values, refer to https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ChangelogEntrySubtype.cs
 ```

--- a/docs/contribute/changelog.md
+++ b/docs/contribute/changelog.md
@@ -13,15 +13,15 @@ The changelogs use the following schema:
 Some of the fields in the schema accept only a specific set of values:
 
 - Product values must exist in [products.yml](https://github.com/elastic/docs-builder/blob/main/config/products.yml). Invalid products will cause the `docs-builder changelog add` command to fail.
-- Type, subtype, and lifecycle values must match the available values defined in [ChangelogConfiguration.cs](https://github.com/elastic/docs-builder/blob/main/src/services/Elastic.Changelog/Configuration/ChangelogConfiguration.cs). Invalid values will cause the `docs-builder changelog add` command to fail.
+- Type, subtype, and lifecycle values must match the available values defined in [ChangelogEntryType.cs](https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ChangelogEntryType.cs), [ChangelogEntrySubtype.cs](https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ChangelogEntrySubtype.cs), and [Lifecycle.cs](https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/Lifecycle.cs) respectively. Invalid values will cause the `docs-builder changelog add` command to fail.
 :::
 
 To use the `docs-builder changelog` commands in your development workflow:
 
 1. Ensure that your products exist in [products.yml](https://github.com/elastic/docs-builder/blob/main/config/products.yml).
-1. Add labels to your GitHub pull requests to represent the types defined in [ChangelogConfiguration.cs](https://github.com/elastic/docs-builder/blob/main/src/services/Elastic.Changelog/Configuration/ChangelogConfiguration.cs). For example, `>bug` and `>enhancement` labels.
+1. Add labels to your GitHub pull requests that map to [changelog types](https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ChangelogEntryType.cs). At a minimum, create labels for the `feature`, `bug-fix`, and `breaking-change` types.
 1. Optional: Choose areas or components that your changes affect and add labels to your GitHub pull requests (such as `:Analytics/Aggregations`).
-1. Optional: Add labels to your GitHub pull requests to indicate that they are not notable and should not generate changelogs. For example, `non-issue` or `release_notes:skip`.
+1. Optional: Add labels to your GitHub pull requests to indicate that they are not notable and should not generate changelogs. For example, `non-issue` or `release_notes:skip`. Alternatively, you can assume that all PRs are *not* notable unless a specific label is present (for example, `@Public`).
 1. [Configure changelog settings](#changelog-settings) to correctly interpret your PR labels.
 1. [Create changelogs](#changelog-add) with the `docs-builder changelog add` command.
 1. [Create changelog bundles](#changelog-bundle) with the `docs-builder changelog bundle` command. For example, create a bundle for the pull requests that are included in a product release.
@@ -49,9 +49,9 @@ You can specify a different path with the `--config` command option.
 
 If a configuration file exists, the command validates its values before generating changelog files:
 
-- If the configuration file contains `lifecycles`, `products`, `subtype`, or `type` values that don't match the values in `products.yml` and `ChangelogConfiguration.cs`, validation fails.
+- If the configuration file contains `lifecycles`, `products`, `subtype`, or `type` values that don't match the values in `ChangelogEntryType.cs`, `ChangelogEntrySubtype.cs`, or `Lifecycle.cs`, validation fails.
 - If the configuration file contains `areas` values and they don't match what you specify in the `--areas` command option, validation fails.
-- If the configuration file contains `lifecycles` or `products` values are a subset of what's defined in `ChangelogConfiguration.cs` and you try to create a changelog with values outside that subset, validation fails.
+- If the configuration file contains `lifecycles` or `products` values are a subset of the available values and you try to create a changelog with values outside that subset, validation fails.
 
 In each of these cases where validation fails, a changelog file is not created.
 
@@ -188,7 +188,7 @@ docs-builder changelog add \
 ```
 
 1. This option is required only if you want to override what's derived from the PR title.
-2. The type values are defined in [ChangelogConfiguration.cs](https://github.com/elastic/docs-builder/blob/main/src/services/Elastic.Changelog/Configuration/ChangelogConfiguration.cs).
+2. The type values are defined in [ChangelogEntryType.cs](https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ChangelogEntryType.cs).
 3. The product values are defined in [products.yml](https://github.com/elastic/docs-builder/blob/main/config/products.yml).
 4. The `--prs` value can be a full URL (such as `https://github.com/owner/repo/pull/123`), a short format (such as `owner/repo#123`), just a number (in which case you must also provide `--owner` and `--repo` options), or a path to a file containing newline-delimited PR URLs or numbers. Multiple PRs can be provided comma-separated, or you can specify a file path. You can also mix both formats by specifying `--prs` multiple times. One changelog file will be created for each PR.
 

--- a/src/services/Elastic.Changelog/Creation/CreateChangelogArgumentsValidator.cs
+++ b/src/services/Elastic.Changelog/Creation/CreateChangelogArgumentsValidator.cs
@@ -72,7 +72,7 @@ public class CreateChangelogArgumentsValidator(IConfigurationContext configurati
 				collector.EmitWarning(string.Empty, "Type is missing. The changelog will be created with type commented out. Please manually update the type field.");
 			else
 			{
-				collector.EmitError(string.Empty, "Type is required. Provide --type or specify --prs to derive it from PR labels (requires label_to_type mapping in changelog.yml).");
+				collector.EmitError(string.Empty, "Type is required. Provide --type or specify --prs to derive it from PR labels (requires pivot.types mapping in changelog.yml).");
 				return false;
 			}
 		}

--- a/src/services/Elastic.Changelog/Creation/PrInfoProcessor.cs
+++ b/src/services/Elastic.Changelog/Creation/PrInfoProcessor.cs
@@ -136,7 +136,7 @@ public class PrInfoProcessor(IGitHubPrService? githubPrService, ILogger logger)
 		{
 			if (config.LabelToType == null || config.LabelToType.Count == 0)
 			{
-				collector.EmitError(string.Empty, $"Cannot derive type from PR {prUrl} labels: no label-to-type mapping configured in changelog.yml. Please provide --type or configure label_to_type in changelog.yml.");
+				collector.EmitError(string.Empty, $"Cannot derive type from PR {prUrl} labels: no type mapping configured in changelog.yml. Please provide --type or configure pivot.types in changelog.yml.");
 				return null;
 			}
 
@@ -144,7 +144,7 @@ public class PrInfoProcessor(IGitHubPrService? githubPrService, ILogger logger)
 			if (mappedType == null)
 			{
 				var availableLabels = prInfo.Labels.Count > 0 ? string.Join(", ", prInfo.Labels) : "none";
-				collector.EmitError(string.Empty, $"Cannot derive type from PR {prUrl} labels ({availableLabels}). No matching label found in label_to_type mapping. Please provide --type or add a label mapping in changelog.yml.");
+				collector.EmitError(string.Empty, $"Cannot derive type from PR {prUrl} labels ({availableLabels}). No matching label found in type mapping. Please provide --type or add pivot.types with labels in changelog.yml.");
 				return null;
 			}
 			derived.Type = mappedType;

--- a/src/services/Elastic.Changelog/GithubRelease/GitHubReleaseChangelogService.cs
+++ b/src/services/Elastic.Changelog/GithubRelease/GitHubReleaseChangelogService.cs
@@ -205,7 +205,7 @@ public class GitHubReleaseChangelogService(
 		// Fetch PR labels
 		var prInfo = await _prService.FetchPrInfoAsync(prUrl, owner, repo, ctx);
 
-		// Check add_blockers - skip PRs with blocking labels
+		// Check block.create - skip PRs with blocking labels
 		if (prInfo != null && ShouldSkipPrDueToLabelBlockers(prInfo.Labels.ToArray(), productInfo, config, collector, prUrl))
 			return false;
 

--- a/tests/Elastic.Changelog.Tests/Changelogs/Create/ValidationTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/Create/ValidationTests.cs
@@ -28,7 +28,7 @@ public class ValidationTests(ITestOutputHelper output) : CreateChangelogTestBase
 				A<CancellationToken>._))
 			.Returns(prInfo);
 
-		// Config without label_to_type mapping
+		// Config without pivot.types mapping
 		// language=yaml
 		var configContent =
 			"""


### PR DESCRIPTION
This PR updates changelog docs and help text:

- fixes links that were broken when the location of the valid changelog types, subtypes, and lifecycles were refactored.
- updates the docs to clearly state that there are a minimal set of changelog types required.
- removes some out-dated text from the command messages (related to old `add_blockers` and `label_to_type` config options)

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->
