### PR TITLE
Fix HTMX link handling

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/web-components/AskAi/RelatedResources.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/AskAi/RelatedResources.tsx
@@ -1,6 +1,5 @@
 /** @jsxImportSource @emotion/react */
 import { useHtmxLink } from '../shared/htmx/useHtmxLink'
-import { getPathFromUrl } from '../shared/htmx/utils'
 import { EuiText, EuiSpacer, useEuiTheme, useEuiFontSize } from '@elastic/eui'
 import { css } from '@emotion/react'
 
@@ -137,15 +136,13 @@ const ReferenceItem = ({
     euiTheme,
     smallFontsize,
 }: ReferenceItemProps) => {
-    // Extract path from URL, falling back to original URL if extraction fails
-    const path = getPathFromUrl(reference.url) ?? reference.url
-    const anchorRef = useHtmxLink(path)
+    const { ref, href } = useHtmxLink(reference.url)
 
     return (
         <li>
             <a
-                ref={anchorRef}
-                href={path}
+                ref={ref}
+                href={href}
                 css={css`
                     width: 100%;
                     background-color: #fff;

--- a/src/Elastic.Documentation.Site/Assets/web-components/NavigationSearch/SearchResultsList.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/NavigationSearch/SearchResultsList.tsx
@@ -150,7 +150,7 @@ const SearchResultRow = ({
 }: SearchResultRowProps) => {
     const { euiTheme } = useEuiTheme()
     const isMobile = useIsWithinMaxBreakpoint('s')
-    const anchorRef = useHtmxLink(result.url)
+    const { ref, href } = useHtmxLink(result.url)
 
     const breadcrumbItems = useMemo(() => {
         const typePrefix = result.type === 'api' ? 'API' : 'Docs'
@@ -159,8 +159,8 @@ const SearchResultRow = ({
 
     return (
         <a
-            ref={anchorRef}
-            href={result.url}
+            ref={ref}
+            href={href}
             data-search-result-index={index}
             onClick={onClick}
             onMouseEnter={onMouseEnter}

--- a/src/Elastic.Documentation.Site/Assets/web-components/shared/htmx/useHtmxContainer.test.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/shared/htmx/useHtmxContainer.test.tsx
@@ -1,0 +1,205 @@
+import { useHtmxContainer } from './useHtmxContainer'
+import { render, screen } from '@testing-library/react'
+import htmx from 'htmx.org'
+import { useRef } from 'react'
+
+// Mock htmx - it uses XPath which jsdom doesn't support properly
+jest.mock('htmx.org', () => ({
+    on: jest.fn(),
+    off: jest.fn(),
+    process: jest.fn(),
+    ajax: jest.fn(),
+}))
+
+const mockHtmx = htmx as jest.Mocked<typeof htmx>
+
+// Test component that uses the hook
+const TestContainer = ({ html }: { html: string }) => {
+    const containerRef = useRef<HTMLDivElement>(null)
+    useHtmxContainer(containerRef, [html])
+    return (
+        <div
+            ref={containerRef}
+            data-testid="container"
+            dangerouslySetInnerHTML={{ __html: html }}
+        />
+    )
+}
+
+describe('useHtmxContainer', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    describe('internal docs links', () => {
+        it('should apply htmx attributes and call htmx.process for internal links', () => {
+            render(
+                <TestContainer html='<a href="/docs/elasticsearch">Link</a>' />
+            )
+
+            const container = screen.getByTestId('container')
+            const anchor = container.querySelector('a')
+
+            expect(anchor).toHaveAttribute('href', '/docs/elasticsearch')
+            expect(anchor).not.toHaveAttribute('hx-disable')
+            expect(mockHtmx.process).toHaveBeenCalledWith(container)
+        })
+
+        it('should normalize full elastic.co docs URLs to paths', () => {
+            render(
+                <TestContainer html='<a href="https://www.elastic.co/docs/kibana">Link</a>' />
+            )
+
+            const container = screen.getByTestId('container')
+            const anchor = container.querySelector('a')
+
+            expect(anchor).toHaveAttribute('href', '/docs/kibana')
+            expect(anchor).not.toHaveAttribute('hx-disable')
+            expect(mockHtmx.process).toHaveBeenCalled()
+        })
+    })
+
+    describe('/docs/api paths should be disabled', () => {
+        it('should add hx-disable for /docs/api paths', () => {
+            render(
+                <TestContainer html='<a href="/docs/api/elasticsearch">API Link</a>' />
+            )
+
+            const container = screen.getByTestId('container')
+            const anchor = container.querySelector('a')
+
+            expect(anchor).toHaveAttribute('href', '/docs/api/elasticsearch')
+            expect(anchor).toHaveAttribute('hx-disable', 'true')
+            expect(mockHtmx.process).not.toHaveBeenCalled()
+        })
+
+        it('should add hx-disable for full elastic.co/docs/api URLs', () => {
+            render(
+                <TestContainer html='<a href="https://www.elastic.co/docs/api/kibana">API Link</a>' />
+            )
+
+            const container = screen.getByTestId('container')
+            const anchor = container.querySelector('a')
+
+            expect(anchor).toHaveAttribute('href', '/docs/api/kibana')
+            expect(anchor).toHaveAttribute('hx-disable', 'true')
+            expect(mockHtmx.process).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('external URLs should be disabled', () => {
+        it('should add hx-disable for GitHub URLs', () => {
+            render(
+                <TestContainer html='<a href="https://github.com/elastic/docs">GitHub</a>' />
+            )
+
+            const container = screen.getByTestId('container')
+            const anchor = container.querySelector('a')
+
+            expect(anchor).toHaveAttribute(
+                'href',
+                'https://github.com/elastic/docs'
+            )
+            expect(anchor).toHaveAttribute('hx-disable', 'true')
+            expect(mockHtmx.process).not.toHaveBeenCalled()
+        })
+
+        it('should add hx-disable for elastic.co non-docs URLs', () => {
+            render(
+                <TestContainer html='<a href="https://www.elastic.co/products">Products</a>' />
+            )
+
+            const container = screen.getByTestId('container')
+            const anchor = container.querySelector('a')
+
+            expect(anchor).toHaveAttribute(
+                'href',
+                'https://www.elastic.co/products'
+            )
+            expect(anchor).toHaveAttribute('hx-disable', 'true')
+            expect(mockHtmx.process).not.toHaveBeenCalled()
+        })
+
+        it('should add hx-disable for elastic.co/guide URLs', () => {
+            render(
+                <TestContainer html='<a href="https://www.elastic.co/guide/en/elasticsearch">Guide</a>' />
+            )
+
+            const container = screen.getByTestId('container')
+            const anchor = container.querySelector('a')
+
+            expect(anchor).toHaveAttribute(
+                'href',
+                'https://www.elastic.co/guide/en/elasticsearch'
+            )
+            expect(anchor).toHaveAttribute('hx-disable', 'true')
+            expect(mockHtmx.process).not.toHaveBeenCalled()
+        })
+
+        it('should add hx-disable for cloud.elastic.co URLs', () => {
+            render(
+                <TestContainer html='<a href="https://cloud.elastic.co/login">Cloud</a>' />
+            )
+
+            const container = screen.getByTestId('container')
+            const anchor = container.querySelector('a')
+
+            expect(anchor).toHaveAttribute(
+                'href',
+                'https://cloud.elastic.co/login'
+            )
+            expect(anchor).toHaveAttribute('hx-disable', 'true')
+            expect(mockHtmx.process).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('mixed content', () => {
+        it('should handle container with both internal and external links', () => {
+            render(
+                <TestContainer
+                    html={`
+                        <a href="/docs/elasticsearch" data-testid="internal">Internal</a>
+                        <a href="/docs/api/kibana" data-testid="api">API</a>
+                        <a href="https://github.com/elastic" data-testid="external">External</a>
+                    `}
+                />
+            )
+
+            const container = screen.getByTestId('container')
+            const internalLink = screen.getByTestId('internal')
+            const apiLink = screen.getByTestId('api')
+            const externalLink = screen.getByTestId('external')
+
+            // Internal link - htmx enabled
+            expect(internalLink).toHaveAttribute('href', '/docs/elasticsearch')
+            expect(internalLink).not.toHaveAttribute('hx-disable')
+
+            // API link - htmx disabled
+            expect(apiLink).toHaveAttribute('href', '/docs/api/kibana')
+            expect(apiLink).toHaveAttribute('hx-disable', 'true')
+
+            // External link - htmx disabled
+            expect(externalLink).toHaveAttribute(
+                'href',
+                'https://github.com/elastic'
+            )
+            expect(externalLink).toHaveAttribute('hx-disable', 'true')
+
+            // htmx.process should be called because there's at least one internal link
+            expect(mockHtmx.process).toHaveBeenCalledWith(container)
+        })
+
+        it('should not call htmx.process if all links are external', () => {
+            render(
+                <TestContainer
+                    html={`
+                        <a href="/docs/api/elasticsearch">API</a>
+                        <a href="https://github.com/elastic">GitHub</a>
+                    `}
+                />
+            )
+
+            expect(mockHtmx.process).not.toHaveBeenCalled()
+        })
+    })
+})

--- a/src/Elastic.Documentation.Site/Assets/web-components/shared/htmx/useHtmxContainer.ts
+++ b/src/Elastic.Documentation.Site/Assets/web-components/shared/htmx/useHtmxContainer.ts
@@ -1,14 +1,16 @@
 import {
     applyHtmxAttributes,
     getPathFromUrl,
+    isExternalDocsUrl,
     useCurrentPathname,
 } from './utils'
 import htmx from 'htmx.org'
 import { RefObject, useEffect } from 'react'
 
 /**
- * Hook that processes all internal docs links in a container element.
- * Finds anchor elements, extracts paths, applies htmx attributes, and processes with htmx.
+ * Hook that processes all links in a container element.
+ * For internal docs links, applies htmx attributes for SPA navigation.
+ * For external links (non-elastic.co or /docs/api), adds hx-disable to prevent htmx processing.
  *
  * @param containerRef - Ref to the container element
  * @param dependencies - Additional dependencies that should trigger reprocessing (e.g., content)
@@ -35,12 +37,21 @@ export const useHtmxContainer = (
             const href = anchor.getAttribute('href') || ''
             const path = getPathFromUrl(href)
 
-            if (!path) return
+            // External non-elastic.co URLs - disable htmx
+            if (!path) {
+                anchor.setAttribute('hx-disable', 'true')
+                return
+            }
 
-            // Update href to use the path
+            // External docs URLs (e.g., /docs/api) - disable htmx
+            if (isExternalDocsUrl(path)) {
+                anchor.setAttribute('href', path)
+                anchor.setAttribute('hx-disable', 'true')
+                return
+            }
+
+            // Internal docs links - apply htmx attributes
             anchor.setAttribute('href', path)
-
-            // Apply htmx attributes for in-page navigation
             applyHtmxAttributes(anchor, path, currentPathname)
             hasProcessedLinks = true
         })

--- a/src/Elastic.Documentation.Site/Assets/web-components/shared/htmx/useHtmxLink.test.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/shared/htmx/useHtmxLink.test.tsx
@@ -1,0 +1,272 @@
+import { useHtmxLink } from './useHtmxLink'
+import { getPathFromUrl, isExternalDocsUrl } from './utils'
+import { render, renderHook, screen } from '@testing-library/react'
+import htmx from 'htmx.org'
+
+// Mock htmx - it uses XPath which jsdom doesn't support properly
+jest.mock('htmx.org', () => ({
+    on: jest.fn(),
+    off: jest.fn(),
+    process: jest.fn(),
+    ajax: jest.fn(),
+}))
+
+const mockHtmx = htmx as jest.Mocked<typeof htmx>
+
+// Test component that uses the hook and renders an anchor
+const TestLink = ({ url }: { url: string }) => {
+    const { ref, href } = useHtmxLink(url)
+    return (
+        <a ref={ref} href={href} data-testid="test-link">
+            Test Link
+        </a>
+    )
+}
+
+describe('isExternalDocsUrl', () => {
+    it('should return true for /docs/api', () => {
+        expect(isExternalDocsUrl('/docs/api')).toBe(true)
+    })
+
+    it('should return true for /docs/api/ paths', () => {
+        expect(isExternalDocsUrl('/docs/api/')).toBe(true)
+        expect(isExternalDocsUrl('/docs/api/elasticsearch')).toBe(true)
+        expect(isExternalDocsUrl('/docs/api/kibana/some/path')).toBe(true)
+    })
+
+    it('should return false for regular docs paths', () => {
+        expect(isExternalDocsUrl('/docs/elasticsearch')).toBe(false)
+        expect(isExternalDocsUrl('/docs/kibana/dashboard')).toBe(false)
+        expect(isExternalDocsUrl('/docs')).toBe(false)
+        expect(isExternalDocsUrl('/docs/')).toBe(false)
+    })
+
+    it('should return false for paths that contain api but not under /docs/api/', () => {
+        expect(isExternalDocsUrl('/docs/elasticsearch/api-reference')).toBe(
+            false
+        )
+        expect(isExternalDocsUrl('/docs/api-guide')).toBe(false)
+    })
+})
+
+describe('getPathFromUrl', () => {
+    describe('paths (starting with /)', () => {
+        it('should return paths as-is', () => {
+            expect(getPathFromUrl('/docs/elasticsearch')).toBe(
+                '/docs/elasticsearch'
+            )
+            expect(getPathFromUrl('/docs/api/kibana')).toBe('/docs/api/kibana')
+            expect(getPathFromUrl('/')).toBe('/')
+        })
+    })
+
+    describe('full elastic.co URLs', () => {
+        it('should extract pathname from elastic.co docs URLs', () => {
+            expect(
+                getPathFromUrl('https://www.elastic.co/docs/elasticsearch')
+            ).toBe('/docs/elasticsearch')
+            expect(
+                getPathFromUrl(
+                    'https://elastic.co/docs/kibana/dashboard/overview'
+                )
+            ).toBe('/docs/kibana/dashboard/overview')
+        })
+
+        it('should return null for non-docs elastic.co URLs', () => {
+            expect(getPathFromUrl('https://www.elastic.co/products')).toBe(null)
+            expect(getPathFromUrl('https://elastic.co/about')).toBe(null)
+        })
+
+        it('should return null for elastic.co root URL', () => {
+            expect(getPathFromUrl('https://www.elastic.co')).toBe(null)
+            expect(getPathFromUrl('https://www.elastic.co/')).toBe(null)
+        })
+
+        it('should return null for elastic.co/guide URLs', () => {
+            expect(getPathFromUrl('https://www.elastic.co/guide')).toBe(null)
+            expect(
+                getPathFromUrl('https://www.elastic.co/guide/en/elasticsearch')
+            ).toBe(null)
+        })
+    })
+
+    describe('external non-elastic.co URLs', () => {
+        it('should return null for external URLs', () => {
+            expect(getPathFromUrl('https://github.com/elastic/docs')).toBe(null)
+            expect(getPathFromUrl('https://google.com')).toBe(null)
+            expect(
+                getPathFromUrl('https://developer.mozilla.org/docs/Web')
+            ).toBe(null)
+        })
+    })
+
+    describe('elastic.co subdomains without /docs path', () => {
+        it('should return null for cloud.elastic.co URLs', () => {
+            expect(getPathFromUrl('https://cloud.elastic.co/login')).toBe(null)
+            expect(getPathFromUrl('https://cloud.elastic.co/deployments')).toBe(
+                null
+            )
+        })
+
+        it('should return null for discuss.elastic.co URLs', () => {
+            expect(getPathFromUrl('https://discuss.elastic.co/t/topic')).toBe(
+                null
+            )
+        })
+    })
+
+    describe('invalid URLs', () => {
+        it('should return null for invalid URLs', () => {
+            expect(getPathFromUrl('not-a-valid-url')).toBe(null)
+            expect(getPathFromUrl('')).toBe(null)
+        })
+    })
+})
+
+describe('useHtmxLink', () => {
+    describe('href normalization', () => {
+        it('should return path as-is for paths', () => {
+            const { result } = renderHook(() =>
+                useHtmxLink('/docs/elasticsearch')
+            )
+            expect(result.current.href).toBe('/docs/elasticsearch')
+        })
+
+        it('should normalize full elastic.co URLs to paths', () => {
+            const { result } = renderHook(() =>
+                useHtmxLink('https://www.elastic.co/docs/elasticsearch')
+            )
+            expect(result.current.href).toBe('/docs/elasticsearch')
+        })
+
+        it('should return the path for /docs/api paths', () => {
+            const { result } = renderHook(() =>
+                useHtmxLink('https://www.elastic.co/docs/api/elasticsearch')
+            )
+            expect(result.current.href).toBe('/docs/api/elasticsearch')
+        })
+    })
+
+    describe('external URLs should use full link', () => {
+        it('should keep GitHub URLs as-is', () => {
+            const { result } = renderHook(() =>
+                useHtmxLink('https://github.com/elastic/docs')
+            )
+            expect(result.current.href).toBe('https://github.com/elastic/docs')
+        })
+
+        it('should keep other external URLs as-is', () => {
+            const { result } = renderHook(() =>
+                useHtmxLink('https://developer.mozilla.org/en-US/docs/Web')
+            )
+            expect(result.current.href).toBe(
+                'https://developer.mozilla.org/en-US/docs/Web'
+            )
+        })
+
+        it('should keep non-docs elastic.co URLs as-is', () => {
+            const { result } = renderHook(() =>
+                useHtmxLink('https://www.elastic.co/products/elasticsearch')
+            )
+            expect(result.current.href).toBe(
+                'https://www.elastic.co/products/elasticsearch'
+            )
+        })
+
+        it('should keep cloud.elastic.co URLs as-is', () => {
+            const { result } = renderHook(() =>
+                useHtmxLink('https://cloud.elastic.co/login')
+            )
+            expect(result.current.href).toBe('https://cloud.elastic.co/login')
+        })
+
+        it('should keep elastic.co root URL as-is', () => {
+            const { result } = renderHook(() =>
+                useHtmxLink('https://www.elastic.co')
+            )
+            expect(result.current.href).toBe('https://www.elastic.co')
+        })
+
+        it('should keep elastic.co/guide URLs as-is', () => {
+            const { result } = renderHook(() =>
+                useHtmxLink('https://www.elastic.co/guide/en/elasticsearch')
+            )
+            expect(result.current.href).toBe(
+                'https://www.elastic.co/guide/en/elasticsearch'
+            )
+        })
+    })
+
+    describe('ref', () => {
+        it('should return a ref object', () => {
+            const { result } = renderHook(() =>
+                useHtmxLink('/docs/elasticsearch')
+            )
+            expect(result.current.ref).toBeDefined()
+            expect(result.current.ref.current).toBe(null) // Not attached yet
+        })
+    })
+
+    describe('HTMX attribute handling', () => {
+        beforeEach(() => {
+            jest.clearAllMocks()
+        })
+
+        it('should call htmx.process for internal docs links', () => {
+            render(<TestLink url="/docs/elasticsearch" />)
+
+            const anchor = screen.getByTestId('test-link')
+
+            // For internal links, htmx.process should be called
+            expect(mockHtmx.process).toHaveBeenCalledWith(anchor)
+            expect(anchor).not.toHaveAttribute('hx-disable')
+        })
+
+        it('should add hx-disable for /docs/api paths', () => {
+            render(<TestLink url="/docs/api/elasticsearch" />)
+
+            const anchor = screen.getByTestId('test-link')
+
+            expect(anchor).toHaveAttribute('hx-disable', 'true')
+            expect(mockHtmx.process).not.toHaveBeenCalled()
+        })
+
+        it('should add hx-disable for external URLs', () => {
+            render(<TestLink url="https://github.com/elastic/docs" />)
+
+            const anchor = screen.getByTestId('test-link')
+
+            expect(anchor).toHaveAttribute('hx-disable', 'true')
+            expect(mockHtmx.process).not.toHaveBeenCalled()
+        })
+
+        it('should add hx-disable for non-docs elastic.co URLs', () => {
+            render(<TestLink url="https://www.elastic.co/products" />)
+
+            const anchor = screen.getByTestId('test-link')
+
+            expect(anchor).toHaveAttribute('hx-disable', 'true')
+            expect(mockHtmx.process).not.toHaveBeenCalled()
+        })
+
+        it('should add hx-disable for elastic.co root URL', () => {
+            render(<TestLink url="https://www.elastic.co" />)
+
+            const anchor = screen.getByTestId('test-link')
+
+            expect(anchor).toHaveAttribute('hx-disable', 'true')
+            expect(mockHtmx.process).not.toHaveBeenCalled()
+        })
+
+        it('should add hx-disable for elastic.co/guide URLs', () => {
+            render(
+                <TestLink url="https://www.elastic.co/guide/en/elasticsearch" />
+            )
+
+            const anchor = screen.getByTestId('test-link')
+
+            expect(anchor).toHaveAttribute('hx-disable', 'true')
+            expect(mockHtmx.process).not.toHaveBeenCalled()
+        })
+    })
+})

--- a/src/Elastic.Documentation.Site/Assets/web-components/shared/htmx/useHtmxLink.ts
+++ b/src/Elastic.Documentation.Site/Assets/web-components/shared/htmx/useHtmxLink.ts
@@ -1,28 +1,64 @@
-import { applyHtmxAttributes, useCurrentPathname } from './utils'
+import {
+    applyHtmxAttributes,
+    getPathFromUrl,
+    isExternalDocsUrl,
+    useCurrentPathname,
+} from './utils'
 import htmx from 'htmx.org'
-import { RefObject, useEffect, useRef } from 'react'
+import { RefObject, useEffect, useMemo, useRef } from 'react'
+
+export interface UseHtmxLinkResult {
+    /** Ref to attach to the anchor element */
+    ref: RefObject<HTMLAnchorElement>
+    /** Normalized path for the href attribute (falls back to original URL if not an elastic.co docs link) */
+    href: string
+}
 
 /**
  * Hook that applies htmx attributes to a single anchor element.
- * Returns a ref to attach to the anchor element.
+ * Returns a ref to attach to the anchor element and the normalized href.
  *
- * @param path - The path/href for the link
- * @returns A ref to attach to the anchor element
+ * Handles both paths (/docs/...) and full URLs (https://elastic.co/docs/...).
+ * HTMX attributes are not applied for:
+ * - External non-elastic.co URLs
+ * - External docs URLs (e.g., /docs/api) which are served from separate sites
+ *
+ * @param url - The path or full URL for the link
+ * @returns Object with ref and normalized href
  *
  * @example
- * const anchorRef = useHtmxLink('/docs/elasticsearch/reference')
- * return <a ref={anchorRef} href="/docs/elasticsearch/reference">Link</a>
+ * const { ref, href } = useHtmxLink('/docs/elasticsearch/reference')
+ * return <a ref={ref} href={href}>Link</a>
+ *
+ * @example
+ * // Also handles full URLs
+ * const { ref, href } = useHtmxLink('https://elastic.co/docs/elasticsearch/reference')
+ * // href will be '/docs/elasticsearch/reference'
  */
-export const useHtmxLink = (path: string): RefObject<HTMLAnchorElement> => {
+export const useHtmxLink = (url: string): UseHtmxLinkResult => {
     const anchorRef = useRef<HTMLAnchorElement>(null)
     const currentPathname = useCurrentPathname()
 
+    // Normalize URL to path, returns null for external non-elastic.co URLs
+    const path = useMemo(() => getPathFromUrl(url), [url])
+
+    // Use normalized path for href, fall back to original URL for external links
+    const href = path ?? url
+
     useEffect(() => {
-        if (anchorRef.current) {
+        if (!anchorRef.current) return
+
+        const isExternal = !path || isExternalDocsUrl(path)
+
+        if (isExternal) {
+            // Explicitly disable HTMX for external links
+            anchorRef.current.setAttribute('hx-disable', 'true')
+        } else {
+            // Apply HTMX attributes for internal docs links
             applyHtmxAttributes(anchorRef.current, path, currentPathname)
             htmx.process(anchorRef.current)
         }
     }, [path, currentPathname])
 
-    return anchorRef
+    return { ref: anchorRef, href }
 }

--- a/src/Elastic.Documentation.Site/Assets/web-components/shared/htmx/utils.ts
+++ b/src/Elastic.Documentation.Site/Assets/web-components/shared/htmx/utils.ts
@@ -1,6 +1,14 @@
 import { useEffect, useState } from 'react'
 
 /**
+ * Checks if a URL points to an external site that should not use HTMX navigation.
+ * Currently, /docs/api paths are served from a separate external site.
+ */
+export const isExternalDocsUrl = (url: string): boolean => {
+    return url.startsWith('/docs/api/') || url === '/docs/api'
+}
+
+/**
  * Extracts the pathname from a URL string.
  * Handles both full URLs (https://...) and relative paths (/docs/...).
  * For full URLs, only returns the pathname if it's an elastic.co docs link.
@@ -16,7 +24,7 @@ export const getPathFromUrl = (url: string): string | null => {
         const parsed = new URL(url)
         // Only process elastic.co docs links
         if (
-            parsed.hostname.includes('elastic.co') &&
+            parsed.hostname.endsWith('elastic.co') &&
             parsed.pathname.startsWith('/docs')
         ) {
             return parsed.pathname


### PR DESCRIPTION
### What was fixed
Links to `/docs/api` and external URLs (like `github.com` or `elastic.co/guide`) were incorrectly using HTMX for navigation. This caused broken navigation because these URLs point to separate websites.

### How it was fixed
- Updated `useHtmxLink` and `useHtmxContainer` hooks to detect external URLs
- Added `hx-disable="true"` attribute to external links, which tells HTMX to ignore them
- Internal docs links (`/docs/*` except `/docs/api`) continue to use HTMX for fast navigation
- External links now use standard browser navigation (full page load)

### Why it was fixed
The `/docs/api` content is hosted on a different server. When HTMX tried to load these pages, it failed because the response format was incompatible. Users experienced broken navigation when clicking API documentation links in search results or AI responses.

### Testing
Added 39 unit tests covering all URL types:
- Internal docs, `/docs/api` paths, external URLs, elastic.co non-docs URLs