### PR TITLE
Wire Explore/Visualize, Share/Alert/Automate, and AI/ML nav sections

### DIFF
--- a/config/navigation-v2.yml
+++ b/config/navigation-v2.yml
@@ -292,88 +292,705 @@ nav:
           - title: Query languages
           - title: Query tools
       - group: Explore and visualize
+        page: docs-content://explore-analyze/explore-and-visualize.md
         children:
-        - title: Learn data exploration and visualization
-        - group: Find and organize content
-          children:
-          - title: Data views
-          - title: Files
-          - title: Find apps and objects
-          - title: Reports
-          - title: Saved objects
-          - title: Tags
-        - group: Reporting and sharing
-          children:
-          - title: Automatically generate reports
-        - group: Panels and visualizations
-          children:
-          - title: Alert panels
-          - title: Custom visualizations with Vega
-          - title: Image panels
-          - title: Legacy editors
-          - title: Lens
-          - title: Link panels
-          - title: Maps
-          - title: Text panels
-        - group: Dashboards
-          children:
-          - title: Add filter controls
-          - title: Organize dashboard panels
-          - title: Building dashboards
-          - title: Create a dashboard
-          - title: "Tutorial: dashboard with time series charts"
-          - title: "Tutorial: dashboard to monitor website logs"
-          - title: Add drilldowns
-          - title: Duplicate a dashboard
-          - title: Import a dashboard
-          - title: Managing dashboards
-          - title: Sharing dashboards
-          - title: Exploring dashboards
+        - page: docs-content://explore-analyze/kibana-data-exploration-learning-tutorial.md
+          title: Learn data exploration and visualization
         - group: Discover
+          page: docs-content://explore-analyze/discover.md
           children:
