### PR TITLE
[storybook] Storybook directive, for inline story rendering

### DIFF
--- a/docs/_docset.yml
+++ b/docs/_docset.yml
@@ -41,6 +41,9 @@ subs:
 
 features:
   primary-nav: false
+
+storybook:
+  registry: https://ci-artifacts.kibana.dev/storybooks/pr-272388/storybook-docs/docs_registry.json
   
 suppress:
   - AutolinkElasticCoDocs
@@ -149,6 +152,7 @@ toc:
       - file: lists.md
       - file: task-lists.md
       - file: line_breaks.md
+      - file: storybook.md
       - file: links.md
       - file: list-sub-pages.md
       - file: page-card.md

--- a/docs/syntax/directives.md
+++ b/docs/syntax/directives.md
@@ -77,6 +77,7 @@ The following directives are available:
 - [Math](math.md) - Mathematical expressions and equations
 - [Page cards](page-card.md) - Full-width clickable navigation rows
 - [Settings](automated_settings.md) - Configuration blocks
+- [Storybook](storybook.md) - Embedded Storybook stories
 - [Stepper](stepper.md) - Step-by-step content
 - [Tabs](tabs.md) - Tabbed content organization
 - [Tables](tables.md) - Data tables

--- a/docs/syntax/index.md
+++ b/docs/syntax/index.md
@@ -12,7 +12,7 @@ Elastic Docs V3 uses a custom implementation of [MyST](https://mystmd.org/) (Mar
 
 If you know [Markdown](https://commonmark.org), you already know most of what you need. If not, the CommonMark project offers a [10-minute tutorial](https://commonmark.org/help/). 
 
-When you need more than basic Markdown, you can use _directives_ to add features like callouts, tabs, and diagrams. To learn how directives work in general, including how to add options and arguments and nest multiple directives, refer to [How directives work](directives.md). For a full list of available directives, refer to the sidebar.
+When you need more than basic Markdown, you can use _directives_ to add features like callouts, tabs, diagrams, and embedded Storybook stories. To learn how directives work in general, including how to add options and arguments and nest multiple directives, refer to [How directives work](directives.md). For a full list of available directives, refer to the sidebar.
 
 ## GitHub Flavored Markdown support
 

--- a/docs/syntax/storybook.md
+++ b/docs/syntax/storybook.md
@@ -1,0 +1,86 @@
+# Storybook
+
+The `{storybook}` directive embeds a Storybook story from a Kibana `docs_registry.json`. The registry supplies the Storybook runtime ID, inline module entry, bootstrap assets, and iframe fallback URL.
+
+Configure the registry URL in `docset.yml`:
+
+```yaml
+storybook:
+  registry: https://example.com/storybook-docs/docs_registry.json
+```
+
+This page uses the Kibana Storybook artifact registry from PR 272388 so docs-builder preview builds can exercise inline module loading from `docs-v3-preview.elastic.dev`.
+
+For local Kibana testing, `yarn storybook_docs shared_ux --serve` serves the registry at:
+
+```text
+http://127.0.0.1:6007/storybook-docs/docs_registry.json
+```
+
+## Usage
+
+Use a registry ID directly:
+
+```markdown
+:::{storybook}
+:id: kibana:shared_ux:ai-components-aibutton--default
+:height: 300
+:title: AI button default story
+:::
+```
+
+:::{storybook}
+:id: kibana:shared_ux:ai-components-aibutton--default
+:height: 300
+:title: AI button default story
+:::
+
+Or use structured properties:
+
+```markdown
+:::{storybook}
+:project: kibana
+:storybook: shared_ux
+:component: ai-components-aibutton
+:story: default
+:::
+```
+
+:::{storybook}
+:project: kibana
+:storybook: shared_ux
+:component: ai-components-aibutton
+:story: default
+:::
+
+If a bare `:id:` is used, it must match exactly one story in the configured registry:
+
+```markdown
+:::{storybook}
+:id: ai-components-aibutton--default
+:::
+```
+
+:::{storybook}
+:id: ai-components-aibutton--default
+:::
+
+## Properties
+
+| Property | Required | Description |
+|---|---|---|
+| `:id:` | Yes* | Full registry ID such as `kibana:shared_ux:ai-components-aibutton--default`, or a bare docs/storybook ID that matches exactly one configured story. |
+| `:project:` | Yes* | Registry project prefix, for example `kibana`. Required when `:id:` is omitted. |
+| `:storybook:` | Yes* | Storybook alias, for example `shared_ux`. Required when `:id:` is omitted. |
+| `:component:` | No | Component ID used with `:story:` to form `{component}--{story}`. |
+| `:story:` | Yes* | Story name or docs ID. Required when `:id:` is omitted. |
+| `:height:` | No | Iframe fallback height in pixels. Defaults to the registry story height when present, otherwise `400`. |
+| `:title:` | No | Accessible title for the iframe fallback. Defaults to `Storybook story`. |
+
+## Rendering
+
+If the registry story has `renderMode: inline` and an `inline` entry, docs-builder renders a `<storybook-story>` element. The browser loads the registry bootstrap styles and scripts, then imports `inline.entry` and calls `mountStory(story.storybookId, container)`.
+
+If the story has `renderMode: iframe`, or no inline entry, docs-builder renders `iframe.url`.
+
+The registry, inline module, bootstrap assets, and iframe fallback can live on different paths. docs-builder uses the URLs from the registry directly; those assets must allow browser access from the docs site.

--- a/docs/syntax/storybook.md
+++ b/docs/syntax/storybook.md
@@ -61,9 +61,7 @@ If a bare `:id:` is used, it must match exactly one story in the configured regi
 :::
 ```
 
-:::{storybook}
-:id: ai-components-aibutton--default
-:::
+In the PR 272388 registry this bare ID is ambiguous — it resolves to both `kibana:presentation:ai-components-aibutton--default` and `kibana:shared_ux:ai-components-aibutton--default` — so it is not rendered live here. Use the fully-qualified `project:storybook:docsId` form when a docs ID is not unique.
 
 ## Properties
 

--- a/src/Elastic.Documentation.Configuration/Builder/ConfigurationFile.cs
+++ b/src/Elastic.Documentation.Configuration/Builder/ConfigurationFile.cs
@@ -59,6 +59,8 @@ public record ConfigurationFile
 
 	public IReadOnlyDictionary<string, IFileInfo>? OpenApiSpecifications { get; }
 
+	public string? StorybookRegistry { get; }
+
 	/// <summary>
 	/// Resolved API configurations with template and specification file information.
 	/// </summary>
@@ -244,6 +246,9 @@ public record ConfigurationFile
 				OpenApiSpecifications = specs.Count > 0 ? specs : null;
 				ApiConfigurations = apiConfigs.Count > 0 ? apiConfigs : null;
 			}
+
+			if (docSetFile.Storybook is not null)
+				StorybookRegistry = docSetFile.Storybook.Registry?.Trim();
 
 			// Process products from docset - resolve ProductLinks to Product objects
 			if (docSetFile.Products.Count > 0)

--- a/src/Elastic.Documentation.Configuration/Serialization/YamlStaticContext.cs
+++ b/src/Elastic.Documentation.Configuration/Serialization/YamlStaticContext.cs
@@ -39,6 +39,7 @@ namespace Elastic.Documentation.Configuration.Serialization;
 // Table of contents
 [YamlSerializable(typeof(DocumentationSetFile))]
 [YamlSerializable(typeof(DocumentationSetFeatures))]
+[YamlSerializable(typeof(DocumentationSetStorybook))]
 [YamlSerializable(typeof(CodexDocSetMetadata))]
 [YamlSerializable(typeof(TableOfContentsFile))]
 [YamlSerializable(typeof(SiteNavigationFile))]

--- a/src/Elastic.Documentation.Configuration/Toc/DocumentationSetFile.cs
+++ b/src/Elastic.Documentation.Configuration/Toc/DocumentationSetFile.cs
@@ -73,6 +73,9 @@ public class DocumentationSetFile : TableOfContentsFile
 	[YamlMember(Alias = "branding")]
 	public BrandingConfiguration? Branding { get; set; }
 
+	[YamlMember(Alias = "storybook")]
+	public DocumentationSetStorybook? Storybook { get; set; }
+
 	public static FileRef[] GetFileRefs(ITableOfContentsItem item)
 	{
 		if (item is FileRef fileRef)
@@ -738,6 +741,13 @@ public class DocumentationSetFeatures
 	public bool? PrimaryNav { get; set; }
 	[YamlMember(Alias = "disable-github-edit-link", ApplyNamingConventions = false)]
 	public bool? DisableGithubEditLink { get; set; }
+}
+
+[YamlSerializable]
+public class DocumentationSetStorybook
+{
+	[YamlMember(Alias = "registry")]
+	public string? Registry { get; set; }
 }
 
 /// <summary>

--- a/src/Elastic.Documentation.Site/Assets/main.ts
+++ b/src/Elastic.Documentation.Site/Assets/main.ts
@@ -41,6 +41,7 @@ import('./web-components/VersionDropdown')
 import('./web-components/AppliesToPopover')
 import('./web-components/FullPageSearch/FullPageSearchComponent')
 import('./web-components/Diagnostics/DiagnosticsComponent')
+import('./web-components/StorybookStory/StorybookStoryComponent')
 
 if (config.buildType === 'isolated' || config.airGapped) {
     import('./isolated')

--- a/src/Elastic.Documentation.Site/Assets/main.ts
+++ b/src/Elastic.Documentation.Site/Assets/main.ts
@@ -135,8 +135,19 @@ document.addEventListener('htmx:load', function () {
 document.addEventListener(
     'htmx:removingHeadElement',
     function (event: HtmxEvent) {
-        const tagName = event.detail.headElement.tagName
-        if (tagName === 'STYLE') {
+        const headElement = event.detail.headElement
+        if (headElement.tagName === 'STYLE') {
+            event.preventDefault()
+            return
+        }
+        // Keep the Storybook bootstrap assets that <storybook-story> injects into
+        // <head>; htmx would otherwise strip them on navigation, which both breaks an
+        // in-flight first load (the stylesheet's onload never fires) and leaves the
+        // module-level load caches pointing at elements that no longer exist.
+        if (
+            headElement.dataset?.storybookScript !== undefined ||
+            headElement.dataset?.storybookStyle !== undefined
+        ) {
             event.preventDefault()
         }
     }

--- a/src/Elastic.Documentation.Site/Assets/markdown/storybook.css
+++ b/src/Elastic.Documentation.Site/Assets/markdown/storybook.css
@@ -1,0 +1,32 @@
+.storybook-embed {
+  border: 1px solid #E3E8F2;
+  border-radius: 6px;
+  margin-block: 1.5rem;
+  overflow: hidden;
+}
+
+.storybook-embed iframe {
+  display: block;
+}
+
+.storybook-embed storybook-story {
+  display: block;
+  padding: 24px;
+}
+
+.storybook-embed-body {
+  padding: 0.75rem 1.5rem;
+  border-top: 1px solid #E3E8F2;
+  background: #F7F8FC;
+}
+
+.storybook-embed-error {
+  padding: 1rem;
+  color: #BD271E;
+  font-size: 14px;
+}
+
+.storybook-embed-error strong {
+  display: block;
+  margin-bottom: 0.25rem;
+}

--- a/src/Elastic.Documentation.Site/Assets/markdown/storybook.css
+++ b/src/Elastic.Documentation.Site/Assets/markdown/storybook.css
@@ -1,32 +1,32 @@
 .storybook-embed {
-  border: 1px solid #E3E8F2;
-  border-radius: 6px;
-  margin-block: 1.5rem;
-  overflow: hidden;
+	border: 1px solid #e3e8f2;
+	border-radius: 6px;
+	margin-block: 1.5rem;
+	overflow: hidden;
 }
 
 .storybook-embed iframe {
-  display: block;
+	display: block;
 }
 
 .storybook-embed storybook-story {
-  display: block;
-  padding: 24px;
+	display: block;
+	padding: 24px;
 }
 
 .storybook-embed-body {
-  padding: 0.75rem 1.5rem;
-  border-top: 1px solid #E3E8F2;
-  background: #F7F8FC;
+	padding: 0.75rem 1.5rem;
+	border-top: 1px solid #e3e8f2;
+	background: #f7f8fc;
 }
 
 .storybook-embed-error {
-  padding: 1rem;
-  color: #BD271E;
-  font-size: 14px;
+	padding: 1rem;
+	color: #bd271e;
+	font-size: 14px;
 }
 
 .storybook-embed-error strong {
-  display: block;
-  margin-bottom: 0.25rem;
+	display: block;
+	margin-bottom: 0.25rem;
 }

--- a/src/Elastic.Documentation.Site/Assets/styles.css
+++ b/src/Elastic.Documentation.Site/Assets/styles.css
@@ -29,6 +29,7 @@
 @import './markdown/agent-skill.css';
 @import './markdown/cli-modifiers.css';
 @import './markdown/contributors.css';
+@import './markdown/storybook.css';
 @import './api-docs.css';
 @import 'tippy.js/dist/tippy.css';
 

--- a/src/Elastic.Documentation.Site/Assets/web-components/StorybookStory/StorybookStoryComponent.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/StorybookStory/StorybookStoryComponent.tsx
@@ -162,7 +162,11 @@ const loadBootstrap = async (bootstrap: StoryBootstrap | null) => {
 
   setKibanaGlobals(bootstrap.publicPath)
 
-  const cacheKey = bootstrap.publicPath || JSON.stringify(bootstrap)
+  const cacheKey = JSON.stringify({
+    publicPath: bootstrap.publicPath ?? '',
+    scripts: bootstrap.scripts ?? [],
+    styles: bootstrap.styles ?? [],
+  })
   if (!bootstrapCache.has(cacheKey)) {
     bootstrapCache.set(
       cacheKey,

--- a/src/Elastic.Documentation.Site/Assets/web-components/StorybookStory/StorybookStoryComponent.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/StorybookStory/StorybookStoryComponent.tsx
@@ -1,32 +1,34 @@
+export {}
+
 type MountFn = (storyId: string, container: HTMLElement) => Promise<void>
 type UnmountFn = (container: HTMLElement) => void
 type KibanaPublicPath = Record<string, string>
 
 declare global {
-  interface Window {
-    __kbnPublicPath__?: KibanaPublicPath
-    __kbnHardenPrototypes__?: boolean
-  }
+    interface Window {
+        __kbnPublicPath__?: KibanaPublicPath
+        __kbnHardenPrototypes__?: boolean
+    }
 }
 
 interface StoryEntry {
-  mountStory: MountFn
-  unmountStory: UnmountFn
+    mountStory: MountFn
+    unmountStory: UnmountFn
 }
 
 interface StoryBootstrap {
-  publicPath?: string
-  scripts?: string[]
-  styles?: string[]
+    publicPath?: string
+    scripts?: string[]
+    styles?: string[]
 }
 
 class StorybookLoadError extends Error {
-  constructor(
-    public readonly title: string,
-    public readonly detail: string
-  ) {
-    super(detail)
-  }
+    constructor(
+        public readonly title: string,
+        public readonly detail: string
+    ) {
+        super(detail)
+    }
 }
 
 const entryCache = new Map<string, Promise<StoryEntry>>()
@@ -35,233 +37,261 @@ const scriptCache = new Map<string, Promise<void>>()
 const styleCache = new Map<string, Promise<void>>()
 
 const loadEntry = (url: string): Promise<StoryEntry> => {
-  if (!entryCache.has(url)) {
-    entryCache.set(
-      url,
-      import(/* @vite-ignore */ url)
-        .then(validateEntry)
-        .catch((err) => {
-          entryCache.delete(url)
-          if (err instanceof StorybookLoadError) throw err
-          throw new StorybookLoadError(
-            'Storybook entry module could not be imported.',
-            `Check that the module exists and CORS allows this docs origin: ${url}`
-          )
-        })
-    )
-  }
-  return entryCache.get(url)!
+    if (!entryCache.has(url)) {
+        entryCache.set(
+            url,
+            import(/* @vite-ignore */ url).then(validateEntry).catch((err) => {
+                entryCache.delete(url)
+                if (err instanceof StorybookLoadError) throw err
+                throw new StorybookLoadError(
+                    'Storybook entry module could not be imported.',
+                    `Check that the module exists and CORS allows this docs origin: ${url}`
+                )
+            })
+        )
+    }
+    return entryCache.get(url)!
 }
 
 const validateEntry = (entry: unknown): StoryEntry => {
-  const candidate = entry as Partial<StoryEntry>
-  if (typeof candidate.mountStory !== 'function' || typeof candidate.unmountStory !== 'function') {
-    throw new StorybookLoadError(
-      'Storybook entry module has an unsupported contract.',
-      'Expected mountStory(storyId, container) and unmountStory(container).'
-    )
-  }
-  return candidate as StoryEntry
+    const candidate = entry as Partial<StoryEntry>
+    if (
+        typeof candidate.mountStory !== 'function' ||
+        typeof candidate.unmountStory !== 'function'
+    ) {
+        throw new StorybookLoadError(
+            'Storybook entry module has an unsupported contract.',
+            'Expected mountStory(storyId, container) and unmountStory(container).'
+        )
+    }
+    return candidate as StoryEntry
 }
 
 const loadStylesheet = (url: string): Promise<void> => {
-  if (!styleCache.has(url)) {
-    styleCache.set(
-      url,
-      new Promise((resolve, reject) => {
-        const existing = Array.from(document.querySelectorAll<HTMLLinkElement>('link[data-storybook-style]')).find(
-          (link) => link.dataset.storybookStyle === url
-        )
-        if (existing) {
-          resolve()
-          return
-        }
+    if (!styleCache.has(url)) {
+        styleCache.set(
+            url,
+            new Promise((resolve, reject) => {
+                const existing = Array.from(
+                    document.querySelectorAll<HTMLLinkElement>(
+                        'link[data-storybook-style]'
+                    )
+                ).find((link) => link.dataset.storybookStyle === url)
+                if (existing) {
+                    resolve()
+                    return
+                }
 
-        const link = document.createElement('link')
-        link.rel = 'stylesheet'
-        link.href = url
-        link.dataset.storybookStyle = url
-        link.onload = () => resolve()
-        link.onerror = () => {
-          styleCache.delete(url)
-          reject(new StorybookLoadError('Storybook stylesheet could not be loaded.', `Missing or blocked stylesheet: ${url}`))
-        }
-        document.head.appendChild(link)
-      })
-    )
-  }
-  return styleCache.get(url)!
+                const link = document.createElement('link')
+                link.rel = 'stylesheet'
+                link.href = url
+                link.dataset.storybookStyle = url
+                link.onload = () => resolve()
+                link.onerror = () => {
+                    styleCache.delete(url)
+                    reject(
+                        new StorybookLoadError(
+                            'Storybook stylesheet could not be loaded.',
+                            `Missing or blocked stylesheet: ${url}`
+                        )
+                    )
+                }
+                document.head.appendChild(link)
+            })
+        )
+    }
+    return styleCache.get(url)!
 }
 
 const loadScript = (url: string): Promise<void> => {
-  if (!scriptCache.has(url)) {
-    scriptCache.set(
-      url,
-      new Promise((resolve, reject) => {
-        const existing = Array.from(document.querySelectorAll<HTMLScriptElement>('script[data-storybook-script]')).find(
-          (script) => script.dataset.storybookScript === url
-        )
-        if (existing) {
-          resolve()
-          return
-        }
+    if (!scriptCache.has(url)) {
+        scriptCache.set(
+            url,
+            new Promise((resolve, reject) => {
+                const existing = Array.from(
+                    document.querySelectorAll<HTMLScriptElement>(
+                        'script[data-storybook-script]'
+                    )
+                ).find((script) => script.dataset.storybookScript === url)
+                if (existing) {
+                    resolve()
+                    return
+                }
 
-        const script = document.createElement('script')
-        script.src = url
-        script.async = false
-        script.dataset.storybookScript = url
-        script.onload = () => resolve()
-        script.onerror = () => {
-          scriptCache.delete(url)
-          reject(new StorybookLoadError('Storybook bootstrap script could not be loaded.', `Missing or blocked script: ${url}`))
-        }
-        document.head.appendChild(script)
-      })
-    )
-  }
-  return scriptCache.get(url)!
+                const script = document.createElement('script')
+                script.src = url
+                script.async = false
+                script.dataset.storybookScript = url
+                script.onload = () => resolve()
+                script.onerror = () => {
+                    scriptCache.delete(url)
+                    reject(
+                        new StorybookLoadError(
+                            'Storybook bootstrap script could not be loaded.',
+                            `Missing or blocked script: ${url}`
+                        )
+                    )
+                }
+                document.head.appendChild(script)
+            })
+        )
+    }
+    return scriptCache.get(url)!
 }
 
 const parseBootstrap = (value: string | null): StoryBootstrap | null => {
-  if (!value) return null
+    if (!value) return null
 
-  try {
-    return JSON.parse(value) as StoryBootstrap
-  } catch {
-    throw new StorybookLoadError(
-      'Storybook bootstrap data is invalid.',
-      'The registry provided bootstrap data that is not valid JSON.'
-    )
-  }
+    try {
+        return JSON.parse(value) as StoryBootstrap
+    } catch {
+        throw new StorybookLoadError(
+            'Storybook bootstrap data is invalid.',
+            'The registry provided bootstrap data that is not valid JSON.'
+        )
+    }
 }
 
 const setKibanaGlobals = (publicPath?: string) => {
-  if (!publicPath) return
+    if (!publicPath) return
 
-  const publicPaths = {
-    'kbn-ui-shared-deps-npm': publicPath,
-    'kbn-ui-shared-deps-src': publicPath,
-    'kbn-monaco': publicPath,
-  }
-
-  window.__kbnPublicPath__ = publicPaths
-  window.__kbnHardenPrototypes__ = false
-
-  try {
-    if (window.top) {
-      window.top.__kbnPublicPath__ = publicPaths
-      window.top.__kbnHardenPrototypes__ = false
+    const publicPaths = {
+        'kbn-ui-shared-deps-npm': publicPath,
+        'kbn-ui-shared-deps-src': publicPath,
+        'kbn-monaco': publicPath,
     }
-  } catch {
-    // Cross-origin frames cannot access `top`.
-  }
+
+    window.__kbnPublicPath__ = publicPaths
+    window.__kbnHardenPrototypes__ = false
+
+    try {
+        if (window.top) {
+            window.top.__kbnPublicPath__ = publicPaths
+            window.top.__kbnHardenPrototypes__ = false
+        }
+    } catch {
+        // Cross-origin frames cannot access `top`.
+    }
 }
 
 const loadBootstrap = async (bootstrap: StoryBootstrap | null) => {
-  if (!bootstrap) return
+    if (!bootstrap) return
 
-  setKibanaGlobals(bootstrap.publicPath)
+    setKibanaGlobals(bootstrap.publicPath)
 
-  const cacheKey = JSON.stringify({
-    publicPath: bootstrap.publicPath ?? '',
-    scripts: bootstrap.scripts ?? [],
-    styles: bootstrap.styles ?? [],
-  })
-  if (!bootstrapCache.has(cacheKey)) {
-    bootstrapCache.set(
-      cacheKey,
-      (async () => {
-        await Promise.all((bootstrap.styles ?? []).map(loadStylesheet))
-        for (const script of bootstrap.scripts ?? []) {
-          await loadScript(script)
-        }
-      })()
-    )
-  }
+    const cacheKey = JSON.stringify({
+        publicPath: bootstrap.publicPath ?? '',
+        scripts: bootstrap.scripts ?? [],
+        styles: bootstrap.styles ?? [],
+    })
+    if (!bootstrapCache.has(cacheKey)) {
+        bootstrapCache.set(
+            cacheKey,
+            (async () => {
+                await Promise.all((bootstrap.styles ?? []).map(loadStylesheet))
+                for (const script of bootstrap.scripts ?? []) {
+                    await loadScript(script)
+                }
+            })()
+        )
+    }
 
-  await bootstrapCache.get(cacheKey)
+    await bootstrapCache.get(cacheKey)
 }
 
 class StorybookStoryElement extends HTMLElement {
-  private container: HTMLDivElement | null = null
-  private entry: StoryEntry | null = null
-  private mountVersion = 0
+    private container: HTMLDivElement | null = null
+    private entry: StoryEntry | null = null
+    private mountVersion = 0
 
-  static get observedAttributes() {
-    return ['story-id', 'entry', 'bootstrap']
-  }
-
-  connectedCallback() {
-    if (!this.container) {
-      this.container = document.createElement('div')
-      this.appendChild(this.container)
+    static get observedAttributes() {
+        return ['story-id', 'entry', 'bootstrap']
     }
-    this.mount()
-  }
 
-  disconnectedCallback() {
-    this.mountVersion++
-    this.unmount()
-  }
-
-  attributeChangedCallback() {
-    if (this.container) {
-      this.mount()
+    connectedCallback() {
+        if (!this.container) {
+            this.container = document.createElement('div')
+            this.appendChild(this.container)
+        }
+        this.mount()
     }
-  }
 
-  private unmount() {
-    if (this.container && this.entry) {
-      this.entry.unmountStory(this.container)
-      this.entry = null
+    disconnectedCallback() {
+        this.mountVersion++
+        this.unmount()
     }
-  }
 
-  private async mount() {
-    const storyId = this.getAttribute('story-id')
-    const entryUrl = this.getAttribute('entry')
-    const currentMount = ++this.mountVersion
-
-    if (!storyId || !entryUrl || !this.container) return
-
-    this.unmount()
-    this.container.replaceChildren()
-
-    try {
-      await loadBootstrap(parseBootstrap(this.getAttribute('bootstrap')))
-      const entry = await loadEntry(entryUrl)
-      if (currentMount !== this.mountVersion || !this.container || !this.isConnected) return
-
-      this.entry = entry
-      try {
-        await entry.mountStory(storyId, this.container)
-      } catch (err) {
-        throw new StorybookLoadError(
-          'Storybook story failed while mounting.',
-          err instanceof Error ? err.message : String(err)
-        )
-      }
-    } catch (err) {
-      if (currentMount === this.mountVersion && this.container) {
-        this.container.replaceChildren(createErrorMessage(err))
-      }
+    attributeChangedCallback() {
+        if (this.container) {
+            this.mount()
+        }
     }
-  }
+
+    private unmount() {
+        if (this.container && this.entry) {
+            this.entry.unmountStory(this.container)
+            this.entry = null
+        }
+    }
+
+    private async mount() {
+        const storyId = this.getAttribute('story-id')
+        const entryUrl = this.getAttribute('entry')
+        const currentMount = ++this.mountVersion
+
+        if (!storyId || !entryUrl || !this.container) return
+
+        this.unmount()
+        this.container.replaceChildren()
+
+        try {
+            await loadBootstrap(parseBootstrap(this.getAttribute('bootstrap')))
+            const entry = await loadEntry(entryUrl)
+            if (
+                currentMount !== this.mountVersion ||
+                !this.container ||
+                !this.isConnected
+            )
+                return
+
+            this.entry = entry
+            try {
+                await entry.mountStory(storyId, this.container)
+            } catch (err) {
+                throw new StorybookLoadError(
+                    'Storybook story failed while mounting.',
+                    err instanceof Error ? err.message : String(err)
+                )
+            }
+        } catch (err) {
+            if (currentMount === this.mountVersion && this.container) {
+                this.container.replaceChildren(createErrorMessage(err))
+            }
+        }
+    }
 }
 
 const createErrorMessage = (err: unknown): HTMLDivElement => {
-  const message = document.createElement('div')
-  message.className = 'storybook-embed-error'
+    const message = document.createElement('div')
+    message.className = 'storybook-embed-error'
 
-  const title = document.createElement('strong')
-  title.textContent = err instanceof StorybookLoadError ? err.title : 'Storybook story failed to load.'
-  message.appendChild(title)
+    const title = document.createElement('strong')
+    title.textContent =
+        err instanceof StorybookLoadError
+            ? err.title
+            : 'Storybook story failed to load.'
+    message.appendChild(title)
 
-  const detail = document.createElement('div')
-  detail.textContent = err instanceof StorybookLoadError ? err.detail : err instanceof Error ? err.message : String(err)
-  message.appendChild(detail)
+    const detail = document.createElement('div')
+    detail.textContent =
+        err instanceof StorybookLoadError
+            ? err.detail
+            : err instanceof Error
+              ? err.message
+              : String(err)
+    message.appendChild(detail)
 
-  return message
+    return message
 }
 
 customElements.define('storybook-story', StorybookStoryElement)

--- a/src/Elastic.Documentation.Site/Assets/web-components/StorybookStory/StorybookStoryComponent.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/StorybookStory/StorybookStoryComponent.tsx
@@ -1,0 +1,263 @@
+type MountFn = (storyId: string, container: HTMLElement) => Promise<void>
+type UnmountFn = (container: HTMLElement) => void
+type KibanaPublicPath = Record<string, string>
+
+declare global {
+  interface Window {
+    __kbnPublicPath__?: KibanaPublicPath
+    __kbnHardenPrototypes__?: boolean
+  }
+}
+
+interface StoryEntry {
+  mountStory: MountFn
+  unmountStory: UnmountFn
+}
+
+interface StoryBootstrap {
+  publicPath?: string
+  scripts?: string[]
+  styles?: string[]
+}
+
+class StorybookLoadError extends Error {
+  constructor(
+    public readonly title: string,
+    public readonly detail: string
+  ) {
+    super(detail)
+  }
+}
+
+const entryCache = new Map<string, Promise<StoryEntry>>()
+const bootstrapCache = new Map<string, Promise<void>>()
+const scriptCache = new Map<string, Promise<void>>()
+const styleCache = new Map<string, Promise<void>>()
+
+const loadEntry = (url: string): Promise<StoryEntry> => {
+  if (!entryCache.has(url)) {
+    entryCache.set(
+      url,
+      import(/* @vite-ignore */ url)
+        .then(validateEntry)
+        .catch((err) => {
+          entryCache.delete(url)
+          if (err instanceof StorybookLoadError) throw err
+          throw new StorybookLoadError(
+            'Storybook entry module could not be imported.',
+            `Check that the module exists and CORS allows this docs origin: ${url}`
+          )
+        })
+    )
+  }
+  return entryCache.get(url)!
+}
+
+const validateEntry = (entry: unknown): StoryEntry => {
+  const candidate = entry as Partial<StoryEntry>
+  if (typeof candidate.mountStory !== 'function' || typeof candidate.unmountStory !== 'function') {
+    throw new StorybookLoadError(
+      'Storybook entry module has an unsupported contract.',
+      'Expected mountStory(storyId, container) and unmountStory(container).'
+    )
+  }
+  return candidate as StoryEntry
+}
+
+const loadStylesheet = (url: string): Promise<void> => {
+  if (!styleCache.has(url)) {
+    styleCache.set(
+      url,
+      new Promise((resolve, reject) => {
+        const existing = Array.from(document.querySelectorAll<HTMLLinkElement>('link[data-storybook-style]')).find(
+          (link) => link.dataset.storybookStyle === url
+        )
+        if (existing) {
+          resolve()
+          return
+        }
+
+        const link = document.createElement('link')
+        link.rel = 'stylesheet'
+        link.href = url
+        link.dataset.storybookStyle = url
+        link.onload = () => resolve()
+        link.onerror = () => {
+          styleCache.delete(url)
+          reject(new StorybookLoadError('Storybook stylesheet could not be loaded.', `Missing or blocked stylesheet: ${url}`))
+        }
+        document.head.appendChild(link)
+      })
+    )
+  }
+  return styleCache.get(url)!
+}
+
+const loadScript = (url: string): Promise<void> => {
+  if (!scriptCache.has(url)) {
+    scriptCache.set(
+      url,
+      new Promise((resolve, reject) => {
+        const existing = Array.from(document.querySelectorAll<HTMLScriptElement>('script[data-storybook-script]')).find(
+          (script) => script.dataset.storybookScript === url
+        )
+        if (existing) {
+          resolve()
+          return
+        }
+
+        const script = document.createElement('script')
+        script.src = url
+        script.async = false
+        script.dataset.storybookScript = url
+        script.onload = () => resolve()
+        script.onerror = () => {
+          scriptCache.delete(url)
+          reject(new StorybookLoadError('Storybook bootstrap script could not be loaded.', `Missing or blocked script: ${url}`))
+        }
+        document.head.appendChild(script)
+      })
+    )
+  }
+  return scriptCache.get(url)!
+}
+
+const parseBootstrap = (value: string | null): StoryBootstrap | null => {
+  if (!value) return null
+
+  try {
+    return JSON.parse(value) as StoryBootstrap
+  } catch {
+    throw new StorybookLoadError(
+      'Storybook bootstrap data is invalid.',
+      'The registry provided bootstrap data that is not valid JSON.'
+    )
+  }
+}
+
+const setKibanaGlobals = (publicPath?: string) => {
+  if (!publicPath) return
+
+  const publicPaths = {
+    'kbn-ui-shared-deps-npm': publicPath,
+    'kbn-ui-shared-deps-src': publicPath,
+    'kbn-monaco': publicPath,
+  }
+
+  window.__kbnPublicPath__ = publicPaths
+  window.__kbnHardenPrototypes__ = false
+
+  try {
+    if (window.top) {
+      window.top.__kbnPublicPath__ = publicPaths
+      window.top.__kbnHardenPrototypes__ = false
+    }
+  } catch {
+    // Cross-origin frames cannot access `top`.
+  }
+}
+
+const loadBootstrap = async (bootstrap: StoryBootstrap | null) => {
+  if (!bootstrap) return
+
+  setKibanaGlobals(bootstrap.publicPath)
+
+  const cacheKey = bootstrap.publicPath || JSON.stringify(bootstrap)
+  if (!bootstrapCache.has(cacheKey)) {
+    bootstrapCache.set(
+      cacheKey,
+      (async () => {
+        await Promise.all((bootstrap.styles ?? []).map(loadStylesheet))
+        for (const script of bootstrap.scripts ?? []) {
+          await loadScript(script)
+        }
+      })()
+    )
+  }
+
+  await bootstrapCache.get(cacheKey)
+}
+
+class StorybookStoryElement extends HTMLElement {
+  private container: HTMLDivElement | null = null
+  private entry: StoryEntry | null = null
+  private mountVersion = 0
+
+  static get observedAttributes() {
+    return ['story-id', 'entry', 'bootstrap']
+  }
+
+  connectedCallback() {
+    if (!this.container) {
+      this.container = document.createElement('div')
+      this.appendChild(this.container)
+    }
+    this.mount()
+  }
+
+  disconnectedCallback() {
+    this.mountVersion++
+    this.unmount()
+  }
+
+  attributeChangedCallback() {
+    if (this.container) {
+      this.mount()
+    }
+  }
+
+  private unmount() {
+    if (this.container && this.entry) {
+      this.entry.unmountStory(this.container)
+      this.entry = null
+    }
+  }
+
+  private async mount() {
+    const storyId = this.getAttribute('story-id')
+    const entryUrl = this.getAttribute('entry')
+    const currentMount = ++this.mountVersion
+
+    if (!storyId || !entryUrl || !this.container) return
+
+    this.unmount()
+    this.container.replaceChildren()
+
+    try {
+      await loadBootstrap(parseBootstrap(this.getAttribute('bootstrap')))
+      const entry = await loadEntry(entryUrl)
+      if (currentMount !== this.mountVersion || !this.container || !this.isConnected) return
+
+      this.entry = entry
+      try {
+        await entry.mountStory(storyId, this.container)
+      } catch (err) {
+        throw new StorybookLoadError(
+          'Storybook story failed while mounting.',
+          err instanceof Error ? err.message : String(err)
+        )
+      }
+    } catch (err) {
+      if (currentMount === this.mountVersion && this.container) {
+        this.container.replaceChildren(createErrorMessage(err))
+      }
+    }
+  }
+}
+
+const createErrorMessage = (err: unknown): HTMLDivElement => {
+  const message = document.createElement('div')
+  message.className = 'storybook-embed-error'
+
+  const title = document.createElement('strong')
+  title.textContent = err instanceof StorybookLoadError ? err.title : 'Storybook story failed to load.'
+  message.appendChild(title)
+
+  const detail = document.createElement('div')
+  detail.textContent = err instanceof StorybookLoadError ? err.detail : err instanceof Error ? err.message : String(err)
+  message.appendChild(detail)
+
+  return message
+}
+
+customElements.define('storybook-story', StorybookStoryElement)

--- a/src/Elastic.Markdown/Myst/Directives/DirectiveBlockParser.cs
+++ b/src/Elastic.Markdown/Myst/Directives/DirectiveBlockParser.cs
@@ -16,6 +16,7 @@ using Elastic.Markdown.Myst.Directives.Math;
 using Elastic.Markdown.Myst.Directives.PageCard;
 using Elastic.Markdown.Myst.Directives.Settings;
 using Elastic.Markdown.Myst.Directives.Stepper;
+using Elastic.Markdown.Myst.Directives.Storybook;
 using Elastic.Markdown.Myst.Directives.SubPages;
 using Elastic.Markdown.Myst.Directives.Table;
 using Elastic.Markdown.Myst.Directives.Tabs;
@@ -140,6 +141,9 @@ public class DirectiveBlockParser : FencedBlockParserBase<DirectiveBlock>
 
 		if (info.IndexOf("{cli-modifiers}") > 0)
 			return new CliModifiersBlock(this, context);
+
+		if (info.IndexOf("{storybook}") > 0)
+			return new StorybookBlock(this, context);
 
 		foreach (var admonition in Admonitions)
 		{

--- a/src/Elastic.Markdown/Myst/Directives/DirectiveHtmlRenderer.cs
+++ b/src/Elastic.Markdown/Myst/Directives/DirectiveHtmlRenderer.cs
@@ -22,6 +22,7 @@ using Elastic.Markdown.Myst.Directives.Math;
 using Elastic.Markdown.Myst.Directives.PageCard;
 using Elastic.Markdown.Myst.Directives.Settings;
 using Elastic.Markdown.Myst.Directives.Stepper;
+using Elastic.Markdown.Myst.Directives.Storybook;
 using Elastic.Markdown.Myst.Directives.SubPages;
 using Elastic.Markdown.Myst.Directives.Table;
 using Elastic.Markdown.Myst.Directives.Tabs;
@@ -128,6 +129,9 @@ public class DirectiveHtmlRenderer : HtmlObjectRenderer<DirectiveBlock>
 				return;
 			case CliModifiersBlock cliModifiersBlock:
 				WriteCliModifiers(renderer, cliModifiersBlock);
+				return;
+			case StorybookBlock storybookBlock:
+				WriteStorybook(renderer, storybookBlock);
 				return;
 			default:
 				// if (!string.IsNullOrEmpty(directiveBlock.Info) && !directiveBlock.Info.StartsWith('{'))
@@ -298,6 +302,25 @@ public class DirectiveHtmlRenderer : HtmlObjectRenderer<DirectiveBlock>
 			InstallCommand = block.InstallCommand,
 			HasBody = block.Count > 0,
 			LearnMoreUrl = $"{prefix}/explore-analyze/ai-features/agent-skills#available-skills"
+		});
+		RenderRazorSlice(slice, renderer);
+	}
+
+	private static void WriteStorybook(HtmlRenderer renderer, StorybookBlock block)
+	{
+		if (string.IsNullOrEmpty(block.StoryUrl))
+			return;
+
+		var slice = StorybookView.Create(new StorybookViewModel
+		{
+			DirectiveBlock = block,
+			StoryUrl = block.StoryUrl,
+			StoryId = block.StoryId ?? string.Empty,
+			Height = block.Height,
+			IframeTitle = block.IframeTitle,
+			HasBody = block.Count > 0,
+			InlineEntry = block.InlineEntry,
+			InlineBootstrapJson = block.InlineBootstrapJson,
 		});
 		RenderRazorSlice(slice, renderer);
 	}

--- a/src/Elastic.Markdown/Myst/Directives/Storybook/StorybookBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Storybook/StorybookBlock.cs
@@ -14,6 +14,16 @@ public class StorybookBlock(DirectiveBlockParser parser, ParserContext context) 
 
 	private static readonly TimeSpan RegistryFetchTimeout = TimeSpan.FromSeconds(30);
 
+	// Shared across all storybook directives to pool connections; PooledConnectionLifetime bounds DNS staleness in long-lived serve/watch runs.
+	private static readonly HttpClient RegistryHttpClient = new(
+		new SocketsHttpHandler
+		{
+			AutomaticDecompression = DecompressionMethods.All,
+			PooledConnectionLifetime = TimeSpan.FromMinutes(5)
+		}
+	)
+	{ Timeout = RegistryFetchTimeout };
+
 	public override string Directive => "storybook";
 
 	public string? Project { get; private set; }
@@ -163,10 +173,8 @@ public class StorybookBlock(DirectiveBlockParser parser, ParserContext context) 
 		{
 			// FinalizeAndValidate is synchronous across all directives, so the fetch is sync-over-async here.
 			// Bound it with an explicit timeout so an unresponsive registry host can never stall the build.
-			using var handler = new HttpClientHandler { AutomaticDecompression = DecompressionMethods.All };
-			using var http = new HttpClient(handler) { Timeout = RegistryFetchTimeout };
 			using var cts = new CancellationTokenSource(RegistryFetchTimeout);
-			return http.GetStringAsync(uri, cts.Token).GetAwaiter().GetResult();
+			return RegistryHttpClient.GetStringAsync(uri, cts.Token).GetAwaiter().GetResult();
 		}
 
 		var registryPath = Path.IsPathRooted(rawRegistry)

--- a/src/Elastic.Markdown/Myst/Directives/Storybook/StorybookBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Storybook/StorybookBlock.cs
@@ -12,6 +12,8 @@ public class StorybookBlock(DirectiveBlockParser parser, ParserContext context) 
 {
 	private const string SupportedRegistrySchemaVersion = "1";
 
+	private static readonly TimeSpan RegistryFetchTimeout = TimeSpan.FromSeconds(30);
+
 	public override string Directive => "storybook";
 
 	public string? Project { get; private set; }
@@ -159,9 +161,12 @@ public class StorybookBlock(DirectiveBlockParser parser, ParserContext context) 
 	{
 		if (Uri.TryCreate(rawRegistry, UriKind.Absolute, out var uri) && uri.Scheme is "http" or "https")
 		{
+			// FinalizeAndValidate is synchronous across all directives, so the fetch is sync-over-async here.
+			// Bound it with an explicit timeout so an unresponsive registry host can never stall the build.
 			using var handler = new HttpClientHandler { AutomaticDecompression = DecompressionMethods.All };
-			using var http = new HttpClient(handler);
-			return http.GetStringAsync(uri).GetAwaiter().GetResult();
+			using var http = new HttpClient(handler) { Timeout = RegistryFetchTimeout };
+			using var cts = new CancellationTokenSource(RegistryFetchTimeout);
+			return http.GetStringAsync(uri, cts.Token).GetAwaiter().GetResult();
 		}
 
 		var registryPath = Path.IsPathRooted(rawRegistry)

--- a/src/Elastic.Markdown/Myst/Directives/Storybook/StorybookBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Storybook/StorybookBlock.cs
@@ -1,0 +1,284 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Net;
+using System.Text.Json;
+using Elastic.Markdown.Diagnostics;
+
+namespace Elastic.Markdown.Myst.Directives.Storybook;
+
+public class StorybookBlock(DirectiveBlockParser parser, ParserContext context) : DirectiveBlock(parser, context)
+{
+	private const string SupportedRegistrySchemaVersion = "1";
+
+	public override string Directive => "storybook";
+
+	public string? Project { get; private set; }
+
+	public string? Storybook { get; private set; }
+
+	public string? DocsId { get; private set; }
+
+	public string? StoryId { get; private set; }
+
+	public string? StoryUrl { get; private set; }
+
+	public string? InlineEntry { get; private set; }
+
+	public string? InlineBootstrapJson { get; private set; }
+
+	public int Height { get; private set; } = 400;
+
+	public string IframeTitle { get; private set; } = "Storybook story";
+
+	public bool HasInlineStory => !string.IsNullOrWhiteSpace(InlineEntry);
+
+	public override void FinalizeAndValidate(ParserContext context)
+	{
+		if (!string.IsNullOrWhiteSpace(Arguments))
+			this.EmitWarning("storybook directive ignores positional arguments. Use properties instead.");
+
+		var reference = ResolveReference();
+		if (reference is null)
+			return;
+
+		if (!TryLoadRegistry(out var registry))
+			return;
+
+		var story = FindStory(registry, reference);
+		if (story is null)
+		{
+			this.EmitError($"storybook registry does not contain id '{reference.RawId}'.");
+			return;
+		}
+
+		if (string.IsNullOrWhiteSpace(story.RenderMode) || !IsSupportedRenderMode(story.RenderMode))
+		{
+			this.EmitError($"storybook registry id '{reference.RawId}' has unsupported renderMode '{story.RenderMode}'.");
+			return;
+		}
+
+		if (string.IsNullOrWhiteSpace(story.DocsId) || string.IsNullOrWhiteSpace(story.StorybookId))
+		{
+			this.EmitError($"storybook registry id '{reference.RawId}' requires docsId and storybookId.");
+			return;
+		}
+
+		if (story.Iframe is null || string.IsNullOrWhiteSpace(story.Iframe.Url))
+		{
+			this.EmitError($"storybook registry id '{reference.RawId}' requires iframe.url.");
+			return;
+		}
+
+		Project = reference.Project;
+		Storybook = reference.Storybook ?? story.Alias;
+		DocsId = story.DocsId;
+		StoryId = story.StorybookId;
+		StoryUrl = ResolveRegistryUrl(registry.BaseUrl, story.Iframe.Url);
+		Height = story.Height ?? Height;
+
+		if (story.RenderMode.Equals("inline", StringComparison.OrdinalIgnoreCase) && !string.IsNullOrWhiteSpace(story.Inline?.Entry))
+		{
+			InlineEntry = ResolveRegistryUrl(registry.BaseUrl, story.Inline.Entry);
+			if (story.Inline.Bootstrap is not null)
+				InlineBootstrapJson = SerializeBootstrap(registry.BaseUrl, story.Inline.Bootstrap);
+		}
+
+		var rawHeight = Prop("height");
+		if (!string.IsNullOrWhiteSpace(rawHeight))
+		{
+			if (int.TryParse(rawHeight.Trim(), out var parsedHeight) && parsedHeight > 0)
+				Height = parsedHeight;
+			else
+				this.EmitWarning($"storybook directive :height: must be a positive integer. Got '{rawHeight}', using default {Height}px.");
+		}
+
+		var rawTitle = Prop("title");
+		if (!string.IsNullOrWhiteSpace(rawTitle))
+			IframeTitle = rawTitle.Trim();
+	}
+
+	private StoryReference? ResolveReference()
+	{
+		var rawId = Prop("id")?.Trim();
+		var project = Prop("project")?.Trim();
+		var storybook = Prop("storybook")?.Trim();
+		var component = Prop("component")?.Trim();
+		var story = Prop("story")?.Trim();
+
+		if (!string.IsNullOrWhiteSpace(rawId))
+			return StoryReference.FromId(rawId, project, storybook, component, story);
+
+		if (string.IsNullOrWhiteSpace(project))
+		{
+			this.EmitError("storybook directive requires :id: or :project:.");
+			return null;
+		}
+
+		if (string.IsNullOrWhiteSpace(storybook))
+		{
+			this.EmitError("storybook directive requires :id: or :storybook:.");
+			return null;
+		}
+
+		if (string.IsNullOrWhiteSpace(story))
+		{
+			this.EmitError("storybook directive requires :id: or :story:.");
+			return null;
+		}
+
+		var docsId = string.IsNullOrWhiteSpace(component) ? story : $"{component}--{story}";
+		return new StoryReference(project, storybook, docsId, component, story, $"{project}:{storybook}:{docsId}");
+	}
+
+	private bool TryLoadRegistry(out StorybookRegistry registry)
+	{
+		registry = new StorybookRegistry();
+
+		var rawRegistry = Build.Configuration.StorybookRegistry;
+		if (string.IsNullOrWhiteSpace(rawRegistry))
+		{
+			this.EmitError("storybook directive requires docset.yml storybook.registry.");
+			return false;
+		}
+
+		try
+		{
+			var registryJson = ReadRegistry(rawRegistry);
+			return TryDeserializeRegistry(rawRegistry, registryJson, out registry);
+		}
+		catch (Exception e)
+		{
+			this.EmitError($"storybook registry could not be read: {rawRegistry}", e);
+			return false;
+		}
+	}
+
+	private string ReadRegistry(string rawRegistry)
+	{
+		if (Uri.TryCreate(rawRegistry, UriKind.Absolute, out var uri) && uri.Scheme is "http" or "https")
+		{
+			using var handler = new HttpClientHandler { AutomaticDecompression = DecompressionMethods.All };
+			using var http = new HttpClient(handler);
+			return http.GetStringAsync(uri).GetAwaiter().GetResult();
+		}
+
+		var registryPath = Path.IsPathRooted(rawRegistry)
+			? rawRegistry
+			: Build.ReadFileSystem.Path.Combine(Build.DocumentationSourceDirectory.FullName, rawRegistry);
+		return Build.ReadFileSystem.File.ReadAllText(registryPath);
+	}
+
+	private bool TryDeserializeRegistry(string rawRegistryPath, string registryJson, out StorybookRegistry registry)
+	{
+		registry = new StorybookRegistry();
+		try
+		{
+			registry = JsonSerializer.Deserialize(registryJson, StorybookRegistryJsonContext.Default.StorybookRegistry)!;
+		}
+		catch (JsonException e)
+		{
+			this.EmitError($"storybook registry could not be parsed: {rawRegistryPath}", e);
+			return false;
+		}
+
+		if (registry is null || registry.Stories.Count == 0)
+		{
+			this.EmitError($"storybook registry is empty: {rawRegistryPath}");
+			return false;
+		}
+
+		var schemaVersion = RegistrySchemaVersion(registry.SchemaVersion);
+		if (!schemaVersion.Equals(SupportedRegistrySchemaVersion, StringComparison.Ordinal))
+		{
+			this.EmitError($"storybook registry schemaVersion '{schemaVersion}' is not supported. Expected '{SupportedRegistrySchemaVersion}'.");
+			return false;
+		}
+
+		return true;
+	}
+
+	private static string RegistrySchemaVersion(JsonElement schemaVersion) =>
+		schemaVersion.ValueKind switch
+		{
+			JsonValueKind.Number => schemaVersion.GetRawText(),
+			JsonValueKind.String => schemaVersion.GetString() ?? string.Empty,
+			_ => string.Empty
+		};
+
+	private static StorybookRegistryStory? FindStory(StorybookRegistry registry, StoryReference reference)
+	{
+		if (registry.Stories.TryGetValue(reference.RawId, out var rawMatch))
+			return rawMatch;
+
+		var namespacedId = $"{reference.Project}:{reference.Storybook}:{reference.DocsId}";
+		if (registry.Stories.TryGetValue(namespacedId, out var namespacedMatch))
+			return namespacedMatch;
+
+		var matches = registry.Stories
+			.Where(story => MatchesReferenceScope(story.Key, story.Value, reference))
+			.Select(story => story.Value)
+			.Where(story =>
+				story.DocsId?.Equals(reference.DocsId, StringComparison.OrdinalIgnoreCase) == true
+				|| story.StorybookId?.Equals(reference.DocsId, StringComparison.OrdinalIgnoreCase) == true)
+			.ToArray();
+
+		return matches.Length == 1 ? matches[0] : null;
+	}
+
+	private static bool MatchesReferenceScope(string registryId, StorybookRegistryStory story, StoryReference reference)
+	{
+		var parts = registryId.Split(':', 3, StringSplitOptions.TrimEntries);
+		if (!string.IsNullOrWhiteSpace(reference.Project) && (parts.Length != 3 || !parts[0].Equals(reference.Project, StringComparison.OrdinalIgnoreCase)))
+			return false;
+
+		if (string.IsNullOrWhiteSpace(reference.Storybook))
+			return true;
+
+		var registryStorybook = parts.Length == 3 ? parts[1] : story.Alias;
+		return registryStorybook?.Equals(reference.Storybook, StringComparison.OrdinalIgnoreCase) == true
+			|| story.Alias?.Equals(reference.Storybook, StringComparison.OrdinalIgnoreCase) == true;
+	}
+
+	private static bool IsSupportedRenderMode(string renderMode) =>
+		renderMode.Equals("inline", StringComparison.OrdinalIgnoreCase) || renderMode.Equals("iframe", StringComparison.OrdinalIgnoreCase);
+
+	private static string SerializeBootstrap(string? baseUrl, StorybookRegistryBootstrap bootstrap)
+	{
+		var resolvedBootstrap = new StorybookRegistryBootstrap
+		{
+			PublicPath = ResolveRegistryUrl(baseUrl, bootstrap.PublicPath),
+			Scripts = bootstrap.Scripts.Select(script => ResolveRegistryUrl(baseUrl, script)!).ToArray(),
+			Styles = bootstrap.Styles.Select(style => ResolveRegistryUrl(baseUrl, style)!).ToArray()
+		};
+		return JsonSerializer.Serialize(resolvedBootstrap, StorybookRegistryJsonContext.Default.StorybookRegistryBootstrap);
+	}
+
+	private static string? ResolveRegistryUrl(string? baseUrl, string? rawUrl)
+	{
+		if (string.IsNullOrWhiteSpace(rawUrl))
+			return rawUrl;
+
+		var trimmed = rawUrl.Trim();
+		if (Uri.TryCreate(trimmed, UriKind.Absolute, out _))
+			return trimmed;
+
+		if (!string.IsNullOrWhiteSpace(baseUrl) && Uri.TryCreate(baseUrl, UriKind.Absolute, out var baseUri))
+			return new Uri(baseUri, trimmed).ToString();
+
+		return trimmed;
+	}
+
+	private sealed record StoryReference(string? Project, string? Storybook, string DocsId, string? Component, string? StoryName, string RawId)
+	{
+		public static StoryReference FromId(string rawId, string? project, string? storybook, string? component, string? story)
+		{
+			var parts = rawId.Split(':', 3, StringSplitOptions.TrimEntries);
+			if (parts.Length == 3)
+				return new StoryReference(parts[0], parts[1], parts[2], component, story, rawId);
+
+			return new StoryReference(project, storybook, rawId, component, story, rawId);
+		}
+	}
+}

--- a/src/Elastic.Markdown/Myst/Directives/Storybook/StorybookRegistry.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Storybook/StorybookRegistry.cs
@@ -1,0 +1,90 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Elastic.Markdown.Myst.Directives.Storybook;
+
+public sealed class StorybookRegistry
+{
+	[JsonPropertyName("schemaVersion")]
+	public JsonElement SchemaVersion { get; init; }
+
+	[JsonPropertyName("producer")]
+	public string? Producer { get; init; }
+
+	[JsonPropertyName("baseUrl")]
+	public string? BaseUrl { get; init; }
+
+	[JsonPropertyName("build")]
+	public Dictionary<string, JsonElement>? Build { get; init; }
+
+	[JsonPropertyName("stories")]
+	public Dictionary<string, StorybookRegistryStory> Stories { get; init; } = new(StringComparer.Ordinal);
+}
+
+public sealed class StorybookRegistryStory
+{
+	[JsonPropertyName("alias")]
+	public string? Alias { get; init; }
+
+	[JsonPropertyName("docsId")]
+	public string? DocsId { get; init; }
+
+	[JsonPropertyName("storybookId")]
+	public string? StorybookId { get; init; }
+
+	[JsonPropertyName("title")]
+	public string? Title { get; init; }
+
+	[JsonPropertyName("name")]
+	public string? Name { get; init; }
+
+	[JsonPropertyName("height")]
+	public int? Height { get; init; }
+
+	[JsonPropertyName("renderMode")]
+	public string? RenderMode { get; init; }
+
+	[JsonPropertyName("inline")]
+	public StorybookRegistryInline? Inline { get; init; }
+
+	[JsonPropertyName("iframe")]
+	public StorybookRegistryIframe? Iframe { get; init; }
+}
+
+public sealed class StorybookRegistryIframe
+{
+	[JsonPropertyName("url")]
+	public string? Url { get; init; }
+}
+
+public sealed class StorybookRegistryInline
+{
+	[JsonPropertyName("entry")]
+	public string? Entry { get; init; }
+
+	[JsonPropertyName("bundleId")]
+	public string? BundleId { get; init; }
+
+	[JsonPropertyName("bootstrap")]
+	public StorybookRegistryBootstrap? Bootstrap { get; init; }
+}
+
+public sealed class StorybookRegistryBootstrap
+{
+	[JsonPropertyName("publicPath")]
+	public string? PublicPath { get; init; }
+
+	[JsonPropertyName("scripts")]
+	public IReadOnlyCollection<string> Scripts { get; init; } = [];
+
+	[JsonPropertyName("styles")]
+	public IReadOnlyCollection<string> Styles { get; init; } = [];
+}
+
+[JsonSerializable(typeof(StorybookRegistry))]
+[JsonSerializable(typeof(StorybookRegistryBootstrap))]
+internal sealed partial class StorybookRegistryJsonContext : JsonSerializerContext;

--- a/src/Elastic.Markdown/Myst/Directives/Storybook/StorybookRegistry.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Storybook/StorybookRegistry.cs
@@ -22,7 +22,7 @@ public sealed class StorybookRegistry
 	public Dictionary<string, JsonElement>? Build { get; init; }
 
 	[JsonPropertyName("stories")]
-	public Dictionary<string, StorybookRegistryStory> Stories { get; init; } = new(StringComparer.Ordinal);
+	public Dictionary<string, StorybookRegistryStory> Stories { get; init; } = [with(StringComparer.Ordinal)];
 }
 
 public sealed class StorybookRegistryStory

--- a/src/Elastic.Markdown/Myst/Directives/Storybook/StorybookView.cshtml
+++ b/src/Elastic.Markdown/Myst/Directives/Storybook/StorybookView.cshtml
@@ -14,6 +14,7 @@ else
 		src="@Model.StoryUrl"
 		title="@Model.IframeTitle"
 		style="width:100%;height:@Model.HeightStyle;border:none;"
+		sandbox="allow-scripts allow-same-origin"
 		loading="lazy"></iframe>
 }
 	@if (Model.HasBody)

--- a/src/Elastic.Markdown/Myst/Directives/Storybook/StorybookView.cshtml
+++ b/src/Elastic.Markdown/Myst/Directives/Storybook/StorybookView.cshtml
@@ -1,0 +1,25 @@
+@inherits RazorSlice<Elastic.Markdown.Myst.Directives.Storybook.StorybookViewModel>
+<div class="storybook-embed">
+@if (Model.HasInlineStory)
+{
+<storybook-story
+	story-id="@Model.StoryId"
+	entry="@Model.InlineEntry"
+	bootstrap="@Model.InlineBootstrapJson">
+</storybook-story>
+}
+else
+{
+	<iframe
+		src="@Model.StoryUrl"
+		title="@Model.IframeTitle"
+		style="width:100%;height:@Model.HeightStyle;border:none;"
+		loading="lazy"></iframe>
+}
+	@if (Model.HasBody)
+	{
+		<div class="storybook-embed-body">
+			@Model.RenderBlock()
+		</div>
+	}
+</div>

--- a/src/Elastic.Markdown/Myst/Directives/Storybook/StorybookViewModel.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Storybook/StorybookViewModel.cs
@@ -1,0 +1,26 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic.Markdown.Myst.Directives.Storybook;
+
+public class StorybookViewModel : DirectiveViewModel
+{
+	public required string StoryUrl { get; init; }
+
+	public required string StoryId { get; init; }
+
+	public required int Height { get; init; }
+
+	public required string IframeTitle { get; init; }
+
+	public bool HasBody { get; init; }
+
+	public string? InlineEntry { get; init; }
+
+	public string? InlineBootstrapJson { get; init; }
+
+	public bool HasInlineStory => !string.IsNullOrWhiteSpace(InlineEntry);
+
+	public string HeightStyle => $"{Height}px";
+}

--- a/src/Elastic.Markdown/Myst/Renderers/LlmMarkdown/LlmBlockRenderers.cs
+++ b/src/Elastic.Markdown/Myst/Renderers/LlmMarkdown/LlmBlockRenderers.cs
@@ -874,10 +874,11 @@ public class LlmDirectiveRenderer : MarkdownObjectRenderer<LlmMarkdownRenderer, 
 			return;
 
 		renderer.EnsureBlockSpacing();
+		var src = WebUtility.HtmlEncode(LlmRenderingHelpers.MakeAbsoluteUrl(renderer, block.StoryUrl));
 		renderer.Writer.Write("<storybook");
-		renderer.Writer.Write($" src=\"{LlmRenderingHelpers.MakeAbsoluteUrl(renderer, block.StoryUrl)}\"");
+		renderer.Writer.Write($" src=\"{src}\"");
 		renderer.Writer.Write($" height=\"{block.Height}\"");
-		renderer.Writer.Write($" title=\"{block.IframeTitle}\"");
+		renderer.Writer.Write($" title=\"{WebUtility.HtmlEncode(block.IframeTitle)}\"");
 		renderer.Writer.WriteLine(">");
 		if (block.Count > 0)
 			WriteChildrenWithIndentation(renderer, block, "  ");

--- a/src/Elastic.Markdown/Myst/Renderers/LlmMarkdown/LlmBlockRenderers.cs
+++ b/src/Elastic.Markdown/Myst/Renderers/LlmMarkdown/LlmBlockRenderers.cs
@@ -874,11 +874,14 @@ public class LlmDirectiveRenderer : MarkdownObjectRenderer<LlmMarkdownRenderer, 
 			return;
 
 		renderer.EnsureBlockSpacing();
-		var src = WebUtility.HtmlEncode(LlmRenderingHelpers.MakeAbsoluteUrl(renderer, block.StoryUrl));
 		renderer.Writer.Write("<storybook");
-		renderer.Writer.Write($" src=\"{src}\"");
-		renderer.Writer.Write($" height=\"{block.Height}\"");
 		renderer.Writer.Write($" title=\"{WebUtility.HtmlEncode(block.IframeTitle)}\"");
+		if (!string.IsNullOrWhiteSpace(block.Project))
+			renderer.Writer.Write($" project=\"{WebUtility.HtmlEncode(block.Project)}\"");
+		if (!string.IsNullOrWhiteSpace(block.Storybook))
+			renderer.Writer.Write($" storybook=\"{WebUtility.HtmlEncode(block.Storybook)}\"");
+		if (!string.IsNullOrWhiteSpace(block.StoryId))
+			renderer.Writer.Write($" story-id=\"{WebUtility.HtmlEncode(block.StoryId)}\"");
 		renderer.Writer.WriteLine(">");
 		if (block.Count > 0)
 			WriteChildrenWithIndentation(renderer, block, "  ");

--- a/src/Elastic.Markdown/Myst/Renderers/LlmMarkdown/LlmBlockRenderers.cs
+++ b/src/Elastic.Markdown/Myst/Renderers/LlmMarkdown/LlmBlockRenderers.cs
@@ -882,6 +882,7 @@ public class LlmDirectiveRenderer : MarkdownObjectRenderer<LlmMarkdownRenderer, 
 			renderer.Writer.Write($" storybook=\"{WebUtility.HtmlEncode(block.Storybook)}\"");
 		if (!string.IsNullOrWhiteSpace(block.StoryId))
 			renderer.Writer.Write($" story-id=\"{WebUtility.HtmlEncode(block.StoryId)}\"");
+		renderer.Writer.Write($" src=\"{WebUtility.HtmlEncode(LlmRenderingHelpers.MakeAbsoluteUrl(renderer, block.StoryUrl) ?? block.StoryUrl)}\"");
 		renderer.Writer.WriteLine(">");
 		if (block.Count > 0)
 			WriteChildrenWithIndentation(renderer, block, "  ");

--- a/src/Elastic.Markdown/Myst/Renderers/LlmMarkdown/LlmBlockRenderers.cs
+++ b/src/Elastic.Markdown/Myst/Renderers/LlmMarkdown/LlmBlockRenderers.cs
@@ -15,6 +15,7 @@ using Elastic.Markdown.Myst.Directives.Image;
 using Elastic.Markdown.Myst.Directives.Include;
 using Elastic.Markdown.Myst.Directives.Math;
 using Elastic.Markdown.Myst.Directives.Settings;
+using Elastic.Markdown.Myst.Directives.Storybook;
 using Markdig.Extensions.DefinitionLists;
 using Markdig.Extensions.Tables;
 using Markdig.Extensions.Yaml;
@@ -496,6 +497,9 @@ public class LlmDirectiveRenderer : MarkdownObjectRenderer<LlmMarkdownRenderer, 
 			case AgentSkillBlock agentSkillBlock:
 				WriteAgentSkillBlock(renderer, agentSkillBlock);
 				return;
+			case StorybookBlock storybookBlock:
+				WriteStorybookBlock(renderer, storybookBlock);
+				return;
 		}
 
 		// Ensure single empty line before directive
@@ -861,6 +865,23 @@ public class LlmDirectiveRenderer : MarkdownObjectRenderer<LlmMarkdownRenderer, 
 		if (block.Count > 0)
 			WriteChildrenWithIndentation(renderer, block, "  ");
 		renderer.Writer.WriteLine("</agent-skill>");
+		renderer.EnsureLine();
+	}
+
+	private static void WriteStorybookBlock(LlmMarkdownRenderer renderer, StorybookBlock block)
+	{
+		if (string.IsNullOrEmpty(block.StoryUrl))
+			return;
+
+		renderer.EnsureBlockSpacing();
+		renderer.Writer.Write("<storybook");
+		renderer.Writer.Write($" src=\"{LlmRenderingHelpers.MakeAbsoluteUrl(renderer, block.StoryUrl)}\"");
+		renderer.Writer.Write($" height=\"{block.Height}\"");
+		renderer.Writer.Write($" title=\"{block.IframeTitle}\"");
+		renderer.Writer.WriteLine(">");
+		if (block.Count > 0)
+			WriteChildrenWithIndentation(renderer, block, "  ");
+		renderer.Writer.WriteLine("</storybook>");
 		renderer.EnsureLine();
 	}
 

--- a/tests/Elastic.Markdown.Tests/Directives/DirectiveBaseTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/DirectiveBaseTests.cs
@@ -67,7 +67,7 @@ $"""
 
 		var root = FileSystem.DirectoryInfo.New(Path.Join(Paths.WorkingDirectoryRoot.FullName, "docs/"));
 		// ReSharper disable once VirtualMemberCallInConstructor
-		FileSystem.GenerateDocSetYaml(root, products: GetDocsetProducts());
+		FileSystem.GenerateDocSetYaml(root, products: GetDocsetProducts(), extraYaml: GetDocsetExtraYaml());
 
 		Collector = new TestDiagnosticsCollector(output);
 		var configurationContext = TestHelpers.CreateConfigurationContext(FileSystem);
@@ -86,6 +86,8 @@ $"""
 	/// Returns null by default (no products configured).
 	/// </summary>
 	protected virtual IReadOnlyList<string>? GetDocsetProducts() => null;
+
+	protected virtual string? GetDocsetExtraYaml() => null;
 
 	public virtual async ValueTask InitializeAsync()
 	{

--- a/tests/Elastic.Markdown.Tests/Directives/StorybookTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/StorybookTests.cs
@@ -1,0 +1,245 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions.TestingHelpers;
+using Elastic.Documentation.Diagnostics;
+using Elastic.Markdown.Myst.Directives.Storybook;
+using FluentAssertions;
+
+namespace Elastic.Markdown.Tests.Directives;
+
+public abstract class StorybookRegistryTest(ITestOutputHelper output, string content) : DirectiveTest<StorybookBlock>(output, content)
+{
+	protected override void AddToFileSystem(MockFileSystem fileSystem) =>
+		fileSystem.AddFile("docs/docs_registry.json", new MockFileData(RegistryJson));
+
+	protected override string? GetDocsetExtraYaml() =>
+"""
+storybook:
+  registry: docs_registry.json
+""";
+
+	private const string RegistryJson =
+		"""
+		{
+		  "schemaVersion": 1,
+		  "producer": "kibana-storybook",
+		  "baseUrl": "http://127.0.0.1:6007/storybook-docs",
+		  "build": {
+		    "commit": "abc123",
+		    "branch": "storybook-to-docs"
+		  },
+		  "stories": {
+		    "kibana:shared_ux:ai-components-aibutton--default": {
+		      "alias": "shared_ux",
+		      "docsId": "ai-components-aibutton--default",
+		      "storybookId": "ai-components-aibutton--default",
+		      "title": "ai-components/aibutton",
+		      "name": "Default",
+		      "height": 360,
+		      "type": "story",
+		      "renderMode": "inline",
+		      "inline": {
+		        "entry": "http://127.0.0.1:6007/storybook-docs/shared_ux/registry.js",
+		        "bundleId": "shared_ux",
+		        "bootstrap": {
+		          "publicPath": "http://127.0.0.1:6007/storybook/shared_ux/",
+		          "scripts": [
+		            "http://127.0.0.1:6007/storybook/shared_ux/kbn-ui-shared-deps-npm.dll.js",
+		            "http://127.0.0.1:6007/storybook/shared_ux/kbn-ui-shared-deps-src.js"
+		          ],
+		          "styles": [
+		            "http://127.0.0.1:6007/storybook/shared_ux/kbn-ui-shared-deps-src.css",
+		            "https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap"
+		          ]
+		        }
+		      },
+		      "iframe": {
+		        "url": "http://127.0.0.1:6007/storybook/shared_ux/iframe.html?id=ai-components-aibutton--default&viewMode=story"
+		      }
+		    },
+		    "kibana:shared_ux:components-callout--info": {
+		      "alias": "shared_ux",
+		      "docsId": "components-callout--info",
+		      "storybookId": "components-callout--info-storybook",
+		      "title": "components-callout",
+		      "name": "Info",
+		      "type": "story",
+		      "renderMode": "iframe",
+		      "iframe": {
+		        "url": "http://127.0.0.1:6007/storybook/shared_ux/iframe.html?id=components-callout--info-storybook&viewMode=story"
+		      }
+		    }
+		  }
+		}
+		""";
+}
+
+public class StorybookInlineIdTests(ITestOutputHelper output) : StorybookRegistryTest(output,
+"""
+:::{storybook}
+:id: kibana:shared_ux:ai-components-aibutton--default
+:title: AI Button / Default story
+:::
+"""
+)
+{
+	[Fact]
+	public void ResolvesStory()
+	{
+		Block!.Project.Should().Be("kibana");
+		Block.Storybook.Should().Be("shared_ux");
+		Block.DocsId.Should().Be("ai-components-aibutton--default");
+		Block.StoryId.Should().Be("ai-components-aibutton--default");
+		Block.InlineEntry.Should().Be("http://127.0.0.1:6007/storybook-docs/shared_ux/registry.js");
+		Block.StoryUrl.Should().Be("http://127.0.0.1:6007/storybook/shared_ux/iframe.html?id=ai-components-aibutton--default&viewMode=story");
+		Block.Height.Should().Be(360);
+	}
+
+	[Fact]
+	public void RendersInlineStory()
+	{
+		Html.Should().Contain("<storybook-story");
+		Html.Should().Contain("story-id=\"ai-components-aibutton--default\"");
+		Html.Should().Contain("entry=\"http://127.0.0.1:6007/storybook-docs/shared_ux/registry.js\"");
+		Html.Should().Contain("http://127.0.0.1:6007/storybook/shared_ux/kbn-ui-shared-deps-src.css");
+		Html.Should().Contain("https://fonts.googleapis.com");
+		Html.Should().NotContain("kibana:shared_ux:ai-components-aibutton--default");
+	}
+}
+
+public class StorybookStructuredReferenceTests(ITestOutputHelper output) : StorybookRegistryTest(output,
+"""
+:::{storybook}
+:project: kibana
+:storybook: shared_ux
+:component: ai-components-aibutton
+:story: default
+:::
+"""
+)
+{
+	[Fact]
+	public void ResolvesComponentAndStory() =>
+		Block!.StoryId.Should().Be("ai-components-aibutton--default");
+}
+
+public class StorybookStructuredReferenceWrongStorybookTests(ITestOutputHelper output) : StorybookRegistryTest(output,
+"""
+:::{storybook}
+:project: kibana
+:storybook: content_management
+:story: ai-components-aibutton--default
+:::
+"""
+)
+{
+	[Fact]
+	public void DoesNotFallbackToAnotherStorybook() =>
+		Collector.Diagnostics.Should().Contain(d => d.Message.Contains("does not contain id 'kibana:content_management:ai-components-aibutton--default'"));
+}
+
+public class StorybookBareIdTests(ITestOutputHelper output) : StorybookRegistryTest(output,
+"""
+:::{storybook}
+:id: ai-components-aibutton--default
+:::
+"""
+)
+{
+	[Fact]
+	public void ResolvesFromConfiguredRegistry() =>
+		Block!.StoryId.Should().Be("ai-components-aibutton--default");
+}
+
+public class StorybookIframeTests(ITestOutputHelper output) : StorybookRegistryTest(output,
+"""
+:::{storybook}
+:id: kibana:shared_ux:components-callout--info
+:::
+"""
+)
+{
+	[Fact]
+	public void RendersIframeFallback()
+	{
+		Block!.HasInlineStory.Should().BeFalse();
+		Html.Should().Contain("<iframe");
+		Html.Should().Contain("src=\"http://127.0.0.1:6007/storybook/shared_ux/iframe.html?id=components-callout--info-storybook&amp;viewMode=story\"");
+	}
+}
+
+public class StorybookBodyTests(ITestOutputHelper output) : StorybookRegistryTest(output,
+"""
+:::{storybook}
+:id: kibana:shared_ux:components-callout--info
+Supporting details for this story.
+:::
+"""
+)
+{
+	[Fact]
+	public void RendersBodyContent() =>
+		Html.Should().Contain("Supporting details for this story.");
+}
+
+public class StorybookInvalidHeightTests(ITestOutputHelper output) : StorybookRegistryTest(output,
+"""
+:::{storybook}
+:id: kibana:shared_ux:components-callout--info
+:height: tall
+:::
+"""
+)
+{
+	[Fact]
+	public void WarnsAndFallsBackToDefaultHeight()
+	{
+		Block!.Height.Should().Be(400);
+		Collector.Diagnostics.Should().ContainSingle(d =>
+			d.Severity == Severity.Warning
+			&& d.Message.Contains(":height: must be a positive integer"));
+		Html.Should().Contain("height:400px");
+	}
+}
+
+public class StorybookMissingRegistryTests(ITestOutputHelper output) : DirectiveTest<StorybookBlock>(output,
+"""
+:::{storybook}
+:id: kibana:shared_ux:ai-components-aibutton--default
+:::
+"""
+)
+{
+	[Fact]
+	public void EmitsError() =>
+		Collector.Diagnostics.Should().Contain(d => d.Message.Contains("requires docset.yml storybook.registry"));
+}
+
+public class StorybookMissingIdTests(ITestOutputHelper output) : StorybookRegistryTest(output,
+"""
+:::{storybook}
+:::
+"""
+)
+{
+	[Fact]
+	public void EmitsError() =>
+		Collector.Diagnostics.Should().Contain(d => d.Message.Contains("requires :id: or :project:"));
+}
+
+public class StorybookPositionalArgumentWarningTests(ITestOutputHelper output) : StorybookRegistryTest(output,
+"""
+:::{storybook} /storybook/ignored
+:id: kibana:shared_ux:components-callout--info
+:::
+"""
+)
+{
+	[Fact]
+	public void EmitsWarning() =>
+		Collector.Diagnostics.Should().ContainSingle(d =>
+			d.Severity == Severity.Warning
+			&& d.Message.Contains("ignores positional arguments"));
+}

--- a/tests/Elastic.Markdown.Tests/Directives/StorybookTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/StorybookTests.cs
@@ -5,7 +5,7 @@
 using System.IO.Abstractions.TestingHelpers;
 using Elastic.Documentation.Diagnostics;
 using Elastic.Markdown.Myst.Directives.Storybook;
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace Elastic.Markdown.Tests.Directives;
 

--- a/tests/Elastic.Markdown.Tests/Directives/StorybookTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/StorybookTests.cs
@@ -3,9 +3,9 @@
 // See the LICENSE file in the project root for more information
 
 using System.IO.Abstractions.TestingHelpers;
+using AwesomeAssertions;
 using Elastic.Documentation.Diagnostics;
 using Elastic.Markdown.Myst.Directives.Storybook;
-using AwesomeAssertions;
 
 namespace Elastic.Markdown.Tests.Directives;
 
@@ -21,7 +21,8 @@ storybook:
 """;
 
 	private const string RegistryJson =
-		"""
+							 /*lang=json,strict*/
+							 """
 		{
 		  "schemaVersion": 1,
 		  "producer": "kibana-storybook",

--- a/tests/Elastic.Markdown.Tests/MockFileSystemExtensions.cs
+++ b/tests/Elastic.Markdown.Tests/MockFileSystemExtensions.cs
@@ -13,7 +13,8 @@ public static class MockFileSystemExtensions
 		this MockFileSystem fileSystem,
 		IDirectoryInfo root,
 		Dictionary<string, string>? globalVariables = null,
-		IReadOnlyList<string>? products = null)
+		IReadOnlyList<string>? products = null,
+		string? extraYaml = null)
 	{
 		// language=yaml
 		var yaml = new StringWriter();
@@ -46,6 +47,9 @@ public static class MockFileSystemExtensions
 			foreach (var (key, value) in globalVariables)
 				yaml.WriteLine($"  {key}: {value}");
 		}
+
+		if (!string.IsNullOrWhiteSpace(extraYaml))
+			yaml.WriteLine(extraYaml.Trim());
 
 		fileSystem.AddFile(Path.Join(root.FullName, "docset.yml"), new MockFileData(yaml.ToString()));
 	}

--- a/tests/authoring/Blocks/Storybook.fs
+++ b/tests/authoring/Blocks/Storybook.fs
@@ -1,0 +1,26 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+module ``AuthoringTests``.``block elements``.``storybook elements``
+
+open Xunit
+open authoring
+
+type ``storybook missing reference`` () =
+    static let markdown = Setup.Markdown """
+:::{storybook}
+:::
+"""
+
+    [<Fact>]
+    let ``has error`` () = markdown |> hasError "requires :id: or :project:"
+
+type ``storybook missing registry`` () =
+    static let markdown = Setup.Markdown """
+:::{storybook}
+:id: kibana:shared_ux:components-button--regular
+:::
+"""
+
+    [<Fact>]
+    let ``has error`` () = markdown |> hasError "requires docset.yml storybook.registry"

--- a/tests/authoring/authoring.fsproj
+++ b/tests/authoring/authoring.fsproj
@@ -51,6 +51,7 @@
     <Compile Include="Blocks\Lists.fs"/>
     <Compile Include="Blocks\Admonitions.fs"/>
     <Compile Include="Blocks\AgentSkill.fs"/>
+    <Compile Include="Blocks\Storybook.fs"/>
     <Compile Include="Blocks\ImageBlocks.fs" />
     <Compile Include="Applicability\AppliesToFrontMatter.fs" />
     <Compile Include="Applicability\AppliesToDirective.fs" />


### PR DESCRIPTION
## Summary

This PR adds a first-class `{storybook}` directive that resolves Kibana Storybook stories from a `docs_registry.json` registry and renders them in docs-builder output.

The current integration path is remote-registry based:

1. A docset configures a Storybook registry URL.
2. Markdown references a story by registry ID or by structured story fields.
3. docs-builder resolves the registry entry during Markdown validation.
4. HTML output renders either an iframe fallback or an inline `<storybook-story>` web component.
5. The web component loads Kibana bootstrap assets, imports the registry module, and calls `mountStory(story.storybookId, container)`.

## Authoring Model

Docsets configure the registry once:

```yaml
storybook:
  registry: https://ci-artifacts.kibana.dev/storybooks/pr-272388/storybook-docs/docs_registry.json
```

Authors can reference the full registry ID:

```markdown
:::{storybook}
:id: kibana:shared_ux:ai-components-aibutton--default
:::
```

Or split the reference into fields:

```markdown
:::{storybook}
:project: kibana
:storybook: shared_ux
:component: ai-components-aibutton
:story: default
:::
```

The full `kibana:...` ID is only used for registry lookup. Inline rendering passes `story.storybookId` to the runtime mount function.

## Rendering Behavior

For `renderMode: inline` stories with an `inline.entry`, docs-builder renders:

```html
<storybook-story story-id="..." entry="..." bootstrap="..."></storybook-story>
```

The web component sets Kibana public path globals, loads bootstrap styles and scripts once, imports the entry module once, calls `mountStory(storybookId, container)`, and calls `unmountStory(container)` on disconnect.

For `renderMode: iframe`, or when inline data is unavailable, docs-builder renders the registry-provided `iframe.url`.

The browser-side loader includes user-facing error messages for invalid bootstrap data, missing or blocked styles/scripts, missing or CORS-blocked entry modules, unsupported module contracts, and mount-time failures.

## Preview Test

This branch includes a live Storybook syntax page wired to the Kibana PR 272388 CI artifacts so the docs-builder PR preview can test module loading from the allowed `https://docs-v3-preview.elastic.dev` origin.

After the preview build finishes, test:

```text
https://docs-v3-preview.elastic.dev/elastic/docs-builder/pull/2910/syntax/storybook
```

Expected browser behavior:

- `registry.js` loads from `https://ci-artifacts.kibana.dev/storybooks/pr-272388/storybook-docs/shared_ux/registry.js`.
- bootstrap CSS and JS load from the Kibana Storybook artifact paths.
- the inline story mounts through `mountStory("ai-components-aibutton--default", container)`.
- no Storybook embed error is shown.

Localhost is not expected to complete the dynamic module import unless the artifact server also allows the local origin. The server-side registry fetch and rendering path can still be tested locally.

## Validation

Run against the staged commit:

```sh
env DOTNET_CLI_HOME=/tmp/dotnet-cli dotnet test tests/Elastic.Markdown.Tests/Elastic.Markdown.Tests.csproj --filter Storybook -nr:false -m:1
env DOTNET_CLI_HOME=/tmp/dotnet-cli dotnet test tests/authoring/authoring.fsproj --filter Storybook -nr:false -m:1
env DOTNET_CLI_HOME=/tmp/dotnet-cli dotnet build -nr:false -m:1
```

All passed. The build still reports existing NuGet advisory, Browserslist, and frontend deprecation warnings.

> [!NOTE]
> This PR was written with extensive assistance from GPT-5.
