### PR TITLE
MCP: fix JWT claim mapping that drops sub and scope claims

### DIFF
--- a/src/api/Elastic.Documentation.Mcp.Remote/McpBearerAuthMiddleware.cs
+++ b/src/api/Elastic.Documentation.Mcp.Remote/McpBearerAuthMiddleware.cs
@@ -17,7 +17,7 @@ public class McpBearerAuthMiddleware(RequestDelegate next, ILogger<McpBearerAuth
 {
 	private const string McpUserKey = "McpUser";
 	private const string ExpectedAlg = "RS256";
-	private static readonly JwtSecurityTokenHandler TokenHandler = new();
+	private static readonly JwtSecurityTokenHandler TokenHandler = new() { MapInboundClaims = false };
 
 	public async Task InvokeAsync(HttpContext context)
 	{


### PR DESCRIPTION
## What

- Disable `MapInboundClaims` on the JWT token handler to preserve standard JWT claim names (`sub`, `scope`)

## Why

- `JwtSecurityTokenHandler` silently renames `sub` to a long .NET URI (`http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier`), causing `FindFirst("sub")` to return null
- This resulted in all valid tokens being rejected with `sub_missing` despite containing a valid `sub` claim


Made with [Cursor](https://cursor.com)