### PR TITLE
Add changelog mapping from labels to products

### DIFF
--- a/config/changelog.example.yml
+++ b/config/changelog.example.yml
@@ -105,6 +105,26 @@ pivot:
     #   - ":Search/Search"
     #   - ":Search/Ranking"
 
+  # Product definitions with labels (optional).
+  # Keys are product spec strings; values are label strings or lists that trigger that product.
+  # A product spec string is: "<product-id> [<target-version>] [<lifecycle>]"
+  #   - Product ID only:           "elasticsearch"
+  #   - Product + target:          "kibana 9.2.0"
+  #   - Full spec:                 "cloud-serverless 2025-06 ga"
+  # When a PR has labels matching any product entry, all matching products are added.
+  # Precedence: --products CLI option > pivot.products label mapping > products.default > repo inference.
+  #
+  # products:
+  #   'elasticsearch':
+  #     - ":stack/elasticsearch"
+  #   'kibana':
+  #     - ":stack/kibana"
+  #   'cloud-serverless':
+  #     - ":cloud/serverless"
+  #   # Specify a target version if known:
+  #   # 'elasticsearch 9.2.0':
+  #   #   - ":feature/new-in-9.2"
+
 # Rules configuration — controls which PRs create changelogs and which entries are published.
 # All list-like fields (exclude, include, exclude_types, etc.) accept BOTH forms:
 #   - Comma-separated string: "value1, value2, value3"

--- a/docs/cli/release/changelog-add.md
+++ b/docs/cli/release/changelog-add.md
@@ -71,9 +71,11 @@ docs-builder changelog add [options...] [-h|--help]
 :   Falls back to `bundle.owner` in `changelog.yml` when not specified. If that value is also absent, defaults to `elastic`.
 
 `--products <List<ProductInfo>>`
