### PR TITLE
Strip preview-build workflow to build-only

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -72,7 +72,7 @@ on:
 permissions:
   contents: read
   id-token: write
-  pull-requests: write
+  pull-requests: read
     
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref }}
@@ -436,9 +436,8 @@ jobs:
       - uses: elastic/docs-builder/.github/actions/aws-auth@main
         if: >
           !cancelled() 
-          && (steps.docs-build.outputs.skip != 'true' || steps.internal-docs-build.outputs.skip != 'true')
           && needs.check.outputs.any_modified != 'false'
-          && (steps.docs-build.outcome == 'success' || steps.internal-docs-build.outcome == 'success')
+          && (steps.validate-path-prefixes.outcome == 'success' || steps.internal-validate-path-prefixes.outcome == 'success')
       - name: Upload to S3
         id: s3-upload
         # disabled: preview uploads are not enabled on this branch
@@ -491,8 +490,10 @@ jobs:
               log_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
             })
   comment:
+    # disabled: preview comments are not enabled on this branch
     if: >
-      startsWith(github.event_name, 'pull_request')
+      false
+      && startsWith(github.event_name, 'pull_request')
       && inputs.disable-comments != true
       && needs.build.outputs.deployment_result
       && needs.check.outputs.any_modified == 'true'


### PR DESCRIPTION
## Summary

Strips the `preview-build` workflow down to build-only mode while preserving the Update Link Index step.

- **Disabled steps** (via `false &&`, not removed): deployment creation, S3 preview upload + CloudFront invalidation, deployment status updates, PATH_PREFIX generation, vale linting, PR preview comments, and cumulative docs comments
- **Replaced** all `steps.deployment.outputs.result` condition gates with `needs.check.outputs.any_modified != 'false'` so build, validation, and link index steps still run
- **Permissions reduced**:
  - Removed `deployments: write` (deployment steps disabled)
  - Downgraded `pull-requests: write` → `read` (comment and vale jobs disabled)
  - Kept `id-token: write` (needed for AWS OIDC auth used by link index update)
- **Added step IDs** to both "Validate local path prefixes" steps so the Update Link Index and AWS auth can depend on their outcome
- **Tightened AWS auth gate** to only acquire credentials when `validate-path-prefixes` or `internal-validate-path-prefixes` succeeds (not just on any modified files)
- **All `workflow_call` inputs preserved** as NOOPs for backward compatibility

### Why keep the Update Link Index?

The link index is the cross-repository link integrity database used by `validate-inbound-local` in every content repo. When a repo publishes or changes its docs, the link index must be updated so that other repos' builds can validate inbound links against current data. Without this step, link validation across Elastic documentation would run against stale data, producing false positives (broken links reported for pages that exist) and false negatives (missing reports for pages that were removed).

## Test plan
- [ ] Verify the workflow runs successfully on a PR in this repo (build + validations pass, disabled steps are skipped)
- [ ] Verify the workflow runs on a push to a matched branch and the Update Link Index step executes
- [ ] Confirm no permission errors occur (no `deployments: write` or `pull-requests: write` needed)
- [ ] Verify downstream repos calling this workflow via `workflow_call` don't break (NOOP inputs accepted)