### PR TITLE
Increase z-index to avoid display errors against the top bar

### DIFF
--- a/src/Elastic.Documentation.Site/Layout/_IsolatedHeader.cshtml
+++ b/src/Elastic.Documentation.Site/Layout/_IsolatedHeader.cshtml
@@ -1,5 +1,5 @@
 @inherits RazorSlice<Elastic.Documentation.Site.GlobalLayoutViewModel>
-<div class="sticky top-0 z-10 h-12">
+<div class="sticky top-0 z-30 h-12">
 	<elastic-docs-header title="@(Model.HeaderTitle ?? Model.DocSetName)"
 	                     logo-href="@(Model.Link("/"))"
 	                     github-repository="@(Model.GitRepository)"


### PR DESCRIPTION
Fixes #2708

Increasing the z-index allows proper ordering between page elements and the top navigation.