### PR TITLE
Codex URL structure and category navigation

### DIFF
--- a/config/codex.example.yml
+++ b/config/codex.example.yml
@@ -11,7 +11,8 @@
 # Site prefix for all codex URLs
 # All documentation sets will be served under this prefix
 # e.g., /internal-docs, /dev-docs, /docs
-site_prefix: /internal-docs
+# Set to "/" or omit for no prefix (site hosted at root, e.g., codex.elastic.dev)
+site_prefix: /
 
 # Title displayed on the codex index page
 title: "Elastic's Internal Dev Docs"
@@ -40,13 +41,27 @@ documentation_sets:
     display_name: "Content Architecture"
     icon: architecture
 
-  # Benchmarking documentation in observability category
+  # Observability group (multiple members)
+  - name: docs-eng-team
+    branch: feature/test
+    category: docs
+    repo_name: docs-eng-team
+    display_name: "Docs Engineering"
+    icon: documentation
+
   - name: docs-eng-team
     branch: main
     category: observability
-    repo_name: benchmarking
-    display_name: "Benchmarking Elasticsearch"
-    icon: benchmark
+    repo_name: uptime-docs
+    display_name: "Uptime Monitoring"
+    icon: observability
+
+  - name: docs-eng-team
+    branch: main
+    category: observability
+    repo_name: apm-agent-docs
+    display_name: "APM Agent"
+    icon: apm
 
   # Migration Guide in tooling category
   - name: docs-eng-team
@@ -96,9 +111,10 @@ documentation_sets:
 #   Defaults to "docs".
 #
 # category (optional):
-#   Group documentation sets under a category.
-#   Creates URL structure: /{site_prefix}/{category}/{repo_name}/
-#   If not specified, URL is: /{site_prefix}/{repo_name}/
+#   Group documentation sets under a category (group).
+#   Repos use stable URLs: /r/{repo_name}/ (or /{site_prefix}/r/{repo_name}/ with prefix)
+#   Group landing: /g/{category}/ (or /{site_prefix}/g/{category}/ with prefix)
+#   Group membership only affects which sidebar navigation is shown, not the URL.
 #
 # repo_name (optional):
 #   Override the name used for checkout directories and URL paths.

--- a/src/Elastic.Codex/Group/GroupLandingView.cshtml
+++ b/src/Elastic.Codex/Group/GroupLandingView.cshtml
@@ -1,0 +1,30 @@
+@inherits RazorSliceHttpResult<Elastic.Codex.Group.GroupLandingViewModel>
+@using Elastic.Codex.Group
+@using Elastic.Codex.Navigation
+@implements IUsesLayout<Elastic.Codex._Layout, GlobalLayoutViewModel>
+@functions {
+	public GlobalLayoutViewModel LayoutModel => Model.CreateGlobalLayoutModel();
+}
+<section id="elastic-docs-v3" class="codex-group-page">
+	<div class="codex-header py-8">
+		<h1 class="text-3xl font-bold mb-4">@Model.Group.DisplayTitle</h1>
+		<p class="text-gray-60">Documentation sets in this group</p>
+	</div>
+
+	<div class="codex-grid grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mt-8">
+		@foreach (var docSet in Model.DocumentationSets.OrderBy(ds => ds.Title))
+		{
+			<a href="@docSet.Url"
+			   hx-select-oob="#main-container"
+			   preload="mousedown"
+			   class="codex-card block p-6 rounded-lg border border-gray-20 hover:border-blue-40 hover:shadow-md transition-all">
+				<div class="codex-card-content">
+					<h3 class="text-xl font-medium mb-2 text-gray-80">@docSet.Title</h3>
+					<div class="codex-card-meta text-sm text-gray-50">
+						<span>@docSet.PageCount pages</span>
+					</div>
+				</div>
+			</a>
+		}
+	</div>
+</section>

--- a/src/Elastic.Codex/Group/GroupLandingViewModel.cs
+++ b/src/Elastic.Codex/Group/GroupLandingViewModel.cs
@@ -1,0 +1,23 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Codex.Navigation;
+
+namespace Elastic.Codex.Group;
+
+/// <summary>
+/// View model for a group landing page (/g/slug) that lists only documentation sets in that group.
+/// </summary>
+public class GroupLandingViewModel(CodexRenderContext context) : CodexViewModel(context)
+{
+	/// <summary>
+	/// The group navigation (landing + repos in this group).
+	/// </summary>
+	public required GroupNavigation Group { get; init; }
+
+	/// <summary>
+	/// Documentation sets in this group (for the group landing cards).
+	/// </summary>
+	public IEnumerable<CodexDocumentationSetInfo> DocumentationSets => Group.DocumentationSetInfos;
+}

