### PR TITLE
Improve changelog render support for relative paths

### DIFF
--- a/docs/cli/release/changelog-render.md
+++ b/docs/cli/release/changelog-render.md
@@ -34,7 +34,7 @@ docs-builder changelog render [options...] [-h|--help]
 :   Only `bundle-file-path` is required for each bundle.
 :   Use `repo` if your changelogs do not contain full URLs for the pull requests or issues; otherwise they will be incorrectly derived with "elastic/elastic" in the URL by default.
 :   Use `link-visibility` to control whether PR/issue links are shown or hidden for entries from this bundle. Valid values are `keep-links` (default) or `hide-links`. Use `hide-links` for bundles from private repositories.
-:   **Important**: Paths must be absolute or use environment variables. Tilde (`~`) expansion is not supported.
+:   Paths support tilde (`~`) expansion and relative paths.
 
 :::{note}
 The `render` command automatically discovers and merges `.amend-*.yaml` files with their parent bundle. For more information about amended bundles, go to [](changelog-bundle-amend.md).
@@ -88,3 +88,46 @@ When `--file-type asciidoc` is specified, the command generates a single asciido
 - Other changes
 
 The asciidoc output uses attribute references for links (for example, `{repo-pull}NUMBER[#NUMBER]`).
+
+## Examples
+
+### Render a single bundle
+
+```sh
+docs-builder changelog render \
+  --input "./docs/changelog/bundles/9.3.0.yaml" \
+  --output ./release-notes
+```
+
+### Render with tilde expansion
+
+```sh
+docs-builder changelog render \
+  --input "~/docs/changelog/bundles/9.3.0.yaml|~/docs/changelog|elasticsearch" \
+  --output ~/release-notes
+```
+
+### Render with relative paths
+
+```sh
+docs-builder changelog render \
+  --input "./bundles/9.3.0.yaml|./changelog|elasticsearch|keep-links" \
+  --file-type markdown \
+  --output ./output
+```
+
+### Merge multiple bundles
+
+```sh
+docs-builder changelog render \
+  --input "./bundles/elasticsearch-9.3.0.yaml|./changelog|elasticsearch,./bundles/kibana-9.3.0.yaml|./changelog|kibana" \
+  --output ./merged-release-notes
+```
+
+### Hide links from private repository bundles
+
+```sh
+docs-builder changelog render \
+  --input "./public-bundle.yaml|./changelog|elasticsearch|keep-links,./private-bundle.yaml|./private-changelog|internal-repo|hide-links" \
+  --output ./release-notes
+```

--- a/src/tooling/docs-builder/Arguments/BundleInputParser.cs
+++ b/src/tooling/docs-builder/Arguments/BundleInputParser.cs
@@ -18,6 +18,7 @@ public static class BundleInputParser
 	/// Format: "bundle-file-path|changelog-file-path|repo|link-visibility" (only bundle-file-path is required)
 	/// Uses pipe (|) as delimiter since ConsoleAppFramework auto-splits string[] by comma.
 	/// link-visibility can be "hide-links" or "keep-links" (default is keep-links if omitted).
+	/// Paths support tilde (~) expansion and relative paths.
 	/// </summary>
 	public static BundleInput? Parse(string input)
 	{
@@ -32,8 +33,8 @@ public static class BundleInputParser
 
 		return new BundleInput
 		{
-			BundleFile = parts[0],
-			Directory = parts.Length > 1 && !string.IsNullOrWhiteSpace(parts[1]) ? parts[1] : null,
+			BundleFile = NormalizePath(parts[0]),
+			Directory = parts.Length > 1 && !string.IsNullOrWhiteSpace(parts[1]) ? NormalizePath(parts[1]) : null,
 			Repo = parts.Length > 2 && !string.IsNullOrWhiteSpace(parts[2]) ? parts[2] : null,
 			HideLinks = parts.Length > 3 && !string.IsNullOrWhiteSpace(parts[3]) && parts[3].Equals("hide-links", StringComparison.OrdinalIgnoreCase)
 		};
@@ -61,6 +62,32 @@ public static class BundleInputParser
 		}
 
 		return result;
+	}
+
+	/// <summary>
+	/// Normalizes a file path by expanding tilde (~) to the user's home directory
+	/// and converting relative paths to absolute paths.
+	/// </summary>
+	private static string NormalizePath(string path)
+	{
+		if (string.IsNullOrWhiteSpace(path))
+			return path;
+
+		var trimmedPath = path.Trim();
+
+		// Expand tilde to user's home directory
+		if (trimmedPath.StartsWith("~/", StringComparison.Ordinal) || trimmedPath.StartsWith("~\\", StringComparison.Ordinal))
+		{
+			var homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+			trimmedPath = Path.Combine(homeDirectory, trimmedPath[2..]);
+		}
+		else if (trimmedPath == "~")
+		{
+			trimmedPath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+		}
+
+		// Convert to absolute path (handles relative paths like ./file or ../file)
+		return Path.GetFullPath(trimmedPath);
 	}
 }
 

