### PR TITLE
fix: support cursor/vscode links without weakening cross-link validation

### DIFF
--- a/docs/building-blocks/outbound-cross-links.md
+++ b/docs/building-blocks/outbound-cross-links.md
@@ -46,6 +46,14 @@ When `docs-builder` encounters a cross-link:
 4. **Validate**: Verifies the link exists and generates an error if not
 5. **Transform**: Replaces the cross-link with the fully resolved URL in the output
 
+If the link scheme is not declared in `cross_links`, `{{dbuild}}` does not treat it as a valid cross-link target.
+The only supported undeclared passthrough protocol schemes are:
+
+- `cursor://...`.
+- `vscode:...`.
+
+Any other undeclared scheme still produces a cross-link validation error.
+
 ## Validation
 
 During a build, `docs-builder`:

--- a/docs/syntax/links.md
+++ b/docs/syntax/links.md
@@ -95,6 +95,13 @@ The syntax follows the format `<scheme>://<path>`, where:
 
 Never use a full URL for links across documentation repositories.
 
+Cross-repository validation only applies to schemes declared in `cross_links` in your `docset.yml`.
+If a scheme is not declared:
+
+- `cursor://...` links pass through as custom protocol links.
+- `vscode:...` links pass through as custom protocol links.
+- Other undeclared schemes are treated as invalid cross-repository links and produce build errors.
+
 ### External links
 
 Link to websites and resources outside the Elastic docs:

--- a/src/Elastic.Documentation.Links/CrossLinks/CrossLinkResolver.cs
+++ b/src/Elastic.Documentation.Links/CrossLinks/CrossLinkResolver.cs
@@ -11,6 +11,13 @@ public interface ICrossLinkResolver
 {
 	bool TryResolve(Action<string> errorEmitter, Uri crossLinkUri, [NotNullWhen(true)] out Uri? resolvedUri);
 	IUriEnvironmentResolver UriResolver { get; }
+
+	/// <summary>
+	/// Determines whether the given URI scheme is a declared cross-link repository scheme.
+	/// Schemes not declared here (e.g. <c>cursor</c>, <c>vscode</c>) are treated as custom
+	/// protocol links and pass through without cross-link validation.
+	/// </summary>
+	bool IsDeclaredCrossLinkScheme(string scheme);
 }
 
 public class NoopCrossLinkResolver : ICrossLinkResolver
@@ -27,6 +34,9 @@ public class NoopCrossLinkResolver : ICrossLinkResolver
 	/// <inheritdoc />
 	public IUriEnvironmentResolver UriResolver { get; } = new IsolatedBuildEnvironmentUriResolver();
 
+	/// <inheritdoc />
+	public bool IsDeclaredCrossLinkScheme(string scheme) => false;
+
 	private NoopCrossLinkResolver() { }
 
 }