-:   Required: Products affected in format "product target lifecycle, ..." (for example, `"elasticsearch 9.2.0 ga, cloud-serverless 2025-08-05"`).
+:   Products affected in format "product target lifecycle, ..." (for example, `"elasticsearch 9.2.0 ga, cloud-serverless 2025-08-05"`).
 :   The valid product identifiers are listed in [products.yml](https://github.com/elastic/docs-builder/blob/main/config/products.yml).
 :   The valid lifecycles are listed in [ChangelogConfiguration.cs](https://github.com/elastic/docs-builder/blob/main/src/services/Elastic.Documentation.Services/Changelog/ChangelogConfiguration.cs).
+:   **Precedence when `--products` is not specified:** products are derived from PR/issue labels via `pivot.products` label mappings (if configured), then from `products.default` in `changelog.yml`, and finally inferred from the current git repository name. An error is raised if no products can be determined by any of these means.
+:   See [Products resolution](#products-resolution) in the how-to guide for full details.
 
 `--prs <string[]?>`
 :   Optional: Pull request URLs or numbers (comma-separated), or a path to a newline-delimited file containing PR URLs or numbers. Can be specified multiple times.
@@ -82,9 +84,9 @@ docs-builder changelog add [options...] [-h|--help]
 :   When specifying a file path, provide a single value that points to a newline-delimited file.
 :   If `--owner` and `--repo` are provided, PR numbers can be used instead of URLs.
 :   If specified, `--title` can be derived from the PR.
-:   If mappings are configured, `--areas` and `--type` can also be derived from the PR.
+:   If mappings are configured, `--areas`, `--type`, and `--products` can also be derived from the PR labels.
 :   Creates one changelog file per PR.
-:   If there are `block ... create` definitions in the changelog configuration file and a PR has a blocking label for any product in `--products`, that PR is skipped and no changelog file is created for it.
+:   If there are `block ... create` definitions in the changelog configuration file and a PR has a blocking label for the resolved products, that PR is skipped and no changelog file is created for it.
 
 `--release-version <string?>`
 :   Optional: GitHub release tag to use as a source of pull requests (for example, `"v9.2.0"` or `"latest"`).

--- a/docs/cli/release/changelog-add.md
+++ b/docs/cli/release/changelog-add.md
@@ -132,7 +132,7 @@ When you run the `changelog add` command without the `--products` option, it res
 1. **`--products` CLI option** — always takes priority.
 2. **`pivot.products` label mapping** — if `pivot.products` is configured and the PR or issue has labels that match, those products are used. Multiple matching entries are all applied.
 3. **`products.default` in `changelog.yml`** — the configured default products are used.
-4. **Git repository inference** — if the current working directory is a git repository, the repository name is matched against known product IDs.
+4. **Repository name inference** — if `--repo` is specified (or `bundle.repo` is set in `changelog.yml`), the repository name is matched against known product IDs in `products.yml`.
 5. **Error** — if none of the above resolves to at least one product, an error is raised.
 
 Product-specific `rules.create` rules are evaluated *after* products are resolved from labels, so label-derived products correctly participate in per-product create rule checks.

--- a/docs/cli/release/changelog-add.md
+++ b/docs/cli/release/changelog-add.md
@@ -75,7 +75,7 @@ docs-builder changelog add [options...] [-h|--help]
 :   The valid product identifiers are listed in [products.yml](https://github.com/elastic/docs-builder/blob/main/config/products.yml).
 :   The valid lifecycles are listed in [ChangelogConfiguration.cs](https://github.com/elastic/docs-builder/blob/main/src/services/Elastic.Documentation.Services/Changelog/ChangelogConfiguration.cs).
 :   **Precedence when `--products` is not specified:** products are derived from PR/issue labels via `pivot.products` label mappings (if configured), then from `products.default` in `changelog.yml`, and finally inferred from the current git repository name. An error is raised if no products can be determined by any of these means.
-:   See [Products resolution](#products-resolution) in the how-to guide for full details.
+:   Refer to [](#products-resolution) for more details.
 
 `--prs <string[]?>`
 :   Optional: Pull request URLs or numbers (comma-separated), or a path to a newline-delimited file containing PR URLs or numbers. Can be specified multiple times.
@@ -124,3 +124,15 @@ docs-builder changelog add [options...] [-h|--help]
 
 `--use-issue-number`
 :   Optional: Use issue numbers for filenames instead of timestamp-slug. With both `--prs` (which creates one changelog per specified PR) and `--issues` (which creates one changelog per specified issue), each changelog filename will be derived from its issues. Requires `--prs` or `--issues`. Mutually exclusive with `--use-pr-number`.
+
+## Products resolution [products-resolution]
+
+When you run the `changelog add` command without the `--products` option, it resolves products in the following order:
+
+1. **`--products` CLI option** — always takes priority.
+2. **`pivot.products` label mapping** — if `pivot.products` is configured and the PR or issue has labels that match, those products are used. Multiple matching entries are all applied.
+3. **`products.default` in `changelog.yml`** — the configured default products are used.
+4. **Git repository inference** — if the current working directory is a git repository, the repository name is matched against known product IDs.
+5. **Error** — if none of the above resolves to at least one product, an error is raised.
+
+Product-specific `rules.create` rules are evaluated *after* products are resolved from labels, so label-derived products correctly participate in per-product create rule checks.

--- a/docs/contribute/changelog.md
+++ b/docs/contribute/changelog.md
@@ -64,7 +64,7 @@ In each of these cases where validation fails, a changelog file is not created.
 
 ### GitHub label mappings
 
-When you run the `docs-builder changelog add` command with the `--prs` or `--issues` options, it can use label mappings in the changelog configuration file to infer the changelog `type` and `areas` fields from your GitHub labels.
+When you run the `docs-builder changelog add` command with the `--prs` or `--issues` options, it can use label mappings in the changelog configuration file to infer the changelog `type`, `areas`, and `products` fields from your GitHub labels.
 
 Refer to the file layout in [changelog.example.yml](https://github.com/elastic/docs-builder/blob/main/config/changelog.example.yml) and an [example usage](#example-map-label).
 
@@ -213,7 +213,7 @@ The following configurations cause validation errors:
 
 You can use the `docs-builder changelog add` command to create a changelog file.
 
-If you specify `--prs` or `--issues`, the command tries to fetch information from GitHub. It derives the changelog `title` from the pull request or issue title, maps labels to type and areas (if configured), and extracts linked references.
+If you specify `--prs` or `--issues`, the command tries to fetch information from GitHub. It derives the changelog `title` from the pull request or issue title, maps labels to areas, products, and type (if configured), and extracts linked references.
 With `--issues`, it extracts linked PRs from the issue body (for example, "Fixed by #123").
 With `--prs`, it extracts linked issues from the PR body (for example, "Fixes #123").
 
@@ -260,6 +260,18 @@ Examples:
 - `"kibana 9.2.0 ga"`
 - `"cloud-serverless 2025-08-05"`
 - `"cloud-enterprise 4.0.3, cloud-hosted 2025-10-31"`
+
+#### Products resolution [products-resolution]
+
+When you run the `changelog add` command without the `--products` option, it resolves products in the following order:
+
+1. **`--products` CLI option** — always takes priority.
+2. **`pivot.products` label mapping** — if `pivot.products` is configured and the PR or issue has labels that match, those products are used. Multiple matching entries are all applied.
+3. **`products.default` in `changelog.yml`** — the configured default products are used.
+4. **Git repository inference** — if the current working directory is a git repository, the repository name is matched against known product IDs.
+5. **Error** — if none of the above resolves to at least one product, an error is raised.
+
+Product-specific `rules.create` rules are evaluated *after* products are resolved from labels, so label-derived products correctly participate in per-product create rule checks.
 
 ### Filenames
 
@@ -331,19 +343,32 @@ pivot:
     # Example mappings - customize based on your label naming conventions
     Autoscaling: ":Distributed Coordination/Autoscaling"
     "ES|QL": ":Search Relevance/ES|QL"
+
+  # Product definitions with labels (optional)
+  # Keys are product spec strings; values are label strings or lists.
+  # A product spec string is: "<product-id> [<target-version>] [<lifecycle>]"
+  products:
+    'elasticsearch':
+      - ":stack/elasticsearch"
+    'kibana':
+      - ":stack/kibana"
+    # Include a target version if known:
+    # 'cloud-serverless 2025-06 ga':
+    #   - ":cloud/serverless"
 ```
 
-When you use the `--prs` option to derive information from a pull request, it can make use of those mappings. Similarly, when you use the `--issues` option (without `--prs`), the command derives title, type, and areas from the GitHub issue labels using the same mappings:
+When you use the `--prs` option to derive information from a pull request, it can make use of those mappings. Similarly, when you use the `--issues` option (without `--prs`), the command derives title, type, areas, and products from the GitHub issue labels using the same mappings.
+
+The following example omits `--products`, so the command derives them from the PR labels:
 
 ```sh
 docs-builder changelog add \
   --prs https://github.com/elastic/elasticsearch/pull/139272 \
-  --products "elasticsearch 9.3.0" \
   --config test/changelog.yml \
   --strip-title-prefix
 ```
 
-In this case, the changelog file derives the title, type, and areas from the pull request.
+In this case, the changelog file derives the title, type, areas, and products from the pull request. If none of the PR's labels match `pivot.products`, the command falls back to `products.default` or git repository inference (see [Products resolution](#products-resolution)).
 The command also looks for patterns like `Fixes #123`, `Closes owner/repo#456`, `Resolves https://github.com/.../issues/789` in the pull request to derive its issues. Similarly, when using `--issues`, the command extracts linked PRs from the issue body (for example, "Fixed by #123"). You can turn off this behavior in either case with the `--no-extract-issues` flag or by setting `extract.issues: false` in the changelog configuration file. The `extract.issues` setting applies to both directions: issues extracted from PR bodies (when using `--prs`) and PRs extracted from issue bodies (when using `--issues`).
 
 The `--strip-title-prefix` option in this example means that if the PR title has a prefix in square brackets (such as `[ES|QL]` or `[Security]`), it is automatically removed from the changelog title. Multiple square bracket prefixes are also supported (for example `[Discover][ESQL] Title` becomes `Title`). If a colon follows the closing bracket, it is also removed.
@@ -380,7 +405,7 @@ You can turn off the release note extraction in the changelog configuration file
 
 You can prevent changelog creation for certain PRs based on their labels.
 
-If you run the `docs-builder changelog add` command with the `--prs` option and a PR has a blocking label for any of the products in the `--products` option, that PR will be skipped and no changelog file will be created for it.
+If you run the `docs-builder changelog add` command with the `--prs` option and a PR has a blocking label for any of the resolved products (from `--products`, `pivot.products` label mapping, or `products.default`), that PR will be skipped and no changelog file will be created for it.
 A warning message will be emitted indicating which PR was skipped and why.
 
 For example, your configuration file can contain a `rules` section like this:

--- a/docs/contribute/changelog.md
+++ b/docs/contribute/changelog.md
@@ -261,18 +261,6 @@ Examples:
 - `"cloud-serverless 2025-08-05"`
 - `"cloud-enterprise 4.0.3, cloud-hosted 2025-10-31"`
 
-#### Products resolution [products-resolution]
-
-When you run the `changelog add` command without the `--products` option, it resolves products in the following order:
-
-1. **`--products` CLI option** — always takes priority.
-2. **`pivot.products` label mapping** — if `pivot.products` is configured and the PR or issue has labels that match, those products are used. Multiple matching entries are all applied.
-3. **`products.default` in `changelog.yml`** — the configured default products are used.
-4. **Git repository inference** — if the current working directory is a git repository, the repository name is matched against known product IDs.
-5. **Error** — if none of the above resolves to at least one product, an error is raised.
-
-Product-specific `rules.create` rules are evaluated *after* products are resolved from labels, so label-derived products correctly participate in per-product create rule checks.
-
 ### Filenames
 
 By default, the `docs-builder changelog add` command generates filenames using a timestamp and a sanitized version of the title:
@@ -368,7 +356,7 @@ docs-builder changelog add \
   --strip-title-prefix
 ```
 
-In this case, the changelog file derives the title, type, areas, and products from the pull request. If none of the PR's labels match `pivot.products`, the command falls back to `products.default` or git repository inference (see [Products resolution](#products-resolution)).
+In this case, the changelog file derives the title, type, areas, and products from the pull request. If none of the PR's labels match `pivot.products`, the command falls back to `products.default` or git repository inference (refer to [Products resolution](/cli/release/changelog-add.md#products-resolution) for more details).
 The command also looks for patterns like `Fixes #123`, `Closes owner/repo#456`, `Resolves https://github.com/.../issues/789` in the pull request to derive its issues. Similarly, when using `--issues`, the command extracts linked PRs from the issue body (for example, "Fixed by #123"). You can turn off this behavior in either case with the `--no-extract-issues` flag or by setting `extract.issues: false` in the changelog configuration file. The `extract.issues` setting applies to both directions: issues extracted from PR bodies (when using `--prs`) and PRs extracted from issue bodies (when using `--issues`).
 
 The `--strip-title-prefix` option in this example means that if the PR title has a prefix in square brackets (such as `[ES|QL]` or `[Security]`), it is automatically removed from the changelog title. Multiple square bracket prefixes are also supported (for example `[Discover][ESQL] Title` becomes `Title`). If a colon follows the closing bracket, it is also removed.

--- a/docs/contribute/changelog.md
+++ b/docs/contribute/changelog.md
@@ -356,7 +356,7 @@ docs-builder changelog add \
   --strip-title-prefix
 ```
 
-In this case, the changelog file derives the title, type, areas, and products from the pull request. If none of the PR's labels match `pivot.products`, the command falls back to `products.default` or git repository inference (refer to [Products resolution](/cli/release/changelog-add.md#products-resolution) for more details).
+In this case, the changelog file derives the title, type, areas, and products from the pull request. If none of the PR's labels match `pivot.products`, the command falls back to `products.default` or repository name inference from `--repo` (refer to [Products resolution](/cli/release/changelog-add.md#products-resolution) for more details).
 The command also looks for patterns like `Fixes #123`, `Closes owner/repo#456`, `Resolves https://github.com/.../issues/789` in the pull request to derive its issues. Similarly, when using `--issues`, the command extracts linked PRs from the issue body (for example, "Fixed by #123"). You can turn off this behavior in either case with the `--no-extract-issues` flag or by setting `extract.issues: false` in the changelog configuration file. The `extract.issues` setting applies to both directions: issues extracted from PR bodies (when using `--prs`) and PRs extracted from issue bodies (when using `--issues`).
 
 The `--strip-title-prefix` option in this example means that if the PR title has a prefix in square brackets (such as `[ES|QL]` or `[Security]`), it is automatically removed from the changelog title. Multiple square bracket prefixes are also supported (for example `[Discover][ESQL] Title` becomes `Title`). If a colon follows the closing bracket, it is also removed.

--- a/src/Elastic.Documentation.Configuration/Changelog/ChangelogConfiguration.cs
+++ b/src/Elastic.Documentation.Configuration/Changelog/ChangelogConfiguration.cs
@@ -90,6 +90,13 @@ public record ChangelogConfiguration
 	public IReadOnlyDictionary<string, string>? LabelToAreas { get; init; }
 
 	/// <summary>
+	/// Mapping from GitHub label names to product spec strings (computed from Pivot.Products).
+	/// Each label maps to a product spec string (e.g., "elasticsearch", "kibana 9.2.0").
+	/// When a PR has labels matching multiple entries, all matching products are collected.
+	/// </summary>
+	public IReadOnlyDictionary<string, string>? LabelToProducts { get; init; }
+
+	/// <summary>
 	/// Rules configuration for create and publish blockers
 	/// </summary>
 	public RulesConfiguration? Rules { get; init; }

--- a/src/Elastic.Documentation.Configuration/Changelog/PivotConfiguration.cs
+++ b/src/Elastic.Documentation.Configuration/Changelog/PivotConfiguration.cs
@@ -32,6 +32,15 @@ public record PivotConfiguration
 	public Dictionary<string, string?>? Areas { get; init; }
 
 	/// <summary>
+	/// Product definitions with labels mapped to product spec strings.
+	/// Keys are product spec strings (e.g., "elasticsearch", "kibana 9.2.0", "cloud-serverless 2025-06 ga").
+	/// Values are label strings (e.g., ":stack/elasticsearch").
+	/// When a PR has labels matching a product's value, that product is added to the changelog entry.
+	/// Multiple matching product entries are all applied (same behavior as areas).
+	/// </summary>
+	public Dictionary<string, string?>? Products { get; init; }
+
+	/// <summary>
 	/// Labels that trigger the highlight flag (comma-separated string).
 	/// When a PR has any of these labels, highlight is set to true.
 	/// Example: ">highlight, >release-highlight"

--- a/src/services/Elastic.Changelog/Configuration/ChangelogConfigurationLoader.cs
+++ b/src/services/Elastic.Changelog/Configuration/ChangelogConfigurationLoader.cs
@@ -116,6 +116,7 @@ public class ChangelogConfigurationLoader(ILoggerFactory logFactory, IConfigurat
 		IReadOnlyList<string>? availableAreas;
 		Dictionary<string, string>? labelToType;
 		Dictionary<string, string>? labelToAreas;
+		Dictionary<string, string>? labelToProducts;
 		PivotConfiguration? pivot = null;
 
 		if (yamlConfig.Pivot != null)
@@ -198,6 +199,24 @@ public class ChangelogConfigurationLoader(ILoggerFactory logFactory, IConfigurat
 
 			// Build LabelToAreas mapping (inverted from pivot.areas)
 			labelToAreas = BuildLabelToAreasMapping(yamlConfig.Pivot.Areas);
+
+			// Validate product IDs in pivot.products keys and build LabelToProducts mapping
+			if (yamlConfig.Pivot.Products is { Count: > 0 })
+			{
+				foreach (var productSpec in yamlConfig.Pivot.Products.Keys)
+				{
+					var specParts = productSpec.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+					if (specParts.Length == 0)
+						continue;
+					var productId = specParts[0].Replace('_', '-');
+					if (validProductIds.Contains(productId))
+						continue;
+					var availableProducts = string.Join(", ", validProductIds.OrderBy(p => p));
+					collector.EmitError(configPath, $"Product '{specParts[0]}' in pivot.products is not in the list of available products from config/products.yml. Available products: {availableProducts}");
+					return null;
+				}
+			}
+			labelToProducts = BuildLabelToProductsMapping(yamlConfig.Pivot.Products);
 		}
 		else
 		{
@@ -207,6 +226,7 @@ public class ChangelogConfigurationLoader(ILoggerFactory logFactory, IConfigurat
 			availableAreas = null;
 			labelToType = null;
 			labelToAreas = null;
+			labelToProducts = null;
 		}
 
 		// Process lifecycles
@@ -285,6 +305,7 @@ public class ChangelogConfigurationLoader(ILoggerFactory logFactory, IConfigurat
 			Products = products,
 			LabelToType = labelToType,
 			LabelToAreas = labelToAreas,
+			LabelToProducts = labelToProducts,
 			Rules = rules,
 			HighlightLabels = highlightLabels,
 			ProductsConfiguration = productsConfig,
@@ -314,6 +335,7 @@ public class ChangelogConfigurationLoader(ILoggerFactory logFactory, IConfigurat
 			Types = types,
 			Subtypes = ConvertLenientDictToStringDict(yamlPivot.Subtypes),
 			Areas = ConvertLenientDictToStringDict(yamlPivot.Areas),
+			Products = ConvertLenientDictToStringDict(yamlPivot.Products),
 			Highlight = JoinLenientList(yamlPivot.Highlight)
 		};
 	}
@@ -834,5 +856,28 @@ public class ChangelogConfigurationLoader(ILoggerFactory logFactory, IConfigurat
 		}
 
 		return labelToAreas.Count > 0 ? labelToAreas : null;
+	}
+
+	/// <summary>
+	/// Builds LabelToProducts mapping by inverting pivot.products entries.
+	/// Each label in a product entry maps to that product spec string.
+	/// </summary>
+	private static Dictionary<string, string>? BuildLabelToProductsMapping(Dictionary<string, YamlLenientList?>? products)
+	{
+		if (products == null || products.Count == 0)
+			return null;
+
+		var labelToProducts = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+		foreach (var (productSpec, labelList) in products)
+		{
+			if (labelList?.Values == null)
+				continue;
+
+			foreach (var label in labelList.Values)
+				labelToProducts[label] = productSpec;
+		}
+
+		return labelToProducts.Count > 0 ? labelToProducts : null;
 	}
 }

--- a/src/services/Elastic.Changelog/Creation/ChangelogCreationService.cs
+++ b/src/services/Elastic.Changelog/Creation/ChangelogCreationService.cs
@@ -125,9 +125,9 @@ IFileSystem? fileSystem = null
 		};
 
 	/// <summary>
-	/// Infers products from configuration defaults or git repository name.
+	/// Infers products from configuration defaults or repository name.
 	/// </summary>
-	private IReadOnlyList<ProductArgument>? InferProducts(ProductsConfig? productsConfig)
+	private IReadOnlyList<ProductArgument>? InferProducts(ProductsConfig? productsConfig, string? repoName)
 	{
 		// First, try config defaults
 		if (productsConfig?.Default is { Count: > 0 })
@@ -142,8 +142,8 @@ IFileSystem? fileSystem = null
 			return products;
 		}
 
-		// Second, try generic product inference from current git repo
-		var product = _productInferService.InferProductFromCurrentRepository();
+		// Second, try inference from the --repo argument (or bundle.repo from config)
+		var product = repoName != null ? _productInferService.InferProductFromRepository(repoName) : null;
 		if (product == null)
 		{
 			_logger.LogDebug("Could not infer product from repository");
@@ -232,10 +232,10 @@ IFileSystem? fileSystem = null
 			}
 		}
 
-		// If still no products, fall back to products.default or git repo inference
+		// If still no products, fall back to products.default or repo name inference
 		if (input.Products.Count == 0)
 		{
-			var inferredProducts = InferProducts(config.ProductsConfiguration);
+			var inferredProducts = InferProducts(config.ProductsConfiguration, input.Repo);
 			if (inferredProducts != null)
 				input = input with { Products = inferredProducts };
 		}
@@ -318,10 +318,10 @@ IFileSystem? fileSystem = null
 		else if (!issueResult.FetchFailed)
 			return false;
 
-		// If still no products, fall back to products.default or git repo inference
+		// If still no products, fall back to products.default or repo name inference
 		if (input.Products.Count == 0)
 		{
-			var inferredProducts = InferProducts(config.ProductsConfiguration);
+			var inferredProducts = InferProducts(config.ProductsConfiguration, input.Repo);
 			if (inferredProducts != null)
 				input = input with { Products = inferredProducts };
 		}

--- a/src/services/Elastic.Changelog/Creation/ChangelogCreationService.cs
+++ b/src/services/Elastic.Changelog/Creation/ChangelogCreationService.cs
@@ -83,14 +83,6 @@ IFileSystem? fileSystem = null
 			// Apply config defaults to input (for extract_release_notes, extract_issues)
 			input = ApplyConfigDefaults(input, config);
 
-			// If no products provided, try to infer from config defaults or repository
-			if (input.Products.Count == 0)
-			{
-				var inferredProducts = InferProducts(config.ProductsConfiguration);
-				if (inferredProducts != null)
-					input = input with { Products = inferredProducts };
-			}
-
 			// Multiple PRs: one changelog per PR (--use-pr-number uses PR number as each filename)
 			if (input.Prs != null && input.Prs.Length > 1)
 				return await CreateChangelogsForMultiplePrsAsync(collector, input, config, ctx);
@@ -230,7 +222,7 @@ IFileSystem? fileSystem = null
 
 			prFetchFailed = prResult.FetchFailed;
 
-			// Apply derived fields if available
+			// Apply derived fields if available (including label-derived products)
 			if (prResult.DerivedFields != null)
 				input = ApplyDerivedFields(input, prResult.DerivedFields);
 			else if (!prFetchFailed)
@@ -238,6 +230,14 @@ IFileSystem? fileSystem = null
 				// DerivedFields is null and fetch didn't fail means validation error occurred
 				return false;
 			}
+		}
+
+		// If still no products, fall back to products.default or git repo inference
+		if (input.Products.Count == 0)
+		{
+			var inferredProducts = InferProducts(config.ProductsConfiguration);
+			if (inferredProducts != null)
+				input = input with { Products = inferredProducts };
 		}
 
 		// Validate required fields
@@ -318,6 +318,14 @@ IFileSystem? fileSystem = null
 		else if (!issueResult.FetchFailed)
 			return false;
 
+		// If still no products, fall back to products.default or git repo inference
+		if (input.Products.Count == 0)
+		{
+			var inferredProducts = InferProducts(config.ProductsConfiguration);
+			if (inferredProducts != null)
+				input = input with { Products = inferredProducts };
+		}
+
 		if (!_validator.ValidateRequiredFields(collector, input, issueResult.FetchFailed, fromIssue: true))
 			return false;
 
@@ -343,6 +351,7 @@ IFileSystem? fileSystem = null
 			Type = derived.Type != null && string.IsNullOrWhiteSpace(input.Type) ? derived.Type : input.Type,
 			Description = derived.Description != null && string.IsNullOrWhiteSpace(input.Description) ? derived.Description : input.Description,
 			Areas = derived.Areas != null && (input.Areas == null || input.Areas.Length == 0) ? derived.Areas : input.Areas,
+			Products = derived.Products is { Count: > 0 } && input.Products.Count == 0 ? derived.Products : input.Products,
 			Highlight = derived.Highlight ?? input.Highlight,
 			Issues = derived.Issues != null && (input.Issues == null || input.Issues.Length == 0) ? derived.Issues : input.Issues,
 			Prs = derived.Prs != null && (input.Prs == null || input.Prs.Length == 0) ? derived.Prs : input.Prs

--- a/src/services/Elastic.Changelog/Creation/IssueInfoProcessor.cs
+++ b/src/services/Elastic.Changelog/Creation/IssueInfoProcessor.cs
@@ -37,7 +37,12 @@ public class IssueInfoProcessor(IGitHubPrService? githubService, ILogger logger)
 			};
 		}
 
-		if (ShouldSkipIssueDueToLabelBlockers(issueInfo.Labels.ToArray(), input.Products, config, collector, issueUrl))
+		// Pre-derive products from labels for accurate blocker check when no products were explicitly provided
+		var effectiveProducts = input.Products;
+		if (input.Products.Count == 0 && config.LabelToProducts != null)
+			effectiveProducts = PrInfoProcessor.MapLabelsToProducts(issueInfo.Labels.ToArray(), config.LabelToProducts);
+
+		if (ShouldSkipIssueDueToLabelBlockers(issueInfo.Labels.ToArray(), effectiveProducts, config, collector, issueUrl))
 		{
 			return new IssueProcessingResult
 			{
@@ -77,7 +82,12 @@ public class IssueInfoProcessor(IGitHubPrService? githubService, ILogger logger)
 			return (false, null);
 		}
 
-		var shouldSkip = ShouldSkipIssueDueToLabelBlockers(issueInfo.Labels.ToArray(), products, config, collector, issueUrl);
+		// Pre-derive products from labels for accurate blocker check when no products were explicitly provided
+		var effectiveProducts = products;
+		if (products.Count == 0 && config.LabelToProducts != null)
+			effectiveProducts = PrInfoProcessor.MapLabelsToProducts(issueInfo.Labels.ToArray(), config.LabelToProducts);
+
+		var shouldSkip = ShouldSkipIssueDueToLabelBlockers(issueInfo.Labels.ToArray(), effectiveProducts, config, collector, issueUrl);
 		return (shouldSkip, issueInfo);
 	}
 
@@ -174,6 +184,19 @@ public class IssueInfoProcessor(IGitHubPrService? githubService, ILogger logger)
 		derived.Issues = input.Issues is { Length: > 0 }
 			? input.Issues
 			: [issueUrl];
+
+		// Map labels to products if products were not explicitly provided
+		if (input.Products.Count == 0 && config.LabelToProducts != null)
+		{
+			var mappedProducts = PrInfoProcessor.MapLabelsToProducts(issueInfo.Labels.ToArray(), config.LabelToProducts);
+			if (mappedProducts.Count > 0)
+			{
+				derived.Products = mappedProducts;
+				logger.LogInformation("Mapped issue labels to products: {Products}", string.Join(", ", mappedProducts.Select(p => p.Product)));
+			}
+		}
+		else if (input.Products.Count > 0)
+			logger.LogDebug("Using explicitly provided products, ignoring issue labels");
 
 		// Extract linked PRs from issue body
 		if ((input.ExtractIssues ?? false) && issueInfo.LinkedPrs.Count > 0)

--- a/src/services/Elastic.Changelog/Creation/PrInfoProcessor.cs
+++ b/src/services/Elastic.Changelog/Creation/PrInfoProcessor.cs
@@ -350,9 +350,7 @@ public class PrInfoProcessor(IGitHubPrService? githubPrService, ILogger logger)
 	/// Maps PR/issue labels to product arguments using the pivot.products mapping.
 	/// All distinct matching product spec strings are collected (same behavior as areas).
 	/// </summary>
-	internal static List<ProductArgument> MapLabelsToProducts(string[] labels, IReadOnlyDictionary<string, string> labelToProductsMapping)
-	{
-		return labels
+	internal static List<ProductArgument> MapLabelsToProducts(string[] labels, IReadOnlyDictionary<string, string> labelToProductsMapping) => labels
 			.Select(label =>
 				labelToProductsMapping.TryGetValue(label, out var productSpec)
 					? productSpec
@@ -375,7 +373,6 @@ public class PrInfoProcessor(IGitHubPrService? githubPrService, ILogger logger)
 			.Where(product => product != null)
 			.Cast<ProductArgument>()
 			.ToList();
-	}
 }
 
 /// <summary>

--- a/src/services/Elastic.Changelog/Creation/PrInfoProcessor.cs
+++ b/src/services/Elastic.Changelog/Creation/PrInfoProcessor.cs
@@ -352,30 +352,29 @@ public class PrInfoProcessor(IGitHubPrService? githubPrService, ILogger logger)
 	/// </summary>
 	internal static List<ProductArgument> MapLabelsToProducts(string[] labels, IReadOnlyDictionary<string, string> labelToProductsMapping)
 	{
-		var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-		var products = new List<ProductArgument>();
-
-		foreach (var label in labels)
-		{
-			if (!labelToProductsMapping.TryGetValue(label, out var productSpec))
-				continue;
-
-			if (!seen.Add(productSpec))
-				continue;
-
-			var parts = productSpec.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-			if (parts.Length == 0)
-				continue;
-
-			products.Add(new ProductArgument
+		return labels
+			.Select(label =>
+				labelToProductsMapping.TryGetValue(label, out var productSpec)
+					? productSpec
+					: null)
+			.Where(productSpec => !string.IsNullOrEmpty(productSpec))
+			.Distinct(StringComparer.OrdinalIgnoreCase)
+			.Select(productSpec =>
 			{
-				Product = parts[0].Replace('_', '-'),
-				Target = parts.Length > 1 ? parts[1] : null,
-				Lifecycle = parts.Length > 2 ? parts[2] : null
-			});
-		}
+				var parts = productSpec!.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+				if (parts.Length == 0)
+					return null;
 
-		return products;
+				return new ProductArgument
+				{
+					Product = parts[0].Replace('_', '-'),
+					Target = parts.Length > 1 ? parts[1] : null,
+					Lifecycle = parts.Length > 2 ? parts[2] : null
+				};
+			})
+			.Where(product => product != null)
+			.Cast<ProductArgument>()
+			.ToList();
 	}
 }
 

