### PR TITLE
docs(settings): document schema and drop stale notes

### DIFF
--- a/docs/syntax/automated_settings.md
+++ b/docs/syntax/automated_settings.md
@@ -1,12 +1,65 @@
 # Automated settings reference
 
-Elastic Docs V3 supports the ability to build a markdown settings reference from a YAML source file.
+Elastic Docs V3 can build a Markdown settings reference from a YAML source file.
+
+The `{settings}` directive is generic. Although the largest current examples come from Kibana, the directive can be used by any documentation repository that wants to render structured settings from YAML.
 
 ### Syntax
 
 ```markdown
-:::{settings} /syntax/settings-with-applies-example.yml
-:::
+::::{settings} /syntax/settings-with-applies-example.yml
+::::
+```
+
+### Schema
+
+The schema below reflects the structure currently supported by docs-builder. For the original settings-gen schema that inspired this format, see [the Kibana schema reference](https://github.com/elastic/kibana/tree/main/docs/settings-gen#schema).
+
+```yaml
+product: REQUIRED
+collection: REQUIRED
+# id: OPTIONAL
+# page_description: OPTIONAL multiline Markdown
+# note: OPTIONAL multiline Markdown or string
+
+groups:
+  - group: REQUIRED
+    # id: OPTIONAL
+    # description: OPTIONAL multiline Markdown
+    # note: OPTIONAL multiline Markdown or string
+    # example: OPTIONAL multiline Markdown
+
+    settings:
+      - setting: REQUIRED
+        description: |
+          REQUIRED
+          Multiline Markdown.
+        # id: OPTIONAL
+        # applies_to: OPTIONAL docs-builder applicability metadata
+        #
+        # Supports docs-builder applies_to syntax, for example:
+        #
+        # applies_to:
+        #   stack: ga 9.2
+        #   ech: ga
+        #   self: ga
+        #
+        # note: OPTIONAL
+        # tip: OPTIONAL
+        # warning: OPTIONAL
+        # important: OPTIONAL
+        # deprecation_details: OPTIONAL
+        # datatype: OPTIONAL
+        # default: OPTIONAL
+        # options:
+        #   - option: OPTIONAL
+        #     description: OPTIONAL
+        # example: OPTIONAL multiline Markdown
+        # settings: OPTIONAL nested settings list
+        #   Child settings inherit applies_to from the parent unless overridden.
+        #   - setting: "[n].url"
+        #     description: |
+        #       REQUIRED
 ```
 
 ### Example
@@ -15,17 +68,18 @@ See `/syntax/settings-with-applies-example.yml` for a full, schema-compliant sam
 
 It demonstrates:
 
-- Group `description` and `example`.
+- Group `description`, `note`, and `example`.
 - Setting `id`, `datatype`, `default`, and `options`.
 - `note`, `tip`, `warning`, `important`, and `deprecation_details`.
 - Nested `settings`.
 - `applies_to` inheritance and override behavior.
+- Top-level `page_description`.
 
 ### Result
 
 _Everything below this line is auto-generated._
 
-:::{settings} /syntax/settings-with-applies-example.yml
-:::
+::::{settings} /syntax/settings-with-applies-example.yml
+::::
 
 For large Kibana-exported YAML samples used in local stress tests, see [Kibana settings YAML samples](../testing/kibana-settings-yaml-samples.md).

--- a/docs/testing/kibana-alert-action-settings.yml
+++ b/docs/testing/kibana-alert-action-settings.yml
@@ -11,8 +11,6 @@ page_description: |
   2. [Set up TLS encryption between {{kib}} and {{es}}](docs-content://deploy-manage/security/set-up-basic-security-plus-https.md#encrypt-kibana-http).
   3. If you are using an **on-premises** Elastic Stack deployment, [specify a value for `xpack.encryptedSavedObjects.encryptionKey`](#general-alert-action-settings).
 
-note: 'If a setting is applicable to {{ech}} environments, its name is followed by this icon: ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")'
-
 groups:
   - group: General settings
     id: general-alert-action-settings

--- a/docs/testing/kibana-fleet-settings.yml
+++ b/docs/testing/kibana-fleet-settings.yml
@@ -11,8 +11,6 @@ page_description: |
 
   Go to the [{{fleet}}](docs-content://reference/fleet/index.md) docs for more information about {{fleet}}.
 
-note: 'In {{ecloud}}, {{fleet}} flags are already configured. If a setting is applicable to {{ech}} environments, its name is followed by this icon: ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")'
-
 groups:
   - group: General {{fleet}} settings
     id: general-fleet-settings-kb

--- a/docs/testing/kibana-general-settings.yml
+++ b/docs/testing/kibana-general-settings.yml
@@ -6,8 +6,6 @@ collection: General settings in Kibana
 id: general-settings-kb
 page_description: |
   Use these settings to configure general features available in Kibana.
-note: 'If a setting is applicable to {{ech}} environments, its name is followed by this icon: ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")'
-
 groups:
   - group: General settings
     id: general-kibana-settings

--- a/docs/testing/kibana-monitoring-settings.yml
+++ b/docs/testing/kibana-monitoring-settings.yml
@@ -13,8 +13,6 @@ page_description: |
 
   For more information, check out [Monitor a cluster](docs-content://deploy-manage/monitor.md).
 
-note: 'If a setting is applicable to {{ech}} environments, its name is followed by this icon: ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")'
-
 groups:
   - group: General monitoring settings
     id: monitoring-general-settings

--- a/docs/testing/kibana-security-settings.yml
+++ b/docs/testing/kibana-security-settings.yml
@@ -7,8 +7,6 @@ id: security-settings-kb
 page_description: |
   You do not need to configure any additional settings to use the {{security-features}} in {{kib}}. They are enabled by default.
 important: "In high-availability deployments, make sure you use the same security settings for all instances of {{kib}}. Also consider storing sensitive security settings, such as encryption and decryption keys, securely in the Kibana keystore, instead of keeping them in clear text in the `kibana.yml` file."
-note: 'If a setting is applicable to {{ech}} environments, its name is followed by this icon: ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")'
-
 groups:
   - group: Authentication security settings
     id: authentication-security-settings


### PR DESCRIPTION
## Summary
- document the supported `{settings}` YAML schema in `docs/syntax/automated_settings.md` using generic wording that applies beyond Kibana
- link the docs page to the upstream Kibana `settings-gen` schema for reference
- remove stale top-level fixture notes in the Kibana sample YAMLs that still mention showing a cloud icon

## Test plan
- [x] `dotnet run --project src/tooling/docs-builder -c release -- --strict -p docs`


Made with [Cursor](https://cursor.com)