### PR TITLE
chore(site): use @theletterf/beautiful-mermaid and add test diagrams

### DIFF
--- a/docs/syntax/diagrams.md
+++ b/docs/syntax/diagrams.md
@@ -2,6 +2,11 @@
 
 You can create diagrams using [Mermaid](https://mermaid.js.org/) with standard fenced code blocks. Diagrams are rendered client-side in the browser.
 
+```mermaid
+flowchart LR
+    A[Write Mermaid] --> B[Render diagram]
+```
+
 ## Basic usage
 
 Use a fenced code block with `mermaid` as the language:
@@ -173,6 +178,108 @@ erDiagram
 ::::
 
 :::::
+
+### Complex flowchart
+
+::::::{tab-set}
+
+:::::{tab-item} Source
+````markdown
+```mermaid
+graph TB
+    A["Painless Operators"]
+
+    B["General"]
+    C["Numeric"]
+    D["Boolean"]
+    E["Reference"]
+    F["Array"]
+
+    B1["Control expression flow and<br/>value assignment"]
+    C1["Mathematical operations and<br/>bit manipulation"]
+    D1["Boolean logic and<br/>conditional evaluation"]
+    E1["Object interaction and<br/>safe data access"]
+    F1["Array manipulation and<br/>element access"]
+
+    B2["Precedence ( )<br/>Function Call ( )<br/>Cast ( )<br/>Conditional ? :<br/>Elvis ?:<br/>Assignment =<br/>Compound Assignment $="]
+    C2["Post/Pre Increment ++<br/>Post/Pre Decrement --<br/>Unary +/-<br/>Bitwise Not ~<br/>Multiplication *<br/>Division /<br/>Remainder %<br/>Addition +<br/>Subtraction -<br/>Shift <<, >>, >>><br/>Bitwise And &<br/>Bitwise Xor ^<br/>Bitwise Or |"]
+    D2["Boolean Not !<br/>Comparison >, >=, <, <=<br/>Instanceof instanceof<br/>Equality ==, !=<br/>Identity ===, !==<br/>Boolean Xor ^<br/>Boolean And &&<br/>Boolean Or ||"]
+    E2["Method Call . ( )<br/>Field Access .<br/>Null Safe ?.<br/>New Instance new ( )<br/>String Concatenation +<br/>List/Map Init [ ], [ : ]<br/>List/Map Access [ ]"]
+    F2["Array Init [ ] { }<br/>Array Access [ ]<br/>Array Length .length<br/>New Array new [ ]"]
+
+    A --> B & C & D & E & F
+    B --> B1
+    C --> C1
+    D --> D1
+    E --> E1
+    F --> F1
+    B1 --> B2
+    C1 --> C2
+    D1 --> D2
+    E1 --> E2
+    F1 --> F2
+
+    classDef rootNode fill:#0B64DD,stroke:#101C3F,stroke-width:2px,color:#fff
+    classDef categoryBox fill:#e1f5fe,stroke:#01579b,stroke-width:2px,color:#343741
+    classDef descBox fill:#48EFCF,stroke:#343741,stroke-width:2px,color:#343741
+    classDef exampleBox fill:#f5f7fa,stroke:#343741,stroke-width:2px,color:#343741
+
+    class A rootNode
+    class B,C,D,E,F categoryBox
+    class B1,C1,D1,E1,F1 descBox
+    class B2,C2,D2,E2,F2 exampleBox
+```
+````
+:::::
+
+:::::{tab-item} Rendered
+```mermaid
+graph TB
+    A["Painless Operators"]
+
+    B["General"]
+    C["Numeric"]
+    D["Boolean"]
+    E["Reference"]
+    F["Array"]
+
+    B1["Control expression flow and<br/>value assignment"]
+    C1["Mathematical operations and<br/>bit manipulation"]
+    D1["Boolean logic and<br/>conditional evaluation"]
+    E1["Object interaction and<br/>safe data access"]
+    F1["Array manipulation and<br/>element access"]
+
+    B2["Precedence ( )<br/>Function Call ( )<br/>Cast ( )<br/>Conditional ? :<br/>Elvis ?:<br/>Assignment =<br/>Compound Assignment $="]
+    C2["Post/Pre Increment ++<br/>Post/Pre Decrement --<br/>Unary +/-<br/>Bitwise Not ~<br/>Multiplication *<br/>Division /<br/>Remainder %<br/>Addition +<br/>Subtraction -<br/>Shift <<, >>, >>><br/>Bitwise And &<br/>Bitwise Xor ^<br/>Bitwise Or |"]
+    D2["Boolean Not !<br/>Comparison >, >=, <, <=<br/>Instanceof instanceof<br/>Equality ==, !=<br/>Identity ===, !==<br/>Boolean Xor ^<br/>Boolean And &&<br/>Boolean Or ||"]
+    E2["Method Call . ( )<br/>Field Access .<br/>Null Safe ?.<br/>New Instance new ( )<br/>String Concatenation +<br/>List/Map Init [ ], [ : ]<br/>List/Map Access [ ]"]
+    F2["Array Init [ ] { }<br/>Array Access [ ]<br/>Array Length .length<br/>New Array new [ ]"]
+
+    A --> B & C & D & E & F
+    B --> B1
+    C --> C1
+    D --> D1
+    E --> E1
+    F --> F1
+    B1 --> B2
+    C1 --> C2
+    D1 --> D2
+    E1 --> E2
+    F1 --> F2
+
+    classDef rootNode fill:#0B64DD,stroke:#101C3F,stroke-width:2px,color:#fff
+    classDef categoryBox fill:#e1f5fe,stroke:#01579b,stroke-width:2px,color:#343741
+    classDef descBox fill:#48EFCF,stroke:#343741,stroke-width:2px,color:#343741
+    classDef exampleBox fill:#f5f7fa,stroke:#343741,stroke-width:2px,color:#343741
+
+    class A rootNode
+    class B,C,D,E,F categoryBox
+    class B1,C1,D1,E1,F1 descBox
+    class B2,C2,D2,E2,F2 exampleBox
+```
+:::::
+
+::::::
 
 ## Interactive controls
 

--- a/src/Elastic.Documentation.Site/package-lock.json
+++ b/src/Elastic.Documentation.Site/package-lock.json
@@ -28,8 +28,8 @@
         "@opentelemetry/semantic-conventions": "^1.38.0",
         "@r2wc/react-to-web-component": "2.1.0",
         "@tanstack/react-query": "^5.90.6",
+        "@theletterf/beautiful-mermaid": "0.1.5",
         "@uidotdev/usehooks": "2.4.1",
-        "beautiful-mermaid": "^0.1.3",
         "dompurify": "3.3.1",
         "highlight.js": "11.11.1",
         "htmx-ext-head-support": "2.0.4",
@@ -155,6 +155,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -2007,6 +2008,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2030,6 +2032,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2358,6 +2361,7 @@
       "version": "11.13.5",
       "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
       "integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
+      "peer": true,
       "dependencies": {
         "@emotion/babel-plugin": "^11.13.5",
         "@emotion/cache": "^11.13.5",
@@ -2380,6 +2384,7 @@
       "version": "11.14.0",
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -4476,6 +4481,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -6143,6 +6149,7 @@
       "integrity": "sha512-b9ll4jaFYfXSv6NZAOJ2P0uuyT/Doel7ho2AHLSUz2thtcL6HEb2+qdV2f9wriVvbEoPAj9VuSOgNc0t0f5iMw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.1",
         "@parcel/cache": "2.16.3",
@@ -23929,6 +23936,15 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@theletterf/beautiful-mermaid": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@theletterf/beautiful-mermaid/-/beautiful-mermaid-0.1.5.tgz",
+      "integrity": "sha512-46MIkRlUYrAJbGDB7zbUkK9D/oOPQg5XKs9Xq3dn61O1MTqXU1aX0FPhc2ZOK2DNETXHKcFEo0f5MKyMPCoSyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dagrejs/dagre": "^1.1.8"
+      }
+    },
     "node_modules/@trivago/prettier-plugin-sort-imports": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-6.0.0.tgz",