-          - title: Run queries in the background
-          - title: Explore fields and data with Discover
-          - title: Search for relevance
-          - title: Customize the Discover view
-          - title: Run a pattern analysis on log data
-          - title: Save a search for reuse
-          - title: Using ES|QL
-      - group: Alert and trigger actions
+          - page: docs-content://explore-analyze/discover/discover-get-started.md
+            title: Explore fields and data with Discover
+          - page: docs-content://explore-analyze/discover/document-explorer.md
+            title: Customize the Discover view
+          - page: docs-content://explore-analyze/discover/discover-search-for-relevance.md
+            title: Search for relevance
+          - page: docs-content://explore-analyze/discover/save-open-search.md
+            title: Save a search for reuse
+          - page: docs-content://explore-analyze/discover/show-field-statistics.md
+            title: View field statistics
+          - page: docs-content://explore-analyze/discover/run-pattern-analysis-discover.md
+            title: Run a pattern analysis on your log data
+          - page: docs-content://explore-analyze/discover/background-search.md
+            title: Run queries in the background
+          - page: docs-content://explore-analyze/discover/try-esql.md
+            title: "Using ES|QL"
+        - group: Dashboards
+          page: docs-content://explore-analyze/dashboards.md
+          children:
+          - page: docs-content://explore-analyze/dashboards/using.md
+            title: Exploring dashboards
+          - group: Building dashboards
+            page: docs-content://explore-analyze/dashboards/building.md
+            children:
+            - page: docs-content://explore-analyze/dashboards/create-dashboard.md
+              title: Create a dashboard
+            - page: docs-content://explore-analyze/dashboards/open-dashboard.md
+              title: Edit a dashboard
+            - page: docs-content://explore-analyze/dashboards/add-controls.md
+              title: Add filter controls
+            - page: docs-content://explore-analyze/dashboards/drilldowns.md
+              title: Add drilldowns
+            - page: docs-content://explore-analyze/dashboards/arrange-panels.md
+              title: Organize dashboard panels
+            - page: docs-content://explore-analyze/dashboards/duplicate-dashboards.md
+              title: Duplicate a dashboard
+            - page: docs-content://explore-analyze/dashboards/import-dashboards.md
+              title: Import a dashboard
+          - page: docs-content://explore-analyze/dashboards/managing.md
+            title: Managing dashboards
+          - page: docs-content://explore-analyze/dashboards/sharing.md
+            title: Sharing dashboards
+          - group: Tutorials
+            page: docs-content://explore-analyze/dashboards/tutorials.md
+            children:
+            - page: docs-content://explore-analyze/dashboards/create-dashboard-of-panels-with-web-server-data.md
+              title: Create a simple dashboard to monitor website logs
+            - page: docs-content://explore-analyze/dashboards/create-dashboard-of-panels-with-ecommerce-data.md
+              title: Create a dashboard with time series charts
+        - group: Panels and visualizations
+          page: docs-content://explore-analyze/visualize.md
+          children:
+          - page: docs-content://explore-analyze/visualize/visualize-library.md
+            title: Visualize Library
+          - page: docs-content://explore-analyze/visualize/manage-panels.md
+            title: Manage panels
+          - group: Lens
+            page: docs-content://explore-analyze/visualize/lens.md
+            children:
+            - page: docs-content://explore-analyze/visualize/charts/area-charts.md
+              title: Area charts
+            - page: docs-content://explore-analyze/visualize/charts/bar-charts.md
+              title: Bar charts
+            - page: docs-content://explore-analyze/visualize/charts/heat-map-charts.md
+              title: Heat map charts
+            - page: docs-content://explore-analyze/visualize/charts/gauge-charts.md
+              title: Gauge charts
+            - page: docs-content://explore-analyze/visualize/charts/line-charts.md
+              title: Line charts
+            - page: docs-content://explore-analyze/visualize/charts/metric-charts.md
+              title: Metric charts
+            - page: docs-content://explore-analyze/visualize/charts/mosaic-charts.md
+              title: Mosaic charts
+            - page: docs-content://explore-analyze/visualize/charts/pie-charts.md
+              title: Pie charts
+            - page: docs-content://explore-analyze/visualize/charts/region-map-charts.md
+              title: Region map charts
+            - page: docs-content://explore-analyze/visualize/charts/tables.md
+              title: Tables
+            - page: docs-content://explore-analyze/visualize/charts/waffle-charts.md
+              title: Waffle charts
+            - page: docs-content://explore-analyze/visualize/charts/tag-cloud-charts.md
+              title: Tag cloud charts
+            - page: docs-content://explore-analyze/visualize/charts/treemap-charts.md
+              title: Treemap charts
+          - page: docs-content://explore-analyze/visualize/esorql.md
+            title: "ES|QL"
+          - page: docs-content://explore-analyze/visualize/custom-visualizations-with-vega.md
+            title: Custom visualizations with Vega
+          - page: docs-content://explore-analyze/visualize/text-panels.md
+            title: Text panels
+          - page: docs-content://explore-analyze/visualize/image-panels.md
+            title: Image panels
+          - page: docs-content://explore-analyze/visualize/link-panels.md
+            title: Link panels
+          - page: docs-content://explore-analyze/visualize/alert-panels.md
+            title: Alert panels
+          - group: Canvas
+            page: docs-content://explore-analyze/visualize/canvas.md
+            children:
+            - page: docs-content://explore-analyze/visualize/canvas/edit-workpads.md
+              title: Edit workpads
+            - page: docs-content://explore-analyze/visualize/canvas/canvas-present-workpad.md
+              title: Present your workpad
+            - page: docs-content://explore-analyze/visualize/canvas/canvas-tutorial.md
+              title: "Tutorial: Create a workpad for monitoring sales"
+            - group: Canvas function reference
+              page: docs-content://explore-analyze/visualize/canvas/canvas-function-reference.md
+              children:
+              - page: docs-content://explore-analyze/visualize/canvas/canvas-tinymath-functions.md
+                title: TinyMath functions
+          - group: Maps
+            page: docs-content://explore-analyze/visualize/maps.md
+            children:
+            - page: docs-content://explore-analyze/visualize/maps/maps-getting-started.md
+              title: Build a map to compare metrics by country or region
+            - page: docs-content://explore-analyze/visualize/maps/asset-tracking-tutorial.md
+              title: Track, visualize, and alert on assets in real time
+            - page: docs-content://explore-analyze/visualize/maps/reverse-geocoding-tutorial.md
+              title: Map custom regions with reverse geocoding
+            - page: docs-content://explore-analyze/visualize/maps/heatmap-layer.md
+              title: Heat map layer
+            - page: docs-content://explore-analyze/visualize/maps/tile-layer.md
+              title: Tile layer
+            - group: Vector layer
+              page: docs-content://explore-analyze/visualize/maps/vector-layer.md
+              children:
+              - page: docs-content://explore-analyze/visualize/maps/vector-style.md
+                title: Vector styling
+              - page: docs-content://explore-analyze/visualize/maps/maps-vector-style-properties.md
+                title: Vector style properties
+              - page: docs-content://explore-analyze/visualize/maps/vector-tooltip.md
+                title: Vector tooltips
+            - group: Map aggregations
+              page: docs-content://explore-analyze/visualize/maps/maps-aggregations.md
+              children:
+              - page: docs-content://explore-analyze/visualize/maps/maps-grid-aggregation.md
+                title: Clusters
+              - page: docs-content://explore-analyze/visualize/maps/maps-top-hits-aggregation.md
+                title: Display the most relevant documents per entity
+              - page: docs-content://explore-analyze/visualize/maps/point-to-point.md
+                title: Point to point
+              - page: docs-content://explore-analyze/visualize/maps/terms-join.md
+                title: Term join
+            - group: Search and filter maps
+              page: docs-content://explore-analyze/visualize/maps/maps-search.md
+              children:
+              - page: docs-content://explore-analyze/visualize/maps/maps-create-filter-from-map.md
+                title: Create filters from a map
+              - page: docs-content://explore-analyze/visualize/maps/maps-layer-based-filtering.md
+                title: Filter a single layer
+              - page: docs-content://explore-analyze/visualize/maps/maps-search-across-multiple-indices.md
+                title: Search across multiple indices
+            - page: docs-content://explore-analyze/visualize/maps/maps-settings.md
+              title: Configure map settings
+            - page: docs-content://explore-analyze/visualize/maps/maps-connect-to-ems.md
+              title: Connect to Elastic Maps Service
+            - group: Import geospatial data
+              page: docs-content://explore-analyze/visualize/maps/import-geospatial-data.md
+              children:
+              - page: docs-content://explore-analyze/visualize/maps/maps-clean-data.md
+                title: Clean your data
+              - page: docs-content://explore-analyze/visualize/maps/indexing-geojson-data-tutorial.md
+                title: "Tutorial: Index GeoJSON data"
+            - page: docs-content://explore-analyze/visualize/maps/maps-troubleshooting.md
+              title: Troubleshoot
+          - group: Graph
+            page: docs-content://explore-analyze/visualize/graph.md
+            children:
+            - page: docs-content://explore-analyze/visualize/graph/graph-configuration.md
+              title: Configure Graph
+            - page: docs-content://explore-analyze/visualize/graph/graph-troubleshooting.md
+              title: Troubleshooting and limitations
+          - group: Legacy editors
+            page: docs-content://explore-analyze/visualize/legacy-editors.md
+            children:
+            - page: docs-content://explore-analyze/visualize/legacy-editors/aggregation-based.md
+              title: Aggregation-based
+            - page: docs-content://explore-analyze/visualize/legacy-editors/tsvb.md
+              title: TSVB
+            - page: docs-content://explore-analyze/visualize/legacy-editors/timelion.md
+              title: Timelion
+        - group: Find and organize content
+          page: docs-content://explore-analyze/find-and-organize.md
+          children:
+          - page: docs-content://explore-analyze/find-and-organize/data-views.md
+            title: Data views
+          - page: docs-content://explore-analyze/find-and-organize/saved-objects.md
+            title: Saved objects
+          - page: docs-content://explore-analyze/find-and-organize/files.md
+            title: Files
+          - page: docs-content://explore-analyze/find-and-organize/reports.md
+            title: Reports
+          - page: docs-content://explore-analyze/find-and-organize/tags.md
+            title: Tags
+          - page: docs-content://explore-analyze/find-and-organize/find-apps-and-objects.md
+            title: Find apps and objects
+      - group: Share, alert, and automate
+        page: docs-content://explore-analyze/share-alert-and-automate.md
         children:
+        - group: Reporting and sharing
+          page: docs-content://explore-analyze/report-and-share.md
+          children:
+          - page: docs-content://explore-analyze/report-and-share/automating-report-generation.md
+            title: Automatically generate reports
+          - group: Reporting troubleshooting
+            page: docs-content://explore-analyze/report-and-share/reporting-troubleshooting.md
+            children:
+            - page: docs-content://explore-analyze/report-and-share/reporting-troubleshooting-csv.md
+              title: CSV
+            - page: docs-content://explore-analyze/report-and-share/reporting-troubleshooting-pdf.md
+              title: PDF/PNG
         - group: Workflows
+          page: docs-content://explore-analyze/workflows.md
           children:
-          - title: Author workflows
-          - title: Data and error handling
-          - title: Get started with workflows
-          - title: Steps
-          - title: Triggers
-        - title: Alerting
+          - page: docs-content://explore-analyze/workflows/setup.md
+            title: Set up workflows
+          - page: docs-content://explore-analyze/workflows/get-started.md
+            title: Get started with workflows
+          - group: Core components
+            page: docs-content://explore-analyze/workflows/core-components.md
+            children:
+            - group: Triggers
+              page: docs-content://explore-analyze/workflows/triggers.md
+              children:
+              - page: docs-content://explore-analyze/workflows/triggers/manual-triggers.md
+                title: Manual triggers
+              - page: docs-content://explore-analyze/workflows/triggers/scheduled-triggers.md
+                title: Scheduled triggers
+              - page: docs-content://explore-analyze/workflows/triggers/alert-triggers.md
+                title: Alert triggers
+            - group: Steps
+              page: docs-content://explore-analyze/workflows/steps.md
+              children:
+              - group: Action steps
+                page: docs-content://explore-analyze/workflows/steps/action-steps.md
+                children:
+                - page: docs-content://explore-analyze/workflows/steps/elasticsearch.md
+                  title: Elasticsearch
+                - page: docs-content://explore-analyze/workflows/steps/kibana.md
+                  title: Kibana
+                - page: docs-content://explore-analyze/workflows/steps/external-systems-apps.md
+                  title: External systems and apps
+              - group: Flow control steps
+                page: docs-content://explore-analyze/workflows/steps/flow-control-steps.md
+                children:
+                - page: docs-content://explore-analyze/workflows/steps/if.md
+                  title: If
+                - page: docs-content://explore-analyze/workflows/steps/foreach.md
+                  title: Foreach
+                - page: docs-content://explore-analyze/workflows/steps/wait.md
+                  title: Wait
+              - page: docs-content://explore-analyze/workflows/steps/ai-steps.md
+                title: AI steps
+          - group: Data and error handling
+            page: docs-content://explore-analyze/workflows/data.md
+            children:
+            - page: docs-content://explore-analyze/workflows/data/templating.md
+              title: Templating engine
+          - page: docs-content://explore-analyze/workflows/author-workflows.md
+            title: Author workflows
+          - page: docs-content://explore-analyze/workflows/monitor-troubleshoot.md
+            title: Monitor and troubleshoot workflows
+          - page: docs-content://explore-analyze/workflows/manage-workflows.md
+            title: Manage workflows
+          - page: docs-content://explore-analyze/workflows/templates.md
+            title: Workflow templates
+        - group: Alerting
+          page: docs-content://explore-analyze/alerting.md
+          children:
+          - group: Alerts
+            page: docs-content://explore-analyze/alerting/alerts.md
+            children:
+            - page: docs-content://explore-analyze/alerting/alerts/alerting-getting-started.md
+              title: Getting started with alerts
+            - page: docs-content://explore-analyze/alerting/alerts/alerting-setup.md
+              title: Set up
+            - page: docs-content://explore-analyze/alerting/alerts/create-manage-rules.md
+              title: Create and manage rules
+            - page: docs-content://explore-analyze/alerting/alerts/view-alerts.md
+              title: View and manage alerts
+            - page: docs-content://explore-analyze/alerting/alerts/query-alerts.md
+              title: Query alert indices
+            - group: Rule types
+              page: docs-content://explore-analyze/alerting/alerts/rule-types.md
+              children:
+              - page: docs-content://explore-analyze/alerting/alerts/rule-type-index-threshold.md
+                title: Index threshold
+              - page: docs-content://explore-analyze/alerting/alerts/rule-type-es-query.md
+                title: Elasticsearch query
+              - page: docs-content://explore-analyze/alerting/alerts/geo-alerting.md
+                title: Tracking containment
+            - page: docs-content://explore-analyze/alerting/alerts/rule-action-variables.md
+              title: Rule action variables
+            - page: docs-content://explore-analyze/alerting/alerts/notifications-domain-allowlist.md
+              title: Notifications domain allowlist
+            - group: Alerting troubleshooting
+              page: docs-content://explore-analyze/alerting/alerts/alerting-troubleshooting.md
+              children:
+              - page: docs-content://explore-analyze/alerting/alerts/alerting-common-issues.md
+                title: Common issues
+              - page: docs-content://explore-analyze/alerting/alerts/event-log-index.md
+                title: Event log index
+              - page: docs-content://explore-analyze/alerting/alerts/testing-connectors.md
+                title: Test connectors
+            - page: docs-content://explore-analyze/alerting/alerts/maintenance-windows.md
+              title: Maintenance windows
+          - group: Watcher
+            page: docs-content://explore-analyze/alerting/watcher.md
+            children:
+            - page: docs-content://explore-analyze/alerting/watcher/watcher-getting-started.md
+              title: Getting started with Watcher
+            - page: docs-content://explore-analyze/alerting/watcher/how-watcher-works.md
+              title: How Watcher works
+            - page: docs-content://explore-analyze/alerting/watcher/enable-watcher.md
+              title: Enable Watcher
+            - page: docs-content://explore-analyze/alerting/watcher/watcher-ui.md
+              title: Watcher UI
+            - page: docs-content://explore-analyze/alerting/watcher/encrypting-data.md
+              title: Encrypting sensitive data in Watcher
+            - group: Input
+              page: docs-content://explore-analyze/alerting/watcher/input.md
+              children:
+              - page: docs-content://explore-analyze/alerting/watcher/input-simple.md
+                title: Simple input
+              - page: docs-content://explore-analyze/alerting/watcher/input-search.md
+                title: Search input
+              - page: docs-content://explore-analyze/alerting/watcher/input-http.md
+                title: HTTP input
+              - page: docs-content://explore-analyze/alerting/watcher/input-chain.md
+                title: Chain input
+            - group: Trigger
+              page: docs-content://explore-analyze/alerting/watcher/trigger.md
+              children:
+              - page: docs-content://explore-analyze/alerting/watcher/trigger-schedule.md
+                title: Schedule trigger
+              - page: docs-content://explore-analyze/alerting/watcher/throttling.md
+                title: Throttling
+              - page: docs-content://explore-analyze/alerting/watcher/schedule-types.md
+                title: Schedule Types
+            - group: Condition
+              page: docs-content://explore-analyze/alerting/watcher/condition.md
+              children:
+              - page: docs-content://explore-analyze/alerting/watcher/condition-always.md
+                title: Always condition
+              - page: docs-content://explore-analyze/alerting/watcher/condition-never.md
+                title: Never condition
+              - page: docs-content://explore-analyze/alerting/watcher/condition-compare.md
+                title: Compare condition
+              - page: docs-content://explore-analyze/alerting/watcher/condition-array-compare.md
+                title: Array compare condition
+              - page: docs-content://explore-analyze/alerting/watcher/condition-script.md
+                title: Script condition
+            - group: Actions
+              page: docs-content://explore-analyze/alerting/watcher/actions.md
+              children:
+              - page: docs-content://explore-analyze/alerting/watcher/action-foreach.md
+                title: Running an action for each element in an array
+              - page: docs-content://explore-analyze/alerting/watcher/action-conditions.md
+                title: Adding conditions to actions
+              - page: docs-content://explore-analyze/alerting/watcher/actions-email.md
+                title: Email action
+              - page: docs-content://explore-analyze/alerting/watcher/actions-webhook.md
+                title: Webhook action
+              - page: docs-content://explore-analyze/alerting/watcher/actions-index.md
+                title: Index action
+              - page: docs-content://explore-analyze/alerting/watcher/actions-logging.md
+                title: Logging action
+              - page: docs-content://explore-analyze/alerting/watcher/actions-slack.md
+                title: Slack action
+              - page: docs-content://explore-analyze/alerting/watcher/actions-pagerduty.md
+                title: PagerDuty action
+              - page: docs-content://explore-analyze/alerting/watcher/actions-jira.md
+                title: Jira action
+            - group: Transform
+              page: docs-content://explore-analyze/alerting/watcher/transform.md
+              children:
+              - page: docs-content://explore-analyze/alerting/watcher/transform-search.md
+                title: Search payload transform
+              - page: docs-content://explore-analyze/alerting/watcher/transform-script.md
+                title: Script payload transform
+              - page: docs-content://explore-analyze/alerting/watcher/transform-chain.md
+                title: Chain payload transform
+            - page: docs-content://explore-analyze/alerting/watcher/managing-watches.md
+              title: Managing watches
+            - group: Example watches
+              page: docs-content://explore-analyze/alerting/watcher/example-watches.md
+              children:
+              - page: docs-content://explore-analyze/alerting/watcher/watch-cluster-status.md
+                title: Watching the status of an Elasticsearch cluster
+              - page: docs-content://explore-analyze/alerting/watcher/execute-watch.md
+                title: Execute a watch
+            - page: docs-content://explore-analyze/alerting/watcher/watcher-limitations.md
+              title: Limitations
         - group: Cases
