### PR TITLE
[DOCS] Add reference info for docset.yml

### DIFF
--- a/docs/_docset.yml
+++ b/docs/_docset.yml
@@ -76,6 +76,7 @@ toc:
       - folder: content-set
         children:
           - file: index.md
+          - file: docset-format.md
           - file: file-structure.md
           - file: attributes.md
           - file: navigation.md

--- a/docs/building-blocks/documentation-set.md
+++ b/docs/building-blocks/documentation-set.md
@@ -41,7 +41,7 @@ my-repo/
 
 ## Configuration
 
-The `docset.yml` file controls how the documentation set is structured and built. See [Content Set Configuration](../configure/content-set/index.md) for complete configuration details.
+The `docset.yml` file controls how the documentation set is structured and built. See [docset.yml format](../configure/content-set/docset-format.md) for the complete field reference, and [Content Set Configuration](../configure/content-set/index.md) for navigation and other details.
 
 ## Related concepts
 

--- a/docs/configure/content-set/docset-format.md
+++ b/docs/configure/content-set/docset-format.md
@@ -1,0 +1,151 @@
+---
+navigation_title: docset.yml format
+---
+
+# docset.yml file format
+
+The `docset.yml` file (or `_docset.yml`) configures a content set's structure and metadata. It defines navigation, cross-links, substitutions, and other content set-level settings. The file is typically located at the root of the documentation folder (for example, `docs/docset.yml` or `docs/_docset.yml`).
+
+For navigation structure and TOC syntax, see [Navigation](./navigation.md). For attributes and substitutions, see [Attributes](./attributes.md).
+
+## Field reference
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `project` | Optional | — | The name of the project. |
+| `toc` | Required | — | Table of contents defining the navigation structure. A minimal docset needs at least one file or folder reference. |
+| `suppress` | Optional | `[]` | Diagnostic hint types to suppress (for example, `DeepLinkingVirtualFile`, `FolderFileNameMismatch`). |
+| `max_toc_depth` | Optional | `2` | Maximum depth of the table of contents. |
+| `dev_docs` | Optional | `false` | When `true`, marks this documentation set as development docs that are not linkable by the assembler. |
+| `cross_links` | Optional | `[]` | Repositories to link to (for example, `docs-content`, `apm-server`). |
+| `exclude` | Optional | `[]` | Glob patterns for files to exclude from the TOC. |
+| `extensions` | Optional | `[]` | Extension configuration. |
+| `subs` | Optional | `{}` | Substitution key-value pairs for consistent terminology across the docset. |
+| `display_name` | Optional | — | **Deprecated.** Use the `index.md` H1 heading instead. |
+| `description` | Optional | — | **Deprecated.** Use the `index.md` frontmatter description instead. |
+| `icon` | Optional | — | Icon identifier for the documentation set. |
+| `registry` | Optional | — | Link index registry (for example, `Public`). |
+| `features` | Optional | `{}` | Feature flags (for example, `primary-nav`, `disable-github-edit-link`). |
+| `api` | Optional | `{}` | OpenAPI specification paths keyed by name. |
+| `products` | Optional | `[]` | Product IDs that this documentation set documents. Used for versioning and other product-aware features. Resolved against [products.yml](https://github.com/elastic/docs-builder/blob/main/config/products.yml). |
+| `codex` | Optional | — | Codex-specific metadata (for example, `group` for navigation grouping). |
+
+## Field details
+
+### `project`
+
+The project name. Used for identification and display.
+
+```yaml
+project: 'APM Java agent reference'
+```
+
+### `toc`
+
+Defines the table of contents. Required for a valid docset. See [Navigation](./navigation.md) for full TOC syntax and structure.
+
+```yaml
+toc:
+  - file: index.md
+  - folder: getting-started
+    children:
+      - file: index.md
+      - file: install.md
+```
+
+### `suppress`
+
+Suppresses specific diagnostic hints. Valid values include `DeepLinkingVirtualFile`, `FolderFileNameMismatch`, and `AutolinkElasticCoDocs`.
+
+```yaml
+suppress:
+  - DeepLinkingVirtualFile
+  - FolderFileNameMismatch
+```
+
+### `cross_links`
+
+Repositories you want to link to. Enables cross-repository links without absolute URLs. See [Navigation](./navigation.md#cross_links) for usage details.
+
+```yaml
+cross_links:
+  - docs-content
+  - apm-server
+  - cloud
+```
+
+### `exclude`
+
+Glob patterns for files to exclude from the TOC.
+
+```yaml
+exclude:
+  - '_*.md'
+```
+
+### `subs`
+
+Substitution key-value pairs. Values can be referenced in Markdown as `{{key}}`. See [Attributes](./attributes.md) for details.
+
+```yaml
+subs:
+  ea: "Elastic Agent"
+  es: "Elasticsearch"
+```
+
+### `features`
+
+Feature flags that control docset behavior.
+
+| Sub-field | Description |
+|-----------|-------------|
+| `primary-nav` | Controls primary navigation display. |
+| `disable-github-edit-link` | Hides the GitHub edit link. |
+
+```yaml
+features:
+  primary-nav: false
+  disable-github-edit-link: false
+```
+
+### `api`
+
+OpenAPI specification file paths, keyed by API name. Paths are relative to the documentation source directory.
+
+```yaml
+api:
+  elasticsearch: elasticsearch-openapi.json
+  kibana: kibana-openapi.json
+```
+
+### `products`
+
+Product IDs that this documentation set documents. Each ID must exist in the global [products.yml](https://github.com/elastic/docs-builder/blob/main/config/products.yml) configuration. When omitted or empty, the docset has no product association.
+
+```yaml
+products:
+  - id: kibana
+```
+
+For a docset that documents multiple products:
+
+```yaml
+products:
+  - id: elasticsearch
+  - id: kibana
+```
+
+### `codex`
+
+Codex-specific metadata. The `group` field controls navigation grouping in codex environments.
+
+```yaml
+codex:
+  group: observability
+```
+
+## Related
+
+* [Navigation](./navigation.md) — TOC structure and cross-links
+* [Attributes](./attributes.md) — Substitutions and attributes
+* [File structure](./file-structure.md) — How content set structure maps to URLs

--- a/docs/configure/content-set/index.md
+++ b/docs/configure/content-set/index.md
@@ -15,6 +15,7 @@ A content set in `docs-builder` is equivalent to an AsciiDoc book. At this level
 
 ## Learn more
 
+* [docset.yml format](./docset-format.md) — Complete reference for all fields, including required vs optional.
 * [File structure](./file-structure.md).
 * [Navigation](./navigation.md).
 * [Attributes](./attributes.md).

--- a/docs/configure/content-set/index.md
+++ b/docs/configure/content-set/index.md
@@ -15,7 +15,7 @@ A content set in `docs-builder` is equivalent to an AsciiDoc book. At this level
 
 ## Learn more
 
-* [docset.yml format](./docset-format.md) — Complete reference for all fields, including required vs optional.
+* [docset.yml format](./docset-format.md) — Complete reference for all fields.
 * [File structure](./file-structure.md).
 * [Navigation](./navigation.md).
 * [Attributes](./attributes.md).

--- a/docs/configure/content-set/navigation.md
+++ b/docs/configure/content-set/navigation.md
@@ -1,6 +1,6 @@
 # Navigation
 
-Two types of nav files are supported: `docset.yml` and `toc.yml`. For a complete list of all `docset.yml` fields and their required/optional status, see [docset.yml format](./docset-format.md).
+Two types of navigation files are supported: `docset.yml` and `toc.yml`. For a complete list of all `docset.yml` fields refer to [docset.yml format](./docset-format.md).
 
 ## `docset.yml`
 

--- a/docs/configure/content-set/navigation.md
+++ b/docs/configure/content-set/navigation.md
@@ -1,6 +1,6 @@
 # Navigation
 
-Two types of nav files are supported: `docset.yml` and `toc.yml`.
+Two types of nav files are supported: `docset.yml` and `toc.yml`. For a complete list of all `docset.yml` fields and their required/optional status, see [docset.yml format](./docset-format.md).
 
 ## `docset.yml`
 


### PR DESCRIPTION
## Summary

Add comprehensive documentation for the `docset.yml` file format in the content-set configuration section, specifying which fields are required vs optional and their purposes.

## Context

The `docset.yml` file (or `_docset.yml`) configures a content set's structure and metadata. Currently, documentation is scattered across [navigation.md](docs/configure/content-set/navigation.md), [building-blocks/documentation-set.md](docs/building-blocks/documentation-set.md), and other pages. There is no single reference that lists all supported fields and their required/optional status. The `products` field, for example, is optional (defaults to empty) but this is not documented.

I identified this gap when I was reviewing https://docs-v3-preview.elastic.dev/elastic/docs-builder/tree/main/syntax/changelog and trying to figure out what product ID defaults that were "auto from docset" were coming from.

## Source of truth

The schema is defined in:

- [TableOfContentsFile.cs](src/Elastic.Documentation.Configuration/Toc/TableOfContentsFile.cs) – base fields: `project`, `toc`, `suppress`
- [DocumentationSetFile.cs](src/Elastic.Documentation.Configuration/Toc/DocumentationSetFile.cs) – extended fields: `max_toc_depth`, `dev_docs`, `cross_links`, `exclude`, `extensions`, `subs`, `display_name`, `description`, `icon`, `registry`, `features`, `api`, `products`, `codex`
- [ConfigurationFile.cs](src/Elastic.Documentation.Configuration/Builder/ConfigurationFile.cs) – how fields are processed (e.g., `products` only applied when `Count > 0`)

## Implementation

- Add [docs/configure/content-set/docset-format.md](docs/configure/content-set/docset-format.md) as the canonical reference for the docset.yml file format.
- Update [docs/configure/content-set/index.md](docs/configure/content-set/index.md) to add a link to the new docset format reference in the "Learn more" section.
- Update [docs/building-blocks/documentation-set.md](docs/building-blocks/documentation-set.md) and [docs/configure/content-set/navigation.md](docs/configure/content-set/navigation.md) to reference the new docset-format.md for the full field list, avoiding duplication.

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: composer-1.5
