### PR TITLE
Codex: redesign landing page with hero, search, and Ask AI

### DIFF
--- a/src/Elastic.Codex/Landing/LandingView.cshtml
+++ b/src/Elastic.Codex/Landing/LandingView.cshtml
@@ -2,36 +2,106 @@
 @using System.Linq
 @using Elastic.Codex.Landing
 @using Elastic.Codex.Navigation
+@using Elastic.Documentation.Svg
 @implements IUsesLayout<Elastic.Codex._Layout, GlobalLayoutViewModel>
 @functions {
 	public GlobalLayoutViewModel LayoutModel => Model.CreateGlobalLayoutModel();
-}
-<section id="elastic-docs-v3" class="codex-landing min-h-screen" style="background-color: #f8fafc; position: relative;">
 
-	<div class="absolute inset-0 z-0"
-		 style="background-image: linear-gradient(to right, #e2e8f0 1px, transparent 1px), linear-gradient(to bottom, #e2e8f0 1px, transparent 1px); background-size: 20px 30px; -webkit-mask-image: radial-gradient(ellipse 70% 60% at 50% 0%, #000 60%, transparent 100%); mask-image: radial-gradient(ellipse 70% 60% at 50% 0%, #000 60%, transparent 100%);">
+	private static HtmlString GetIconSvg(string? icon, string? cssClass = null)
+	{
+		if (icon == null)
+			return new HtmlString(EuiSvgIcons.GetIcon("question", cssClass)!);
+		return new HtmlString(EuiSvgIcons.GetIcon(icon, cssClass) ?? EuiSvgIcons.GetIcon("question", cssClass)!);
+	}
+}
+<section id="elastic-docs-v3" class="codex-landing codex-root-landing min-h-screen" style="background-color: #f8fafc; position: relative;">
+
+	<div class="fixed inset-0 z-0"
+		 style="background-image: linear-gradient(to right, #e7e5e4 1px, transparent 1px), linear-gradient(to bottom, #e7e5e4 1px, transparent 1px); background-size: 20px 20px; background-position: 0 0, 0 0; mask-image: repeating-linear-gradient(to right, black 0px, black 3px, transparent 3px, transparent 8px), repeating-linear-gradient(to bottom, black 0px, black 3px, transparent 3px, transparent 8px), radial-gradient(ellipse 70% 60% at 50% 0%, #000 60%, transparent 100%); -webkit-mask-image: repeating-linear-gradient(to right, black 0px, black 3px, transparent 3px, transparent 8px), repeating-linear-gradient(to bottom, black 0px, black 3px, transparent 3px, transparent 8px), radial-gradient(ellipse 70% 60% at 50% 0%, #000 60%, transparent 100%); mask-composite: intersect; -webkit-mask-composite: source-in;">
 	</div>
 
-	<div class="codex-hero flex flex-col px-4 py-12 items-center text-center max-w-7xl mx-auto" style="position: relative; z-index: 1;" hx-select-oob="#main-container">
-		<div class="codex-hero-content">
-			<h1 class="text-7xl font-sans font-semibold text-ink">Codex</h1>
-			<p class="mt-4 text-xl text-ink-light">Discover documentation, best practices, and resources across all teams and organizations.</p>
+	<div class="codex-hero flex flex-col px-4 pt-10 pb-20 items-center text-center max-w-4xl mx-auto" style="position: relative; z-index: 1;" hx-select-oob="#main-container">
+
+		<div class="flex items-center justify-between gap-2 mb-10 w-full">
+			<img src="@LayoutModel.Static("logo-elastic-horizontal-color.svg")" alt="Elastic" class="h-10"/>
+			<div class="flex items-center gap-4">
+				<a href="https://github.com/elastic/docs-builder" target="_blank" rel="noopener" class="text-subdued hover:text-ink-dark transition-colors" title="elastic/docs-builder">
+					@GetIconSvg("logo_github", "size-5 icon-mono")
+				</a>
+				<a href="https://elastic.slack.com/archives/C0JF80CJZ" target="_blank" rel="noopener" class="text-subdued hover:text-ink-dark transition-colors" title="#docs">
+					@GetIconSvg("logo_slack", "size-5 icon-mono")
+				</a>
+			</div>
 		</div>
