### PR TITLE
fix: nullable Error dereference after ES client 9.3.3 upgrade

### DIFF
--- a/src/services/Elastic.Documentation.Search/ChangesGateway.cs
+++ b/src/services/Elastic.Documentation.Search/ChangesGateway.cs
@@ -39,7 +39,7 @@ public partial class ChangesGateway(
 
 			if (!response.IsValidResponse)
 			{
-				var reason = response.ElasticsearchServerError?.Error.Reason ?? "Unknown";
+				var reason = response.ElasticsearchServerError?.Error?.Reason ?? "Unknown";
 				throw new InvalidOperationException(
 					$"Elasticsearch changes query failed (HTTP {response.ApiCallDetails?.HttpStatusCode}): {reason}"
 				);
@@ -97,9 +97,9 @@ public partial class ChangesGateway(
 		}, ctx);
 
 	private static bool IsExpiredPit(SearchResponse<DocumentationDocument> response) =>
-		response.ElasticsearchServerError?.Error.Type is "search_phase_execution_exception"
-		|| response.ElasticsearchServerError?.Error.Reason?.Contains("point in time", StringComparison.OrdinalIgnoreCase) == true
-		|| response.ElasticsearchServerError?.Error.Reason?.Contains("No search context found", StringComparison.OrdinalIgnoreCase) == true;
+		response.ElasticsearchServerError?.Error?.Type is "search_phase_execution_exception"
+		|| response.ElasticsearchServerError?.Error?.Reason?.Contains("point in time", StringComparison.OrdinalIgnoreCase) == true
+		|| response.ElasticsearchServerError?.Error?.Reason?.Contains("No search context found", StringComparison.OrdinalIgnoreCase) == true;
 
 	private static ChangesResult BuildResult(SearchResponse<DocumentationDocument> response, int pageSize)
 	{

--- a/src/services/Elastic.Documentation.Search/SharedPointInTimeManager.cs
+++ b/src/services/Elastic.Documentation.Search/SharedPointInTimeManager.cs
@@ -62,7 +62,7 @@ public sealed partial class SharedPointInTimeManager(
 		if (!response.IsValidResponse)
 		{
 			throw new InvalidOperationException(
-				$"Failed to open PIT: {response.ElasticsearchServerError?.Error.Reason ?? "Unknown"}"
+				$"Failed to open PIT: {response.ElasticsearchServerError?.Error?.Reason ?? "Unknown"}"
 			);
 		}
 


### PR DESCRIPTION
## Summary
- Adds null-conditional operator (`?.`) on `ElasticsearchServerError.Error` in `ChangesGateway` and `SharedPointInTimeManager`
- The ES client 9.3.3 upgrade (#2946) made `Error` nullable but missed these two files, causing 5 CS8602 compilation errors that broke the [pre-release workflow](https://github.com/elastic/docs-builder/actions/runs/23490427483)

## Test plan
- [x] `dotnet build src/services/Elastic.Documentation.Search/` passes with 0 errors, 0 warnings
- [ ] Pre-release workflow succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)