@@ -24019,8 +24035,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -24235,6 +24250,7 @@
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -24365,6 +24381,7 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -24893,6 +24910,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -25366,15 +25384,6 @@
         }
       ]
     },
-    "node_modules/beautiful-mermaid": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/beautiful-mermaid/-/beautiful-mermaid-0.1.3.tgz",
-      "integrity": "sha512-lVEHCnlVLtVRbO03T+D9kY5BZlkpvFU6F18LEu2N2VLB0eo5evG1FJWg3SvREErKY+zZ7j9f+cNsgtiOhYI2Nw==",
-      "license": "MIT",
-      "dependencies": {
-        "@dagrejs/dagre": "^1.1.8"
-      }
-    },
     "node_modules/binary": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
@@ -25436,6 +25445,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -26140,8 +26150,7 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -26492,6 +26501,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -29072,6 +29082,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -29652,7 +29663,6 @@
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -29897,6 +29907,7 @@
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -30887,6 +30898,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -30934,6 +30946,7 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -31028,7 +31041,6 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -31043,7 +31055,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -31172,6 +31183,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -31194,6 +31206,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -31530,6 +31543,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
       "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }
@@ -32528,6 +32542,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -32674,8 +32689,7 @@
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "peer": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -32722,6 +32736,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -33568,7 +33583,8 @@
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
       "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/zustand": {
       "version": "5.0.8",

--- a/src/Elastic.Documentation.Site/package.json
+++ b/src/Elastic.Documentation.Site/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "watch": "parcel watch",
     "build": "parcel build && npm run copy:mermaid",
-    "copy:mermaid": "cp node_modules/beautiful-mermaid/dist/beautiful-mermaid.browser.global.js _static/mermaid.min.js",
+    "copy:mermaid": "cp node_modules/@theletterf/beautiful-mermaid/dist/beautiful-mermaid.browser.global.js _static/mermaid.min.js",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
@@ -127,7 +127,7 @@
     "@r2wc/react-to-web-component": "2.1.0",
     "@tanstack/react-query": "^5.90.6",
     "@uidotdev/usehooks": "2.4.1",
-    "beautiful-mermaid": "^0.1.3",
+    "@theletterf/beautiful-mermaid": "0.1.5",
     "dompurify": "3.3.1",
     "highlight.js": "11.11.1",
     "htmx-ext-head-support": "2.0.4",


### PR DESCRIPTION
## Summary
- Switch the site frontend Mermaid renderer dependency from `beautiful-mermaid` to `@theletterf/beautiful-mermaid` (and update the build copy step to vendor the bundle into `_static/`).
- Add an intro Mermaid diagram plus a complex flowchart example to `docs/syntax/diagrams.md` to help validate rendering and interactions.

Closes https://github.com/elastic/docs-builder/issues/2632

## LLM usage
- This PR was authored with assistance from GPT-5.2.

Made with [Cursor](https://cursor.com)