### PR TITLE
Fix x-state in API explorer

### DIFF
--- a/src/Elastic.ApiExplorer/Operations/OperationView.cshtml
+++ b/src/Elastic.ApiExplorer/Operations/OperationView.cshtml
@@ -75,7 +75,7 @@
 			<span class="beta-badge">Beta</span>
 		}
 		@{
-			var versionInfo = operation.Extensions?.TryGetValue("x-state", out var stateValue) == true && stateValue is System.Text.Json.Nodes.JsonNode stateNode ? stateNode.ToString() : null;
+			var versionInfo = (operation.Extensions?.TryGetValue("x-state", out var stateValue) == true && stateValue is JsonNodeExtension stateExt) ? stateExt.Node.GetValue<string>() : null;
 		}
 		@if (!string.IsNullOrEmpty(versionInfo))
 		{

--- a/src/Elastic.ApiExplorer/Shared/_PropertyItem.cshtml
+++ b/src/Elastic.ApiExplorer/Shared/_PropertyItem.cshtml
@@ -128,7 +128,7 @@
 			}
 			@if (ctx.ShowVersionInfo)
 			{
-				var propVersionInfo = propSchema.Extensions?.TryGetValue("x-state", out var propStateValue) == true && propStateValue is System.Text.Json.Nodes.JsonNode propStateNode ? propStateNode.ToString() : null;
+				var propVersionInfo = (propSchema.Extensions?.TryGetValue("x-state", out var propStateValue) == true && propStateValue is JsonNodeExtension propStateExt) ? propStateExt.Node.GetValue<string>() : null;
 				if (!string.IsNullOrEmpty(propVersionInfo))
 				{
 					<span class="version-badge">@propVersionInfo</span>


### PR DESCRIPTION
While playing in docs-builder I noticed that the code for handling `x-state` in the OpenAPI files was present, it just wasn't being rendered.

This PR seems to address the issue with two simple fixes.

For information about how to test this feature, refer to the docs I've crafted in https://github.com/elastic/docs-builder/pull/2879

## Screenshots

### Before

<img width="1671" height="360" alt="image" src="https://github.com/user-attachments/assets/b9d480d7-539d-4ab0-96e3-436f1dced208" />

### After

Works at both the operation-level:

<img width="1540" height="419" alt="image" src="https://github.com/user-attachments/assets/f97cc791-76d1-4cd4-afe8-1869a21d6373" />

Note that I extended that text to make sure it handled both the "since" and "lifecycle" info.
I also added one for testing purposes at the property-level:

<img width="1627" height="819" alt="image" src="https://github.com/user-attachments/assets/a4ff7889-b8cf-440b-b8d4-52826cbcd154" />


## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: composer-1.5, claude-4.6-sonnet-medium