### PR TITLE
Fix stale AI enrichment detection when prompts change

### DIFF
--- a/src/Elastic.Documentation/Search/DocumentationDocument.cs
+++ b/src/Elastic.Documentation/Search/DocumentationDocument.cs
@@ -143,4 +143,12 @@ public record DocumentationDocument
 	[JsonPropertyName("ai_use_cases")]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public string[]? AiUseCases { get; set; }
+
+	/// <summary>
+	/// Hash of the LLM prompt templates used to generate AI fields.
+	/// Used to detect stale enrichments when prompts change.
+	/// </summary>
+	[JsonPropertyName("enrichment_prompt_hash")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public string? EnrichmentPromptHash { get; set; }
 }

--- a/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchIngestChannel.Mapping.cs
+++ b/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchIngestChannel.Mapping.cs
@@ -244,6 +244,9 @@ public abstract partial class ElasticsearchIngestChannel<TChannelOptions, TChann
 		        "fields": {
 		          {{(!string.IsNullOrWhiteSpace(inferenceId) ? $"\"semantic_text\": {{{InferenceMapping(inferenceId)}}}" : "")}}
 		        }
+		      },
+		      "enrichment_prompt_hash": {
+		        "type": "keyword"
 		      }
 		    }
 		  }

--- a/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchMarkdownExporter.Export.cs
+++ b/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchMarkdownExporter.Export.cs
@@ -274,6 +274,7 @@ public partial class ElasticsearchMarkdownExporter
 			doc.AiSearchQuery = enrichment.SearchQuery;
 			doc.AiQuestions = enrichment.Questions;
 			doc.AiUseCases = enrichment.UseCases;
+			doc.EnrichmentPromptHash = ElasticsearchLlmClient.PromptHash;
 		}
 		catch (Exception ex) when (ex is not OperationCanceledException)
 		{


### PR DESCRIPTION
### Problem

When we update the LLM prompts (to improve AI-generated summaries, questions, etc.), existing documents keep their outdated AI content indefinitely.

**Why this happens:**
- Documents are only re-indexed when their content changes
- If content is unchanged, the document keeps its old AI fields
- Our system didn't track *which prompt version* was used to generate the AI fields
- So we couldn't identify which documents had stale enrichments

### Solution

Store a `enrichment_prompt_hash` on each document that tracks which prompt version was used.

**How it works:**
1. Each document now includes a hash of the prompt templates used to generate its AI fields
2. When prompts change, the hash changes
3. The backfill process now finds documents where:
   - AI fields are missing (never enriched), OR
   - `enrichment_prompt_hash` doesn't match the current prompt (stale)
4. These documents get updated with fresh AI content

**Gradual migration:**
- Up to 100 documents are re-enriched per build run (rate limit)
- Stale documents are updated via the enrich pipeline
- Over multiple runs, all documents converge to the latest prompt version