@@ -38,6 +48,9 @@ public class CrossLinkResolver(FetchedCrossLinks crossLinks, IUriEnvironmentReso
 
 	public bool TryResolve(Action<string> errorEmitter, Uri crossLinkUri, [NotNullWhen(true)] out Uri? resolvedUri) =>
 		TryResolve(errorEmitter, _crossLinks, UriResolver, crossLinkUri, out resolvedUri);
+
+	/// <inheritdoc />
+	public bool IsDeclaredCrossLinkScheme(string scheme) => _crossLinks.DeclaredRepositories.Contains(scheme);
 
 	public FetchedCrossLinks UpdateLinkReference(string repository, RepositoryLinks repositoryLinks)
 	{

--- a/src/Elastic.Markdown/Myst/Directives/Stepper/StepViewModel.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Stepper/StepViewModel.cs
@@ -42,6 +42,9 @@ public class StepViewModel : DirectiveViewModel
 
 		/// <inheritdoc />
 		public IUriEnvironmentResolver UriResolver { get; } = new IsolatedBuildEnvironmentUriResolver();
+
+		/// <inheritdoc />
+		public bool IsDeclaredCrossLinkScheme(string scheme) => false;
 	}
 
 	/// <summary>

--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -135,6 +135,14 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 
 		if (IsCrossLink(uri))
 		{
+			if (!context.CrossLinkResolver.IsDeclaredCrossLinkScheme(uri.Scheme))
+			{
+				// Custom protocol URI (e.g. cursor://, vscode:) — not a declared cross-link scheme.
+				// Treat as an external passthrough link without validation.
+				link.SetData("isCrossLink", false);
+				return;
+			}
+
 			link.SetData("isCrossLink", true);
 			ProcessCrossLink(link, processor, context, uri);
 			return;

--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -137,10 +137,13 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 		{
 			if (!context.CrossLinkResolver.IsDeclaredCrossLinkScheme(uri.Scheme))
 			{
-				// Custom protocol URI (e.g. cursor://, vscode:) — not a declared cross-link scheme.
-				// Treat as an external passthrough link without validation.
-				link.SetData("isCrossLink", false);
-				return;
+				// Only known custom protocol schemes should bypass cross-link validation.
+				// Undeclared schemes still surface errors to catch cross-link typos.
+				if (IsPassthroughCustomProtocolScheme(uri.Scheme))
+				{
+					link.SetData("isCrossLink", false);
+					return;
+				}
 			}
 
 			link.SetData("isCrossLink", true);
@@ -458,4 +461,8 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 
 	private static bool IsCrossLink([NotNullWhen(true)] Uri? uri) =>
 		CrossLinkValidator.IsCrossLink(uri);
+
+	private static bool IsPassthroughCustomProtocolScheme(string scheme) =>
+		scheme.Equals("cursor", StringComparison.OrdinalIgnoreCase)
+		|| scheme.Equals("vscode", StringComparison.OrdinalIgnoreCase);
 }

--- a/tests/Elastic.Markdown.Tests/Directives/ButtonTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/ButtonTests.cs
@@ -183,6 +183,42 @@ public class ButtonCrossLinkTests(ITestOutputHelper output) : DirectiveTest<Butt
 	public void RendersLinkHref() => Html.Should().Contain("href=\"");
 }
 
+public class ButtonCursorProtocolTests(ITestOutputHelper output) : DirectiveTest<ButtonBlock>(output,
+"""
+:::{button}
+[Install with Cursor](cursor://anysphere.cursor-deeplink/mcp/install?name=elastic&config=eyJmb28iOiJiYXIifQ==)
+:::
+"""
+)
+{
+	[Fact]
+	public void ParsesBlock() => Block.Should().NotBeNull();
+
+	[Fact]
+	public void RendersLinkHref() => Html.Should().Contain("href=\"cursor://");
+
+	[Fact]
+	public void EmitsNoErrors() => Collector.Diagnostics.Should().BeEmpty();
+}
+
+public class ButtonVscodeProtocolTests(ITestOutputHelper output) : DirectiveTest<ButtonBlock>(output,
+"""
+:::{button}
+[Install with VS Code](vscode:extension/elastic.elasticsearch)
+:::
+"""
+)
+{
+	[Fact]
+	public void ParsesBlock() => Block.Should().NotBeNull();
+
+	[Fact]
+	public void RendersLinkHref() => Html.Should().Contain("href=\"vscode:");
+
+	[Fact]
+	public void EmitsNoErrors() => Collector.Diagnostics.Should().BeEmpty();
+}
+
 public class ButtonEmptyTests(ITestOutputHelper output) : DirectiveTest<ButtonBlock>(output,
 """
 :::{button}

--- a/tests/Elastic.Markdown.Tests/Inline/InlineLinkTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/InlineLinkTests.cs
@@ -344,3 +344,37 @@ public class NonExistingLinkShouldFail(ITestOutputHelper output) : LinkTestBase(
 	[Fact]
 	public void HasErrors() => Collector.Diagnostics.Should().HaveCount(3);
 }
+
+public class CursorProtocolLinkTest(ITestOutputHelper output) : LinkTestBase(output,
+	"""
+	[Install with Cursor](cursor://anysphere.cursor-deeplink/mcp/install?name=elastic&config=eyJmb28iOiJiYXIifQ==)
+	"""
+)
+{
+	[Fact]
+	public void GeneratesHtml() =>
+		Html.Should().Contain("""href="cursor://""");
+
+	[Fact]
+	public void HasNoErrors() => Collector.Diagnostics.Should().HaveCount(0);
+
+	[Fact]
+	public void EmitsNoCrossLinks() => Collector.CrossLinks.Should().HaveCount(0);
+}
+
+public class VscodeProtocolLinkTest(ITestOutputHelper output) : LinkTestBase(output,
+	"""
+	[Install VS Code Extension](vscode:extension/elastic.elasticsearch)
+	"""
+)
+{
+	[Fact]
+	public void GeneratesHtml() =>
+		Html.Should().Contain("""href="vscode:""");
+
+	[Fact]
+	public void HasNoErrors() => Collector.Diagnostics.Should().HaveCount(0);
+
+	[Fact]
+	public void EmitsNoCrossLinks() => Collector.CrossLinks.Should().HaveCount(0);
+}

--- a/tests/Elastic.Markdown.Tests/TestCodexCrossLinkResolver.cs
+++ b/tests/Elastic.Markdown.Tests/TestCodexCrossLinkResolver.cs
@@ -74,4 +74,6 @@ public class TestCodexCrossLinkResolver : ICrossLinkResolver
 
 	public bool TryResolve(Action<string> errorEmitter, Uri crossLinkUri, [NotNullWhen(true)] out Uri? resolvedUri) =>
 		CrossLinkResolver.TryResolve(errorEmitter, _crossLinks, UriResolver, crossLinkUri, out resolvedUri);
+
+	public bool IsDeclaredCrossLinkScheme(string scheme) => _crossLinks.DeclaredRepositories.Contains(scheme);
 }

