### PR TITLE
Codex: add canonical_base_url config for frontmatter URLs

### DIFF
--- a/src/Elastic.Codex/Building/CodexBuildService.cs
+++ b/src/Elastic.Codex/Building/CodexBuildService.cs
@@ -157,6 +157,12 @@ public class CodexBuildService(
 			// Pre-compute codex site root for HTMX (no URL parsing in providers)
 			var siteRootPath = string.IsNullOrEmpty(sitePrefix) ? "/" : $"/{sitePrefix.Trim('/')}/";
 
+			// Parse canonical base URL from config for frontmatter URLs, canonical links, and report-issue
+			var canonicalBaseUrl = !string.IsNullOrWhiteSpace(context.Configuration.CanonicalBaseUrl) &&
+				Uri.TryCreate(context.Configuration.CanonicalBaseUrl, UriKind.Absolute, out var parsed)
+				? parsed
+				: null;
+
 			// Create build context for this documentation set
 			var buildContext = new BuildContext(
 				context.Collector,
@@ -170,6 +176,7 @@ public class CodexBuildService(
 			{
 				UrlPathPrefix = pathPrefix,
 				SiteRootPath = siteRootPath,
+				CanonicalBaseUrl = canonicalBaseUrl,
 				Force = true,
 				AllowIndexing = false,
 				BuildType = BuildType.Codex

--- a/src/Elastic.Documentation.Configuration/Codex/CodexConfiguration.cs
+++ b/src/Elastic.Documentation.Configuration/Codex/CodexConfiguration.cs
@@ -40,6 +40,13 @@ public record CodexConfiguration
 	public IReadOnlyList<CodexGroupDefinition> Groups { get; set; } = [];
 
 	/// <summary>
+	/// The base URL for canonical links and frontmatter URLs (e.g., "https://codex.elastic.dev").
+	/// Used by the LLM markdown exporter, canonical link tags, and report-issue links.
+	/// </summary>
+	[YamlMember(Alias = "canonical_base_url")]
+	public string? CanonicalBaseUrl { get; set; }
+
+	/// <summary>
 	/// Deserializes a codex configuration from YAML content.
 	/// </summary>
 	public static CodexConfiguration Deserialize(string yaml)

--- a/src/Elastic.Markdown/Exporters/LlmMarkdownExporter.cs
+++ b/src/Elastic.Markdown/Exporters/LlmMarkdownExporter.cs
@@ -156,7 +156,9 @@ public class LlmMarkdownExporter : IMarkdownExporter
 			_ = metadata.AppendLine($"description: {generateDescription}");
 		}
 
-		var url = $"{context.BuildContext.CanonicalBaseUrl?.Scheme}://{context.BuildContext.CanonicalBaseUrl?.Host}{context.NavigationItem.Url}";
+		var url = context.BuildContext.CanonicalBaseUrl is { } baseUrl
+			? new Uri(baseUrl, context.NavigationItem.Url).ToString().TrimEnd('/')
+			: context.NavigationItem.Url.TrimEnd('/');
 		_ = metadata.AppendLine($"url: {url}");
 
 		// Use DocumentInferrerService to get merged products


### PR DESCRIPTION
## What

- Add `canonical_base_url` to codex config so each environment can specify its base URL (e.g. `https://codex.elastic.dev`)
- Wire `CanonicalBaseUrl` into the build context for Codex docsets
- Fix LLM markdown frontmatter `url:` field: emit full URL when `canonical_base_url` is set, otherwise emit the path only

## Why

- The `url:` field in LLM markdown frontmatter was broken in Codex builds (e.g. `url: ://r/codex-environments/get-started`) because `CanonicalBaseUrl` was never set
- This also affects `<link rel="canonical">`, `<meta property="og:url">`, and report-issue links

## Notes

- Add `canonical_base_url: https://codex.elastic.dev` to `codex-environments/environments/internal/config.yml` in a separate PR to enable full URLs for the internal Codex

Made with [Cursor](https://cursor.com)