--- a/src/services/Elastic.Changelog/Creation/PrInfoProcessor.cs
+++ b/src/services/Elastic.Changelog/Creation/PrInfoProcessor.cs
@@ -353,34 +353,29 @@ public class PrInfoProcessor(IGitHubPrService? githubPrService, ILogger logger)
 	internal static List<ProductArgument> MapLabelsToProducts(string[] labels, IReadOnlyDictionary<string, string> labelToProductsMapping)
 	{
 		var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+		var products = new List<ProductArgument>();
 
-		IEnumerable<ProductArgument> GetProducts()
+		foreach (var label in labels)
 		{
-			return labels
-				.Where(label => labelToProductsMapping.TryGetValue(label, out _))
-				.Select(label =>
-				{
-					if (!labelToProductsMapping.TryGetValue(label, out var productSpec))
-						return null;
+			if (!labelToProductsMapping.TryGetValue(label, out var productSpec))
+				continue;
 
-					if (!seen.Add(productSpec))
-						return null;
+			if (!seen.Add(productSpec))
+				continue;
 
-					var parts = productSpec.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-					if (parts.Length == 0)
-						return null;
+			var parts = productSpec.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+			if (parts.Length == 0)
+				continue;
 
-					return new ProductArgument
-					{
-						Product = parts[0],
-						Target = parts.Length > 1 ? parts[1] : null,
-						Lifecycle = parts.Length > 2 ? parts[2] : null
-					};
-				})
-				.Where(product => product is not null)!;
+			products.Add(new ProductArgument
+			{
+				Product = parts[0].Replace('_', '-'),
+				Target = parts.Length > 1 ? parts[1] : null,
+				Lifecycle = parts.Length > 2 ? parts[2] : null
+			});
 		}
 
-		return GetProducts().ToList();
+		return products;
 	}
 }
 

