### PR TITLE
Fix changelog config

### DIFF
--- a/config/changelog.example.yml
+++ b/config/changelog.example.yml
@@ -1,11 +1,20 @@
 # Changelog Configuration
 # This file configures the valid values for changelog fields using the pivot structure.
 # Place this file as `changelog.yml` in the `docs/` directory
+#
+# NOTE: All list-like fields accept BOTH forms:
+#   - Comma-separated string: "value1, value2, value3"
+#   - YAML list:
+#     - value1
+#     - value2
+#     - value3
+# Both forms produce the same result. Choose whichever is more readable for your use case.
 
 # Products configuration (optional)
 # If not specified, all products from products.yml are allowed
 products:
   # List of available product IDs (empty = all from products.yml)
+  # Accepts string or list: "elasticsearch, kibana" or [elasticsearch, kibana]
   available: []
   # Default products when --products not specified
   # default:
@@ -23,6 +32,7 @@ extract:
   issues: true
 
 # Available lifecycle values (strongly typed: preview, beta, ga)
+# Accepts string or list: "preview, beta, ga" or a YAML list
 lifecycles:
   - preview
   - beta
@@ -37,13 +47,20 @@ pivot:
   # At a minimum, feature, bug-fix, and breaking-change must be configured.
   # Keys are type names, values can be:
   #   - simple string: comma-separated label list (e.g., ">bug, >fix")
+  #   - YAML list: [">bug", ">fix"]
   #   - empty/null: no labels for this type
   #   - object: { labels: "...", subtypes: {...} } for breaking-change type only
+  #     (labels and subtype values also accept string or list)
   types:
     # Complex object form with subtypes (ONLY allowed for breaking-change)
     # Subtypes help categorize breaking changes by their nature
+    # Both labels and subtype values accept string or list form
     breaking-change:
       labels: ">breaking, >bc"
+      # Equivalent list form:
+      # labels:
+      #   - ">breaking"
+      #   - ">bc"
       subtypes:
         api: ">api-breaking"
         behavioral: ">behavioral-breaking"
@@ -65,22 +82,44 @@ pivot:
     regression:
     security:
 
+  # Labels that trigger the highlight flag (accepts string or list)
+  # String form: highlight: ">highlight, >release-highlight"
+  # List form:
+  # highlight:
+  #   - ">highlight"
+  #   - ">release-highlight"
+
   # Area definitions with labels
-  # Keys are area display names, values are label strings
-  # Multiple labels can be comma-separated
+  # Keys are area display names, values are label strings or lists
+  # String form: "label1, label2" | List form: [label1, label2]
   areas:
     # Example mappings - customize based on your label naming conventions
     # Autoscaling: ":Distributed Coordination/Autoscaling"
     # Search: ":Search/Search"
     # Security: ":Security/Security"
     # Watcher: ":Data Management/Watcher"
+    # List form example:
+    # Search:
+    #   - ":Search/Search"
+    #   - ":Search/Ranking"
 
 # Block configuration - combined create and publish blockers
+# All list-like fields (create, types, areas) accept string or list form
 block:
-  # Global labels that block changelog creation for all products (comma-separated string)
+  # Global labels that block changelog creation for all products
+  # String form:
   # create: ">non-issue, >test"
+  # List form:
+  # create:
+  #   - ">non-issue"
+  #   - ">test"
 
   # Block changelog entries from publishing based on entry type or area
+  # Both types and areas accept string or list form
+  # publish:
+  #   types: "deprecation, known-issue"
+  #   areas: "Internal"
+  # Or equivalently:
   # publish:
   #   types:
   #     - deprecation
@@ -90,6 +129,7 @@ block:
 
   # Product-specific overrides (override global blockers, don't merge)
   # Dictionary key can be a single product ID or comma-separated product IDs
+  # The create and publish fields accept string or list form
   product:
     # Example: Block these labels for elasticsearch and kibana
     # 'elasticsearch, kibana':
@@ -124,7 +164,7 @@ bundle:
     # serverless-release:
     #   products: "cloud-serverless {version} *"
     #   output: "serverless-{version}.yaml"
