### PR TITLE
Draft initial API explorer docs

### DIFF
--- a/docs/_docset.yml
+++ b/docs/_docset.yml
@@ -80,6 +80,7 @@ toc:
           - file: attributes.md
           - file: navigation.md
           - file: extensions.md
+          - file: api-explorer.md
       - file: page.md
       - file: content-sources.md
   - folder: syntax

--- a/docs/cli/docset/build.md
+++ b/docs/cli/docset/build.md
@@ -60,3 +60,6 @@ docs-builder [command] [options...] [-h|--help] [--version]
 
 `--canonical-base-url` `<string>`
 :   The base URL for the canonical url tag (optional)
+
+`--skip-api`
+:   Skip [API Explorer](../../configure/content-set/api-explorer.md) generation for faster builds. (optional)

--- a/docs/cli/docset/serve.md
+++ b/docs/cli/docset/serve.md
@@ -21,3 +21,13 @@ docs-builder serve [options...] [-h|--help] [--version]
 
 `--port` `<int>`
 :   Port to serve the documentation. (Default:   3000)
+
+## API documentation
+
+When your content set includes an [API Explorer configuration](../../configure/content-set/api-explorer.md) in `docset.yml`, `docs-builder serve` generates API documentation on startup and serves it under `/api/{product-key}/`. For example, an `elasticsearch` key produces pages at `http://localhost:3000/api/elasticsearch/`.
+
+API spec files are watched for changes and regenerated automatically when they're updated.
+
+:::{note}
+API generation is skipped when running `docs-builder serve --watch`. This is a performance optimization for `dotnet watch` workflows. Run `serve` without `--watch` to include API docs in your local preview.
+:::

--- a/docs/configure/content-set/api-explorer.md
+++ b/docs/configure/content-set/api-explorer.md
@@ -1,0 +1,78 @@
+---
+navigation_title: API Explorer
+---
+
+# API Explorer
+
+The API Explorer renders OpenAPI specifications as interactive API documentation. When you configure it in your content set, `docs-builder` automatically generates pages for each API operation, request and response schemas, shared type definitions, and inline examples.
+
+:::{warning}
+This feature is still under development and the functionality described on this page might change.
+:::
+
+## Configure the API Explorer
+
+Add the `api` key to your `docset.yml` file to enable the API Explorer. The key maps product names to OpenAPI JSON specification files. Paths are relative to the folder that contains `docset.yml`.
+
+```yaml
+api:
+  elasticsearch: elasticsearch-openapi.json
+  kibana: kibana-openapi.json
+```
+
+Each product key produces its own section of API documentation. For example, `elasticsearch` generates pages under `/api/elasticsearch/` and `kibana` generates pages under `/api/kibana/`.
+
+The `api` key is only valid in `docset.yml`. You can't use it in `toc.yml` files.
+
+## Place your spec files
+
+OpenAPI specification files must be in JSON format and located in the same folder as your `docset.yml` (or in a subfolder of it). The path you specify in `api` is resolved relative to the `docset.yml` location.
+
+For example, if your content set is structured like this:
+
+```
+docs/
+  docset.yml
+  elasticsearch-openapi.json
+  kibana-openapi.json
+  index.md
+  ...
+```
+
+Your `docset.yml` references the specs as follows:
+
+```yaml
+api:
+  elasticsearch: elasticsearch-openapi.json
+  kibana: kibana-openapi.json
+```
+
+## When the API Explorer runs
+
+The API Explorer generates documentation in two scenarios:
+
+- **`docs-builder build`**: API docs are generated as part of the standard build. Use `--skip-api` to skip generation for faster iteration on content.
+- **`docs-builder serve`**: API docs are generated on startup and regenerated automatically when spec files change.
+
+:::{note}
+API generation is skipped when running `docs-builder serve --watch`. This is a performance optimization for `dotnet watch` workflows. Run `serve` without `--watch` to include API docs in your local preview.
+:::
+
+## Link to API pages in navigation
+
+You can reference API pages in your `toc.yml` or `docset.yml` navigation using cross-link syntax:
+
+```yaml
+toc:
+  - file: index.md
+  - title: Elasticsearch API Reference
+    crosslink: elasticsearch://api/elasticsearch/
+```
+
+## What the API Explorer renders
+
+The API Explorer generates the following types of pages from your OpenAPI spec:
+
+- **Landing page**: An overview of the API grouped by tag
+- **Operation pages**: One page per API operation, with the HTTP method, path, parameters, request body, response schemas, and examples
+- **Schema type pages**: Dedicated pages for complex shared types such as `QueryContainer` and `AggregationContainer`

