### PR TITLE
MCP: fix signature validation by setting KeyId on RsaSecurityKey

### DIFF
--- a/src/api/Elastic.Documentation.Mcp.Remote/McpBearerAuthMiddleware.cs
+++ b/src/api/Elastic.Documentation.Mcp.Remote/McpBearerAuthMiddleware.cs
@@ -149,7 +149,7 @@ public class McpBearerAuthMiddleware(RequestDelegate next, ILogger<McpBearerAuth
 
 		var validationParams = new TokenValidationParameters
 		{
-			IssuerSigningKey = new RsaSecurityKey(rsa),
+			IssuerSigningKey = new RsaSecurityKey(rsa) { KeyId = env.McpJwtKeyId },
 			ValidateIssuerSigningKey = true,
 			ValidateIssuer = env.McpOAuthIssuer is not null,
 			ValidIssuer = env.McpOAuthIssuer,


### PR DESCRIPTION
## What

- Set `KeyId` on the `RsaSecurityKey` used for JWT validation so it matches the token's `kid` claim

## Why

- The validation library (`Microsoft.IdentityModel`) requires the key's `KeyId` to match the token's `kid` header for signature verification
- Without it, the key has `KeyId: ''` while the token has `kid: '5y_pv_K7'`, causing `IDX10503: Signature validation failed` on follow-up MCP requests
- This prevents MCP clients from completing the protocol handshake (initialize succeeds, but tools/list fails)


Made with [Cursor](https://cursor.com)