### PR TITLE
htmx: Revert 'smart' solution and use easy and dumb fix

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/main.ts
+++ b/src/Elastic.Documentation.Site/Assets/main.ts
@@ -133,41 +133,6 @@ document.addEventListener(
     }
 )
 
-// Disable htmx boost for links that don't point to /docs paths.
-// This runs before htmx wires up event listeners, so these links
-// behave as normal anchors and htmx never intercepts their clicks.
-document.addEventListener(
-    'htmx:beforeProcessNode',
-    function (event: HtmxEvent) {
-        const elt = event.detail.elt
-        if (elt?.tagName !== 'A') {
-            return
-        }
-        const href = elt.getAttribute('href')
-        if (!href) {
-            return
-        }
-
-        const disablehtmx = (el: HTMLElement) => {
-            el.setAttribute('hx-disable', 'true')
-        }
-
-        let url: URL
-        try {
-            url = new URL(href)
-        } catch {
-            return
-        }
-        // Not checking for same hostname because htmx `selfRequestsOnly` is enabled
-        if (
-            config.buildType === 'assembler' &&
-            !url.pathname?.startsWith('/docs')
-        ) {
-            disablehtmx(elt)
-        }
-    }
-)
-
 document.addEventListener('htmx:beforeRequest', function (event: HtmxEvent) {
     if (
         event.detail.requestConfig.verb === 'get' &&

--- a/src/Elastic.Markdown/Layout/_LandingPage.cshtml
+++ b/src/Elastic.Markdown/Layout/_LandingPage.cshtml
@@ -54,7 +54,7 @@
 							<p class="mt-2 grow">Build powerful search and RAG applications using Elasticsearch's vector database, AI toolkit, and advanced retrieval capabilities.</p>
 							<div class="grid grid-cols-1 mt-6 gap-2">
 								<a href="@Model.Link("/solutions/search")" class="text-blue-elastic hover:text-blue-elastic-100 font-sans font-semibold">9.0+ (latest @Model.CurrentVersion) docs</a>
-								<a href="https://www.elastic.co/guide/en/elasticsearch/reference/index.html" class="text-sm text-grey-70 hover:text-grey-100 font-sans font-semibold">Previous versions</a>
+								<a href="https://www.elastic.co/guide/en/elasticsearch/reference/index.html" class="text-sm text-grey-70 hover:text-grey-100 font-sans font-semibold" hx-disable="true">Previous versions</a>
 							</div>
 						</div>
 					</div>
@@ -67,7 +67,7 @@
 							<p class="mt-2 grow">Resolve problems with open, flexible, and unified observability powered by advanced machine learning and analytics.</p>
 							<div class="grid grid-cols-1 mt-6 gap-2">
 								<a href="@Model.Link("/solutions/observability")" class="text-blue-elastic hover:text-blue-elastic-100 font-sans font-semibold">9.0+ (latest @Model.CurrentVersion) docs</a>
-								<a href="https://www.elastic.co/guide/en/observability/index.html" class="text-sm text-grey-70 hover:text-grey-100 font-sans font-semibold">Previous versions</a>
+								<a href="https://www.elastic.co/guide/en/observability/index.html" class="text-sm text-grey-70 hover:text-grey-100 font-sans font-semibold" hx-disable="true">Previous versions</a>
 							</div>
 						</div>
 					</div>
@@ -81,7 +81,7 @@
 							<p class="mt-2 grow">Detect, investigate, and respond to threats with AI-driven security analytics to protect your organization at scale.</p>
 							<div class="grid grid-cols-1 mt-6 gap-2">
 								<a href="@Model.Link("/solutions/security")" class="text-blue-elastic hover:text-blue-elastic-100 font-sans font-semibold">9.0+ (latest @Model.CurrentVersion) docs</a>
-								<a href="https://www.elastic.co/guide/en/security/index.html" class="text-sm text-grey-70 hover:text-grey-100 font-sans font-semibold">Previous versions</a>
+								<a href="https://www.elastic.co/guide/en/security/index.html" class="text-sm text-grey-70 hover:text-grey-100 font-sans font-semibold" hx-disable="true">Previous versions</a>
 							</div>
 						</div>
 					</div>
@@ -267,7 +267,7 @@
 					<h3 class="font-sans font-bold text-2xl">Previous versions</h3>
 					<p class="grow mt-4">Browse the docs for previous Elastic product versions.</p>
 					<div class="mt-6">
-						<a href="https://www.elastic.co/guide?lang=en" target="_blank" rel="noopener noreferrer" class="link text-white">
+						<a href="https://www.elastic.co/guide?lang=en" target="_blank" rel="noopener noreferrer" class="link text-white" hx-disable="true">
 							View previous versions
 							<svg class="link-arrow"
 							     xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">


### PR DESCRIPTION
Reverting the logic because it doesn't work as expected.

It only happens in production and cannot be reproduced in other environments.