-		<div class="flex gap-3 mt-6">
+		
+		<div class="codex-hero-content max-w-4xl">
+			<h1 class="text-6xl md:text-7xl font-sans font-bold text-slate-900 tracking-tight mb-6">
+				@(LayoutModel.HeaderTitle ?? LayoutModel.DocSetName)
+			</h1>
+			<p class="mt-6 text-xl text-slate-600 max-w-2xl mx-auto leading-relaxed">
+				Elastic's internal documentation platform. Discover docs, best practices, and resources across all teams and organizations.
+			</p>
+		</div>
+
+		<div class="w-full max-w-xl mt-10 mb-10 border border-grey-20 rounded-lg p-4 bg-white shadow-2xl">
+			<div class="flex items-center gap-3">
+				<div class="flex-1">
+					<navigation-search placeholder="Search"></navigation-search>
+				</div>
+				<div class="text-subdued text-xs flex items-center">
+					OR
+				</div>
+				<button type="button"
+						aria-label="Ask AI"
+						onclick="document.dispatchEvent(new CustomEvent('ask-ai:open'))"
+						class="select-none cursor-pointer text-white text-nowrap font-sans rounded-full px-6 py-2 h-10 flex items-center gap-2 justify-center shrink-0 hover:opacity-90 transition-opacity"
+						style="background: linear-gradient(131deg, #1750ba 2.98%, #731dcf 66.24%);">
+					@GetIconSvg("ai", "w-4 h-4 icon-mono")
+					Ask AI
+				</button>
+			</div>
+		</div>
+
+
+		<div class="flex gap-6 mt-6 text-slate-600">
 			<a href="/r/codex-environments/get-started"
-			   class="select-none cursor-pointer text-white text-nowrap bg-blue-elastic hover:bg-blue-elastic-110 focus:ring-4 focus:ring-blue-elastic-50 font-semibold font-sans rounded-sm px-6 py-2 focus:outline-none h-10 flex items-center justify-center">
-				Publish your docs
+			   class="flex items-center gap-1.5 text-blue-elastic hover:underline">
+				@GetIconSvg("plus", "w-4 h-4 fill-current")
+				Add your docs
 			</a>
 			<a href="https://docs-v3-preview.elastic.dev/elastic/docs-builder/tree/main/syntax"
 			   target="_blank"
 			   rel="noopener"
-			   class="cursor-pointer bg-white hover:bg-grey-20 text-blue-elastic hover:text-blue-elastic-100 text-nowrap border-2 border-blue-elastic hover:border-blue-elastic-100 focus:ring-4 focus:outline-none focus:ring-blue-elastic-50 font-semibold font-sans rounded-sm px-6 py-2 text-center h-10 flex items-center justify-center">
+			   class="flex items-center gap-1.5 text-blue-elastic hover:underline">
+				@GetIconSvg("code", "w-4 h-4 fill-current")
 				Explore the syntax
 			</a>
 		</div>
 	</div>
 
-	<div id="codex-grid" class="pt-8 max-w-7xl p-4 mx-auto grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4" style="position: relative; z-index: 1;">
+	@{
+		var totalGroups = Model.CodexNavigation?.GroupNavigations?.Count ?? 0;
+		var totalDocSets = Model.CodexNavigation?.DocumentationSetInfos?.Count ?? 0;
+		var totalPages = Model.CodexNavigation?.DocumentationSetInfos?.Sum(ds => ds.PageCount) ?? 0;
+	}
+	<div class="flex items-center justify-center gap-8 py-6 text-sm text-slate-500" style="position: relative; z-index: 1;">
+		<div class="flex items-center gap-2">
+			@GetIconSvg("cluster", "w-4 h-4 fill-current")
+			<span><strong class="text-slate-700">@totalGroups</strong> groups</span>
+		</div>
+		<div class="w-px h-4 bg-slate-300"></div>
+		<div class="flex items-center gap-2">
+			@GetIconSvg("app_notebook", "w-4 h-4 fill-current")
+			<span><strong class="text-slate-700">@totalDocSets</strong> documentation sets</span>
+		</div>
+		<div class="w-px h-4 bg-slate-300"></div>
+		<div class="flex items-center gap-2">
+			@GetIconSvg("documents", "w-4 h-4 fill-current")
+			<span><strong class="text-slate-700">@totalPages.ToString("N0")</strong> pages</span>
+		</div>
+	</div>
+
+	<div id="codex-grid" class="pt-8 pb-8 max-w-7xl p-4 mx-auto grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4" style="position: relative; z-index: 1;">
 		@foreach (var group in Model.Groups)
 		{
 			@(await RenderPartialAsync(_CodexCard.Create(new CodexCardModel
@@ -54,9 +124,5 @@
 				PageCount = docSet.PageCount
 			})))
 		}
-	</div>
-
-	<div id="codex-no-results" class="hidden" style="text-align: center; padding: 48px 0; color: #69707D;">
-		<p>No documentation sets match your filter.</p>
 	</div>
 </section>