--- a/tests/Elastic.Markdown.Tests/TestCrossLinkResolver.cs
+++ b/tests/Elastic.Markdown.Tests/TestCrossLinkResolver.cs
@@ -68,4 +68,6 @@ public class TestCrossLinkResolver : ICrossLinkResolver
 
 	public bool TryResolve(Action<string> errorEmitter, Uri crossLinkUri, [NotNullWhen(true)] out Uri? resolvedUri) =>
 		CrossLinkResolver.TryResolve(errorEmitter, _crossLinks, UriResolver, crossLinkUri, out resolvedUri);
+
+	public bool IsDeclaredCrossLinkScheme(string scheme) => _crossLinks.DeclaredRepositories.Contains(scheme);
 }

--- a/tests/Navigation.Tests/TestDocumentationSetContext.cs
+++ b/tests/Navigation.Tests/TestDocumentationSetContext.cs
@@ -63,6 +63,9 @@ public class TestCrossLinkResolver : ICrossLinkResolver
 	/// <inheritdoc />
 	public IUriEnvironmentResolver UriResolver { get; } = new IsolatedBuildEnvironmentUriResolver();
 
+	/// <inheritdoc />
+	public bool IsDeclaredCrossLinkScheme(string scheme) => true;
+
 	private TestCrossLinkResolver() { }
 
 }

--- a/tests/authoring/Framework/TestCrossLinkResolver.fs
+++ b/tests/authoring/Framework/TestCrossLinkResolver.fs
@@ -89,5 +89,8 @@ type TestCrossLinkResolver (config: ConfigurationFile) =
         member this.TryResolve(errorEmitter, crossLinkUri, [<Out>]resolvedUri : byref<Uri|null>) =
             CrossLinkResolver.TryResolve(errorEmitter, crossLinks, uriResolver, crossLinkUri, &resolvedUri)
 
+        member this.IsDeclaredCrossLinkScheme(scheme) =
+            declared.Contains(scheme)
+
 
 


### PR DESCRIPTION
## Summary
- Add `IsDeclaredCrossLinkScheme(string)` to cross-link resolver plumbing so link parsing can differentiate declared cross-link repositories from protocol links.
- Allow `cursor://` and `vscode:` links to pass through without cross-link validation, while keeping validation errors for other undeclared schemes.
- Document the behavior in links docs and outbound cross-links docs.

## Test plan
- [x] `dotnet build`
- [x] `dotnet test tests/authoring/authoring.fsproj --filter \"FullyQualifiedName~cross links\"`
- [x] `dotnet test tests/Elastic.Markdown.Tests/Elastic.Markdown.Tests.csproj --filter \"FullyQualifiedName~CursorProtocol|FullyQualifiedName~VscodeProtocol|FullyQualifiedName~ButtonCursorProtocol|FullyQualifiedName~ButtonVscodeProtocol\"`

Made with [Cursor](https://cursor.com)