### PR TITLE
Fix spacing between title and description in changelog output

### DIFF
--- a/src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogInlineRenderer.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogInlineRenderer.cs
@@ -307,6 +307,7 @@ public static class ChangelogInlineRenderer
 
 		if (!string.IsNullOrWhiteSpace(entry.Description))
 		{
+			_ = sb.AppendLine();
 			var indented = ChangelogTextUtilities.Indent(entry.Description);
 			_ = sb.AppendLine(indented);
 		}

--- a/src/services/Elastic.Changelog/Rendering/Markdown/IndexMarkdownRenderer.cs
+++ b/src/services/Elastic.Changelog/Rendering/Markdown/IndexMarkdownRenderer.cs
@@ -204,8 +204,8 @@ public class IndexMarkdownRenderer(IFileSystem fileSystem) : MarkdownRendererBas
 
 				if (!string.IsNullOrWhiteSpace(entry.Description))
 				{
-					// Add blank line before description
 					_ = sb.AppendLine(entryHideLinks && hasCommentedLinks ? "  " : "");
+					_ = sb.AppendLine();
 					var indented = ChangelogTextUtilities.Indent(entry.Description);
 					if (shouldHide)
 					{

--- a/tests/Elastic.Markdown.Tests/Directives/ChangelogBasicTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/ChangelogBasicTests.cs
@@ -570,3 +570,43 @@ public class ChangelogHeaderLevelsTests : DirectiveTest<ChangelogBlock>
 		return count;
 	}
 }
+
+/// <summary>
+/// Verifies that when a changelog entry has both a title and a description,
+/// the rendered output does not concatenate them without a separator.
+/// Regression test for: "allowlist.This PR introduces..." (no space between title and description).
+/// </summary>
+public class ChangelogTitleDescriptionSpacingTests : DirectiveTest<ChangelogBlock>
+{
+	public ChangelogTitleDescriptionSpacingTests(ITestOutputHelper output) : base(output,
+		// language=markdown
+		"""
+		:::{changelog}
+		:::
+		""") => FileSystem.AddFile("docs/changelog/bundles/9.3.0.yaml", new MockFileData(
+		// language=yaml
+		"""
+		products:
+		- product: elasticsearch
+		  target: 9.3.0
+		entries:
+		- title: Added missing banner-related Kibana settings to the settings allowlist
+		  type: feature
+		  products:
+		  - product: elasticsearch
+		    target: 9.3.0
+		  description: This PR introduces the following settings.
+		"""));
+
+	[Fact]
+	public void RendersTitleText() =>
+		Html.Should().Contain("Added missing banner-related Kibana settings to the settings allowlist");
+
+	[Fact]
+	public void RendersDescriptionText() =>
+		Html.Should().Contain("This PR introduces the following settings");
+
+	[Fact]
+	public void DoesNotConcatenateTitleAndDescriptionWithoutSeparator() =>
+		Html.Should().NotContain("allowlist.This PR introduces");
+}


### PR DESCRIPTION
## Summary
Fix missing separator between changelog entry title and description in rendered output, by emitting a genuine blank line between them in the generated output so they parse as separate paragraphs in all rendering contexts.

## Root cause

The generated intermediate markdown for a list-item changelog entry (feature, bug-fix, etc.) looks like:

```markdown
* Title. [#123](url)
  Description text
```

`RenderEntryLinks` in both renderers always ends with `sb.AppendLine()`, and the description is then appended as a tight continuation (same paragraph). Markdig parses this as a single `ParagraphBlock` whose inline nodes are `LiteralInline("Title.")` + `SoftlineBreak` + `LiteralInline("Description text")`.

In **HTML rendering** browsers collapse `\n` to a space, so the bug is invisible there. But in the **LLM markdown exporter** (`LlmLineBreakInlineRenderer`, `LlmInlineRenderers.cs` line 84–89), ALL `LineBreakInline` nodes — both hard and soft — are rendered as `\n` via `renderer.WriteLine()`, never as `" "` (space). Downstream processors that strip bare `\n` produce `"Title.Description text"` with no separator.

One option for fixing was to use `IndentWithSeparator`, which was ultimately deemed the wrong solution since using 3 spaces instead of 2 still produces a tight list continuation — the AST still has a `SoftlineBreak` inline. It does not fix the issue.

`IndexMarkdownRenderer` has the same bug: the comment `// Add blank line before description` is misleading — `sb.AppendLine("")` only appends ONE `\n` (terminating the title line). It does not create a genuine blank line.

## Fix details

Add an extra `sb.AppendLine()` *before* the description in both renderers. This creates a **genuine blank line** (`\n\n`) in the generated markdown, making the list item "loose". Markdig then parses title+links and description as separate `ParagraphBlock`s — no `SoftlineBreak` inline is generated — so the separator is unambiguous in all rendering contexts (HTML, LLM markdown, plain text, search indexing).

## Files changed

**`ChangelogInlineRenderer.cs`** — `RenderSingleEntry`: added `_ = sb.AppendLine();` before indenting the description. The extra blank line forces Markdig to parse the title/links and description as separate `ParagraphBlock`s (a "loose" list item) rather than a single paragraph with a `SoftlineBreak` inline — which eliminates the concatenation in all rendering contexts.

**`IndexMarkdownRenderer.cs`** — `RenderEntriesByArea`: same fix; added a second `_ = sb.AppendLine();` after the line that terminates the title/links line.

**`ChangelogBasicTests.cs`**: added `ChangelogTitleDescriptionSpacingTests` with three assertions — title text is present, description text is present, and `"allowlist.This PR introduces"` (no separator) is absent. All 4 tests (including `BlockIsNotNull` inherited from the base) pass.

## Screenshots

### Before

<img width="1679" height="721" alt="image" src="https://github.com/user-attachments/assets/8ee374cc-4fac-4e74-8ccd-f6daa9c10610" />

### After

<img width="1393" height="830" alt="image" src="https://github.com/user-attachments/assets/a27d6f27-aafc-4417-a8aa-043037bf6dcf" />

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: composer-1.5, clause-4.6-sonnet-medium
