### PR TITLE
Switch MCP transport to stateless mode to fix 400 Bad Request errors

### DIFF
--- a/src/api/Elastic.Documentation.Mcp.Remote/Program.cs
+++ b/src/api/Elastic.Documentation.Mcp.Remote/Program.cs
@@ -54,9 +54,13 @@ try
 		options.SerializerOptions.TypeInfoResolverChain.Insert(0, McpJsonUtilities.DefaultOptions.TypeInfoResolver!);
 	});
 
+	// Stateless mode: no Mcp-Session-Id header is issued or expected, which avoids a known
+	// Cursor bug where it opens the SSE stream without the session header and receives 400.
+	// Stateless mode is appropriate here because all tools are pure request/response (no
+	// server-initiated push) and the server runs behind a load balancer without session affinity.
 	_ = builder.Services
 		.AddMcpServer()
-		.WithHttpTransport()
+		.WithHttpTransport(o => o.Stateless = true)
 		.WithTools<SearchTools>()
 		.WithTools<CoherenceTools>()
 		.WithTools<DocumentTools>()

--- a/src/api/Elastic.Documentation.Mcp.Remote/SseKeepAliveMiddleware.cs
+++ b/src/api/Elastic.Documentation.Mcp.Remote/SseKeepAliveMiddleware.cs
@@ -9,7 +9,6 @@ namespace Elastic.Documentation.Mcp.Remote;
 /// <summary>
 /// Middleware that sends periodic SSE keepalive comments on <c>text/event-stream</c> responses
 /// to prevent clients (notably Cursor) from timing out idle SSE connections.
-/// Covers both Streamable HTTP (<c>/docs/_mcp/</c>) and legacy SSE (<c>/docs/_mcp/sse</c>) endpoints.
 /// </summary>
 public class SseKeepAliveMiddleware(RequestDelegate next, ILogger<SseKeepAliveMiddleware> logger)
 {


### PR DESCRIPTION
Cursor intermittently produces:

```
Streamable HTTP error: Failed to open SSE stream: Bad Request
```

This is caused by a [known Cursor bug](https://forum.cursor.com/t/mcp-cursor-makes-get-request-without-mcp-session-id/146964): after the initial POST handshake the client opens the SSE GET stream without sending the `Mcp-Session-Id` header it just received. A stateful MCP server correctly returns 400 per spec, but Cursor has no recovery path, so the session is lost.

## Solution

Switch `WithHttpTransport` to stateless mode (`o.Stateless = true`). In stateless mode the server never issues or expects a session ID, so Cursor's omission of it is harmless.

## Trade-offs

| | Stateless | Stateful (previous) |
|---|---|---|
| Session ID | None | Per-connection `Mcp-Session-Id` |
| Server-to-client push | Not supported | Supported |
| Legacy `/sse` endpoint | Disabled | Enabled |
| Load balancer affinity | Not required | Required |
| Cursor "Bad Request" bug | Not triggered | Triggered intermittently |

Losing server-to-client push and the `/sse` endpoint is acceptable here because all tools are pure request/response and the server runs on ECS Fargate behind a load balancer where session affinity would be a liability anyway.

## AI disclosure

Authored with the assistance of **Claude 4.6 Sonnet** via **Cursor IDE**.

Sources consulted:
- [Cursor forum: MCP Cursor makes GET request without Mcp-Session-Id](https://forum.cursor.com/t/mcp-cursor-makes-get-request-without-mcp-session-id/146964)
- [MCP C# SDK `HttpServerTransportOptions.Stateless` docs](https://modelcontextprotocol.github.io/csharp-sdk/api/ModelContextProtocol.AspNetCore.HttpServerTransportOptions.html#ModelContextProtocol_AspNetCore_HttpServerTransportOptions_Stateless)