--- a/src/Elastic.Codex/Navigation/GroupNavigation.cs
+++ b/src/Elastic.Codex/Navigation/GroupNavigation.cs
@@ -1,0 +1,155 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Collections.Frozen;
+using System.Diagnostics;
+using Elastic.Documentation.Extensions;
+using Elastic.Documentation.Navigation;
+
+namespace Elastic.Codex.Navigation;
+
+/// <summary>
+/// Root navigation for a group (e.g. observability) that shows the group landing plus all repos in the group as top-level items.
+/// Used so the same sidebar appears on the group landing and on every repo page in that group.
+/// </summary>
+[DebuggerDisplay("{Url}")]
+public class GroupNavigation : IRootNavigationItem<IDocumentationFile, INavigationItem>
+{
+	public GroupNavigation(string groupSlug, string displayTitle, string url)
+	{
+		GroupSlug = groupSlug;
+		DisplayTitle = displayTitle;
+		Url = url.TrimEnd('/');
+		Id = ShortId.Create($"group-{groupSlug}");
+		Identifier = new Uri($"codex://group/{groupSlug}");
+		var leaf = new GroupIndexLeaf(new GroupIndexPage(displayTitle), Url, this);
+		Index = leaf;
+		leaf.Parent = this;
+	}
+
+	/// <summary>
+	/// Gets the group slug (used in URL, e.g. "observability" for /g/observability).
+	/// </summary>
+	public string GroupSlug { get; }
+
+	/// <summary>
+	/// Gets the display title for the group.
+	/// </summary>
+	public string DisplayTitle { get; }
+
+	/// <summary>
+	/// Gets information about documentation sets in this group for the group landing page.
+	/// </summary>
+	public FrozenSet<CodexDocumentationSetInfo> DocumentationSetInfos { get; set; } = [];
+
+	/// <inheritdoc />
+	public string Url { get; }
+
+	/// <inheritdoc />
+	public string NavigationTitle => DisplayTitle;
+
+	/// <inheritdoc />
+	public IRootNavigationItem<INavigationModel, INavigationItem> NavigationRoot => this;
+
+	/// <inheritdoc />
+	public INodeNavigationItem<INavigationModel, INavigationItem>? Parent { get; set; }
+
+	/// <inheritdoc />
+	public bool Hidden => false;
+
+	/// <inheritdoc />
+	public int NavigationIndex { get; set; }
+
+	/// <inheritdoc />
+	public string Id { get; }
+
+	/// <inheritdoc />
+	public ILeafNavigationItem<IDocumentationFile> Index { get; }
+
+	/// <inheritdoc />
+	public IReadOnlyCollection<INavigationItem> NavigationItems { get; private set; } = [];
+
+	/// <inheritdoc />
+	public bool IsUsingNavigationDropdown => false;
+
+	/// <inheritdoc />
+	public Uri Identifier { get; }
+
+	/// <inheritdoc />
+	void IAssignableChildrenNavigation.SetNavigationItems(IReadOnlyCollection<INavigationItem> navigationItems) =>
+		NavigationItems = navigationItems;
+}
+
+/// <summary>
+/// Virtual index page for a group landing.
+/// </summary>
+public record GroupIndexPage(string NavigationTitle) : IDocumentationFile;
+
+/// <summary>
+/// Leaf navigation item for a group's index (landing) page.
+/// </summary>
+[DebuggerDisplay("{Url}")]
+public class GroupIndexLeaf(
+	GroupIndexPage model,
+	string url,
+	GroupNavigation groupRoot
+) : ILeafNavigationItem<IDocumentationFile>
+{
+	/// <inheritdoc />
+	public IDocumentationFile Model { get; } = model;
+
+	/// <inheritdoc />
+	public string Url { get; } = url;
+
+	/// <inheritdoc />
+	public string NavigationTitle => Model.NavigationTitle;
+
+	/// <inheritdoc />
+	public IRootNavigationItem<INavigationModel, INavigationItem> NavigationRoot => groupRoot;
+
+	/// <inheritdoc />
+	public INodeNavigationItem<INavigationModel, INavigationItem>? Parent { get; set; }
+
+	/// <inheritdoc />
+	public bool Hidden => false;
+
+	/// <inheritdoc />
+	public int NavigationIndex { get; set; }
+}
+
+/// <summary>
+/// Model for a codex nav link to a group landing page.
+/// </summary>
+public record GroupLinkPage(string NavigationTitle, string Url) : IDocumentationFile;
+
+/// <summary>
+/// Leaf in the codex nav that links to a group landing page (/g/slug).
+/// </summary>
+[DebuggerDisplay("{Url}")]
+public class GroupLinkLeaf(
+	GroupLinkPage model,
+	CodexNavigation codexRoot
+) : ILeafNavigationItem<IDocumentationFile>
+{
+	/// <inheritdoc />
+	public IDocumentationFile Model { get; } = model;
+
+	/// <inheritdoc />
+	public string Url => model.Url;
+
+	/// <inheritdoc />
+	public string NavigationTitle => Model.NavigationTitle;
+
+	/// <inheritdoc />
+	public IRootNavigationItem<INavigationModel, INavigationItem> NavigationRoot => codexRoot;
+
+	/// <inheritdoc />
+	public INodeNavigationItem<INavigationModel, INavigationItem>? Parent { get; set; }
+
+	/// <inheritdoc />
+	public bool Hidden => false;
+
+	/// <inheritdoc />
+	public int NavigationIndex { get; set; }
+}

--- a/src/Elastic.Documentation.Configuration/Codex/CodexConfiguration.cs
+++ b/src/Elastic.Documentation.Configuration/Codex/CodexConfiguration.cs
@@ -15,9 +15,10 @@ public record CodexConfiguration
 	/// <summary>
 	/// The URL prefix for all codex URLs (e.g., "/internal-docs").
 	/// All documentation sets will be served under this prefix.
+	/// Set to "/" or empty for no prefix (site hosted at root, e.g., codex.elastic.dev).
 	/// </summary>
 	[YamlMember(Alias = "site_prefix")]
-	public string SitePrefix { get; set; } = "/docs";
+	public string SitePrefix { get; set; } = "/";
 
 	/// <summary>
 	/// The title displayed on the codex index page.
@@ -64,11 +65,20 @@ public record CodexConfiguration
 
 	private static CodexConfiguration NormalizeConfiguration(CodexConfiguration config)
 	{
-		// Normalize site prefix to ensure it starts with / and doesn't end with /
-		var sitePrefix = config.SitePrefix.Trim();
-		if (!sitePrefix.StartsWith('/'))
-			sitePrefix = "/" + sitePrefix;
-		sitePrefix = sitePrefix.TrimEnd('/');
+		// Normalize site prefix: empty or "/" means root (no prefix)
+		var sitePrefix = config.SitePrefix?.Trim() ?? "";
+		if (string.IsNullOrEmpty(sitePrefix) || sitePrefix == "/")
+		{
+			// Root prefix - no path segment
+			sitePrefix = "";
+		}
+		else
+		{
+			// Ensure it starts with / and doesn't end with /
+			if (!sitePrefix.StartsWith('/'))
+				sitePrefix = "/" + sitePrefix;
+			sitePrefix = sitePrefix.TrimEnd('/');
+		}
 
 		return config with { SitePrefix = sitePrefix };
 	}

--- a/src/Elastic.Documentation.Navigation/Isolated/Node/DocumentationSetNavigation.cs
+++ b/src/Elastic.Documentation.Navigation/Isolated/Node/DocumentationSetNavigation.cs
@@ -15,6 +15,11 @@ namespace Elastic.Documentation.Navigation.Isolated.Node;
 public interface IDocumentationSetNavigation
 {
 	IReadOnlyDictionary<Uri, IRootNavigationItem<IDocumentationFile, INavigationItem>> TableOfContentNodes { get; }
+
+	/// <summary>
+	/// Optional override for the navigation title. When set, this is used instead of the index page's title.
+	/// </summary>
+	string? NavigationTitleOverride { get; set; }
 }
 
 [DebuggerDisplay("{Url}")]
@@ -114,8 +119,14 @@ public class DocumentationSetNavigation<TModel>
 	/// <inheritdoc />
 	public string Url => Index.Url;
 
+	/// <summary>
+	/// Optional override for the navigation title. When set, this is used instead of the index page's title.
+	/// Useful for codex builds where the display name is configured externally.
+	/// </summary>
+	public string? NavigationTitleOverride { get; set; }
+
 	/// <inheritdoc />
