### PR TITLE
Fix static assets on codex build

### DIFF
--- a/src/Elastic.ApiExplorer/ApiViewModel.cs
+++ b/src/Elastic.ApiExplorer/ApiViewModel.cs
@@ -74,6 +74,7 @@ public abstract partial class ApiViewModel(ApiRenderContext context)
 			GoogleTagManager = new GoogleTagManagerConfiguration(),
 			Features = new FeatureFlags([]),
 			StaticFileContentHashProvider = StaticFileContentHashProvider,
+			BuildType = BuildContext.BuildType,
 			TocItems = GetTocItems(),
 			// Header properties for isolated mode
 			HeaderTitle = Document.Info.Title,

--- a/src/Elastic.Codex/Building/CodexBuildService.cs
+++ b/src/Elastic.Codex/Building/CodexBuildService.cs
@@ -122,7 +122,8 @@ public class CodexBuildService(
 			{
 				UrlPathPrefix = pathPrefix,
 				Force = true,
-				AllowIndexing = false
+				AllowIndexing = false,
+				BuildType = BuildType.Codex
 			};
 
 			// Create cross-link resolver (simplified for codex - no external links)
@@ -228,7 +229,7 @@ internal sealed class CodexDocumentationContext(CodexContext codexContext) : ICo
 	public IDirectoryInfo OutputDirectory => codexContext.OutputDirectory;
 
 	/// <inheritdoc />
-	public bool AssemblerBuild => false;
+	public BuildType BuildType => BuildType.Codex;
 
 	/// <inheritdoc />
 	public void EmitError(string message) =>

--- a/src/Elastic.Codex/CodexViewModel.cs
+++ b/src/Elastic.Codex/CodexViewModel.cs
@@ -62,6 +62,7 @@ public abstract class CodexViewModel(CodexRenderContext context)
 			GoogleTagManager = new GoogleTagManagerConfiguration(),
 			Features = new FeatureFlags([]),
 			StaticFileContentHashProvider = StaticFileContentHashProvider,
+			BuildType = BuildContext.BuildType,
 			RenderHamburgerIcon = false
 		};
 }

--- a/src/Elastic.Documentation.Configuration/BuildContext.cs
+++ b/src/Elastic.Documentation.Configuration/BuildContext.cs
@@ -48,7 +48,7 @@ public record BuildContext : IDocumentationSetContext, IDocumentationConfigurati
 
 	public bool Force { get; init; }
 
-	public bool AssemblerBuild { get; init; }
+	public BuildType BuildType { get; init; } = BuildType.Isolated;
 
 	// This property is used to determine if the site should be indexed by search engines
 	public bool AllowIndexing { get; init; }

--- a/src/Elastic.Documentation.Navigation/Isolated/Node/DocumentationSetNavigation.cs
+++ b/src/Elastic.Documentation.Navigation/Isolated/Node/DocumentationSetNavigation.cs
@@ -382,7 +382,7 @@ public class DocumentationSetNavigation<TModel>
 			context.ReadFileSystem.Path.Combine(context.DocumentationSourceDirectory.FullName, fullTocPath)
 		);
 
-		var assemblerBuild = context.AssemblerBuild;
+		var assemblerBuild = context.BuildType == BuildType.Assembler;
 		// for assembler builds we ensure toc's create their own home provider sot that they can be re-homed easily
 		var isolatedHomeProvider = assemblerBuild
 			? new NavigationHomeProvider(homeAccessor.HomeProvider.PathPrefix, homeAccessor.HomeProvider.NavigationRoot)

--- a/src/Elastic.Documentation/BuildType.cs
+++ b/src/Elastic.Documentation/BuildType.cs
@@ -1,0 +1,12 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic.Documentation;
+
+public enum BuildType
+{
+	Isolated,
+	Assembler,
+	Codex
+}

--- a/src/Elastic.Documentation/IDocumentationContext.cs
+++ b/src/Elastic.Documentation/IDocumentationContext.cs
@@ -14,7 +14,7 @@ public interface IDocumentationContext
 	IFileSystem WriteFileSystem { get; }
 	IDirectoryInfo OutputDirectory { get; }
 	IFileInfo ConfigurationPath { get; }
