### PR TITLE
MCP OAuth: use canonical issuer URL in metadata endpoints

### DIFF
--- a/src/api/Elastic.Documentation.Mcp.Remote/McpOAuthMetadata.cs
+++ b/src/api/Elastic.Documentation.Mcp.Remote/McpOAuthMetadata.cs
@@ -31,19 +31,14 @@ public static class McpOAuthMetadata
 	{
 		var env = SystemEnvironmentVariables.Instance;
 		var issuer = env.McpOAuthIssuer!;
-		var mcpPrefix = env.McpPrefix;
 
 		_ = group.MapGet("/.well-known/oauth-protected-resource", (HttpContext context) =>
 		{
-			var host = context.Request.Host.Value;
-			var scheme = context.Request.Scheme;
-			var resource = $"{scheme}://{host}{mcpPrefix}";
-
 			context.Response.Headers.CacheControl = CacheControlValue;
 			return Results.Json(
 				new ProtectedResourceMetadata
 				{
-					Resource = resource,
+					Resource = issuer,
 					AuthorizationServers = [issuer],
 					ScopesSupported = ScopesSupported,
 					BearerMethodsSupported = BearerMethodsSupported
@@ -54,18 +49,14 @@ public static class McpOAuthMetadata
 
 		_ = group.MapGet("/.well-known/openid-configuration", (HttpContext context) =>
 		{
-			var host = context.Request.Host.Value;
-			var scheme = context.Request.Scheme;
-			var baseUrl = $"{scheme}://{host}{mcpPrefix}";
-
 			context.Response.Headers.CacheControl = CacheControlValue;
 			return Results.Json(
 				new AuthorizationServerMetadata
 				{
 					Issuer = issuer,
-					AuthorizationEndpoint = $"{baseUrl}/authorize",
-					TokenEndpoint = $"{baseUrl}/token",
-					RegistrationEndpoint = $"{baseUrl}/register",
+					AuthorizationEndpoint = $"{issuer}/authorize",
+					TokenEndpoint = $"{issuer}/token",
+					RegistrationEndpoint = $"{issuer}/register",
 					ResponseTypesSupported = ResponseTypesSupported,
 					GrantTypesSupported = GrantTypesSupported,
 					CodeChallengeMethodsSupported = CodeChallengeMethodsSupported,


### PR DESCRIPTION
## What

- Use `MCP_OAUTH_ISSUER` for all URLs in the OAuth `.well-known` metadata responses instead of deriving them from the request host and scheme

## Why

- Behind CloudFront and ALB, `Request.Host` resolves to the internal ALB hostname and `Request.Scheme` to `http`, producing unreachable URLs in discovery responses
- MCP clients reject the metadata because the `resource` field (`http://<alb>/mcp`) does not match the expected `https://codex.elastic.dev/mcp`
- Companion to #2804 which fixed the same issue in the `WWW-Authenticate` header and audience validation


Made with [Cursor](https://cursor.com)