-	public string NavigationTitle => Index.NavigationTitle;
+	public string NavigationTitle => NavigationTitleOverride ?? Index.NavigationTitle;
 
 	public IRootNavigationItem<INavigationModel, INavigationItem> NavigationRoot =>
 		HomeProvider == this ? field : HomeProvider.NavigationRoot;

--- a/tests/Navigation.Tests/Codex/CodexNavigationRenderingTests.cs
+++ b/tests/Navigation.Tests/Codex/CodexNavigationRenderingTests.cs
@@ -1,0 +1,232 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Codex.Navigation;
+using Elastic.Documentation.Configuration.Codex;
+using Elastic.Documentation.Navigation.Isolated.Node;
+using FluentAssertions;
+
+namespace Elastic.Documentation.Navigation.Tests.Codex;
+
+/// <summary>
+/// Tests that verify navigation is correctly structured for grouped and ungrouped repos.
+/// Even though URLs are stable (/r/repo-name), the sidebar navigation should differ:
+/// - Grouped repos: sidebar shows the group landing + all group members as top-level items
+/// - Ungrouped repos: sidebar shows only that repo's internal navigation
+/// </summary>
+public class CodexNavigationRenderingTests(ITestOutputHelper output) : CodexNavigationTestBase(output)
+{
+	[Fact]
+	public void GroupNavigation_TopLevelItems_ContainsAllGroupMembers()
+	{
+		// Arrange: Create a codex with grouped repos
+		var config = CreateCodexConfiguration(
+			sitePrefix: "/docs",
+			docSets: [
+				new CodexDocumentationSetReference { Name = "apm-agent", Branch = "main", Category = "observability", DisplayName = "APM Agent" },
+				new CodexDocumentationSetReference { Name = "uptime", Branch = "main", Category = "observability", DisplayName = "Uptime" },
+				new CodexDocumentationSetReference { Name = "logs", Branch = "main", Category = "observability", DisplayName = "Logs" }
+			]);
+
+		var docSetNavigations = CreateMockDocSetNavigations(["apm-agent", "uptime", "logs"]);
+		var codexNav = new CodexNavigation(config, CreateContext(), docSetNavigations);
+
+		// Get the group navigation
+		var groupNav = codexNav.GroupNavigations.First();
+
+		// Assert: Group navigation's top-level items should contain all 3 repos
+		groupNav.NavigationItems.Should().HaveCount(3);
+		groupNav.NavigationItems.Select(i => i.Url).Should().BeEquivalentTo([
+			"/docs/r/apm-agent",
+			"/docs/r/uptime",
+			"/docs/r/logs"
+		]);
+	}
+
+	[Fact]
+	public void GroupNavigation_TopLevelItems_UseDisplayNames()
+	{
+		// Arrange
+		var config = CreateCodexConfiguration(
+			sitePrefix: "/docs",
+			docSets: [
+				new CodexDocumentationSetReference { Name = "apm-agent", Branch = "main", Category = "observability", DisplayName = "APM Agent Docs" },
+				new CodexDocumentationSetReference { Name = "uptime", Branch = "main", Category = "observability", DisplayName = "Uptime Monitoring" }
+			]);
+
+		var docSetNavigations = CreateMockDocSetNavigations(["apm-agent", "uptime"]);
+		var codexNav = new CodexNavigation(config, CreateContext(), docSetNavigations);
+
+		var groupNav = codexNav.GroupNavigations.First();
+
+		// Assert: Navigation titles should use the display names from config
+		groupNav.NavigationItems.Select(i => i.NavigationTitle).Should().BeEquivalentTo([
+			"APM Agent Docs",
+			"Uptime Monitoring"
+		]);
+	}
+
+	[Fact]
+	public void UngroupedRepo_NavigationRoot_IsItself()
+	{
+		// Arrange
+		var config = CreateCodexConfiguration(
+			sitePrefix: "/docs",
+			docSets: [
+				new CodexDocumentationSetReference { Name = "standalone", Branch = "main" }
+			]);
+
+		var docSetNavigations = CreateMockDocSetNavigations(["standalone"]);
+		var codexNav = new CodexNavigation(config, CreateContext(), docSetNavigations);
+
+		// Get the standalone repo's navigation
+		var standaloneNav = docSetNavigations["standalone"] as INavigationHomeAccessor;
+		standaloneNav.Should().NotBeNull();
+
+		// Assert: The HomeProvider's NavigationRoot should be the repo itself
+		standaloneNav!.HomeProvider.Should().NotBeNull();
+
+		// The navigation root for an ungrouped repo should be itself (DocumentationSetNavigation)
+		// This means when rendering, it will show only its own navigation tree
+		var navRoot = standaloneNav.HomeProvider!.NavigationRoot;
+		navRoot.Should().BeAssignableTo<IDocumentationSetNavigation>();
+		navRoot.Url.Should().Be("/docs/r/standalone");
+	}
+
+	[Fact]
+	public void GroupedRepo_NavigationRoot_IsGroupNavigation()
+	{
+		// Arrange
+		var config = CreateCodexConfiguration(
+			sitePrefix: "/docs",
+			docSets: [
+				new CodexDocumentationSetReference { Name = "apm", Branch = "main", Category = "observability" },
+				new CodexDocumentationSetReference { Name = "uptime", Branch = "main", Category = "observability" }
+			]);
+
+		var docSetNavigations = CreateMockDocSetNavigations(["apm", "uptime"]);
+		var codexNav = new CodexNavigation(config, CreateContext(), docSetNavigations);
+
+		// Get the grouped repo's navigation
+		var apmNav = docSetNavigations["apm"] as INavigationHomeAccessor;
+		apmNav.Should().NotBeNull();
+
+		// Assert: The HomeProvider's NavigationRoot should be the GroupNavigation
+		apmNav!.HomeProvider.Should().NotBeNull();
+
+		var navRoot = apmNav.HomeProvider!.NavigationRoot;
+		navRoot.Should().BeOfType<GroupNavigation>();
+		navRoot.Url.Should().Be("/docs/g/observability");
+
+		// The group navigation should contain both repos
+		var groupNav = (GroupNavigation)navRoot;
+		groupNav.NavigationItems.Should().HaveCount(2);
+	}
+
+	[Fact]
+	public void CodexNavigation_TopLevelItems_ShowsGroupLinksAndUngroupedRepos()
+	{
+		// Arrange: Mix of grouped and ungrouped repos
+		var config = CreateCodexConfiguration(
+			sitePrefix: "/docs",
+			docSets: [
+				new CodexDocumentationSetReference { Name = "apm", Branch = "main", Category = "observability" },
+				new CodexDocumentationSetReference { Name = "uptime", Branch = "main", Category = "observability" },
+				new CodexDocumentationSetReference { Name = "standalone1", Branch = "main" },
+				new CodexDocumentationSetReference { Name = "standalone2", Branch = "main" }
+			]);
+
+		var docSetNavigations = CreateMockDocSetNavigations(["apm", "uptime", "standalone1", "standalone2"]);
+		var codexNav = new CodexNavigation(config, CreateContext(), docSetNavigations);
+
+		// Assert: Codex nav should have 3 top-level items:
+		// 1 group link (/g/observability) + 2 ungrouped repos
+		codexNav.NavigationItems.Should().HaveCount(3);
+
+		// One should be a group link
+		var groupLinks = codexNav.NavigationItems.OfType<GroupLinkLeaf>().ToList();
+		groupLinks.Should().HaveCount(1);
+		groupLinks[0].Url.Should().Be("/docs/g/observability");
+
+		// Two should be doc set navigations (ungrouped repos)
+		var docSetNavs = codexNav.NavigationItems.OfType<IRootNavigationItem<IDocumentationFile, INavigationItem>>().ToList();
+		docSetNavs.Should().HaveCount(2);
+		docSetNavs.Select(n => n.Url).Should().BeEquivalentTo(["/docs/r/standalone1", "/docs/r/standalone2"]);
+	}
+
+	[Fact]
+	public void AllGroupMembers_ShareSameNavigationRoot()
+	{
+		// Arrange
+		var config = CreateCodexConfiguration(
+			sitePrefix: "/docs",
+			docSets: [
+				new CodexDocumentationSetReference { Name = "repo1", Branch = "main", Category = "group1" },
+				new CodexDocumentationSetReference { Name = "repo2", Branch = "main", Category = "group1" },
+				new CodexDocumentationSetReference { Name = "repo3", Branch = "main", Category = "group1" }
+			]);
+
+		var docSetNavigations = CreateMockDocSetNavigations(["repo1", "repo2", "repo3"]);
+		var codexNav = new CodexNavigation(config, CreateContext(), docSetNavigations);
+
+		// Get each repo's navigation root
+		var repo1Root = ((INavigationHomeAccessor)docSetNavigations["repo1"]).HomeProvider?.NavigationRoot;
+		var repo2Root = ((INavigationHomeAccessor)docSetNavigations["repo2"]).HomeProvider?.NavigationRoot;
+		var repo3Root = ((INavigationHomeAccessor)docSetNavigations["repo3"]).HomeProvider?.NavigationRoot;
+
+		// Assert: All 3 should share the same GroupNavigation instance
+		repo1Root.Should().BeSameAs(repo2Root);
+		repo2Root.Should().BeSameAs(repo3Root);
+		repo1Root.Should().BeOfType<GroupNavigation>();
+	}
+
+	[Fact]
+	public void DifferentGroups_HaveDifferentNavigationRoots()
+	{
+		// Arrange
+		var config = CreateCodexConfiguration(
+			sitePrefix: "/docs",
+			docSets: [
+				new CodexDocumentationSetReference { Name = "obs-repo", Branch = "main", Category = "observability" },
+				new CodexDocumentationSetReference { Name = "sec-repo", Branch = "main", Category = "security" }
+			]);
+
+		var docSetNavigations = CreateMockDocSetNavigations(["obs-repo", "sec-repo"]);
+		var codexNav = new CodexNavigation(config, CreateContext(), docSetNavigations);
+
+		// Get each repo's navigation root
+		var obsRoot = ((INavigationHomeAccessor)docSetNavigations["obs-repo"]).HomeProvider?.NavigationRoot;
+		var secRoot = ((INavigationHomeAccessor)docSetNavigations["sec-repo"]).HomeProvider?.NavigationRoot;
+
+		// Assert: Different groups should have different navigation roots
+		obsRoot.Should().NotBeSameAs(secRoot);
+		((GroupNavigation)obsRoot!).GroupSlug.Should().Be("observability");
+		((GroupNavigation)secRoot!).GroupSlug.Should().Be("security");
+	}
+
+	[Fact]
+	public void GroupLandingPage_HasAllMembersAsNavigationItems()
+	{
+		// Arrange
+		var config = CreateCodexConfiguration(
+			sitePrefix: "",
+			docSets: [
+				new CodexDocumentationSetReference { Name = "a", Branch = "main", Category = "tools" },
+				new CodexDocumentationSetReference { Name = "b", Branch = "main", Category = "tools" },
+				new CodexDocumentationSetReference { Name = "c", Branch = "main", Category = "tools" }
+			]);
+
+		var docSetNavigations = CreateMockDocSetNavigations(["a", "b", "c"]);
+		var codexNav = new CodexNavigation(config, CreateContext(), docSetNavigations);
+
+		var groupNav = codexNav.GroupNavigations.First();
+
+		// Assert: Group navigation should have all members
+		groupNav.NavigationItems.Should().HaveCount(3);
+
+		// And the index page should be the group landing
+		groupNav.Index.Url.Should().Be("/g/tools");
+		groupNav.Index.NavigationTitle.Should().Be("Tools");
+	}
+}

