### PR TITLE
Fix area name comma-split bug in changelog label mapping

### DIFF
--- a/config/changelog.example.yml
+++ b/config/changelog.example.yml
@@ -100,14 +100,22 @@ pivot:
   #   - ">release-highlight"
 
   # Area definitions with labels
-  # Keys are area display names, values are label strings or lists
+  # Keys are area display names (can contain commas), values are label strings or lists
+  # Each label maps to exactly one area.
   # String form: "label1, label2" | List form: [label1, label2]
+  # To map one label to multiple areas, repeat the label under each area name.
   areas:
     # Example mappings - customize based on your label naming conventions
     # Autoscaling: ":Distributed Coordination/Autoscaling"
     # Search: ":Search/Search"
     # Security: ":Security/Security"
     # Watcher: ":Data Management/Watcher"
+    # To map a label to multiple areas (e.g., "Team:Search" to both "Search" and "Observability"):
+    # Search:
+    #   - ":Search/Search"
+    #   - "Team:Search"
+    # Observability:
+    #   - "Team:Search"
     # List form example:
     # Search:
     #   - ":Search/Search"

--- a/src/Elastic.Documentation.Configuration/Changelog/ChangelogConfiguration.cs
+++ b/src/Elastic.Documentation.Configuration/Changelog/ChangelogConfiguration.cs
@@ -85,7 +85,7 @@ public record ChangelogConfiguration
 
 	/// <summary>
 	/// Mapping from GitHub label names to changelog area values (computed from Pivot.Areas)
-	/// Multiple labels can map to the same area, and a single label can map to multiple areas (comma-separated)
+	/// Multiple labels can map to the same area. To map one label to multiple areas, repeat the label under each area.
 	/// </summary>
 	public IReadOnlyDictionary<string, string>? LabelToAreas { get; init; }
 

--- a/src/Elastic.Documentation.Configuration/Changelog/ChangelogConfiguration.cs
+++ b/src/Elastic.Documentation.Configuration/Changelog/ChangelogConfiguration.cs
@@ -85,9 +85,9 @@ public record ChangelogConfiguration
 
 	/// <summary>
 	/// Mapping from GitHub label names to changelog area values (computed from Pivot.Areas)
-	/// Multiple labels can map to the same area. To map one label to multiple areas, repeat the label under each area.
+	/// Multiple labels can map to the same area. To map one label to multiple areas, repeat the label under each area in pivot.areas.
 	/// </summary>
-	public IReadOnlyDictionary<string, string>? LabelToAreas { get; init; }
+	public IReadOnlyDictionary<string, IReadOnlyList<string>>? LabelToAreas { get; init; }
 
 	/// <summary>
 	/// Mapping from GitHub label names to product spec strings (computed from Pivot.Products).

