### PR TITLE
Search: add DOCUMENTATION_ELASTIC_INDEX_OVERRIDE env var

### DIFF
--- a/src/Elastic.Documentation.Configuration/DocumentationEndpoints.cs
+++ b/src/Elastic.Documentation.Configuration/DocumentationEndpoints.cs
@@ -20,6 +20,14 @@ public class DocumentationEndpoints
 	/// Build type identifier (assembler, isolated, codex). Controlled by DOCS_BUILD_TYPE env var.
 	/// </summary>
 	public string BuildType { get; set; } = "isolated";
+
+	/// <summary>
+	/// Optional comma-separated list of index names that override the computed search index.
+	/// When set, search queries target these indices instead of the one derived from
+	/// <see cref="BuildType"/> and <see cref="Environment"/>.
+	/// Controlled by <c>DOCUMENTATION_ELASTIC_INDEX_OVERRIDE</c> env var.
+	/// </summary>
+	public string? SearchIndexOverride { get; set; }
 }
 
 public class ElasticsearchEndpoint

--- a/src/Elastic.Documentation.ServiceDefaults/ElasticsearchEndpointFactory.cs
+++ b/src/Elastic.Documentation.ServiceDefaults/ElasticsearchEndpointFactory.cs
@@ -58,7 +58,17 @@ public static class ElasticsearchEndpointFactory
 		environment ??= ResolveEnvironment(config, appConfiguration);
 		buildType ??= appConfiguration?["DOCS_BUILD_TYPE"] ?? config["DOCS_BUILD_TYPE"] ?? "isolated";
 
-		return new DocumentationEndpoints { Elasticsearch = endpoint, Environment = environment, BuildType = buildType };
+		var searchIndexOverride =
+			config["Parameters:DocumentationElasticIndexOverride"]
+			?? config["DOCUMENTATION_ELASTIC_INDEX_OVERRIDE"];
+
+		return new DocumentationEndpoints
+		{
+			Elasticsearch = endpoint,
+			Environment = environment,
+			BuildType = buildType,
+			SearchIndexOverride = !string.IsNullOrEmpty(searchIndexOverride) ? searchIndexOverride : null
+		};
 	}
 
 	/// <summary>

--- a/src/services/Elastic.Documentation.Search/Common/ElasticsearchClientAccessor.cs
+++ b/src/services/Elastic.Documentation.Search/Common/ElasticsearchClientAccessor.cs
@@ -22,7 +22,14 @@ public class ElasticsearchClientAccessor : IDisposable
 	public ElasticsearchClient Client { get; }
 	public ElasticsearchEndpoint Endpoint { get; }
 	public SearchConfiguration SearchConfiguration { get; }
+
+	/// <summary>
+	/// Index target for search queries. When <c>DOCUMENTATION_ELASTIC_INDEX_OVERRIDE</c> is set,
+	/// this contains the override value (which may be comma-separated for multiple indices);
+	/// otherwise it is derived from <see cref="DocumentationEndpoints.BuildType"/> and <see cref="DocumentationEndpoints.Environment"/>.
+	/// </summary>
 	public string SearchIndex { get; }
+
 	public string? RulesetName { get; }
 	public IReadOnlyDictionary<string, string[]> SynonymBiDirectional { get; }
 	public IReadOnlyCollection<string> DiminishTerms { get; }
@@ -38,9 +45,13 @@ public class ElasticsearchClientAccessor : IDisposable
 		SynonymBiDirectional = searchConfiguration.SynonymBiDirectional;
 		DiminishTerms = searchConfiguration.DiminishTerms;
 
-		SearchIndex = DocumentationMappingContext.DocumentationDocumentSemantic
+		var computedIndex = DocumentationMappingContext.DocumentationDocumentSemantic
 			.CreateContext(type: endpoints.BuildType, env: endpoints.Environment)
 			.ResolveReadTarget();
+
+		SearchIndex = !string.IsNullOrEmpty(endpoints.SearchIndexOverride)
+			? endpoints.SearchIndexOverride
+			: computedIndex;
 
 		RulesetName = searchConfiguration.Rules.Count > 0
 			? $"docs-ruleset-{endpoints.BuildType}-{endpoints.Environment}"


### PR DESCRIPTION
## What

- Add `DOCUMENTATION_ELASTIC_INDEX_OVERRIDE` environment variable to override the search index used by the API and MCP server
- Support comma-separated values for searching across multiple indices (e.g. for testing)

## Why

- Enables testing against different indices without changing `DOCS_BUILD_TYPE` or `ENVIRONMENT`
- Allows searching across multiple indices in a single query when needed

## Notes

- When set, the override replaces the computed index derived from `BuildType` and `Environment`
- Elasticsearch natively handles comma-separated index names in search requests

Made with [Cursor](https://cursor.com)