### PR TITLE
Update updatecli.yml

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -4,7 +4,7 @@ name: updatecli
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 5 * * 1-5"
+    - cron: "0 8 * * 1-5"
 
 permissions:
   contents: read


### PR DESCRIPTION
Changing cron job execution time to avoid this:

```
ERROR: Pipeline "Bump release versions in the config/versions.yml" failed to update: template: cfg:514:59: executing "cfg" at <source "latest-edot-collector-version">: error calling source: parent source "latest-edot-collector-version" failed
ERROR: Failed to clean up action(s): API rate limit already exceeded for installation ID 54531629.
ERROR:   - API rate limit already exceeded for installation ID 54531629.
ERROR: cleaning action stage:	"failed to clean up action(s):\n\tAPI rate limit already exceeded for installation ID 54531629."
```