### PR TITLE
Expand .claude/settings.json with read-only permissions and schema reference

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,7 +11,7 @@
       "Bash(git status:*)",
       "Bash(git diff:*)",
       "Bash(git show:*)",
-      "Bash(git branch:*)",
+      "Bash(git branch --list:*)",
       "Bash(git grep:*)",
       "Bash(./build.sh:*)",
       "Bash(dotnet build:*)",


### PR DESCRIPTION
## Why

The previous `.claude/settings.json` only pre-approved a handful of build commands, so every file read, search, web lookup, and common build step triggered an approval prompt. This creates friction during routine exploration and development — the most common things Claude does before and while making changes.

Read-only operations carry no risk of modifying the codebase, so requiring approval adds noise without adding safety. Common build/test commands are similarly low-risk and needed constantly during development.

## What changed

**Read-only exploration (no prompts):**
- `Read`, `Glob`, `Grep` — file exploration tools
- `WebSearch`, `WebFetch` — web research (API docs, error messages, etc.)
- `Bash(git log:*)`, `git status`, `git diff`, `git show`, `git branch` — read-only git inspection

**Build & development workflow:**
- `Bash(./build.sh:*)` — the main build wrapper covering all targets (compile, test, lint, format, watch)
- `Bash(dotnet restore:*)` — package restore
- `Bash(dotnet test:*)` — direct test runs
- `Bash(dotnet run:*)` — covers both `dotnet run --project build` and `dotnet run --project src/tooling/docs-builder`
- `Bash(dotnet format:*)` — formatting and lint checks
- `Bash(dotnet watch:*)` — watch mode development
- `Bash(dotnet workload:*)` — workload management (aspire etc.)
- `Bash(npm ci:*)`, `npm run lint`, `npm run fmt:*`, `npm run test:*`, `npm run watch:*` — JS toolchain

**Not pre-approved (still prompt):** `dotnet publish`, container builds, docker — these have broader impact and are infrequent enough that a prompt is appropriate.

**`$schema`** added for IDE autocomplete and validation via SchemaStore.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)