--- a/tests/Navigation.Tests/Codex/CodexNavigationRenderingTests.cs
+++ b/tests/Navigation.Tests/Codex/CodexNavigationRenderingTests.cs
@@ -83,13 +83,14 @@ public class CodexNavigationRenderingTests(ITestOutputHelper output) : CodexNavi
 		// Get the standalone repo's navigation
 		var standaloneNav = docSetNavigations["standalone"] as INavigationHomeAccessor;
 		standaloneNav.Should().NotBeNull();
+		var homeProvider = standaloneNav!.HomeProvider;
 
 		// Assert: The HomeProvider's NavigationRoot should be the repo itself
-		standaloneNav!.HomeProvider.Should().NotBeNull();
+		homeProvider.Should().NotBeNull();
 
 		// The navigation root for an ungrouped repo should be itself (DocumentationSetNavigation)
 		// This means when rendering, it will show only its own navigation tree
-		var navRoot = standaloneNav.HomeProvider!.NavigationRoot;
+		var navRoot = homeProvider!.NavigationRoot;
 		navRoot.Should().BeAssignableTo<IDocumentationSetNavigation>();
 		navRoot.Url.Should().Be("/docs/r/standalone");
 	}

--- a/tests/Navigation.Tests/Codex/CodexNavigationTestBase.cs
+++ b/tests/Navigation.Tests/Codex/CodexNavigationTestBase.cs
@@ -1,0 +1,90 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
+using Elastic.Codex.Navigation;
+using Elastic.Documentation.Configuration.Codex;
+using Elastic.Documentation.Configuration.Toc;
+using Elastic.Documentation.Diagnostics;
+using Elastic.Documentation.Navigation;
+using Elastic.Documentation.Navigation.Isolated.Node;
+
+namespace Elastic.Documentation.Navigation.Tests.Codex;
+
+public abstract class CodexNavigationTestBase(ITestOutputHelper output)
+{
+	protected TestDiagnosticsCollector Collector { get; } = new(output);
+
+	protected ICodexDocumentationContext CreateContext() => new TestCodexDocumentationContext(Collector);
+
+	protected static CodexConfiguration CreateCodexConfiguration(
+		string sitePrefix,
+		List<CodexDocumentationSetReference> docSets) =>
+		new()
+		{
+			Title = "Test Codex",
+			SitePrefix = sitePrefix,
+			DocumentationSets = docSets
+		};
+
+	protected IReadOnlyDictionary<string, IDocumentationSetNavigation> CreateMockDocSetNavigations(
+		IEnumerable<string> repoNames)
+	{
+		var result = new Dictionary<string, IDocumentationSetNavigation>();
+		var fileSystem = new MockFileSystem();
+
+		foreach (var repoName in repoNames)
+		{
+			var docSet = CreateMockDocumentationSet(fileSystem, repoName);
+			var context = new TestDocumentationSetContext(
+				fileSystem,
+				fileSystem.DirectoryInfo.New($"/{repoName}/docs"),
+				fileSystem.DirectoryInfo.New($"/{repoName}/output"),
+				fileSystem.FileInfo.New($"/{repoName}/docs/docset.yml"),
+				output,
+				repoName);
+
+			var navigation = new DocumentationSetNavigation<TestDocumentationFile>(
+				docSet, context, TestDocumentationFileFactory.Instance);
+
+			result[repoName] = navigation;
+		}
+
+		return result;
+	}
+
+	private static DocumentationSetFile CreateMockDocumentationSet(MockFileSystem fileSystem, string repoName)
+	{
+		var docsPath = $"/{repoName}/docs";
+		fileSystem.AddDirectory(docsPath);
+		fileSystem.AddFile($"{docsPath}/index.md", new MockFileData($"# {repoName}"));
+
+		// language=yaml
+		var yaml = $"""
+		            project: '{repoName}'
+		            toc:
+		              - file: index.md
+		            """;
+
+		return DocumentationSetFile.LoadAndResolve(
+			new DiagnosticsCollector([]),
+			yaml,
+			fileSystem.DirectoryInfo.New(docsPath));
+	}
+}
+
+internal sealed class TestCodexDocumentationContext(IDiagnosticsCollector collector) : ICodexDocumentationContext
+{
+	private readonly MockFileSystem _fileSystem = new();
+
+	public IFileInfo ConfigurationPath => _fileSystem.FileInfo.New("/codex.yml");
+	public IDiagnosticsCollector Collector => collector;
+	public IFileSystem ReadFileSystem => _fileSystem;
+	public IFileSystem WriteFileSystem => _fileSystem;
+	public IDirectoryInfo OutputDirectory => _fileSystem.DirectoryInfo.New("/output");
+	public bool AssemblerBuild => false;
+
+	public void EmitError(string message) => collector.EmitError(ConfigurationPath, message);
+}