--- a/src/services/Elastic.Changelog/Creation/PrInfoProcessor.cs
+++ b/src/services/Elastic.Changelog/Creation/PrInfoProcessor.cs
@@ -355,26 +355,33 @@ public class PrInfoProcessor(IGitHubPrService? githubPrService, ILogger logger)
 		var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 		var products = new List<ProductArgument>();
 
-		foreach (var label in labels)
+		IEnumerable<ProductArgument> GetProducts()
 		{
-			if (!labelToProductsMapping.TryGetValue(label, out var productSpec))
-				continue;
-			if (!seen.Add(productSpec))
-				continue;
+			return labels
+				.Where(label => labelToProductsMapping.TryGetValue(label, out _))
+				.Select(label =>
+				{
+					if (!labelToProductsMapping.TryGetValue(label, out var productSpec))
+						return null;
 
-			var parts = productSpec.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-			if (parts.Length == 0)
-				continue;
+					if (!seen.Add(productSpec))
+						return null;
 
-			products.Add(new ProductArgument
-			{
-				Product = parts[0],
-				Target = parts.Length > 1 ? parts[1] : null,
-				Lifecycle = parts.Length > 2 ? parts[2] : null
-			});
+					var parts = productSpec.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+					if (parts.Length == 0)
+						return null;
+
+					return new ProductArgument
+					{
+						Product = parts[0],
+						Target = parts.Length > 1 ? parts[1] : null,
+						Lifecycle = parts.Length > 2 ? parts[2] : null
+					};
+				})
+				.Where(product => product is not null)!;
 		}
 
-		return products;
+		return GetProducts().ToList();
 	}
 }
 

--- a/src/services/Elastic.Changelog/Creation/PrInfoProcessor.cs
+++ b/src/services/Elastic.Changelog/Creation/PrInfoProcessor.cs
@@ -353,7 +353,6 @@ public class PrInfoProcessor(IGitHubPrService? githubPrService, ILogger logger)
 	internal static List<ProductArgument> MapLabelsToProducts(string[] labels, IReadOnlyDictionary<string, string> labelToProductsMapping)
 	{
 		var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-		var products = new List<ProductArgument>();
 
 		IEnumerable<ProductArgument> GetProducts()
 		{

--- a/src/services/Elastic.Changelog/Creation/PrInfoProcessor.cs
+++ b/src/services/Elastic.Changelog/Creation/PrInfoProcessor.cs
@@ -37,8 +37,13 @@ public class PrInfoProcessor(IGitHubPrService? githubPrService, ILogger logger)
 			};
 		}
 
