### PR TITLE
Fix multi-product rule resolution for changelog render

### DIFF
--- a/docs/cli/release/changelog-render.md
+++ b/docs/cli/release/changelog-render.md
@@ -63,6 +63,9 @@ The `render` command automatically discovers and merges `.amend-*.yaml` files wi
 You can configure `block` definitions in your `changelog.yml` configuration file to automatically comment out changelog entries based on their products, areas, and/or types.
 For more information, refer to [](/contribute/changelog.md#example-block-label).
 
+When (deprecated) `rules.publish.products` per-product overrides are configured and changelog entries belong to multiple products, the applicable rule is chosen using the intersection + alphabetical first-match algorithm.
+For details, refer to [Per-product rule resolution for multi-product entries](/contribute/changelog.md#changelog-bundle-multi-product-rules).
+
 ## Output formats
 
 ### Markdown format

--- a/docs/contribute/changelog.md
+++ b/docs/contribute/changelog.md
@@ -223,6 +223,10 @@ When `--output-products` is not set, the entry's own product list is used as the
 
 `rules.publish` still works for backward compatibility, but will be removed in a future release. The migration is straightforward — copy the same fields from `rules.publish` into `rules.bundle`.
 
+When a changelog entry belongs to more than one product and `rules.publish.products` per-product overrides are configured, the applicable rule is resolved using the same intersection + alphabetical first-match algorithm as `rules.bundle`.
+The difference is how the *context* is determined: for `rules.publish`, the context is the **bundle's top-level `products:` array** — the products declared in the bundle YAML file being rendered, not a CLI option.
+For details, refer to [Per-product rule resolution for multi-product entries](#changelog-bundle-multi-product-rules).
+
 **Before (deprecated):**
 
 ```yaml

--- a/docs/syntax/changelog.md
+++ b/docs/syntax/changelog.md
@@ -185,6 +185,8 @@ Each field supports **exclude** (block if matches) or **include** (block if does
 
 For details, refer to the [Rules reference](/contribute/changelog.md#rules-reference).
 
+The `{changelog}` directive selects **one** product's rule using the resolved `:product:` value and applies it uniformly to all entries in the bundle. This differs from the `changelog render` command, which determines the applicable rule per entry using the bundle's top-level `products:` array as context. For details about the `changelog render` behavior for multi-product entries, refer to [Per-product rule resolution for multi-product entries](/contribute/changelog.md#changelog-bundle-multi-product-rules).
+
 ## Feature hiding from bundles
 
 When bundles contain a `hide-features` field, entries with matching `feature-id` values are automatically filtered out from the rendered output. This allows you to hide unreleased or experimental features without modifying the bundle at render time.

--- a/src/services/Elastic.Changelog/Rendering/ChangelogRenderUtilities.cs
+++ b/src/services/Elastic.Changelog/Rendering/ChangelogRenderUtilities.cs
@@ -28,18 +28,18 @@ public static class ChangelogRenderUtilities
 
 	private static PublishBlocker? GetPublishBlockerForEntry(ChangelogEntry entry, ChangelogRenderContext context)
 	{
-		var productIds = context.EntryToBundleProducts.GetValueOrDefault(entry);
-		if (productIds == null || context.Configuration?.Rules?.Publish == null)
+		var bundleProducts = context.EntryToBundleProducts.GetValueOrDefault(entry);
+		if (bundleProducts == null || context.Configuration?.Rules?.Publish == null)
 			return null;
 
-		foreach (var productId in productIds)
-		{
-			var blocker = GetPublishBlockerForProduct(context.Configuration.Rules.Publish, productId);
-			if (blocker != null)
-				return blocker;
-		}
+		var publishRules = context.Configuration.Rules.Publish;
 
-		return null;
+		// When no per-product overrides are configured, return the global blocker directly.
+		if (publishRules.ByProduct is not { Count: > 0 } byProduct)
+			return publishRules.Blocker;
+
+		var entryOwnIds = entry.Products?.Select(p => p.ProductId) ?? [];
+		return PublishBlockerExtensions.ResolveBlocker(bundleProducts, entryOwnIds, byProduct, publishRules.Blocker);
 	}
 
 	/// <summary>
@@ -72,32 +72,7 @@ public static class ChangelogRenderUtilities
 		if (context?.Configuration?.Rules?.Publish == null)
 			return false;
 
-		// Get product IDs for this entry
-		var productIds = context.EntryToBundleProducts.GetValueOrDefault(entry, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
-		if (productIds.Count == 0)
-			return false;
-
-		// Check each product's publish configuration
-		foreach (var productId in productIds)
-		{
-			var blocker = GetPublishBlockerForProduct(context.Configuration.Rules.Publish, productId);
-			if (blocker != null && blocker.ShouldBlock(entry))
-				return true;
-		}
-
-		return false;
-	}
-
-	/// <summary>
-	/// Gets the publish blocker configuration for a specific product, checking product-specific overrides first
-	/// </summary>
-	private static PublishBlocker? GetPublishBlockerForProduct(PublishRules publishRules, string productId)
-	{
-		// Check product-specific override first
-		if (publishRules.ByProduct?.TryGetValue(productId, out var productBlocker) == true)
-			return productBlocker;
-
-		// Fall back to global publish blocker
-		return publishRules.Blocker;
+		var blocker = GetPublishBlockerForEntry(entry, context);
+		return blocker?.ShouldBlock(entry) ?? false;
 	}
 }

--- a/src/services/Elastic.Changelog/Rendering/ChangelogRenderingService.cs
+++ b/src/services/Elastic.Changelog/Rendering/ChangelogRenderingService.cs
@@ -215,30 +215,29 @@ public class ChangelogRenderingService(
 		if (context.Configuration?.Rules?.Publish == null)
 			return;
 
+		var publishRules = context.Configuration.Rules.Publish;
+		var byProduct = publishRules.ByProduct ?? new Dictionary<string, PublishBlocker>(StringComparer.OrdinalIgnoreCase);
+
 		var visibleEntries = entries.Where(resolved =>
 			string.IsNullOrWhiteSpace(resolved.Entry.FeatureId) ||
 			!context.FeatureIdsToHide.Contains(resolved.Entry.FeatureId));
 
 		foreach (var resolved in visibleEntries)
 		{
-			// Get product IDs for this entry
-			var productIds = context.EntryToBundleProducts.GetValueOrDefault(resolved.Entry, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
-			if (productIds.Count == 0)
+			var bundleProducts = context.EntryToBundleProducts.GetValueOrDefault(resolved.Entry, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+			if (bundleProducts.Count == 0)
 				continue;
 
-			// Check each product's publish configuration
-			foreach (var productId in productIds)
-			{
-				var blocker = GetPublishBlockerForProduct(context.Configuration.Rules.Publish, productId);
-				if (blocker != null && blocker.ShouldBlock(resolved.Entry))
-				{
-					var reasons = GetBlockReasons(resolved.Entry, blocker);
-					var prefix = blocker.TypesMode == FieldMode.Include || blocker.AreasMode == FieldMode.Include ? "[+include]" : "[-exclude]";
-					var productInfo = productIds.Count > 1 ? $" for product '{productId}'" : "";
-					var entryIdentifier = GetEntryIdentifier(resolved.Entry, context);
-					collector.EmitWarning(string.Empty, $"{prefix} Changelog entry {entryIdentifier} will be commented out{productInfo} because it matches rules configuration: {reasons}");
-				}
-			}
+			var entryOwnIds = resolved.Entry.Products?.Select(p => p.ProductId) ?? [];
+			var blocker = PublishBlockerExtensions.ResolveBlocker(bundleProducts, entryOwnIds, byProduct, publishRules.Blocker);
+
+			if (blocker == null || !blocker.ShouldBlock(resolved.Entry))
+				continue;
+
+			var reasons = GetBlockReasons(resolved.Entry, blocker);
+			var prefix = blocker.TypesMode == FieldMode.Include || blocker.AreasMode == FieldMode.Include ? "[+include]" : "[-exclude]";
+			var entryIdentifier = GetEntryIdentifier(resolved.Entry, context);
+			collector.EmitWarning(string.Empty, $"{prefix} Changelog entry {entryIdentifier} will be commented out because it matches rules configuration: {reasons}");
 		}
 	}
 
@@ -300,16 +299,6 @@ public class ChangelogRenderingService(
 		}
 
 		return string.Join(" and ", reasons);
-	}
-
-	private static PublishBlocker? GetPublishBlockerForProduct(PublishRules publishRules, string productId)
-	{
-		// Check product-specific override first
-		if (publishRules.ByProduct?.TryGetValue(productId, out var productBlocker) == true)
-			return productBlocker;
-
-		// Fall back to global publish blocker
-		return publishRules.Blocker;
 	}
 
 	private static bool ValidateEntryTypes(

--- a/tests/Elastic.Changelog.Tests/Changelogs/Render/BlockConfigurationTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/Render/BlockConfigurationTests.cs
@@ -1526,6 +1526,367 @@ public class BlockConfigurationTests(ITestOutputHelper output) : RenderChangelog
 	}
 
 	[Fact]
+	public async Task RenderChangelogs_WithMultipleProducts_SharedEntry_UsesAlphabeticalFirstMatch()
+	{
+		// Arrange
+		// Bundle has [elasticsearch, kibana]. Entry belongs to both (shared).
+		// elasticsearch rule: exclude_areas: "Internal" (e < k alphabetically → wins)
+		// kibana rule: no area filter
+		// Expected: elasticsearch rule fires → shared entry with area "Internal" is commented out.
+		// A kibana-only entry with area "Internal" uses the kibana rule (no filter) → visible.
+		var changelogDir = FileSystem.Path.Combine(FileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		FileSystem.Directory.CreateDirectory(changelogDir);
+
+		// language=yaml
+		var sharedEntry =
+			"""
+			title: Shared internal feature
+			type: feature
+			products:
+			  - product: elasticsearch
+			    target: 9.2.0
+			  - product: kibana
+			    target: 9.2.0
+			areas:
+			  - Internal
+			prs:
+			- "200"
+			""";
+
+		// language=yaml
+		var kibanaOnlyEntry =
+			"""
+			title: Kibana internal feature
+			type: feature
+			products:
+			  - product: kibana
+			    target: 9.2.0
+			areas:
+			  - Internal
+			prs:
+			- "201"
+			""";
+
+		var changelogFile1 = FileSystem.Path.Combine(changelogDir, "1755268200-shared.yaml");
+		var changelogFile2 = FileSystem.Path.Combine(changelogDir, "1755268201-kibana-only.yaml");
+		await FileSystem.File.WriteAllTextAsync(changelogFile1, sharedEntry, TestContext.Current.CancellationToken);
+		await FileSystem.File.WriteAllTextAsync(changelogFile2, kibanaOnlyEntry, TestContext.Current.CancellationToken);
+
+		var bundleDir = FileSystem.Path.Combine(FileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		FileSystem.Directory.CreateDirectory(bundleDir);
+
+		var bundleFile = FileSystem.Path.Combine(bundleDir, "bundle.yaml");
+		// language=yaml
+		var bundleContent =
+			$"""
+			products:
+			  - product: elasticsearch
+			    target: 9.2.0
+			  - product: kibana
+			    target: 9.2.0
+			entries:
+			  - file:
+			      name: 1755268200-shared.yaml
+			      checksum: {ComputeSha1(sharedEntry)}
+			  - file:
+			      name: 1755268201-kibana-only.yaml
+			      checksum: {ComputeSha1(kibanaOnlyEntry)}
+			""";
+		await FileSystem.File.WriteAllTextAsync(bundleFile, bundleContent, TestContext.Current.CancellationToken);
+
+		var configDir = FileSystem.Path.Combine(FileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		FileSystem.Directory.CreateDirectory(configDir);
+		var configFile = FileSystem.Path.Combine(configDir, "changelog.yml");
+		// language=yaml
+		var configContent =
+			"""
+			pivot:
+			  types:
+			    feature:
+			    bug-fix:
+			    breaking-change:
+			  areas:
+			    Internal:
+			    Search:
+			lifecycles:
+			  - ga
+			rules:
+			  publish:
+			    products:
+			      elasticsearch:
+			        exclude_areas:
+			          - Internal
+			""";
+		await FileSystem.File.WriteAllTextAsync(configFile, configContent, TestContext.Current.CancellationToken);
+
+		var outputDir = FileSystem.Path.Combine(FileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		var input = new RenderChangelogsArguments
+		{
+			Bundles = [new BundleInput { BundleFile = bundleFile, Directory = changelogDir }],
+			Output = outputDir,
+			Title = "9.2.0",
+			Config = configFile
+		};
+
+		// Act
+		var result = await Service.RenderChangelogs(Collector, input, TestContext.Current.CancellationToken);
+
+		// Assert
+		result.Should().BeTrue($"Errors: {string.Join("; ", Collector.Diagnostics.Select(d => d.Message))}");
+		Collector.Errors.Should().Be(0);
+
+		var indexFile = FileSystem.Path.Combine(outputDir, "9.2.0", "index.md");
+		var indexContent = await FileSystem.File.ReadAllTextAsync(indexFile, TestContext.Current.CancellationToken);
+
+		// Shared entry: elasticsearch rule wins (e < k) → blocked
+		indexContent.Should().Contain("% * Shared internal feature",
+			"elasticsearch rule is alphabetically first and excludes Internal area for the shared entry");
+
+		// Kibana-only entry: no elasticsearch rule applies; kibana has no area rule → visible
+		indexContent.Should().Contain("* Kibana internal feature",
+			"kibana-only entry has no matching rule and should be visible");
+		indexContent.Should().NotContain("% * Kibana internal feature");
+	}
+
+	[Fact]
+	public async Task RenderChangelogs_WithMultipleProducts_SingleProductEntries_UseTheirOwnRules()
+	{
+		// Arrange
+		// Bundle has [elasticsearch, kibana].
+		// elasticsearch-only entry uses elasticsearch rule (exclude Internal).
+		// kibana-only entry uses kibana rule (no area filter) → visible even with Internal area.
+		var changelogDir = FileSystem.Path.Combine(FileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		FileSystem.Directory.CreateDirectory(changelogDir);
+
+		// language=yaml
+		var esEntry =
+			"""
+			title: Elasticsearch internal feature
+			type: feature
+			products:
+			  - product: elasticsearch
+			    target: 9.2.0
+			areas:
+			  - Internal
+			prs:
+			- "300"
+			""";
+
+		// language=yaml
+		var kibanaEntry =
+			"""
+			title: Kibana internal feature
+			type: feature
+			products:
+			  - product: kibana
+			    target: 9.2.0
+			areas:
+			  - Internal
+			prs:
+			- "301"
+			""";
+
+		var changelogFile1 = FileSystem.Path.Combine(changelogDir, "1755268300-es.yaml");
+		var changelogFile2 = FileSystem.Path.Combine(changelogDir, "1755268301-kibana.yaml");
+		await FileSystem.File.WriteAllTextAsync(changelogFile1, esEntry, TestContext.Current.CancellationToken);
+		await FileSystem.File.WriteAllTextAsync(changelogFile2, kibanaEntry, TestContext.Current.CancellationToken);
+
+		var bundleDir = FileSystem.Path.Combine(FileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		FileSystem.Directory.CreateDirectory(bundleDir);
+
+		var bundleFile = FileSystem.Path.Combine(bundleDir, "bundle.yaml");
+		// language=yaml
+		var bundleContent =
+			$"""
+			products:
+			  - product: elasticsearch
+			    target: 9.2.0
+			  - product: kibana
+			    target: 9.2.0
+			entries:
+			  - file:
+			      name: 1755268300-es.yaml
+			      checksum: {ComputeSha1(esEntry)}
+			  - file:
+			      name: 1755268301-kibana.yaml
+			      checksum: {ComputeSha1(kibanaEntry)}
+			""";
+		await FileSystem.File.WriteAllTextAsync(bundleFile, bundleContent, TestContext.Current.CancellationToken);
+
+		var configDir = FileSystem.Path.Combine(FileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		FileSystem.Directory.CreateDirectory(configDir);
+		var configFile = FileSystem.Path.Combine(configDir, "changelog.yml");
+		// language=yaml
+		var configContent =
+			"""
+			pivot:
+			  types:
+			    feature:
+			    bug-fix:
+			    breaking-change:
+			  areas:
+			    Internal:
+			lifecycles:
+			  - ga
+			rules:
+			  publish:
+			    products:
+			      elasticsearch:
+			        exclude_areas:
+			          - Internal
+			""";
+		await FileSystem.File.WriteAllTextAsync(configFile, configContent, TestContext.Current.CancellationToken);
+
+		var outputDir = FileSystem.Path.Combine(FileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		var input = new RenderChangelogsArguments
+		{
+			Bundles = [new BundleInput { BundleFile = bundleFile, Directory = changelogDir }],
+			Output = outputDir,
+			Title = "9.2.0",
+			Config = configFile
+		};
+
+		// Act
+		var result = await Service.RenderChangelogs(Collector, input, TestContext.Current.CancellationToken);
+
+		// Assert
+		result.Should().BeTrue($"Errors: {string.Join("; ", Collector.Diagnostics.Select(d => d.Message))}");
+		Collector.Errors.Should().Be(0);
+
+		var indexFile = FileSystem.Path.Combine(outputDir, "9.2.0", "index.md");
+		var indexContent = await FileSystem.File.ReadAllTextAsync(indexFile, TestContext.Current.CancellationToken);
+
+		// elasticsearch entry: elasticsearch rule applies → blocked
+		indexContent.Should().Contain("% * Elasticsearch internal feature",
+			"elasticsearch rule excludes Internal area");
+
+		// kibana entry: kibana has no per-product rule; falls through to global (none) → visible
+		indexContent.Should().Contain("* Kibana internal feature",
+			"kibana entry has no matching per-product rule and should be visible");
+		indexContent.Should().NotContain("% * Kibana internal feature");
+	}
+
+	[Fact]
+	public async Task RenderChangelogs_WithDisjointBundleAndEntryProducts_FallsBackToGlobalBlocker()
+	{
+		// Arrange
+		// Bundle has [kibana]. Entry belongs to [elasticsearch] only (disjoint).
+		// Intersection is empty → falls back to entry's own products ([elasticsearch]).
+		// No per-product rule for elasticsearch → global blocker (exclude_areas: Internal) applies.
+		var changelogDir = FileSystem.Path.Combine(FileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		FileSystem.Directory.CreateDirectory(changelogDir);
+
+		// language=yaml
+		var esEntry =
+			"""
+			title: Elasticsearch internal entry
+			type: feature
+			products:
+			  - product: elasticsearch
+			    target: 9.2.0
+			areas:
+			  - Internal
+			prs:
+			- "400"
+			""";
+
+		// language=yaml
+		var esSearchEntry =
+			"""
+			title: Elasticsearch search entry
+			type: feature
+			products:
+			  - product: elasticsearch
+			    target: 9.2.0
+			areas:
+			  - Search
+			prs:
+			- "401"
+			""";
+
+		var changelogFile1 = FileSystem.Path.Combine(changelogDir, "1755268400-es-internal.yaml");
+		var changelogFile2 = FileSystem.Path.Combine(changelogDir, "1755268401-es-search.yaml");
+		await FileSystem.File.WriteAllTextAsync(changelogFile1, esEntry, TestContext.Current.CancellationToken);
+		await FileSystem.File.WriteAllTextAsync(changelogFile2, esSearchEntry, TestContext.Current.CancellationToken);
+
+		var bundleDir = FileSystem.Path.Combine(FileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		FileSystem.Directory.CreateDirectory(bundleDir);
+
+		var bundleFile = FileSystem.Path.Combine(bundleDir, "bundle.yaml");
+		// language=yaml
+		var bundleContent =
+			$"""
+			products:
+			  - product: kibana
+			    target: 9.2.0
+			entries:
+			  - file:
+			      name: 1755268400-es-internal.yaml
+			      checksum: {ComputeSha1(esEntry)}
+			  - file:
+			      name: 1755268401-es-search.yaml
+			      checksum: {ComputeSha1(esSearchEntry)}
+			""";
+		await FileSystem.File.WriteAllTextAsync(bundleFile, bundleContent, TestContext.Current.CancellationToken);
+
+		var configDir = FileSystem.Path.Combine(FileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		FileSystem.Directory.CreateDirectory(configDir);
+		var configFile = FileSystem.Path.Combine(configDir, "changelog.yml");
+		// language=yaml
+		var configContent =
+			"""
+			pivot:
+			  types:
+			    feature:
+			    bug-fix:
+			    breaking-change:
+			  areas:
+			    Internal:
+			    Search:
+			lifecycles:
+			  - ga
+			rules:
+			  publish:
+			    exclude_areas:
+			      - Internal
+			    products:
+			      kibana:
+			        exclude_types:
+			          - feature
+			""";
+		await FileSystem.File.WriteAllTextAsync(configFile, configContent, TestContext.Current.CancellationToken);
+
+		var outputDir = FileSystem.Path.Combine(FileSystem.Path.GetTempPath(), Guid.NewGuid().ToString());
+		var input = new RenderChangelogsArguments
+		{
+			Bundles = [new BundleInput { BundleFile = bundleFile, Directory = changelogDir }],
+			Output = outputDir,
+			Title = "9.2.0",
+			Config = configFile
+		};
+
+		// Act
+		var result = await Service.RenderChangelogs(Collector, input, TestContext.Current.CancellationToken);
+
+		// Assert
+		result.Should().BeTrue($"Errors: {string.Join("; ", Collector.Diagnostics.Select(d => d.Message))}");
+		Collector.Errors.Should().Be(0);
+
+		var indexFile = FileSystem.Path.Combine(outputDir, "9.2.0", "index.md");
+		var indexContent = await FileSystem.File.ReadAllTextAsync(indexFile, TestContext.Current.CancellationToken);
+
+		// elasticsearch Internal entry: disjoint intersection → falls back to entry's own [elasticsearch],
+		// no elasticsearch per-product rule → global blocker (exclude Internal) applies → blocked
+		indexContent.Should().Contain("% * Elasticsearch internal entry",
+			"global exclude_areas rule should apply via fallback to entry's own product");
+
+		// elasticsearch Search entry: global blocker does not match Search → visible
+		indexContent.Should().Contain("* Elasticsearch search entry",
+			"Search area is not excluded globally and kibana rule should not bleed across to elasticsearch entries");
+		indexContent.Should().NotContain("% * Elasticsearch search entry");
+	}
+
+	[Fact]
 	public async Task RenderChangelogs_WithBlockedEntries_EmitsWarnings()
 	{
 		// Arrange


### PR DESCRIPTION
## Summary

This PR relates to a bug found while testing https://github.com/elastic/docs-builder/pull/2874:

Make per-product type/area rules (in `rules.bundle.products` and `rules.publish.products`) resolve consistently using intersection + alphabetical first-match, with `output_products` / bundle `Products` as the authoritative product context.

###  The core problem

The two existing behaviors are inconsistent and both wrong for multi-product entries:

- `**changelog bundle**` (`GetBlockerForEntry`): "first-match from the entry's own product list in YAML order" — ignores which product(s) the bundle is being assembled for; YAML order is arbitrary
- `**changelog render**` (`ShouldHideEntry`): "any-blocks from the bundle's `Products` array" — too aggressive; one product's exclusion rules block the entry from a different product's output

This PR fixes the render-specific scenario.

## Implementation details

- `src/services/Elastic.Changelog/Rendering/ChangelogRenderUtilities.cs`:
    - `GetPublishBlockerForEntry`: replaced the first-match-from-iteration-order loop over bundle products with a call to the shared `PublishBlockerExtensions.ResolveBlocker(bundleProducts, entryOwnIds, byProduct, globalBlocker)`. The `contextIds` are the bundle's top-level product IDs (`EntryToBundleProducts[entry]`); the `entryOwnIds` come from `entry.Products.Select(p => p.ProductId)`.
    - `ShouldHideEntry`: replaced the "any-blocks" loop with a single `GetPublishBlockerForEntry` call, returning `blocker?.ShouldBlock(entry) ?? false`.
    - Removed the now-unused private `GetPublishBlockerForProduct` method.

- `src/services/Elastic.Changelog/Rendering/ChangelogRenderingService.cs`:
    - `EmitBlockedEntryWarnings`: replaced the "any-blocks" loop (which would emit a warning for every product whose rule blocked the entry) with a single `PublishBlockerExtensions.ResolveBlocker` call per entry. The resolved blocker is checked once; if it blocks, one warning is emitted without the now-incorrect "for product X" annotation.
    - Removed the duplicate private `GetPublishBlockerForProduct` method.

- `tests/Elastic.Changelog.Tests/Changelogs/Render/BlockConfigurationTests.cs` — three new tests:
    1. `RenderChangelogs_WithMultipleProducts_SharedEntry_UsesAlphabeticalFirstMatch` — bundle has `[elasticsearch, kibana]`; a shared entry uses the alphabetically-first (`elasticsearch`) rule, while a kibana-only entry has no matching rule and stays visible.
    2. `RenderChangelogs_WithMultipleProducts_SingleProductEntries_UseTheirOwnRules` — each single-product entry (elasticsearch, kibana) in a mixed bundle uses only its own per-product rule.
    3. `RenderChangelogs_WithDisjointBundleAndEntryProducts_FallsBackToGlobalBlocker` — when the bundle's products (`[kibana]`) and the entry's own products (`[elasticsearch]`) are disjoint, the algorithm falls back to the entry's own product list and then to the global blocker, ensuring that per-product rules for the bundle context don't bleed across to unrelated entries.

- Documentation:
    - `docs/contribute/changelog.md` — added a paragraph to the `rules.publish` section explaining that the same intersection + alphabetical first-match algorithm applies to per-product `rules.publish` overrides, with one key difference: at render time the context comes from the **bundle's top-level `products:` array**, not from a CLI flag like `--output-products`. Links to the existing `#changelog-bundle-multi-product-rules` anchor where the algorithm is documented in full.
    - `docs/syntax/changelog.md` — appended three lines to the "Filtering entries with publish rules" section noting that the directive picks one product's rule via `:product:` and applies it to everything, while the `changelog render` command is what uses the intersection + alphabetical first-match algorithm with the bundle's `products:` array as context.
   - `docs/cli/release/changelog-render.md` — extended the existing "block definitions" paragraph with a note covering `rules.publish.products`, and linking to the algorithm reference. This is the command reference page users will land on directly, so having the pointer here means they don't have to go digging.

## Steps to test

1. Create a changelog configuration file and generate changelogs and bundles. Alternatively, check out a PR like https://github.com/elastic/kibana/pull/250840
1. Test with `rules.bundle` and/or `rules.publishing` in the config file.
1. Create a bundle that has multiple products in its metadata. For example:
    ```sh
    docs-builder/release/docs-builder changelog bundle \
    --prs ./docs/9.3.0-security.txt \
    --output ./docs/releases/security/9.3.0.yaml \
    --output-products "security 9.3.0 ga, kibana 9.3.0 ga"
    ```
1. Test that the output is as expected when the bundle is used in a changelog directive.
1. Test that the output is as expected when the bundle is rendered as asciidoc or markdown output.

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: composer-1.5, claude-4.6-sonnet-medium