### PR TITLE
Make clone directories git worktree-aware

### DIFF
--- a/src/Elastic.Codex/CodexContext.cs
+++ b/src/Elastic.Codex/CodexContext.cs
@@ -45,7 +45,7 @@ public class CodexContext
 		ReadFileSystem = readFileSystem;
 		WriteFileSystem = writeFileSystem;
 
-		var defaultCheckoutDirectory = Path.Combine(Paths.WorkingDirectoryRoot.FullName, ".artifacts", "codex", "clone");
+		var defaultCheckoutDirectory = Path.Combine(Paths.GitCommonRoot.FullName, ".artifacts", "codex", "clone");
 		CheckoutDirectory = ReadFileSystem.DirectoryInfo.New(checkoutDirectory ?? defaultCheckoutDirectory);
 
 		var defaultOutputDirectory = Path.Combine(Paths.WorkingDirectoryRoot.FullName, ".artifacts", "codex", "docs");

--- a/src/Elastic.Documentation.Configuration/Paths.cs
+++ b/src/Elastic.Documentation.Configuration/Paths.cs
@@ -11,6 +11,8 @@ public static class Paths
 {
 	public static readonly DirectoryInfo WorkingDirectoryRoot = DetermineWorkingDirectoryRoot();
 
+	public static readonly DirectoryInfo GitCommonRoot = InitGitCommonRoot();
+
 	public static readonly DirectoryInfo ApplicationData = GetApplicationFolder();
 
 	private static DirectoryInfo DetermineWorkingDirectoryRoot()
@@ -46,6 +48,42 @@ public static class Paths
 		}
 		sourceRoot ??= directory;
 		return sourceRoot;
+	}
+
+	/// <summary>Resolves the root of the main git repository, following worktree links when present. Disabled on CI.</summary>
+	public static IDirectoryInfo ResolveGitCommonRoot(IFileSystem fileSystem, IDirectoryInfo workingDirectoryRoot, bool? isCI = null)
+	{
+		if (isCI ?? !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("GITHUB_ACTIONS")))
+			return workingDirectoryRoot;
+
+		var gitPath = Path.Combine(workingDirectoryRoot.FullName, ".git");
+
+		if (fileSystem.Directory.Exists(gitPath))
+			return workingDirectoryRoot;
+
+		if (!fileSystem.File.Exists(gitPath))
+			return workingDirectoryRoot;
+
+		var content = fileSystem.File.ReadAllText(gitPath).Trim();
+		if (!content.StartsWith("gitdir:", StringComparison.OrdinalIgnoreCase))
+			return workingDirectoryRoot;
+
+		var gitDirPath = content["gitdir:".Length..].Trim();
+		if (!Path.IsPathRooted(gitDirPath))
+			gitDirPath = Path.GetFullPath(gitDirPath, workingDirectoryRoot.FullName);
+
+		var dir = fileSystem.DirectoryInfo.New(gitDirPath);
+		while (dir != null && dir.Name != ".git")
+			dir = dir.Parent;
+
+		return dir?.Parent ?? workingDirectoryRoot;
+	}
+
+	private static DirectoryInfo InitGitCommonRoot()
+	{
+		var fs = new FileSystem();
+		var root = fs.DirectoryInfo.New(WorkingDirectoryRoot.FullName);
+		return new DirectoryInfo(ResolveGitCommonRoot(fs, root).FullName);
 	}
 
 	/// Used in debug to locate static folder, so we can change js/css files while the server is running

--- a/src/services/Elastic.Documentation.Assembler/AssembleContext.cs
+++ b/src/services/Elastic.Documentation.Assembler/AssembleContext.cs
@@ -88,7 +88,7 @@ public class AssembleContext : IDocumentationConfigurationContext
 		Endpoints.Environment = environment;
 
 		var contentSource = Environment.ContentSource.ToStringFast(true);
-		var defaultCheckoutDirectory = Path.Combine(Paths.WorkingDirectoryRoot.FullName, ".artifacts", "checkouts", contentSource);
+		var defaultCheckoutDirectory = Path.Combine(Paths.GitCommonRoot.FullName, ".artifacts", "checkouts", contentSource);
 		CheckoutDirectory = ReadFileSystem.DirectoryInfo.New(checkoutDirectory ?? defaultCheckoutDirectory);
 		var defaultOutputDirectory = Path.Combine(Paths.WorkingDirectoryRoot.FullName, ".artifacts", "assembly");
 		OutputDirectory = ReadFileSystem.DirectoryInfo.New(output ?? defaultOutputDirectory);

