### PR TITLE
Adjust anchoring strategy according to how the title labeling is formed

### DIFF
--- a/src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogBlock.cs
@@ -8,6 +8,7 @@ using Elastic.Documentation.Configuration.ReleaseNotes;
 using Elastic.Documentation.Extensions;
 using Elastic.Documentation.ReleaseNotes;
 using Elastic.Markdown.Diagnostics;
+using Elastic.Markdown.Helpers;
 
 namespace Elastic.Markdown.Myst.Directives.Changelog;
 
@@ -308,6 +309,7 @@ public class ChangelogBlock(DirectiveBlockParser parser, ParserContext context) 
 		foreach (var bundle in LoadedBundles)
 		{
 			var titleSlug = ChangelogTextUtilities.TitleToSlug(bundle.Version);
+			var anchorSlug = titleSlug.Slugify();
 			var repo = bundle.Repo;
 
 			// Group filtered entries by type to determine which sections will exist
@@ -318,38 +320,38 @@ public class ChangelogBlock(DirectiveBlockParser parser, ParserContext context) 
 
 			// Critical sections
 			if (shouldInclude(ChangelogEntryType.BreakingChange) && entriesByType.ContainsKey(ChangelogEntryType.BreakingChange))
-				yield return $"{repo}-{titleSlug}-breaking-changes";
+				yield return $"{repo}-{anchorSlug}-breaking-changes";
 
 			if (shouldInclude(ChangelogEntryType.Security) && entriesByType.ContainsKey(ChangelogEntryType.Security))
-				yield return $"{repo}-{titleSlug}-security";
+				yield return $"{repo}-{anchorSlug}-security";
 
 			if (shouldInclude(ChangelogEntryType.KnownIssue) && entriesByType.ContainsKey(ChangelogEntryType.KnownIssue))
-				yield return $"{repo}-{titleSlug}-known-issues";
+				yield return $"{repo}-{anchorSlug}-known-issues";
 
 			if (shouldInclude(ChangelogEntryType.Deprecation) && entriesByType.ContainsKey(ChangelogEntryType.Deprecation))
-				yield return $"{repo}-{titleSlug}-deprecations";
+				yield return $"{repo}-{anchorSlug}-deprecations";
 
 			// Features and enhancements section
 			if (shouldInclude(ChangelogEntryType.Feature) &&
 				(entriesByType.ContainsKey(ChangelogEntryType.Feature) ||
 				 entriesByType.ContainsKey(ChangelogEntryType.Enhancement)))
-				yield return $"{repo}-{titleSlug}-features-enhancements";
+				yield return $"{repo}-{anchorSlug}-features-enhancements";
 
 			// Fixes section (bug fixes only, security is separate)
 			if (shouldInclude(ChangelogEntryType.BugFix) && entriesByType.ContainsKey(ChangelogEntryType.BugFix))
-				yield return $"{repo}-{titleSlug}-fixes";
+				yield return $"{repo}-{anchorSlug}-fixes";
 
 			// Documentation section
 			if (shouldInclude(ChangelogEntryType.Docs) && entriesByType.ContainsKey(ChangelogEntryType.Docs))
-				yield return $"{repo}-{titleSlug}-docs";
+				yield return $"{repo}-{anchorSlug}-docs";
 
 			// Regressions section
 			if (shouldInclude(ChangelogEntryType.Regression) && entriesByType.ContainsKey(ChangelogEntryType.Regression))
-				yield return $"{repo}-{titleSlug}-regressions";
+				yield return $"{repo}-{anchorSlug}-regressions";
 
 			// Other changes section
 			if (shouldInclude(ChangelogEntryType.Other) && entriesByType.ContainsKey(ChangelogEntryType.Other))
-				yield return $"{repo}-{titleSlug}-other";
+				yield return $"{repo}-{anchorSlug}-other";
 		}
 	}
 