+          page: docs-content://explore-analyze/cases.md
           children:
-          - title: Attach objects to cases
-          - title: Configure case settings
-          - title: Create cases
-          - title: Manage cases
-          - title: Search and share cases
+          - page: docs-content://explore-analyze/cases/control-case-access.md
+            title: Control access
+          - page: docs-content://explore-analyze/cases/create-cases.md
+            title: Create cases
+          - page: docs-content://explore-analyze/cases/manage-cases.md
+            title: Manage cases
+          - page: docs-content://explore-analyze/cases/attach-objects-to-cases.md
+            title: Attach objects
+          - page: docs-content://explore-analyze/cases/search-share-cases.md
+            title: Search and share
+          - page: docs-content://explore-analyze/cases/configure-case-settings.md
+            title: Configure settings
+          - page: docs-content://explore-analyze/cases/cases-as-data.md
+            title: Cases as data
     - label: AI and machine learning
       children:
       - group: Machine Learning and NLP
+        page: docs-content://explore-analyze/machine-learning.md
         children:
-        - title: Anomaly detection
-        - title: Data frame analytics
+        - page: docs-content://explore-analyze/machine-learning/setting-up-machine-learning.md
+          title: Setup and security
+        - group: Anomaly detection
+          page: docs-content://explore-analyze/machine-learning/anomaly-detection.md
+          children:
+          - group: Finding anomalies
+            page: docs-content://explore-analyze/machine-learning/anomaly-detection/ml-ad-finding-anomalies.md
+            children:
+            - page: docs-content://explore-analyze/machine-learning/anomaly-detection/ml-ad-plan.md
+              title: Plan your analysis
+            - page: docs-content://explore-analyze/machine-learning/anomaly-detection/ml-ad-run-jobs.md
+              title: Run a job
+            - page: docs-content://explore-analyze/machine-learning/anomaly-detection/ml-ad-view-results.md
+              title: View the results
+            - page: docs-content://explore-analyze/machine-learning/anomaly-detection/ml-ad-forecast.md
+              title: Forecast future behavior
+          - page: docs-content://explore-analyze/machine-learning/anomaly-detection/ml-getting-started.md
+            title: Tutorial
+          - group: Concepts
+            page: docs-content://explore-analyze/machine-learning/anomaly-detection/ml-ad-concepts.md
+            children:
+            - page: docs-content://explore-analyze/machine-learning/anomaly-detection/ml-ad-algorithms.md
+              title: Anomaly detection algorithms
+            - page: docs-content://explore-analyze/machine-learning/anomaly-detection/ml-ad-explain.md
+              title: Anomaly score explanation
+            - page: docs-content://explore-analyze/machine-learning/anomaly-detection/ml-anomaly-detection-job-types.md
+              title: Job types
+            - page: docs-content://explore-analyze/machine-learning/anomaly-detection/anomaly-detection-scale.md
+              title: Working with anomaly detection at scale
+            - page: docs-content://explore-analyze/machine-learning/anomaly-detection/ml-delayed-data-detection.md
+              title: Handling delayed data
+          - page: docs-content://explore-analyze/machine-learning/anomaly-detection/ml-api-quickref.md
+            title: API quick reference
+          - group: How-tos
+            page: docs-content://explore-analyze/machine-learning/anomaly-detection/anomaly-how-tos.md
+            children:
+            - page: docs-content://explore-analyze/machine-learning/anomaly-detection/ml-configuring-alerts.md
+              title: Generating alerts for anomaly detection jobs
+            - page: docs-content://explore-analyze/machine-learning/anomaly-detection/ml-configuring-aggregation.md
+              title: Aggregating data for faster performance
+            - page: docs-content://explore-analyze/machine-learning/anomaly-detection/ml-configuring-transform.md
+              title: Altering data in your datafeed with runtime fields
+            - page: docs-content://explore-analyze/machine-learning/anomaly-detection/ml-configuring-detector-custom-rules.md
+              title: Customizing detectors with custom rules
+            - page: docs-content://explore-analyze/machine-learning/anomaly-detection/ml-configuring-categories.md
+              title: Detecting anomalous categories of data
+            - page: docs-content://explore-analyze/machine-learning/anomaly-detection/ml-configuring-populations.md
+              title: Performing population analysis
+            - page: docs-content://explore-analyze/machine-learning/anomaly-detection/ml-reverting-model-snapshot.md
+              title: Reverting to a model snapshot
+            - page: docs-content://explore-analyze/machine-learning/anomaly-detection/geographic-anomalies.md
+              title: Detecting anomalous locations in geographic data
+            - page: docs-content://explore-analyze/machine-learning/anomaly-detection/mapping-anomalies.md
+              title: Mapping anomalies by location
+            - page: docs-content://explore-analyze/machine-learning/anomaly-detection/ml-configuring-url.md
+              title: Adding custom URLs to machine learning results
+            - page: docs-content://explore-analyze/machine-learning/anomaly-detection/ml-jobs-from-lens.md
+              title: Anomaly detection jobs from visualizations
+          - group: Resources
+            page: docs-content://explore-analyze/machine-learning/anomaly-detection/ml-ad-resources.md
+            children:
+            - page: docs-content://explore-analyze/machine-learning/anomaly-detection/ml-limitations.md
+              title: Limitations
+            - page: docs-content://explore-analyze/machine-learning/anomaly-detection/ml-functions.md
+              title: Analysis function reference
+            - page: docs-content://explore-analyze/machine-learning/anomaly-detection/ootb-ml-jobs.md
+              title: Supplied configurations
+            - page: docs-content://explore-analyze/machine-learning/anomaly-detection/ml-ad-troubleshooting.md
+              title: Troubleshooting and FAQ
+        - group: Data frame analytics
+          page: docs-content://explore-analyze/machine-learning/data-frame-analytics.md
+          children:
+          - page: docs-content://explore-analyze/machine-learning/data-frame-analytics/ml-dfa-overview.md
+            title: Overview
+          - page: docs-content://explore-analyze/machine-learning/data-frame-analytics/ml-dfa-finding-outliers.md
+            title: Finding outliers
+          - page: docs-content://explore-analyze/machine-learning/data-frame-analytics/ml-dfa-regression.md
+            title: Predicting numerical values with regression
+          - page: docs-content://explore-analyze/machine-learning/data-frame-analytics/ml-dfa-classification.md
+            title: Predicting classes with classification
+          - group: Concepts
+            page: docs-content://explore-analyze/machine-learning/data-frame-analytics/ml-dfa-concepts.md
+            children:
+            - page: docs-content://explore-analyze/machine-learning/data-frame-analytics/ml-dfa-phases.md
+              title: How data frame analytics jobs work
+            - page: docs-content://explore-analyze/machine-learning/data-frame-analytics/ml-dfa-scale.md
+              title: Working with data frame analytics at scale
+            - page: docs-content://explore-analyze/machine-learning/data-frame-analytics/ml-dfa-custom-urls.md
+              title: Adding custom URLs to data frame analytics jobs
+            - page: docs-content://explore-analyze/machine-learning/data-frame-analytics/ml-feature-encoding.md
+              title: Feature encoding
+            - page: docs-content://explore-analyze/machine-learning/data-frame-analytics/ml-feature-processors.md
+              title: Feature processors
+            - page: docs-content://explore-analyze/machine-learning/data-frame-analytics/ml-feature-importance.md
+              title: Feature importance
+            - page: docs-content://explore-analyze/machine-learning/data-frame-analytics/dfa-regression-lossfunction.md
+              title: Loss functions for regression analyses
+            - page: docs-content://explore-analyze/machine-learning/data-frame-analytics/hyperparameters.md
+              title: Hyperparameter optimization
+            - page: docs-content://explore-analyze/machine-learning/data-frame-analytics/ml-trained-models.md
+              title: Trained models
+          - page: docs-content://explore-analyze/machine-learning/data-frame-analytics/ml-dfanalytics-apis.md
+            title: API quick reference
+          - group: Resources
+            page: docs-content://explore-analyze/machine-learning/data-frame-analytics/ml-dfa-resources.md
+            children:
+            - page: docs-content://explore-analyze/machine-learning/data-frame-analytics/ml-dfa-limitations.md
+              title: Limitations
+        - group: NLP
+          page: docs-content://explore-analyze/machine-learning/nlp.md
+          children:
+          - group: Overview
+            page: docs-content://explore-analyze/machine-learning/nlp/ml-nlp-overview.md
+            children:
+            - page: docs-content://explore-analyze/machine-learning/nlp/ml-nlp-extract-info.md
+              title: Extract information
+            - page: docs-content://explore-analyze/machine-learning/nlp/ml-nlp-classify-text.md
+              title: Classify text
+            - page: docs-content://explore-analyze/machine-learning/nlp/ml-nlp-search-compare.md
+              title: Search and compare text
+          - group: Deploy models
+            page: docs-content://explore-analyze/machine-learning/nlp/ml-nlp-deploy-models.md
+            children:
+            - page: docs-content://explore-analyze/machine-learning/nlp/ml-nlp-select-model.md
+              title: Select a trained model
+            - page: docs-content://explore-analyze/machine-learning/nlp/ml-nlp-import-model.md
+              title: Import the trained model and vocabulary
+            - page: docs-content://explore-analyze/machine-learning/nlp/ml-nlp-deploy-model.md
+              title: Deploy the model in your cluster
+            - page: docs-content://explore-analyze/machine-learning/nlp/ml-nlp-test-inference.md
+              title: Try it out
+          - page: docs-content://explore-analyze/machine-learning/nlp/ml-nlp-inference.md
+            title: Add NLP inference to ingest pipelines
+          - page: docs-content://explore-analyze/machine-learning/nlp/ml-nlp-apis.md
+            title: API quick reference
+          - group: Built-in models
+            page: docs-content://explore-analyze/machine-learning/nlp/ml-nlp-built-in-models.md
+            children:
+            - page: docs-content://explore-analyze/machine-learning/nlp/ml-nlp-elser.md
+              title: ELSER
+            - page: docs-content://explore-analyze/machine-learning/nlp/ml-nlp-jina.md
+              title: Jina
+            - page: docs-content://explore-analyze/machine-learning/nlp/ml-nlp-rerank.md
+              title: Elastic Rerank
+            - page: docs-content://explore-analyze/machine-learning/nlp/ml-nlp-e5.md
+              title: E5
+            - page: docs-content://explore-analyze/machine-learning/nlp/ml-nlp-lang-ident.md
+              title: Language identification
+          - page: docs-content://explore-analyze/machine-learning/nlp/ml-nlp-model-ref.md
+            title: Compatible third party models
+          - group: Examples
+            page: docs-content://explore-analyze/machine-learning/nlp/ml-nlp-examples.md
+            children:
+            - page: docs-content://explore-analyze/machine-learning/nlp/nlp-end-to-end-tutorial.md
+              title: End-to-end tutorial
+            - page: docs-content://explore-analyze/machine-learning/nlp/ml-nlp-ner-example.md
+              title: Named entity recognition
+            - page: docs-content://explore-analyze/machine-learning/nlp/ml-nlp-text-emb-vector-search-example.md
+              title: Text embedding and semantic search
+          - page: docs-content://explore-analyze/machine-learning/nlp/ml-nlp-limitations.md
+            title: Limitations
+        - group: Machine learning in Kibana
+          page: docs-content://explore-analyze/machine-learning/machine-learning-in-kibana.md
+          children:
+          - page: docs-content://explore-analyze/machine-learning/machine-learning-in-kibana/xpack-ml-aiops.md
+            title: AIOps Labs
+          - page: docs-content://explore-analyze/machine-learning/machine-learning-in-kibana/inference-processing.md
+            title: Inference processing
       - group: AI framework
