### PR TITLE
Include parent titles in document hash to fix stale breadcrumbs

### DIFF
--- a/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchMarkdownExporter.Export.cs
+++ b/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchMarkdownExporter.Export.cs
@@ -34,7 +34,8 @@ public partial class ElasticsearchMarkdownExporter
 			doc.SearchTitle ?? string.Empty,
 			doc.NavigationSection ?? string.Empty, doc.NavigationDepth.ToString("N0"),
 			doc.NavigationTableOfContents.ToString("N0"),
-			_fixedSynonymsHash
+			_fixedSynonymsHash,
+			string.Join(",", doc.Parents?.Select(p => $"{p.Url}:{p.Title}") ?? [])
 		);
 		doc.Hash = hash;
 		doc.LastUpdated = _batchIndexDate;


### PR DESCRIPTION
## What

- Add parent URL and title to the document hash used for indexing
- Child documents are now re-indexed when a parent page's title changes

## Why

- Documents were showing stale parent titles in search results because the hash did not include parent information
- The hash-based bulk upsert treated child docs as unchanged when only parent titles changed, so they were skipped

## Notes

- One-line change in `AssignDocumentMetadata`; no structural changes

Made with [Cursor](https://cursor.com)