--- a/src/Elastic.Codex/Layout/_CodexHeader.cshtml
+++ b/src/Elastic.Codex/Layout/_CodexHeader.cshtml
@@ -1,5 +1,5 @@
 @inherits RazorSlice<Elastic.Documentation.Site.GlobalLayoutViewModel>
-<div class="sticky top-0 z-10 h-(--header-height)">
+<div class="sticky top-0 z-10 h-(--header-height) group-has-[.codex-root-landing]/body:h-0 group-has-[.codex-root-landing]/body:min-h-0 group-has-[.codex-root-landing]/body:overflow-hidden group-has-[.codex-root-landing]/body:opacity-0 group-has-[.codex-root-landing]/body:pointer-events-none">
 <codex-header title="@(Model.HeaderTitle ?? Model.DocSetName)"
                      logo-href="@(Model.SiteLink("/"))"></codex-header>
 </div>

--- a/src/Elastic.Documentation.Site/Assets/codex.css
+++ b/src/Elastic.Documentation.Site/Assets/codex.css
@@ -38,3 +38,17 @@
 		}
 	}
 }
+
+.icon-mono path {
+	fill: currentColor !important;
+}
+
+.codex-hero {
+	navigation-search > div {
+		position: static;
+		padding: 0;
+		& > hr.euiHorizontalRule {
+			display: none;
+		}
+	}
+}

--- a/src/Elastic.Documentation.Site/Assets/web-components/AskAi/useAskAiFlyout.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/AskAi/useAskAiFlyout.tsx
@@ -115,6 +115,13 @@ export const useAskAiFlyout = () => {
         return () => window.removeEventListener('keydown', handleKeydown)
     }, [openModal, closeModal])
 
