### PR TITLE
AskAi: add header button to Codex and centralize config per build type

### DIFF
--- a/src/Elastic.Documentation.ServiceDefaults/Logging/CondensedConsoleLogger.cs
+++ b/src/Elastic.Documentation.ServiceDefaults/Logging/CondensedConsoleLogger.cs
@@ -27,6 +27,9 @@ public class CondensedConsoleFormatter() : ConsoleFormatter("condensed")
 			: now.ToString("[yyyy-MM-ddTHH:mm:ss.fffZ] ", System.Globalization.CultureInfo.InvariantCulture);
 
 		textWriter.WriteLine($"{nowString}{logLevel}::{ShortCategoryName(categoryName)}:: {message}");
+
+		if (logEntry.Exception is { } exception)
+			textWriter.WriteLine(exception.ToString());
 	}
 
 	private static string GetLogLevel(LogLevel logLevel) => logLevel switch

--- a/src/Elastic.Documentation.Site/Assets/web-components/AskAi/AskAi.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/AskAi/AskAi.tsx
@@ -1,15 +1,9 @@
 import '../../eui-icons-cache'
 import { sharedQueryClient } from '../shared/queryClient'
 import { ElasticAiAssistantButton } from './ElasticAiAssistantButton'
-import {
-    useAskAiModalActions,
-    useAskAiModalIsOpen,
-    useFlyoutWidth,
-} from './askAi.modal.store'
+import { AskAiFlyoutBodyContent, useAskAiFlyout } from './useAskAiFlyout'
 import {
     EuiFlyout,
-    EuiFlyoutBody,
-    EuiLoadingSpinner,
     EuiProvider,
     euiShadow,
     euiShadowHover,
@@ -17,41 +11,12 @@ import {
 } from '@elastic/eui'
 import { css } from '@emotion/react'
 import r2wc from '@r2wc/react-to-web-component'
-import { QueryClientProvider, useQuery } from '@tanstack/react-query'
-import { useEffect, Suspense, lazy, StrictMode } from 'react'
+import { QueryClientProvider } from '@tanstack/react-query'
+import { StrictMode } from 'react'
 
-// Lazy load the modal component
-const LazyAskAiModal = lazy(() =>
-    import('./AskAiModal').then((module) => ({
-        default: module.AskAiModal,
-    }))
-)
-
-const AskAiButton = () => {
-    const isModalOpen = useAskAiModalIsOpen()
-    const { openModal, closeModal, setFlyoutWidth } = useAskAiModalActions()
-    const flyoutWidth = useFlyoutWidth()
-    const euiThemeContext = useEuiTheme()
+const fabContainerCss = (euiThemeContext: ReturnType<typeof useEuiTheme>) => {
     const { euiTheme } = euiThemeContext
-
-    const { data: isApiAvailable } = useQuery({
-        queryKey: ['api-health'],
-        queryFn: async () => {
-            const response = await fetch('/docs/_api/v1/', { method: 'POST' })
-            return response.ok
-        },
-        staleTime: 60 * 60 * 1000, // 60 minutes
-        retry: false,
-    })
-
-    const loadingCss = css`
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        padding: 2rem;
-    `
-
-    const fabContainerCss = css`
+    return css`
         position: fixed;
         bottom: ${euiTheme.size.xxxxl};
         right: ${euiTheme.size.xxxxl};
@@ -69,67 +34,45 @@ const AskAiButton = () => {
             transform: translateY(0);
         }
     `
+}
 
-    useEffect(() => {
-        const handleKeydown = (event: KeyboardEvent) => {
-            if (event.key === 'Escape') {
-                event.preventDefault()
-                closeModal()
-            }
-            // Cmd+; to open Ask AI flyout
-            if (
-                (event.metaKey || event.ctrlKey) &&
-                event.code === 'Semicolon'
-            ) {
-                event.preventDefault()
-                openModal()
-            }
-        }
-        window.addEventListener('keydown', handleKeydown)
-        return () => window.removeEventListener('keydown', handleKeydown)
-    }, [openModal, closeModal])
+const AskAiButton = () => {
+    const euiThemeContext = useEuiTheme()
+    const {
+        isApiAvailable,
+        isModalOpen,
+        openModal,
+        closeModal,
+        setFlyoutWidth,
+        flyoutWidth,
+    } = useAskAiFlyout()
 
     if (!isApiAvailable) {
         return null
     }
 
-    let flyout
-    if (isModalOpen) {
-        flyout = (
-            <EuiFlyout
-                ownFocus={false}
-                onClose={closeModal}
-                aria-label="Ask AI"
-                resizable={true}
-                minWidth={376}
-                maxWidth={700}
-                paddingSize="none"
-                hideCloseButton={true}
-                size={flyoutWidth}
-                onResize={setFlyoutWidth}
-                outsideClickCloses={false}
-            >
-                <EuiFlyoutBody>
-                    <div css={backgroundWrapperCss}>
-                        <Suspense
-                            fallback={
-                                <div css={loadingCss}>
-                                    <EuiLoadingSpinner size="xl" />
-                                </div>
-                            }
-                        >
-                            <LazyAskAiModal />
-                        </Suspense>
-                    </div>
-                </EuiFlyoutBody>
-            </EuiFlyout>
-        )
-    }
+    const flyout = isModalOpen ? (
+        <EuiFlyout
+            ownFocus={false}
+            onClose={closeModal}
+            aria-label="Ask AI"
+            resizable={true}
+            minWidth={376}
+            maxWidth={700}
+            paddingSize="none"
+            hideCloseButton={true}
+            size={flyoutWidth}
+            onResize={setFlyoutWidth}
+            outsideClickCloses={false}
+        >
+            <AskAiFlyoutBodyContent />
+        </EuiFlyout>
+    ) : null
 
     return (
         <>
             {!isModalOpen && (
-                <div css={fabContainerCss}>
+                <div css={fabContainerCss(euiThemeContext)}>
                     <ElasticAiAssistantButton
                         onClick={openModal}
                         aria-label="Open Ask AI"
@@ -143,47 +86,6 @@ const AskAiButton = () => {
         </>
     )
 }
-
-const backgroundWrapperCss = css`
-    position: relative;
-    min-height: 100%;
-
-    &::before {
-        content: '';
-        position: absolute;
-        top: 38px;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background-color: #e5e5f7;
-        pointer-events: none;
-        z-index: 0;
-
-        opacity: 0.4;
-        background-image: radial-gradient(#444cf7 0.5px, #ffffff 0.5px);
-        background-size: 10px 10px;
-
-        mask-image: linear-gradient(
-            to bottom,
-            rgba(0, 0, 0, 1) 0%,
-            rgba(0, 0, 0, 1) 10%,
-            rgba(0, 0, 0, 0.5) 20%,
-            rgba(0, 0, 0, 0) 30%
-        );
-        -webkit-mask-image: linear-gradient(
-            to bottom,
-            rgba(0, 0, 0, 1) 0%,
-            rgba(0, 0, 0, 1) 10%,
-            rgba(0, 0, 0, 0.5) 20%,
-            rgba(0, 0, 0, 0) 30%
-        );
-    }
-
-    & > * {
-        position: relative;
-        z-index: 1;
-    }
-`
 
 const AskAi = () => {
     return (

--- a/src/Elastic.Documentation.Site/Assets/web-components/AskAi/AskAiHeaderButton.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/AskAi/AskAiHeaderButton.tsx
@@ -1,0 +1,63 @@
+import '../../eui-icons-cache'
+import { ElasticAiAssistantButton } from './ElasticAiAssistantButton'
+import { AskAiFlyoutBodyContent, useAskAiFlyout } from './useAskAiFlyout'
+import { EuiFlyout, EuiPortal, EuiThemeProvider } from '@elastic/eui'
+import { css } from '@emotion/react'
+
+const headerButtonWrapperCss = css`
+    display: flex;
+    align-items: center;
+    margin-left: 8px;
+`
+
+export const AskAiHeaderButton = () => {
+    const {
+        isApiAvailable,
+        isModalOpen,
+        openModal,
+        closeModal,
+        setFlyoutWidth,
+        flyoutWidth,
+    } = useAskAiFlyout()
+
+    if (!isApiAvailable) {
+        return null
+    }
+
+    return (
+        <>
+            <span css={headerButtonWrapperCss}>
+                <ElasticAiAssistantButton
+                    aria-label="Ask AI"
+                    onClick={isModalOpen ? closeModal : openModal}
+                    fill={true}
+                    size="s"
+                >
+                    Ask AI
+                </ElasticAiAssistantButton>
+            </span>
+
+            {isModalOpen && (
+                <EuiPortal>
+                    <EuiThemeProvider colorMode="light">
+                        <EuiFlyout
+                            ownFocus={false}
+                            onClose={closeModal}
+                            aria-label="Ask AI"
+                            resizable={true}
+                            minWidth={376}
+                            maxWidth={700}
+                            paddingSize="none"
+                            hideCloseButton={true}
+                            size={flyoutWidth}
+                            onResize={setFlyoutWidth}
+                            outsideClickCloses={false}
+                        >
+                            <AskAiFlyoutBodyContent />
+                        </EuiFlyout>
+                    </EuiThemeProvider>
+                </EuiPortal>
+            )}
+        </>
+    )
+}

--- a/src/Elastic.Documentation.Site/Assets/web-components/AskAi/AskAiSuggestions.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/AskAi/AskAiSuggestions.tsx
@@ -1,50 +1,19 @@
+import { askAiConfig } from './askAi.config'
 import { useChatActions } from './chat.store'
 import { useIsAskAiCooldownActive } from './useAskAiCooldown'
 import { EuiButton, EuiText, useEuiTheme, EuiSpacer } from '@elastic/eui'
 import { css } from '@emotion/react'
 import { useMemo } from 'react'
 
-export interface AskAiSuggestion {
-    question: string
-}
-
-// Comprehensive list of AI suggestion questions
-const ALL_SUGGESTIONS: AskAiSuggestion[] = [
-    { question: 'How do I set up a data stream in Elasticsearch?' },
-    { question: 'What are the best practices for indexing performance?' },
-    { question: 'How can I create a dashboard in Kibana?' },
-    { question: 'What is the difference between a keyword and text field?' },
-    { question: 'How do I configure machine learning jobs?' },
-    { question: 'What are aggregations and how do I use them?' },
-    { question: 'How do I set up Elasticsearch security and authentication?' },
-    { question: 'What are the different types of Elasticsearch queries?' },
-    { question: 'How do I monitor cluster health and performance?' },
-    {
-        question:
-            'What is the Elastic Stack and how do the components work together?',
-    },
-    { question: 'How do I create and manage Elasticsearch indices?' },
-    { question: 'What are the best practices for Elasticsearch mapping?' },
-    { question: 'How do I set up log shipping with Beats?' },
-    { question: 'What is APM and how do I use it for application monitoring?' },
-    { question: 'How do I create custom visualizations in Kibana?' },
-    { question: 'What are Elasticsearch snapshots and how do I use them?' },
-    { question: 'How do I configure cross-cluster search?' },
-    {
-        question:
-            'What are the different Elasticsearch node types and their roles?',
-    },
-]
-
 export const AskAiSuggestions = () => {
     const { submitQuestion } = useChatActions()
     const disabled = useIsAskAiCooldownActive()
     const { euiTheme } = useEuiTheme()
 
-    // Randomly select 3 questions from the comprehensive list
     const selectedSuggestions = useMemo(() => {
-        // Shuffle the array and take first 3
-        const shuffled = [...ALL_SUGGESTIONS].sort(() => Math.random() - 0.5)
+        const shuffled = [...askAiConfig.suggestions].sort(
+            () => Math.random() - 0.5
+        )
         return shuffled.slice(0, 3)
     }, [])
 

--- a/src/Elastic.Documentation.Site/Assets/web-components/AskAi/Chat.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/AskAi/Chat.tsx
@@ -4,6 +4,7 @@ import { ChatMessageList } from './ChatMessageList'
 import { InfoBanner } from './InfoBanner'
 import { LegalDisclaimer } from './LegalDisclaimer'
 import AiIcon from './ai-icon.svg'
+import { askAiConfig } from './askAi.config'
 import { useAskAiModalActions } from './askAi.modal.store'
 import {
     ChatMessage,
@@ -74,14 +75,8 @@ export const Chat = () => {
                 <EuiFlexItem grow={true} css={emptyStateContainerStyles}>
                     <EuiEmptyPrompt
                         icon={<EuiIcon type={AiIcon} size="xxl" />}
-                        title={<h2>Hi! I'm the Elastic Docs AI Assistant</h2>}
-                        body={
-                            <p>
-                                I'm here to help you find answers about Elastic,
-                                powered entirely by our technical documentation.
-                                How can I help?
-                            </p>
-                        }
+                        title={<h2>Hi! I'm the {askAiConfig.assistantName}</h2>}
+                        body={<p>{askAiConfig.assistantDescription}</p>}
                     />
                 </EuiFlexItem>
             ) : !hasHydrated ? (
@@ -178,7 +173,7 @@ const ChatHeader = () => {
                             font-weight: ${euiTheme.font.weight.medium};
                         `}
                     >
-                        Elastic Docs AI Assistant
+                        {askAiConfig.assistantName}
                     </span>
                 </div>
                 <div

--- a/src/Elastic.Documentation.Site/Assets/web-components/AskAi/ChatInput.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/AskAi/ChatInput.tsx
@@ -1,4 +1,5 @@
 import { ElasticAiAssistantButtonIcon } from './ElasticAiAssistantButton'
+import { askAiConfig } from './askAi.config'
 import { euiShadow, useEuiScrollBar, useEuiTheme } from '@elastic/eui'
 import { css } from '@emotion/react'
 import { useCallback, useEffect, useRef } from 'react'
@@ -28,7 +29,7 @@ export const ChatInput = ({
     onSubmit,
     onAbort,
     disabled = false,
-    placeholder = 'Ask the Elastic Docs AI Assistant',
+    placeholder = askAiConfig.inputPlaceholder,
     inputRef,
     isStreaming = false,
     onMetaSemicolon,

--- a/src/Elastic.Documentation.Site/Assets/web-components/AskAi/askAi.config.ts
+++ b/src/Elastic.Documentation.Site/Assets/web-components/AskAi/askAi.config.ts
@@ -1,0 +1,84 @@
+import { config } from '../../config'
+
+interface AskAiSuggestion {
+    question: string
+}
+
+interface AskAiConfig {
+    assistantName: string
+    assistantDescription: string
+    inputPlaceholder: string
+    defaultAiProvider: 'AgentBuilder' | 'LlmGateway'
+    forceAiProvider: boolean
+    suggestions: AskAiSuggestion[]
+}
+
+const codexConfig: AskAiConfig = {
+    assistantName: 'Codex AI Assistant',
+    assistantDescription:
+        "I'm here to help you navigate Elastic's internal documentation. Ask me anything about our internal processes, tools, and standards. How can I help?",
+    inputPlaceholder: 'Ask the Codex AI Assistant',
+    defaultAiProvider: 'AgentBuilder',
+    forceAiProvider: true,
+    suggestions: [
+        { question: 'How do I get started with Codex?' },
+        { question: 'How do I set up Codex for my repository?' },
+        {
+            question:
+                'How does Codex assemble docs from multiple repositories?',
+        },
+        { question: 'How do I migrate my docs from Docsmobile to Codex?' },
+        {
+            question:
+                'How do I configure Codex CI previews for my documentation?',
+        },
+        { question: 'What is a Codex docset.yml and how do I configure it?' },
+    ],
+}
+
+const defaultConfig: AskAiConfig = {
+    assistantName: 'Elastic Docs AI Assistant',
+    assistantDescription:
+        "I'm here to help you find answers about Elastic, powered entirely by our technical documentation. How can I help?",
+    inputPlaceholder: 'Ask the Elastic Docs AI Assistant',
+    defaultAiProvider: 'LlmGateway',
+    forceAiProvider: false,
+    suggestions: [
+        { question: 'How do I set up a data stream in Elasticsearch?' },
+        { question: 'What are the best practices for indexing performance?' },
+        { question: 'How can I create a dashboard in Kibana?' },
+        {
+            question:
+                'What is the difference between a keyword and text field?',
+        },
+        { question: 'How do I configure machine learning jobs?' },
+        { question: 'What are aggregations and how do I use them?' },
+        {
+            question:
+                'How do I set up Elasticsearch security and authentication?',
+        },
+        { question: 'What are the different types of Elasticsearch queries?' },
+        { question: 'How do I monitor cluster health and performance?' },
+        {
+            question:
+                'What is the Elastic Stack and how do the components work together?',
+        },
+        { question: 'How do I create and manage Elasticsearch indices?' },
+        { question: 'What are the best practices for Elasticsearch mapping?' },
+        { question: 'How do I set up log shipping with Beats?' },
+        {
+            question:
+                'What is APM and how do I use it for application monitoring?',
+        },
+        { question: 'How do I create custom visualizations in Kibana?' },
+        { question: 'What are Elasticsearch snapshots and how do I use them?' },
+        { question: 'How do I configure cross-cluster search?' },
+        {
+            question:
+                'What are the different Elasticsearch node types and their roles?',
+        },
+    ],
+}
+
+export const askAiConfig =
+    config.buildType === 'codex' ? codexConfig : defaultConfig

--- a/src/Elastic.Documentation.Site/Assets/web-components/AskAi/useAskAiFlyout.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/AskAi/useAskAiFlyout.tsx
@@ -1,0 +1,123 @@
+import {
+    useAskAiModalActions,
+    useAskAiModalIsOpen,
+    useFlyoutWidth,
+} from './askAi.modal.store'
+import { EuiFlyoutBody, EuiLoadingSpinner } from '@elastic/eui'
+import { css } from '@emotion/react'
+import { useQuery } from '@tanstack/react-query'
+import { useEffect, Suspense, lazy } from 'react'
+
+const LazyAskAiModal = lazy(() =>
+    import('./AskAiModal').then((module) => ({
+        default: module.AskAiModal,
+    }))
+)
+
+const loadingCss = css`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 2rem;
+`
+
+const backgroundWrapperCss = css`
+    position: relative;
+    min-height: 100%;
+
+    &::before {
+        content: '';
+        position: absolute;
+        top: 38px;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: #e5e5f7;
+        pointer-events: none;
+        z-index: 0;
+
+        opacity: 0.4;
+        background-image: radial-gradient(#444cf7 0.5px, #ffffff 0.5px);
+        background-size: 10px 10px;
+
+        mask-image: linear-gradient(
+            to bottom,
+            rgba(0, 0, 0, 1) 0%,
+            rgba(0, 0, 0, 1) 10%,
+            rgba(0, 0, 0, 0.5) 20%,
+            rgba(0, 0, 0, 0) 30%
+        );
+        -webkit-mask-image: linear-gradient(
+            to bottom,
+            rgba(0, 0, 0, 1) 0%,
+            rgba(0, 0, 0, 1) 10%,
+            rgba(0, 0, 0, 0.5) 20%,
+            rgba(0, 0, 0, 0) 30%
+        );
+    }
+
+    & > * {
+        position: relative;
+        z-index: 1;
+    }
+`
+
+export const AskAiFlyoutBodyContent = () => (
+    <EuiFlyoutBody>
+        <div css={backgroundWrapperCss}>
+            <Suspense
+                fallback={
+                    <div css={loadingCss}>
+                        <EuiLoadingSpinner size="xl" />
+                    </div>
+                }
+            >
+                <LazyAskAiModal />
+            </Suspense>
+        </div>
+    </EuiFlyoutBody>
+)
+
+export const useAskAiFlyout = () => {
+    const isModalOpen = useAskAiModalIsOpen()
+    const { openModal, closeModal, setFlyoutWidth } = useAskAiModalActions()
+    const flyoutWidth = useFlyoutWidth()
+
+    const { data: isApiAvailable } = useQuery({
+        queryKey: ['api-health'],
+        queryFn: async () => {
+            const response = await fetch('/docs/_api/v1/', { method: 'POST' })
+            return response.ok
+        },
+        staleTime: 60 * 60 * 1000, // 60 minutes
+        retry: false,
+    })
+
+    useEffect(() => {
+        const handleKeydown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                event.preventDefault()
+                closeModal()
+            }
+            // Cmd+; to open Ask AI flyout
+            if (
+                (event.metaKey || event.ctrlKey) &&
+                event.code === 'Semicolon'
+            ) {
+                event.preventDefault()
+                openModal()
+            }
+        }
+        window.addEventListener('keydown', handleKeydown)
+        return () => window.removeEventListener('keydown', handleKeydown)
+    }, [openModal, closeModal])
+
+    return {
+        isApiAvailable: isApiAvailable ?? false,
+        isModalOpen,
+        openModal,
+        closeModal,
+        setFlyoutWidth,
+        flyoutWidth,
+    }
+}

--- a/src/Elastic.Documentation.Site/Assets/web-components/CodexHeader/Header.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/CodexHeader/Header.tsx
@@ -1,14 +1,9 @@
 import '../../eui-icons-cache'
+import { AskAiHeaderButton } from '../AskAi/AskAiHeaderButton'
 import { NavigationSearch } from '../NavigationSearch/NavigationSearch'
 import { useHtmxContainer } from '../shared/htmx/useHtmxContainer'
 import { sharedQueryClient } from '../shared/queryClient'
-import {
-    EuiHeader,
-    EuiHeaderLogo,
-    EuiHeaderSectionItemButton,
-    EuiIcon,
-    EuiProvider,
-} from '@elastic/eui'
+import { EuiHeader, EuiHeaderLogo, EuiProvider } from '@elastic/eui'
 import r2wc from '@r2wc/react-to-web-component'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { useRef } from 'react'
@@ -51,9 +46,10 @@ export const Header = ({ title, logoHref }: Props) => {
                                     size="s"
                                     placeholder="Search"
                                 />,
-                                <EuiHeaderSectionItemButton>
-                                    <EuiIcon type="sun" />
-                                </EuiHeaderSectionItemButton>,
+                                <AskAiHeaderButton key="ask-ai" />,
+                                // <EuiHeaderSectionItemButton key="theme">
+                                //     <EuiIcon type="sun" />
+                                // </EuiHeaderSectionItemButton>,
                             ],
                         },
                     ]}

