### PR TITLE
Fix `--skip-private-repositories` filtering consecutive private repo entries

### DIFF
--- a/src/Elastic.Documentation.Configuration/ConfigurationFileProvider.cs
+++ b/src/Elastic.Documentation.Configuration/ConfigurationFileProvider.cs
@@ -158,7 +158,7 @@ public partial class ConfigurationFileProvider
 				reindenting = spacing;
 			}
 
-			else if (spacing == -1 && TocPrefixRegex().IsMatch(line))
+			if (spacing == -1 && TocPrefixRegex().IsMatch(line))
 			{
 				var matches = Regex.Match(line, $@"^(?<spacing>\s+)-\s?toc:\s?(?:{targets})\:");
 				if (matches.Success)

--- a/src/services/Elastic.Documentation.Assembler/Building/AssemblerBuilder.cs
+++ b/src/services/Elastic.Documentation.Assembler/Building/AssemblerBuilder.cs
@@ -102,9 +102,14 @@ public class AssemblerBuilder(
 
 		if (exportOptions.Contains(Exporter.Redirects))
 		{
-			await OutputRedirectsAsync(redirects
-				.Where(r => !r.Key.TrimEnd('/').Equals(r.Value.TrimEnd('/'), StringComparison.OrdinalIgnoreCase))
-				.ToDictionary(r => r.Key.TrimEnd('/'), r => r.Value), ctx);
+			var trimmedRedirects = new Dictionary<string, string>();
+			foreach (var r in redirects)
+			{
+				var key = r.Key.TrimEnd('/');
+				if (!key.Equals(r.Value.TrimEnd('/'), StringComparison.OrdinalIgnoreCase))
+					trimmedRedirects[key] = r.Value;
+			}
+			await OutputRedirectsAsync(trimmedRedirects, ctx);
 		}
 
 		tasks = markdownExporters.Select(async e => await e.StopAsync(ctx));

--- a/tests/Elastic.Documentation.Configuration.Tests/CreateNavigationFileTests.cs
+++ b/tests/Elastic.Documentation.Configuration.Tests/CreateNavigationFileTests.cs
@@ -1,0 +1,172 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions.TestingHelpers;
+using Elastic.Documentation.Configuration.Assembler;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Elastic.Documentation.Configuration.Tests;
+
+public class CreateNavigationFileTests
+{
+	private static ConfigurationFileProvider CreateProvider(MockFileSystem fileSystem) =>
+		new(NullLoggerFactory.Instance, fileSystem, skipPrivateRepositories: true, ConfigurationSource.Embedded);
+
+	private static AssemblyConfiguration CreateConfig(params string[] privateRepoNames)
+	{
+		var refsYaml = string.Join("\n", privateRepoNames.Select(name => $"  {name}:\n    private: true"));
+		var yaml = $"narrative:\n  repo: git@github.com:elastic/docs-content.git\nreferences:\n{refsYaml}";
+		return AssemblyConfiguration.Deserialize(yaml, skipPrivateRepositories: true);
+	}
+
+	[Fact]
+	public void ConsecutiveSiblingPrivateEntries_BothRemoved()
+	{
+		var fileSystem = new MockFileSystem();
+		var provider = CreateProvider(fileSystem);
+
+		// language=yaml
+		var navYaml = """
+		              toc:
+		                - toc: docs-content://getting-started
+		                  path_prefix: getting-started
+		                  children:
+		                    - toc: public-repo://section-a
+		                      path_prefix: section-a
+		                    - toc: private-a://section-b
+		                      path_prefix: section-b
+		                    - toc: private-b://section-c
+		                      path_prefix: section-c
+		                    - toc: public-repo-two://section-d
+		                      path_prefix: section-d
+		              """;
+		fileSystem.File.WriteAllText(provider.NavigationFile.FullName, navYaml);
+
+		var config = CreateConfig("private-a", "private-b");
+		var result = provider.CreateNavigationFile(config);
+		var output = fileSystem.File.ReadAllText(result.FullName);
+
+		output.Should().NotContain("private-a://");
+		output.Should().NotContain("private-b://");
+		output.Should().Contain("public-repo://section-a");
+		output.Should().Contain("public-repo-two://section-d");
+	}
+
+	[Fact]
+	public void DeeplyNestedConsecutivePrivateEntries_BothRemoved()
+	{
+		var fileSystem = new MockFileSystem();
+		var provider = CreateProvider(fileSystem);
+
+		// language=yaml
+		var navYaml = """
+		              toc:
+		                - toc: docs-content://top
+		                  path_prefix: top
+		                  children:
+		                    - toc: docs-content://mid
+		                      path_prefix: mid
+		                      children:
+		                        - toc: public-repo://leaf-a
+		                          path_prefix: leaf-a
+		                        - toc: private-a://leaf-b
+		                          path_prefix: leaf-b
+		                        - toc: private-b://leaf-c
+		                          path_prefix: leaf-c
+		                        - toc: public-repo-two://leaf-d
+		                          path_prefix: leaf-d
+		              """;
+		fileSystem.File.WriteAllText(provider.NavigationFile.FullName, navYaml);
+
+		var config = CreateConfig("private-a", "private-b");
+		var result = provider.CreateNavigationFile(config);
+		var output = fileSystem.File.ReadAllText(result.FullName);
+
+		output.Should().NotContain("private-a://");
+		output.Should().NotContain("private-b://");
+		output.Should().Contain("public-repo://leaf-a");
+		output.Should().Contain("public-repo-two://leaf-d");
+	}
+
+	[Fact]
+	public void PrivateRepoWithChildren_EntryRemovedChildrenReindented()
+	{
+		var fileSystem = new MockFileSystem();
+		var provider = CreateProvider(fileSystem);
+
+		// language=yaml
+		var navYaml = """
+		              toc:
+		                - toc: docs-content://top
+		                  path_prefix: top
+		                  children:
+		                    - toc: private-a://parent
+		                      path_prefix: parent
+		                      children:
+		                        - toc: public-child://nested
+		                          path_prefix: nested
+		                    - toc: public-repo://after
+		                      path_prefix: after
+		              """;
+		fileSystem.File.WriteAllText(provider.NavigationFile.FullName, navYaml);
+
+		var config = CreateConfig("private-a");
+		var result = provider.CreateNavigationFile(config);
+		var output = fileSystem.File.ReadAllText(result.FullName);
+
+		output.Should().NotContain("private-a://");
+		output.Should().Contain("public-child://nested");
+		output.Should().Contain("public-repo://after");
+	}
+
+	[Fact]
+	public void PublicEntriesBetweenPrivateEntries_Preserved()
+	{
+		var fileSystem = new MockFileSystem();
+		var provider = CreateProvider(fileSystem);
+
+		// language=yaml
+		var navYaml = """
+		              toc:
+		                - toc: docs-content://top
+		                  path_prefix: top
+		                  children:
+		                    - toc: private-a://first
+		                      path_prefix: first
+		                    - toc: public-repo://middle
+		                      path_prefix: middle
+		                    - toc: private-b://last
+		                      path_prefix: last
+		              """;
+		fileSystem.File.WriteAllText(provider.NavigationFile.FullName, navYaml);
+
+		var config = CreateConfig("private-a", "private-b");
+		var result = provider.CreateNavigationFile(config);
+		var output = fileSystem.File.ReadAllText(result.FullName);
+
+		output.Should().NotContain("private-a://");
+		output.Should().NotContain("private-b://");
+		output.Should().Contain("public-repo://middle");
+	}
+
+	[Fact]
+	public void NoPrivateRepositories_ReturnsOriginalFile()
+	{
+		var fileSystem = new MockFileSystem();
+		var provider = CreateProvider(fileSystem);
+
+		var originalContent = fileSystem.File.ReadAllText(provider.NavigationFile.FullName);
+
+		// Empty config with no private repos
+		var yaml = "narrative:\n  repo: git@github.com:elastic/docs-content.git\nreferences:\n  public-repo:\n    private: false";
+		var config = AssemblyConfiguration.Deserialize(yaml, skipPrivateRepositories: true);
+
+		var result = provider.CreateNavigationFile(config);
+
+		result.FullName.Should().Be(provider.NavigationFile.FullName);
+		var output = fileSystem.File.ReadAllText(result.FullName);
+		output.Should().Be(originalContent);
+	}
+}


### PR DESCRIPTION
## Summary
- Fix navigation filtering where consecutive sibling private repo `toc:` entries at the same indentation level were not all removed — only the first was filtered, the rest slipped through
- Fix redirect output crash (`ArgumentException: duplicate key`) when redirect paths differ only by trailing `/`

## Details

**Navigation fix** (`ConfigurationFileProvider.cs`): Changed `else if` to `if` for the block that detects private repo `toc:` entries. The bug occurred because when the sibling-detection block fired (resetting `spacing = -1`), the private-repo check was chained as `else if` and got skipped — even if the sibling was also a private repo.

**Redirects fix** (`AssemblerBuilder.cs`): Replaced `.ToDictionary()` (which throws on duplicate keys) with a loop using dictionary indexer semantics to safely deduplicate redirects after trimming trailing slashes.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
