### PR TITLE
Codex: fix redirect path format in CloudFront KVS

### DIFF
--- a/src/Elastic.Codex/Building/CodexBuildService.cs
+++ b/src/Elastic.Codex/Building/CodexBuildService.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Collections.Frozen;
 using System.IO.Abstractions;
 using System.Text.Json;
 using Elastic.Codex.Navigation;
@@ -195,6 +196,8 @@ public class CodexBuildService(
 			};
 
 			ICrossLinkResolver crossLinkResolver;
+			var codexRepos = new HashSet<string> { repoName };
+
 			if (buildContext.Configuration.CrossLinkEntries.Length > 0)
 			{
 				var fetcher = new DocSetConfigurationCrossLinkFetcher(
@@ -202,14 +205,15 @@ public class CodexBuildService(
 					buildContext.Configuration,
 					codexLinkIndexReader: buildContext.Configuration.Registry != DocSetRegistry.Public ? codexLinkIndexReader : null);
 				var crossLinks = await fetcher.FetchCrossLinks(ctx);
-				IUriEnvironmentResolver? uriResolver = crossLinks.CodexRepositories is not null
-					? new CodexAwareUriResolver(crossLinks.CodexRepositories, useRelativePaths: true)
-					: null;
+				if (crossLinks.CodexRepositories is not null)
+					codexRepos.UnionWith(crossLinks.CodexRepositories);
+				var uriResolver = new CodexAwareUriResolver(codexRepos.ToFrozenSet(), useRelativePaths: true);
 				crossLinkResolver = new CrossLinkResolver(crossLinks, uriResolver);
 			}
 			else
 			{
-				crossLinkResolver = NoopCrossLinkResolver.Instance;
+				var uriResolver = new CodexAwareUriResolver(codexRepos.ToFrozenSet(), useRelativePaths: true);
+				crossLinkResolver = new CrossLinkResolver(FetchedCrossLinks.Empty, uriResolver);
 			}
 
 			// Create documentation set
@@ -295,7 +299,9 @@ public class CodexBuildService(
 					CrossLinkResolver.ToTargetUrlPath(path));
 			}
 
-			return uri?.AbsolutePath ?? string.Empty;
+			return uri is null
+				? string.Empty
+				: uri.IsAbsoluteUri ? uri.AbsolutePath : uri.OriginalString;
 		}
 	}
 

--- a/tests/Elastic.Markdown.Tests/CrossLinks/UriEnvironmentResolverTests.cs
+++ b/tests/Elastic.Markdown.Tests/CrossLinks/UriEnvironmentResolverTests.cs
@@ -8,6 +8,15 @@ using FluentAssertions;
 
 namespace Elastic.Markdown.Tests.CrossLinks;
 
+/// <summary>Mirrors the path extraction logic in CodexBuildService.CollectRedirects.</summary>
+internal static class RedirectPathExtractor
+{
+	public static string GetPath(Uri? uri) =>
+		uri is null
+			? string.Empty
+			: uri.IsAbsoluteUri ? uri.AbsolutePath : uri.OriginalString;
+}
+
 public class CodexAwareUriResolverTests
 {
 	private static readonly FrozenSet<string> CodexRepos =
@@ -85,6 +94,34 @@ public class CodexAwareUriResolverTests
 		result.IsAbsoluteUri.Should().BeTrue();
 		result.ToString().Should().Be("https://codex.elastic.dev/r/observability-robots/page");
 	}
+
+	[Fact]
+	public void SameRepoRedirect_CurrentRepoInCodexSet_ProducesCodexPath()
+	{
+		var codexRepos = new HashSet<string> { "ai-guild" }.ToFrozenSet();
+		var resolver = new CodexAwareUriResolver(codexRepos, useRelativePaths: true);
+		var crossLinkUri = new Uri("ai-guild://best-practices/tools", UriKind.Absolute);
+		var targetPath = CrossLinkResolver.ToTargetUrlPath("best-practices/tools");
+
+		var result = resolver.Resolve(crossLinkUri, targetPath);
+
+		result.IsAbsoluteUri.Should().BeFalse();
+		result.ToString().Should().Be("/r/ai-guild/best-practices/tools");
+	}
+
+	[Fact]
+	public void SameRepoRedirect_WithIndexNormalization_StripsTrailingIndex()
+	{
+		var codexRepos = new HashSet<string> { "ai-guild" }.ToFrozenSet();
+		var resolver = new CodexAwareUriResolver(codexRepos, useRelativePaths: true);
+		var crossLinkUri = new Uri("ai-guild://best-practices/tools/index.md", UriKind.Absolute);
+		var targetPath = CrossLinkResolver.ToTargetUrlPath("best-practices/tools/index.md");
+
+		var result = resolver.Resolve(crossLinkUri, targetPath);
+
+		result.IsAbsoluteUri.Should().BeFalse();
+		result.ToString().Should().Be("/r/ai-guild/best-practices/tools");
+	}
 }
 
 public class IsolatedBuildEnvironmentUriResolverTests
