### PR TITLE
Codex: add icon to page frontmatter with docset override

### DIFF
--- a/docs/syntax/frontmatter.md
+++ b/docs/syntax/frontmatter.md
@@ -10,21 +10,23 @@ In the frontmatter block, you can define the following fields:
 ---
 navigation_title: This is the navigation title. <1>
 description: This is a description of the page. <2>
-applies_to: <3>
+icon: logo_elasticsearch <3>
+applies_to: <4>
   serverless: all
-products: <4>
+products: <5>
   - id: apm-agent
   - id: edot-sdk
-sub: <5>
+sub: <6>
   key: value 
 ---
 ```
 
 1. [`navigation_title`](#navigation-title)
 2. [`description`](#description)
-3. [`applies_to`](#applies-to)
-4. [`products`](#products)
-5. [`sub`](#subs)
+3. [`icon`](#icon)
+4. [`applies_to`](#applies-to)
+5. [`products`](#products)
+6. [`sub`](#subs)
 
 ## Navigation Title
 
@@ -38,6 +40,13 @@ It also sets the `og:description` and `twitter:description` meta tags.
 
 The `description` frontmatter is a string, recommended to be around 150 characters. If you don't set a `description`,
 it will be generated from the first few paragraphs of the page until it reaches 150 characters.
+
+## Icon
+
+Use the `icon` frontmatter to set the icon shown on the Codex landing page card for the documentation set.
+This overrides the deprecated `icon` field in `docset.yml` when set on the index page.
+The value is an icon name. See [Icons](icons.md) for available icons.
+In the future, this icon may also be used for navigation.
 
 ## Applies to
 

--- a/src/Elastic.Codex/Elastic.Codex.csproj
+++ b/src/Elastic.Codex/Elastic.Codex.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <!-- CS0618: DocumentationSetFile.Icon is deprecated but still used as fallback when frontmatter has no icon -->
+    <NoWarn>$(NoWarn);CS0618</NoWarn>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <InvariantGlobalization>true</InvariantGlobalization>

--- a/src/Elastic.Codex/Navigation/CategoryNavigation.cs
+++ b/src/Elastic.Codex/Navigation/CategoryNavigation.cs
@@ -76,6 +76,9 @@ public record CategoryIndexPage(string NavigationTitle) : IDocumentationFile
 
 	/// <inheritdoc />
 	public string? Description => null;
+
+	/// <inheritdoc />
+	public string? Icon => null;
 }
 
 /// <summary>

--- a/src/Elastic.Codex/Navigation/CodexIndexPage.cs
+++ b/src/Elastic.Codex/Navigation/CodexIndexPage.cs
@@ -16,6 +16,9 @@ public record CodexIndexPage(string NavigationTitle) : IDocumentationFile
 
 	/// <inheritdoc />
 	public string? Description => null;
+
+	/// <inheritdoc />
+	public string? Icon => null;
 }
 
 /// <summary>

--- a/src/Elastic.Codex/Navigation/CodexNavigation.cs
+++ b/src/Elastic.Codex/Navigation/CodexNavigation.cs
@@ -119,7 +119,7 @@ public class CodexNavigation : IRootNavigationItem<IDocumentationFile, INavigati
 				Group = docSetRef.Group,
 				PageCount = CountPages(rootNavItem),
 				Description = rootNavItem.Index.Model.Description,
-				Icon = docSetRef.Icon
+				Icon = rootNavItem.Index.Model.Icon ?? docSetRef.Icon
 			};
 
 		private void AttachToGroup(

--- a/src/Elastic.Codex/Navigation/GroupNavigation.cs
+++ b/src/Elastic.Codex/Navigation/GroupNavigation.cs
@@ -103,6 +103,9 @@ public record GroupIndexPage(string NavigationTitle) : IDocumentationFile
 
 	/// <inheritdoc />
 	public string? Description => null;
+
+	/// <inheritdoc />
+	public string? Icon => null;
 }
 
 /// <summary>
@@ -147,6 +150,9 @@ public record GroupLinkPage(string NavigationTitle, string Url) : IDocumentation
 
 	/// <inheritdoc />
 	public string? Description => null;
+
+	/// <inheritdoc />
+	public string? Icon => null;
 }
 
 /// <summary>

--- a/src/Elastic.Documentation.Configuration/Toc/DocumentationSetFile.cs
+++ b/src/Elastic.Documentation.Configuration/Toc/DocumentationSetFile.cs
@@ -41,6 +41,7 @@ public class DocumentationSetFile : TableOfContentsFile
 	[YamlMember(Alias = "description")]
 	public string? Description { get; set; }
 
+	[Obsolete("Use the index.md frontmatter icon instead. This field will be removed in a future version.")]
 	[YamlMember(Alias = "icon")]
 	public string? Icon { get; set; }
 
@@ -116,6 +117,8 @@ public class DocumentationSetFile : TableOfContentsFile
 		fileSystem ??= sourceDirectory.FileSystem;
 		var docSet = Deserialize(yaml);
 		var docsetPath = fileSystem.Path.Combine(sourceDirectory.FullName, "docset.yml").OptionalWindowsReplace();
+		if (docSet.Icon is not null)
+			collector.EmitHint(docsetPath, "'icon' in docset.yml is deprecated. Use the 'icon' frontmatter in index.md instead.");
 		docSet.SuppressDiagnostics.ExceptWith(noSuppress ?? []);
 		docSet.TableOfContents = ResolveTableOfContents(collector, docSet.TableOfContents, sourceDirectory, fileSystem, parentPath: "", containerPath: "", context: docsetPath, docSet.SuppressDiagnostics);
 		return docSet;

--- a/src/Elastic.Documentation.Navigation/IDocumentationFile.cs
+++ b/src/Elastic.Documentation.Navigation/IDocumentationFile.cs
@@ -14,6 +14,9 @@ public interface IDocumentationFile : INavigationModel
 	/// Gets the page description from frontmatter, if set.
 	string? Description { get; }
 
+	/// Gets the icon from frontmatter, if set.
+	string? Icon { get; }
+
 	/// Gets the title to display in navigation for this documentation file.
 	string NavigationTitle { get; }
 }

--- a/src/Elastic.Documentation.Navigation/Isolated/Leaf/CrossLinkNavigationLeaf.cs
+++ b/src/Elastic.Documentation.Navigation/Isolated/Leaf/CrossLinkNavigationLeaf.cs
@@ -18,6 +18,9 @@ public record CrossLinkModel(Uri CrossLinkUri, string NavigationTitle) : IDocume
 
 	/// <inheritdoc />
 	public string? Description => null;
+
+	/// <inheritdoc />
+	public string? Icon => null;
 }
 
 [DebuggerDisplay("{Url}")]

--- a/src/Elastic.Markdown/IO/MarkdownFile.cs
+++ b/src/Elastic.Markdown/IO/MarkdownFile.cs
@@ -74,6 +74,8 @@ public record MarkdownFile : DocumentationFile, ITableOfContentsScope, IDocument
 
 	public string? Description { get; private set; }
 
+	public string? Icon { get; private set; }
+
 	[field: AllowNull, MaybeNull]
 	public string NavigationTitle
 	{
@@ -161,6 +163,8 @@ public record MarkdownFile : DocumentationFile, ITableOfContentsScope, IDocument
 			NavigationTitle = yamlFrontMatter.NavigationTitle;
 		if (yamlFrontMatter.Description is not null)
 			Description = yamlFrontMatter.Description;
+		if (yamlFrontMatter.Icon is not null)
+			Icon = yamlFrontMatter.Icon;
 
 		var subs = GetSubstitutions();
 

--- a/src/Elastic.Markdown/Myst/FrontMatter/FrontMatterParser.cs
+++ b/src/Elastic.Markdown/Myst/FrontMatter/FrontMatterParser.cs
@@ -19,6 +19,9 @@ public class YamlFrontMatter
 	[YamlMember(Alias = "description")]
 	public string? Description { get; set; }
 
+	[YamlMember(Alias = "icon")]
+	public string? Icon { get; set; }
+
 	[YamlMember(Alias = "navigation_title")]
 	public string? NavigationTitle { get; set; }
 

--- a/tests/Navigation.Tests/TestDocumentationSetContext.cs
+++ b/tests/Navigation.Tests/TestDocumentationSetContext.cs
@@ -110,13 +110,16 @@ public class TestDocumentationSetContext : IDocumentationSetContext
 	public IReadOnlyCollection<Diagnostic> Diagnostics => ((TestDiagnosticsCollector)Collector).Diagnostics;
 }
 
-public class TestDocumentationFile(string title, string? navigationTitle = null, string? description = null) : IDocumentationFile
+public class TestDocumentationFile(string title, string? navigationTitle = null, string? description = null, string? icon = null) : IDocumentationFile
 {
 	/// <inheritdoc />
 	public string Title { get; } = title;
 
 	/// <inheritdoc />
 	public string? Description { get; } = description;
+
+	/// <inheritdoc />
+	public string? Icon { get; } = icon;
 
 	/// <inheritdoc />
 	public string NavigationTitle { get; } = navigationTitle ?? title;


### PR DESCRIPTION
## What

- Add `icon` to page frontmatter alongside `description`
- Frontmatter icon overrides docset icon on Codex landing page cards
- Deprecate `icon` in docset.yml with a build-time hint

## Why

- Title and description live in index.md frontmatter, but icon was in docset.yml. Keeping icon in the same document as title and description is more consistent.
- This prepares for a future navigation refactor or redesign where icon may be used in navigation.

Made with [Cursor](https://cursor.com)