### PR TITLE
Pass through enable-vale-spelling flag to Vale linter action

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -63,6 +63,11 @@ on:
         type: boolean
         default: false
         required: false
+      enable-vale-spelling:
+        description: 'Enable Vale spelling checks (requires enable-vale-linting). Experimental.'
+        type: boolean
+        default: false
+        required: false
       include-paths:
         description: 'Paths to include for Vale linting (multi-line). Only files matching these paths will be linted.'
         type: string
@@ -709,6 +714,7 @@ jobs:
         with: 
           files: ${{ needs.check.outputs.all_changed_files }}
           include-paths: ${{ inputs.include-paths }}
+          enable_spelling: ${{ inputs.enable-vale-spelling && 'true' || 'false' }}
       - name: Post Vale Results
         uses: elastic/vale-rules/report@main
         with:


### PR DESCRIPTION
## Summary

- Adds a new `enable-vale-spelling` input to the `preview-build` reusable workflow (default: `false`).
- Passes it through to `elastic/vale-rules/lint@main` as `enable_spelling`.

This lets repos opt into the new experimental spelling check rule without any changes to the Vale action itself.

Depends on https://github.com/elastic/vale-rules/pull/110

### Usage

```yaml
uses: elastic/docs-builder/.github/workflows/preview-build.yml@main
with:
  enable-vale-linting: true
  enable-vale-spelling: true
```

### Dependencies

Requires [elastic/vale-rules#110](https://github.com/elastic/vale-rules/pull/110) to be merged first (adds the `Elastic.Spelling` rule and the `enable_spelling` input to the lint action).

## Test plan

- [ ] Verify existing repos with `enable-vale-linting: true` are unaffected (spelling stays off by default)
- [ ] After vale-rules#110 merges, test a repo with both flags enabled to confirm spelling checks fire

Made with [Cursor](https://cursor.com)