### PR TITLE
Fix changelog title inference

### DIFF
--- a/src/services/Elastic.Changelog/Creation/ChangelogCreationService.cs
+++ b/src/services/Elastic.Changelog/Creation/ChangelogCreationService.cs
@@ -391,6 +391,7 @@ IEnvironmentVariables? env = null
 
 		var prNumber = env.GetEnvironmentVariable("CHANGELOG_PR_NUMBER");
 		var ciTitle = env.GetEnvironmentVariable("CHANGELOG_TITLE");
+		var ciDescription = env.GetEnvironmentVariable("CHANGELOG_DESCRIPTION");
 		var ciType = env.GetEnvironmentVariable("CHANGELOG_TYPE");
 		var ciOwner = env.GetEnvironmentVariable("CHANGELOG_OWNER");
 		var ciRepo = env.GetEnvironmentVariable("CHANGELOG_REPO");
@@ -414,6 +415,7 @@ IEnvironmentVariables? env = null
 		{
 			Prs = enrichedPrs,
 			Title = !string.IsNullOrWhiteSpace(input.Title) ? input.Title : ciTitle,
+			Description = !string.IsNullOrWhiteSpace(input.Description) ? input.Description : ciDescription,
 			Type = !string.IsNullOrWhiteSpace(input.Type) ? input.Type : ciType,
 			Owner = input.Owner ?? ciOwner,
 			Repo = !string.IsNullOrWhiteSpace(input.Repo) ? input.Repo : ciRepo,

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogPrEvaluationService.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogPrEvaluationService.cs
@@ -32,10 +32,10 @@ public class ChangelogPrEvaluationService(
 
 	public async Task<bool> EvaluatePr(IDiagnosticsCollector collector, EvaluatePrArguments input, Cancel ctx)
 	{
-		// Body-only edit check
-		if (input.EventAction == "edited" && !input.TitleChanged)
+		// Body-only edit check: skip when neither title nor body changed
+		if (input is { EventAction: "edited", TitleChanged: false, BodyChanged: false })
 		{
-			_logger.LogInformation("Skipping: body-only edit (title unchanged)");
+			_logger.LogInformation("Skipping: edit with no title or body change");
 			return await SetOutputs(PrEvaluationResult.Skipped);
 		}
 
@@ -80,10 +80,33 @@ public class ChangelogPrEvaluationService(
 			return await SetOutputs(PrEvaluationResult.Skipped);
 		}
 
-		// Resolve title
-		var title = input.PrTitle;
+		// Resolve title: prefer release notes from PR body, fall back to PR title
+		var prTitle = input.PrTitle;
 		if (input.StripTitlePrefix)
-			title = ChangelogTextUtilities.StripSquareBracketPrefix(title);
+			prTitle = ChangelogTextUtilities.StripSquareBracketPrefix(prTitle);
+
+		string? title = null;
+		string? description = null;
+
+		if (config.Extract.ReleaseNotes && !string.IsNullOrWhiteSpace(input.PrBody))
+		{
+			var (releaseNoteTitle, releaseNoteDescription) = ReleaseNotesExtractor.ExtractReleaseNotes(input.PrBody);
+
+			if (releaseNoteTitle != null)
+			{
+				title = releaseNoteTitle;
+				_logger.LogInformation("Using extracted release note as title: {Title}", title);
+			}
+
+			if (releaseNoteDescription != null)
+			{
+				description = releaseNoteDescription;
+				_logger.LogInformation("Using extracted release note as description (length: {Length} characters)", description.Length);
+			}
+		}
+
+		// Fall back to PR title when no short release note was found
+		title ??= prTitle;
 
 		if (string.IsNullOrWhiteSpace(title))
 		{
@@ -116,6 +139,7 @@ public class ChangelogPrEvaluationService(
 			_logger.LogInformation("No type label found on PR");
 			return await SetOutputs(
 				PrEvaluationResult.NoLabel, title,
+				resolvedDescription: description,
 				labelTable: BuildLabelTable(config.LabelToType),
 				productLabelTable: productLabelTable
 			);
@@ -124,6 +148,7 @@ public class ChangelogPrEvaluationService(
 		_logger.LogInformation("PR evaluation complete: title={Title}, type={Type}, products={Products}, existingFile={File}", title, resolvedType, resolvedProducts, existingFilename);
 		return await SetOutputs(
 			PrEvaluationResult.Success, title, resolvedType,
+			resolvedDescription: description,
 			resolvedProducts: resolvedProducts,
 			productLabelTable: productLabelTable,
 			changelogDir: changelogDir,
@@ -138,6 +163,7 @@ public class ChangelogPrEvaluationService(
 		PrEvaluationResult status,
 		string? resolvedTitle = null,
 		string? resolvedType = null,
+		string? resolvedDescription = null,
 		string? resolvedProducts = null,
 		string? labelTable = null,
 		string? productLabelTable = null,
@@ -155,6 +181,8 @@ public class ChangelogPrEvaluationService(
 
 		if (resolvedTitle != null)
 			await coreService.SetOutputAsync("title", resolvedTitle);
+		if (resolvedDescription != null)
+			await coreService.SetOutputAsync("description", resolvedDescription);
 		if (resolvedType != null)
 			await coreService.SetOutputAsync("type", resolvedType);
 		if (resolvedProducts != null)

--- a/src/services/Elastic.Changelog/Evaluation/EvaluatePrArguments.cs
+++ b/src/services/Elastic.Changelog/Evaluation/EvaluatePrArguments.cs
@@ -12,11 +12,13 @@ public record EvaluatePrArguments
 	public required string Repo { get; init; }
 	public required int PrNumber { get; init; }
 	public required string PrTitle { get; init; }
+	public string? PrBody { get; init; }
 	public required string[] PrLabels { get; init; }
 	public required string HeadRef { get; init; }
 	public required string HeadSha { get; init; }
 	public string? EventAction { get; init; }
 	public bool TitleChanged { get; init; }
+	public bool BodyChanged { get; init; }
 	public bool StripTitlePrefix { get; init; }
 	public string BotName { get; init; } = "github-actions[bot]";
 }

--- a/src/tooling/docs-builder/Commands/ChangelogCommand.cs
+++ b/src/tooling/docs-builder/Commands/ChangelogCommand.cs
@@ -29,7 +29,8 @@ internal sealed partial class ChangelogCommand(
 	ILoggerFactory logFactory,
 	IDiagnosticsCollector collector,
 	IConfigurationContext configurationContext,
-	ICoreService githubActionsService
+	ICoreService githubActionsService,
+	IEnvironmentVariables environmentVariables
 )
 {
 	[GeneratedRegex(@"^( *directory:\s*).+$", RegexOptions.Multiline)]
@@ -1198,6 +1199,7 @@ internal sealed partial class ChangelogCommand(
 	/// <param name="headSha">PR head commit SHA</param>
 	/// <param name="eventAction">Optional: GitHub event action (e.g., opened, synchronize, edited). When omitted, body-only-edit and bot-loop checks are skipped.</param>
 	/// <param name="titleChanged">Whether the PR title changed (for edited events)</param>
+	/// <param name="bodyChanged">Whether the PR body changed (for edited events)</param>
 	/// <param name="stripTitlePrefix">Remove square-bracket prefixes from the PR title</param>
 	/// <param name="botName">Bot login name for loop detection</param>
 	/// <param name="ctx"></param>
@@ -1213,6 +1215,7 @@ internal sealed partial class ChangelogCommand(
 		string headSha,
 		string? eventAction = null,
 		bool titleChanged = false,
+		bool bodyChanged = false,
 		bool stripTitlePrefix = false,
 		string botName = "github-actions[bot]",
 		Cancel ctx = default
@@ -1223,6 +1226,8 @@ internal sealed partial class ChangelogCommand(
 		IGitHubPrService prService = new GitHubPrService(logFactory);
 		var service = new ChangelogPrEvaluationService(logFactory, configurationContext, prService, githubActionsService);
 
+		var prBody = environmentVariables.GetEnvironmentVariable("PR_BODY");
+
 		var args = new EvaluatePrArguments
 		{
 			Config = config,
@@ -1230,11 +1235,13 @@ internal sealed partial class ChangelogCommand(
 			Repo = repo,
 			PrNumber = prNumber,
 			PrTitle = prTitle,
+			PrBody = prBody,
 			PrLabels = prLabels.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
 			HeadRef = headRef,
 			HeadSha = headSha,
 			EventAction = eventAction,
 			TitleChanged = titleChanged,
+			BodyChanged = bodyChanged,
 			StripTitlePrefix = stripTitlePrefix,
 			BotName = botName
 		};

--- a/tests/Elastic.Changelog.Tests/Evaluation/ChangelogPrEvaluationServiceTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/ChangelogPrEvaluationServiceTests.cs
@@ -68,7 +68,9 @@ public class ChangelogPrEvaluationServiceTests : ChangelogTestBase
 	private EvaluatePrArguments DefaultArgs(
 		string eventAction = "opened",
 		bool titleChanged = false,
+		bool bodyChanged = false,
 		string prTitle = "Fix something",
+		string? prBody = null,
 		string[]? prLabels = null,
 		string? config = null
 	)
@@ -81,11 +83,13 @@ public class ChangelogPrEvaluationServiceTests : ChangelogTestBase
 			Repo = "test-repo",
 			PrNumber = 42,
 			PrTitle = prTitle,
+			PrBody = prBody,
 			PrLabels = prLabels ?? ["type:feature"],
 			HeadRef = "feature/test",
 			HeadSha = "abc123",
 			EventAction = eventAction,
-			TitleChanged = titleChanged
+			TitleChanged = titleChanged,
+			BodyChanged = bodyChanged
 		};
 	}
 
@@ -100,10 +104,10 @@ public class ChangelogPrEvaluationServiceTests : ChangelogTestBase
 		A.CallTo(() => _mockCore.SetOutputAsync(name, value)).MustHaveHappened();
 
 	[Fact]
-	public async Task EvaluatePr_BodyOnlyEdit_ReturnsSkipped()
+	public async Task EvaluatePr_EditedNoRelevantChange_ReturnsSkipped()
 	{
 		var service = CreateService();
-		var args = DefaultArgs(eventAction: "edited", titleChanged: false);
+		var args = DefaultArgs(eventAction: "edited", titleChanged: false, bodyChanged: false);
 
 		var result = await service.EvaluatePr(Collector, args, CancellationToken.None);
 
@@ -118,6 +122,20 @@ public class ChangelogPrEvaluationServiceTests : ChangelogTestBase
 		await WriteMinimalConfig();
 		var service = CreateService();
 		var args = DefaultArgs(eventAction: "edited", titleChanged: true);
+
+		var result = await service.EvaluatePr(Collector, args, CancellationToken.None);
+
+		result.Should().BeTrue();
+		VerifyOutputSet("status", "proceed");
+		VerifyOutputSet("should-generate", "true");
+	}
+
+	[Fact]
+	public async Task EvaluatePr_EditedWithBodyChange_DoesNotSkip()
+	{
+		await WriteMinimalConfig();
+		var service = CreateService();
+		var args = DefaultArgs(eventAction: "edited", bodyChanged: true);
 
 		var result = await service.EvaluatePr(Collector, args, CancellationToken.None);
 
@@ -494,5 +512,124 @@ public class ChangelogPrEvaluationServiceTests : ChangelogTestBase
 		A.CallTo(() => _mockCore.SetOutputAsync("products", A<string>._)).MustNotHaveHappened();
 		A.CallTo(() => _mockCore.SetOutputAsync("product-label-table", A<string>.That.Contains("@Product:ECH"))).MustHaveHappened();
 		A.CallTo(() => _mockCore.SetOutputAsync("product-label-table", A<string>.That.Contains("cloud-hosted"))).MustHaveHappened();
+	}
+
+	[Fact]
+	public async Task EvaluatePr_ShortReleaseNote_OverridesPrTitle()
+	{
+		await WriteMinimalConfig();
+		var service = CreateService();
+		var args = DefaultArgs(
+			prTitle: "Some PR title",
+			prBody: "Release Notes: Added new search API endpoint"
+		);
+
+		var result = await service.EvaluatePr(Collector, args, CancellationToken.None);
+
+		result.Should().BeTrue();
+		VerifyOutputSet("title", "Added new search API endpoint");
+		A.CallTo(() => _mockCore.SetOutputAsync("description", A<string>._)).MustNotHaveHappened();
+	}
+
+	[Fact]
+	public async Task EvaluatePr_LongReleaseNote_UsedAsDescription_PrTitleAsTitle()
+	{
+		await WriteMinimalConfig();
+		var service = CreateService();
+		var longNote = new string('x', 130);
+		var args = DefaultArgs(
+			prTitle: "Some PR title",
+			prBody: $"Release Notes: {longNote}"
+		);
+
+		var result = await service.EvaluatePr(Collector, args, CancellationToken.None);
+
+		result.Should().BeTrue();
+		VerifyOutputSet("title", "Some PR title");
+		VerifyOutputSet("description", longNote);
+	}
+
+	[Fact]
+	public async Task EvaluatePr_NoReleaseNote_FallsBackToPrTitle()
+	{
+		await WriteMinimalConfig();
+		var service = CreateService();
+		var args = DefaultArgs(
+			prTitle: "Fix something",
+			prBody: "This PR fixes a bug in the search API."
+		);
+
+		var result = await service.EvaluatePr(Collector, args, CancellationToken.None);
+
+		result.Should().BeTrue();
+		VerifyOutputSet("title", "Fix something");
+		A.CallTo(() => _mockCore.SetOutputAsync("description", A<string>._)).MustNotHaveHappened();
+	}
+
+	[Fact]
+	public async Task EvaluatePr_NullBody_FallsBackToPrTitle()
+	{
+		await WriteMinimalConfig();
+		var service = CreateService();
+		var args = DefaultArgs(prTitle: "Fix something", prBody: null);
+
+		var result = await service.EvaluatePr(Collector, args, CancellationToken.None);
+
+		result.Should().BeTrue();
+		VerifyOutputSet("title", "Fix something");
+	}
+
+	[Fact]
+	public async Task EvaluatePr_ExtractionDisabled_IgnoresReleaseNote()
+	{
+		var configWithExtractionDisabled = """
+			extract:
+			  release_notes: false
+			pivot:
+			  types:
+			    feature: "type:feature"
+			    bug-fix: "type:bug"
+			    breaking-change: "type:breaking"
+			    enhancement:
+			    deprecation:
+			    docs:
+			    known-issue:
+			    other:
+			    regression:
+			    security:
+			""";
+		await WriteMinimalConfig(content: configWithExtractionDisabled);
+		var service = CreateService();
+		var args = DefaultArgs(
+			prTitle: "Original PR title",
+			prBody: "Release Notes: Should be ignored"
+		);
+
+		var result = await service.EvaluatePr(Collector, args, CancellationToken.None);
+
+		result.Should().BeTrue();
+		VerifyOutputSet("title", "Original PR title");
+	}
+
+	[Fact]
+	public async Task EvaluatePr_ReleaseNoteHeader_ExtractedAsTitle()
+	{
+		await WriteMinimalConfig();
+		var service = CreateService();
+		var args = DefaultArgs(
+			prTitle: "Some PR title",
+			prBody: """
+				## Description
+				This PR adds a new feature.
+
+				## Release Note
+				New aggregation pipeline support
+				"""
+		);
+
+		var result = await service.EvaluatePr(Collector, args, CancellationToken.None);
+
+		result.Should().BeTrue();
+		VerifyOutputSet("title", "New aggregation pipeline support");
 	}
 }


### PR DESCRIPTION
This pull request enhances the changelog and PR evaluation logic to better handle PR body content, especially extracting release notes, and improves the accuracy of PR edit detection. It also updates the related test suite to cover these new behaviors.

**Changelog and PR Evaluation Improvements:**

* The PR evaluation now distinguishes between title and body changes, skipping processing only if neither changed, improving efficiency and accuracy for edited events. (`src/services/Elastic.Changelog/Evaluation/ChangelogPrEvaluationService.cs` [src/services/Elastic.Changelog/Evaluation/ChangelogPrEvaluationService.csL35-R38](diffhunk://#diff-37df27cba13363ff150536d3e4dac531776b6035e6efacbbe87f115dc4796efeL35-R38))
* Release notes are now extracted from the PR body (when enabled in config): if a short release note is found, it overrides the PR title; longer notes are used as the description. Fallbacks to the PR title if no release note is found. (`src/services/Elastic.Changelog/Evaluation/ChangelogPrEvaluationService.cs` [[1]](diffhunk://#diff-37df27cba13363ff150536d3e4dac531776b6035e6efacbbe87f115dc4796efeL83-R109) [[2]](diffhunk://#diff-37df27cba13363ff150536d3e4dac531776b6035e6efacbbe87f115dc4796efeR142) [[3]](diffhunk://#diff-37df27cba13363ff150536d3e4dac531776b6035e6efacbbe87f115dc4796efeR151)
* The PR evaluation outputs now include the extracted description, and the output logic is updated to set the new "description" field. (`src/services/Elastic.Changelog/Evaluation/ChangelogPrEvaluationService.cs` [[1]](diffhunk://#diff-37df27cba13363ff150536d3e4dac531776b6035e6efacbbe87f115dc4796efeR166) [[2]](diffhunk://#diff-37df27cba13363ff150536d3e4dac531776b6035e6efacbbe87f115dc4796efeR184-R185)
* The changelog creation process is updated to use the extracted description from CI environment variables if available. (`src/services/Elastic.Changelog/Creation/ChangelogCreationService.cs` [[1]](diffhunk://#diff-c122c4de08a6a5b3a38821b3da497a507629b4f00c590c7f4c2105050187819eR394) [[2]](diffhunk://#diff-c122c4de08a6a5b3a38821b3da497a507629b4f00c590c7f4c2105050187819eR418)

**API and Argument Structure Updates:**

* The `EvaluatePrArguments` record now includes `PrBody` and `BodyChanged` fields to support the new evaluation logic. (`src/services/Elastic.Changelog/Evaluation/EvaluatePrArguments.cs` [src/services/Elastic.Changelog/Evaluation/EvaluatePrArguments.csR15-R21](diffhunk://#diff-1455b45a7514acb8a698e9c6ee33970dd701d7ece19bc7d261a51a4c2ec9cb65R15-R21))
* The changelog command and its evaluation method are updated to accept and pass through the new arguments, including reading the PR body from environment variables. (`src/tooling/docs-builder/Commands/ChangelogCommand.cs` [[1]](diffhunk://#diff-a3b9a6dd03fde3fe1ac00ff9a4141ba962f6455593d6fbf408d815077dfa132fL32-R33) [[2]](diffhunk://#diff-a3b9a6dd03fde3fe1ac00ff9a4141ba962f6455593d6fbf408d815077dfa132fR1202) [[3]](diffhunk://#diff-a3b9a6dd03fde3fe1ac00ff9a4141ba962f6455593d6fbf408d815077dfa132fR1218) [[4]](diffhunk://#diff-a3b9a6dd03fde3fe1ac00ff9a4141ba962f6455593d6fbf408d815077dfa132fR1229-R1244)

**Test Suite Enhancements:**

* The test helper and test cases are updated to support and verify the new logic for body changes and release note extraction, including new tests for various release note scenarios and the updated skip logic for edits. (`tests/Elastic.Changelog.Tests/Evaluation/ChangelogPrEvaluationServiceTests.cs` [[1]](diffhunk://#diff-66684fd0d4789baeb07adf43a8f7f75b3bd7cf72f86935dffd9300a61eb69889R71-R73) [[2]](diffhunk://#diff-66684fd0d4789baeb07adf43a8f7f75b3bd7cf72f86935dffd9300a61eb69889R86-R92) [[3]](diffhunk://#diff-66684fd0d4789baeb07adf43a8f7f75b3bd7cf72f86935dffd9300a61eb69889L103-R110) [[4]](diffhunk://#diff-66684fd0d4789baeb07adf43a8f7f75b3bd7cf72f86935dffd9300a61eb69889R133-R146) [[5]](diffhunk://#diff-66684fd0d4789baeb07adf43a8f7f75b3bd7cf72f86935dffd9300a61eb69889R516-R634)