--- a/tests/Navigation.Tests/Codex/CodexNavigationTests.cs
+++ b/tests/Navigation.Tests/Codex/CodexNavigationTests.cs
@@ -1,0 +1,255 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions.TestingHelpers;
+using Elastic.Codex.Navigation;
+using Elastic.Documentation.Configuration.Codex;
+using Elastic.Documentation.Navigation.Isolated.Node;
+using FluentAssertions;
+
+namespace Elastic.Documentation.Navigation.Tests.Codex;
+
+public class CodexNavigationTests(ITestOutputHelper output) : CodexNavigationTestBase(output)
+{
+	[Fact]
+	public void UngroupedRepos_UseStableRUrls()
+	{
+		var config = CreateCodexConfiguration(
+			sitePrefix: "/docs",
+			docSets: [
+				new CodexDocumentationSetReference { Name = "repo-a", Branch = "main" },
+				new CodexDocumentationSetReference { Name = "repo-b", Branch = "main" }
+			]);
+
+		var docSetNavigations = CreateMockDocSetNavigations(["repo-a", "repo-b"]);
+		var codexNav = new CodexNavigation(config, CreateContext(), docSetNavigations);
+
+		codexNav.DocumentationSetInfos.Should().HaveCount(2);
+		codexNav.DocumentationSetInfos.Select(d => d.Url).Should().BeEquivalentTo(["/docs/r/repo-a", "/docs/r/repo-b"]);
+	}
+
+	[Fact]
+	public void GroupedRepos_UseStableRUrls_NotCategoryUrls()
+	{
+		var config = CreateCodexConfiguration(
+			sitePrefix: "/docs",
+			docSets: [
+				new CodexDocumentationSetReference { Name = "apm-agent", Branch = "main", Category = "observability" },
+				new CodexDocumentationSetReference { Name = "uptime", Branch = "main", Category = "observability" }
+			]);
+
+		var docSetNavigations = CreateMockDocSetNavigations(["apm-agent", "uptime"]);
+		var codexNav = new CodexNavigation(config, CreateContext(), docSetNavigations);
+
+		// Repos still use /r/ prefix even when in a category
+		codexNav.DocumentationSetInfos.Select(d => d.Url).Should().BeEquivalentTo(["/docs/r/apm-agent", "/docs/r/uptime"]);
+
+		// Category landing pages use /g/ prefix
+		codexNav.GroupNavigations.Should().HaveCount(1);
+		codexNav.GroupNavigations.First().Url.Should().Be("/docs/g/observability");
+	}
+
+	[Fact]
+	public void GroupNavigation_ContainsAllGroupMembers()
+	{
+		var config = CreateCodexConfiguration(
+			sitePrefix: "/docs",
+			docSets: [
+				new CodexDocumentationSetReference { Name = "apm-agent", Branch = "main", Category = "observability" },
+				new CodexDocumentationSetReference { Name = "uptime", Branch = "main", Category = "observability" },
+				new CodexDocumentationSetReference { Name = "standalone", Branch = "main" }
+			]);
+
+		var docSetNavigations = CreateMockDocSetNavigations(["apm-agent", "uptime", "standalone"]);
+		var codexNav = new CodexNavigation(config, CreateContext(), docSetNavigations);
+
+		var observabilityGroup = codexNav.GroupNavigations.First();
+		observabilityGroup.NavigationItems.Should().HaveCount(2);
+		observabilityGroup.DocumentationSetInfos.Should().HaveCount(2);
+		observabilityGroup.DocumentationSetInfos.Select(d => d.Name).Should().BeEquivalentTo(["apm-agent", "uptime"]);
+	}
+
+	[Fact]
+	public void GroupedRepos_HaveGroupNavigationAsRoot()
+	{
+		var config = CreateCodexConfiguration(
+			sitePrefix: "/docs",
+			docSets: [
+				new CodexDocumentationSetReference { Name = "apm-agent", Branch = "main", Category = "observability" }
+			]);
+
+		var docSetNavigations = CreateMockDocSetNavigations(["apm-agent"]);
+		var codexNav = new CodexNavigation(config, CreateContext(), docSetNavigations);
+
+		var groupNav = codexNav.GroupNavigations.First();
+		var docSetNavItem = groupNav.NavigationItems.First();
+
+		// The doc set's parent should be the group navigation
+		docSetNavItem.Parent.Should().BeSameAs(groupNav);
+
+		// Verify the HomeProvider was set (check via the navigation interfaces)
+		if (docSetNavigations["apm-agent"] is INavigationHomeAccessor homeAccessor)
+		{
+			homeAccessor.HomeProvider.Should().NotBeNull();
+			homeAccessor.HomeProvider!.NavigationRoot.Should().BeSameAs(groupNav);
+		}
+	}
+
+	[Fact]
+	public void UngroupedRepos_HaveOwnNavigationAsRoot()
+	{
+		var config = CreateCodexConfiguration(
+			sitePrefix: "/docs",
+			docSets: [
+				new CodexDocumentationSetReference { Name = "standalone", Branch = "main" }
+			]);
+
+		var docSetNavigations = CreateMockDocSetNavigations(["standalone"]);
+		var codexNav = new CodexNavigation(config, CreateContext(), docSetNavigations);
+
+		// Ungrouped repos are direct children of codex
+		var standaloneNavItem = codexNav.NavigationItems.First();
+		standaloneNavItem.Parent.Should().BeSameAs(codexNav);
+
+		// Verify the HomeProvider points to itself (for isolated sidebar)
+		if (docSetNavigations["standalone"] is INavigationHomeAccessor homeAccessor)
+		{
+			homeAccessor.HomeProvider.Should().NotBeNull();
+			homeAccessor.HomeProvider!.NavigationRoot.Should().BeSameAs(standaloneNavItem);
+		}
+	}
+
+	[Fact]
+	public void DisplayName_OverridesNavigationTitle()
+	{
+		var config = CreateCodexConfiguration(
+			sitePrefix: "/docs",
+			docSets: [
+				new CodexDocumentationSetReference
+				{
+					Name = "apm-agent",
+					Branch = "main",
+					DisplayName = "APM Agent Documentation"
+				}
+			]);
+
+		var docSetNavigations = CreateMockDocSetNavigations(["apm-agent"]);
+		var codexNav = new CodexNavigation(config, CreateContext(), docSetNavigations);
+
+		// The DocumentationSetInfo should use the display name
+		codexNav.DocumentationSetInfos.First().Title.Should().Be("APM Agent Documentation");
+
+		// The navigation title override should be set
+		docSetNavigations["apm-agent"].NavigationTitleOverride.Should().Be("APM Agent Documentation");
+	}
+
+	[Fact]
+	public void EmptySitePrefix_GeneratesRootUrls()
+	{
+		var config = CreateCodexConfiguration(
+			sitePrefix: "",
+			docSets: [
+				new CodexDocumentationSetReference { Name = "repo-a", Branch = "main" },
+				new CodexDocumentationSetReference { Name = "repo-b", Branch = "main", Category = "tools" }
+			]);
+
+		var docSetNavigations = CreateMockDocSetNavigations(["repo-a", "repo-b"]);
+		var codexNav = new CodexNavigation(config, CreateContext(), docSetNavigations);
+
+		codexNav.Url.Should().BeEmpty();
+		codexNav.DocumentationSetInfos.Select(d => d.Url).Should().Contain("/r/repo-a");
+		codexNav.DocumentationSetInfos.Select(d => d.Url).Should().Contain("/r/repo-b");
+		codexNav.GroupNavigations.First().Url.Should().Be("/g/tools");
+	}
+
+	[Fact]
+	public void SlashSitePrefix_TreatedAsRoot()
+	{
+		// When loading from YAML, "/" gets normalized to empty by CodexConfiguration.Deserialize
+		// language=yaml
+		var yaml = """
+		           title: "Test Codex"
+		           site_prefix: /
+		           documentation_sets:
+		             - name: repo-a
+		               branch: main
+		           """;
+		var config = CodexConfiguration.Deserialize(yaml);
+
+		var docSetNavigations = CreateMockDocSetNavigations(["repo-a"]);
+		var codexNav = new CodexNavigation(config, CreateContext(), docSetNavigations);
+
+		// "/" should be normalized to empty string
+		codexNav.Url.Should().BeEmpty();
+		codexNav.DocumentationSetInfos.First().Url.Should().Be("/r/repo-a");
+	}
+
+	[Fact]
+	public void MultipleCategories_CreateSeparateGroupNavigations()
+	{
+		var config = CreateCodexConfiguration(
+			sitePrefix: "/docs",
+			docSets: [
+				new CodexDocumentationSetReference { Name = "apm", Branch = "main", Category = "observability" },
+				new CodexDocumentationSetReference { Name = "uptime", Branch = "main", Category = "observability" },
+				new CodexDocumentationSetReference { Name = "siem", Branch = "main", Category = "security" },
+				new CodexDocumentationSetReference { Name = "endpoint", Branch = "main", Category = "security" }
+			]);
+
+		var docSetNavigations = CreateMockDocSetNavigations(["apm", "uptime", "siem", "endpoint"]);
+		var codexNav = new CodexNavigation(config, CreateContext(), docSetNavigations);
+
+		codexNav.GroupNavigations.Should().HaveCount(2);
+
+		var observability = codexNav.GroupNavigations.First(g => g.GroupSlug == "observability");
+		observability.NavigationItems.Should().HaveCount(2);
+		observability.DocumentationSetInfos.Select(d => d.Name).Should().BeEquivalentTo(["apm", "uptime"]);
+
+		var security = codexNav.GroupNavigations.First(g => g.GroupSlug == "security");
+		security.NavigationItems.Should().HaveCount(2);
+		security.DocumentationSetInfos.Select(d => d.Name).Should().BeEquivalentTo(["siem", "endpoint"]);
+	}
+
+	[Fact]
+	public void CategoryTitle_FormatsSlugToTitleCase()
+	{
+		var config = CreateCodexConfiguration(
+			sitePrefix: "/docs",
+			docSets: [
+				new CodexDocumentationSetReference { Name = "tool", Branch = "main", Category = "developer-tools" }
+			]);
+
+		var docSetNavigations = CreateMockDocSetNavigations(["tool"]);
+		var codexNav = new CodexNavigation(config, CreateContext(), docSetNavigations);
+
+		var group = codexNav.GroupNavigations.First();
+		group.DisplayTitle.Should().Be("Developer Tools");
+	}
+
+	[Fact]
+	public void CodexNavigationItems_ContainGroupLinksAndUngroupedRepos()
+	{
+		var config = CreateCodexConfiguration(
+			sitePrefix: "/docs",
+			docSets: [
+				new CodexDocumentationSetReference { Name = "grouped1", Branch = "main", Category = "tools" },
+				new CodexDocumentationSetReference { Name = "grouped2", Branch = "main", Category = "tools" },
+				new CodexDocumentationSetReference { Name = "ungrouped", Branch = "main" }
+			]);
+
+		var docSetNavigations = CreateMockDocSetNavigations(["grouped1", "grouped2", "ungrouped"]);
+		var codexNav = new CodexNavigation(config, CreateContext(), docSetNavigations);
+
+		// Codex navigation items should contain:
+		// 1. A GroupLinkLeaf pointing to /g/tools
+		// 2. The ungrouped repo directly
+		codexNav.NavigationItems.Should().HaveCount(2);
+
+		var groupLink = codexNav.NavigationItems.OfType<GroupLinkLeaf>().Should().ContainSingle().Subject;
+		groupLink.Url.Should().Be("/docs/g/tools");
+
+		var ungroupedNav = codexNav.NavigationItems.OfType<IRootNavigationItem<IDocumentationFile, INavigationItem>>().Should().ContainSingle().Subject;
+		ungroupedNav.Url.Should().Be("/docs/r/ungrouped");
+	}
+}

