### PR TITLE
Introduce a configuration option to set changelog naming scheme

### DIFF
--- a/config/changelog.example.yml
+++ b/config/changelog.example.yml
@@ -10,6 +10,14 @@
 #     - value3
 # Both forms produce the same result. Choose whichever is more readable for your use case.
 
+# Filename strategy for generated changelog files.
+# Controls how files created by 'changelog add' are named.
+#   pr        — use the PR number (e.g., 12345.yaml). Default.
+#   issue     — use the issue number (e.g., 67890.yaml).
+#   timestamp — use a Unix timestamp with a title slug (e.g., 1735689600-fix-search.yaml).
+# Can be overridden per invocation with --use-pr-number or --use-issue-number CLI flags.
+filename: pr
+
 # Products configuration (optional)
 # If not specified, all products from products.yml are allowed
 products:

--- a/config/changelog.example.yml
+++ b/config/changelog.example.yml
@@ -12,11 +12,11 @@
 
 # Filename strategy for generated changelog files.
 # Controls how files created by 'changelog add' are named.
-#   pr        — use the PR number (e.g., 12345.yaml). Default.
+#   pr        — use the PR number (e.g., 12345.yaml).
 #   issue     — use the issue number (e.g., 67890.yaml).
-#   timestamp — use a Unix timestamp with a title slug (e.g., 1735689600-fix-search.yaml).
+#   timestamp — use a Unix timestamp with a title slug (e.g., 1735689600-fix-search.yaml). Default.
 # Can be overridden per invocation with --use-pr-number or --use-issue-number CLI flags.
-filename: pr
+filename: timestamp
 
 # Products configuration (optional)
 # If not specified, all products from products.yml are allowed

--- a/docs/cli/release/changelog-add.md
+++ b/docs/cli/release/changelog-add.md
@@ -142,7 +142,7 @@ When running inside GitHub Actions, `changelog add` automatically reads the foll
 
 **Precedence**: explicit CLI arguments always take priority over environment variables. Environment variables are only used when the corresponding CLI argument is not provided.
 