--- a/tests/Elastic.Documentation.Configuration.Tests/GitCommonRootTests.cs
+++ b/tests/Elastic.Documentation.Configuration.Tests/GitCommonRootTests.cs
@@ -1,0 +1,98 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions.TestingHelpers;
+using AwesomeAssertions;
+
+namespace Elastic.Documentation.Configuration.Tests;
+
+public class GitCommonRootTests
+{
+	[Fact]
+	public void NormalRepo_ReturnsWorkingDirectoryRoot()
+	{
+		var fs = new MockFileSystem();
+		fs.AddDirectory("/repo/.git");
+		var root = fs.DirectoryInfo.New("/repo");
+
+		var result = Paths.ResolveGitCommonRoot(fs, root, isCI: false);
+
+		result.FullName.Should().Be(root.FullName);
+	}
+
+	[Fact]
+	public void Worktree_AbsoluteGitDir_ReturnsMainRepoRoot()
+	{
+		var fs = new MockFileSystem();
+		fs.AddFile("/worktree/.git", new MockFileData("gitdir: /main-repo/.git/worktrees/feature-branch"));
+		fs.AddDirectory("/main-repo/.git/worktrees/feature-branch");
+		var root = fs.DirectoryInfo.New("/worktree");
+
+		var result = Paths.ResolveGitCommonRoot(fs, root, isCI: false);
+
+		result.FullName.Should().Be(fs.DirectoryInfo.New("/main-repo").FullName);
+	}
+
+	[Fact]
+	public void Worktree_RelativeGitDir_ReturnsMainRepoRoot()
+	{
+		var fs = new MockFileSystem();
+		fs.AddFile("/repos/worktree/.git", new MockFileData("gitdir: ../main-repo/.git/worktrees/feature-branch"));
+		fs.AddDirectory("/repos/main-repo/.git/worktrees/feature-branch");
+		var root = fs.DirectoryInfo.New("/repos/worktree");
+
+		var result = Paths.ResolveGitCommonRoot(fs, root, isCI: false);
+
+		result.FullName.Should().Be(fs.DirectoryInfo.New("/repos/main-repo").FullName);
+	}
+
+	[Fact]
+	public void NoGitPresent_ReturnsWorkingDirectoryRoot()
+	{
+		var fs = new MockFileSystem();
+		fs.AddDirectory("/repo");
+		var root = fs.DirectoryInfo.New("/repo");
+
+		var result = Paths.ResolveGitCommonRoot(fs, root, isCI: false);
+
+		result.FullName.Should().Be(root.FullName);
+	}
+
+	[Fact]
+	public void MalformedGitFile_ReturnsWorkingDirectoryRoot()
+	{
+		var fs = new MockFileSystem();
+		fs.AddFile("/repo/.git", new MockFileData("not a valid gitdir reference"));
+		var root = fs.DirectoryInfo.New("/repo");
+
+		var result = Paths.ResolveGitCommonRoot(fs, root, isCI: false);
+
+		result.FullName.Should().Be(root.FullName);
+	}
+
+	[Fact]
+	public void Worktree_GitDirPathHasNoGitAncestor_ReturnsWorkingDirectoryRoot()
+	{
+		var fs = new MockFileSystem();
+		fs.AddFile("/worktree/.git", new MockFileData("gitdir: /some/path/without/git/ancestor"));
+		var root = fs.DirectoryInfo.New("/worktree");
+
+		var result = Paths.ResolveGitCommonRoot(fs, root, isCI: false);
+
+		result.FullName.Should().Be(root.FullName);
+	}
+
+	[Fact]
+	public void OnCI_Worktree_ReturnsWorkingDirectoryRoot()
+	{
+		var fs = new MockFileSystem();
+		fs.AddFile("/worktree/.git", new MockFileData("gitdir: /main-repo/.git/worktrees/feature-branch"));
+		fs.AddDirectory("/main-repo/.git/worktrees/feature-branch");
+		var root = fs.DirectoryInfo.New("/worktree");
+
+		var result = Paths.ResolveGitCommonRoot(fs, root, isCI: true);
+
+		result.FullName.Should().Be(root.FullName);
+	}
+}


