### PR TITLE
Add KQL syntax highlighting for kuery code blocks

### DIFF
--- a/docs/testing/custom-highlighters.md
+++ b/docs/testing/custom-highlighters.md
@@ -73,6 +73,38 @@ modulo(10, 0.5)
 
 
 
+## KQL
+
+Simple field-value query:
+
+```kuery
+status: active
+```
+
+Boolean operators and quoted strings:
+
+```kuery
+status: active and extension: "php"
+```
+
+Wildcards and negation:
+
+```kql
+machine.os: win* and not status: 503
+```
+
+Nested queries:
+
+```kql
+items: { name: "laptop" and price > 500 }
+```
+
+Grouped values with range operators:
+
+```kuery
+response: (200 or 404) and bytes >= 1000
+```
+
  ## ESQL
 
 

--- a/src/Elastic.Documentation.Site/Assets/hljs.ts
+++ b/src/Elastic.Documentation.Site/Assets/hljs.ts
@@ -165,6 +165,52 @@ hljs.registerLanguage('painless', function () {
     }
 })
 
+hljs.registerLanguage('kuery', function () {
+    return {
+        case_insensitive: true,
+        keywords: {
+            keyword: 'and or not',
+            literal: ['true', 'false', 'null'],
+        },
+        contains: [
+            // Field names followed by : or range operators
+            {
+                scope: 'attribute',
+                match: /[a-zA-Z_][a-zA-Z0-9._]*(?=\s*(?::|<=|>=|<|>))/,
+            },
+            // Quoted strings
+            {
+                scope: 'string',
+                begin: /"/,
+                end: /"/,
+                contains: [
+                    {
+                        scope: 'char.escape',
+                        match: /\\[\\"\t\r\n]|\\u[0-9a-fA-F]{4}/,
+                    },
+                ],
+            },
+            // Range and match operators
+            {
+                scope: 'operator',
+                match: /<=|>=|<|>|:/,
+            },
+            // Wildcards
+            {
+                scope: 'operator',
+                match: /\*/,
+            },
+            // Parentheses and braces (grouping / nested queries)
+            {
+                scope: 'punctuation',
+                match: /[(){}]/,
+            },
+            NUMBER,
+        ],
+    }
+})
+hljs.registerAliases(['kql'], { languageName: 'kuery' })
+
 hljs.addPlugin(mergeHTMLPlugin)
 
 // The unescaped HTML warning is caused by the mergeHTMLPlugin which we are using

--- a/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockParser.cs
+++ b/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockParser.cs
@@ -98,7 +98,6 @@ public class EnhancedCodeBlockParser : FencedBlockParserBase<EnhancedCodeBlock>
 			"terminal" => "bash",
 			"painless" => "java",
 			//TODO support these natively
-			"kuery" => "json",
 			"lucene" => "json",
 			_ => codeBlock.Language
 		};

--- a/src/Elastic.Markdown/Myst/CodeBlocks/SupportedLanguages.cs
+++ b/src/Elastic.Markdown/Myst/CodeBlocks/SupportedLanguages.cs
@@ -44,12 +44,13 @@ public static class CodeBlock
 		{ "xml", "html, xhtml, rss, atom, xjb, xsd, xsl, plist, svg" }, // HTML, XML
 		{ "yml", "yaml" }, // YAML
 
-		//CUSTOM, Elastic language we wrote highlighters for
-		{ "apiheader", "" },
-		{ "eql", "" },
-		{ "esql", "" },
-		{ "mermaid", "" },
-		{ "painless", "" }
+	//CUSTOM, Elastic language we wrote highlighters for
+	{ "apiheader", "" },
+	{ "eql", "" },
+	{ "esql", "" },
+	{ "kuery", "kql" },
+	{ "mermaid", "" },
+	{ "painless", "" }
 	};
 
 	public static HashSet<string> Languages { get; } = new(


### PR DESCRIPTION
## Summary

- Add a custom highlight.js language definition for KQL (Kibana Query Language), replacing the previous JSON fallback for `kuery` code blocks.
- Register `kuery` (with `kql` alias) as a supported language in the server-side language map.
- Add KQL examples to the custom highlighters test page.

The grammar is based on the [KQL Peggy grammar from Kibana](https://github.com/elastic/kibana/blob/153f65990ee614677a9c3b2beda634219b6eeee8/packages/kbn-es-query/grammar/grammar.peggy) and highlights keywords (`and`, `or`, `not`), field names, quoted strings, operators, wildcards, literals, and nested query syntax.

## LLM disclosure

This PR was co-authored with Claude (Anthropic). The highlight.js language definition, server-side registration changes, and documentation examples were generated with AI assistance and reviewed by a human.

Made with [Cursor](https://cursor.com)