--- a/docs/configure/content-set/index.md
+++ b/docs/configure/content-set/index.md
@@ -18,3 +18,5 @@ A content set in `docs-builder` is equivalent to an AsciiDoc book. At this level
 * [File structure](./file-structure.md).
 * [Navigation](./navigation.md).
 * [Attributes](./attributes.md).
+* [Extensions](./extensions.md).
+* [API Explorer](./api-explorer.md).

--- a/docs/configure/content-set/navigation.md
+++ b/docs/configure/content-set/navigation.md
@@ -94,6 +94,20 @@ exclude:
   - '_*.md'
 ```
 
+### `api`
+
+Maps product names to OpenAPI specification files to enable the [API Explorer](api-explorer.md). Paths are relative to the folder containing `docset.yml`. Only valid in `docset.yml`, not in `toc.yml` files.
+
+```yaml
+api:
+  elasticsearch: elasticsearch-openapi.json
+  kibana: kibana-openapi.json
+```
+
+Each key becomes a sub-path of the generated API docs: `elasticsearch` → `/api/elasticsearch/`, `kibana` → `/api/kibana/`.
+
+See [API Explorer](api-explorer.md) for full configuration details.
+
 ### `toc`
 
 Defines the table of contents (navigation) for the content set. A minimal toc is:
@@ -127,8 +141,8 @@ If a folder does define `children` all markdown files within that folder have to
 
 #### Virtual grouping
 
-A `file` element may include children to create a virtual grouping that 
-does not match the directory structure. 
+A `file` element can include children to create a virtual grouping that
+does not match the directory structure.
 
 ```yaml
   ...
@@ -138,7 +152,7 @@ does not match the directory structure.
       - file: subsection/page-two.md
 ```
 
-A `file` may only select siblings and more deeply nested files as its children. It may not select files outside its own subtree on disk.
+A `file` can only select siblings and more deeply nested files as its children. It can't select files outside its own subtree on disk.
 
 #### Hidden files
 
@@ -147,9 +161,9 @@ A hidden file can be declared in the TOC.
   - hidden: developer-pages.md
 ```
 
-It may not have any children and won't show up in the navigation.
+It can't have any children and won't show up in the navigation.
 
-It [may be linked to locally however](../../developer-notes.md)
+You can still [link to it locally](../../developer-notes.md).
 
 #### Nesting `toc`
 
@@ -284,7 +298,7 @@ See https://www.elastic.co/docs/solutions/search for more details.
 
 **When to suppress**: This hint can be useful to suppress when:
 
-- Processing generated content from external sources (e.g., TOML files) that contain elastic.co URLs
+- Processing generated content from external sources (for example, TOML files) that contain elastic.co URLs
 - During migration periods when converting large amounts of legacy content
 - For documentation that intentionally links to specific hosted versions
 
@@ -320,7 +334,7 @@ toc:
       - file: first-steps.md
 ```
 
-All children must be siblings of the parent file (in the same directory). The parent file may not select files outside its own subtree.
+All children must be siblings of the parent file (in the same directory). The parent file can't select files outside its own subtree.
 
 ### Folder without explicit children
 
@@ -376,7 +390,7 @@ toc:
   - toc: guides
 ```
 
-Each `toc` reference loads the corresponding `toc.yml` file from that directory (e.g., `api-reference/toc.yml`).
+Each `toc` reference loads the corresponding `toc.yml` file from that directory (for example, `api-reference/toc.yml`).
 
 ### Mixed patterns
 


### PR DESCRIPTION
This PR adds very basic documentation for the API explorer feature in `docs-builder`. 
Relates to https://github.com/elastic/docs-builder/pull/2425

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: composer-1.5, clause-4.6-sonnet-medium