-    #   # Feature IDs to hide when bundling with this profile
+    #   # Feature IDs to hide when bundling with this profile (accepts string or list)
     #   hide_features:
     #     - feature-flag-1
     #     - feature-flag-2

--- a/src/Elastic.Documentation.Configuration/ReleaseNotes/ReleaseNotesSerialization.cs
+++ b/src/Elastic.Documentation.Configuration/ReleaseNotes/ReleaseNotesSerialization.cs
@@ -31,10 +31,12 @@ public static partial class ReleaseNotesSerialization
 
 	/// <summary>
 	/// Used for loading minimal changelog configuration (publish blocker).
+	/// Includes LenientStringListConverter so List&lt;string&gt; fields accept both comma-separated strings and YAML lists.
 	/// </summary>
 	private static readonly IDeserializer IgnoreUnmatchedDeserializer =
 		new StaticDeserializerBuilder(new YamlStaticContext())
 			.WithNamingConvention(UnderscoredNamingConvention.Instance)
+			.WithTypeConverter(new LenientStringListConverter())
 			.IgnoreUnmatchedProperties()
 			.Build();
 

--- a/src/Elastic.Documentation.Configuration/Serialization/LenientStringListConverter.cs
+++ b/src/Elastic.Documentation.Configuration/Serialization/LenientStringListConverter.cs
@@ -1,0 +1,66 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization;
+
+namespace Elastic.Documentation.Configuration.Serialization;
+
+/// <summary>
+/// YAML type converter for <c>List&lt;string&gt;</c> that accepts both comma-separated strings and YAML sequences.
+/// Used by the minimal changelog DTO deserializer so that publish blocker fields like <c>types</c> and <c>areas</c>
+/// can be specified as either <c>"deprecation, known-issue"</c> or a YAML list.
+/// </summary>
+public class LenientStringListConverter : IYamlTypeConverter
+{
+	public bool Accepts(Type type) => type == typeof(List<string>);
+
+	public object? ReadYaml(IParser parser, Type type, ObjectDeserializer rootDeserializer)
+	{
+		if (parser.TryConsume<Scalar>(out var scalar))
+		{
+			if (string.IsNullOrEmpty(scalar.Value) || scalar.Value == "~")
+				return null;
+
+			var items = scalar.Value
+				.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+				.ToList();
+
+			return items.Count > 0 ? items : null;
+		}
+
+		if (parser.TryConsume<SequenceStart>(out _))
+		{
+			var items = new List<string>();
+
+			while (!parser.TryConsume<SequenceEnd>(out _))
+			{
+				var item = parser.Consume<Scalar>();
+				if (!string.IsNullOrWhiteSpace(item.Value))
+					items.Add(item.Value.Trim());
+			}
+
+			return items.Count > 0 ? items : null;
+		}
+
+		return null;
+	}
+
+	public void WriteYaml(IEmitter emitter, object? value, Type type, ObjectSerializer serializer)
+	{
+		if (value is not List<string> { Count: > 0 } items)
+		{
+			emitter.Emit(new Scalar(null, null, string.Empty, ScalarStyle.Plain, true, false));
+			return;
+		}
+
+		emitter.Emit(new SequenceStart(null, null, false, SequenceStyle.Block));
+
+		foreach (var item in items)
+			emitter.Emit(new Scalar(null, null, item, ScalarStyle.Plain, true, false));
+
+		emitter.Emit(new SequenceEnd());
+	}
+}

--- a/src/services/Elastic.Changelog/Serialization/ChangelogConfigurationYaml.cs
+++ b/src/services/Elastic.Changelog/Serialization/ChangelogConfigurationYaml.cs
@@ -16,9 +16,9 @@ internal record ChangelogConfigurationYaml
 	public PivotConfigurationYaml? Pivot { get; set; }
 
 	/// <summary>
-	/// Available lifecycle values.
+	/// Available lifecycle values (string or list).
 	/// </summary>
-	public List<string>? Lifecycles { get; set; }
+	public YamlLenientList? Lifecycles { get; set; }
 
 	/// <summary>
 	/// Products configuration.
