### PR TITLE
Increase git fetch timeout from 10 to 30 minutes in CI

### DIFF
--- a/src/services/Elastic.Documentation.Assembler/Sourcing/GitFacade.cs
+++ b/src/services/Elastic.Documentation.Assembler/Sourcing/GitFacade.cs
@@ -25,7 +25,7 @@ public interface IGitRepository
 // This git repository implementation is optimized for pull and fetching single commits.
 // It uses `git pull --depth 1` and `git fetch --depth 1` to minimize the amount of data transferred.
 public class SingleCommitOptimizedGitRepository(ILoggerFactory logFactory, IDiagnosticsCollector collector, IDirectoryInfo workingDirectory)
-	: ExternalCommandExecutor(collector, workingDirectory, Environment.GetEnvironmentVariable("CI") is null or "" ? null : TimeSpan.FromMinutes(10))
+	: ExternalCommandExecutor(collector, workingDirectory, Environment.GetEnvironmentVariable("CI") is null or "" ? null : TimeSpan.FromMinutes(30))
 		, IGitRepository
 {
 	/// <inheritdoc />


### PR DESCRIPTION
## Summary

- The `SingleCommitOptimizedGitRepository` had a hardcoded 10-minute timeout for git operations when running in CI
- This caused transient failures during `assembler clone` when fetching large repositories (e.g. `integrations`) under slow network conditions
- Increases the timeout to 30 minutes to give fetches more headroom

## Test plan

- [ ] Verify the assembler prod build completes successfully without hitting the timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)