### PR TITLE
feat: add cross-repo snippet index with lazy loading

### DIFF
--- a/docs/syntax/file_inclusion.md
+++ b/docs/syntax/file_inclusion.md
@@ -20,6 +20,17 @@ Files to be included must live in a `_snippets` folder to be considered a snippe
 :::{include} _snippets/reusable-snippet.md
 :::
 
+### Cross-repository snippet reuse
+
+You can also include snippets from repositories listed in your `cross_links` configuration.
+
+```markdown
+:::{include} docs-content://_snippets/reusable.md
+:::
+```
+
+This syntax uses `<repository>://<path>`, and the path must point to a file in a `_snippets` folder.
+
 #### Linking to snippets with custom anchors
 
 To link to a heading with a [custom anchor (ID)](./headings.md#custom-anchor-links) defined in a snippet, target the parent file + anchor. 

--- a/src/Elastic.Documentation.LinkIndex/GitLinkIndexReader.cs
+++ b/src/Elastic.Documentation.LinkIndex/GitLinkIndexReader.cs
@@ -73,6 +73,20 @@ public class GitLinkIndexReader : ILinkIndexReader, IDisposable
 		return RepositoryLinks.Deserialize(json);
 	}
 
+	/// <inheritdoc />
+	public async Task<RepositorySnippets> GetRepositorySnippets(string key, Cancel cancellationToken = default)
+	{
+		await EnsureCloneAsync(cancellationToken);
+		if (Path.IsPathRooted(key))
+			throw new ArgumentException($"Repository key '{key}' must be a relative path.", nameof(key));
+		var snippetsPath = Path.Combine(CloneDirectory, key);
+		if (!_fileSystem.File.Exists(snippetsPath))
+			throw new FileNotFoundException($"Repository snippets not found at {snippetsPath}.");
+
+		var json = await _fileSystem.File.ReadAllTextAsync(snippetsPath, cancellationToken);
+		return RepositorySnippets.Deserialize(json);
+	}
+
 	private async Task EnsureCloneAsync(Cancel cancellationToken)
 	{
 		await _cloneLock.WaitAsync(cancellationToken);

--- a/src/Elastic.Documentation.LinkIndex/ILinkIndexReader.cs
+++ b/src/Elastic.Documentation.LinkIndex/ILinkIndexReader.cs
@@ -10,5 +10,6 @@ public interface ILinkIndexReader
 {
 	Task<LinkRegistry> GetRegistry(Cancel cancellationToken = default);
 	Task<RepositoryLinks> GetRepositoryLinks(string key, Cancel cancellationToken = default);
+	Task<RepositorySnippets> GetRepositorySnippets(string key, Cancel cancellationToken = default);
 	string RegistryUrl { get; }
 }

--- a/src/Elastic.Documentation.LinkIndex/LinkIndexReader.cs
+++ b/src/Elastic.Documentation.LinkIndex/LinkIndexReader.cs
@@ -51,5 +51,17 @@ public class Aws3LinkIndexReader(IAmazonS3 s3Client, string bucketName = "elasti
 		return RepositoryLinks.Deserialize(stream);
 	}
 
+	public async Task<RepositorySnippets> GetRepositorySnippets(string key, Cancel cancellationToken)
+	{
+		var getObjectRequest = new GetObjectRequest
+		{
+			BucketName = bucketName,
+			Key = key
+		};
+		var getObjectResponse = await s3Client.GetObjectAsync(getObjectRequest, cancellationToken);
+		await using var stream = getObjectResponse.ResponseStream;
+		return RepositorySnippets.Deserialize(stream);
+	}
+
 	public string RegistryUrl { get; } = $"https://{bucketName}.s3.{s3Client.Config.RegionEndpoint.SystemName}.amazonaws.com/{registryKey}";
 }

--- a/src/Elastic.Documentation.Links/CrossLinks/CrossLinkFetcher.cs
+++ b/src/Elastic.Documentation.Links/CrossLinks/CrossLinkFetcher.cs
@@ -7,6 +7,7 @@ using System.Collections.Frozen;
 using System.Text.Json;
 using Elastic.Documentation.Configuration;
 using Elastic.Documentation.LinkIndex;
+using Elastic.Documentation.Links;
 using Elastic.Documentation.Serialization;
 using Microsoft.Extensions.Logging;
 
@@ -32,19 +33,26 @@ public record FetchedCrossLinks
 	/// </summary>
 	public FrozenSet<string>? CodexRepositories { get; init; }
 
+	/// <summary>
+	/// Optional lazy snippet fetcher, keyed by repository.
+	/// </summary>
+	public Func<string, Cancel, Task<RepositorySnippets?>>? SnippetFetcher { get; init; }
+
 	public static FetchedCrossLinks Empty { get; } = new()
 	{
 		DeclaredRepositories = [],
 		LinkReferences = new Dictionary<string, RepositoryLinks>().ToFrozenDictionary(),
 		LinkIndexEntries = new Dictionary<string, LinkRegistryEntry>().ToFrozenDictionary(),
 		RegistryUrlsByRepository = null,
-		CodexRepositories = null
+		CodexRepositories = null,
+		SnippetFetcher = null
 	};
 }
 
 public abstract class CrossLinkFetcher(ILoggerFactory logFactory, ILinkIndexReader linkIndexProvider) : IDisposable
 {
 	protected ILogger Logger { get; } = logFactory.CreateLogger(nameof(CrossLinkFetcher));
+	protected ILinkIndexReader LinkIndexProvider { get; } = linkIndexProvider;
 	private LinkRegistry? _linkIndex;
 
 	public static RepositoryLinks Deserialize(string json) =>
@@ -64,7 +72,7 @@ public abstract class CrossLinkFetcher(ILoggerFactory logFactory, ILinkIndexRead
 		}
 
 		Logger.LogInformation("Fetching link index registry (link-index.json)");
-		_linkIndex = await linkIndexProvider.GetRegistry(ctx);
+		_linkIndex = await LinkIndexProvider.GetRegistry(ctx);
 		return _linkIndex;
 	}
 
