### PR TITLE
Use internal span kind for MCP tool calls

### DIFF
--- a/src/api/Elastic.Documentation.Mcp.Remote/Telemetry/McpToolTelemetry.cs
+++ b/src/api/Elastic.Documentation.Mcp.Remote/Telemetry/McpToolTelemetry.cs
@@ -23,7 +23,7 @@ public static class McpToolTelemetry
 
 	public static Activity? StartActivity(string toolName)
 	{
-		var activity = McpActivitySource.StartActivity($"mcp.tool.{toolName}", ActivityKind.Server);
+		var activity = McpActivitySource.StartActivity($"mcp.tool.{toolName}", ActivityKind.Internal);
 		_ = activity?.SetTag("mcp.tool.name", toolName);
 		_ = activity?.SetTag("mcp.server.profile", ServerProfile.Name);
 		if (!string.IsNullOrWhiteSpace(ServerVersion))

--- a/tests/Mcp.Remote.Tests/McpToolTelemetryTests.cs
+++ b/tests/Mcp.Remote.Tests/McpToolTelemetryTests.cs
@@ -52,6 +52,16 @@ public class McpToolTelemetryTests
 	}
 
 	[Fact]
+	public void StartActivity_UsesInternalKind()
+	{
+		using var listener = CreateListener();
+		using var activity = McpToolTelemetry.StartActivity("test_tool");
+
+		activity.Should().NotBeNull();
+		activity!.Kind.Should().Be(ActivityKind.Internal);
+	}
+
+	[Fact]
 	public void MarkSuccess_SetsSuccessTagAndOkStatus()
 	{
 		using var listener = CreateListener();


### PR DESCRIPTION
## Summary
- Switch `McpToolTelemetry.StartActivity()` from `ActivityKind.Server` to `ActivityKind.Internal`.
- Keep existing MCP telemetry tags and naming intact while modeling tool execution as in-process work.
- Add a unit test assertion to verify MCP tool spans are created with internal kind.

## Test plan
- [x] `dotnet build src/api/Elastic.Documentation.Mcp.Remote/Elastic.Documentation.Mcp.Remote.csproj`
- [x] `dotnet test tests/Mcp.Remote.Tests/Mcp.Remote.Tests.csproj --filter FullyQualifiedName~McpToolTelemetryTests`

Made with [Cursor](https://cursor.com)