-		// Check for label blockers
-		if (ShouldSkipPrDueToLabelBlockers(prInfo.Labels.ToArray(), input.Products, config, collector, prUrl))
+		// Pre-derive products from labels for accurate blocker check when no products were explicitly provided
+		var effectiveProducts = input.Products;
+		if (input.Products.Count == 0 && config.LabelToProducts != null)
+			effectiveProducts = MapLabelsToProducts(prInfo.Labels.ToArray(), config.LabelToProducts);
+
+		// Check for label blockers using effective products (including label-derived ones)
+		if (ShouldSkipPrDueToLabelBlockers(prInfo.Labels.ToArray(), effectiveProducts, config, collector, prUrl))
 		{
 			return new PrProcessingResult
 			{
@@ -79,7 +84,12 @@ public class PrInfoProcessor(IGitHubPrService? githubPrService, ILogger logger)
 			return (false, null);
 		}
 
-		var shouldSkip = ShouldSkipPrDueToLabelBlockers(prInfo.Labels.ToArray(), products, config, collector, prUrl);
+		// Pre-derive products from labels for accurate blocker check when no products were explicitly provided
+		var effectiveProducts = products;
+		if (products.Count == 0 && config.LabelToProducts != null)
+			effectiveProducts = MapLabelsToProducts(prInfo.Labels.ToArray(), config.LabelToProducts);
+
+		var shouldSkip = ShouldSkipPrDueToLabelBlockers(prInfo.Labels.ToArray(), effectiveProducts, config, collector, prUrl);
 		return (shouldSkip, prInfo);
 	}
 
@@ -179,6 +189,19 @@ public class PrInfoProcessor(IGitHubPrService? githubPrService, ILogger logger)
 		}
 		else if (input.Highlight != null)
 			logger.LogDebug("Using explicitly provided highlight value, ignoring PR labels");
+
+		// Map labels to products if products were not explicitly provided
+		if (input.Products.Count == 0 && config.LabelToProducts != null)
+		{
+			var mappedProducts = MapLabelsToProducts(prInfo.Labels.ToArray(), config.LabelToProducts);
+			if (mappedProducts.Count > 0)
+			{
+				derived.Products = mappedProducts;
+				logger.LogInformation("Mapped PR labels to products: {Products}", string.Join(", ", mappedProducts.Select(p => p.Product)));
+			}
+		}
+		else if (input.Products.Count > 0)
+			logger.LogDebug("Using explicitly provided products, ignoring PR labels");
 
 		// Extract linked issues from PR body if config enabled and issues not provided
 		if ((input.ExtractIssues ?? false) && (input.Issues == null || input.Issues.Length == 0))
@@ -322,6 +345,37 @@ public class PrInfoProcessor(IGitHubPrService? githubPrService, ILogger logger)
 			_ = areas.Add(area);
 		return areas.ToList();
 	}
+
+	/// <summary>
+	/// Maps PR/issue labels to product arguments using the pivot.products mapping.
+	/// All distinct matching product spec strings are collected (same behavior as areas).
+	/// </summary>
+	internal static List<ProductArgument> MapLabelsToProducts(string[] labels, IReadOnlyDictionary<string, string> labelToProductsMapping)
+	{
+		var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+		var products = new List<ProductArgument>();
+
+		foreach (var label in labels)
+		{
+			if (!labelToProductsMapping.TryGetValue(label, out var productSpec))
+				continue;
+			if (!seen.Add(productSpec))
+				continue;
+
+			var parts = productSpec.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+			if (parts.Length == 0)
+				continue;
+
+			products.Add(new ProductArgument
+			{
+				Product = parts[0],
+				Target = parts.Length > 1 ? parts[1] : null,
+				Lifecycle = parts.Length > 2 ? parts[2] : null
+			});
+		}
+
+		return products;
+	}
 }
 
 /// <summary>
@@ -346,6 +400,12 @@ public record DerivedPrFields
 	public string[]? Areas { get; set; }
 	public bool? Highlight { get; set; }
 	public string[]? Issues { get; set; }
+
+	/// <summary>
+	/// Products derived from PR/issue labels via pivot.products mapping.
+	/// Only set when labels matched and no products were explicitly provided.
+	/// </summary>
+	public IReadOnlyList<ProductArgument>? Products { get; set; }
 
 	/// <summary>
 	/// Linked PRs derived from issue body (when creating changelog from --issues)

--- a/src/services/Elastic.Changelog/Elastic.Changelog.csproj
+++ b/src/services/Elastic.Changelog/Elastic.Changelog.csproj
@@ -10,6 +10,9 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Elastic.Documentation.Services.Tests</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Elastic.Changelog.Tests</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/services/Elastic.Changelog/Serialization/ChangelogConfigurationYaml.cs
+++ b/src/services/Elastic.Changelog/Serialization/ChangelogConfigurationYaml.cs
@@ -155,6 +155,13 @@ internal record PivotConfigurationYaml
 	public Dictionary<string, YamlLenientList?>? Areas { get; set; }
 
 	/// <summary>
+	/// Product definitions with labels (string or list per value).
+	/// Keys are product spec strings (e.g., "elasticsearch", "kibana 9.2.0").
+	/// Values are label strings that trigger adding the product.
+	/// </summary>
+	public Dictionary<string, YamlLenientList?>? Products { get; set; }
+
+	/// <summary>
 	/// Labels that trigger the highlight flag (string or list).
 	/// </summary>
 	public YamlLenientList? Highlight { get; set; }

--- a/tests/Elastic.Changelog.Tests/Changelogs/ChangelogConfigurationTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/ChangelogConfigurationTests.cs
@@ -1045,9 +1045,9 @@ public class ChangelogConfigurationTests(ITestOutputHelper output) : ChangelogTe
 			// Assert
 			config.Should().NotBeNull();
 			Collector.Errors.Should().Be(0);
-			config!.LabelToProducts.Should().NotBeNull();
+			config.LabelToProducts.Should().NotBeNull();
 			config.LabelToProducts.Should().ContainKey(":stack/elasticsearch");
-			config.LabelToProducts![":stack/elasticsearch"].Should().Be("elasticsearch");
+			config.LabelToProducts[":stack/elasticsearch"].Should().Be("elasticsearch");
 			config.LabelToProducts.Should().ContainKey(":stack/kibana");
 			config.LabelToProducts[":stack/kibana"].Should().Be("kibana");
 		}
@@ -1093,8 +1093,8 @@ public class ChangelogConfigurationTests(ITestOutputHelper output) : ChangelogTe
 			// Assert
 			config.Should().NotBeNull();
 			Collector.Errors.Should().Be(0);
-			config!.LabelToProducts.Should().NotBeNull();
-			config.LabelToProducts![":feature/new-in-9.2"].Should().Be("elasticsearch 9.2.0");
+			config.LabelToProducts.Should().NotBeNull();
+			config.LabelToProducts[":feature/new-in-9.2"].Should().Be("elasticsearch 9.2.0");
 			config.LabelToProducts[":kibana/new-in-9.2"].Should().Be("kibana 9.2.0 ga");
 		}
 		finally

--- a/tests/Elastic.Changelog.Tests/Changelogs/ChangelogConfigurationTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/ChangelogConfigurationTests.cs
@@ -1008,4 +1008,139 @@ public class ChangelogConfigurationTests(ITestOutputHelper output) : ChangelogTe
 			FileSystem.Directory.SetCurrentDirectory(originalDir);
 		}
 	}
