### PR TITLE
Skip link index upload when no docs files changed on push

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -167,7 +167,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Get changed files
-        if: contains(fromJSON('["merge_group", "pull_request", "pull_request_target"]'), github.event_name)
+        if: contains(fromJSON('["push", "merge_group", "pull_request", "pull_request_target"]'), github.event_name)
         id: check-files
         uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46.0.1
         with:
@@ -512,6 +512,7 @@ jobs:
       - name: Update Link Index
         if: >
           env.MATCH == 'true'
+          && needs.check.outputs.any_modified != 'false'
           && (
             contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name) 
             && steps.s3-upload.outcome == 'success'


### PR DESCRIPTION
## What

- Skip the "Update Link Index" step in `preview-build.yml` when a push to main does not include changes to docs files
- Extend the changed-files check to also run on `push` events (previously only ran for PRs and merge groups)

## Why

- Every push to main (across all 96 configured repos) was uploading `links.json` to S3, even when no docs files changed
- Each upload triggers the link-index updater Lambda, which rewrites `link-index.json`, which triggers the dispatcher Lambda, which triggers a full assembler rebuild
- High-velocity repos like Kibana (13k+ workflow runs) were generating constant redundant rebuilds — commits like "skip flaky suite" or dependency bumps were triggering the full chain

## Notes

- The `!= 'false'` check (rather than `== 'true'`) ensures `workflow_dispatch` events still proceed, since `any_modified` is unset for those
- Repos that don't set `path-pattern` (all files are docs) will still upload on every push, which is correct behavior

Made with [Cursor](https://cursor.com)