### PR TITLE
Add profile-based changelog removal

### DIFF
--- a/config/changelog.example.yml
+++ b/config/changelog.example.yml
@@ -170,7 +170,12 @@ bundle:
   # Whether to resolve (copy contents) by default
   resolve: true
 
-  # Named bundle profiles for different release scenarios
+  # Named bundle profiles for different release scenarios.
+  # Profiles can be used with both 'changelog bundle' and 'changelog remove':
+  #   docs-builder changelog bundle elasticsearch-release 9.2.0
+  #   docs-builder changelog remove elasticsearch-release 9.2.0
+  # When used with 'changelog remove', only the 'products' field is applied.
+  # The 'output' and 'hide_features' fields are bundle-specific and are ignored for removal.
   profiles:
     # Example: Elasticsearch release profile
     # elasticsearch-release:

--- a/docs/contribute/changelog.md
+++ b/docs/contribute/changelog.md
@@ -836,8 +836,7 @@ Likewise, the `docs-builder changelog render` command fails for "unresolved" bun
 :::
 
 You can use the `docs-builder changelog remove` command to remove changelogs.
-It has the same filter options as `changelog bundle` (that is to say, you can remove changelogs based their issues or pull requests, product metadata, or folder).
-Exactly one filter option must be specified.
+It supports the same two modes as `changelog bundle`: profile-based and raw flags.
 
 Before deleting, the command automatically scans for bundles that still hold unresolved (`file:`) references to the matching changelog files.
 If any are found, the command reports an error for each dependency.
@@ -847,7 +846,41 @@ To proceed with removal even when unresolved bundle dependencies exist, use `--f
 To preview what would be removed without deleting anything, use `--dry-run`.
 Bundle dependency conflicts are also reported in dry-run mode.
 
-For example:
+### Removal with profiles [changelog-remove-profile]
+
+If your `changelog.yml` configuration file defines `bundle.profiles`, you can use those profiles with `changelog remove`.
+This is the easiest way to remove exactly the changelogs that were included in a profile-based bundle.
+The command syntax is:
+
+```sh
+docs-builder changelog remove <profile> <version|promotion-report>
+```
+
+For example, if you bundled with:
+
+```sh
+docs-builder changelog bundle elasticsearch-release 9.2.0
+```
+
+You can remove the same changelogs with:
+
+```sh
+docs-builder changelog remove elasticsearch-release 9.2.0 --dry-run
+```
+
+Only the `products` field from the profile configuration is used for removal.
+The `output` and `hide_features` fields are bundle-specific and are ignored.
+
+You can also pass a promotion report URL or file path as the second argument, and the command removes changelogs whose pull request URLs appear in the report:
+
+```sh
+docs-builder changelog remove elasticsearch-release https://buildkite.../promotion-report.html
+```
+
+### Removal with command options [changelog-remove-raw]
+
+You can alternatively remove changelogs based on their issues, pull requests, product metadata, or remove all changelogs from a folder.
+Exactly one filter option must be specified: `--all`, `--products`, `--prs`, or `--issues`.
 
 ```sh
 docs-builder changelog remove --products "elasticsearch 9.3.0 *" --dry-run