@@ -50,9 +50,9 @@ internal record ChangelogConfigurationYaml
 internal record BlockConfigurationYaml
 {
 	/// <summary>
-	/// Global labels that block changelog creation (comma-separated string).
+	/// Global labels that block changelog creation (string or list).
 	/// </summary>
-	public string? Create { get; set; }
+	public YamlLenientList? Create { get; set; }
 
 	/// <summary>
 	/// Configuration for blocking changelog entries from publishing based on type or area.
@@ -72,9 +72,9 @@ internal record BlockConfigurationYaml
 internal record ProductBlockersYaml
 {
 	/// <summary>
-	/// Labels that block creation for this product (comma-separated string).
+	/// Labels that block creation for this product (string or list).
 	/// </summary>
-	public string? Create { get; set; }
+	public YamlLenientList? Create { get; set; }
 
 	/// <summary>
 	/// Configuration for blocking changelog entries from publishing based on type or area.
@@ -88,14 +88,14 @@ internal record ProductBlockersYaml
 internal record PublishBlockerYaml
 {
 	/// <summary>
-	/// Entry types to block from publishing.
+	/// Entry types to block from publishing (string or list).
 	/// </summary>
-	public List<string>? Types { get; set; }
+	public YamlLenientList? Types { get; set; }
 
 	/// <summary>
-	/// Entry areas to block from publishing.
+	/// Entry areas to block from publishing (string or list).
 	/// </summary>
-	public List<string>? Areas { get; set; }
+	public YamlLenientList? Areas { get; set; }
 }
 
 /// <summary>
@@ -109,19 +109,19 @@ internal record PivotConfigurationYaml
 	public Dictionary<string, TypeEntryYaml?>? Types { get; set; }
 
 	/// <summary>
-	/// Default subtype definitions with optional labels.
+	/// Default subtype definitions with optional labels (string or list per value).
 	/// </summary>
-	public Dictionary<string, string?>? Subtypes { get; set; }
+	public Dictionary<string, YamlLenientList?>? Subtypes { get; set; }
 
 	/// <summary>
-	/// Area definitions with labels.
+	/// Area definitions with labels (string or list per value).
 	/// </summary>
-	public Dictionary<string, string?>? Areas { get; set; }
+	public Dictionary<string, YamlLenientList?>? Areas { get; set; }
 
 	/// <summary>
-	/// Labels that trigger the highlight flag (comma-separated string).
+	/// Labels that trigger the highlight flag (string or list).
 	/// </summary>
-	public string? Highlight { get; set; }
+	public YamlLenientList? Highlight { get; set; }
 }
 
 /// <summary>
@@ -130,9 +130,9 @@ internal record PivotConfigurationYaml
 internal record ProductsConfigYaml
 {
 	/// <summary>
-	/// List of available product IDs (empty = all from products.yml).
+	/// List of available product IDs (string or list, empty = all from products.yml).
 	/// </summary>
-	public List<string>? Available { get; set; }
+	public YamlLenientList? Available { get; set; }
 
 	/// <summary>
 	/// Default products to use when --products is not specified.
@@ -200,9 +200,9 @@ internal record BundleProfileYaml
 	public string? Output { get; set; }
 
 	/// <summary>
-	/// Feature IDs to mark as hidden in the bundle output.
+	/// Feature IDs to mark as hidden in the bundle output (string or list).
 	/// </summary>
-	public List<string>? HideFeatures { get; set; }
+	public YamlLenientList? HideFeatures { get; set; }
 }
 
 /// <summary>
@@ -235,9 +235,9 @@ internal record TypeEntryYaml
 	public string? Labels { get; set; }
 
 	/// <summary>
-	/// Type-specific subtype definitions.
+	/// Type-specific subtype definitions (string or list per value).
 	/// </summary>
-	public Dictionary<string, string?>? Subtypes { get; set; }
+	public Dictionary<string, YamlLenientList?>? Subtypes { get; set; }
 
 	/// <summary>
 	/// Creates a TypeEntryYaml from a simple label string.

--- a/src/services/Elastic.Changelog/Serialization/ChangelogYamlStaticContext.cs
+++ b/src/services/Elastic.Changelog/Serialization/ChangelogYamlStaticContext.cs
@@ -19,4 +19,5 @@ namespace Elastic.Changelog.Serialization;
 [YamlSerializable(typeof(BundleConfigurationYaml))]
 [YamlSerializable(typeof(BundleProfileYaml))]
 [YamlSerializable(typeof(ExtractConfigurationYaml))]
+[YamlSerializable(typeof(YamlLenientList))]
 public partial class ChangelogYamlStaticContext;

--- a/src/services/Elastic.Changelog/Serialization/YamlLenientList.cs
+++ b/src/services/Elastic.Changelog/Serialization/YamlLenientList.cs
@@ -7,5 +7,13 @@ namespace Elastic.Changelog.Serialization;
 /// <summary>
 /// Wrapper type for YAML fields that can be specified as either a comma-separated string
 /// or a YAML list/sequence. Deserialized by <see cref="YamlLenientListConverter"/>.
+/// Uses mutable property for compatibility with YamlDotNet source generator.
 /// </summary>
-internal record YamlLenientList(List<string>? Values);
+internal class YamlLenientList
+{
+	public List<string>? Values { get; set; }
+
+	public YamlLenientList() { }
+
+	public YamlLenientList(List<string>? values) => Values = values;
+}

--- a/src/services/Elastic.Changelog/Serialization/YamlLenientList.cs
+++ b/src/services/Elastic.Changelog/Serialization/YamlLenientList.cs
@@ -1,0 +1,11 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic.Changelog.Serialization;
+
+/// <summary>
+/// Wrapper type for YAML fields that can be specified as either a comma-separated string
+/// or a YAML list/sequence. Deserialized by <see cref="YamlLenientListConverter"/>.
+/// </summary>
+internal record YamlLenientList(List<string>? Values);

--- a/src/services/Elastic.Changelog/Serialization/YamlLenientListConverter.cs
+++ b/src/services/Elastic.Changelog/Serialization/YamlLenientListConverter.cs
@@ -1,0 +1,95 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization;
+
+namespace Elastic.Changelog.Serialization;
+
+/// <summary>
+/// YAML type converter for <see cref="YamlLenientList"/> that accepts both string and list forms.
+/// <list type="bullet">
+/// <item>Scalar: splits by comma, trims entries, removes empties.</item>
+/// <item>Sequence: reads each scalar item into a list.</item>
+/// <item>Null/empty: returns <c>YamlLenientList(null)</c>.</item>
+/// </list>
+/// </summary>
+public class YamlLenientListConverter : IYamlTypeConverter
+{
+	public bool Accepts(Type type) => type == typeof(YamlLenientList);
+
+	public object? ReadYaml(IParser parser, Type type, ObjectDeserializer rootDeserializer)
+	{
+		if (parser.TryConsume<Scalar>(out var scalar))
+		{
+			if (string.IsNullOrEmpty(scalar.Value) || scalar.Value == "~")
+				return new YamlLenientList(null);
+
+			var items = scalar.Value
+				.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+				.ToList();
+
+			return new YamlLenientList(items.Count > 0 ? items : null);
+		}
+
+		if (parser.TryConsume<SequenceStart>(out _))
+		{
+			var items = new List<string>();
+
+			while (!parser.TryConsume<SequenceEnd>(out _))
+			{
+				var item = parser.Consume<Scalar>();
+				if (!string.IsNullOrWhiteSpace(item.Value))
+					items.Add(item.Value.Trim());
+			}
+
+			return new YamlLenientList(items.Count > 0 ? items : null);
+		}
+
+		return new YamlLenientList(null);
+	}
+
+	public void WriteYaml(IEmitter emitter, object? value, Type type, ObjectSerializer serializer)
+	{
+		if (value is not YamlLenientList { Values: { Count: > 0 } values })
+		{
+			emitter.Emit(new Scalar(null, null, string.Empty, ScalarStyle.Plain, true, false));
+			return;
+		}
+
+		emitter.Emit(new SequenceStart(null, null, false, SequenceStyle.Block));
+
+		foreach (var item in values)
+			emitter.Emit(new Scalar(null, null, item, ScalarStyle.Plain, true, false));
+
+		emitter.Emit(new SequenceEnd());
+	}
+
+	/// <summary>
+	/// Reads a scalar-or-sequence value from the parser and returns a joined comma-separated string.
+	/// Useful for fields that stay as <c>string?</c> in the domain model (e.g., TypeEntryYaml.Labels).
+	/// </summary>
+	internal static string? ReadAsString(IParser parser)
+	{
+		if (parser.TryConsume<Scalar>(out var scalar))
+			return string.IsNullOrEmpty(scalar.Value) || scalar.Value == "~" ? null : scalar.Value;
+
+		if (parser.TryConsume<SequenceStart>(out _))
+		{
+			var items = new List<string>();
+
+			while (!parser.TryConsume<SequenceEnd>(out _))
+			{
+				var item = parser.Consume<Scalar>();
+				if (!string.IsNullOrWhiteSpace(item.Value))
+					items.Add(item.Value.Trim());
+			}
+
+			return items.Count > 0 ? string.Join(", ", items) : null;
+		}
+
+		return null;
+	}
+}


### PR DESCRIPTION
## Problem

Changelog configuration YAML had mixed support for list-like fields:

- `block.create` and `block.product.*.create` only accepted comma-separated strings
- `block.publish.types` and `block.publish.areas` only accepted YAML lists
- `pivot.highlight` only accepted a comma-separated string
- `pivot.areas` dictionary values only accepted comma-separated strings
- `pivot.types` labels and subtype values only supported one form in some cases

Using the wrong form produced unclear `"No node deserializer was able to deserialize..."` errors.

## Solution

All list-like fields now accept both:

1. **Comma-separated string**: `"label1, label2, label3"`
2. **YAML list**: `["label1", "label2", "label3"]`

Both forms yield the same `List<string>` internally; domain models and APIs stay the same.

## Changes

### Serialization layer

- **`YamlLenientList`** – Wrapper type with `Values` (`List<string>?`). Implemented as a class with parameterless constructor and mutable property for compatibility with the YamlDotNet source generator.
- **`YamlLenientListConverter`** – `IYamlTypeConverter` that:
  - Reads scalar (comma-split, trimmed, empty removed) → `YamlLenientList`
  - Reads sequence → `YamlLenientList`
  - Writes as a YAML sequence

### YAML DTO updates (`ChangelogConfigurationYaml.cs`)

- `BlockConfigurationYaml.Create` → `YamlLenientList?`
- `ProductBlockersYaml.Create` → `YamlLenientList?`
- `PublishBlockerYaml.Types` and `.Areas` → `YamlLenientList?`
- `PivotConfigurationYaml.Highlight` → `YamlLenientList?`
- `PivotConfigurationYaml.Areas` and `.Subtypes` → `Dictionary<string, YamlLenientList?>?`
- `ProductsConfigYaml.Available`, `BundleProfileYaml.HideFeatures` → `YamlLenientList?`

### `ChangelogConfigurationLoader`

- Uses `block.Create?.Values`, `productBlockers?.Create?.Values`, `Highlight?.Values`, `Types?.Values`, `Areas?.Values`
- Added `ConvertLenientDictToStringDict` and `JoinLenientList` for pivot area/subtype conversion
- Removed `SplitLabels` helper (handled by the converter)

### `TypeEntryYamlConverter`

- `labels` in object form supports both scalar and sequence
- Subtype values support both scalar and sequence

### `ReleaseNotesSerialization`

- **`LenientStringListConverter`** – Converter for `List<string>` for the minimal changelog DTO path (`ChangelogConfigMinimalDto`, `PublishBlockerMinimalDto`)
- `IgnoreUnmatchedDeserializer` updated to use `LenientStringListConverter` so `LoadPublishBlocker` also accepts both forms

### Tests

- Added 13 tests for string and list forms of:
  - `block.create`, `block.publish.types`, `block.publish.areas`
  - `pivot.highlight`, `pivot.areas` (including list values)
  - `pivot.types` labels and subtype labels (list form)
  - `block.product.*.create`
- Added `LoadChangelogConfiguration_MixedStringAndListForms_ParsesCorrectly` integration test

### Documentation

- **`config/changelog.example.yml`** – Comments document both string and list forms for all list-like fields

## Backward compatibility

Existing YAML files remain valid. No breaking changes; only additional input forms are supported.

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  

5. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: composer 1.5, claude 4.6-opus-high