### PR TITLE
Update release API endpoint

### DIFF
--- a/.github/updatecli/updatecli.d/versions.yml
+++ b/.github/updatecli/updatecli.d/versions.yml
@@ -30,7 +30,7 @@ sources:
     kind: json
     spec:
       files:
-        - https://artifacts.elastic.co/releases/stack.json
+        - https://elastic-release-api.s3.us-west-2.amazonaws.com/public/past-releases.json
       engine: dasel/v2
       key: "releases.last().version"
 


### PR DESCRIPTION
Release API migration to new endpoints is now complete.

Past Release Endpoint : https://elastic-release-api.s3.us-west-2.amazonaws.com/public/past-releases.json
Future Release Endpoint : https://elastic-release-api.s3.us-west-2.amazonaws.com/public/future-releases.json

This PR updates the old Release API endpoints to new one's

More Info:
https://groups.google.com/a/elastic.co/g/release-eng-team/c/qgXaCX-y29k/m/jzm2S8MeAwAJ