### PR TITLE
Fix ruleset name

### DIFF
--- a/src/services/Elastic.Documentation.Search/Common/ElasticsearchClientAccessor.cs
+++ b/src/services/Elastic.Documentation.Search/Common/ElasticsearchClientAccessor.cs
@@ -57,7 +57,7 @@ public class ElasticsearchClientAccessor : IDisposable
 	{
 		const string prefix = "semantic-docs-";
 		const string suffix = "-latest";
-		if (!indexName.StartsWith(prefix) || !indexName.EndsWith(suffix))
+		if (!indexName.StartsWith(prefix, StringComparison.Ordinal) || !indexName.EndsWith(suffix, StringComparison.Ordinal))
 			return null;
 
 		var ns = indexName[prefix.Length..^suffix.Length];


### PR DESCRIPTION
While indexing with codex, the namespace is `codex-engineering`. This fixes how the ruleset name is constructed.