### PR TITLE
Update Markdig 0.44.0 to 0.45.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -75,7 +75,7 @@
     <PackageVersion Include="Github.Actions.Core" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
-    <PackageVersion Include="Markdig" Version="0.44.0" />
+    <PackageVersion Include="Markdig" Version="0.45.0" />
     <PackageVersion Include="ModelContextProtocol" Version="0.2.0-preview.1" />
     <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="0.2.0-preview.1" />
     <PackageVersion Include="NetEscapades.EnumGenerators" Version="1.0.0-beta12" PrivateAssets="all" ExcludeAssets="runtime" />


### PR DESCRIPTION
Includes https://github.com/xoofx/markdig/pull/922

## Benchmark — Best-of-3 (16,949 files)

| Repository | Files | 0.44.0 | 0.45.0 | Delta |
|---|---|---|---|---|
| logstash-docs-md | 3,054 | 1.85 ms/file | 1.89 ms/file | +0.04 (~same) |
| integration-docs | 645 | 6.21 ms/file | 4.91 ms/file | **-1.30 (21% faster)** |
| docs-content | 5,058 | 0.56 ms/file | 0.56 ms/file | 0.00 (same) |
| detection-rules | 1,728 | 1.74 ms/file | 1.63 ms/file | **-0.11 (6% faster)** |
| beats | 1,813 | 1.31 ms/file | 1.26 ms/file | -0.05 (~same) |
| elasticsearch | 2,460 | 0.85 ms/file | 0.87 ms/file | +0.02 (~same) |
| **Total** | **16,949** | **26.75s (1.58 ms/file)** | **25.40s (1.50 ms/file)** | **-1.35s (5% faster)** |

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
