### PR TITLE
Fix changelog bundle --directory

### DIFF
--- a/src/tooling/docs-builder/Commands/ChangelogCommand.cs
+++ b/src/tooling/docs-builder/Commands/ChangelogCommand.cs
@@ -627,7 +627,7 @@ internal sealed partial class ChangelogCommand(
 
 		var input = new BundleChangelogsArguments
 		{
-			Directory = directory ?? Directory.GetCurrentDirectory(),
+			Directory = directory,
 			Output = processedOutput,
 			All = all,
 			InputProducts = inputProducts,


### PR DESCRIPTION
Relates to https://github.com/elastic/docs-builder/issues/2775

## Summary

The `docs-builder changelog bundle` command has some bugginess around the `--directory` option when the `bundle.directory` changelog configuration setting exists.

## Implementation

1. `ChangelogBundlingService.cs`
   - `BundleChangelogsArguments.Directory` is now `string?` so “not specified” is distinct from “specified”.
   - `ApplyConfigDefaults` only applies config when `input.Directory == null`; if the user passes `--directory .` (or any path), that value is kept.
   - `ProcessProfile` and call sites correctly support a null directory.

2. `ChangelogCommand.cs`
   - The bundle command now forwards `Directory = directory` instead of `Directory = directory ?? Directory.GetCurrentDirectory()`, so `null` is passed when `--directory` is omitted.

3. Tests
   - `BundleChangelogs_WithConfigDirectory_WhenDirectoryNotSpecified_UsesConfigDirectory` – asserts config is used when `Directory` is null.
   - `BundleChangelogs_WithExplicitDirectory_OverridesConfigDirectory` – asserts the CLI directory overrides config when `--directory` is set, even when it equals the current directory.

## Steps to test

1. Add a changelog configuration file (I used the one from https://github.com/elastic/kibana/pull/250840)
2. Verify that the `bundle.directory` is set in the changelog configuration file (e.g. to `docs/changelog`).
3. Copy a changelog file into a directory other than what's set in the changelog configuration file (e.g. I copied `224552.yaml` into `docs/test` and changed its `title` value so I'd know where it was being found).
4. Go into that new directory and try to create a changelog bundle with changelogs derived from the current directory. For example, from the `docs/test` directory, I ran:
    ```sh
    docs-builder changelog bundle \
    --config ~/Documents/GitHub/kibana/docs/changelog.yml \                             
    --prs 224552 --repo kibana --owner elastic \                          
    --output-products "kibana 9.3.0 *" --resolve \
    --directory . 
    ```
   In https://github.com/elastic/docs-builder/issues/2775 it said this failed but in my test it succeeded (i.e. I could not recreate the exact problem the AI analysis identified).
5. Create a changelog bundle and use the `--directory` option with something other than the current directory. For example:
    ```sh
    docs-builder changelog bundle \
    --config ~/Documents/GitHub/kibana/docs/changelog.yml \
    --prs 224552 --repo kibana --owner elastic \
    --output-products "kibana 9.3.0 *"  --resolve \
    --directory ~/Documents/GitHub/kibana/docs/test
    ```
    Before this PR, this second command failed with this error, which seems to indicate that it was trying to use the `bundle.directory` value instead of (or as well as) the `--directory` value:
    ```sh
    info ::d.b.f.StopwatchFilter :: changelog bundle :: Starting...
    error::d.b.d.Log             :: Directory does not exist (docs/changelog:0)
    The following errors and warnings were found in the documentation
    Error: Directory does not exist
    NOTE: docs/changelog
    ```
    After this PR, the second command succeeds (i.e. it no longer returns this error and bundles the changelog from the directory that was specified in `--directory`).

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
6. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: composer-1.5