+        page: docs-content://explore-analyze/ai-features.md
         children:
         - group: Elastic Inference Service
+          page: docs-content://explore-analyze/elastic-inference.md
           children:
-          - title: Elastic Inference Service
-          - title: Inference integrations
+          - group: Elastic Inference Service
+            page: docs-content://explore-analyze/elastic-inference/eis.md
+            children:
+            - page: docs-content://explore-analyze/elastic-inference/connect-self-managed-cluster-to-eis.md
+              title: EIS for self-managed clusters
+          - page: docs-content://explore-analyze/elastic-inference/inference-api.md
+            title: Inference integrations
         - group: Agent builder
+          page: docs-content://explore-analyze/ai-features/elastic-agent-builder.md
           children:
-          - title: Elasticsearch MCP
-        - title: AI chats
-        - title: LLM guides
-        - title: Manage access to AI features
-      - title: AI agent skills for Elastic
+          - page: docs-content://explore-analyze/ai-features/agent-builder/get-started.md
+            title: Get started
+          - page: docs-content://explore-analyze/ai-features/agent-builder/models.md
+            title: Models
+          - group: Chat
+            page: docs-content://explore-analyze/ai-features/agent-builder/chat.md
+            children:
+            - page: docs-content://explore-analyze/ai-features/agent-builder/standalone-and-flyout-modes.md
+              title: Chat UI modes
+          - group: Agents
+            page: docs-content://explore-analyze/ai-features/agent-builder/agent-builder-agents.md
+            children:
+            - page: docs-content://explore-analyze/ai-features/agent-builder/custom-agents.md
+              title: Custom agents
+            - page: docs-content://explore-analyze/ai-features/agent-builder/builtin-agents-reference.md
+              title: Built-in agents
+            - page: docs-content://explore-analyze/ai-features/agent-builder/prompt-engineering.md
+              title: Prompting best practices
+            - page: docs-content://explore-analyze/ai-features/agent-builder/agents-and-workflows.md
+              title: Call agents from workflows
+          - group: Tools
+            page: docs-content://explore-analyze/ai-features/agent-builder/tools.md
+            children:
+            - page: docs-content://explore-analyze/ai-features/agent-builder/tools/builtin-tools-reference.md
+              title: Built-in tools
+            - group: Custom tools
+              page: docs-content://explore-analyze/ai-features/agent-builder/tools/custom-tools.md
+              children:
+              - page: docs-content://explore-analyze/ai-features/agent-builder/tools/esql-tools.md
+                title: "ES|QL tools"
+              - page: docs-content://explore-analyze/ai-features/agent-builder/tools/index-search-tools.md
+                title: Index search tools
+              - page: docs-content://explore-analyze/ai-features/agent-builder/tools/mcp-tools.md
+                title: MCP tools
+              - page: docs-content://explore-analyze/ai-features/agent-builder/tools/workflow-tools.md
+                title: Workflow tools
+          - group: Programmatic access
+            page: docs-content://explore-analyze/ai-features/agent-builder/programmatic-access.md
+            children:
+            - group: Kibana API
+              page: docs-content://explore-analyze/ai-features/agent-builder/kibana-api.md
+              children:
+              - page: docs-content://explore-analyze/ai-features/agent-builder/agent-builder-api-tutorial.md
+                title: Kibana API tutorial
+            - page: docs-content://explore-analyze/ai-features/agent-builder/a2a-server.md
+              title: A2A server
+            - page: docs-content://explore-analyze/ai-features/agent-builder/mcp-server.md
+              title: MCP server
+          - page: docs-content://explore-analyze/ai-features/agent-builder/monitor-usage.md
+            title: Monitor token usage
+          - page: docs-content://explore-analyze/ai-features/agent-builder/permissions.md
+            title: Permissions
+          - group: Troubleshooting
+            page: docs-content://explore-analyze/ai-features/agent-builder/troubleshooting.md
+            children:
+            - page: docs-content://explore-analyze/ai-features/agent-builder/troubleshooting/context-length-exceeded.md
+              title: Context length exceeded
+            - page: docs-content://explore-analyze/ai-features/agent-builder/troubleshooting/api-calls-return-403-forbidden.md
+              title: 403 Forbidden
+          - page: docs-content://explore-analyze/ai-features/agent-builder/limitations-known-issues.md
+            title: Limitations
+        - group: AI chats
+          page: docs-content://explore-analyze/ai-features/ai-chat-experiences.md
+          children:
+          - page: docs-content://explore-analyze/ai-features/ai-chat-experiences/ai-agent-or-ai-assistant.md
+            title: Compare Agent Builder and AI Assistant
+          - page: docs-content://explore-analyze/ai-features/ai-chat-experiences/ai-assistant.md
+            title: AI assistants
+        - group: LLM guides
+          page: docs-content://explore-analyze/ai-features/llm-guides/llm-connectors.md
+          children:
+          - page: docs-content://explore-analyze/ai-features/llm-guides/connect-to-azure-openai.md
+            title: Connect to Azure OpenAI
+          - page: docs-content://explore-analyze/ai-features/llm-guides/connect-to-amazon-bedrock.md
+            title: Connect to Amazon Bedrock
+          - page: docs-content://explore-analyze/ai-features/llm-guides/connect-to-openai.md
+            title: Connect to OpenAI
+          - page: docs-content://explore-analyze/ai-features/llm-guides/connect-to-google-vertex.md
+            title: Connect to Google Vertex
+          - group: Local LLMs
+            page: docs-content://explore-analyze/ai-features/llm-guides/local-llms-overview.md
+            children:
+            - page: docs-content://explore-analyze/ai-features/llm-guides/connect-to-lmstudio-observability.md
+              title: Connect to LM Studio for Observability
+            - page: docs-content://explore-analyze/ai-features/llm-guides/connect-to-lmstudio-security.md
+              title: Connect to LM Studio for Elastic Security
+            - page: docs-content://explore-analyze/ai-features/llm-guides/connect-to-vLLM.md
+              title: Connect to vLLM for Elastic Security
+        - page: docs-content://explore-analyze/ai-features/manage-access-to-ai-assistant.md
+          title: Manage access to AI features
+      - page: docs-content://explore-analyze/ai-features/agent-skills.md
+        title: AI agent skills for Elastic
   - label: Solutions and project types
     children:
     - title: Solutions overview (NEW)


