### PR TITLE
Add extract.strip_title_prefix changelog configuration option

### DIFF
--- a/config/changelog.example.yml
+++ b/config/changelog.example.yml
@@ -40,6 +40,10 @@ extract:
   # When using --issues: looks for patterns like "Fixed by #123" in issue body to derive PRs.
   # Can be overridden by CLI --no-extract-issues
   issues: true
+  # Remove square-bracket prefixes from PR titles (default: false)
+  # When enabled (true or via --strip-title-prefix), titles like "[ES|QL] Fix bug" become "Fix bug".
+  # Can be overridden by CLI --strip-title-prefix
+  strip_title_prefix: false
 
 # Available lifecycle values (strongly typed: preview, beta, ga)
 # Accepts string or list: "preview, beta, ga" or a YAML list

--- a/docs/cli/release/changelog-add.md
+++ b/docs/cli/release/changelog-add.md
@@ -106,6 +106,7 @@ docs-builder changelog add [options...] [-h|--help]
 :   For example, if a PR title is `"[Attack discovery]: Improves Attack discovery hallucination detection"`, the changelog title will be `"Improves Attack discovery hallucination detection"`.
 :   Multiple square bracket prefixes are also supported (for example `"[Discover][ESQL] Fix filtering by multiline string fields"` becomes `"Fix filtering by multiline string fields"`).
 :   This option applies only when the title is derived from the PR (when `--title` is not explicitly provided).
+:   By default, the behavior is determined by the `extract.strip_title_prefix` changelog configuration setting (which defaults to `false`).
 
 `--subtype <string?>`
 :   Optional: Subtype for breaking changes (for example, `api`, `behavioral`, or `configuration`).

--- a/docs/cli/release/changelog-gh-release.md
+++ b/docs/cli/release/changelog-gh-release.md
@@ -38,7 +38,7 @@ docs-builder changelog gh-release <repo> [version] [options...] [-h|--help]
 :   Optional: Remove square brackets and the text within them from the beginning of pull request titles, and also remove a colon if it follows the closing bracket.
 :   For example, `"[Inference API] New embedding model support"` becomes `"New embedding model support"`.
 :   Multiple bracket prefixes are also supported (for example, `"[Discover][ESQL] Fix filtering"` becomes `"Fix filtering"`).
-
+:   By default, the behavior is determined by the `extract.strip_title_prefix` changelog configuration setting (which defaults to `false`).
 `--warn-on-type-mismatch`
 :   Optional: Warn when the type inferred from Release Drafter section headers (for example, "Bug Fixes") doesn't match the type derived from the pull request's labels. Defaults to `true`.
 

--- a/docs/contribute/changelog.md
+++ b/docs/contribute/changelog.md
@@ -463,6 +463,8 @@ The command also looks for patterns like `Fixes #123`, `Closes owner/repo#456`, 
 
 The `--strip-title-prefix` option in this example means that if the PR title has a prefix in square brackets (such as `[ES|QL]` or `[Security]`), it is automatically removed from the changelog title. Multiple square bracket prefixes are also supported (for example `[Discover][ESQL] Title` becomes `Title`). If a colon follows the closing bracket, it is also removed.
 
+By default, `--strip-title-prefix` is disabled. You can enable it globally by setting `extract.strip_title_prefix: true` in the changelog configuration file, which will apply the prefix stripping to all `changelog add` and `changelog gh-release` commands without requiring the CLI flag. The CLI flag `--strip-title-prefix` overrides the configuration setting.
+
 :::{note}
 The `--strip-title-prefix` option only applies when the title is derived from the PR (when `--title` is not explicitly provided). If you specify `--title` explicitly, that title is used as-is without any prefix stripping.
 :::

--- a/src/Elastic.Documentation.Configuration/Changelog/ExtractConfiguration.cs
+++ b/src/Elastic.Documentation.Configuration/Changelog/ExtractConfiguration.cs
@@ -20,4 +20,11 @@ public record ExtractConfiguration
 	/// Defaults to true. Looks for patterns like "Fixes #123", "Closes #456", etc.
 	/// </summary>
 	public bool Issues { get; init; } = true;