--- a/src/services/Elastic.Changelog/Bundling/ProfileFilterResolver.cs
+++ b/src/services/Elastic.Changelog/Bundling/ProfileFilterResolver.cs
@@ -1,0 +1,145 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions;
+using Elastic.Documentation.Configuration.Changelog;
+using Elastic.Documentation.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Elastic.Changelog.Bundling;
+
+/// <summary>
+/// The resolved filter derived from a bundle profile — either a product list or a set of PR URLs.
+/// Exactly one of <see cref="Products"/> and <see cref="Prs"/> will be non-null on a successful result.
+/// </summary>
+public record ProfileFilterResult
+{
+	/// <summary>Product/target/lifecycle filters parsed from the profile's products pattern.</summary>
+	public IReadOnlyList<ProductArgument>? Products { get; init; }
+
+	/// <summary>PR URLs extracted from a promotion report supplied as the profile argument.</summary>
+	public string[]? Prs { get; init; }
+
+	/// <summary>
+	/// The resolved version string used for placeholder substitution.
+	/// This is the profile argument itself for version-based invocations, or <c>"unknown"</c> when
+	/// a promotion report was parsed (because the actual version is not available from the report).
+	/// </summary>
+	public string Version { get; init; } = "unknown";
+}
+
+/// <summary>
+/// Resolves a <see cref="BundleProfile"/> and a profile argument (version string or promotion
+/// report URL/path) into a concrete filter that can be used by both
+/// <see cref="ChangelogBundlingService"/> and <see cref="ChangelogRemoveService"/>.
+/// </summary>
+public static class ProfileFilterResolver
+{
+	/// <summary>
+	/// Resolves the profile into a <see cref="ProfileFilterResult"/>, or returns <c>null</c> and
+	/// emits diagnostics errors on failure.
+	/// </summary>
+	public static async Task<ProfileFilterResult?> ResolveAsync(
+		IDiagnosticsCollector collector,
+		string profileName,
+		string? profileArgument,
+		ChangelogConfiguration? config,
+		IFileSystem fileSystem,
+		ILogger? logger,
+		Cancel ctx)
+	{
+		if (config?.Bundle?.Profiles == null || !config.Bundle.Profiles.TryGetValue(profileName, out var profile))
+		{
+			collector.EmitError(string.Empty, $"Profile '{profileName}' not found in bundle.profiles configuration");
+			return null;
+		}
+
+		if (string.IsNullOrWhiteSpace(profileArgument))
+		{
+			collector.EmitError(string.Empty, $"Profile '{profileName}' requires a version number or promotion report URL as the second argument");
+			return null;
+		}
+
+		// Auto-detect argument type
+		var argType = PromotionReportParser.DetectArgumentType(profileArgument);
+
+		// Treat an existing local file path as a promotion report
+		if (argType == ProfileArgumentType.Version && fileSystem.File.Exists(profileArgument))
+			argType = ProfileArgumentType.PromotionReportFile;
+
+		string version;
+		string[]? prsFromReport = null;
+
+		if (argType is ProfileArgumentType.PromotionReportUrl or ProfileArgumentType.PromotionReportFile)
+		{
+			var parser = new PromotionReportParser(NullLoggerFactory.Instance, fileSystem);
+			var reportResult = await parser.ParsePromotionReportAsync(profileArgument, ctx);
+
+			if (!reportResult.IsValid)
+			{
+				collector.EmitError(string.Empty, reportResult.ErrorMessage ?? "Failed to parse promotion report");
+				return null;
+			}
+
+			prsFromReport = reportResult.PrUrls.ToArray();
+			logger?.LogInformation("Extracted {Count} PRs from promotion report", prsFromReport.Length);
+
+			version = "unknown";
+		}
+		else
+		{
+			version = profileArgument;
+		}
+
+		// Substitute {version} and {lifecycle} in the products pattern
+		var lifecycle = VersionLifecycleInference.InferLifecycle(version);
+		var productsPattern = profile.Products?
+			.Replace("{version}", version)
+			.Replace("{lifecycle}", lifecycle);
+
+		// If we have PRs from a report, return those directly
+		if (prsFromReport != null)
+			return new ProfileFilterResult { Prs = prsFromReport, Version = version };
+
+		// Without a promotion report we need a products pattern to filter by
+		if (string.IsNullOrWhiteSpace(productsPattern))
+		{
+			collector.EmitError(
+				string.Empty,
+				$"Profile '{profileName}' has no 'products' pattern configured and no promotion report was provided — cannot determine filter"
+			);
+			return null;
+		}
+
+		var products = ParseProfileProducts(productsPattern);
+		return new ProfileFilterResult { Products = products, Version = version };
+	}
+
+	/// <summary>
+	/// Parses a products pattern like <c>"elasticsearch 9.2.0 ga"</c> or
+	/// <c>"cloud-serverless {version} *"</c> (after placeholder substitution) into a
+	/// <see cref="ProductArgument"/> list.
+	/// </summary>
+	internal static List<ProductArgument> ParseProfileProducts(string pattern)
+	{
+		var parts = pattern.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+		if (parts.Length < 1)
+			return [];
+
+		var productId = parts[0];
+		var target = parts.Length > 1 ? parts[1] : "*";
+		var lifecycle = parts.Length > 2 ? parts[2] : "*";
+
+		return
+		[
+			new ProductArgument
+			{
+				Product = productId == "*" ? "*" : productId,
+				Target = target == "*" ? "*" : target,
+				Lifecycle = lifecycle == "*" ? "*" : lifecycle
+			}
+		];
+	}
+}