@@ -121,5 +158,68 @@ public class IsolatedBuildEnvironmentUriResolverTests
 		var result = resolver.Resolve(uri, "page");
 
 		result.ToString().Should().Contain("/tree/main/");
+	}
+}
+
+public class CodexRedirectPathExtractionTests
+{
+	[Fact]
+	public void RelativeUri_FromCodexAwareResolver_ExtractsPathCorrectly()
+	{
+		var codexRepos = new HashSet<string> { "ai-guild" }.ToFrozenSet();
+		var resolver = new CodexAwareUriResolver(codexRepos, useRelativePaths: true);
+		var uri = resolver.Resolve(new Uri("ai-guild://tools", UriKind.Absolute), "tools");
+
+		var path = RedirectPathExtractor.GetPath(uri);
+
+		path.Should().Be("/r/ai-guild/tools");
+	}
+
+	[Fact]
+	public void AbsoluteUri_FromCodexAwareResolver_ExtractsPathCorrectly()
+	{
+		var codexRepos = new HashSet<string> { "ai-guild" }.ToFrozenSet();
+		var resolver = new CodexAwareUriResolver(codexRepos, useRelativePaths: false);
+		var uri = resolver.Resolve(new Uri("ai-guild://tools", UriKind.Absolute), "tools");
+
+		var path = RedirectPathExtractor.GetPath(uri);
+
+		path.Should().Be("/r/ai-guild/tools");
+	}
+
+	[Fact]
+	public void AbsoluteUri_FromIsolatedBuildResolver_ExtractsPathCorrectly()
+	{
+		var resolver = new IsolatedBuildEnvironmentUriResolver();
+		var uri = resolver.Resolve(new Uri("docs-content://get-started", UriKind.Absolute), "get-started");
+
+		var path = RedirectPathExtractor.GetPath(uri);
+
+		path.Should().Be("/elastic/docs-content/tree/main/get-started");
+	}
+
+	[Fact]
+	public void NullUri_ReturnsEmptyString()
+	{
+		var path = RedirectPathExtractor.GetPath(null);
+
+		path.Should().BeEmpty();
+	}
+}
+
+public class CodexCrossRepoRedirectTests
+{
+	[Fact]
+	public void CrossRepoRedirect_TargetInCodexRepo_ResolvesToCodexPath()
+	{
+		var resolver = new Elastic.Markdown.Tests.TestCodexCrossLinkResolver(useRelativePaths: true);
+		var crossRepoUri = new Uri("kibana://get-started/index.md", UriKind.Absolute);
+
+		var success = resolver.TryResolve(_ => { }, crossRepoUri, out var resolvedUri);
+
+		success.Should().BeTrue();
+		resolvedUri.Should().NotBeNull();
+		resolvedUri!.IsAbsoluteUri.Should().BeFalse();
+		resolvedUri.ToString().Should().Be("/r/kibana/get-started");
 	}
 }


### PR DESCRIPTION
## What

- Codex redirects now use `/r/{repo}/{path}` format in the CloudFront KeyValueStore instead of `/elastic/{repo}/tree/main/{path}`
- Same-repo and cross-repo redirects both resolve correctly for codex builds

## Why

- The KVS redirect lookup expects codex URLs (e.g. `/r/ai-guild/best-practices/tools`), but redirects were being stored with the preview URL format
- This caused redirects like `best-practices/tools` -> `tools` to fail because the stored keys did not match incoming requests

## Notes

- Include current repo in `codexRepositories` when building the URI resolver so same-repo redirects use the codex path format
- Handle relative URIs in path extraction (CodexAwareUriResolver returns relative URIs in codex build mode)

Made with [Cursor](https://cursor.com)