+    useEffect(() => {
+        const handleOpenEvent = () => openModal()
+        document.addEventListener('ask-ai:open', handleOpenEvent)
+        return () =>
+            document.removeEventListener('ask-ai:open', handleOpenEvent)
+    }, [openModal])
+
     return {
         isApiAvailable: isApiAvailable ?? false,
         isModalOpen,

--- a/src/Elastic.Documentation.Site/Assets/web-components/CodexHeader/Header.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/CodexHeader/Header.tsx
@@ -3,7 +3,12 @@ import { AskAiHeaderButton } from '../AskAi/AskAiHeaderButton'
 import { NavigationSearch } from '../NavigationSearch/NavigationSearch'
 import { useHtmxContainer } from '../shared/htmx/useHtmxContainer'
 import { sharedQueryClient } from '../shared/queryClient'
-import { EuiHeader, EuiHeaderLogo, EuiProvider } from '@elastic/eui'
+import {
+    EuiHeader,
+    EuiHeaderLogo,
+    EuiProvider,
+    EuiThemeProvider,
+} from '@elastic/eui'
 import r2wc from '@r2wc/react-to-web-component'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { useRef } from 'react'
@@ -42,10 +47,12 @@ export const Header = ({ title, logoHref }: Props) => {
                         },
                         {
                             items: [
-                                <NavigationSearch
-                                    size="s"
-                                    placeholder="Search"
-                                />,
+                                <EuiThemeProvider colorMode="light">
+                                    <NavigationSearch
+                                        size="s"
+                                        placeholder="Search"
+                                    />
+                                </EuiThemeProvider>,
                                 <AskAiHeaderButton key="ask-ai" />,
                                 // <EuiHeaderSectionItemButton key="theme">
                                 //     <EuiIcon type="sun" />

--- a/src/Elastic.Documentation.Site/Assets/web-components/NavigationSearch/NavigationSearch.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/NavigationSearch/NavigationSearch.tsx
@@ -146,6 +146,7 @@ export const NavigationSearch = ({
             isOpen={hasContent}
             closePopover={() => setIsPopoverOpen(false)}
             ownFocus={false}
+            anchorPosition="downLeft"
             disableFocusTrap={true}
             panelMinWidth={isMobile ? undefined : 640}
             panelPaddingSize="none"

--- a/src/Elastic.Documentation.Site/Assets/web-components/NavigationSearch/NavigationSearchComponent.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/NavigationSearch/NavigationSearchComponent.tsx
@@ -8,7 +8,11 @@ import r2wc from '@r2wc/react-to-web-component'
 import { QueryClientProvider, useQuery } from '@tanstack/react-query'
 import { StrictMode } from 'react'
 
-const NavigationSearchInner = () => {
+interface NavigationSearchProps {
+    placeholder?: string
+}
+
+const NavigationSearchInner = ({ placeholder }: NavigationSearchProps) => {
     const { euiTheme } = useEuiTheme()
     const { data: isApiAvailable } = useQuery({
         queryKey: ['api-health'],
@@ -34,7 +38,7 @@ const NavigationSearchInner = () => {
                 padding-right: ${euiTheme.size.base};
             `}
         >
-            <NavigationSearch />
+            <NavigationSearch placeholder={placeholder} />
             <EuiHorizontalRule
                 margin="none"
                 css={css`
@@ -45,7 +49,7 @@ const NavigationSearchInner = () => {
     )
 }
 
-const NavigationSearchWrapper = () => {
+const NavigationSearchWrapper = ({ placeholder }: NavigationSearchProps) => {
     return (
         <StrictMode>
             <EuiProvider
@@ -54,11 +58,18 @@ const NavigationSearchWrapper = () => {
                 utilityClasses={false}
             >
                 <QueryClientProvider client={sharedQueryClient}>
-                    <NavigationSearchInner />
+                    <NavigationSearchInner placeholder={placeholder} />
                 </QueryClientProvider>
             </EuiProvider>
         </StrictMode>
     )
 }
 
-customElements.define('navigation-search', r2wc(NavigationSearchWrapper))
+customElements.define(
+    'navigation-search',
+    r2wc(NavigationSearchWrapper, {
+        props: {
+            placeholder: 'string',
+        },
+    })
+)

--- a/src/Elastic.Documentation.Svg/svgs/ai.svg
+++ b/src/Elastic.Documentation.Svg/svgs/ai.svg
@@ -1,0 +1,24 @@
+<svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9 7H15V16H9V7Z" fill="url(#paint0_linear_382_1202)"/>
+<path d="M1 11.5C1 9.01472 3.01472 7 5.5 7H7V16H5.5C3.01472 16 1 13.9853 1 11.5Z" fill="url(#paint1_linear_382_1202)"/>
+<path d="M15 3C15 4.65685 13.6569 6 12 6C10.3431 6 9 4.65685 9 3C9 1.34315 10.3431 0 12 0C13.6569 0 15 1.34315 15 3Z" fill="url(#paint2_linear_382_1202)"/>
+<path d="M1.5 5.75C1.5 2.71243 3.96243 0.25 7 0.25V5.75H1.5Z" fill="url(#paint3_linear_382_1202)"/>
+<defs>
+<linearGradient id="paint0_linear_382_1202" x1="-0.53125" y1="-2.5" x2="15.3422" y2="9.5049" gradientUnits="userSpaceOnUse">
+<stop offset="0.168292" stop-color="#0B64DD"/>
+<stop offset="0.83" stop-color="#731DCF"/>
+</linearGradient>
+<linearGradient id="paint1_linear_382_1202" x1="-0.53125" y1="-2.5" x2="15.3422" y2="9.5049" gradientUnits="userSpaceOnUse">
+<stop offset="0.168292" stop-color="#0B64DD"/>
+<stop offset="0.83" stop-color="#731DCF"/>
+</linearGradient>
+<linearGradient id="paint2_linear_382_1202" x1="-0.53125" y1="-2.5" x2="15.3422" y2="9.5049" gradientUnits="userSpaceOnUse">
+<stop offset="0.168292" stop-color="#0B64DD"/>
+<stop offset="0.83" stop-color="#731DCF"/>
+</linearGradient>
+<linearGradient id="paint3_linear_382_1202" x1="-0.53125" y1="-2.5" x2="15.3422" y2="9.5049" gradientUnits="userSpaceOnUse">
+<stop offset="0.168292" stop-color="#0B64DD"/>
+<stop offset="0.83" stop-color="#731DCF"/>
+</linearGradient>
+</defs>
+</svg>


### PR DESCRIPTION
## What

- Redesign the Codex root landing page with a new hero section, inline search bar, Ask AI button, and stats showing group/docset/page counts
- Hide the default Codex header on the root landing page and replace it with a minimal top bar (Elastic logo, GitHub, Slack links)

## Why

- Improve discoverability by surfacing search and Ask AI directly on the landing page
- Give the landing page a cleaner, more modern look with better visual hierarchy

## Notes

- Adds a new `ai.svg` icon for the Ask AI button gradient style
- The `navigation-search` web component now accepts a `placeholder` prop
- Ask AI flyout can be triggered via a custom `ask-ai:open` DOM event

## Screenshot

<img width="1728" height="874" alt="image" src="https://github.com/user-attachments/assets/8e91ee7f-6e62-4e52-ba48-9f22d98f271f" />


Made with [Cursor](https://cursor.com)