### PR DESCRIPTION
Relates to https://github.com/elastic/docs-builder/pull/2773#pullrequestreview-3849355922

## Summary

Adds profile-based mode to `docs-builder changelog remove` so users can run `docs-builder changelog remove <profile> <version|promotion-report>` to remove the same changelogs that would be included in a bundle created with `docs-builder changelog bundle <profile> <version|promotion-report>`. Profile mode is mutually exclusive with `--all`, `--products`, `--prs`, and `--issues`.

## Architecture

```mermaid
flowchart TD
    subgraph CLI [ChangelogCommand.Remove]
        Args[profile, profileArg arguments]
        Validate[Validate profile vs flags mutually exclusive]
    end

    subgraph Service [ChangelogRemoveService]
        ProcessProfile[ProcessProfile - resolve to Products or Prs]
        ApplyConfig[ApplyConfigDefaults]
        ValidateInput[ValidateInput]
        Match[MatchChangelogsAsync]
        Remove[Delete files]
    end

    subgraph Shared [Shared Profile Logic]
        Resolver[ProfileFilterResolver]
    end

    Args --> Validate
    Validate --> ProcessProfile
    ProcessProfile --> Resolver
    Resolver --> ApplyConfig
    ApplyConfig --> ValidateInput
    ValidateInput --> Match
    Match --> Remove
```

## Implementation

The following details come from the AI plan for this work:

### 1. Extract shared profile filter logic

Create a reusable `ProfileFilterResolver` that both bundle and remove services can use. This avoids duplicating the promotion report parsing, version lifecycle inference, and product pattern substitution.

**New file**: `[src/services/Elastic.Changelog/Bundling/ProfileFilterResolver.cs](src/services/Elastic.Changelog/Bundling/ProfileFilterResolver.cs)`

- Record `ProfileFilterResult(Products?, Prs?)` for the resolved filter
- Static async method `ResolveAsync(collector, profileName, profileArg, config, fileSystem, logger, ctx)` returning `ProfileFilterResult?`
- Logic extracted from `[ChangelogBundlingService.ProcessProfile](src/services/Elastic.Changelog/Bundling/ChangelogBundlingService.cs)` (lines 213–295): profile lookup, argument type detection, promotion report parsing, `{version}`/`{lifecycle}` substitution, `ParseProfileProducts`
- Explicit error if the profile has no `products` and the argument is a version (not a promotion report): emit a specific error like `"Profile '{name}' has no 'products' pattern configured and no promotion report was provided — cannot determine filter"`, rather than allowing a vague "At least one filter option must be specified" failure later
- Exclude bundle-specific concerns: `Output`, `HideFeatures`

**Refactor** (prerequisite): Update `[ChangelogBundlingService.ProcessProfile](src/services/Elastic.Changelog/Bundling/ChangelogBundlingService.cs)` to call `ProfileFilterResolver.ResolveAsync` and apply Output/HideFeatures to the result. Run the existing bundle profile tests to confirm no regression before adding new remove tests.