--- a/src/Elastic.Documentation.Site/Assets/web-components/shared/askAiStreamClient.ts
+++ b/src/Elastic.Documentation.Site/Assets/web-components/shared/askAiStreamClient.ts
@@ -4,6 +4,7 @@
  */
 import { logWarn } from '../../telemetry/logging'
 import { AskAiEvent, AskAiEventSchema } from '../AskAi/AskAiEvent'
+import { askAiConfig } from '../AskAi/askAi.config'
 import {
     ApiError,
     createApiErrorFromResponse,
@@ -16,6 +17,8 @@ import {
 } from '@microsoft/fetch-event-source'
 
 export type AiProvider = 'AgentBuilder' | 'LlmGateway'
+
+const defaultAiProvider: AiProvider = askAiConfig.defaultAiProvider
 
 const API_ENDPOINT = '/docs/_api/v1/ask-ai/stream'
 
@@ -52,7 +55,7 @@ export async function startAskAiStream(options: StreamOptions): Promise<void> {
     const {
         message,
         conversationId,
-        aiProvider = 'LlmGateway',
+        aiProvider = defaultAiProvider,
         signal,
         callbacks,
     } = options


### PR DESCRIPTION
## What

- Add an Ask AI button to the Codex header and extract shared flyout logic into a reusable hook
- Introduce a centralized config that controls AI provider defaults and suggestions per build type (Codex vs Assembler)

## Why

- Codex needs its own Ask AI entry point in the header, separate from the floating action button used in Assembler
- AI provider selection was hardcoded in multiple places, making it difficult to switch between providers per build type

## Notes

- The flyout body, keyboard shortcuts, and API health check are now shared via a `useAskAiFlyout` hook
- Codex forces `AgentBuilder` as the AI provider; Assembler continues to default to `LlmGateway`
- Console logger now prints exception details when available


Made with [Cursor](https://cursor.com)