@@ -102,7 +110,7 @@ public abstract class CrossLinkFetcher(ILoggerFactory logFactory, ILinkIndexRead
 	}
 
 	protected Task<RepositoryLinks> FetchLinkIndexEntry(string repository, LinkRegistryEntry linkRegistryEntry, Cancel ctx) =>
-		FetchLinkIndexEntryFromReader(linkIndexProvider, repository, linkRegistryEntry, ctx);
+		FetchLinkIndexEntryFromReader(LinkIndexProvider, repository, linkRegistryEntry, ctx);
 
 	/// <summary>
 	/// Fetches repository links from a specific reader. Used for dual-registry (public + codex) fetching.

--- a/src/Elastic.Documentation.Links/CrossLinks/CrossLinkResolver.cs
+++ b/src/Elastic.Documentation.Links/CrossLinks/CrossLinkResolver.cs
@@ -3,13 +3,16 @@
 // See the LICENSE file in the project root for more information
 
 using System.Collections.Frozen;
+using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using Elastic.Documentation.Links;
 
 namespace Elastic.Documentation.Links.CrossLinks;
 
 public interface ICrossLinkResolver
 {
 	bool TryResolve(Action<string> errorEmitter, Uri crossLinkUri, [NotNullWhen(true)] out Uri? resolvedUri);
+	bool TryResolveSnippet(Action<string> errorEmitter, Uri snippetUri, [NotNullWhen(true)] out SnippetMetadata? snippetMetadata);
 	IUriEnvironmentResolver UriResolver { get; }
 
 	/// <summary>
@@ -32,6 +35,13 @@ public class NoopCrossLinkResolver : ICrossLinkResolver
 	}
 
 	/// <inheritdoc />
+	public bool TryResolveSnippet(Action<string> errorEmitter, Uri snippetUri, [NotNullWhen(true)] out SnippetMetadata? snippetMetadata)
+	{
+		snippetMetadata = null;
+		return false;
+	}
+
+	/// <inheritdoc />
 	public IUriEnvironmentResolver UriResolver { get; } = new IsolatedBuildEnvironmentUriResolver();
 
 	/// <inheritdoc />
