### PR TITLE
MCP: use RSAParameters for signing key to prevent disposal issues

### DIFF
--- a/src/api/Elastic.Documentation.Mcp.Remote/McpBearerAuthMiddleware.cs
+++ b/src/api/Elastic.Documentation.Mcp.Remote/McpBearerAuthMiddleware.cs
@@ -129,10 +129,12 @@ public class McpBearerAuthMiddleware(RequestDelegate next, ILogger<McpBearerAuth
 			return (null, 401);
 		}
 
-		using var rsa = RSA.Create();
+		RSAParameters rsaParams;
 		try
 		{
+			using var rsa = RSA.Create();
 			rsa.ImportFromPem(env.McpJwtPublicKey);
+			rsaParams = rsa.ExportParameters(includePrivateParameters: false);
 		}
 		catch (CryptographicException)
 		{
@@ -149,7 +151,7 @@ public class McpBearerAuthMiddleware(RequestDelegate next, ILogger<McpBearerAuth
 
 		var validationParams = new TokenValidationParameters
 		{
-			IssuerSigningKey = new RsaSecurityKey(rsa) { KeyId = env.McpJwtKeyId },
+			IssuerSigningKey = new RsaSecurityKey(rsaParams) { KeyId = env.McpJwtKeyId },
 			ValidateIssuerSigningKey = true,
 			ValidateIssuer = env.McpOAuthIssuer is not null,
 			ValidIssuer = env.McpOAuthIssuer,


### PR DESCRIPTION
## What

- Create `RsaSecurityKey` from exported `RSAParameters` instead of a live `RSA` object to prevent premature key disposal during JWT validation

## Why

- The previous implementation used `using var rsa = RSA.Create()` and passed the `RSA` instance directly to `RsaSecurityKey`, which could be disposed before the static `JwtSecurityTokenHandler` finished validating the token signature
- This caused intermittent `IDX10511: Signature validation failed` errors on follow-up MCP requests


Made with [Cursor](https://cursor.com)