### PR TITLE
fix: support vscode-insiders: and other hyphenated vscode schemes as passthrough

### DIFF
--- a/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
+++ b/src/Elastic.Markdown/Myst/InlineParsers/DiagnosticLinkInlineParser.cs
@@ -464,5 +464,5 @@ public class DiagnosticLinkInlineParser : LinkInlineParser
 
 	private static bool IsPassthroughCustomProtocolScheme(string scheme) =>
 		scheme.Equals("cursor", StringComparison.OrdinalIgnoreCase)
-		|| scheme.Equals("vscode", StringComparison.OrdinalIgnoreCase);
+		|| scheme.StartsWith("vscode", StringComparison.OrdinalIgnoreCase);
 }

--- a/tests/Elastic.Markdown.Tests/Directives/ButtonTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/ButtonTests.cs
@@ -219,6 +219,24 @@ public class ButtonVscodeProtocolTests(ITestOutputHelper output) : DirectiveTest
 	public void EmitsNoErrors() => Collector.Diagnostics.Should().BeEmpty();
 }
 
+public class ButtonVscodeInsidersProtocolTests(ITestOutputHelper output) : DirectiveTest<ButtonBlock>(output,
+"""
+:::{button}
+[Install with VS Code Insiders](vscode-insiders:mcp/install?%7B%22name%22%3A%22oblt-cli%22%7D)
+:::
+"""
+)
+{
+	[Fact]
+	public void ParsesBlock() => Block.Should().NotBeNull();
+
+	[Fact]
+	public void RendersLinkHref() => Html.Should().Contain("href=\"vscode-insiders:");
+
+	[Fact]
+	public void EmitsNoErrors() => Collector.Diagnostics.Should().BeEmpty();
+}
+
 public class ButtonEmptyTests(ITestOutputHelper output) : DirectiveTest<ButtonBlock>(output,
 """
 :::{button}

--- a/tests/Elastic.Markdown.Tests/Inline/InlineLinkTests.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/InlineLinkTests.cs
@@ -378,3 +378,20 @@ public class VscodeProtocolLinkTest(ITestOutputHelper output) : LinkTestBase(out
 	[Fact]
 	public void EmitsNoCrossLinks() => Collector.CrossLinks.Should().HaveCount(0);
 }
+
+public class VscodeInsidersProtocolLinkTest(ITestOutputHelper output) : LinkTestBase(output,
+	"""
+	[Install with VS Code Insiders](vscode-insiders:mcp/install?%7B%22name%22%3A%22oblt-cli%22%7D)
+	"""
+)
+{
+	[Fact]
+	public void GeneratesHtml() =>
+		Html.Should().Contain("""href="vscode-insiders:""");
+
+	[Fact]
+	public void HasNoErrors() => Collector.Diagnostics.Should().HaveCount(0);
+
+	[Fact]
+	public void EmitsNoCrossLinks() => Collector.CrossLinks.Should().HaveCount(0);
+}


### PR DESCRIPTION
## Summary

Extends the custom protocol passthrough fix from #2886 to cover URI schemes containing hyphens, such as `vscode-insiders:`.

### Problem

`IsPassthroughCustomProtocolScheme` used `Equals("vscode")` which missed `vscode-insiders:` — causing the build to fail with:

```
'vscode-insiders' was not found in the cross link index.
Ensure it is listed under 'cross_links' in your docset.yml
```

### Fix

Changed `Equals("vscode")` to `StartsWith("vscode")` — covers `vscode:`, `vscode-insiders:`, and any future VS Code variant schemes without requiring individual entries.

### Tests

Added `ButtonVscodeInsidersProtocolTests` and `VscodeInsidersProtocolLinkTest` alongside the existing `cursor`/`vscode` test cases. All 27 protocol-related tests pass.

Closes #2911
Follows #2886

🤖 Generated with [Claude Code](https://claude.com/claude-code)