@@ -44,10 +54,66 @@ public class NoopCrossLinkResolver : ICrossLinkResolver
 public class CrossLinkResolver(FetchedCrossLinks crossLinks, IUriEnvironmentResolver? uriResolver = null) : ICrossLinkResolver
 {
 	private FetchedCrossLinks _crossLinks = crossLinks;
+	private readonly ConcurrentDictionary<string, RepositorySnippets?> _snippetIndexByRepository = new(StringComparer.OrdinalIgnoreCase);
 	public IUriEnvironmentResolver UriResolver { get; } = uriResolver ?? new IsolatedBuildEnvironmentUriResolver();
 
 	public bool TryResolve(Action<string> errorEmitter, Uri crossLinkUri, [NotNullWhen(true)] out Uri? resolvedUri) =>
 		TryResolve(errorEmitter, _crossLinks, UriResolver, crossLinkUri, out resolvedUri);
+
+	/// <inheritdoc />
+	public bool TryResolveSnippet(Action<string> errorEmitter, Uri snippetUri, [NotNullWhen(true)] out SnippetMetadata? snippetMetadata)
+	{
+		snippetMetadata = null;
+		if (!_crossLinks.LinkReferences.ContainsKey(snippetUri.Scheme))
+		{
+			errorEmitter($"'{snippetUri.Scheme}' was not found in the cross link index. Ensure it is listed under 'cross_links' in your docset.yml");
+			return false;
+		}
+
+		var snippetIndex = GetSnippetIndex(snippetUri.Scheme);
+		var snippets = snippetIndex?.Snippets;
+		if (snippets is null || snippets.Count == 0)
+		{
+			errorEmitter($"'{snippetUri.Scheme}' does not expose any reusable snippets in its snippets.json index.");
+			return false;
+		}
+
+		var lookupPath = (snippetUri.Host + '/' + snippetUri.AbsolutePath.TrimStart('/')).Trim('/');
+		if (string.IsNullOrEmpty(lookupPath) && snippetUri.Host.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+			lookupPath = snippetUri.Host;
+
+		if (snippets.TryGetValue(lookupPath, out var exact))
+		{
+			snippetMetadata = exact;
+			return true;
+		}
+
+		var matched = snippets.FirstOrDefault(kvp => string.Equals(kvp.Key, lookupPath, StringComparison.OrdinalIgnoreCase));
+		if (!string.IsNullOrEmpty(matched.Key))
+		{
+			snippetMetadata = matched.Value;
+			return true;
+		}
+
+		errorEmitter($"'{lookupPath}' is not a valid snippet in the '{snippetUri.Scheme}' cross link snippet index.");
+		return false;
+	}
+
+	private RepositorySnippets? GetSnippetIndex(string repository) =>
+		_snippetIndexByRepository.GetOrAdd(repository, repo =>
+		{
+			var fetcher = _crossLinks.SnippetFetcher;
+			if (fetcher is null)
+				return null;
+			try
+			{
+				return fetcher(repo, default).GetAwaiter().GetResult();
+			}
+			catch
+			{
+				return null;
+			}
+		});
 
 	/// <inheritdoc />
 	public bool IsDeclaredCrossLinkScheme(string scheme) => _crossLinks.DeclaredRepositories.Contains(scheme);

--- a/src/Elastic.Documentation.Links/CrossLinks/DocSetConfigurationCrossLinkFetcher.cs
+++ b/src/Elastic.Documentation.Links/CrossLinks/DocSetConfigurationCrossLinkFetcher.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System.Collections.Frozen;
+using System.IO;
 using Elastic.Documentation.Configuration;
 using Elastic.Documentation.Configuration.Builder;
 using Elastic.Documentation.LinkIndex;
@@ -29,6 +30,7 @@ public class DocSetConfigurationCrossLinkFetcher(
 		var registryUrlsByRepository = new Dictionary<string, string>();
 		var codexRepositories = new HashSet<string>();
 		var declaredRepositories = new HashSet<string>();
+		var readersByRepository = new Dictionary<string, ILinkIndexReader>();
 
 		var publicReader = linkIndexProvider ?? Aws3LinkIndexReader.CreateAnonymous();
 		var useDualRegistry = configuration.Registry != DocSetRegistry.Public && _codexReader is not null;
@@ -47,6 +49,7 @@ public class DocSetConfigurationCrossLinkFetcher(
 				var linkReference = await FetchCrossLinksFromReader(reader, entry.Repository, this, ctx);
 				linkReferences.Add(entry.Repository, linkReference);
 				registryUrlsByRepository[entry.Repository] = reader.RegistryUrl;
+				readersByRepository[entry.Repository] = reader;
 
 				var registry = await reader.GetRegistry(ctx);
 				if (registry.Repositories.TryGetValue(entry.Repository, out var repoBranches))
@@ -59,6 +62,7 @@ public class DocSetConfigurationCrossLinkFetcher(
 			{
 				_logger.LogWarning(ex, "Error fetching link data for repository '{Repository}'. Cross-links to this repository may not resolve correctly.", entry.Repository);
 				_ = registryUrlsByRepository.TryAdd(entry.Repository, reader.RegistryUrl);
+				readersByRepository[entry.Repository] = reader;
 
 				if (!linkReferences.ContainsKey(entry.Repository))
 				{
@@ -86,6 +90,21 @@ public class DocSetConfigurationCrossLinkFetcher(
 			LinkIndexEntries = linkIndexEntries.ToFrozenDictionary(),
 			RegistryUrlsByRepository = registryUrlsByRepository.ToFrozenDictionary(),
 			CodexRepositories = codexRepositories.Count > 0 ? codexRepositories.ToFrozenSet() : null,
+			SnippetFetcher = async (repository, cancellationToken) =>
+			{
+				if (!readersByRepository.TryGetValue(repository, out var reader))
+					return null;
+				if (!linkIndexEntries.TryGetValue(repository, out var linkIndexEntry))
+					return null;
+
+				var snippetsPath = GetSnippetsIndexPath(linkIndexEntry.Path);
+				return await reader.GetRepositorySnippets(snippetsPath, cancellationToken);
+			}
 		};
 	}
+
+	private static string GetSnippetsIndexPath(string linksPath) =>
+		linksPath.EndsWith("links.json", StringComparison.OrdinalIgnoreCase)
+			? linksPath[..^"links.json".Length] + "snippets.json"
+			: Path.Combine(Path.GetDirectoryName(linksPath) ?? string.Empty, "snippets.json").Replace('\\', '/');
 }

--- a/src/Elastic.Documentation.Links/InboundLinks/LinkIndexCrossLinkFetcher.cs
+++ b/src/Elastic.Documentation.Links/InboundLinks/LinkIndexCrossLinkFetcher.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System.Collections.Frozen;
+using System.IO;
 using Elastic.Documentation.Configuration.Assembler;
 using Elastic.Documentation.LinkIndex;
 using Elastic.Documentation.Links.CrossLinks;
@@ -35,7 +36,19 @@ public class LinksIndexCrossLinkFetcher(ILoggerFactory logFactory, ILinkIndexRea
 			DeclaredRepositories = declaredRepositories,
 			LinkReferences = linkReferences.ToFrozenDictionary(),
 			LinkIndexEntries = linkEntries.ToFrozenDictionary(),
+			SnippetFetcher = async (repository, cancellationToken) =>
+			{
+				if (!linkEntries.TryGetValue(repository, out var linkIndexEntry))
+					return null;
+				var snippetsPath = GetSnippetsIndexPath(linkIndexEntry.Path);
+				return await LinkIndexProvider.GetRepositorySnippets(snippetsPath, cancellationToken);
+			}
 		};
 	}
+
+	private static string GetSnippetsIndexPath(string linksPath) =>
+		linksPath.EndsWith("links.json", StringComparison.OrdinalIgnoreCase)
+			? linksPath[..^"links.json".Length] + "snippets.json"
+			: Path.Combine(Path.GetDirectoryName(linksPath) ?? string.Empty, "snippets.json").Replace('\\', '/');
 
 }

--- a/src/Elastic.Documentation/Links/RepositoryLinks.cs
+++ b/src/Elastic.Documentation/Links/RepositoryLinks.cs
@@ -19,6 +19,31 @@ public record LinkMetadata
 	public bool Hidden { get; init; }
 }
 
+public record SnippetMetadata
+{
+	[JsonPropertyName("content")]
+	public required string Content { get; init; }
+
+	[JsonPropertyName("anchors")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public string[]? Anchors { get; init; } = [];
+}
+
+public record RepositorySnippets
+{
+	[JsonPropertyName("snippets")]
+	public required Dictionary<string, SnippetMetadata> Snippets { get; init; } = [];
+
+	public static RepositorySnippets Deserialize(Stream json) =>
+		JsonSerializer.Deserialize(json, SourceGenerationContext.Default.RepositorySnippets)!;
+
+	public static RepositorySnippets Deserialize(string json) =>
+		JsonSerializer.Deserialize(json, SourceGenerationContext.Default.RepositorySnippets)!;
+
+	public static string Serialize(RepositorySnippets reference) =>
+		JsonSerializer.Serialize(reference, SourceGenerationContext.Default.RepositorySnippets);
+}
+
 public record LinkSingleRedirect
 {
 	[JsonPropertyName("anchors")]

--- a/src/Elastic.Documentation/Serialization/SourceGenerationContext.cs
+++ b/src/Elastic.Documentation/Serialization/SourceGenerationContext.cs
@@ -15,6 +15,7 @@ namespace Elastic.Documentation.Serialization;
 [JsonSourceGenerationOptions(WriteIndented = true, UseStringEnumConverter = true, PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
 [JsonSerializable(typeof(GenerationState))]
 [JsonSerializable(typeof(RepositoryLinks))]
+[JsonSerializable(typeof(RepositorySnippets))]
 [JsonSerializable(typeof(GitCheckoutInformation))]
 [JsonSerializable(typeof(LinkRegistry))]
 [JsonSerializable(typeof(LinkRegistryEntry))]

--- a/src/Elastic.Markdown/DocumentationGenerator.cs
+++ b/src/Elastic.Markdown/DocumentationGenerator.cs
@@ -401,12 +401,17 @@ public partial class DocumentationGenerator
 	{
 		var file = DocumentationSet.LinkReferenceFile;
 		var state = DocumentationSet.CreateLinkReference();
+		var snippetsFile = DocumentationSet.SnippetReferenceFile;
+		var snippetsState = DocumentationSet.CreateSnippetReference();
 		if (writeToDisk)
 		{
 			if (!file.Directory!.Exists)
 				file.Directory.Create();
 			var bytes = JsonSerializer.SerializeToUtf8Bytes(state, SourceGenerationContext.Default.RepositoryLinks);
 			await DocumentationSet.OutputDirectory.FileSystem.File.WriteAllBytesAsync(file.FullName, bytes, ctx);
+
+			var snippetBytes = JsonSerializer.SerializeToUtf8Bytes(snippetsState, SourceGenerationContext.Default.RepositorySnippets);
+			await DocumentationSet.OutputDirectory.FileSystem.File.WriteAllBytesAsync(snippetsFile.FullName, snippetBytes, ctx);
 		}
 		return state;
 	}

--- a/src/Elastic.Markdown/IO/DocumentationSet.cs
+++ b/src/Elastic.Markdown/IO/DocumentationSet.cs
@@ -35,6 +35,7 @@ public class DocumentationSet : INavigationTraversable
 	public string Name { get; }
 	public IFileInfo OutputStateFile { get; }
 	public IFileInfo LinkReferenceFile { get; }
+	public IFileInfo SnippetReferenceFile { get; }
 
 	public IDirectoryInfo SourceDirectory { get; }
 	public IDirectoryInfo OutputDirectory { get; }
@@ -85,6 +86,7 @@ public class DocumentationSet : INavigationTraversable
 			: Context.DocumentationCheckoutDirectory?.Name ?? $"unknown-{Context.DocumentationSourceDirectory.Name}";
 		OutputStateFile = OutputDirectory.FileSystem.FileInfo.New(Path.Combine(OutputDirectory.FullName, ".doc.state"));
 		LinkReferenceFile = OutputDirectory.FileSystem.FileInfo.New(Path.Combine(OutputDirectory.FullName, "links.json"));
+		SnippetReferenceFile = OutputDirectory.FileSystem.FileInfo.New(Path.Combine(OutputDirectory.FullName, "snippets.json"));
 
 		Files = fileFactory.Files;
 		var files = Files.Values.ToArray();
@@ -273,6 +275,26 @@ public class DocumentationSet : INavigationTraversable
 			Links = links,
 			CrossLinks = crossLinks
 		};
+	}
+
+	public RepositorySnippets CreateSnippetReference()
+	{
+		var snippets = Files.Values
+			.OfType<SnippetFile>()
+			.Select(snippet =>
+			{
+				var path = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+					? snippet.RelativePath.Replace('\\', '/')
+					: snippet.RelativePath;
+
+				var content = Context.ReadFileSystem.File.ReadAllText(snippet.SourceFile.FullName);
+				var anchors = snippet.GetAnchors(Context.Collector, TryFindDocumentByRelativePath, MarkdownParser, null)?.Anchors;
+				return (Path: path, Metadata: new SnippetMetadata { Content = content, Anchors = anchors });
+			})
+			.OrderBy(tuple => tuple.Path)
+			.ToDictionary(tuple => tuple.Path, tuple => tuple.Metadata);
+
+		return new RepositorySnippets { Snippets = snippets };
 	}
 
 	public void ClearOutputDirectory()

--- a/src/Elastic.Markdown/IO/MarkdownFile.cs
+++ b/src/Elastic.Markdown/IO/MarkdownFile.cs
@@ -203,6 +203,9 @@ public record MarkdownFile : DocumentationFile, ITableOfContentsScope, IDocument
 			.Where(i => i.Found)
 			.Select(i =>
 			{
+				if (i.IncludedAnchors.Length > 0)
+					return new { Block = i, Anchors = new SnippetAnchors(i.IncludedAnchors, []) };
+
 				var relativePath = i.IncludePathRelativeToSource;
 				if (relativePath is null)
 					return null;
@@ -211,6 +214,8 @@ public record MarkdownFile : DocumentationFile, ITableOfContentsScope, IDocument
 					return null;
 
 				var anchors = snippet.GetAnchors(collector, documentationFileLookup, parser, frontMatter);
+				if (anchors is null)
+					return null;
 				return new { Block = i, Anchors = anchors };
 			})
 			.Where(i => i is not null)

--- a/src/Elastic.Markdown/Myst/Directives/DirectiveHtmlRenderer.cs
+++ b/src/Elastic.Markdown/Myst/Directives/DirectiveHtmlRenderer.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using Elastic.Documentation.AppliesTo;
 using Elastic.Markdown.Diagnostics;
 using Elastic.Markdown.Helpers;
@@ -393,11 +394,15 @@ public class DirectiveHtmlRenderer : HtmlObjectRenderer<DirectiveBlock>
 
 	private static void WriteLiteralIncludeBlock(HtmlRenderer renderer, IncludeBlock block)
 	{
-		if (!block.Found || block.IncludePath is null)
+		if (!block.Found || (block.IncludePath is null && block.IncludeContent is null))
 			return;
 
-		var file = block.Build.ReadFileSystem.FileInfo.New(block.IncludePath);
-		var content = block.Build.ReadFileSystem.File.ReadAllText(file.FullName);
+		var content = block.IncludeContent;
+		if (content is null)
+		{
+			var file = block.Build.ReadFileSystem.FileInfo.New(block.IncludePath!);
+			content = block.Build.ReadFileSystem.File.ReadAllText(file.FullName);
+		}
 		if (string.IsNullOrEmpty(block.Language))
 			_ = renderer.Write(content);
 		else
@@ -416,14 +421,31 @@ public class DirectiveHtmlRenderer : HtmlObjectRenderer<DirectiveBlock>
 
 	private static void WriteIncludeBlock(HtmlRenderer renderer, IncludeBlock block)
 	{
-		if (!block.Found || block.IncludePath is null)
+		if (!block.Found || (block.IncludePath is null && block.IncludeContent is null))
 			return;
 
-		var snippet = block.Build.ReadFileSystem.FileInfo.New(block.IncludePath);
-
 		var parentPath = block.Context.MarkdownParentPath ?? block.Context.MarkdownSourcePath;
-		var document = MarkdownParser.ParseSnippetAsync(block.Build, block.Context, snippet, parentPath, block.Context.YamlFrontMatter, default, block.Line)
-			.GetAwaiter().GetResult();
+		Markdig.Syntax.MarkdownDocument document;
+		if (block.IncludeContent is not null)
+		{
+			var virtualSnippetPath = block.Build.ReadFileSystem.FileInfo.New(
+				Path.Combine(block.Build.DocumentationSourceDirectory.FullName, "_snippets", "__external__", $"{Guid.NewGuid():N}.md"));
+			document = MarkdownParser.ParseSnippetStringAsync(
+				block.Build,
+				block.Context,
+				block.IncludeContent,
+				virtualSnippetPath,
+				parentPath,
+				block.Context.YamlFrontMatter,
+				block.Line
+			);
+		}
+		else
+		{
+			var snippet = block.Build.ReadFileSystem.FileInfo.New(block.IncludePath!);
+			document = MarkdownParser.ParseSnippetAsync(block.Build, block.Context, snippet, parentPath, block.Context.YamlFrontMatter, default, block.Line)
+				.GetAwaiter().GetResult();
+		}
 
 		var html = document.ToHtml(MarkdownParser.Pipeline);
 		_ = renderer.Write(html);

--- a/src/Elastic.Markdown/Myst/Directives/Include/IncludeBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Include/IncludeBlock.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System.IO.Abstractions;
+using Elastic.Documentation.Links;
 using Elastic.Documentation.Extensions;
 using Elastic.Markdown.Diagnostics;
 
@@ -25,6 +26,10 @@ public class IncludeBlock(DirectiveBlockParser parser, ParserContext context) : 
 	public string? IncludePath { get; private set; }
 
 	public string? IncludePathRelativeToSource { get; private set; }
+
+	public string? IncludeContent { get; private set; }
+
+	public string[] IncludedAnchors { get; private set; } = [];
 
 	public bool Found { get; private set; }
 
@@ -53,6 +58,10 @@ public class IncludeBlock(DirectiveBlockParser parser, ParserContext context) : 
 			this.EmitError("include requires an argument.");
 			return;
 		}
+
+		includePath = includePath.Trim();
+		if (TryExtractCrossRepoInclude(context, includePath))
+			return;
 
 		var includeFrom = context.MarkdownSourcePath.Directory!.FullName;
 		if (includePath.StartsWith('/'))
@@ -97,6 +106,45 @@ public class IncludeBlock(DirectiveBlockParser parser, ParserContext context) : 
 			this.EmitError($"{{include}} cyclical include detected `{IncludePath}` points to itself");
 			Found = false;
 		}
+	}
+
+	private bool TryExtractCrossRepoInclude(ParserContext context, string includePath)
+	{
+		if (!Uri.TryCreate(includePath, UriKind.Absolute, out var includeUri))
+			return false;
+		if (includeUri.Scheme is "http" or "https" or "file")
+			return false;
+		if (!context.CrossLinkResolver.IsDeclaredCrossLinkScheme(includeUri.Scheme))
+			return false;
+
+		var lookupPath = $"{includeUri.Host}/{includeUri.AbsolutePath.TrimStart('/')}".Trim('/');
+		if (string.IsNullOrWhiteSpace(lookupPath))
+		{
+			this.EmitError("Cross-repository include requires a non-empty path.");
+			return true;
+		}
+
+		if (lookupPath.Contains("..", StringComparison.Ordinal))
+		{
+			this.EmitError("Cross-repository include path must not contain relative traversal segments.");
+			return true;
+		}
+
+		if (!lookupPath.Contains("_snippets", StringComparison.Ordinal))
+		{
+			this.EmitError($"{{include}} only supports including snippets from `_snippet` folders. `{includePath}` is not a snippet");
+			return true;
+		}
+
+		if (!context.CrossLinkResolver.TryResolveSnippet(message => this.EmitError(message), includeUri, out var snippetMetadata))
+			return true;
+
+		IncludePath = includePath;
+		IncludePathRelativeToSource = $"{includeUri.Scheme}://{lookupPath}";
+		IncludeContent = snippetMetadata.Content;
+		IncludedAnchors = snippetMetadata.Anchors ?? [];
+		Found = true;
+		return true;
 	}
 
 	private void ValidateIncludePath(IFileInfo file)

--- a/src/Elastic.Markdown/Myst/Directives/Stepper/StepViewModel.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Stepper/StepViewModel.cs
@@ -5,6 +5,7 @@
 using System.Collections.Frozen;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using Elastic.Documentation.Links;
 using Elastic.Documentation.Links.CrossLinks;
 using Elastic.Documentation.Navigation;
 using Elastic.Markdown.Helpers;
@@ -37,6 +38,13 @@ public class StepViewModel : DirectiveViewModel
 		public bool TryResolve(Action<string> errorEmitter, Uri crossLinkUri, [NotNullWhen(true)] out Uri? resolvedUri)
 		{
 			resolvedUri = null;
+			return false;
+		}
+
+		/// <inheritdoc />
+		public bool TryResolveSnippet(Action<string> errorEmitter, Uri snippetUri, [NotNullWhen(true)] out SnippetMetadata? snippetMetadata)
+		{
+			snippetMetadata = null;
 			return false;
 		}
 

--- a/src/Elastic.Markdown/Myst/MarkdownParser.cs
+++ b/src/Elastic.Markdown/Myst/MarkdownParser.cs
@@ -116,6 +116,31 @@ public partial class MarkdownParser(BuildContext build, IParserResolvers resolve
 		return ParseAsync(path, context, Pipeline, ctx);
 	}
 
+	public static MarkdownDocument ParseSnippetStringAsync(
+		BuildContext build,
+		IParserResolvers resolvers,
+		string markdown,
+		IFileInfo path,
+		IFileInfo parentPath,
+		YamlFrontMatter? matter,
+		int? includeLine = null)
+	{
+		var state = new ParserState(build)
+		{
+			MarkdownSourcePath = path,
+			YamlFrontMatter = matter,
+			TryFindDocument = resolvers.TryFindDocument,
+			TryFindDocumentByRelativePath = resolvers.TryFindDocumentByRelativePath,
+			CrossLinkResolver = resolvers.CrossLinkResolver,
+			NavigationTraversable = resolvers.NavigationTraversable,
+			ParentMarkdownPath = parentPath,
+			IncludeLine = includeLine
+		};
+		var context = new ParserContext(state);
+		var preprocessedMarkdown = PreprocessLinkSubstitutions(markdown, context);
+		return Markdig.Markdown.Parse(preprocessedMarkdown, Pipeline, context);
+	}
+
 
 	private static async Task<MarkdownDocument> ParseAsync(
 		IFileInfo path,

--- a/src/services/Elastic.Documentation.Assembler/Links/AssemblerCrossLinkFetcher.cs
+++ b/src/services/Elastic.Documentation.Assembler/Links/AssemblerCrossLinkFetcher.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System.Collections.Frozen;
+using System.IO;
 using Elastic.Documentation.Configuration.Assembler;
 using Elastic.Documentation.LinkIndex;
 using Elastic.Documentation.Links;
@@ -60,6 +61,19 @@ public class AssemblerCrossLinkFetcher(ILoggerFactory logFactory, AssemblyConfig
 			DeclaredRepositories = declaredRepositories,
 			LinkIndexEntries = linkIndexEntries.ToFrozenDictionary(),
 			LinkReferences = linkReferences.ToFrozenDictionary(),
+			SnippetFetcher = async (repository, cancellationToken) =>
+			{
+				if (!linkIndexEntries.TryGetValue(repository, out var linkIndexEntry))
+					return null;
+
+				var snippetsPath = GetSnippetsIndexPath(linkIndexEntry.Path);
+				return await LinkIndexProvider.GetRepositorySnippets(snippetsPath, cancellationToken);
+			}
 		};
 	}
+
+	private static string GetSnippetsIndexPath(string linksPath) =>
+		linksPath.EndsWith("links.json", StringComparison.OrdinalIgnoreCase)
+			? linksPath[..^"links.json".Length] + "snippets.json"
+			: Path.Combine(Path.GetDirectoryName(linksPath) ?? string.Empty, "snippets.json").Replace('\\', '/');
 }

--- a/tests/Elastic.Markdown.Tests/DocSet/RepositoryLinksTests.cs
+++ b/tests/Elastic.Markdown.Tests/DocSet/RepositoryLinksTests.cs
@@ -11,9 +11,14 @@ namespace Elastic.Markdown.Tests.DocSet;
 
 public class RepositoryLinksTests : NavigationTestsBase
 {
-	public RepositoryLinksTests(ITestOutputHelper output) : base(output) => Reference = Set.CreateLinkReference();
+	public RepositoryLinksTests(ITestOutputHelper output) : base(output)
+	{
+		Reference = Set.CreateLinkReference();
+		SnippetReference = Set.CreateSnippetReference();
+	}
 
 	private RepositoryLinks Reference { get; }
+	private RepositorySnippets SnippetReference { get; }
 
 	[Fact]
 	public void ShouldNotBeNull() =>
@@ -26,6 +31,10 @@ public class RepositoryLinksTests : NavigationTestsBase
 	[Fact]
 	public void ShouldNotIncludeSnippets() =>
 		Reference.Links.Should().NotContain(l => l.Key.Contains("_snippets/"));
+
+	[Fact]
+	public void EmitsSnippets() =>
+		SnippetReference.Snippets.Should().NotBeNullOrEmpty();
 
 }
 
@@ -108,6 +117,26 @@ public class LinkReferenceSerializationTests
 			""";
 		var linkReference = RepositoryLinks.Deserialize(json);
 		linkReference.Origin.Ref.Should().Be("ref");
+	}
+
+	[Fact]
+	public void SnippetsSerializeAndDeserialize()
+	{
+		var snippets = new RepositorySnippets
+		{
+			Snippets = new Dictionary<string, SnippetMetadata>
+			{
+				["_snippets/example.md"] = new()
+				{
+					Content = "A \"quoted\" line",
+					Anchors = ["example-anchor"]
+				}
+			}
+		};
+		var json = RepositorySnippets.Serialize(snippets);
+		var roundtrip = RepositorySnippets.Deserialize(json);
+		roundtrip.Snippets.Should().ContainKey("_snippets/example.md");
+		roundtrip.Snippets["_snippets/example.md"].Content.Should().Be("A \"quoted\" line");
 	}
 
 }

--- a/tests/Elastic.Markdown.Tests/FileInclusion/IncludeTests.cs
+++ b/tests/Elastic.Markdown.Tests/FileInclusion/IncludeTests.cs
@@ -196,3 +196,36 @@ public class CanNotIncludeItself(ITestOutputHelper output) : DirectiveTest<Inclu
 			.Contain(d => d.Message.Contains("cyclical include detected"));
 	}
 }
+
+public class CrossRepositoryIncludeTests(ITestOutputHelper output) : DirectiveTest<IncludeBlock>(output,
+"""
+:::{include} docs-content://_snippets/reusable.md
+:::
+"""
+)
+{
+	[Fact]
+	public void IncludesCrossRepositorySnippetHtml() =>
+		Html.Should().Contain("Cross repo snippet content.");
+
+	[Fact]
+	public void ExposesIndexedSnippetAnchors() =>
+		Block!.IncludedAnchors.Should().Contain("reusable-heading");
+}
+
+public class CrossRepositoryIncludeRequiresSnippetFolderTests(ITestOutputHelper output) : DirectiveTest<IncludeBlock>(output,
+"""
+:::{include} docs-content://guides/not-a-snippet.md
+:::
+"""
+)
+{
+	[Fact]
+	public void EmitsError()
+	{
+		Collector.Diagnostics.Should().NotBeNullOrEmpty();
+		Collector.Diagnostics.Should()
+			.Contain(d => d.Severity == Severity.Error &&
+				d.Message.Contains("only supports including snippets from `_snippet` folders."));
+	}
+}

--- a/tests/Elastic.Markdown.Tests/TestCodexCrossLinkResolver.cs
+++ b/tests/Elastic.Markdown.Tests/TestCodexCrossLinkResolver.cs
@@ -66,7 +66,22 @@ public class TestCodexCrossLinkResolver : ICrossLinkResolver
 			DeclaredRepositories = declaredRepositories,
 			LinkReferences = linkReferences.ToFrozenDictionary(),
 			LinkIndexEntries = indexEntries.ToFrozenDictionary(),
-			CodexRepositories = codexRepositories
+			CodexRepositories = codexRepositories,
+			SnippetFetcher = (repository, _) =>
+			{
+				var snippets = new RepositorySnippets
+				{
+					Snippets = new Dictionary<string, SnippetMetadata>
+					{
+						["_snippets/reusable.md"] = new()
+						{
+							Content = "## Reusable heading\n\nCross repo snippet content.",
+							Anchors = ["reusable-heading"]
+						}
+					}
+				};
+				return Task.FromResult<RepositorySnippets?>(snippets);
+			}
 		};
 
 		UriResolver = new CodexAwareUriResolver(codexRepositories, useRelativePaths);
@@ -74,6 +89,9 @@ public class TestCodexCrossLinkResolver : ICrossLinkResolver
 
 	public bool TryResolve(Action<string> errorEmitter, Uri crossLinkUri, [NotNullWhen(true)] out Uri? resolvedUri) =>
 		CrossLinkResolver.TryResolve(errorEmitter, _crossLinks, UriResolver, crossLinkUri, out resolvedUri);
+
+	public bool TryResolveSnippet(Action<string> errorEmitter, Uri snippetUri, [NotNullWhen(true)] out SnippetMetadata? snippetMetadata) =>
+		new CrossLinkResolver(_crossLinks, UriResolver).TryResolveSnippet(errorEmitter, snippetUri, out snippetMetadata);
 
 	public bool IsDeclaredCrossLinkScheme(string scheme) => _crossLinks.DeclaredRepositories.Contains(scheme);
 }

--- a/tests/Elastic.Markdown.Tests/TestCrossLinkResolver.cs
+++ b/tests/Elastic.Markdown.Tests/TestCrossLinkResolver.cs
@@ -62,12 +62,30 @@ public class TestCrossLinkResolver : ICrossLinkResolver
 		{
 			DeclaredRepositories = declaredRepositories,
 			LinkReferences = linkReferences.ToFrozenDictionary(),
-			LinkIndexEntries = indexEntries.ToFrozenDictionary()
+			LinkIndexEntries = indexEntries.ToFrozenDictionary(),
+			SnippetFetcher = (repository, _) =>
+			{
+				var snippets = new RepositorySnippets
+				{
+					Snippets = new Dictionary<string, SnippetMetadata>
+					{
+						["_snippets/reusable.md"] = new()
+						{
+							Content = "## Reusable heading\n\nCross repo snippet content.",
+							Anchors = ["reusable-heading"]
+						}
+					}
+				};
+				return Task.FromResult<RepositorySnippets?>(snippets);
+			}
 		};
 	}
 
 	public bool TryResolve(Action<string> errorEmitter, Uri crossLinkUri, [NotNullWhen(true)] out Uri? resolvedUri) =>
 		CrossLinkResolver.TryResolve(errorEmitter, _crossLinks, UriResolver, crossLinkUri, out resolvedUri);
+
+	public bool TryResolveSnippet(Action<string> errorEmitter, Uri snippetUri, [NotNullWhen(true)] out SnippetMetadata? snippetMetadata) =>
+		new CrossLinkResolver(_crossLinks, UriResolver).TryResolveSnippet(errorEmitter, snippetUri, out snippetMetadata);
 
 	public bool IsDeclaredCrossLinkScheme(string scheme) => _crossLinks.DeclaredRepositories.Contains(scheme);
 }

--- a/tests/Navigation.Tests/TestDocumentationSetContext.cs
+++ b/tests/Navigation.Tests/TestDocumentationSetContext.cs
@@ -7,6 +7,7 @@ using System.IO.Abstractions;
 using Elastic.Documentation;
 using Elastic.Documentation.Diagnostics;
 using Elastic.Documentation.Extensions;
+using Elastic.Documentation.Links;
 using Elastic.Documentation.Links.CrossLinks;
 using Elastic.Documentation.Navigation.Isolated;
 using Markdig;
@@ -58,6 +59,13 @@ public class TestCrossLinkResolver : ICrossLinkResolver
 	{
 		resolvedUri = new Uri("https://docs-v3-preview.elastic.dev/elastic/docs-builder/tree/main");
 		return true;
+	}
+
+	/// <inheritdoc />
+	public bool TryResolveSnippet(Action<string> errorEmitter, Uri snippetUri, [NotNullWhen(true)] out SnippetMetadata? snippetMetadata)
+	{
+		snippetMetadata = null;
+		return false;
 	}
 
 	/// <inheritdoc />

--- a/tests/authoring/Framework/TestCrossLinkResolver.fs
+++ b/tests/authoring/Framework/TestCrossLinkResolver.fs
@@ -89,6 +89,10 @@ type TestCrossLinkResolver (config: ConfigurationFile) =
         member this.TryResolve(errorEmitter, crossLinkUri, [<Out>]resolvedUri : byref<Uri|null>) =
             CrossLinkResolver.TryResolve(errorEmitter, crossLinks, uriResolver, crossLinkUri, &resolvedUri)
 
+        member this.TryResolveSnippet(errorEmitter, snippetUri, [<Out>]snippetMetadata : byref<SnippetMetadata|null>) =
+            let resolver = CrossLinkResolver(crossLinks, uriResolver)
+            resolver.TryResolveSnippet(errorEmitter, snippetUri, &snippetMetadata)
+
         member this.IsDeclaredCrossLinkScheme(scheme) =
             declared.Contains(scheme)
 


### PR DESCRIPTION
## Summary
- add cross-repository snippet includes via `<repo>://...` while enforcing `_snippets` path constraints.
- `snippets.json`, generated at build time alongside links metadata.
- load `snippets.json` lazily through link-index readers and cross-link fetchers, and cache per-repository snippet indexes in the resolver.
- update docs and tests for cross-repo includes and snippet serialization behavior.

Fixes https://github.com/elastic/docs-builder/issues/2950

Made with [Cursor](https://cursor.com)