### PR TITLE
fix(mcp): add missing required fields to document query source filters

### DIFF
--- a/src/api/Elastic.Documentation.Mcp.Remote/Gateways/DocumentGateway.cs
+++ b/src/api/Elastic.Documentation.Mcp.Remote/Gateways/DocumentGateway.cs
@@ -28,24 +28,25 @@ public class DocumentGateway(
 				.Indices(clientAccessor.Options.IndexName)
 				.Query(q => q.Term(t => t.Field(f => f.Url).Value(normalizedUrl)))
 				.Size(1)
-				.Source(sf => sf.Filter(f => f.Includes(
-					e => e.Url,
-					e => e.Title,
-					e => e.Type,
-					e => e.Description,
-					e => e.NavigationSection,
-					e => e.Body,
-					e => e.Parents,
-					e => e.Headings,
-					e => e.Links,
-					e => e.AiShortSummary,
-					e => e.AiRagOptimizedSummary,
-					e => e.AiQuestions,
-					e => e.AiUseCases,
-					e => e.LastUpdated,
-					e => e.Product,
-					e => e.RelatedProducts
-				))),
+			.Source(sf => sf.Filter(f => f.Includes(
+				e => e.Url,
+				e => e.Title,
+				e => e.SearchTitle,
+				e => e.Type,
+				e => e.Description,
+				e => e.NavigationSection,
+				e => e.Body,
+				e => e.Parents,
+				e => e.Headings,
+				e => e.Links,
+				e => e.AiShortSummary,
+				e => e.AiRagOptimizedSummary,
+				e => e.AiQuestions,
+				e => e.AiUseCases,
+				e => e.LastUpdated,
+				e => e.Product,
+				e => e.RelatedProducts
+			))),
 				ct);
 
 			if (!response.IsValidResponse || response.Documents.Count == 0)
@@ -106,17 +107,19 @@ public class DocumentGateway(
 				.Indices(clientAccessor.Options.IndexName)
 				.Query(q => q.Term(t => t.Field(f => f.Url).Value(normalizedUrl)))
 				.Size(1)
-				.Source(sf => sf.Filter(f => f.Includes(
-					e => e.Url,
-					e => e.Title,
-					e => e.Parents,
-					e => e.Headings,
-					e => e.Links,
-					e => e.Body,
-					e => e.AiShortSummary,
-					e => e.AiQuestions,
-					e => e.AiUseCases
-				))),
+			.Source(sf => sf.Filter(f => f.Includes(
+				e => e.Url,
+				e => e.Title,
+				e => e.SearchTitle,
+				e => e.Type,
+				e => e.Parents,
+				e => e.Headings,
+				e => e.Links,
+				e => e.Body,
+				e => e.AiShortSummary,
+				e => e.AiQuestions,
+				e => e.AiUseCases
+			))),
 				ct);
 
 			if (!response.IsValidResponse || response.Documents.Count == 0)


### PR DESCRIPTION
## Issue

`GetDocumentByUrl` and `AnalyzeDocumentStructure` return a JSON deserialization error for every document:

```
JSON deserialization for type 'Elastic.Documentation.Search.DocumentationDocument'
was missing required properties including: 'search_title'
```

## Root cause

The Elasticsearch `_source` filter in `DocumentGateway` omits fields that are marked `required` on the `DocumentationDocument` record:

- `GetByUrlAsync` was missing `search_title`.
- `GetStructureAsync` was missing both `search_title` and `type`.

When partial documents come back from Elasticsearch, the System.Text.Json deserializer throws because required properties are absent.

## Fix

Add `SearchTitle` to the `GetByUrlAsync` source filter, and both `SearchTitle` and `Type` to the `GetStructureAsync` source filter.

## LLM usage

This fix was developed with Claude 4.6 Opus and Cursor.

Made with [Cursor](https://cursor.com)