-	bool AssemblerBuild { get; }
+	BuildType BuildType { get; }
 }
 
 public interface IDocumentationSetContext : IDocumentationContext

--- a/src/Elastic.Markdown/HtmlWriter.cs
+++ b/src/Elastic.Markdown/HtmlWriter.cs
@@ -130,7 +130,7 @@ public class HtmlWriter(
 
 		var slice = Page.Index.Create(new IndexViewModel
 		{
-			IsAssemblerBuild = DocumentationSet.Context.AssemblerBuild,
+			BuildType = DocumentationSet.Context.BuildType,
 			SiteName = siteName,
 			DocSetName = DocumentationSet.Name,
 			Title = markdown.Title ?? "[TITLE NOT SET]",

--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO.Abstractions;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
+using Elastic.Documentation;
 using Elastic.Documentation.Extensions;
 using Elastic.Documentation.Links;
 using Elastic.Markdown.Diagnostics;
@@ -410,7 +411,7 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 				newUrl = new Uri(baseUri, relativePath).AbsolutePath;
 		}
 
-		if (context.Build.AssemblerBuild && context.TryFindDocument(fi) is MarkdownFile currentMarkdown)
+		if (context.Build.BuildType == BuildType.Assembler && context.TryFindDocument(fi) is MarkdownFile currentMarkdown)
 		{
 			// Acquire navigation-aware path
 			if (context.NavigationTraversable.NavigationDocumentationFileLookup.TryGetValue(currentMarkdown, out var currentNavigation))

--- a/src/Elastic.Markdown/Page/Index.cshtml
+++ b/src/Elastic.Markdown/Page/Index.cshtml
@@ -1,4 +1,5 @@
 @using System.Text.Json
+@using Elastic.Documentation
 @using Elastic.Documentation.Configuration
 @using Elastic.Documentation.Extensions
 @using Elastic.Markdown
@@ -29,7 +30,8 @@
 		UrlPathPrefix = Model.UrlPathPrefix,
 		GithubEditUrl = Model.GithubEditUrl,
 		MarkdownUrl = Model.MarkdownUrl,
-		HideEditThisPage = Model.Features.DisableGitHubEditLink && Model.IsAssemblerBuild,
+		BuildType = Model.BuildType,
+		HideEditThisPage = Model.Features.DisableGitHubEditLink && Model.BuildType != BuildType.Isolated,
 		AllowIndexing = Model.AllowIndexing,
 		CanonicalBaseUrl = Model.CanonicalBaseUrl,
 		GoogleTagManager = Model.GoogleTagManager,

--- a/src/Elastic.Markdown/Page/IndexViewModel.cs
+++ b/src/Elastic.Markdown/Page/IndexViewModel.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System.Text.Json.Serialization;
+using Elastic.Documentation;
 using Elastic.Documentation.AppliesTo;
 using Elastic.Documentation.Configuration.Assembler;
 using Elastic.Documentation.Configuration.Builder;
@@ -18,7 +19,7 @@ namespace Elastic.Markdown.Page;
 
 public class IndexViewModel
 {
-	public required bool IsAssemblerBuild { get; init; }
+	public required BuildType BuildType { get; init; }
 	public required string SiteName { get; init; }
 	public required string DocSetName { get; init; }
 	public required string Title { get; init; }

--- a/src/services/Elastic.Documentation.Assembler/AssembleContext.cs
+++ b/src/services/Elastic.Documentation.Assembler/AssembleContext.cs
@@ -52,7 +52,7 @@ public class AssembleContext : IDocumentationConfigurationContext
 	public IFileInfo ConfigurationPath { get; }
 
 	/// <inheritdoc />
-	public bool AssemblerBuild => true;
+	public BuildType BuildType => BuildType.Assembler;
 
 	public PublishEnvironment Environment { get; }
 

--- a/src/services/Elastic.Documentation.Assembler/Navigation/AssemblerDocumentationSet.cs
+++ b/src/services/Elastic.Documentation.Assembler/Navigation/AssemblerDocumentationSet.cs
@@ -71,7 +71,7 @@ public record AssemblerDocumentationSet
 				CookiesWin = env.GoogleTagManager.CookiesWin
 			},
 			CanonicalBaseUrl = new Uri("https://www.elastic.co"), // Always use the production URL. In case a page is leaked to a search engine, it should point to the production site.
-			AssemblerBuild = true
+			BuildType = BuildType.Assembler
 		};
 		BuildContext = buildContext;
 

--- a/tests/Navigation.Tests/Assembler/SiteNavigationTestFixture.cs
+++ b/tests/Navigation.Tests/Assembler/SiteNavigationTestFixture.cs
@@ -224,7 +224,7 @@ public static class SiteNavigationTestFixture
 	)
 	{
 		var context = CreateContext(fileSystem, repositoryPath, output, collector);
-		context.AssemblerBuild = true;
+		context.BuildType = BuildType.Assembler;
 		return context;
 	}
 

--- a/tests/Navigation.Tests/Codex/CodexNavigationTestBase.cs
+++ b/tests/Navigation.Tests/Codex/CodexNavigationTestBase.cs
@@ -84,7 +84,7 @@ internal sealed class TestCodexDocumentationContext(IDiagnosticsCollector collec
 	public IFileSystem ReadFileSystem => _fileSystem;
 	public IFileSystem WriteFileSystem => _fileSystem;
 	public IDirectoryInfo OutputDirectory => _fileSystem.DirectoryInfo.New("/output");
-	public bool AssemblerBuild => false;
+	public BuildType BuildType => BuildType.Codex;
 
 	public void EmitError(string message) => collector.EmitError(ConfigurationPath, message);
 }

--- a/tests/Navigation.Tests/Codex/GroupNavigationTests.cs
+++ b/tests/Navigation.Tests/Codex/GroupNavigationTests.cs
@@ -140,7 +140,7 @@ public class GroupNavigationTests
 		public System.IO.Abstractions.IFileSystem ReadFileSystem => _fs;
 		public System.IO.Abstractions.IFileSystem WriteFileSystem => _fs;
 		public System.IO.Abstractions.IDirectoryInfo OutputDirectory => _fs.DirectoryInfo.New("/output");
-		public bool AssemblerBuild => false;
+		public BuildType BuildType => BuildType.Codex;
 		public void EmitError(string message) { }
 	}
 }

