### PR TITLE
fix(mcp): remove GET redirect that blocks Streamable HTTP SSE stream

### DIFF
--- a/src/api/Elastic.Documentation.Mcp.Remote/Program.cs
+++ b/src/api/Elastic.Documentation.Mcp.Remote/Program.cs
@@ -97,7 +97,6 @@ try
 	_ = mcp.MapHealthChecks("/health");
 	_ = mcp.MapHealthChecks("/alive", new HealthCheckOptions { Predicate = r => r.Tags.Contains("live") });
 	_ = mcp.MapMcp("");
-	_ = mcp.MapGet("/", () => Results.Redirect(mcpPrefix, permanent: true));
 
 	Console.WriteLine("MCP server startup completed successfully");
 	app.Run();


### PR DESCRIPTION
## Issue

Cursor gets stuck in an infinite "Loading tools" / "fetch failed" reconnect loop when connecting to the MCP server.

## Root cause

Line 100 in `Program.cs` maps a GET handler on the MCP group root that issues a permanent redirect:

```csharp
_ = mcp.MapGet("/", () => Results.Redirect(mcpPrefix, permanent: true));
```

The Streamable HTTP transport uses **GET on the same path as POST** to open the SSE stream for server-to-client notifications. This redirect intercepts every GET before it reaches the MCP handler, producing an infinite 301 loop (`/docs/_mcp/` → `/docs/_mcp` → `/docs/_mcp` → …). POST requests (initialize, tools/list, tool calls) are unaffected, so the server appears healthy but clients can never open the SSE stream.

Confirmed by curl:

```
> GET /docs/_mcp/ HTTP/2
< HTTP/2 301
< location: /docs/_mcp

> GET /docs/_mcp HTTP/2
< HTTP/2 301
< location: /docs/_mcp
(infinite loop)
```

## Fix

Remove the `MapGet` redirect. The MCP SDK's `MapMcp("")` already handles both POST and GET on the group root.

## LLM usage

This fix was developed with Claude 4.6 Opus and Cursor.

Made with [Cursor](https://cursor.com)