--- a/src/services/Elastic.Changelog/Configuration/ChangelogConfigurationLoader.cs
+++ b/src/services/Elastic.Changelog/Configuration/ChangelogConfigurationLoader.cs
@@ -115,7 +115,7 @@ public class ChangelogConfigurationLoader(ILoggerFactory logFactory, IConfigurat
 		IReadOnlyList<string> availableSubtypes;
 		IReadOnlyList<string>? availableAreas;
 		Dictionary<string, string>? labelToType;
-		Dictionary<string, string>? labelToAreas;
+		Dictionary<string, List<string>>? labelToAreas;
 		Dictionary<string, string>? labelToProducts;
 		PivotConfiguration? pivot = null;
 
@@ -308,6 +308,11 @@ public class ChangelogConfigurationLoader(ILoggerFactory logFactory, IConfigurat
 			filenameStrategy = parsed;
 		}
 
+		var labelToAreasReadOnly = labelToAreas?.ToDictionary(
+			kvp => kvp.Key,
+			kvp => (IReadOnlyList<string>)kvp.Value,
+			StringComparer.OrdinalIgnoreCase);
+
 		return new ChangelogConfiguration
 		{
 			Pivot = pivot,
@@ -317,7 +322,7 @@ public class ChangelogConfigurationLoader(ILoggerFactory logFactory, IConfigurat
 			Areas = availableAreas,
 			Products = products,
 			LabelToType = labelToType,
-			LabelToAreas = labelToAreas,
+			LabelToAreas = labelToAreasReadOnly,
 			LabelToProducts = labelToProducts,
 			Rules = rules,
 			HighlightLabels = highlightLabels,
@@ -1009,14 +1014,14 @@ public class ChangelogConfigurationLoader(ILoggerFactory logFactory, IConfigurat
 
 	/// <summary>
 	/// Builds LabelToAreas mapping by inverting pivot.areas entries.
-	/// Each label in an area entry maps to that area name.
+	/// Each label in an area entry maps to that area name. The same label may appear under multiple areas; all area names are collected.
 	/// </summary>
-	private static Dictionary<string, string>? BuildLabelToAreasMapping(Dictionary<string, YamlLenientList?>? areas)
+	private static Dictionary<string, List<string>>? BuildLabelToAreasMapping(Dictionary<string, YamlLenientList?>? areas)
 	{
 		if (areas == null || areas.Count == 0)
 			return null;
 
-		var labelToAreas = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+		var labelToAreas = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
 
 		foreach (var (areaName, labelList) in areas)
 		{
@@ -1024,7 +1029,16 @@ public class ChangelogConfigurationLoader(ILoggerFactory logFactory, IConfigurat
 				continue;
 
 			foreach (var label in labelList.Values)
-				labelToAreas[label] = areaName;
+			{
+				if (!labelToAreas.TryGetValue(label, out var areaNames))
+				{
+					areaNames = [];
+					labelToAreas[label] = areaNames;
+				}
+
+				if (!areaNames.Exists(a => a.Equals(areaName, StringComparison.OrdinalIgnoreCase)))
+					areaNames.Add(areaName);
+			}
 		}
 
 		return labelToAreas.Count > 0 ? labelToAreas : null;

--- a/src/services/Elastic.Changelog/Creation/PrInfoProcessor.cs
+++ b/src/services/Elastic.Changelog/Creation/PrInfoProcessor.cs
@@ -389,12 +389,11 @@ public class PrInfoProcessor(IGitHubPrService? githubPrService, ILogger logger)
 	internal static List<string> MapLabelsToAreas(string[] labels, IReadOnlyDictionary<string, string> labelToAreasMapping)
 	{
 		var areas = new HashSet<string>();
-		var areaList = labels
-			.Where(label => labelToAreasMapping.ContainsKey(label))
-			.SelectMany(label => labelToAreasMapping[label]
-				.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
-		foreach (var area in areaList)
-			_ = areas.Add(area);
+		foreach (var label in labels)
+		{
+			if (labelToAreasMapping.TryGetValue(label, out var area))
+				_ = areas.Add(area);
+		}
 		return areas.ToList();
 	}
 

--- a/src/services/Elastic.Changelog/Creation/PrInfoProcessor.cs
+++ b/src/services/Elastic.Changelog/Creation/PrInfoProcessor.cs
@@ -386,12 +386,15 @@ public class PrInfoProcessor(IGitHubPrService? githubPrService, ILogger logger)
 		.Select(label => labelToTypeMapping.TryGetValue(label, out var mappedType) ? mappedType : null)
 		.FirstOrDefault(mappedType => mappedType != null);
 
-	internal static List<string> MapLabelsToAreas(string[] labels, IReadOnlyDictionary<string, string> labelToAreasMapping)
+	internal static List<string> MapLabelsToAreas(string[] labels, IReadOnlyDictionary<string, IReadOnlyList<string>> labelToAreasMapping)
 	{
 		var areas = new HashSet<string>();
 		foreach (var label in labels)
 		{
-			if (labelToAreasMapping.TryGetValue(label, out var area))
+			if (!labelToAreasMapping.TryGetValue(label, out var mappedAreas))
+				continue;
+
+			foreach (var area in mappedAreas)
 				_ = areas.Add(area);
 		}
 		return areas.ToList();

--- a/src/services/Elastic.Changelog/GithubRelease/GitHubReleaseChangelogService.cs
+++ b/src/services/Elastic.Changelog/GithubRelease/GitHubReleaseChangelogService.cs
@@ -345,12 +345,11 @@ public class GitHubReleaseChangelogService(
 	private static List<string> MapLabelsToAreas(string[] labels, IReadOnlyDictionary<string, string> labelToAreasMapping)
 	{
 		var areas = new HashSet<string>();
-		var areaList = labels
-			.Where(label => labelToAreasMapping.ContainsKey(label))
-			.SelectMany(label => labelToAreasMapping[label]
-				.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
-		foreach (var area in areaList)
-			_ = areas.Add(area);
+		foreach (var label in labels)
+		{
+			if (labelToAreasMapping.TryGetValue(label, out var area))
+				_ = areas.Add(area);
+		}
 		return areas.ToList();
 	}
 

--- a/src/services/Elastic.Changelog/GithubRelease/GitHubReleaseChangelogService.cs
+++ b/src/services/Elastic.Changelog/GithubRelease/GitHubReleaseChangelogService.cs
@@ -342,12 +342,15 @@ public class GitHubReleaseChangelogService(
 			.Select(label => labelToTypeMapping.TryGetValue(label, out var mappedType) ? mappedType : null)
 			.FirstOrDefault(mappedType => mappedType != null);
 
-	private static List<string> MapLabelsToAreas(string[] labels, IReadOnlyDictionary<string, string> labelToAreasMapping)
+	private static List<string> MapLabelsToAreas(string[] labels, IReadOnlyDictionary<string, IReadOnlyList<string>> labelToAreasMapping)
 	{
 		var areas = new HashSet<string>();
 		foreach (var label in labels)
 		{
-			if (labelToAreasMapping.TryGetValue(label, out var area))
+			if (!labelToAreasMapping.TryGetValue(label, out var mappedAreas))
+				continue;
+
+			foreach (var area in mappedAreas)
 				_ = areas.Add(area);
 		}
 		return areas.ToList();

--- a/tests/Elastic.Changelog.Tests/Changelogs/ChangelogConfigurationTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/ChangelogConfigurationTests.cs
@@ -191,9 +191,9 @@ public class ChangelogConfigurationTests(ITestOutputHelper output) : ChangelogTe
 			// Should have inverted label mappings
 			config.LabelToAreas.Should().NotBeNull();
 			config.LabelToAreas.Should().ContainKey(":Search/Search");
-			config.LabelToAreas[":Search/Search"].Should().Be("Search");
+			config.LabelToAreas[":Search/Search"].Should().ContainSingle().Which.Should().Be("Search");
 			config.LabelToAreas.Should().ContainKey(":Security/Security");
-			config.LabelToAreas[":Security/Security"].Should().Be("Security");
+			config.LabelToAreas[":Security/Security"].Should().ContainSingle().Which.Should().Be("Security");
 		}
 		finally
 		{
@@ -695,12 +695,12 @@ public class ChangelogConfigurationTests(ITestOutputHelper output) : ChangelogTe
 		// Both labels from the list should map to "Search"
 		config.LabelToAreas.Should().NotBeNull();
 		config.LabelToAreas.Should().ContainKey(":Search/Search");
-		config.LabelToAreas[":Search/Search"].Should().Be("Search");
+		config.LabelToAreas[":Search/Search"].Should().ContainSingle().Which.Should().Be("Search");
 		config.LabelToAreas.Should().ContainKey(":Search/Ranking");
-		config.LabelToAreas[":Search/Ranking"].Should().Be("Search");
+		config.LabelToAreas[":Search/Ranking"].Should().ContainSingle().Which.Should().Be("Search");
 		// String form should still work
 		config.LabelToAreas.Should().ContainKey(":Security/Security");
-		config.LabelToAreas[":Security/Security"].Should().Be("Security");
+		config.LabelToAreas[":Security/Security"].Should().ContainSingle().Which.Should().Be("Security");
 	}
 
 	[Fact]
@@ -860,11 +860,11 @@ public class ChangelogConfigurationTests(ITestOutputHelper output) : ChangelogTe
 
 		// Areas: string for Search, list for Security
 		config.LabelToAreas.Should().ContainKey(":Search/Search");
-		config.LabelToAreas[":Search/Search"].Should().Be("Search");
+		config.LabelToAreas[":Search/Search"].Should().ContainSingle().Which.Should().Be("Search");
 		config.LabelToAreas.Should().ContainKey(":Security/Security");
-		config.LabelToAreas[":Security/Security"].Should().Be("Security");
+		config.LabelToAreas[":Security/Security"].Should().ContainSingle().Which.Should().Be("Security");
 		config.LabelToAreas.Should().ContainKey(":Security/Auth");
-		config.LabelToAreas[":Security/Auth"].Should().Be("Security");
+		config.LabelToAreas[":Security/Auth"].Should().ContainSingle().Which.Should().Be("Security");
 	}
 
 	/// <summary>

--- a/tests/Elastic.Changelog.Tests/Changelogs/Create/LabelMappingTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/Create/LabelMappingTests.cs
@@ -432,4 +432,154 @@ public class LabelMappingTests(ITestOutputHelper output) : CreateChangelogTestBa
 		yamlContent.Should().Contain("- security");
 		yamlContent.Should().Contain("- search");
 	}
+
+	[Fact]
+	public void MapLabelsToAreas_WithAreaNameContainingCommas_PresservesFullName()
+	{
+		// Arrange
+		var labelToAreas = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+		{
+			["Team:Alerting Services"] = "Alerting, connectors, and reporting",
+			["Team:Search"] = "Search"
+		};
+
+		// Act
+		var result = PrInfoProcessor.MapLabelsToAreas(
+			["Team:Alerting Services", "Team:Search"],
+			labelToAreas
+		);
+
+		// Assert
+		result.Should().HaveCount(2);
+		result.Should().Contain("Alerting, connectors, and reporting");  // Not split
+		result.Should().Contain("Search");
+	}
+
+	[Fact]
+	public async Task CreateChangelog_WithAreaNameContainingCommas_PreservesAreaName()
+	{
+		// Arrange: Area name contains commas
+		var prInfo = new GitHubPrInfo
+		{
+			Title = "Fix alerting issues",
+			Labels = ["type:bug", "Team:Alerting Services"]
+		};
+
+		A.CallTo(() => MockGitHubService.FetchPrInfoAsync(
+				A<string>._,
+				A<string?>._,
+				A<string?>._,
+				A<CancellationToken>._))
+			.Returns(prInfo);
+
+		// language=yaml
+		var configContent =
+			"""
+			pivot:
+			  types:
+			    bug-fix: "type:bug"
+			    feature:
+			    breaking-change:
+			  areas:
+			    "Alerting, connectors, and reporting":
+			      - "Team:Alerting Services"
+			lifecycles:
+			  - preview
+			  - beta
+			  - ga
+			""";
+		var configPath = await CreateConfigDirectory(configContent);
+
+		var service = CreateService();
+
+		var input = new CreateChangelogArguments
+		{
+			Prs = ["https://github.com/elastic/elasticsearch/pull/12345"],
+			Products = [new ProductArgument { Product = "elasticsearch", Target = "9.2.0" }],
+			Config = configPath,
+			Output = CreateOutputDirectory()
+		};
+
+		// Act
+		var result = await service.CreateChangelog(Collector, input, TestContext.Current.CancellationToken);
+
+		// Assert
+		if (!result)
+		{
+			foreach (var diagnostic in Collector.Diagnostics)
+				Output.WriteLine($"{diagnostic.Severity}: {diagnostic.Message}");
+		}
+
+		result.Should().BeTrue();
+		Collector.Errors.Should().Be(0);
+
+		var outputDir = input.Output ?? FileSystem.Directory.GetCurrentDirectory();
+		if (!FileSystem.Directory.Exists(outputDir))
+			FileSystem.Directory.CreateDirectory(outputDir);
+		var files = FileSystem.Directory.GetFiles(outputDir, "*.yaml");
+		var yamlContent = await FileSystem.File.ReadAllTextAsync(files[0], TestContext.Current.CancellationToken);
+		yamlContent.Should().Contain("- Alerting, connectors, and reporting");  // Full name, not split
+	}
+
+	[Fact]
+	public async Task CreateChangelog_WithOneLabelMappedToMultipleAreas_AddsAllAreas()
+	{
+		// Arrange: Same label under multiple areas
+		var prInfo = new GitHubPrInfo
+		{
+			Title = "Cross-area change",
+			Labels = ["type:enhancement", "Team:Search"]
+		};
+
+		A.CallTo(() => MockGitHubService.FetchPrInfoAsync(
+				A<string>._,
+				A<string?>._,
+				A<string?>._,
+				A<CancellationToken>._))
+			.Returns(prInfo);
+
+		// language=yaml
+		var configContent =
+			"""
+			pivot:
+			  types:
+			    enhancement: "type:enhancement"
+			    feature:
+			    bug-fix:
+			    breaking-change:
+			  areas:
+			    "Search":
+			      - "Team:Search"
+			    "Observability":
+			      - "Team:Search"
+			lifecycles:
+			  - ga
+			""";
+		var configPath = await CreateConfigDirectory(configContent);
+
+		var service = CreateService();
+
+		var input = new CreateChangelogArguments
+		{
+			Prs = ["https://github.com/elastic/elasticsearch/pull/12345"],
+			Products = [new ProductArgument { Product = "elasticsearch" }],
+			Config = configPath,
+			Output = CreateOutputDirectory()
+		};
+
+		// Act
+		var result = await service.CreateChangelog(Collector, input, TestContext.Current.CancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		Collector.Errors.Should().Be(0);
+
+		var outputDir = input.Output;
+		if (!FileSystem.Directory.Exists(outputDir))
+			FileSystem.Directory.CreateDirectory(outputDir);
+		var files = FileSystem.Directory.GetFiles(outputDir, "*.yaml");
+		var yamlContent = await FileSystem.File.ReadAllTextAsync(files[0], TestContext.Current.CancellationToken);
+		yamlContent.Should().Contain("- Search");
+		yamlContent.Should().Contain("- Observability");
+	}
 }

--- a/tests/Elastic.Changelog.Tests/Changelogs/Create/LabelMappingTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/Create/LabelMappingTests.cs
@@ -437,10 +437,10 @@ public class LabelMappingTests(ITestOutputHelper output) : CreateChangelogTestBa
 	public void MapLabelsToAreas_WithAreaNameContainingCommas_PresservesFullName()
 	{
 		// Arrange
-		var labelToAreas = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+		var labelToAreas = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
 		{
-			["Team:Alerting Services"] = "Alerting, connectors, and reporting",
-			["Team:Search"] = "Search"
+			["Team:Alerting Services"] = ["Alerting, connectors, and reporting"],
+			["Team:Search"] = ["Search"]
 		};
 
 		// Act


### PR DESCRIPTION
Fixes https://github.com/elastic/docs-builder/issues/2934

## Summary

The `MapLabelsToAreas` method was splitting area names by comma, which broke area names containing commas (e.g., "Alerting, connectors, and reporting").

## Changes

- Remove comma-splitting logic from `PrInfoProcessor.MapLabelsToAreas`
- Remove comma-splitting logic from `GitHubReleaseChangelogService.MapLabelsToAreas`
- Update `ChangelogConfiguration.cs` doc comment to clarify behavior
- Update `changelog.example.yml` comments with examples of mapping one label to multiple areas
- Add unit tests to verify area names with commas are preserved
- Add integration tests for the multi-area per label pattern

To map one label to multiple areas, repeat the label under each area:

```yaml
  areas:
    "Search":
      - "Team:Search" "Observability":
      - "Team:Search"
```

NOTE: Some changes were required on top of the original plan (in https://github.com/elastic/docs-builder/issues/2934) to address the following test failure:

### Test fixes

The test expected one GitHub label (`Team:Search`) listed under **two** `pivot.areas` entries to produce **both** areas.  
`BuildLabelToAreasMapping` used `Dictionary<string, string>` and did `labelToAreas[label] = areaName`, so **each label could only map to one area**—the last area in file order won. That’s why the test failed even after removing the comma split.

The fix is as follows:

1. `BuildLabelToAreasMapping` now builds `Dictionary<string, List<string>>` and **appends** each area for a label (deduped case-insensitively).
2. `ChangelogConfiguration.LabelToAreas` is now  
   `IReadOnlyDictionary<string, IReadOnlyList<string>>?` so each label can map to multiple areas.
3. `MapLabelsToAreas` (in `PrInfoProcessor` and `GitHubReleaseChangelogService`) iterates every mapped area for each label.
4. Loader converts the dictionary to `IReadOnlyDictionary<string, IReadOnlyList<string>>` with `labelToAreas?.ToDictionary(...)` (also fixes IDE0031).
5. `ChangelogConfigurationTests` assert with `.ContainSingle().Which` where each label still maps to one area.
6. `LabelMappingTests` use `IReadOnlyList<string>` in the `MapLabelsToAreas` unit test; the multi-area integration test keeps assertions `- Search`/ `- Observability` to match emitted YAML (capitalized keys from your config).

`dotnet test tests/Elastic.Changelog.Tests` now reports **399 passed**.

**Note:** This is a **public API change** on `ChangelogConfiguration`: anything that read `LabelToAreas[label]` as a `string` must now treat the value as `IReadOnlyList<string>` (usually one element).

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: claude-4.5-haiku