### PR TITLE
Decrease LogToStandardErrorThreshold to Trace

### DIFF
--- a/src/Elastic.Documentation.ServiceDefaults/AppDefaultsExtensions.cs
+++ b/src/Elastic.Documentation.ServiceDefaults/AppDefaultsExtensions.cs
@@ -57,7 +57,11 @@ public static class AppDefaultsExtensions
 			if (!noConsole)
 			{
 				services.TryAddEnumerable(ServiceDescriptor.Singleton<ConsoleFormatter, CondensedConsoleFormatter>());
-				_ = x.AddConsole(c => c.FormatterName = "condensed");
+				_ = x.AddConsole(c =>
+				{
+					c.FormatterName = "condensed";
+					c.LogToStandardErrorThreshold = LogLevel.Trace;
+				});
 			}
 		});
 		return services;


### PR DESCRIPTION
## Summary

- Redirect all console log output to stderr by setting `LogToStandardErrorThreshold` to `LogLevel.Trace`, keeping stdout reserved for program output only.

## Motivation

Currently all log messages are written to stdout alongside actual program output. This makes it impossible to reliably capture program output in scripts:
```
# Before: captures logs + version string
version=$(docs-builder --version)
# $version = "info ::e.d.c.tionFileProvider:: ConfigurationSource.Local: ...\n...0.118.0"

# After: captures only the version string
version=$(docs-builder --version)
# $version = "0.118.0"
```