-The filename strategy is controlled by the `filename` option in `changelog.yml` (defaulting to `pr`). Refer to [changelog.example.yml](https://github.com/elastic/docs-builder/blob/main/config/changelog.example.yml) for details.
+The filename strategy is controlled by the `filename` option in `changelog.yml` (defaulting to `timestamp`). Refer to [changelog.example.yml](https://github.com/elastic/docs-builder/blob/main/config/changelog.example.yml) for details.
 
 This allows the CI action to invoke `changelog add` with a minimal command line:
 

--- a/docs/cli/release/changelog-add.md
+++ b/docs/cli/release/changelog-add.md
@@ -123,10 +123,10 @@ docs-builder changelog add [options...] [-h|--help]
 :   The valid types are listed in [ChangelogConfiguration.cs](https://github.com/elastic/docs-builder/blob/main/src/services/Elastic.Documentation.Services/Changelog/ChangelogConfiguration.cs).
 
 `--use-pr-number`
-:   Optional: Use PR numbers for filenames instead of timestamp-slug. With both `--prs` (which creates one changelog per specified PR) and `--issues` (which creates one changelog per specified issue), each changelog filename will be derived from its PR numbers. Requires `--prs` or `--issues`. Mutually exclusive with `--use-issue-number`.
+:   Optional: Use PR numbers for filenames instead of the configured `filename` strategy. With both `--prs` (which creates one changelog per specified PR) and `--issues` (which creates one changelog per specified issue), each changelog filename will be derived from its PR numbers. Requires `--prs` or `--issues`. Mutually exclusive with `--use-issue-number`.
 
 `--use-issue-number`
-:   Optional: Use issue numbers for filenames instead of timestamp-slug. With both `--prs` (which creates one changelog per specified PR) and `--issues` (which creates one changelog per specified issue), each changelog filename will be derived from its issues. Requires `--prs` or `--issues`. Mutually exclusive with `--use-pr-number`.
+:   Optional: Use issue numbers for filenames instead of the configured `filename` strategy. With both `--prs` (which creates one changelog per specified PR) and `--issues` (which creates one changelog per specified issue), each changelog filename will be derived from its issues. Requires `--prs` or `--issues`. Mutually exclusive with `--use-pr-number`.
 
 ## CI auto-detection [ci-auto-detection]
 
@@ -142,7 +142,7 @@ When running inside GitHub Actions, `changelog add` automatically reads the foll
 
 **Precedence**: explicit CLI arguments always take priority over environment variables. Environment variables are only used when the corresponding CLI argument is not provided.
 
-When `CHANGELOG_PR_NUMBER` is set and `--prs` is not provided, `--use-pr-number` is also implicitly enabled so the generated filename uses the PR number.
+The filename strategy is controlled by the `filename` option in `changelog.yml` (defaulting to `pr`). Refer to [changelog.example.yml](https://github.com/elastic/docs-builder/blob/main/config/changelog.example.yml) for details.
 
 This allows the CI action to invoke `changelog add` with a minimal command line:
 

--- a/docs/cli/release/changelog-evaluate-pr.md
+++ b/docs/cli/release/changelog-evaluate-pr.md
@@ -68,6 +68,7 @@ docs-builder changelog evaluate-pr [options...] [-h|--help]
 | `title` | Resolved PR title |
 | `type` | Resolved changelog type |
 | `label-table` | Markdown table of configured label-to-type mappings |
+| `existing-changelog-filename` | Filename of a previously committed changelog for this PR (if any) |
 
 ## Environment variables
 

--- a/docs/contribute/changelog.md
+++ b/docs/contribute/changelog.md
@@ -313,12 +313,23 @@ Examples:
 
 ### Filenames
 
-By default, the `docs-builder changelog add` command generates filenames using a timestamp and a sanitized version of the title:
-`{timestamp}-{sanitized-title}.yaml`
+The `docs-builder changelog add` command names generated files according to the `filename` strategy in `changelog.yml`:
 
-For example: `1735689600-fixes-enrich-and-lookup-join-resolution.yaml`
+| Strategy | Example filename | Description |
+|---|---|---|
+| `pr` (default) | `137431.yaml` | Uses the PR number. |
+| `issue` | `2571.yaml` | Uses the issue number. |
+| `timestamp` | `1735689600-fixes-enrich-and-lookup-join-resolution.yaml` | Uses a Unix timestamp with a sanitized title slug. |
 
-If you want to use PR numbers for filenames, add the `--use-pr-number` option. With both `--prs` (which creates one changelog per specified PR) and `--issues` (which creates one changelog per specified issue), each changelog filename will be derived from its PR numbers:
+Set the strategy in your changelog configuration file:
+
+```yaml
+filename: pr
+```
+
+Refer to [changelog.example.yml](https://github.com/elastic/docs-builder/blob/main/config/changelog.example.yml) for full documentation.
+
+You can override the configured strategy per invocation with the `--use-pr-number` or `--use-issue-number` CLI flags:
 
 ```sh
 docs-builder changelog add \
@@ -330,13 +341,13 @@ docs-builder changelog add \
   --issues https://github.com/elastic/docs-builder/issues/2571 \
   --products "elasticsearch 9.3.0" \
   --config docs/changelog.yml \
-  --use-pr-number
+  --use-issue-number
 ```
-
-For filenames that match issue numbers instead of PR numbers, specify `--use-issue-number`.
 
 :::{important}
 `--use-pr-number` and `--use-issue-number` are mutually exclusive; specify only one. Each requires `--prs` or `--issues`. The numbers are extracted from the URLs or identifiers you provide, or from linked references in the issue or PR body when extraction is enabled.
+
+**Precedence**: CLI flags (`--use-pr-number` / `--use-issue-number`) > `filename` in `changelog.yml` > default (`pr`).
 :::
 
 ### Examples

--- a/docs/contribute/changelog.md
+++ b/docs/contribute/changelog.md
@@ -317,14 +317,14 @@ The `docs-builder changelog add` command names generated files according to the 
 
 | Strategy | Example filename | Description |
 |---|---|---|
-| `pr` (default) | `137431.yaml` | Uses the PR number. |
+| `timestamp` (default) | `1735689600-fixes-enrich-and-lookup-join-resolution.yaml` | Uses a Unix timestamp with a sanitized title slug. |
+| `pr` | `137431.yaml` | Uses the PR number. |
 | `issue` | `2571.yaml` | Uses the issue number. |
-| `timestamp` | `1735689600-fixes-enrich-and-lookup-join-resolution.yaml` | Uses a Unix timestamp with a sanitized title slug. |
 
 Set the strategy in your changelog configuration file:
 
 ```yaml
-filename: pr
+filename: timestamp
 ```
 
 Refer to [changelog.example.yml](https://github.com/elastic/docs-builder/blob/main/config/changelog.example.yml) for full documentation.
@@ -347,7 +347,7 @@ docs-builder changelog add \
 :::{important}
 `--use-pr-number` and `--use-issue-number` are mutually exclusive; specify only one. Each requires `--prs` or `--issues`. The numbers are extracted from the URLs or identifiers you provide, or from linked references in the issue or PR body when extraction is enabled.
 
-**Precedence**: CLI flags (`--use-pr-number` / `--use-issue-number`) > `filename` in `changelog.yml` > default (`pr`).
+**Precedence**: CLI flags (`--use-pr-number` / `--use-issue-number`) > `filename` in `changelog.yml` > default (`timestamp`).
 :::
 
 ### Examples

--- a/src/Elastic.Documentation.Configuration/Changelog/ChangelogConfiguration.cs
+++ b/src/Elastic.Documentation.Configuration/Changelog/ChangelogConfiguration.cs
@@ -115,7 +115,7 @@ public record ChangelogConfiguration
 	/// Filename strategy for generated changelog files.
 	/// Controls how files created by 'changelog add' are named.
 	/// </summary>
-	public FilenameStrategy Filename { get; init; } = FilenameStrategy.Pr;
+	public FilenameStrategy Filename { get; init; } = FilenameStrategy.Timestamp;
 
 	/// <summary>
 	/// Bundle configuration with profiles and defaults.

--- a/src/Elastic.Documentation.Configuration/Changelog/ChangelogConfiguration.cs
+++ b/src/Elastic.Documentation.Configuration/Changelog/ChangelogConfiguration.cs
@@ -112,6 +112,12 @@ public record ChangelogConfiguration
 	public ProductsConfig? ProductsConfiguration { get; init; }
 
 	/// <summary>
+	/// Filename strategy for generated changelog files.
+	/// Controls how files created by 'changelog add' are named.
+	/// </summary>
+	public FilenameStrategy Filename { get; init; } = FilenameStrategy.Pr;
+
+	/// <summary>
 	/// Bundle configuration with profiles and defaults.
 	/// </summary>
 	public BundleConfiguration? Bundle { get; init; }

--- a/src/Elastic.Documentation.Configuration/Changelog/FilenameStrategy.cs
+++ b/src/Elastic.Documentation.Configuration/Changelog/FilenameStrategy.cs
@@ -1,0 +1,25 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.ComponentModel.DataAnnotations;
+using NetEscapades.EnumGenerators;
+
+namespace Elastic.Documentation.Configuration.Changelog;
+
+/// <summary>Controls how changelog files created by 'changelog add' are named.</summary>
+[EnumExtensions]
+public enum FilenameStrategy
+{
+	/// <summary>Use the PR number as filename (e.g., 12345.yaml).</summary>
+	[Display(Name = "pr")]
+	Pr,
+
+	/// <summary>Use the issue number as filename (e.g., 67890.yaml).</summary>
+	[Display(Name = "issue")]
+	Issue,
+
+	/// <summary>Use a Unix timestamp with a title slug (e.g., 1735689600-fix-search.yaml).</summary>
+	[Display(Name = "timestamp")]
+	Timestamp
+}

--- a/src/services/Elastic.Changelog/Configuration/ChangelogConfigurationLoader.cs
+++ b/src/services/Elastic.Changelog/Configuration/ChangelogConfigurationLoader.cs
@@ -295,6 +295,19 @@ public class ChangelogConfigurationLoader(ILoggerFactory logFactory, IConfigurat
 			Issues = yamlConfig.Extract?.Issues ?? true
 		};
 
+		// Process filename strategy
+		var filenameStrategy = FilenameStrategy.Pr;
+		if (!string.IsNullOrWhiteSpace(yamlConfig.Filename))
+		{
+			if (!FilenameStrategyExtensions.TryParse(yamlConfig.Filename, out var parsed, ignoreCase: true, allowMatchingMetadataAttribute: true))
+			{
+				var valid = string.Join(", ", FilenameStrategyExtensions.GetValues().Select(v => v.ToStringFast(true)));
+				collector.EmitError(configPath, $"filename: '{yamlConfig.Filename}' is not valid. Use one of: {valid}");
+				return null;
+			}
+			filenameStrategy = parsed;
+		}
+
 		return new ChangelogConfiguration
 		{
 			Pivot = pivot,
@@ -310,7 +323,8 @@ public class ChangelogConfigurationLoader(ILoggerFactory logFactory, IConfigurat
 			HighlightLabels = highlightLabels,
 			ProductsConfiguration = productsConfig,
 			Bundle = bundleConfig,
-			Extract = extract
+			Extract = extract,
+			Filename = filenameStrategy
 		};
 	}
 

--- a/src/services/Elastic.Changelog/Configuration/ChangelogConfigurationLoader.cs
+++ b/src/services/Elastic.Changelog/Configuration/ChangelogConfigurationLoader.cs
@@ -296,7 +296,7 @@ public class ChangelogConfigurationLoader(ILoggerFactory logFactory, IConfigurat
 		};
 
 		// Process filename strategy
-		var filenameStrategy = FilenameStrategy.Pr;
+		var filenameStrategy = FilenameStrategy.Timestamp;
 		if (!string.IsNullOrWhiteSpace(yamlConfig.Filename))
 		{
 			if (!FilenameStrategyExtensions.TryParse(yamlConfig.Filename, out var parsed, ignoreCase: true, allowMatchingMetadataAttribute: true))

--- a/src/services/Elastic.Changelog/Creation/ChangelogCreationService.cs
+++ b/src/services/Elastic.Changelog/Creation/ChangelogCreationService.cs
@@ -125,12 +125,25 @@ IEnvironmentVariables? env = null
 		}
 	}
 
-	private static CreateChangelogArguments ApplyConfigDefaults(CreateChangelogArguments input, ChangelogConfiguration config) =>
-		input with
+	internal static CreateChangelogArguments ApplyConfigDefaults(CreateChangelogArguments input, ChangelogConfiguration config)
+	{
+		var usePrNumber = input.UsePrNumber;
+		var useIssueNumber = input.UseIssueNumber;
+
+		if (!usePrNumber && !useIssueNumber)
+		{
+			usePrNumber = config.Filename == FilenameStrategy.Pr;
+			useIssueNumber = config.Filename == FilenameStrategy.Issue;
+		}
+
+		return input with
 		{
 			ExtractReleaseNotes = input.ExtractReleaseNotes ?? config.Extract.ReleaseNotes,
-			ExtractIssues = input.ExtractIssues ?? config.Extract.Issues
+			ExtractIssues = input.ExtractIssues ?? config.Extract.Issues,
+			UsePrNumber = usePrNumber,
+			UseIssueNumber = useIssueNumber
 		};
+	}
 
 	/// <summary>
 	/// Infers products from configuration defaults or repository name.
@@ -389,17 +402,13 @@ IEnvironmentVariables? env = null
 			? input.Prs
 			: !string.IsNullOrEmpty(prNumber) ? [prNumber] : input.Prs;
 
-		// TODO: filename strategy (use-pr-number) will move to changelog.yml configuration
-		var usePrNumber = input.UsePrNumber || (input.Prs is not { Length: > 0 } && !string.IsNullOrEmpty(prNumber));
-
 		return input with
 		{
 			Prs = enrichedPrs,
 			Title = !string.IsNullOrWhiteSpace(input.Title) ? input.Title : ciTitle,
 			Type = !string.IsNullOrWhiteSpace(input.Type) ? input.Type : ciType,
 			Owner = input.Owner ?? ciOwner,
-			Repo = !string.IsNullOrWhiteSpace(input.Repo) ? input.Repo : ciRepo,
-			UsePrNumber = usePrNumber
+			Repo = !string.IsNullOrWhiteSpace(input.Repo) ? input.Repo : ciRepo
 		};
 	}
 }

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogArtifactEvaluationService.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogArtifactEvaluationService.cs
@@ -92,6 +92,7 @@ public class ChangelogArtifactEvaluationService(
 		await coreService.SetOutputAsync("status", metadata.Status);
 		await coreService.SetOutputAsync("config-file", metadata.ConfigFile ?? string.Empty);
 		await coreService.SetOutputAsync("changelog-dir", metadata.ChangelogDir ?? string.Empty);
+		await coreService.SetOutputAsync("changelog-filename", metadata.ChangelogFilename ?? string.Empty);
 		await coreService.SetOutputAsync("label-table", metadata.LabelTable ?? string.Empty);
 		await coreService.SetOutputAsync("should-commit", shouldCommit ? "true" : "false");
 		await coreService.SetOutputAsync("should-comment-success", shouldCommentSuccess ? "true" : "false");

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogArtifactMetadata.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogArtifactMetadata.cs
@@ -18,6 +18,7 @@ public record ChangelogArtifactMetadata
 	public string? LabelTable { get; init; }
 	public string? ConfigFile { get; init; }
 	public string? ChangelogDir { get; init; }
+	public string? ChangelogFilename { get; init; }
 	public CreateRules? CreateRules { get; init; }
 }
 

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogPrEvaluationService.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogPrEvaluationService.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Globalization;
 using System.IO.Abstractions;
 using Actions.Core.Services;
 using Elastic.Changelog.Configuration;
@@ -26,6 +27,7 @@ public class ChangelogPrEvaluationService(
 ) : IService
 {
 	private readonly ILogger _logger = logFactory.CreateLogger<ChangelogPrEvaluationService>();
+	private readonly IFileSystem _fileSystem = fileSystem ?? new FileSystem();
 	private readonly ChangelogConfigurationLoader _configLoader = new(logFactory, configurationContext, fileSystem ?? new FileSystem());
 
 	public async Task<bool> EvaluatePr(IDiagnosticsCollector collector, EvaluatePrArguments input, Cancel ctx)
@@ -52,15 +54,23 @@ public class ChangelogPrEvaluationService(
 			}
 		}
 
-		// Manual edit detection
-		var changelogFilePath = $"{changelogDir}/{input.PrNumber}.yaml";
-		var fileAuthor = await gitHubPrService.FetchLastFileCommitAuthorAsync(
-			input.Owner, input.Repo, changelogFilePath, input.HeadRef, ctx
-		);
-		if (!string.IsNullOrEmpty(fileAuthor) && !string.Equals(fileAuthor, input.BotName, StringComparison.OrdinalIgnoreCase))
+		// Find existing changelog file for this PR (handles all filename strategies)
+		var existingFilename = FindExistingChangelog(changelogDir, input.PrNumber);
+		var changelogFilePath = existingFilename != null
+			? $"{changelogDir}/{existingFilename}"
+			: null;
+
+		// Manual edit detection (only if a file exists)
+		if (changelogFilePath != null)
 		{
-			_logger.LogInformation("Skipping: changelog file manually edited by {Author}", fileAuthor);
-			return await SetOutputs(PrEvaluationResult.ManuallyEdited);
+			var fileAuthor = await gitHubPrService.FetchLastFileCommitAuthorAsync(
+				input.Owner, input.Repo, changelogFilePath, input.HeadRef, ctx
+			);
+			if (!string.IsNullOrEmpty(fileAuthor) && !string.Equals(fileAuthor, input.BotName, StringComparison.OrdinalIgnoreCase))
+			{
+				_logger.LogInformation("Skipping: changelog file {File} manually edited by {Author}", changelogFilePath, fileAuthor);
+				return await SetOutputs(PrEvaluationResult.ManuallyEdited);
+			}
 		}
 
 		// Label-based skip check
@@ -88,13 +98,12 @@ public class ChangelogPrEvaluationService(
 
 		if (resolvedType == null)
 		{
-			// Build label table for no-label case
 			_logger.LogInformation("No type label found on PR");
 			return await SetOutputs(PrEvaluationResult.NoLabel, title, labelTable: BuildLabelTable(config.LabelToType));
 		}
 
-		_logger.LogInformation("PR evaluation complete: title={Title}, type={Type}", title, resolvedType);
-		return await SetOutputs(PrEvaluationResult.Success, title, resolvedType);
+		_logger.LogInformation("PR evaluation complete: title={Title}, type={Type}, existingFile={File}", title, resolvedType, existingFilename);
+		return await SetOutputs(PrEvaluationResult.Success, title, resolvedType, existingFilename: existingFilename);
 	}
 
 	/// <summary>The evaluate-pr output value when evaluation succeeds and generation should proceed.</summary>
@@ -104,7 +113,8 @@ public class ChangelogPrEvaluationService(
 		PrEvaluationResult status,
 		string? resolvedTitle = null,
 		string? resolvedType = null,
-		string? labelTable = null)
+		string? labelTable = null,
+		string? existingFilename = null)
 	{
 		// evaluate-pr outputs "proceed" (not "success") to signal the generate step should run
 		var statusString = status == PrEvaluationResult.Success
@@ -124,9 +134,40 @@ public class ChangelogPrEvaluationService(
 			await coreService.SetOutputAsync("type", resolvedType);
 		if (labelTable != null)
 			await coreService.SetOutputAsync("label-table", labelTable);
+		if (existingFilename != null)
+			await coreService.SetOutputAsync("existing-changelog-filename", existingFilename);
 
 		return true;
 	}
+
+	/// <summary>
+	/// Finds an existing changelog file for the given PR in the changelog directory.
+	/// Returns the filename (not the full path) if found, or null.
+	/// </summary>
+	internal string? FindExistingChangelog(string changelogDir, int prNumber)
+	{
+		if (!_fileSystem.Directory.Exists(changelogDir))
+			return null;
+
+		var prFilename = $"{prNumber}.yaml";
+		if (_fileSystem.File.Exists(_fileSystem.Path.Combine(changelogDir, prFilename)))
+			return prFilename;
+
+		var prString = prNumber.ToString(CultureInfo.InvariantCulture);
+		foreach (var filePath in _fileSystem.Directory.GetFiles(changelogDir, "*.yaml"))
+		{
+			var content = _fileSystem.File.ReadAllText(filePath);
+			if (ContentReferencesPr(content, prString))
+				return _fileSystem.Path.GetFileName(filePath);
+		}
+
+		return null;
+	}
+
+	internal static bool ContentReferencesPr(string content, string prNumber) =>
+		content.Contains($"/pull/{prNumber}", StringComparison.Ordinal) ||
+		content.Contains($"- \"{prNumber}\"", StringComparison.Ordinal) ||
+		content.Contains($"- '{prNumber}'", StringComparison.Ordinal);
 
 	internal static string BuildLabelTable(IReadOnlyDictionary<string, string>? labelToType)
 	{

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogPrepareArtifactService.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogPrepareArtifactService.cs
@@ -33,19 +33,26 @@ public class ChangelogPrepareArtifactService(
 
 		_ = _fileSystem.Directory.CreateDirectory(input.OutputDir);
 
+		string? changelogFilename = null;
 		if (status == PrEvaluationResult.Success)
 		{
-			var sourceYaml = _fileSystem.Path.Combine(input.StagingDir, $"{input.PrNumber}.yaml");
-			var destYaml = _fileSystem.Path.Combine(input.OutputDir, $"{input.PrNumber}.yaml");
+			var sourceYaml = FindStagingYaml(input.StagingDir);
 
-			if (_fileSystem.File.Exists(sourceYaml))
+			if (sourceYaml != null)
 			{
+				changelogFilename = input.ExistingChangelogFilename
+					?? _fileSystem.Path.GetFileName(sourceYaml);
+
+				if (input.ExistingChangelogFilename != null)
+					_logger.LogInformation("Reusing existing filename {Filename} for stable path on branch", changelogFilename);
+
+				var destYaml = _fileSystem.Path.Combine(input.OutputDir, changelogFilename);
 				_fileSystem.File.Copy(sourceYaml, destYaml, overwrite: true);
 				_logger.LogInformation("Copied changelog YAML: {Source} → {Dest}", sourceYaml, destYaml);
 			}
 			else
 			{
-				collector.EmitError(sourceYaml, "Generated changelog YAML not found in staging directory");
+				collector.EmitError(input.StagingDir, "No generated changelog YAML found in staging directory");
 				status = PrEvaluationResult.Error;
 			}
 		}
@@ -66,6 +73,7 @@ public class ChangelogPrepareArtifactService(
 			LabelTable = input.LabelTable,
 			ConfigFile = resolvedConfigPath,
 			ChangelogDir = changelogDir,
+			ChangelogFilename = changelogFilename,
 			CreateRules = createRules
 		};
 
@@ -77,6 +85,25 @@ public class ChangelogPrepareArtifactService(
 		await coreService.SetOutputAsync("status", statusString);
 
 		return true;
+	}
+
+	/// <summary>
+	/// Finds the changelog YAML in the staging directory regardless of filename strategy.
+	/// Returns null if no YAML file is found.
+	/// </summary>
+	private string? FindStagingYaml(string stagingDir)
+	{
+		if (!_fileSystem.Directory.Exists(stagingDir))
+			return null;
+
+		var yamlFiles = _fileSystem.Directory.GetFiles(stagingDir, "*.yaml");
+		if (yamlFiles.Length == 0)
+			return null;
+
+		if (yamlFiles.Length > 1)
+			_logger.LogWarning("Multiple YAML files found in staging directory, using first: {File}", yamlFiles[0]);
+
+		return yamlFiles[0];
 	}
 
 	internal static PrEvaluationResult ResolveStatus(string evaluateStatus, string generateOutcome)

--- a/src/services/Elastic.Changelog/Evaluation/PrepareArtifactArguments.cs
+++ b/src/services/Elastic.Changelog/Evaluation/PrepareArtifactArguments.cs
@@ -16,4 +16,10 @@ public record PrepareArtifactArguments
 	public required string HeadSha { get; init; }
 	public string? LabelTable { get; init; }
 	public string? Config { get; init; }
+
+	/// <summary>
+	/// Filename of a previously committed changelog for this PR.
+	/// When set, the staging file is renamed to match so the same path is overwritten on the branch.
+	/// </summary>
+	public string? ExistingChangelogFilename { get; init; }
 }

--- a/src/services/Elastic.Changelog/Serialization/ChangelogConfigurationYaml.cs
+++ b/src/services/Elastic.Changelog/Serialization/ChangelogConfigurationYaml.cs
@@ -11,6 +11,11 @@ namespace Elastic.Changelog.Serialization;
 internal record ChangelogConfigurationYaml
 {
 	/// <summary>
+	/// Filename strategy for generated changelog files (pr, issue, timestamp).
+	/// </summary>
+	public string? Filename { get; set; }
+
+	/// <summary>
 	/// Pivot configuration for types, subtypes, and areas with label mappings.
 	/// </summary>
 	public PivotConfigurationYaml? Pivot { get; set; }

--- a/src/tooling/docs-builder/Commands/ChangelogCommand.cs
+++ b/src/tooling/docs-builder/Commands/ChangelogCommand.cs
@@ -1264,6 +1264,7 @@ internal sealed partial class ChangelogCommand(
 		string headSha,
 		string? labelTable = null,
 		string? config = null,
+		string? existingChangelogFilename = null,
 		Cancel ctx = default
 	)
 	{
@@ -1281,7 +1282,8 @@ internal sealed partial class ChangelogCommand(
 			HeadRef = headRef,
 			HeadSha = headSha,
 			LabelTable = labelTable,
-			Config = config
+			Config = config,
+			ExistingChangelogFilename = existingChangelogFilename
 		};
 
 		serviceInvoker.AddCommand(service, args,

--- a/tests/Elastic.Changelog.Tests/Changelogs/ChangelogConfigurationTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/ChangelogConfigurationTests.cs
@@ -1216,7 +1216,7 @@ public class ChangelogConfigurationTests(ITestOutputHelper output) : ChangelogTe
 
 		config.Should().NotBeNull();
 		Collector.Errors.Should().Be(0);
-		config!.Filename.Should().Be(expected);
+		config.Filename.Should().Be(expected);
 	}
 
 	[Fact]
@@ -1230,7 +1230,7 @@ public class ChangelogConfigurationTests(ITestOutputHelper output) : ChangelogTe
 
 		config.Should().NotBeNull();
 		Collector.Errors.Should().Be(0);
-		config!.Filename.Should().Be(FilenameStrategy.Pr);
+		config.Filename.Should().Be(FilenameStrategy.Pr);
 	}
 
 	[Fact]

--- a/tests/Elastic.Changelog.Tests/Changelogs/ChangelogConfigurationTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/ChangelogConfigurationTests.cs
@@ -1203,6 +1203,51 @@ public class ChangelogConfigurationTests(ITestOutputHelper output) : ChangelogTe
 		Collector.Diagnostics.Should().Contain(d => d.Message.Contains("cannot have both 'exclude_products' and 'include_products'"));
 	}
 
+	[Theory]
+	[InlineData("pr", FilenameStrategy.Pr)]
+	[InlineData("issue", FilenameStrategy.Issue)]
+	[InlineData("timestamp", FilenameStrategy.Timestamp)]
+	public async Task LoadChangelogConfiguration_Filename_ParsesStrategy(string yamlValue, FilenameStrategy expected)
+	{
+		var config = await LoadConfig(
+			$"""
+			filename: {yamlValue}
+			""");
+
+		config.Should().NotBeNull();
+		Collector.Errors.Should().Be(0);
+		config!.Filename.Should().Be(expected);
+	}
+
+	[Fact]
+	public async Task LoadChangelogConfiguration_Filename_Missing_DefaultsToPr()
+	{
+		var config = await LoadConfig(
+			"""
+			lifecycles:
+			  - ga
+			""");
+
+		config.Should().NotBeNull();
+		Collector.Errors.Should().Be(0);
+		config!.Filename.Should().Be(FilenameStrategy.Pr);
+	}
+
+	[Fact]
+	public async Task LoadChangelogConfiguration_Filename_Invalid_ReturnsError()
+	{
+		var config = await LoadConfig(
+			"""
+			filename: random-value
+			""");
+
+		config.Should().BeNull();
+		Collector.Errors.Should().BeGreaterThan(0);
+		Collector.Diagnostics.Should().Contain(d =>
+			d.Severity == Severity.Error &&
+			d.Message.Contains("filename: 'random-value' is not valid"));
+	}
+
 	[Fact]
 	public async Task LoadChangelogConfiguration_WithRulesBundle_UnknownProductId_ReturnsError()
 	{

--- a/tests/Elastic.Changelog.Tests/Changelogs/ChangelogConfigurationTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/ChangelogConfigurationTests.cs
@@ -1220,7 +1220,7 @@ public class ChangelogConfigurationTests(ITestOutputHelper output) : ChangelogTe
 	}
 
 	[Fact]
-	public async Task LoadChangelogConfiguration_Filename_Missing_DefaultsToPr()
+	public async Task LoadChangelogConfiguration_Filename_Missing_DefaultsToTimestamp()
 	{
 		var config = await LoadConfig(
 			"""
@@ -1230,7 +1230,7 @@ public class ChangelogConfigurationTests(ITestOutputHelper output) : ChangelogTe
 
 		config.Should().NotBeNull();
 		Collector.Errors.Should().Be(0);
-		config.Filename.Should().Be(FilenameStrategy.Pr);
+		config.Filename.Should().Be(FilenameStrategy.Timestamp);
 	}
 
 	[Fact]

--- a/tests/Elastic.Changelog.Tests/Creation/CIEnrichmentTests.cs
+++ b/tests/Elastic.Changelog.Tests/Creation/CIEnrichmentTests.cs
@@ -78,7 +78,6 @@ public class CIEnrichmentTests(ITestOutputHelper output) : ChangelogTestBase(out
 		result.Type.Should().Be("bug-fix");
 		result.Owner.Should().Be("elastic");
 		result.Repo.Should().Be("kibana");
-		result.UsePrNumber.Should().BeTrue();
 	}
 
 	[Fact]
@@ -91,7 +90,6 @@ public class CIEnrichmentTests(ITestOutputHelper output) : ChangelogTestBase(out
 		var result = service.EnrichFromCI(input);
 
 		result.Prs.Should().BeEquivalentTo(["99"]);
-		result.UsePrNumber.Should().BeFalse();
 	}
 
 	[Fact]
@@ -146,7 +144,6 @@ public class CIEnrichmentTests(ITestOutputHelper output) : ChangelogTestBase(out
 		result.Type.Should().BeNull();
 		result.Owner.Should().BeNull();
 		result.Repo.Should().BeNull();
-		result.UsePrNumber.Should().BeTrue();
 	}
 
 	[Fact]
@@ -160,7 +157,6 @@ public class CIEnrichmentTests(ITestOutputHelper output) : ChangelogTestBase(out
 
 		result.Title.Should().Be("CI title");
 		result.Prs.Should().BeNull();
-		result.UsePrNumber.Should().BeFalse();
 	}
 
 	[Fact]

--- a/tests/Elastic.Changelog.Tests/Creation/FilenameStrategyTests.cs
+++ b/tests/Elastic.Changelog.Tests/Creation/FilenameStrategyTests.cs
@@ -74,14 +74,14 @@ public class FilenameStrategyTests
 	}
 
 	[Fact]
-	public void ApplyConfigDefaults_DefaultConfig_UsePrNumber()
+	public void ApplyConfigDefaults_DefaultConfig_UsesTimestamp()
 	{
 		var config = ChangelogConfiguration.Default;
 		var input = DefaultInput();
 
 		var result = ChangelogCreationService.ApplyConfigDefaults(input, config);
 
-		result.UsePrNumber.Should().BeTrue("default FilenameStrategy is Pr");
-		result.UseIssueNumber.Should().BeFalse();
+		result.UsePrNumber.Should().BeFalse("default FilenameStrategy is Timestamp");
+		result.UseIssueNumber.Should().BeFalse("default FilenameStrategy is Timestamp");
 	}
 }

--- a/tests/Elastic.Changelog.Tests/Creation/FilenameStrategyTests.cs
+++ b/tests/Elastic.Changelog.Tests/Creation/FilenameStrategyTests.cs
@@ -1,0 +1,87 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Changelog.Creation;
+using Elastic.Documentation.Configuration.Changelog;
+using FluentAssertions;
+
+namespace Elastic.Changelog.Tests.Creation;
+
+public class FilenameStrategyTests
+{
+	private static CreateChangelogArguments DefaultInput() =>
+		new() { Products = [] };
+
+	[Fact]
+	public void ApplyConfigDefaults_FilenamePr_SetsUsePrNumber()
+	{
+		var config = ChangelogConfiguration.Default with { Filename = FilenameStrategy.Pr };
+		var input = DefaultInput();
+
+		var result = ChangelogCreationService.ApplyConfigDefaults(input, config);
+
+		result.UsePrNumber.Should().BeTrue();
+		result.UseIssueNumber.Should().BeFalse();
+	}
+
+	[Fact]
+	public void ApplyConfigDefaults_FilenameIssue_SetsUseIssueNumber()
+	{
+		var config = ChangelogConfiguration.Default with { Filename = FilenameStrategy.Issue };
+		var input = DefaultInput();
+
+		var result = ChangelogCreationService.ApplyConfigDefaults(input, config);
+
+		result.UsePrNumber.Should().BeFalse();
+		result.UseIssueNumber.Should().BeTrue();
+	}
+
+	[Fact]
+	public void ApplyConfigDefaults_FilenameTimestamp_NeitherFlagSet()
+	{
+		var config = ChangelogConfiguration.Default with { Filename = FilenameStrategy.Timestamp };
+		var input = DefaultInput();
+
+		var result = ChangelogCreationService.ApplyConfigDefaults(input, config);
+
+		result.UsePrNumber.Should().BeFalse();
+		result.UseIssueNumber.Should().BeFalse();
+	}
+
+	[Fact]
+	public void ApplyConfigDefaults_CLIUsePrNumber_OverridesConfigIssue()
+	{
+		var config = ChangelogConfiguration.Default with { Filename = FilenameStrategy.Issue };
+		var input = DefaultInput() with { UsePrNumber = true };
+
+		var result = ChangelogCreationService.ApplyConfigDefaults(input, config);
+
+		result.UsePrNumber.Should().BeTrue();
+		result.UseIssueNumber.Should().BeFalse();
+	}
+
+	[Fact]
+	public void ApplyConfigDefaults_CLIUseIssueNumber_OverridesConfigPr()
+	{
+		var config = ChangelogConfiguration.Default with { Filename = FilenameStrategy.Pr };
+		var input = DefaultInput() with { UseIssueNumber = true };
+
+		var result = ChangelogCreationService.ApplyConfigDefaults(input, config);
+
+		result.UsePrNumber.Should().BeFalse();
+		result.UseIssueNumber.Should().BeTrue();
+	}
+
+	[Fact]
+	public void ApplyConfigDefaults_DefaultConfig_UsePrNumber()
+	{
+		var config = ChangelogConfiguration.Default;
+		var input = DefaultInput();
+
+		var result = ChangelogCreationService.ApplyConfigDefaults(input, config);
+
+		result.UsePrNumber.Should().BeTrue("default FilenameStrategy is Pr");
+		result.UseIssueNumber.Should().BeFalse();
+	}
+}

--- a/tests/Elastic.Changelog.Tests/Evaluation/ChangelogArtifactEvaluationServiceTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/ChangelogArtifactEvaluationServiceTests.cs
@@ -38,7 +38,7 @@ public class ChangelogArtifactEvaluationServiceTests(ITestOutputHelper output) :
 		await FileSystem.File.WriteAllTextAsync(path, json);
 	}
 
-	private static ChangelogArtifactMetadata DefaultMetadata(string status = "success") =>
+	private static ChangelogArtifactMetadata DefaultMetadata(string status = "success", string? changelogFilename = "42.yaml") =>
 		new()
 		{
 			PrNumber = 42,
@@ -47,6 +47,7 @@ public class ChangelogArtifactEvaluationServiceTests(ITestOutputHelper output) :
 			Status = status,
 			ConfigFile = "docs/changelog.yml",
 			ChangelogDir = "changelogs",
+			ChangelogFilename = changelogFilename,
 			CreateRules = new CreateRules { Labels = ["changelog:skip"], Mode = FieldMode.Exclude }
 		};
 
@@ -136,6 +137,7 @@ public class ChangelogArtifactEvaluationServiceTests(ITestOutputHelper output) :
 		VerifyOutputSet("head-ref", "feature/test");
 		VerifyOutputSet("head-sha", "abc123");
 		VerifyOutputSet("status", "success");
+		VerifyOutputSet("changelog-filename", "42.yaml");
 	}
 
 	[Fact]
@@ -165,6 +167,19 @@ public class ChangelogArtifactEvaluationServiceTests(ITestOutputHelper output) :
 		result.Should().BeTrue();
 		VerifyOutputSet("should-commit", "false");
 		VerifyOutputSet("should-comment-success", "true");
+	}
+
+	[Fact]
+	public async Task EvaluateArtifact_TimestampFilename_OutputsOriginalFilename()
+	{
+		await WriteMetadata(DefaultMetadata(changelogFilename: "1735689600-fix-search.yaml"));
+		SetupPrInfo();
+
+		var service = CreateService();
+		var result = await service.EvaluateArtifact(Collector, DefaultArgs(), CancellationToken.None);
+
+		result.Should().BeTrue();
+		VerifyOutputSet("changelog-filename", "1735689600-fix-search.yaml");
 	}
 
 	[Fact]

--- a/tests/Elastic.Changelog.Tests/Evaluation/ChangelogPrEvaluationServiceTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/ChangelogPrEvaluationServiceTests.cs
@@ -127,7 +127,7 @@ public class ChangelogPrEvaluationServiceTests : ChangelogTestBase
 	public async Task EvaluatePr_ManuallyEdited_PrFilename_ReturnsManuallyEdited()
 	{
 		FileSystem.Directory.CreateDirectory("docs/changelog");
-		await FileSystem.File.WriteAllTextAsync("docs/changelog/42.yaml", "title: test");
+		await FileSystem.File.WriteAllTextAsync("docs/changelog/42.yaml", "title: test", TestContext.Current.CancellationToken);
 
 		A.CallTo(() => _mockGitHub.FetchLastFileCommitAuthorAsync(
 				"elastic", "test-repo", "docs/changelog/42.yaml", "feature/test", A<CancellationToken>._))
@@ -147,7 +147,7 @@ public class ChangelogPrEvaluationServiceTests : ChangelogTestBase
 	{
 		FileSystem.Directory.CreateDirectory("docs/changelog");
 		await FileSystem.File.WriteAllTextAsync("docs/changelog/1735689600-fix-something.yaml",
-			"title: Fix something\nprs:\n  - \"42\"");
+			"title: Fix something\nprs:\n  - \"42\"", TestContext.Current.CancellationToken);
 
 		A.CallTo(() => _mockGitHub.FetchLastFileCommitAuthorAsync(
 				"elastic", "test-repo", "docs/changelog/1735689600-fix-something.yaml", "feature/test", A<CancellationToken>._))
@@ -281,7 +281,7 @@ public class ChangelogPrEvaluationServiceTests : ChangelogTestBase
 		await WriteMinimalConfig();
 		FileSystem.Directory.CreateDirectory("docs/changelog");
 		await FileSystem.File.WriteAllTextAsync("docs/changelog/1735689600-fix-something.yaml",
-			"title: Fix something\nprs:\n  - \"42\"");
+			"title: Fix something\nprs:\n  - \"42\"", TestContext.Current.CancellationToken);
 
 		var service = CreateService();
 		var args = DefaultArgs();
@@ -298,7 +298,7 @@ public class ChangelogPrEvaluationServiceTests : ChangelogTestBase
 	{
 		await WriteMinimalConfig();
 		FileSystem.Directory.CreateDirectory("docs/changelog");
-		await FileSystem.File.WriteAllTextAsync("docs/changelog/42.yaml", "title: Fix something");
+		await FileSystem.File.WriteAllTextAsync("docs/changelog/42.yaml", "title: Fix something", TestContext.Current.CancellationToken);
 
 		var service = CreateService();
 		var args = DefaultArgs();

--- a/tests/Elastic.Changelog.Tests/Evaluation/ChangelogPrEvaluationServiceTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/ChangelogPrEvaluationServiceTests.cs
@@ -124,8 +124,11 @@ public class ChangelogPrEvaluationServiceTests : ChangelogTestBase
 	}
 
 	[Fact]
-	public async Task EvaluatePr_ManuallyEdited_ReturnsManuallyEdited()
+	public async Task EvaluatePr_ManuallyEdited_PrFilename_ReturnsManuallyEdited()
 	{
+		FileSystem.Directory.CreateDirectory("docs/changelog");
+		await FileSystem.File.WriteAllTextAsync("docs/changelog/42.yaml", "title: test");
+
 		A.CallTo(() => _mockGitHub.FetchLastFileCommitAuthorAsync(
 				"elastic", "test-repo", "docs/changelog/42.yaml", "feature/test", A<CancellationToken>._))
 			.Returns("human-user");
@@ -137,6 +140,42 @@ public class ChangelogPrEvaluationServiceTests : ChangelogTestBase
 
 		result.Should().BeTrue();
 		VerifyOutputSet("status", "manually-edited");
+	}
+
+	[Fact]
+	public async Task EvaluatePr_ManuallyEdited_TimestampFilename_ReturnsManuallyEdited()
+	{
+		FileSystem.Directory.CreateDirectory("docs/changelog");
+		await FileSystem.File.WriteAllTextAsync("docs/changelog/1735689600-fix-something.yaml",
+			"title: Fix something\nprs:\n  - \"42\"");
+
+		A.CallTo(() => _mockGitHub.FetchLastFileCommitAuthorAsync(
+				"elastic", "test-repo", "docs/changelog/1735689600-fix-something.yaml", "feature/test", A<CancellationToken>._))
+			.Returns("human-user");
+
+		var service = CreateService();
+		var args = DefaultArgs();
+
+		var result = await service.EvaluatePr(Collector, args, CancellationToken.None);
+
+		result.Should().BeTrue();
+		VerifyOutputSet("status", "manually-edited");
+	}
+
+	[Fact]
+	public async Task EvaluatePr_NoExistingFile_SkipsManualEditCheck()
+	{
+		await WriteMinimalConfig();
+		var service = CreateService();
+		var args = DefaultArgs();
+
+		var result = await service.EvaluatePr(Collector, args, CancellationToken.None);
+
+		result.Should().BeTrue();
+		VerifyOutputSet("status", "proceed");
+		A.CallTo(() => _mockGitHub.FetchLastFileCommitAuthorAsync(
+			A<string>._, A<string>._, A<string>._, A<string>._, A<CancellationToken>._
+		)).MustNotHaveHappened();
 	}
 
 	[Fact]
@@ -235,4 +274,108 @@ public class ChangelogPrEvaluationServiceTests : ChangelogTestBase
 		ChangelogPrEvaluationService.BuildLabelTable(null).Should().BeEmpty();
 		ChangelogPrEvaluationService.BuildLabelTable(new Dictionary<string, string>()).Should().BeEmpty();
 	}
+
+	[Fact]
+	public async Task EvaluatePr_ExistingTimestampFile_OutputsFilename()
+	{
+		await WriteMinimalConfig();
+		FileSystem.Directory.CreateDirectory("docs/changelog");
+		await FileSystem.File.WriteAllTextAsync("docs/changelog/1735689600-fix-something.yaml",
+			"title: Fix something\nprs:\n  - \"42\"");
+
+		var service = CreateService();
+		var args = DefaultArgs();
+
+		var result = await service.EvaluatePr(Collector, args, CancellationToken.None);
+
+		result.Should().BeTrue();
+		VerifyOutputSet("status", "proceed");
+		VerifyOutputSet("existing-changelog-filename", "1735689600-fix-something.yaml");
+	}
+
+	[Fact]
+	public async Task EvaluatePr_ExistingPrFile_OutputsFilename()
+	{
+		await WriteMinimalConfig();
+		FileSystem.Directory.CreateDirectory("docs/changelog");
+		await FileSystem.File.WriteAllTextAsync("docs/changelog/42.yaml", "title: Fix something");
+
+		var service = CreateService();
+		var args = DefaultArgs();
+
+		var result = await service.EvaluatePr(Collector, args, CancellationToken.None);
+
+		result.Should().BeTrue();
+		VerifyOutputSet("status", "proceed");
+		VerifyOutputSet("existing-changelog-filename", "42.yaml");
+	}
+
+	[Fact]
+	public void FindExistingChangelog_PrFilename_FindsByName()
+	{
+		FileSystem.Directory.CreateDirectory("docs/changelog");
+		FileSystem.File.WriteAllText("docs/changelog/42.yaml", "title: test");
+
+		var service = CreateService();
+		var result = service.FindExistingChangelog("docs/changelog", 42);
+
+		result.Should().Be("42.yaml");
+	}
+
+	[Fact]
+	public void FindExistingChangelog_TimestampFilename_FindsByContent()
+	{
+		FileSystem.Directory.CreateDirectory("docs/changelog");
+		FileSystem.File.WriteAllText("docs/changelog/1735689600-fix.yaml",
+			"title: Fix\nprs:\n  - \"42\"");
+
+		var service = CreateService();
+		var result = service.FindExistingChangelog("docs/changelog", 42);
+
+		result.Should().Be("1735689600-fix.yaml");
+	}
+
+	[Fact]
+	public void FindExistingChangelog_GitHubUrl_FindsByContent()
+	{
+		FileSystem.Directory.CreateDirectory("docs/changelog");
+		FileSystem.File.WriteAllText("docs/changelog/1735689600-fix.yaml",
+			"title: Fix\nprs:\n  - \"https://github.com/elastic/test-repo/pull/42\"");
+
+		var service = CreateService();
+		var result = service.FindExistingChangelog("docs/changelog", 42);
+
+		result.Should().Be("1735689600-fix.yaml");
+	}
+
+	[Fact]
+	public void FindExistingChangelog_NoMatch_ReturnsNull()
+	{
+		FileSystem.Directory.CreateDirectory("docs/changelog");
+		FileSystem.File.WriteAllText("docs/changelog/99.yaml", "title: other PR");
+
+		var service = CreateService();
+		var result = service.FindExistingChangelog("docs/changelog", 42);
+
+		result.Should().BeNull();
+	}
+
+	[Fact]
+	public void FindExistingChangelog_DirectoryMissing_ReturnsNull()
+	{
+		var service = CreateService();
+		var result = service.FindExistingChangelog("nonexistent/path", 42);
+
+		result.Should().BeNull();
+	}
+
+	[Theory]
+	[InlineData("prs:\n  - \"42\"", true)]
+	[InlineData("prs:\n  - '42'", true)]
+	[InlineData("prs:\n  - \"https://github.com/elastic/repo/pull/42\"", true)]
+	[InlineData("prs:\n  - \"142\"", false)]
+	[InlineData("prs:\n  - \"4\"", false)]
+	[InlineData("title: Issue #42 was fixed", false)]
+	public void ContentReferencesPr_MatchesPrNumberCorrectly(string content, bool expected) =>
+		ChangelogPrEvaluationService.ContentReferencesPr(content, "42").Should().Be(expected);
 }

--- a/tests/Elastic.Changelog.Tests/Evaluation/ChangelogPrepareArtifactServiceTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/ChangelogPrepareArtifactServiceTests.cs
@@ -55,10 +55,11 @@ public class ChangelogPrepareArtifactServiceTests(ITestOutputHelper output) : Ch
 			Config = config ?? "/config/changelog.yml"
 		};
 
-	private async Task SetupStagingYaml(int prNumber = 42)
+	private async Task SetupStagingYaml(string? filename = null)
 	{
 		FileSystem.Directory.CreateDirectory("/staging");
-		await FileSystem.File.WriteAllTextAsync($"/staging/{prNumber}.yaml", "title: test changelog");
+		filename ??= "42.yaml";
+		await FileSystem.File.WriteAllTextAsync($"/staging/{filename}", "title: test changelog");
 	}
 
 	private async Task SetupConfig(string configPath = "/config/changelog.yml")
@@ -90,6 +91,7 @@ public class ChangelogPrepareArtifactServiceTests(ITestOutputHelper output) : Ch
 		metadata.PrNumber.Should().Be(42);
 		metadata.HeadRef.Should().Be("feature/test");
 		metadata.HeadSha.Should().Be("abc123");
+		metadata.ChangelogFilename.Should().Be("42.yaml");
 		A.CallTo(() => _mockCore.SetOutputAsync("status", "success")).MustHaveHappened();
 	}
 
@@ -123,6 +125,7 @@ public class ChangelogPrepareArtifactServiceTests(ITestOutputHelper output) : Ch
 		var metadata = ReadMetadata();
 		metadata.Status.Should().Be("no-label");
 		metadata.LabelTable.Should().Contain("Label");
+		metadata.ChangelogFilename.Should().BeNull();
 	}
 
 	[Fact]
@@ -138,6 +141,58 @@ public class ChangelogPrepareArtifactServiceTests(ITestOutputHelper output) : Ch
 		metadata.CreateRules.Should().NotBeNull();
 		metadata.CreateRules.Labels.Should().Contain("changelog:skip");
 		metadata.CreateRules.Mode.Should().Be(FieldMode.Exclude);
+	}
+
+	[Fact]
+	public async Task PrepareArtifact_TimestampFilename_PreservesOriginalName()
+	{
+		await SetupStagingYaml("1735689600-fix-search.yaml");
+		await SetupConfig();
+		var service = CreateService();
+
+		var result = await service.PrepareArtifact(Collector, DefaultArgs(), CancellationToken.None);
+
+		result.Should().BeTrue();
+		FileSystem.File.Exists("/output/1735689600-fix-search.yaml").Should().BeTrue();
+		var content = await FileSystem.File.ReadAllTextAsync("/output/1735689600-fix-search.yaml");
+		content.Should().Be("title: test changelog");
+		var metadata = ReadMetadata();
+		metadata.Status.Should().Be("success");
+		metadata.ChangelogFilename.Should().Be("1735689600-fix-search.yaml");
+	}
+
+	[Fact]
+	public async Task PrepareArtifact_IssueFilename_PreservesOriginalName()
+	{
+		await SetupStagingYaml("789.yaml");
+		await SetupConfig();
+		var service = CreateService();
+
+		var result = await service.PrepareArtifact(Collector, DefaultArgs(), CancellationToken.None);
+
+		result.Should().BeTrue();
+		FileSystem.File.Exists("/output/789.yaml").Should().BeTrue();
+		var metadata = ReadMetadata();
+		metadata.Status.Should().Be("success");
+		metadata.ChangelogFilename.Should().Be("789.yaml");
+	}
+
+	[Fact]
+	public async Task PrepareArtifact_ExistingFilename_RenamesStagingFileToMatch()
+	{
+		await SetupStagingYaml("1735700000-new-title.yaml");
+		await SetupConfig();
+		var service = CreateService();
+		var args = DefaultArgs() with { ExistingChangelogFilename = "1735689600-old-title.yaml" };
+
+		var result = await service.PrepareArtifact(Collector, args, CancellationToken.None);
+
+		result.Should().BeTrue();
+		FileSystem.File.Exists("/output/1735689600-old-title.yaml").Should().BeTrue();
+		FileSystem.File.Exists("/output/1735700000-new-title.yaml").Should().BeFalse();
+		var metadata = ReadMetadata();
+		metadata.Status.Should().Be("success");
+		metadata.ChangelogFilename.Should().Be("1735689600-old-title.yaml");
 	}
 
 	[Fact]

--- a/tests/Elastic.Changelog.Tests/Evaluation/ChangelogPrepareArtifactServiceTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/ChangelogPrepareArtifactServiceTests.cs
@@ -154,7 +154,7 @@ public class ChangelogPrepareArtifactServiceTests(ITestOutputHelper output) : Ch
 
 		result.Should().BeTrue();
 		FileSystem.File.Exists("/output/1735689600-fix-search.yaml").Should().BeTrue();
-		var content = await FileSystem.File.ReadAllTextAsync("/output/1735689600-fix-search.yaml");
+		var content = await FileSystem.File.ReadAllTextAsync("/output/1735689600-fix-search.yaml", TestContext.Current.CancellationToken);
 		content.Should().Be("title: test changelog");
 		var metadata = ReadMetadata();
 		metadata.Status.Should().Be("success");


### PR DESCRIPTION
This pull request introduces a configurable filename strategy for generated changelog files, allowing users to specify how changelog filenames are constructed (by PR number, issue number, or timestamp/title slug) via the `changelog.yml` configuration. The change is thoroughly documented, integrated into the configuration and creation logic, and covered by new and updated tests.

Key changes include:

**Filename Strategy Configuration and Implementation:**

* Added a new `filename` option to `changelog.yml` (with documentation and example) to control the naming strategy for generated changelog files. Supported values are `pr`, `issue`, and `timestamp`, with `pr` as the default. [[1]](diffhunk://#diff-08523c69553512f2d0b7d4b267d9011dc960ca7ba1a09d31f2f09de1b2b57d46R13-R20) [[2]](diffhunk://#diff-17e66f193aae14b64dd5a115273b66a746f463953e5ad6db847d838d502426a5R13-R17)
* Introduced the `FilenameStrategy` enum in `FilenameStrategy.cs` to represent and document the available strategies.
* Updated `ChangelogConfiguration` and its loader to parse, validate, and store the filename strategy, emitting errors for invalid values and defaulting to `pr` if unspecified. [[1]](diffhunk://#diff-d2b6ff2cd3573433e0bd77d2781bc8e33d0a97279cbcee93ab738a4cb9788014R114-R119) [[2]](diffhunk://#diff-d106aace999fd72742473aecd659c63a90392d2386432527bc529f8608fa51a9R298-R310) [[3]](diffhunk://#diff-d106aace999fd72742473aecd659c63a90392d2386432527bc529f8608fa51a9L313-R327)

**Changelog Creation Logic:**

* Modified `ChangelogCreationService.ApplyConfigDefaults` to set `UsePrNumber` or `UseIssueNumber` flags based on the configured filename strategy, unless explicitly overridden by CLI flags.
* Adjusted CI enrichment logic to remove legacy filename strategy handling, deferring to the new configuration-driven approach.

**Documentation Updates:**

* Updated user documentation to explain the new `filename` strategy, its precedence (CLI flags > config > default), and provided usage examples and tables. [[1]](diffhunk://#diff-3496554c1c37c0e85bb2fd6626a0cefdd5240d9403e4099023c0faae5a57f0b3L316-R332) [[2]](diffhunk://#diff-3496554c1c37c0e85bb2fd6626a0cefdd5240d9403e4099023c0faae5a57f0b3L333-R350) [[3]](diffhunk://#diff-3300123aeac34a060340dc43d8af2191cd72f341a02defd89f9bb69dba90bf10L126-R129) [[4]](diffhunk://#diff-3300123aeac34a060340dc43d8af2191cd72f341a02defd89f9bb69dba90bf10L145-R145)

**Testing:**

* Added and updated unit tests to verify correct parsing, error handling, and precedence of the filename strategy in both configuration and changelog creation logic. [[1]](diffhunk://#diff-b27a8555daf7755ba017d501e573cd693ffb498ac911f09c281abe7c0cb38c4aR1206-R1250) [[2]](diffhunk://#diff-658fc733aee24423fe38675c655f1a39c1f981ac47c7e25238237bd9137a9949L81) [[3]](diffhunk://#diff-658fc733aee24423fe38675c655f1a39c1f981ac47c7e25238237bd9137a9949L94) [[4]](diffhunk://#diff-658fc733aee24423fe38675c655f1a39c1f981ac47c7e25238237bd9137a9949L149) [[5]](diffhunk://#diff-658fc733aee24423fe38675c655f1a39c1f981ac47c7e25238237bd9137a9949L163) [[6]](diffhunk://#diff-8391a5b7ff83cac4b1ccda72f1c15a3f543f4ca77e71f3f75edff11f8d20077cR1-R87)