@@ -392,14 +394,19 @@ public class ChangelogBlock(DirectiveBlockParser parser, ParserContext context) 
 		foreach (var bundle in LoadedBundles)
 		{
 			var titleSlug = ChangelogTextUtilities.TitleToSlug(bundle.Version);
+			// Slugify the title slug to match what SectionedHeadingRenderer produces from explicit anchors.
+			// e.g. "9.3.0" -> "9-3-0", "2025-11" -> "2025-11"
+			var anchorSlug = titleSlug.Slugify();
 			var repo = bundle.Repo;
 			var displayVersion = VersionOrDate.FormatDisplayVersion(bundle.Version);
 
-			// Version header
+			// Version header: slug must match what SectionedHeadingRenderer auto-derives from
+			// the display text (since there is no explicit anchor on the version heading).
+			// e.g. "November 2025" -> "november-2025", "9.3.0" -> "9-3-0"
 			yield return new PageTocItem
 			{
 				Heading = displayVersion,
-				Slug = titleSlug,
+				Slug = displayVersion.Slugify(),
 				Level = 2
 			};
 
@@ -414,7 +421,7 @@ public class ChangelogBlock(DirectiveBlockParser parser, ParserContext context) 
 				yield return new PageTocItem
 				{
 					Heading = "Breaking changes",
-					Slug = $"{repo}-{titleSlug}-breaking-changes",
+					Slug = $"{repo}-{anchorSlug}-breaking-changes",
 					Level = 3
 				};
 
@@ -424,7 +431,7 @@ public class ChangelogBlock(DirectiveBlockParser parser, ParserContext context) 
 				yield return new PageTocItem
 				{
 					Heading = "Highlights",
-					Slug = $"{repo}-{titleSlug}-highlights",
+					Slug = $"{repo}-{anchorSlug}-highlights",
 					Level = 3
 				};
 
@@ -436,7 +443,7 @@ public class ChangelogBlock(DirectiveBlockParser parser, ParserContext context) 
 				yield return new PageTocItem
 				{
 					Heading = "Security",
-					Slug = $"{repo}-{titleSlug}-security",
+					Slug = $"{repo}-{anchorSlug}-security",
 					Level = 3
 				};
 
@@ -444,7 +451,7 @@ public class ChangelogBlock(DirectiveBlockParser parser, ParserContext context) 
 				yield return new PageTocItem
 				{
 					Heading = "Known issues",
-					Slug = $"{repo}-{titleSlug}-known-issues",
+					Slug = $"{repo}-{anchorSlug}-known-issues",
 					Level = 3
 				};
 
@@ -452,7 +459,7 @@ public class ChangelogBlock(DirectiveBlockParser parser, ParserContext context) 
 				yield return new PageTocItem
 				{
 					Heading = "Deprecations",
-					Slug = $"{repo}-{titleSlug}-deprecations",
+					Slug = $"{repo}-{anchorSlug}-deprecations",
 					Level = 3
 				};
 
@@ -463,7 +470,7 @@ public class ChangelogBlock(DirectiveBlockParser parser, ParserContext context) 
 				yield return new PageTocItem
 				{
 					Heading = "Features and enhancements",
-					Slug = $"{repo}-{titleSlug}-features-enhancements",
+					Slug = $"{repo}-{anchorSlug}-features-enhancements",
 					Level = 3
 				};
 
@@ -472,7 +479,7 @@ public class ChangelogBlock(DirectiveBlockParser parser, ParserContext context) 
 				yield return new PageTocItem
 				{
 					Heading = "Fixes",
-					Slug = $"{repo}-{titleSlug}-fixes",
+					Slug = $"{repo}-{anchorSlug}-fixes",
 					Level = 3
 				};
 
@@ -481,7 +488,7 @@ public class ChangelogBlock(DirectiveBlockParser parser, ParserContext context) 
 				yield return new PageTocItem
 				{
 					Heading = "Documentation",
-					Slug = $"{repo}-{titleSlug}-docs",
+					Slug = $"{repo}-{anchorSlug}-docs",
 					Level = 3
 				};
 
@@ -490,7 +497,7 @@ public class ChangelogBlock(DirectiveBlockParser parser, ParserContext context) 
 				yield return new PageTocItem
 				{
 					Heading = "Regressions",
-					Slug = $"{repo}-{titleSlug}-regressions",
+					Slug = $"{repo}-{anchorSlug}-regressions",
 					Level = 3
 				};
 
@@ -499,7 +506,7 @@ public class ChangelogBlock(DirectiveBlockParser parser, ParserContext context) 
 				yield return new PageTocItem
 				{
 					Heading = "Other changes",
-					Slug = $"{repo}-{titleSlug}-other",
+					Slug = $"{repo}-{anchorSlug}-other",
 					Level = 3
 				};
 		}

