### PR TITLE
Search bar: fix theme consistency, make placeholder configurable, shorten AI prompt

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/web-components/AskAi/askAi.config.ts
+++ b/src/Elastic.Documentation.Site/Assets/web-components/AskAi/askAi.config.ts
@@ -17,7 +17,7 @@ const codexConfig: AskAiConfig = {
     assistantName: 'Elastic Internal Docs AI Assistant',
     assistantDescription:
         "I'm here to help you navigate Elastic's internal documentation. Ask me anything about our internal processes, tools, and standards. How can I help?",
-    inputPlaceholder: 'Ask the Elastic Internal Docs AI Assistant',
+    inputPlaceholder: 'Ask me anything...',
     defaultAiProvider: 'AgentBuilder',
     forceAiProvider: true,
     suggestions: [

--- a/src/Elastic.Documentation.Site/Assets/web-components/CodexHeader/SearchBar.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/CodexHeader/SearchBar.tsx
@@ -2,23 +2,21 @@ import '../../eui-icons-cache'
 import { AskAiHeaderButton } from '../AskAi/AskAiHeaderButton'
 import { ModalSearch } from '../ModalSearch/ModalSearch'
 import { sharedQueryClient } from '../shared/queryClient'
-import { EuiProvider, EuiThemeProvider } from '@elastic/eui'
+import { EuiProvider } from '@elastic/eui'
 import r2wc from '@r2wc/react-to-web-component'
 import { QueryClientProvider } from '@tanstack/react-query'
 
 export const SearchBar = () => (
     <QueryClientProvider client={sharedQueryClient}>
         <EuiProvider
-            colorMode="dark"
+            colorMode="light"
             globalStyles={false}
             utilityClasses={false}
         >
             <div className="flex items-center gap-1 min-w-0">
-                <EuiThemeProvider colorMode="light">
-                    <div className="min-w-0 shrink">
-                        <ModalSearch size="s" placeholder="Search" />
-                    </div>
-                </EuiThemeProvider>
+                <div className="min-w-0 md:min-w-60 shrink">
+                    <ModalSearch size="s" placeholder="Search" />
+                </div>
                 <AskAiHeaderButton />
             </div>
         </EuiProvider>

--- a/src/Elastic.Documentation.Site/Assets/web-components/ModalSearch/ModalSearch.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/ModalSearch/ModalSearch.tsx
@@ -39,10 +39,14 @@ const SEARCH_KEYBOARD_SHORTCUTS = [
 ]
 
 interface ModalSearchContentProps {
+    placeholder?: string
     onClose: () => void
 }
 
-const ModalSearchContent = ({ onClose }: ModalSearchContentProps) => {
+const ModalSearchContent = ({
+    onClose,
+    placeholder,
+}: ModalSearchContentProps) => {
     const { euiTheme } = useEuiTheme()
     const mFontSize = useEuiFontSize('m').fontSize
     const searchTerm = useSearchTerm()
@@ -170,7 +174,7 @@ const ModalSearchContent = ({ onClose }: ModalSearchContentProps) => {
                     autoFocus
                     inputRef={inputRef}
                     fullWidth
-                    placeholder="Search in Elastic Internal Docs"
+                    placeholder={placeholder}
                     value={searchTerm}
                     onChange={(e) => setSearchTerm(e.target.value)}
                     onKeyDown={handleKeyDown}
@@ -492,7 +496,10 @@ export const ModalSearch = ({
                                 ${euiShadow(euiThemeContext, 'xl')};
                             `}
                         >
-                            <ModalSearchContent onClose={closeModal} />
+                            <ModalSearchContent
+                                onClose={closeModal}
+                                placeholder={placeholder}
+                            />
                         </EuiPanel>
                     </div>
                 </EuiPortal>


### PR DESCRIPTION
## What

- Fix inconsistent theme wrapping in the search bar by using a single light color mode instead of a nested dark/light provider split
- Make the modal search placeholder configurable via prop instead of hardcoding it, and shorten the Codex AI assistant placeholder

## Why

- The nested `EuiThemeProvider` override was unnecessary after recent refactors and caused theme inconsistency
- Hardcoded placeholder text prevented reuse across different contexts (Codex vs public docs)
- The previous AI placeholder was too long for the input field


Made with [Cursor](https://cursor.com)