+
+	[Fact]
+	public async Task LoadChangelogConfiguration_WithPivotProducts_ComputesLabelToProductsMapping()
+	{
+		// Arrange
+		var configLoader = new ChangelogConfigurationLoader(LoggerFactory, ConfigurationContext, FileSystem);
+		var configDir = FileSystem.Path.Combine(FileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		var docsDir = FileSystem.Path.Combine(configDir, "docs");
+		FileSystem.Directory.CreateDirectory(docsDir);
+		var configPath = FileSystem.Path.Combine(docsDir, "changelog.yml");
+		// language=yaml
+		var configContent =
+			"""
+			pivot:
+			  types:
+			    feature:
+			    bug-fix:
+			    breaking-change:
+			  products:
+			    'elasticsearch':
+			      - ":stack/elasticsearch"
+			    'kibana':
+			      - ":stack/kibana"
+			""";
+		await FileSystem.File.WriteAllTextAsync(configPath, configContent, TestContext.Current.CancellationToken);
+
+		var originalDir = FileSystem.Directory.GetCurrentDirectory();
+		try
+		{
+			FileSystem.Directory.SetCurrentDirectory(configDir);
+
+			// Act
+			var config = await configLoader.LoadChangelogConfiguration(Collector, null, TestContext.Current.CancellationToken);
+
+			// Assert
+			config.Should().NotBeNull();
+			Collector.Errors.Should().Be(0);
+			config!.LabelToProducts.Should().NotBeNull();
+			config.LabelToProducts.Should().ContainKey(":stack/elasticsearch");
+			config.LabelToProducts![":stack/elasticsearch"].Should().Be("elasticsearch");
+			config.LabelToProducts.Should().ContainKey(":stack/kibana");
+			config.LabelToProducts[":stack/kibana"].Should().Be("kibana");
+		}
+		finally
+		{
+			FileSystem.Directory.SetCurrentDirectory(originalDir);
+		}
+	}
+
+	[Fact]
+	public async Task LoadChangelogConfiguration_WithPivotProducts_ProductSpecWithTarget_PreservesSpec()
+	{
+		// Arrange
+		var configLoader = new ChangelogConfigurationLoader(LoggerFactory, ConfigurationContext, FileSystem);
+		var configDir = FileSystem.Path.Combine(FileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		var docsDir = FileSystem.Path.Combine(configDir, "docs");
+		FileSystem.Directory.CreateDirectory(docsDir);
+		var configPath = FileSystem.Path.Combine(docsDir, "changelog.yml");
+		// language=yaml
+		var configContent =
+			"""
+			pivot:
+			  types:
+			    feature:
+			    bug-fix:
+			    breaking-change:
+			  products:
+			    'elasticsearch 9.2.0':
+			      - ":feature/new-in-9.2"
+			    'kibana 9.2.0 ga':
+			      - ":kibana/new-in-9.2"
+			""";
+		await FileSystem.File.WriteAllTextAsync(configPath, configContent, TestContext.Current.CancellationToken);
+
+		var originalDir = FileSystem.Directory.GetCurrentDirectory();
+		try
+		{
+			FileSystem.Directory.SetCurrentDirectory(configDir);
+
+			// Act
+			var config = await configLoader.LoadChangelogConfiguration(Collector, null, TestContext.Current.CancellationToken);
+
+			// Assert
+			config.Should().NotBeNull();
+			Collector.Errors.Should().Be(0);
+			config!.LabelToProducts.Should().NotBeNull();
+			config.LabelToProducts![":feature/new-in-9.2"].Should().Be("elasticsearch 9.2.0");
+			config.LabelToProducts[":kibana/new-in-9.2"].Should().Be("kibana 9.2.0 ga");
+		}
+		finally
+		{
+			FileSystem.Directory.SetCurrentDirectory(originalDir);
+		}
+	}
+
+	[Fact]
+	public async Task LoadChangelogConfiguration_WithPivotProducts_InvalidProductId_ReturnsError()
+	{
+		// Arrange
+		var configLoader = new ChangelogConfigurationLoader(LoggerFactory, ConfigurationContext, FileSystem);
+		var configDir = FileSystem.Path.Combine(FileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		var docsDir = FileSystem.Path.Combine(configDir, "docs");
+		FileSystem.Directory.CreateDirectory(docsDir);
+		var configPath = FileSystem.Path.Combine(docsDir, "changelog.yml");
+		// language=yaml
+		var configContent =
+			"""
+			pivot:
+			  types:
+			    feature:
+			    bug-fix:
+			    breaking-change:
+			  products:
+			    'not-a-valid-product':
+			      - ":some/label"
+			""";
+		await FileSystem.File.WriteAllTextAsync(configPath, configContent, TestContext.Current.CancellationToken);
+
+		var originalDir = FileSystem.Directory.GetCurrentDirectory();
+		try
+		{
+			FileSystem.Directory.SetCurrentDirectory(configDir);
+
+			// Act
+			var config = await configLoader.LoadChangelogConfiguration(Collector, null, TestContext.Current.CancellationToken);
+
+			// Assert
+			config.Should().BeNull();
+			Collector.Errors.Should().BeGreaterThan(0);
+		}
+		finally
+		{
+			FileSystem.Directory.SetCurrentDirectory(originalDir);
+		}
+	}
 }

--- a/tests/Elastic.Changelog.Tests/Changelogs/Create/BlockingLabelTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/Create/BlockingLabelTests.cs
@@ -262,7 +262,7 @@ public class BlockingLabelTests(ITestOutputHelper output) : CreateChangelogTestB
 		result.Should().BeTrue(); // Succeed but skip
 		Collector.Diagnostics.Should().Contain(d => d.Message.Contains("Skipping changelog creation") && d.Message.Contains("skip:releaseNotes"));
 
-		var outputDir = input.Output!;
+		var outputDir = input.Output;
 		if (!FileSystem.Directory.Exists(outputDir))
 			FileSystem.Directory.CreateDirectory(outputDir);
 		var files = FileSystem.Directory.GetFiles(outputDir, "*.yaml");

--- a/tests/Elastic.Changelog.Tests/Changelogs/Create/BlockingLabelTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/Create/BlockingLabelTests.cs
@@ -204,4 +204,68 @@ public class BlockingLabelTests(ITestOutputHelper output) : CreateChangelogTestB
 		var files = FileSystem.Directory.GetFiles(outputDir, "*.yaml");
 		files.Should().HaveCount(0); // No files should be created
 	}
+
+	[Fact]
+	public async Task CreateChangelog_WithLabelDerivedProduct_AppliesProductSpecificCreateRule()
+	{
+		// This test verifies the timing fix: products derived from pivot.products label mapping
+		// are available before rules.create.products is evaluated (the blocker check).
+		var prInfo = new GitHubPrInfo
+		{
+			Title = "PR with product label and blocking label",
+			Labels = ["type:feature", ":stack/elasticsearch", "skip:releaseNotes"]
+		};
+
+		A.CallTo(() => MockGitHubService.FetchPrInfoAsync(
+				A<string>._,
+				A<string?>._,
+				A<string?>._,
+				A<CancellationToken>._))
+			.Returns(prInfo);
+
+		// language=yaml
+		var configContent =
+			"""
+			pivot:
+			  types:
+			    feature: "type:feature"
+			    bug-fix:
+			    breaking-change:
+			  products:
+			    'elasticsearch':
+			      - ":stack/elasticsearch"
+			lifecycles:
+			  - ga
+			rules:
+			  create:
+			    products:
+			      elasticsearch:
+			        exclude: "skip:releaseNotes"
+			""";
+		var configPath = await CreateConfigDirectory(configContent);
+
+		var service = CreateService();
+
+		// No --products provided; products must be derived from labels to trigger the product-specific rule
+		var input = new CreateChangelogArguments
+		{
+			Prs = ["https://github.com/elastic/elasticsearch/pull/12345"],
+			Products = [],
+			Config = configPath,
+			Output = CreateOutputDirectory()
+		};
+
+		// Act
+		var result = await service.CreateChangelog(Collector, input, TestContext.Current.CancellationToken);
+
+		// Assert — product-specific rule should have blocked creation
+		result.Should().BeTrue(); // Succeed but skip
+		Collector.Diagnostics.Should().Contain(d => d.Message.Contains("Skipping changelog creation") && d.Message.Contains("skip:releaseNotes"));
+
+		var outputDir = input.Output!;
+		if (!FileSystem.Directory.Exists(outputDir))
+			FileSystem.Directory.CreateDirectory(outputDir);
+		var files = FileSystem.Directory.GetFiles(outputDir, "*.yaml");
+		files.Should().HaveCount(0);
+	}
 }

--- a/tests/Elastic.Changelog.Tests/Changelogs/Create/LabelMappingTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/Create/LabelMappingTests.cs
@@ -231,7 +231,7 @@ public class LabelMappingTests(ITestOutputHelper output) : CreateChangelogTestBa
 		result.Should().BeTrue();
 		Collector.Errors.Should().Be(0);
 
-		var outputDir = input.Output!;
+		var outputDir = input.Output;
 		if (!FileSystem.Directory.Exists(outputDir))
 			FileSystem.Directory.CreateDirectory(outputDir);
 		var files = FileSystem.Directory.GetFiles(outputDir, "*.yaml");
@@ -292,7 +292,7 @@ public class LabelMappingTests(ITestOutputHelper output) : CreateChangelogTestBa
 		result.Should().BeTrue();
 		Collector.Errors.Should().Be(0);
 
-		var outputDir = input.Output!;
+		var outputDir = input.Output;
 		if (!FileSystem.Directory.Exists(outputDir))
 			FileSystem.Directory.CreateDirectory(outputDir);
 		var files = FileSystem.Directory.GetFiles(outputDir, "*.yaml");
@@ -352,7 +352,7 @@ public class LabelMappingTests(ITestOutputHelper output) : CreateChangelogTestBa
 		result.Should().BeTrue();
 		Collector.Errors.Should().Be(0);
 
-		var outputDir = input.Output!;
+		var outputDir = input.Output;
 		if (!FileSystem.Directory.Exists(outputDir))
 			FileSystem.Directory.CreateDirectory(outputDir);
 		var files = FileSystem.Directory.GetFiles(outputDir, "*.yaml");

--- a/tests/Elastic.Changelog.Tests/Changelogs/Create/LabelMappingTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/Create/LabelMappingTests.cs
@@ -79,6 +79,289 @@ public class LabelMappingTests(ITestOutputHelper output) : CreateChangelogTestBa
 	}
 
 	[Fact]