--- a/tests/Elastic.Markdown.Tests/Directives/ChangelogAnchorNavigationTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/ChangelogAnchorNavigationTests.cs
@@ -1,0 +1,415 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions.TestingHelpers;
+using Elastic.Markdown.Myst.Directives.Changelog;
+using FluentAssertions;
+
+namespace Elastic.Markdown.Tests.Directives;
+
+// ── yyyy-MM (Cloud Hosted style) ─────────────────────────────────────────────
+
+/// <summary>
+/// yyyy-MM versions display as "Month Year" (e.g. "November 2025").
+/// The version heading anchor must therefore be the Slugify of the display name
+/// ("november-2025"), NOT the raw key ("2025-11").
+/// </summary>
+public class ChangelogYearMonthAnchorNavigationTests : DirectiveTest<ChangelogBlock>
+{
+	public ChangelogYearMonthAnchorNavigationTests(ITestOutputHelper output) : base(output,
+		// language=markdown
+		"""
+		:::{changelog}
+		:::
+		""") => FileSystem.AddFile("docs/changelog/bundles/2025-11.yaml", new MockFileData(
+			// language=yaml
+			"""
+			products:
+			- product: cloud-hosted
+			  target: 2025-11
+			entries:
+			- title: November feature
+			  type: feature
+			  products:
+			  - product: cloud-hosted
+			    target: 2025-11
+			  prs:
+			  - "111111"
+			- title: November bugfix
+			  type: bug-fix
+			  products:
+			  - product: cloud-hosted
+			    target: 2025-11
+			  prs:
+			  - "222222"
+			"""));
+
+	[Fact]
+	public void VersionHeadingTocSlugIsSlugifiedDisplayName()
+	{
+		var toc = Block!.GeneratedTableOfContent.ToList();
+		var versionItem = toc.Single(t => t.Level == 2);
+
+		// The display name "November 2025" slugified is "november-2025".
+		// It must NOT be the raw yyyy-MM key "2025-11".
+		versionItem.Slug.Should().Be("november-2025");
+		versionItem.Slug.Should().NotBe("2025-11");
+	}
+
+	[Fact]
+	public void VersionHeadingHtmlIdMatchesTocSlug()
+	{
+		var toc = Block!.GeneratedTableOfContent.ToList();
+		var versionItem = toc.Single(t => t.Level == 2);
+
+		Html.Should().Contain($"id=\"{versionItem.Slug}\"",
+			$"heading-wrapper id must match TOC slug '{versionItem.Slug}' so the right-nav link scrolls to the section");
+	}
+
+	[Fact]
+	public void SubSectionTocSlugsHaveMatchingHtmlIds()
+	{
+		var toc = Block!.GeneratedTableOfContent.ToList();
+		foreach (var item in toc.Where(t => t.Level == 3))
+		{
+			Html.Should().Contain($"id=\"{item.Slug}\"",
+				$"sub-section TOC item '{item.Heading}' (slug '{item.Slug}') must have a matching heading-wrapper id");
+		}
+	}
+
+	[Fact]
+	public void AllTocSlugsHaveMatchingHtmlIds()
+	{
+		var toc = Block!.GeneratedTableOfContent.ToList();
+		foreach (var item in toc)
+		{
+			Html.Should().Contain($"id=\"{item.Slug}\"",
+				$"TOC item '{item.Heading}' (slug '{item.Slug}') must have a matching heading-wrapper id in the rendered HTML");
+		}
+	}
+
+	[Fact]
+	public void SubSectionSlugsUseYearMonthKeyNotDisplayName()
+	{
+		// Sub-section explicit anchors embed the raw yyyy-MM key (via titleSlug).
+		// Slugify of "2025-11" is still "2025-11" (already URL-safe), so the
+		// sub-section slugs must contain "2025-11", not "november-2025".
+		var toc = Block!.GeneratedTableOfContent.ToList();
+		foreach (var item in toc.Where(t => t.Level == 3))
+			item.Slug.Should().Contain("2025-11",
+				$"sub-section slug for a yyyy-MM bundle should retain the original date key");
+	}
+}
+
+// ── yyyy-MM-dd (Cloud Serverless style) ──────────────────────────────────────
+
+/// <summary>
+/// Full-date versions display as "Month D, Year" (e.g. "August 5, 2025").
+/// The version heading anchor must be the Slugify of that display name ("august-5-2025").
+/// </summary>
+public class ChangelogFullDateAnchorNavigationTests : DirectiveTest<ChangelogBlock>
+{
+	public ChangelogFullDateAnchorNavigationTests(ITestOutputHelper output) : base(output,
+		// language=markdown
+		"""
+		:::{changelog}
+		:::
+		""") => FileSystem.AddFile("docs/changelog/bundles/2025-08-05.yaml", new MockFileData(
+			// language=yaml
+			"""
+			products:
+			- product: cloud-serverless
+			  target: 2025-08-05
+			entries:
+			- title: August 5th feature
+			  type: feature
+			  products:
+			  - product: cloud-serverless
+			    target: 2025-08-05
+			  prs:
+			  - "111111"
+			- title: August 5th breaking change
+			  type: breaking-change
+			  products:
+			  - product: cloud-serverless
+			    target: 2025-08-05
+			  description: A breaking change.
+			  impact: Some impact.
+			  action: Take action.
+			  prs:
+			  - "222222"
+			"""));
+
+	[Fact]
+	public void VersionHeadingTocSlugIsSlugifiedDisplayName()
+	{
+		var toc = Block!.GeneratedTableOfContent.ToList();
+		var versionItem = toc.Single(t => t.Level == 2);
+
+		// "August 5, 2025" slugified is "august-5-2025"
+		versionItem.Slug.Should().Be("august-5-2025");
+		versionItem.Slug.Should().NotBe("2025-08-05");
+	}
+
+	[Fact]
+	public void VersionHeadingHtmlIdMatchesTocSlug()
+	{
+		var toc = Block!.GeneratedTableOfContent.ToList();
+		var versionItem = toc.Single(t => t.Level == 2);
+
+		Html.Should().Contain($"id=\"{versionItem.Slug}\"",
+			$"heading-wrapper id must match TOC slug '{versionItem.Slug}'");
+	}
+
+	[Fact]
+	public void AllTocSlugsHaveMatchingHtmlIds()
+	{
+		var toc = Block!.GeneratedTableOfContent.ToList();
+		foreach (var item in toc)
+		{
+			Html.Should().Contain($"id=\"{item.Slug}\"",
+				$"TOC item '{item.Heading}' (slug '{item.Slug}') must have a matching heading-wrapper id");
+		}
+	}
+}
+
+// ── Semver (standard Elasticsearch / Kibana style) ───────────────────────────
+
+/// <summary>
+/// Semver versions display unchanged (e.g. "9.3.0").  However dots are not
+/// valid in URL anchors produced by <c>SlugHelper</c>, which converts them to
+/// dashes.  The TOC slug and heading-wrapper id must therefore both be "9-3-0",
+/// not "9.3.0".
+/// </summary>
+public class ChangelogSemverAnchorNavigationTests : DirectiveTest<ChangelogBlock>
+{
+	public ChangelogSemverAnchorNavigationTests(ITestOutputHelper output) : base(output,
+		// language=markdown
+		"""
+		:::{changelog}
+		:::
+		""") => FileSystem.AddFile("docs/changelog/bundles/9.3.0.yaml", new MockFileData(
+			// language=yaml
+			"""
+			products:
+			- product: elasticsearch
+			  target: 9.3.0
+			entries:
+			- title: New search feature
+			  type: feature
+			  products:
+			  - product: elasticsearch
+			    target: 9.3.0
+			  prs:
+			  - "111111"
+			- title: Security fix
+			  type: security
+			  products:
+			  - product: elasticsearch
+			    target: 9.3.0
+			  prs:
+			  - "222222"
+			- title: Breaking API change
+			  type: breaking-change
+			  products:
+			  - product: elasticsearch
+			    target: 9.3.0
+			  description: This breaks things.
+			  impact: You will notice.
+			  action: Do this.
+			  prs:
+			  - "333333"
+			"""));
+
+	[Fact]
+	public void VersionHeadingTocSlugMatchesDisplayVersion()
+	{
+		var toc = Block!.GeneratedTableOfContent.ToList();
+		var versionItem = toc.Single(t => t.Level == 2);
+
+		// Slugify.Core preserves dots, so "9.3.0" slugifies to "9.3.0".
+		// The TOC slug must match the heading ID derived from the display text.
+		versionItem.Slug.Should().Be("9.3.0");
+	}
+
+	[Fact]
+	public void VersionHeadingHtmlIdMatchesTocSlug()
+	{
+		var toc = Block!.GeneratedTableOfContent.ToList();
+		var versionItem = toc.Single(t => t.Level == 2);
+
+		Html.Should().Contain($"id=\"{versionItem.Slug}\"",
+			$"heading-wrapper id must match TOC slug '{versionItem.Slug}'");
+	}
+
+	[Fact]
+	public void SubSectionTocSlugsContainVersionString()
+	{
+		var toc = Block!.GeneratedTableOfContent.ToList();
+		foreach (var item in toc.Where(t => t.Level == 3))
+			item.Slug.Should().Contain("9.3.0",
+				$"sub-section slug should contain the version string — Slugify.Core preserves dots");
+	}
+
+	[Fact]
+	public void AllTocSlugsHaveMatchingHtmlIds()
+	{
+		var toc = Block!.GeneratedTableOfContent.ToList();
+		foreach (var item in toc)
+			Html.Should().Contain($"id=\"{item.Slug}\"",
+				$"TOC item '{item.Heading}' (slug '{item.Slug}') must have a matching heading-wrapper id");
+	}
+
+	[Fact]
+	public void GeneratedAnchorsContainVersionString()
+	{
+		// Slugify.Core preserves dots, so sub-section anchors retain "9.3.0".
+		var anchors = Block!.GeneratedAnchors.ToList();
+		foreach (var anchor in anchors)
+			anchor.Should().Contain("9.3.0",
+				$"generated anchor '{anchor}' should contain the semver version string");
+	}
+}
+
+// ── Raw / fallback version strings ───────────────────────────────────────────
+
+/// <summary>
+/// Non-semver, non-date version strings (e.g. "release-alpha") are used as-is
+/// as both the display text and the slug base.  Slugify should preserve safe
+/// characters (alphanumeric + hyphens) so the TOC slug and HTML id agree.
+/// </summary>
+public class ChangelogRawVersionAnchorNavigationTests : DirectiveTest<ChangelogBlock>
+{
+	public ChangelogRawVersionAnchorNavigationTests(ITestOutputHelper output) : base(output,
+		// language=markdown
+		"""
+		:::{changelog}
+		:::
+		""") => FileSystem.AddFile("docs/changelog/bundles/release-alpha.yaml", new MockFileData(
+			// language=yaml
+			"""
+			products:
+			- product: experimental
+			  target: release-alpha
+			entries:
+			- title: Alpha feature
+			  type: feature
+			  products:
+			  - product: experimental
+			    target: release-alpha
+			  prs:
+			  - "111111"
+			"""));
+
+	[Fact]
+	public void VersionHeadingTocSlugMatchesRawVersion()
+	{
+		var toc = Block!.GeneratedTableOfContent.ToList();
+		var versionItem = toc.Single(t => t.Level == 2);
+
+		// "release-alpha" is already URL-safe so the slug should be identical.
+		versionItem.Slug.Should().Be("release-alpha");
+	}
+
+	[Fact]
+	public void VersionHeadingHtmlIdMatchesTocSlug()
+	{
+		var toc = Block!.GeneratedTableOfContent.ToList();
+		var versionItem = toc.Single(t => t.Level == 2);
+
+		Html.Should().Contain($"id=\"{versionItem.Slug}\"",
+			$"heading-wrapper id must match TOC slug '{versionItem.Slug}'");
+	}
+
+	[Fact]
+	public void AllTocSlugsHaveMatchingHtmlIds()
+	{
+		var toc = Block!.GeneratedTableOfContent.ToList();
+		foreach (var item in toc)
+		{
+			Html.Should().Contain($"id=\"{item.Slug}\"",
+				$"TOC item '{item.Heading}' (slug '{item.Slug}') must have a matching heading-wrapper id");
+		}
+	}
+}
+
+// ── Multiple versions — cross-bundle consistency ──────────────────────────────
+
+/// <summary>
+/// When a changelog page spans multiple bundles (the common case), every
+/// version-level and sub-section-level TOC item must independently link to a
+/// real heading in the HTML.  This is the end-to-end "right-nav works" check.
+/// </summary>
+public class ChangelogMultiVersionAnchorNavigationTests : DirectiveTest<ChangelogBlock>
+{
+	public ChangelogMultiVersionAnchorNavigationTests(ITestOutputHelper output) : base(output,
+		// language=markdown
+		"""
+		:::{changelog}
+		:::
+		""")
+	{
+		FileSystem.AddFile("docs/changelog/bundles/9.3.0.yaml", new MockFileData(
+			// language=yaml
+			"""
+			products:
+			- product: elasticsearch
+			  target: 9.3.0
+			entries:
+			- title: Semver feature
+			  type: feature
+			  products:
+			  - product: elasticsearch
+			    target: 9.3.0
+			  prs:
+			  - "111111"
+			"""));
+
+		FileSystem.AddFile("docs/changelog/bundles/2025-11.yaml", new MockFileData(
+			// language=yaml
+			"""
+			products:
+			- product: elasticsearch
+			  target: 2025-11
+			entries:
+			- title: Date-version feature
+			  type: feature
+			  products:
+			  - product: elasticsearch
+			    target: 2025-11
+			  prs:
+			  - "222222"
+			"""));
+	}
+
+	[Fact]
+	public void AllTocSlugsHaveMatchingHtmlIds()
+	{
+		var toc = Block!.GeneratedTableOfContent.ToList();
+		foreach (var item in toc)
+		{
+			Html.Should().Contain($"id=\"{item.Slug}\"",
+				$"TOC item '{item.Heading}' (slug '{item.Slug}') must have a matching heading-wrapper id");
+		}
+	}
+
+	[Fact]
+	public void SemverVersionHeadingSlugPreservesDots()
+	{
+		// Slugify.Core preserves dots, so "9.3.0" remains "9.3.0" as the slug.
+		var toc = Block!.GeneratedTableOfContent.ToList();
+		var semverItem = toc.Single(t => t.Level == 2 && t.Heading == "9.3.0");
+
+		semverItem.Slug.Should().Be("9.3.0");
+	}
+
+	[Fact]
+	public void DateVersionHeadingSlugUsesDisplayName()
+	{
+		var toc = Block!.GeneratedTableOfContent.ToList();
+		var dateItem = toc.Single(t => t.Level == 2 && t.Heading == "November 2025");
+
+		dateItem.Slug.Should().Be("november-2025");
+	}
+}