### PR DESCRIPTION
## Summary

- Replace placeholder `title:` entries with full-depth `page:` references for three navigation sections (313 pages total, all with `title:` overrides)
- Rename "Alert and trigger actions" → **"Share, alert, and automate"** and move Reporting and sharing into it
- Reorder Explore and visualize children: Learn → Discover → Dashboards → Panels → Find & organize
- Wire new overview landing pages for both groups (added in elastic/docs-content#5601)

### Explore and visualize
Discover, Dashboards, Panels & visualizations (Lens charts, Maps, Canvas, Graph, Legacy editors), Find and organize content — all with full child hierarchies from the existing `toc.yml`.

### Share, alert, and automate
Reporting and sharing, Workflows (triggers, steps, data handling), Alerting (alerts + full Watcher tree), Cases.

### AI and machine learning
ML/NLP (anomaly detection, data frame analytics, NLP, ML in Kibana), AI framework (Elastic Inference, Agent Builder with tools/agents/programmatic access, AI chats, LLM guides), AI agent skills.

## Files left behind (expected)
71 files from `explore-analyze/toc.yml` are not yet placed — they belong to sections not covered here: Scripting (36), Query-filter (18), Transforms (12), Cross-cluster search (2), Geospatial (1), numeral-formatting (1), index.md (1).

<img width="260" height="706" alt="image" src="https://github.com/user-attachments/assets/87e07001-36a4-4941-8896-ffe79f558708" />


## Test plan
- [ ] `assembler clone && assembler build && assembler serve` — verify the nav renders with clickable links
- [ ] Spot-check that group headings link to overview pages
- [ ] Verify no regressions in sections not touched (Ingest, Install, Reference, Troubleshooting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)