### PR TITLE
Fix vale and comment jobs running on PRs with no docs changes

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -543,7 +543,7 @@ jobs:
       startsWith(github.event_name, 'pull_request')
       && inputs.disable-comments != true
       && needs.build.outputs.deployment_result
-      && needs.check.outputs.any_modified
+      && needs.check.outputs.any_modified == 'true'
     runs-on: ubuntu-latest
     needs:
       - check
@@ -689,7 +689,7 @@ jobs:
     if: >
       startsWith(github.event_name, 'pull_request')
       && inputs.enable-vale-linting == true
-      && needs.check.outputs.any_modified
+      && needs.check.outputs.any_modified == 'true'
     runs-on: ubuntu-latest
     needs: check
     permissions:


### PR DESCRIPTION
## Summary

The `vale` and `comment` job conditions in `preview-build.yml` use bare `needs.check.outputs.any_modified`, which evaluates to truthy even when the string value is `"false"`. In GitHub Actions expressions, any non-empty string is truthy — only an empty string `''` is falsy.

This causes both jobs to run unnecessarily on PRs that don't touch any files matching `path-pattern`. When the vale job runs with an empty file list, the [lint action falls back to `git diff`-based auto-detection](https://github.com/elastic/vale-rules/blob/b599bdf7603050685c57e9f482a4f21a440c1fd9/lint/action.yml#L171-L193) and ends up linting non-docs files.

**Evidence:** [elastic/elasticsearch-rs#281](https://github.com/elastic/elasticsearch-rs/pull/281) only changed files like `CONTRIBUTING.md`, `Cargo.toml`, and `Makefile.toml` — no files under `docs/`. Despite `path-pattern: docs/**` being set, the [vale job ran and linted `CONTRIBUTING.md`](https://github.com/elastic/elasticsearch-rs/actions/runs/22405311519/job/64863350415).

## Fix

Explicitly compare to `== 'true'` instead of relying on truthiness, consistent with how the `build` job already checks this output (line 273).

```diff
-      && needs.check.outputs.any_modified
+      && needs.check.outputs.any_modified == 'true'
```

Applied to both the `vale` and `comment` jobs.

cc @pquentin


Made with [Cursor](https://cursor.com)