--- a/tests/Elastic.Markdown.Tests/Directives/ChangelogVersionSortingTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/ChangelogVersionSortingTests.cs
@@ -347,14 +347,16 @@ public class ChangelogYearMonthVersionTests : DirectiveTest<ChangelogBlock>
 	}
 
 	[Fact]
-	public void TocSlugUsesOriginalFormat()
+	public void TocSlugMatchesHeadingId()
 	{
+		// The TOC slug must match the heading ID that SectionedHeadingRenderer derives from
+		// the display text, so that right-nav links scroll to the correct section.
 		var toc = Block!.GeneratedTableOfContent.ToList();
 		var versionSlugs = toc.Where(t => t.Level == 2).Select(t => t.Slug).ToList();
 
-		versionSlugs.Should().Contain("2025-12");
-		versionSlugs.Should().Contain("2025-10");
-		versionSlugs.Should().Contain("2025-08");
+		versionSlugs.Should().Contain("december-2025");
+		versionSlugs.Should().Contain("october-2025");
+		versionSlugs.Should().Contain("august-2025");
 	}
 }
 


### PR DESCRIPTION
This pull request updates the logic for generating anchor slugs and table of contents (TOC) slugs in the changelog directive to ensure they consistently match the heading IDs produced by the renderer. This improves navigation accuracy, especially for version headings and section links in the right-hand navigation. The changes also update the corresponding test to reflect the new slug format.

