### PR TITLE
Remove label event from assembler preview

### DIFF
--- a/.github/workflows/assembler-preview.yml
+++ b/.github/workflows/assembler-preview.yml
@@ -1,12 +1,7 @@
 name: assembler-preview
 
 on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - labeled
+  pull_request: ~
   workflow_dispatch:
     inputs:
       pr_number:


### PR DESCRIPTION
It's running anyway on every PR, which proved to be useful.

This way it won't re-trigger when a label is added.