+	public void MapLabelsToProducts_WithProductIdOnly_ParsesCorrectly()
+	{
+		// Arrange
+		var labelToProducts = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+		{
+			[":stack/elasticsearch"] = "elasticsearch",
+			[":stack/kibana"] = "kibana"
+		};
+
+		// Act
+		var result = PrInfoProcessor.MapLabelsToProducts(
+			[":stack/elasticsearch", ":stack/kibana", "unrelated-label"],
+			labelToProducts
+		);
+
+		// Assert
+		result.Should().HaveCount(2);
+		result.Should().Contain(p => p.Product == "elasticsearch" && p.Target == null && p.Lifecycle == null);
+		result.Should().Contain(p => p.Product == "kibana" && p.Target == null && p.Lifecycle == null);
+	}
+
+	[Fact]
+	public void MapLabelsToProducts_WithProductAndTarget_ParsesCorrectly()
+	{
+		// Arrange
+		var labelToProducts = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+		{
+			[":feature/new"] = "elasticsearch 9.2.0"
+		};
+
+		// Act
+		var result = PrInfoProcessor.MapLabelsToProducts([":feature/new"], labelToProducts);
+
+		// Assert
+		result.Should().HaveCount(1);
+		result[0].Product.Should().Be("elasticsearch");
+		result[0].Target.Should().Be("9.2.0");
+		result[0].Lifecycle.Should().BeNull();
+	}
+
+	[Fact]
+	public void MapLabelsToProducts_WithFullSpec_ParsesCorrectly()
+	{
+		// Arrange
+		var labelToProducts = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+		{
+			[":cloud/serverless"] = "cloud-serverless 2025-06 ga"
+		};
+
+		// Act
+		var result = PrInfoProcessor.MapLabelsToProducts([":cloud/serverless"], labelToProducts);
+
+		// Assert
+		result.Should().HaveCount(1);
+		result[0].Product.Should().Be("cloud-serverless");
+		result[0].Target.Should().Be("2025-06");
+		result[0].Lifecycle.Should().Be("ga");
+	}
+
+	[Fact]
+	public void MapLabelsToProducts_WithDuplicateMatchingLabels_DeduplicatesProducts()
+	{
+		// Arrange
+		var labelToProducts = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+		{
+			[":label-a"] = "elasticsearch",
+			[":label-b"] = "elasticsearch"
+		};
+
+		// Act
+		var result = PrInfoProcessor.MapLabelsToProducts([":label-a", ":label-b"], labelToProducts);
+
+		// Assert — same product spec only included once
+		result.Should().HaveCount(1);
+		result[0].Product.Should().Be("elasticsearch");
+	}
+
+	[Fact]
+	public void MapLabelsToProducts_WithNoMatchingLabels_ReturnsEmpty()
+	{
+		// Arrange
+		var labelToProducts = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+		{
+			[":stack/elasticsearch"] = "elasticsearch"
+		};
+
+		// Act
+		var result = PrInfoProcessor.MapLabelsToProducts(["unrelated-label", ">bug"], labelToProducts);
+
+		// Assert
+		result.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task CreateChangelog_WithLabelProductMapping_DerviesProductsFromLabels()
+	{
+		// Arrange
+		var prInfo = new GitHubPrInfo
+		{
+			Title = "Add new search feature",
+			Labels = ["type:feature", ":stack/elasticsearch"]
+		};
+
+		A.CallTo(() => MockGitHubService.FetchPrInfoAsync(
+				A<string>._,
+				A<string?>._,
+				A<string?>._,
+				A<CancellationToken>._))
+			.Returns(prInfo);
+
+		// language=yaml
+		var configContent =
+			"""
+			pivot:
+			  types:
+			    feature: "type:feature"
+			    bug-fix:
+			    breaking-change:
+			  products:
+			    'elasticsearch':
+			      - ":stack/elasticsearch"
+			lifecycles:
+			  - preview
+			  - beta
+			  - ga
+			""";
+		var configPath = await CreateConfigDirectory(configContent);
+
+		var service = CreateService();
+
+		// No --products provided: should be derived from PR labels
+		var input = new CreateChangelogArguments
+		{
+			Prs = ["https://github.com/elastic/elasticsearch/pull/12345"],
+			Products = [],
+			Config = configPath,
+			Output = CreateOutputDirectory()
+		};
+
+		// Act
+		var result = await service.CreateChangelog(Collector, input, TestContext.Current.CancellationToken);
+
+		// Assert
+		if (!result)
+		{
+			foreach (var diagnostic in Collector.Diagnostics)
+				Output.WriteLine($"{diagnostic.Severity}: {diagnostic.Message}");
+		}
+
+		result.Should().BeTrue();
+		Collector.Errors.Should().Be(0);
+
+		var outputDir = input.Output!;
+		if (!FileSystem.Directory.Exists(outputDir))
+			FileSystem.Directory.CreateDirectory(outputDir);
+		var files = FileSystem.Directory.GetFiles(outputDir, "*.yaml");
+		files.Should().HaveCount(1);
+		var yamlContent = await FileSystem.File.ReadAllTextAsync(files[0], TestContext.Current.CancellationToken);
+		yamlContent.Should().Contain("- product: elasticsearch");
+	}
+
+	[Fact]
+	public async Task CreateChangelog_WithLabelProductMapping_MultipleMatchingLabels_AddsAllProducts()
+	{
+		// Arrange
+		var prInfo = new GitHubPrInfo
+		{
+			Title = "Cross-product change",
+			Labels = ["type:feature", ":stack/elasticsearch", ":stack/kibana"]
+		};
+
+		A.CallTo(() => MockGitHubService.FetchPrInfoAsync(
+				A<string>._,
+				A<string?>._,
+				A<string?>._,
+				A<CancellationToken>._))
+			.Returns(prInfo);
+
+		// language=yaml
+		var configContent =
+			"""
+			pivot:
+			  types:
+			    feature: "type:feature"
+			    bug-fix:
+			    breaking-change:
+			  products:
+			    'elasticsearch':
+			      - ":stack/elasticsearch"
+			    'kibana':
+			      - ":stack/kibana"
+			lifecycles:
+			  - ga
+			""";
+		var configPath = await CreateConfigDirectory(configContent);
+
+		var service = CreateService();
+
+		var input = new CreateChangelogArguments
+		{
+			Prs = ["https://github.com/elastic/elasticsearch/pull/12345"],
+			Products = [],
+			Config = configPath,
+			Output = CreateOutputDirectory()
+		};
+
+		// Act
+		var result = await service.CreateChangelog(Collector, input, TestContext.Current.CancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		Collector.Errors.Should().Be(0);
+
+		var outputDir = input.Output!;
+		if (!FileSystem.Directory.Exists(outputDir))
+			FileSystem.Directory.CreateDirectory(outputDir);
+		var files = FileSystem.Directory.GetFiles(outputDir, "*.yaml");
+		var yamlContent = await FileSystem.File.ReadAllTextAsync(files[0], TestContext.Current.CancellationToken);
+		yamlContent.Should().Contain("- product: elasticsearch");
+		yamlContent.Should().Contain("- product: kibana");
+	}
+
+	[Fact]
+	public async Task CreateChangelog_WithLabelProductMapping_ExplicitProductsOverrideLabels()
+	{
+		// Arrange — PR has label for elasticsearch but --products specifies kibana
+		var prInfo = new GitHubPrInfo
+		{
+			Title = "Fix something",
+			Labels = ["type:bug", ":stack/elasticsearch"]
+		};
+
+		A.CallTo(() => MockGitHubService.FetchPrInfoAsync(
+				A<string>._,
+				A<string?>._,
+				A<string?>._,
+				A<CancellationToken>._))
+			.Returns(prInfo);
+
+		// language=yaml
+		var configContent =
+			"""
+			pivot:
+			  types:
+			    feature:
+			    bug-fix: "type:bug"
+			    breaking-change:
+			  products:
+			    'elasticsearch':
+			      - ":stack/elasticsearch"
+			lifecycles:
+			  - ga
+			""";
+		var configPath = await CreateConfigDirectory(configContent);
+
+		var service = CreateService();
+
+		var input = new CreateChangelogArguments
+		{
+			Prs = ["https://github.com/elastic/elasticsearch/pull/12345"],
+			// Explicit product takes precedence over label mapping
+			Products = [new ProductArgument { Product = "kibana", Target = "9.2.0" }],
+			Config = configPath,
+			Output = CreateOutputDirectory()
+		};
+
+		// Act
+		var result = await service.CreateChangelog(Collector, input, TestContext.Current.CancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		Collector.Errors.Should().Be(0);
+
+		var outputDir = input.Output!;
+		if (!FileSystem.Directory.Exists(outputDir))
+			FileSystem.Directory.CreateDirectory(outputDir);
+		var files = FileSystem.Directory.GetFiles(outputDir, "*.yaml");
+		var yamlContent = await FileSystem.File.ReadAllTextAsync(files[0], TestContext.Current.CancellationToken);
+		yamlContent.Should().Contain("- product: kibana");
+		yamlContent.Should().NotContain("- product: elasticsearch");
+	}
+
+	[Fact]
 	public async Task CreateChangelog_WithPrOptionAndAreaMapping_MapsLabelsToAreas()
 	{
 		// Arrange

--- a/tests/Elastic.Changelog.Tests/Changelogs/Create/ValidationTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/Create/ValidationTests.cs
@@ -155,6 +155,67 @@ public class ValidationTests(ITestOutputHelper output) : CreateChangelogTestBase
 	}
 
 	[Fact]
+	public async Task CreateChangelog_WithRepoMatchingKnownProduct_InfersProduct()
+	{
+		// Arrange — no --products, but --repo matches a known product ID in products.yml
+		var service = CreateService();
+
+		var outputDir = CreateOutputDirectory();
+		FileSystem.Directory.CreateDirectory(outputDir);
+
+		var input = new CreateChangelogArguments
+		{
+			Title = "Test inference from repo name",
+			Type = "feature",
+			Products = [],
+			Repo = "kibana",
+			Output = outputDir
+		};
+
+		// Act
+		var result = await service.CreateChangelog(Collector, input, TestContext.Current.CancellationToken);
+
+		// Assert
+		if (!result)
+		{
+			foreach (var diagnostic in Collector.Diagnostics)
+				Output.WriteLine($"{diagnostic.Severity}: {diagnostic.Message}");
+		}
+
+		result.Should().BeTrue();
+		Collector.Errors.Should().Be(0);
+
+		var files = FileSystem.Directory.GetFiles(outputDir, "*.yaml");
+		files.Should().HaveCount(1);
+		var yamlContent = await FileSystem.File.ReadAllTextAsync(files[0], TestContext.Current.CancellationToken);
+		yamlContent.Should().Contain("- product: kibana");
+	}
+
+	[Fact]
+	public async Task CreateChangelog_WithUnknownRepo_ReturnsProductError()
+	{
+		// Arrange — no --products, --repo value does not match any known product ID
+		var service = CreateService();
+
+		var input = new CreateChangelogArguments
+		{
+			Title = "Test unknown repo",
+			Type = "feature",
+			Products = [],
+			Repo = "my-unknown-repo",
+			Output = CreateOutputDirectory()
+		};
+
+		// Act
+		var result = await service.CreateChangelog(Collector, input, TestContext.Current.CancellationToken);
+
+		// Assert
+		result.Should().BeFalse();
+		Collector.Errors.Should().BeGreaterThan(0);
+		Collector.Diagnostics.Should().Contain(d => d.Message.Contains("product"));
+	}
+
+	[Fact]
 	public async Task CreateChangelog_WithValidProductInAddBlockers_Succeeds()
 	{
 		// Arrange

--- a/tests/Elastic.Changelog.Tests/Changelogs/Render/BundleValidationTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/Render/BundleValidationTests.cs
@@ -108,7 +108,8 @@ public class BundleValidationTests(ITestOutputHelper output) : RenderChangelogTe
 		Collector.Warnings.Should().Be(0, "all checksums match, no warnings expected");
 
 		// Verify all 3 entries were rendered
-		var indexFile = FileSystem.Path.Combine(input.Output!, "9.2.0", "index.md");
+		var outputDir = input.Output ?? throw new InvalidOperationException("Output must be set");
+		var indexFile = FileSystem.Path.Combine(outputDir, "9.2.0", "index.md");
 		FileSystem.File.Exists(indexFile).Should().BeTrue("output should be rendered");
 		var content = await FileSystem.File.ReadAllTextAsync(indexFile, TestContext.Current.CancellationToken);
 		content.Should().Contain("Feature one");
@@ -215,7 +216,8 @@ public class BundleValidationTests(ITestOutputHelper output) : RenderChangelogTe
 		result.Should().BeTrue();
 		Collector.Warnings.Should().Be(0, "resolved entries skip checksum validation");
 
-		var indexFile = FileSystem.Path.Combine(input.Output!, "9.2.0", "index.md");
+		var outputDir = input.Output ?? throw new InvalidOperationException("Output must be set");
+		var indexFile = FileSystem.Path.Combine(outputDir, "9.2.0", "index.md");
 		var content = await FileSystem.File.ReadAllTextAsync(indexFile, TestContext.Current.CancellationToken);
 		content.Should().Contain("Resolved amend feature");
 	}


### PR DESCRIPTION
## Summary

Add a `pivot.products` field to `pivot:`, mirroring `pivot.types` and `pivot.areas`. 
When `changelog add` processes a PR/issue and no `--products` option was given, the command maps the PR's labels to product specs and uses them. The full resolution chain:

1. `--products` CLI option (highest priority)
2. PR/issue label → `pivot.products` mapping (when a PR/issue is fetched and a label matches)
3. `products.default` from changelog config
4. ~~Infer from current git repository name (existing behavior, preserved)~~ Infer from the `--repo` command option or `bundle.repo` changelog config
5. Error: "At least one product is required"

> **Note**: When `--products` is not provided and no PR/issue is fetched (no `--prs`/`--issues`), the chain starts at step 3.

## Design decisions

**Product spec format**: The key in `pivot.products` is a product spec string using the same partial or full `--products` format: bare product ID (`elasticsearch`), product + target (`kibana 9.2.0`), or full spec (`cloud-serverless 2025-06 ga`). Parsing reuses the existing `ProductArgument` logic. Structurally identical to `pivot.areas` — key = product spec string, value = labels.

**Multiple matches**: If a PR has labels matching multiple entries, all matching products are added (same behavior as `pivot.areas` for multiple area matches).

~~**Repo inference**: The existing repo-name-based inference step between `products.default` and error is preserved.~~ Per details below, this was a bug that was not working so it's been fixed.

## Pivot.products addition

### Config plumbing
- **`PivotConfiguration.cs`** — Added `Products` property (`Dictionary<string, string?>?`) documenting the key-as-product-spec-string pattern
- **`PivotConfigurationYaml.cs`** — Added `Products` (`Dictionary<string, YamlLenientList?>?`) to the YAML DTO, mirroring the `Areas` pattern so both string and list values work
- **`ChangelogConfiguration.cs`** — Added `LabelToProducts` (`IReadOnlyDictionary<string, string>?`) — the inverted label→product-spec mapping
- **`ChangelogConfigurationLoader.cs`** — Added product ID validation for `pivot.products` keys, `BuildLabelToProductsMapping` (mirror of `BuildLabelToAreasMapping`), and `ConvertPivot` extension for `Products`

### Label-to-product derivation
- **`PrInfoProcessor.cs`** — Added `Products` to `DerivedPrFields`, the `MapLabelsToProducts` static helper (collects all matching product specs as `ProductArgument` objects), and derivation logic in `DeriveFieldsFromPr`
- **`IssueInfoProcessor.cs`** — Mirrored the same derivation logic in `DeriveFieldsFromIssue`

### `rules.create.products` timing fix
- **`PrInfoProcessor.cs`** — In both `ProcessPrAsync` and `CheckPrForBlockersAsync`, products are now pre-derived from labels *before* `ShouldSkipPrDueToLabelBlockers` so product-specific create rules fire correctly
- **`IssueInfoProcessor.cs`** — Same fix in `ProcessIssueAsync` and `CheckIssueForBlockersAsync`

### Product inference reordering
- **`ChangelogCreationService.cs`** — Removed the top-level `InferProducts` call from `CreateChangelog`; added it inside `CreateSingleChangelogAsync` and `CreateSingleChangelogFromIssueAsync` *after* `ApplyDerivedFields` so the precedence chain is: CLI → label mapping → `products.default` → repo inference. `ApplyDerivedFields` now also applies `derived.Products`

### Documentation
- **`config/changelog.example.yml`** — Added commented `pivot.products` example
- **`docs/cli/release/changelog-add.md`** — Updated `--products` to reflect it's now optional with the new precedence chain
- **`docs/contribute/changelog.md`** — Added "Products resolution" section explaining the full precedence chain; updated label mappings example to include `pivot.products`; updated blocking label description

### Tests (302 passing, all green)
- **`ChangelogConfigurationTests.cs`** — 3 new tests: basic mapping, product+target spec preservation, invalid product ID validation
- **`LabelMappingTests.cs`** — 8 new tests: `MapLabelsToProducts` unit tests (product ID only, with target, full spec, deduplication, no match), plus integration tests for label-derived products, multiple products, and `--products` precedence
- **`BlockingLabelTests.cs`** — 1 new test for the timing fix: product-specific create rule applied when products come from labels

## Repo inference bug fix

While testing the original assertion that product could be inferred from "current git repository name (existing behavior, preserved)", I discovered that this was not working. 

### Root cause

In `[ChangelogCreationService.cs](src/services/Elastic.Changelog/Creation/ChangelogCreationService.cs)`, `ProductInferService` is constructed with no `gitCheckout`:

```csharp
// line 68-69 — gitCheckout is always null
private readonly ProductInferService _productInferService = new(
    configurationContext.ProductsConfiguration);
```

So `InferProductFromCurrentRepository()` always returns `null`. Meanwhile, `input.Repo` (populated from `--repo` or `bundle.repo`) is already available at every `InferProducts` call site but never used for inference.

### Fix: pass `input.Repo` into `InferProducts`

**Code fix** — [`src/services/Elastic.Changelog/Creation/ChangelogCreationService.cs`](src/services/Elastic.Changelog/Creation/ChangelogCreationService.cs):
- `InferProducts` now accepts `string? repoName` and calls `_productInferService.InferProductFromRepository(repoName)` instead of `InferProductFromCurrentRepository()` (which was always returning `null`).
- Both call sites updated to pass `input.Repo`.

**Docs** — [`docs/cli/release/changelog-add.md`](docs/cli/release/changelog-add.md): Point 4 of "Products resolution" now reads "Repository name inference — if `--repo` is specified (or `bundle.repo` is set in `changelog.yml`), the repository name is matched against known product IDs in `products.yml`."

**Tests** — [`tests/Elastic.Changelog.Tests/Changelogs/Create/ValidationTests.cs`](tests/Elastic.Changelog.Tests/Changelogs/Create/ValidationTests.cs): Two new tests added:
- `CreateChangelog_WithRepoMatchingKnownProduct_InfersProduct` — confirms `--repo kibana` infers `kibana` when no products are provided.
- `CreateChangelog_WithUnknownRepo_ReturnsProductError` — confirms an unrecognised repo name produces the expected error.

The full test suite went from 302 → 304 changelog tests, all passing.

## Steps for testing

1. Create a changelog configuration file and add the new product pivots. For example, I checked out https://github.com/elastic/kibana/pull/250840 then added the following info to the `changelog.yml`:
    ```yaml
    pivot:
      products:
        'security':
            - "Team: SecuritySolution"
     ```
1. Create a changelog for a PR that uses this label. For example:
    ```sh
    ./docs-builder changelog add \
    --prs https://github.com/elastic/kibana/pull/255341 \
    --repo kibana --owner elastic \
    --config ~/Documents/GitHub/kibana/docs/changelog.yml \
    --output ~/Documents/GitHub/kibana/docs/changelog \
    --use-pr-number --strip-title-prefix
    ```
1. Verify that the changelog contains the appropriate product value. For example:
    ```yaml
    prs:
    - https://github.com/elastic/kibana/pull/255341
    type: bug-fix
    products:
    - product: security
    areas:
    - Elastic Security solution
    - Detection rules and alerts
    title: Fix ES|QL fetchSourceDocuments missing data tier exclusion filter
    ```
    In this case the `Elastic Security solution` area also exists because I didn't remove that from the `pivot.areas` section of the changelog config file. At this time Kibana treats those labels as areas, but this new feature means that can be reconsidered.
1. Comment out the new `pivot.products` and re-run the command. The changelog now contains the product values defined in the `products.default` section of the config:
    ```yaml
    prs:
    - https://github.com/elastic/kibana/pull/255341
    type: bug-fix
    products:
    - product: kibana
       lifecycle: ga
    areas:
    - Elastic Security solution
    - Detection rules and alerts
    title: Fix ES|QL fetchSourceDocuments missing data tier exclusion filter
    ```
1. Comment out the `products.default` and re-run the command. The changelog infers the product ID from the `bundle.repo`, which has the same result as the previous step.
1. Comment out the `bundle.repo`, omit the `--repo` option and re-run the command. It returns the following error: "Error: At least one product is required"

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
3. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: composer-1.5, clause-4.6-sonnet-medium