Slug consistency improvements:

* Updated `ComputeGeneratedAnchors()` and `ComputeTableOfContent()` in `ChangelogBlock.cs` to use a new `anchorSlug` (created by applying `.Slugify()` to the title slug) for all section anchors, ensuring consistency between generated anchors and heading IDs. This affects all section links such as "breaking changes", "security", etc. [[1]](diffhunk://#diff-ec89035fc45dfc832e4a3e38cb05c811df2cce53e4a5fe321a5b0c5d2dbb1b5cR312) [[2]](diffhunk://#diff-ec89035fc45dfc832e4a3e38cb05c811df2cce53e4a5fe321a5b0c5d2dbb1b5cL321-R354) [[3]](diffhunk://#diff-ec89035fc45dfc832e4a3e38cb05c811df2cce53e4a5fe321a5b0c5d2dbb1b5cL417-R424) [[4]](diffhunk://#diff-ec89035fc45dfc832e4a3e38cb05c811df2cce53e4a5fe321a5b0c5d2dbb1b5cL427-R434) [[5]](diffhunk://#diff-ec89035fc45dfc832e4a3e38cb05c811df2cce53e4a5fe321a5b0c5d2dbb1b5cL439-R462) [[6]](diffhunk://#diff-ec89035fc45dfc832e4a3e38cb05c811df2cce53e4a5fe321a5b0c5d2dbb1b5cL466-R473) [[7]](diffhunk://#diff-ec89035fc45dfc832e4a3e38cb05c811df2cce53e4a5fe321a5b0c5d2dbb1b5cL475-R482) [[8]](diffhunk://#diff-ec89035fc45dfc832e4a3e38cb05c811df2cce53e4a5fe321a5b0c5d2dbb1b5cL484-R491) [[9]](diffhunk://#diff-ec89035fc45dfc832e4a3e38cb05c811df2cce53e4a5fe321a5b0c5d2dbb1b5cL493-R500) [[10]](diffhunk://#diff-ec89035fc45dfc832e4a3e38cb05c811df2cce53e4a5fe321a5b0c5d2dbb1b5cL502-R509)
* Changed the TOC version header slug to use the display version's `.Slugify()` instead of the raw title slug, so that TOC links scroll to the correct section (e.g., "November 2025" becomes "november-2025").

Testing updates:

* Updated the test `TocSlugMatchesHeadingId` in `ChangelogVersionSortingTests.cs` to check for the new slug format (e.g., "december-2025" instead of "2025-12").

Dependency update:

* Added a `using Elastic.Markdown.Helpers;` directive to `ChangelogBlock.cs` to enable use of the `.Slugify()` extension method.