### PR TITLE
Fix updatecli token scope for public EDOT browser repo

### DIFF
--- a/.github/updatecli/values.d/scm.yml
+++ b/.github/updatecli/values.d/scm.yml
@@ -6,5 +6,4 @@ scm:
     edot-cloud-forwarder-aws
     edot-cloud-forwarder-azure
     edot-cloud-forwarder-gcp
-    elastic-otel-rum-js
   branch: main

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -31,7 +31,6 @@ jobs:
             edot-cloud-forwarder-aws
             edot-cloud-forwarder-azure
             edot-cloud-forwarder-gcp
-            elastic-otel-rum-js
 
       - uses: elastic/oblt-actions/updatecli/run@v1
         with:


### PR DESCRIPTION
## Summary
- Remove `elastic-otel-rum-js` from the GitHub App repository allowlist used by the `updatecli` workflow.
- Keep `.github/updatecli/values.d/scm.yml` aligned with the workflow repository list.
- Prevent the GitHub App token step from failing when that now-public repository is not part of the app installation.

+CC @alexandra5000 for future reference

Made with [Cursor](https://cursor.com)