### PR TITLE
Fix System.String JSON serialization error in MCP Remote SSE handler

### DIFF
--- a/src/api/Elastic.Documentation.Mcp.Remote/Program.cs
+++ b/src/api/Elastic.Documentation.Mcp.Remote/Program.cs
@@ -9,6 +9,7 @@ using Elastic.Documentation.Search;
 using Elastic.Documentation.ServiceDefaults;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using ModelContextProtocol;
 
 try
 {
@@ -29,6 +30,14 @@ try
 	_ = builder.Services.AddSearchServices();
 
 	_ = builder.Services.AddScoped<IDocumentGateway, DocumentGateway>();
+
+	// CreateSlimBuilder disables reflection-based JSON serialization.
+	// The MCP SDK's legacy SSE handler uses Results.BadRequest(string) which needs
+	// ASP.NET Core's HTTP JSON options to have type metadata for System.String.
+	_ = builder.Services.ConfigureHttpJsonOptions(options =>
+	{
+		options.SerializerOptions.TypeInfoResolverChain.Insert(0, McpJsonUtilities.DefaultOptions.TypeInfoResolver!);
+	});
 
 	_ = builder.Services
 		.AddMcpServer()


### PR DESCRIPTION
Register McpJsonUtilities type resolver with ASP.NET Core's HTTP JSON
options. CreateSlimBuilder disables reflection-based JSON, causing
Results.BadRequest(string) in the MCP SDK's legacy SSE handler to fail
with missing TypeInfo for System.String.