--- a/tests/Navigation.Tests/Codex/GroupNavigationTests.cs
+++ b/tests/Navigation.Tests/Codex/GroupNavigationTests.cs
@@ -1,0 +1,146 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Codex.Navigation;
+using FluentAssertions;
+
+namespace Elastic.Documentation.Navigation.Tests.Codex;
+
+public class GroupNavigationTests
+{
+	[Fact]
+	public void GroupNavigation_SetsPropertiesCorrectly()
+	{
+		var groupNav = new GroupNavigation("observability", "Observability", "/docs/g/observability");
+
+		groupNav.GroupSlug.Should().Be("observability");
+		groupNav.DisplayTitle.Should().Be("Observability");
+		groupNav.Url.Should().Be("/docs/g/observability");
+		groupNav.NavigationTitle.Should().Be("Observability");
+	}
+
+	[Fact]
+	public void GroupNavigation_TrimsTrailingSlash()
+	{
+		var groupNav = new GroupNavigation("tools", "Tools", "/docs/g/tools/");
+
+		groupNav.Url.Should().Be("/docs/g/tools");
+	}
+
+	[Fact]
+	public void GroupNavigation_HasIndexPage()
+	{
+		var groupNav = new GroupNavigation("observability", "Observability", "/docs/g/observability");
+
+		groupNav.Index.Should().NotBeNull();
+		groupNav.Index.Url.Should().Be("/docs/g/observability");
+		groupNav.Index.NavigationTitle.Should().Be("Observability");
+	}
+
+	[Fact]
+	public void GroupNavigation_IndexNavigationRootPointsToGroup()
+	{
+		var groupNav = new GroupNavigation("observability", "Observability", "/docs/g/observability");
+
+		groupNav.Index.NavigationRoot.Should().BeSameAs(groupNav);
+	}
+
+	[Fact]
+	public void GroupNavigation_IsItsOwnNavigationRoot()
+	{
+		var groupNav = new GroupNavigation("observability", "Observability", "/docs/g/observability");
+
+		groupNav.NavigationRoot.Should().BeSameAs(groupNav);
+	}
+
+	[Fact]
+	public void GroupNavigation_StartsWithEmptyNavigationItems()
+	{
+		var groupNav = new GroupNavigation("observability", "Observability", "/docs/g/observability");
+
+		groupNav.NavigationItems.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void GroupNavigation_CanSetNavigationItems()
+	{
+		var groupNav = new GroupNavigation("observability", "Observability", "/docs/g/observability");
+		var mockItems = new List<INavigationItem>();
+
+		((IAssignableChildrenNavigation)groupNav).SetNavigationItems(mockItems);
+
+		groupNav.NavigationItems.Should().BeSameAs(mockItems);
+	}
+
+	[Fact]
+	public void GroupNavigation_HasUniqueIdentifier()
+	{
+		var group1 = new GroupNavigation("observability", "Observability", "/g/observability");
+		var group2 = new GroupNavigation("security", "Security", "/g/security");
+
+		group1.Id.Should().NotBe(group2.Id);
+		group1.Identifier.Should().NotBe(group2.Identifier);
+	}
+
+	[Fact]
+	public void GroupNavigation_IdentifierUsesCodexScheme()
+	{
+		var groupNav = new GroupNavigation("observability", "Observability", "/g/observability");
+
+		groupNav.Identifier.Scheme.Should().Be("codex");
+		groupNav.Identifier.Host.Should().Be("group");
+		groupNav.Identifier.AbsolutePath.Should().Be("/observability");
+	}
+
+	[Fact]
+	public void GroupLinkLeaf_PropertiesSetCorrectly()
+	{
+		var codexNav = CreateMinimalCodexNavigation();
+		var linkPage = new GroupLinkPage("Observability", "/docs/g/observability");
+		var linkLeaf = new GroupLinkLeaf(linkPage, codexNav);
+
+		linkLeaf.Url.Should().Be("/docs/g/observability");
+		linkLeaf.NavigationTitle.Should().Be("Observability");
+		linkLeaf.NavigationRoot.Should().BeSameAs(codexNav);
+		linkLeaf.Hidden.Should().BeFalse();
+	}
+
+	[Fact]
+	public void GroupIndexLeaf_PropertiesSetCorrectly()
+	{
+		var groupNav = new GroupNavigation("observability", "Observability", "/docs/g/observability");
+
+		var indexLeaf = groupNav.Index as GroupIndexLeaf;
+		indexLeaf.Should().NotBeNull();
+		indexLeaf!.Url.Should().Be("/docs/g/observability");
+		indexLeaf.NavigationTitle.Should().Be("Observability");
+		indexLeaf.NavigationRoot.Should().BeSameAs(groupNav);
+		indexLeaf.Parent.Should().BeSameAs(groupNav);
+	}
+
+	private static CodexNavigation CreateMinimalCodexNavigation()
+	{
+		// Create a minimal codex navigation for testing GroupLinkLeaf
+		var config = new Documentation.Configuration.Codex.CodexConfiguration
+		{
+			Title = "Test Codex",
+			SitePrefix = "/docs",
+			DocumentationSets = []
+		};
+
+		return new CodexNavigation(config, new MinimalCodexContext(), new Dictionary<string, Navigation.Isolated.Node.IDocumentationSetNavigation>());
+	}
+
+	private sealed class MinimalCodexContext : ICodexDocumentationContext
+	{
+		private readonly System.IO.Abstractions.TestingHelpers.MockFileSystem _fs = new();
+		public System.IO.Abstractions.IFileInfo ConfigurationPath => _fs.FileInfo.New("/codex.yml");
+		public Elastic.Documentation.Diagnostics.IDiagnosticsCollector Collector => new Elastic.Documentation.Diagnostics.DiagnosticsCollector([]);
+		public System.IO.Abstractions.IFileSystem ReadFileSystem => _fs;
+		public System.IO.Abstractions.IFileSystem WriteFileSystem => _fs;
+		public System.IO.Abstractions.IDirectoryInfo OutputDirectory => _fs.DirectoryInfo.New("/output");
+		public bool AssemblerBuild => false;
+		public void EmitError(string message) { }
+	}
+}

--- a/tests/Navigation.Tests/Navigation.Tests.csproj
+++ b/tests/Navigation.Tests/Navigation.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Elastic.Codex\Elastic.Codex.csproj"/>
     <ProjectReference Include="..\..\src\Elastic.Documentation.Configuration\Elastic.Documentation.Configuration.csproj"/>
     <ProjectReference Include="..\..\src\Elastic.Documentation.Navigation\Elastic.Documentation.Navigation.csproj"/>
     <ProjectReference Include="..\..\src\Elastic.Documentation.ServiceDefaults\Elastic.Documentation.ServiceDefaults.csproj" />


### PR DESCRIPTION
## Summary

Adds a new URL structure and navigation model for the documentation codex:

- **Stable repository URLs** (`/r/{repo-name}`) that do not change when category membership changes
- **Category landing pages** (`/g/{category}`) that group related documentation sets
- **Shared navigation** for repositories in the same category (same sidebar on group landing and all member repo pages)
- **Isolated navigation** for ungrouped repositories (sidebar shows only that repo’s tree)
- **Optional site prefix** so the codex can be hosted at the domain root (e.g. `codex.elastic.dev`)

## Motivation

Previously, repository URLs could be tied to category structure, so changing a repo’s category could break links. We also lacked a way to show a single navigation tree for a set of related docs.

This change separates URL shape from organisation:

- URLs are stable and predictable: `/r/apm-agent` always targets the APM Agent docs
- Categories are for navigation only: any page in the “observability” category shows the same sidebar (group landing + all observability repos)
- Ungrouped repos use their own navigation root so the sidebar stays focused on that repo

## Implementation

### URL patterns

| Pattern | Purpose | Example |
|--------|---------|---------|
| `/r/{repo-name}` | Stable repo URL | `/r/apm-agent`, `/r/uptime-docs` |
| `/g/{category}` | Category landing | `/g/observability`, `/g/tooling` |
| `/` or `/{site_prefix}` | Codex landing | `/`, `/internal-docs` |

### Architecture

- **`GroupNavigation`** – New navigation root type per category. It is the `NavigationRoot` for all repos in that category, holds the category landing page and member repos as top-level items, and ensures the same sidebar on the category landing and every member repo page.
- **Ungrouped repos** – Their `DocumentationSetNavigation` is their own `NavigationRoot`, so the sidebar shows only that repo’s tree.
- **`IsolatedBuildNavigationHtmlWriter`** – Uses `SelectNavigationRoot()` so when a different root is requested (e.g. `GroupNavigation`), that root is used for rendering instead of the site root. `TopLevelItems` come from the selected navigation, so the sidebar reflects the correct tree.

### Key changes

**New**

- `GroupNavigation.cs` – Category navigation root and related types (`GroupIndexLeaf`, `GroupLinkLeaf`, etc.)
- `GroupLandingView.cshtml` – Razor view for category landing pages
- `GroupLandingViewModel.cs` – View model for category landing pages


### Navigation behaviour

| Repo type | Sidebar shows | NavigationRoot |
|-----------|----------------|----------------|
| In a category | Category landing + all category members | `GroupNavigation` |
| No category | Only that repo’s tree | `DocumentationSetNavigation` |

### Configuration

```yaml
documentation_sets:
  # Ungrouped – sidebar shows only this repo
  - name: docs-eng-team
    repo_name: ci-guide
    display_name: "CI Developer Guide"

  # In a category – shared sidebar with other observability repos
  - name: docs-eng-team
    category: observability
    repo_name: apm-agent-docs
    display_name: "APM Agent"

# Optional – omit or set to "/" for root hosting
site_prefix: /
```

## Manual verification

- [ ] Build codex with mixed grouped/ungrouped repos
  - [ ] `dotnet run --project src/tooling/docs-builder -- codex clone config/codex.example.yml`
  - [ ] `dotnet run --project src/tooling/docs-builder -- codex build config/codex.example.yml`
  - [ ] `dotnet run --project src/tooling/docs-builder -- codex serve`
- [ ] Confirm `/r/{repo}` works for all repos regardless of category
- [ ] Confirm `/g/{category}` shows only that category’s members
- [ ] Confirm grouped repo pages show shared category sidebar
- [ ] Confirm ungrouped repo pages show only that repo’s sidebar
- [ ] Confirm `display_name` from config appears in the sidebar
- [ ] Confirm codex works with no `site_prefix` and with a prefix
- [ ] Confirm HTMX attributes on category landing work as expected

## Recording


https://github.com/user-attachments/assets/0aafb05f-4235-4a17-aa84-9370f8d63a27