--- a/tests/Navigation.Tests/TestDocumentationSetContext.cs
+++ b/tests/Navigation.Tests/TestDocumentationSetContext.cs
@@ -105,7 +105,7 @@ public class TestDocumentationSetContext : IDocumentationSetContext
 	public IFileInfo ConfigurationPath { get; }
 
 	/// <inheritdoc />
-	public bool AssemblerBuild { get; set; }
+	public BuildType BuildType { get; set; }
 
 	public IReadOnlyCollection<Diagnostic> Diagnostics => ((TestDiagnosticsCollector)Collector).Diagnostics;
 }

--- a/tests/authoring/Framework/CrossLinkResolverAssertions.fs
+++ b/tests/authoring/Framework/CrossLinkResolverAssertions.fs
@@ -34,7 +34,7 @@ module CrossLinkResolverAssertions =
                 member _.WriteFileSystem = mockFileSystem
                 member _.ConfigurationPath = mockFileSystem.FileInfo.New("mock_docset.yml")
                 member _.OutputDirectory = mockFileSystem.DirectoryInfo.New(".artifacts")
-                member _.AssemblerBuild = false
+                member _.BuildType = BuildType.Isolated
             }
         let redirectFileParser = RedirectFile(docContext, mockRedirectsFile)
         redirectFileParser.Redirects


### PR DESCRIPTION
## Changes

- Fix Codex builds copying static assets (JS/CSS) into every documentation set -- they should only exist once at the root
- Replace `bool AssemblerBuild` with a `BuildType` enum (`Isolated`, `Assembler`, `Codex`) so build-type checks are explicit

## Why

The Codex build was duplicating static assets across all documentation sets. Fixing this required detecting the build type.

Since we already had a boolean for Assembler, it made sense to unify everything into a single enum. With an enum we get a single source of truth for the build type and readable conditionals like `BuildType == BuildType.Codex`. This makes it straightforward to customize behavior or rendering per build type as we need to.