--- a/src/tooling/docs-builder/Commands/ChangelogCommand.cs
+++ b/src/tooling/docs-builder/Commands/ChangelogCommand.cs
@@ -410,7 +410,7 @@ internal sealed class ChangelogCommand(
 	/// <summary>
 	/// Render bundled changelog(s) to markdown or asciidoc files
 	/// </summary>
-	/// <param name="input">Required: Bundle input(s) in format "bundle-file-path|changelog-file-path|repo|link-visibility" (use pipe as delimiter). To merge multiple bundles, separate them with commas. Only bundle-file-path is required. link-visibility can be "hide-links" or "keep-links" (default). Paths must be absolute or use environment variables; tilde (~) expansion is not supported.</param>
+	/// <param name="input">Required: Bundle input(s) in format "bundle-file-path|changelog-file-path|repo|link-visibility" (use pipe as delimiter). To merge multiple bundles, separate them with commas. Only bundle-file-path is required. link-visibility can be "hide-links" or "keep-links" (default). Paths support tilde (~) expansion and relative paths.</param>
 	/// <param name="config">Optional: Path to the changelog.yml configuration file. Defaults to 'docs/changelog.yml'</param>
 	/// <param name="fileType">Optional: Output file type. Valid values: "markdown" or "asciidoc". Defaults to "markdown"</param>
 	/// <param name="hideFeatures">Filter by feature IDs (comma-separated), or a path to a newline-delimited file containing feature IDs. Can be specified multiple times. Entries with matching feature-id values will be commented out in the output.</param>


### PR DESCRIPTION
This PR builds on the enhancements in https://github.com/elastic/docs-builder/pull/2672

In particular, it extends the path normalization to the `changelog render` command's `--input` option.

## Changes Implemented

### 1. **Updated `BundleInputParser.cs`**
- Added `NormalizePath()` method with the same implementation used in other commands
- Applied normalization to:
  - `BundleFile` path (the required bundle file path)
  - `Directory` path (the optional changelog directory path)
- Updated XML documentation to mention path support

### 2. **Updated `ChangelogCommand.cs`**
- Changed the `--input` parameter documentation from:
  > "Paths must be absolute or use environment variables; tilde (~) expansion is not supported"
  
  To:
  > "Paths support tilde (~) expansion and relative paths"

### 3. **Updated `docs/cli/release/changelog-render.md`**
- Updated the `--input` option description to reflect path normalization support
- Added comprehensive "Examples" section showing:
  - Rendering a single bundle with relative paths
  - Using tilde expansion
  - Using relative paths
  - Merging multiple bundles
  - Hiding links from private repository bundles

## What Now Works

All these path styles now work for the `--input` option:

```bash
# Relative paths
docs-builder changelog render \
  --input "./bundles/9.3.0.yaml|./changelog|elasticsearch"

# Tilde expansion
docs-builder changelog render \
  --input "~/docs/bundles/9.3.0.yaml|~/docs/changelog|elasticsearch"

# Mixed styles in multiple bundles
docs-builder changelog render \
  --input "./bundle1.yaml|./changelog1,~/bundle2.yaml|~/changelog2"

# Absolute paths (still work as before)
docs-builder changelog render \
  --input "/full/path/bundle.yaml|/full/path/changelog"
```

The `changelog render` command now has consistent path handling with all other changelog commands!

## Testing

Tested by using the files in https://github.com/elastic/kibana/pull/250840.

When I run the following command:

```sh
./docs-builder changelog render \
  --config ~/Documents/GitHub/kibana/docs/changelog.yml \
  --input "~/Documents/GitHub/kibana/docs/releases/kibana/9.3.0.yaml|~/Documents/GitHub/kibana/docs/changelog/|kibana|keep-links" \
 --output ~/Documents/GitHub/kibana/docs/release-notes/_snippets/ \
 --subsections \
 --hide-features "test_feature3"
 ```

... before this PR, it returned the following error:

```sh
The following errors and warnings were found in the documentation

Error: Bundle file does not exist
NOTE: ~/Documents/GitHub/kibana/docs/releases/kibana/9.3.0.yaml
```

With this PR, the command successfully creates output. 

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  

5. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: Claude-4.5-sonnet