### PR DESCRIPTION
## Summary

When developing with git worktrees, each worktree previously got its own `.artifacts/checkouts` and `.artifacts/codex/clone` directories. These checkout directories can be very large (they contain full clones of all configured repositories), so duplicating them per worktree wastes significant disk space.

This PR adds `Paths.GitCommonRoot` which resolves to the **main repository root** by following the worktree `.git` file's `gitdir:` pointer. Clone/checkout directories now default to this shared root, while build output directories remain worktree-local for isolation.

On CI (`GITHUB_ACTIONS`), worktree resolution is **disabled** — `GitCommonRoot` always equals `WorkingDirectoryRoot` to prevent unexpected path pollution in clean CI checkouts.

## How it works

In a git worktree, `.git` is a **file** (not a directory) containing a pointer like:

```
gitdir: /path/to/main-repo/.git/worktrees/feature-branch
```

`ResolveGitCommonRoot` reads this file, walks up the path to find the `.git` directory, and returns its parent — the main repo root. For normal (non-worktree) repos or CI environments, it returns the working directory unchanged.

```mermaid
flowchart TD
    Start[ResolveGitCommonRoot] --> CICheck{Running on CI?}
    CICheck -->|Yes| ReturnRoot[Return WorkingDirectoryRoot]
    CICheck -->|No| IsDir{.git is a directory?}
    IsDir -->|Yes| ReturnRoot
    IsDir -->|No| IsFile{.git is a file?}
    IsFile -->|No| ReturnRoot
    IsFile -->|Yes| Parse["Parse gitdir: path"]
    Parse --> WalkUp["Walk up to find .git/ directory"]
    WalkUp --> ReturnParent[Return .git parent = main repo root]
```

## Path behavior after this change

```mermaid
flowchart LR
    subgraph mainRepo [Main Repo Root - GitCommonRoot]
        Checkouts[".artifacts/checkouts/"]
        CodexClone[".artifacts/codex/clone/"]
    end

    subgraph worktreeA [Worktree A - WorkingDirectoryRoot]
        OutputA[".artifacts/docs/html/"]
        AssemblyA[".artifacts/assembly/"]
        CodexDocsA[".artifacts/codex/docs/"]
    end

    subgraph worktreeB [Worktree B - WorkingDirectoryRoot]
        OutputB[".artifacts/docs/html/"]
        AssemblyB[".artifacts/assembly/"]
        CodexDocsB[".artifacts/codex/docs/"]
    end

    worktreeA -->|"shared clones"| Checkouts
    worktreeB -->|"shared clones"| Checkouts
    worktreeA -->|"shared clones"| CodexClone
    worktreeB -->|"shared clones"| CodexClone
```

| Path | Root used | Shared? |
|------|-----------|---------|
| `.artifacts/checkouts/{source}` | `GitCommonRoot` | Yes, across worktrees |
| `.artifacts/codex/clone` | `GitCommonRoot` | Yes, across worktrees |
| `.artifacts/docs/html` | `WorkingDirectoryRoot` | No, isolated per worktree |
| `.artifacts/assembly` | `WorkingDirectoryRoot` | No, isolated per worktree |
| `.artifacts/codex/docs` | `WorkingDirectoryRoot` | No, isolated per worktree |

## Changes

- **`Paths.cs`** — Added `ResolveGitCommonRoot(IFileSystem, IDirectoryInfo, bool? isCI)` (testable with `MockFileSystem`) and static `GitCommonRoot` field. CI guard skips worktree resolution when `GITHUB_ACTIONS` is set.
- **`AssembleContext.cs`** — Checkout directory default now uses `Paths.GitCommonRoot`
- **`CodexContext.cs`** — Clone directory default now uses `Paths.GitCommonRoot`
- **`GitCommonRootTests.cs`** — 7 unit tests covering normal repo, worktree (absolute/relative gitdir), missing `.git`, malformed `.git` file, invalid gitdir path, and CI bypass

## Test plan

- [x] All 7 new `GitCommonRootTests` pass
- [x] Full unit test suite passes (2,931 tests, 0 failures)
- [ ] Manual verification: run `dotnet run` from a git worktree and confirm checkouts land in the main repo's `.artifacts/checkouts`