### 2. Extend ChangelogRemoveArguments

**File**: `[src/services/Elastic.Changelog/Bundling/ChangelogRemoveService.cs](src/services/Elastic.Changelog/Bundling/ChangelogRemoveService.cs)`

Add to `ChangelogRemoveArguments`:

- `Profile?: string` — profile name from `bundle.profiles`
- `ProfileArgument?: string` — version or promotion report URL/path

### 3. Add profile resolution to ChangelogRemoveService

**File**: `[ChangelogRemoveService.cs](src/services/Elastic.Changelog/Bundling/ChangelogRemoveService.cs)`

- Call `ProfileFilterResolver.ResolveAsync` when `input.Profile` is set (before `ApplyConfigDefaults`, same ordering as bundle)
- Map `ProfileFilterResult` to `ChangelogRemoveArguments`: set `Products` or `Prs`, clear `All`
- Existing `ValidateInput` requires exactly one of `all`, `products`, `prs`, `issues` — because profile resolution populates one of these before validation runs, no changes to `ValidateInput` are needed
- `output` from the profile config is not read or applied — only `products` is used for filtering

### 4. Update ChangelogCommand.Remove

**File**: `[src/tooling/docs-builder/Commands/ChangelogCommand.cs](src/tooling/docs-builder/Commands/ChangelogCommand.cs)`

- Add `[Argument] string? profile = null` and `[Argument] string? profileArg = null` as the first two parameters (same pattern as `Bundle`)
- Compute `isProfileMode = !string.IsNullOrWhiteSpace(profile)`
- **Profile mode**: error if `--all`, `--products`, `--prs`, or `--issues` are also specified; `--force` and `--dry-run` remain valid alongside a profile
- **Profile mode without `profileArg**`: emit a clear CLI-level error (`"Profile 'X' requires a version number or promotion report URL as the second argument"`) rather than letting it fall through to the service
- **Raw mode**: keep existing validation (exactly one of `--all`, `--products`, `--prs`, `--issues`)
- Pass `Profile` and `ProfileArgument` into `ChangelogRemoveArguments`
- `--owner` and `--repo` remain valid in profile mode (no restriction needed — promotion reports yield full URLs, so they are not required but not harmful)

### 5. Documentation updates

**File**: `[docs/cli/release/changelog-remove.md](docs/cli/release/changelog-remove.md)`

- Add "Arguments" section for profile-based usage (mirror `changelog-bundle.md` structure)
- Document: `[0]` profile name, `[1]` version or promotion report URL
- Update "Options" to state that profile mode is mutually exclusive with `--all`, `--products`, `--prs`, `--issues`; `--force` and `--dry-run` remain valid in profile mode
- Note that the `output` field of a profile config is ignored for `remove` — only `products` is used
- Add example: `docs-builder changelog remove elasticsearch-release 9.2.0 --dry-run`

**File**: `[docs/contribute/changelog.md](docs/contribute/changelog.md)`

- Update the [changelog-remove](docs/contribute/changelog.md) section to document profile-based removal
- Add example showing profile usage alongside the existing raw-flag examples
- Cross-reference the fact that the same profile used for `changelog bundle` can be used for `changelog remove`

**File**: `[config/changelog.example.yml](config/changelog.example.yml)`

- In the `profiles:` comment block, add a note that profiles are also usable with `changelog remove`, and that only the `products` field (not `output` or `hide_features`) is relevant for removal

### 6. Tests

**Order of operations**: Run existing bundle profile tests first to confirm `ChangelogBundlingService` still works correctly after the `ProfileFilterResolver` refactor, then add the following remove-specific tests.

**Service-level tests** — `[tests/Elastic.Changelog.Tests/Changelogs/ChangelogRemoveTests.cs](tests/Elastic.Changelog.Tests/Changelogs/ChangelogRemoveTests.cs)`:

