### PR TITLE
Deploy: Use write-scoped filesystem for apply command

### DIFF
--- a/src/tooling/docs-builder/Commands/Assembler/DeployCommands.cs
+++ b/src/tooling/docs-builder/Commands/Assembler/DeployCommands.cs
@@ -51,7 +51,7 @@ internal sealed class DeployCommands(
 	{
 		await using var serviceInvoker = new ServiceInvoker(collector);
 
-		var fs = FileSystemFactory.RealRead;
+		var fs = FileSystemFactory.RealWrite;
 		var service = new IncrementalDeployService(logFactory, assemblyConfiguration, configurationContext, githubActionsService, fs);
 		serviceInvoker.AddCommand(service, (environment, s3BucketName, planFile),
 			static async (s, collector, state, ctx) => await s.Apply(collector, state.environment, state.s3BucketName, state.planFile, ctx)


### PR DESCRIPTION
## What
Use `FileSystemFactory.RealWrite` instead of `RealRead` in the deploy apply command.

## Why
The deploy apply command was failing with `ScopedFileSystemException` because `RealRead` doesn't include `AllowedSpecialFolder.Temp`. When `AwsS3SyncApplyStrategy.Upload()` stages files in `/tmp/` for S3 upload, the scoped filesystem rejected the path as outside all configured scope roots.

Fixes https://github.com/elastic/docs-internal-workflows/actions/runs/23892263097/job/69668233142#step:14:13663

## How
Changed `DeployCommands.Apply()` to use `FileSystemFactory.RealWrite` which permits temp directory access. The `Plan` command remains on `RealRead` since it doesn't need temp access.

## Test plan
- Existing `DocsSyncTests.TestApply` already uses separate read/write scoped filesystems and passes
- Deploy apply in CI should no longer throw `ScopedFileSystemException` for `/tmp/` paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)