+
+	/// <summary>
+	/// Whether to strip square-bracket prefixes from PR titles by default.
+	/// Defaults to false. When enabled, titles like "[ES|QL] Fix bug" become "Fix bug".
+	/// Can be overridden by CLI --strip-title-prefix flag.
+	/// </summary>
+	public bool StripTitlePrefix { get; init; }
 }

--- a/src/services/Elastic.Changelog/Configuration/ChangelogConfigurationLoader.cs
+++ b/src/services/Elastic.Changelog/Configuration/ChangelogConfigurationLoader.cs
@@ -292,7 +292,8 @@ public class ChangelogConfigurationLoader(ILoggerFactory logFactory, IConfigurat
 		var extract = new ExtractConfiguration
 		{
 			ReleaseNotes = yamlConfig.Extract?.ReleaseNotes ?? true,
-			Issues = yamlConfig.Extract?.Issues ?? true
+			Issues = yamlConfig.Extract?.Issues ?? true,
+			StripTitlePrefix = yamlConfig.Extract?.StripTitlePrefix ?? false
 		};
 
 		// Process filename strategy

--- a/src/services/Elastic.Changelog/Creation/ChangelogCreationService.cs
+++ b/src/services/Elastic.Changelog/Creation/ChangelogCreationService.cs
@@ -37,7 +37,7 @@ public record CreateChangelogArguments
 	public string? Config { get; init; }
 	public bool UsePrNumber { get; init; }
 	public bool UseIssueNumber { get; init; }
-	public bool StripTitlePrefix { get; init; }
+	public bool? StripTitlePrefix { get; init; }
 	/// <summary>
 	/// Whether to extract release notes from PR/issue descriptions. null = use config default.
 	/// </summary>
@@ -140,6 +140,7 @@ IEnvironmentVariables? env = null
 		{
 			ExtractReleaseNotes = input.ExtractReleaseNotes ?? config.Extract.ReleaseNotes,
 			ExtractIssues = input.ExtractIssues ?? config.Extract.Issues,
+			StripTitlePrefix = input.StripTitlePrefix ?? config.Extract.StripTitlePrefix,
 			UsePrNumber = usePrNumber,
 			UseIssueNumber = useIssueNumber
 		};

--- a/src/services/Elastic.Changelog/Creation/IssueInfoProcessor.cs
+++ b/src/services/Elastic.Changelog/Creation/IssueInfoProcessor.cs
@@ -126,7 +126,7 @@ public class IssueInfoProcessor(IGitHubPrService? githubService, ILogger logger)
 			}
 
 			var issueTitle = issueInfo.Title;
-			if (input.StripTitlePrefix)
+			if (input.StripTitlePrefix == true)
 				issueTitle = ChangelogTextUtilities.StripSquareBracketPrefix(issueTitle);
 			derived.Title = issueTitle;
 			logger.LogInformation("Using issue title: {Title}", derived.Title);

--- a/src/services/Elastic.Changelog/Creation/PrInfoProcessor.cs
+++ b/src/services/Elastic.Changelog/Creation/PrInfoProcessor.cs
@@ -133,7 +133,7 @@ public class PrInfoProcessor(IGitHubPrService? githubPrService, ILogger logger)
 
 			var prTitle = prInfo.Title;
 			// Strip prefix if requested
-			if (input.StripTitlePrefix)
+			if (input.StripTitlePrefix == true)
 				prTitle = ChangelogTextUtilities.StripSquareBracketPrefix(prTitle);
 			derived.Title = prTitle;
 			logger.LogInformation("Using PR title: {Title}", derived.Title);

--- a/src/services/Elastic.Changelog/GithubRelease/GitHubReleaseChangelogService.cs
+++ b/src/services/Elastic.Changelog/GithubRelease/GitHubReleaseChangelogService.cs
@@ -46,7 +46,7 @@ public record CreateChangelogsFromReleaseArguments
 	/// <summary>
 	/// Whether to strip [prefix] from PR titles
 	/// </summary>