- `Remove_WithProfileAndVersion_DeletesMatchingProducts` — profile with `products: "elasticsearch {version} {lifecycle}"`, version `9.2.0`, removes only elasticsearch 9.2.0 ga changelogs
- `Remove_WithProfileAndPromotionReport_DeletesMatchingPrs` — profile with a promotion report file, removes changelogs whose PRs appear in the report
- `Remove_WithProfile_UnknownProfile_ReturnsError` — profile name not in config emits a specific error
- `Remove_WithProfile_MissingProfileArg_ReturnsError` — profile set, `ProfileArgument` null/empty emits a specific error
- `Remove_WithProfile_NoProductsAndVersionArg_ReturnsSpecificError` — profile has no `products`, argument is a version string; confirm the specific "no products pattern" error is emitted (not the generic filter-missing error)

**CLI-level validation test** — best placed in a `ChangelogCommand` integration or command test, not in the service unit tests:

- `Remove_WithProfileAndRawFilterOption_ReturnsError` — pass both `profile` and `--products`, confirm early error before service is invoked

## Key Files

- `[ProfileFilterResolver.cs](src/services/Elastic.Changelog/Bundling/ProfileFilterResolver.cs)` — **New**: shared profile-to-filter resolution
- `[ChangelogBundlingService.cs](src/services/Elastic.Changelog/Bundling/ChangelogBundlingService.cs)` — Refactor `ProcessProfile` to delegate to `ProfileFilterResolver`
- `[ChangelogRemoveService.cs](src/services/Elastic.Changelog/Bundling/ChangelogRemoveService.cs)` — Add `Profile`/`ProfileArgument` to arguments record; call resolver before `ApplyConfigDefaults`
- `[ChangelogCommand.cs](src/tooling/docs-builder/Commands/ChangelogCommand.cs)` — Add profile positional args to `Remove`, CLI-level mutual exclusivity and missing-arg validation
- `[changelog-remove.md](docs/cli/release/changelog-remove.md)` — Document profile-based usage and `output`-field caveat
- `[changelog.md](docs/contribute/changelog.md)` — Mention profile-based remove with examples
- `[changelog.example.yml](config/changelog.example.yml)` — Note dual use of profiles
- `[ChangelogRemoveTests.cs](tests/Elastic.Changelog.Tests/Changelogs/ChangelogRemoveTests.cs)` — Service-level profile tests

## Product pattern equivalence

The `bundle.profiles.<name>.products` option uses the same format as `--products` (e.g. `"elasticsearch {version} {lifecycle}"`), with `{version}` and `{lifecycle}` substituted at runtime. The remove command uses the same substitution logic via `ProfileFilterResolver`, ensuring that `remove elasticsearch-release 9.2.0` removes exactly the changelogs that `bundle elasticsearch-release 9.2.0` would include.

The `output` and `hide_features` fields in a profile are bundle-specific and are not applied when using a profile with `changelog remove`.

## Steps to test

1. Create a changelog configuration file (e.g. I checked out https://github.com/elastic/kibana/pull/250840)
1. Verify that the `bundle` and `profiles` sections are enabled. For example, I edited as follows and copied a few changelogs into that `docs/test` folder.
    ```yaml
    bundle:
      directory: docs/test
      output_directory: docs/test-releases
      resolve: true
      profiles:
      kibana-release:
        products: "kibana {version}"
        output: "kibana/kibana-{version}.yaml"
        hide_features:
          - test_feature1
    ```
1. Create a profile-based bundle, for example, in the kibana repo:
    ```sh
     docs-builder changelog bundle kibana-release 9.3.0
    ```
1. Do a profile-based changelog removal, for example, in the kibana repo:
    ```sh
     /path/to/GitHub/docs-builder/.artifacts/publish/docs-builder/release/docs-builder changelog remove kibana-release 9.3.0 
     ```
1. Confirm that all the appropriate changelogs are removed from the `docs/test` directory in this example.

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
4. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: composer-1.5, claude-4.6-sonnet-medium