-	public bool StripTitlePrefix { get; init; }
+	public bool? StripTitlePrefix { get; init; }
 
 	/// <summary>
 	/// Whether to warn when Release Drafter type doesn't match label-derived type (defaults to true)
@@ -118,6 +118,9 @@ public class GitHubReleaseChangelogService(
 				return false;
 			}
 
+			// Resolve StripTitlePrefix from input or config default
+			var stripTitlePrefix = input.StripTitlePrefix ?? config.Extract.StripTitlePrefix;
+
 			// 4. Fetch GitHub release
 			var release = await _releaseService.FetchReleaseAsync(owner, repo, input.Version, ctx);
 			if (release == null)
@@ -167,7 +170,7 @@ public class GitHubReleaseChangelogService(
 			{
 				var success = await ProcessPrReference(
 					collector, config, owner, repo, prRef,
-					productInfo, input, parsedNotes.Format, outputDir, createdFiles, ctx);
+					productInfo, stripTitlePrefix, parsedNotes.Format, outputDir, createdFiles, input.WarnOnTypeMismatch, ctx);
 				if (success)
 					successCount++;
 			}
@@ -203,10 +206,11 @@ public class GitHubReleaseChangelogService(
 		string repo,
 		ExtractedPrReference prRef,
 		ProductArgument productInfo,
-		CreateChangelogsFromReleaseArguments input,
+		bool stripTitlePrefix,
 		ReleaseNoteFormat format,
 		string outputDir,
 		List<string> createdFiles,
+		bool warnOnTypeMismatch,
 		Cancel ctx)
 	{
 		var prUrl = $"https://github.com/{owner}/{repo}/pull/{prRef.PrNumber}";
@@ -243,7 +247,7 @@ public class GitHubReleaseChangelogService(
 
 		// Warn on type mismatch if Release Drafter format and warning enabled
 		if (format == ReleaseNoteFormat.ReleaseDrafter &&
-			input.WarnOnTypeMismatch &&
+			warnOnTypeMismatch &&
 			labelDerivedType != null &&
 			prRef.InferredType != null &&
 			!string.Equals(labelDerivedType, prRef.InferredType, StringComparison.OrdinalIgnoreCase))
@@ -256,7 +260,7 @@ public class GitHubReleaseChangelogService(
 
 		// Build title
 		var title = prRef.Title ?? prInfo?.Title ?? $"PR #{prRef.PrNumber}";
-		if (input.StripTitlePrefix)
+		if (stripTitlePrefix)
 			title = ChangelogTextUtilities.StripSquareBracketPrefix(title);
 
 		// Create changelog data

--- a/src/services/Elastic.Changelog/Serialization/ChangelogConfigurationYaml.cs
+++ b/src/services/Elastic.Changelog/Serialization/ChangelogConfigurationYaml.cs
@@ -359,6 +359,12 @@ internal record ExtractConfigurationYaml
 	/// Defaults to true.
 	/// </summary>
 	public bool? Issues { get; set; }
+
+	/// <summary>
+	/// Whether to strip square-bracket prefixes from PR titles by default.
+	/// Defaults to false.
+	/// </summary>
+	public bool? StripTitlePrefix { get; set; }
 }
 
 /// <summary>

--- a/src/tooling/docs-builder/Commands/ChangelogCommand.cs
+++ b/src/tooling/docs-builder/Commands/ChangelogCommand.cs
@@ -293,6 +293,9 @@ internal sealed partial class ChangelogCommand(
 		var resolvedOwner = owner ?? bundleConfig?.Bundle?.Owner ?? "elastic";
 		var resolvedOutput = !string.IsNullOrWhiteSpace(output) ? output : bundleConfig?.Bundle?.Directory;
 
+		// Resolve stripTitlePrefix: CLI flag true → explicit true; otherwise null (use config default)
+		var stripTitlePrefixResolved = stripTitlePrefix ? true : (bool?)null;
+
 		// --release-version mode: delegate entirely to GitHubReleaseChangelogService without creating a bundle
 		if (releaseVersion != null)
 		{
@@ -316,7 +319,7 @@ internal sealed partial class ChangelogCommand(
 				Version = releaseVersion,
 				Config = config,
 				Output = resolvedOutput,
-				StripTitlePrefix = stripTitlePrefix,
+				StripTitlePrefix = stripTitlePrefixResolved,
 				CreateBundle = false
 			};
 
@@ -463,7 +466,7 @@ internal sealed partial class ChangelogCommand(
 			Config = config,
 			UsePrNumber = usePrNumber,
 			UseIssueNumber = useIssueNumber,
-			StripTitlePrefix = stripTitlePrefix,
+			StripTitlePrefix = stripTitlePrefixResolved,
 			ExtractReleaseNotes = extractReleaseNotes,
 			ExtractIssues = extractIssues,
 			Concise = concise
@@ -1108,13 +1111,16 @@ internal sealed partial class ChangelogCommand(
 		IGitHubPrService prService = new GitHubPrService(logFactory);
 		var service = new GitHubReleaseChangelogService(logFactory, configurationContext, releaseService, prService);
 
+		// Resolve stripTitlePrefix: CLI flag true → explicit true; otherwise null (use config default)
+		var stripTitlePrefixResolved = stripTitlePrefix ? true : (bool?)null;
+
 		var input = new CreateChangelogsFromReleaseArguments
 		{
 			Repository = repo,
 			Version = version,
 			Config = config,
 			Output = resolvedOutput,
-			StripTitlePrefix = stripTitlePrefix,
+			StripTitlePrefix = stripTitlePrefixResolved,
 			WarnOnTypeMismatch = warnOnTypeMismatch
 		};
 

--- a/tests/Elastic.Changelog.Tests/Changelogs/ChangelogConfigurationTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/ChangelogConfigurationTests.cs
@@ -1331,4 +1331,80 @@ public class ChangelogConfigurationTests(ITestOutputHelper output) : ChangelogTe
 		bundle.ByProduct!["cloud-serverless"].Areas.Should().BeEquivalentTo(["Search", "Monitoring"]);
 		bundle.ByProduct["cloud-serverless"].AreasMode.Should().Be(FieldMode.Include);
 	}
+
+	// -----------------------------------------------------------------------
+	// extract section: strip_title_prefix
+	// -----------------------------------------------------------------------
+
+	[Fact]
+	public async Task LoadChangelogConfiguration_ExtractStripTitlePrefix_True_LoadsCorrectly()
+	{
+		// Arrange
+		var config = await LoadConfig(
+			"""
+			extract:
+			  strip_title_prefix: true
+			""");
+
+		// Act & Assert
+		config.Should().NotBeNull();
+		Collector.Errors.Should().Be(0);
+		config.Extract.Should().NotBeNull();
+		config.Extract.StripTitlePrefix.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task LoadChangelogConfiguration_ExtractStripTitlePrefix_False_LoadsCorrectly()
+	{
+		// Arrange
+		var config = await LoadConfig(
+			"""
+			extract:
+			  strip_title_prefix: false
+			""");
+
+		// Act & Assert
+		config.Should().NotBeNull();
+		Collector.Errors.Should().Be(0);
+		config.Extract.Should().NotBeNull();
+		config.Extract.StripTitlePrefix.Should().BeFalse();
+	}
+
+	[Fact]
+	public async Task LoadChangelogConfiguration_ExtractStripTitlePrefix_Missing_DefaultsFalse()
+	{
+		// Arrange
+		var config = await LoadConfig(
+			"""
+			lifecycles:
+			  - ga
+			""");
+
+		// Act & Assert
+		config.Should().NotBeNull();
+		Collector.Errors.Should().Be(0);
+		config.Extract.Should().NotBeNull();
+		config.Extract.StripTitlePrefix.Should().BeFalse("default is false");
+	}
+
+	[Fact]
+	public async Task LoadChangelogConfiguration_ExtractStripTitlePrefix_WithOtherExtractSettings_LoadsCorrectly()
+	{
+		// Arrange
+		var config = await LoadConfig(
+			"""
+			extract:
+			  release_notes: false
+			  issues: true
+			  strip_title_prefix: true
+			""");
+
+		// Act & Assert
+		config.Should().NotBeNull();
+		Collector.Errors.Should().Be(0);
+		config.Extract.Should().NotBeNull();
+		config.Extract.ReleaseNotes.Should().BeFalse();
+		config.Extract.Issues.Should().BeTrue();
+		config.Extract.StripTitlePrefix.Should().BeTrue();
+	}
 }


### PR DESCRIPTION
Implements https://github.com/elastic/docs-builder/issues/2932

## Summary

- Add `extract.strip_title_prefix` to `changelog.yml` so users can set the default behavior without passing `--strip-title-prefix` at the command line
- When the CLI flag is not specified, use the config value
- CLI flag overrides the config when explicitly provided
- Default value in configuration: `false` (preserves current behavior where stripping is OFF by default)

## Implementation details 

All components of the `extract.strip_title_prefix` configuration option have been successfully implemented:

### 1. **Configuration Model** ✓
- Added `StripTitlePrefix { get; init; } = false` to `ExtractConfiguration.cs`
- Added `bool? StripTitlePrefix { get; set; }` to `ChangelogConfigurationYaml.cs`

### 2. **Configuration Loader** ✓
- Updated `ChangelogConfigurationLoader.cs` to parse `extract.strip_title_prefix` from YAML with default `false`

### 3. **Arguments and Defaults** ✓
- Changed `CreateChangelogArguments.StripTitlePrefix` from `bool` to `bool?` (nullable)
- Updated `ChangelogCreationService.ApplyConfigDefaults()` to apply `config.Extract.StripTitlePrefix` when input is `null`

### 4. **GitHub Release Service** ✓
- Changed `CreateChangelogsFromReleaseArguments.StripTitlePrefix` from `bool` to `bool?`
- Added resolution logic in `GitHubReleaseChangelogService.CreateChangelogsFromRelease()` to apply config defaults
- Updated `ProcessPrReference()` method signature and usage to use resolved value

### 5. **CLI Wiring** ✓
- Updated `ChangelogCommand.Create()` (changelog add) to resolve: `stripTitlePrefix ? true : (bool?)null`
- Updated `ChangelogCommand.GitHubRelease()` (changelog gh-release) with same resolution logic
- Both now pass nullable value to services, which apply config defaults

### 6. **Config Example** ✓
- Added `strip_title_prefix: false` to `config/changelog.example.yml` under `extract` section with explanation

### 7. **Documentation** ✓
- Updated `docs/cli/release/changelog-add.md` to mention config fallback
- Updated `docs/cli/release/changelog-gh-release.md` to mention config fallback
- Updated `docs/contribute/changelog.md` with full explanation of `extract.strip_title_prefix` setting and precedence

### 8. **Tests** ✓
- Added 4 tests to `ChangelogConfigurationTests.cs`:
  - `LoadChangelogConfiguration_ExtractStripTitlePrefix_True_LoadsCorrectly`
  - `LoadChangelogConfiguration_ExtractStripTitlePrefix_False_LoadsCorrectly`
  - `LoadChangelogConfiguration_ExtractStripTitlePrefix_Missing_DefaultsFalse`
  - `LoadChangelogConfiguration_ExtractStripTitlePrefix_WithOtherExtractSettings_LoadsCorrectly`

### Precedence Chain
1. CLI `--strip-title-prefix` flag → `true` (explicit enable)
2. `extract.strip_title_prefix` in `changelog.yml` → config value (defaults to `false`)
3. Hardcoded default → `false` (when config not set)

### Behavior
- **Default**: Prefix stripping is OFF (preserves existing behavior)
- **Config-driven**: Users can set `extract.strip_title_prefix: true` in config to enable globally
- **CLI override**: `--strip-title-prefix` flag enables it for a single command regardless of config
- **Applies to**: Both `changelog add` and `changelog gh-release` commands

All files compile without errors. The implementation mirrors the existing `extract.issues` → `--no-extract-issues` pattern for consistency.

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: composer-1.5, claude-4.5-haiku