### PR TITLE
Deploy: separate read/write scoped filesystems in IncrementalDeployService

### DIFF
--- a/src/services/Elastic.Documentation.Assembler/Deploying/IncrementalDeployService.cs
+++ b/src/services/Elastic.Documentation.Assembler/Deploying/IncrementalDeployService.cs
@@ -2,7 +2,6 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-using System.IO.Abstractions;
 using Actions.Core.Services;
 using Amazon.S3;
 using Amazon.S3.Transfer;
@@ -21,14 +20,15 @@ public class IncrementalDeployService(
 	AssemblyConfiguration assemblyConfiguration,
 	IConfigurationContext configurationContext,
 	ICoreService githubActionsService,
-	ScopedFileSystem fileSystem
+	ScopedFileSystem readFileSystem,
+	ScopedFileSystem writeFileSystem
 ) : IService
 {
 	private readonly ILogger _logger = logFactory.CreateLogger<IncrementalDeployService>();
 
 	public async Task<bool> Plan(IDiagnosticsCollector collector, string environment, string s3BucketName, string @out, float? deleteThreshold, Cancel ctx)
 	{
-		var assembleContext = new AssembleContext(assemblyConfiguration, configurationContext, environment, collector, fileSystem, fileSystem, null, null);
+		var assembleContext = new AssembleContext(assemblyConfiguration, configurationContext, environment, collector, readFileSystem, writeFileSystem, null, null);
 		var s3Client = new AmazonS3Client();
 		var planner = new AwsS3SyncPlanStrategy(logFactory, s3Client, s3BucketName, assembleContext);
 		var plan = await planner.Plan(deleteThreshold, ctx);
@@ -51,7 +51,7 @@ public class IncrementalDeployService(
 		if (!string.IsNullOrEmpty(@out))
 		{
 			var output = SyncPlan.Serialize(plan);
-			await using var fileStream = fileSystem.File.Create(@out);
+			await using var fileStream = writeFileSystem.File.Create(@out);
 			await using var writer = new StreamWriter(fileStream);
 			await writer.WriteAsync(output);
 			_logger.LogInformation("Plan written to {OutputFile}", @out);
@@ -62,19 +62,19 @@ public class IncrementalDeployService(
 
 	public async Task<bool> Apply(IDiagnosticsCollector collector, string environment, string s3BucketName, string planFile, Cancel ctx)
 	{
-		var assembleContext = new AssembleContext(assemblyConfiguration, configurationContext, environment, collector, fileSystem, fileSystem, null, null);
+		var assembleContext = new AssembleContext(assemblyConfiguration, configurationContext, environment, collector, readFileSystem, writeFileSystem, null, null);
 		var s3Client = new AmazonS3Client();
 		var transferUtility = new TransferUtility(s3Client, new TransferUtilityConfig
 		{
 			ConcurrentServiceRequests = Environment.ProcessorCount * 2,
 			MinSizeBeforePartUpload = S3EtagCalculator.PartSize
 		});
-		if (!fileSystem.File.Exists(planFile))
+		if (!readFileSystem.File.Exists(planFile))
 		{
 			collector.EmitError(planFile, "Plan file does not exist.");
 			return false;
 		}
-		var planJson = await fileSystem.File.ReadAllTextAsync(planFile, ctx);
+		var planJson = await readFileSystem.File.ReadAllTextAsync(planFile, ctx);
 		var plan = SyncPlan.Deserialize(planJson);
 		_logger.LogInformation("Remote listing completed: {RemoteListingCompleted}", plan.RemoteListingCompleted);
 		_logger.LogInformation("Total files to sync: {TotalFiles}", plan.TotalSyncRequests);

--- a/src/tooling/docs-builder/Commands/Assembler/DeployCommands.cs
+++ b/src/tooling/docs-builder/Commands/Assembler/DeployCommands.cs
@@ -2,7 +2,6 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-using System.IO.Abstractions;
 using Actions.Core.Services;
 using ConsoleAppFramework;
 using Elastic.Documentation.Assembler.Deploying;
@@ -33,8 +32,7 @@ internal sealed class DeployCommands(
 	{
 		await using var serviceInvoker = new ServiceInvoker(collector);
 
-		var fs = FileSystemFactory.RealRead;
-		var service = new IncrementalDeployService(logFactory, assemblyConfiguration, configurationContext, githubActionsService, fs);
+		var service = new IncrementalDeployService(logFactory, assemblyConfiguration, configurationContext, githubActionsService, FileSystemFactory.RealRead, FileSystemFactory.RealWrite);
 		serviceInvoker.AddCommand(service, (environment, s3BucketName, @out, deleteThreshold),
 			static async (s, collector, state, ctx) => await s.Plan(collector, state.environment, state.s3BucketName, state.@out, state.deleteThreshold, ctx)
 		);
@@ -51,8 +49,7 @@ internal sealed class DeployCommands(
 	{
 		await using var serviceInvoker = new ServiceInvoker(collector);
 
-		var fs = FileSystemFactory.RealWrite;
-		var service = new IncrementalDeployService(logFactory, assemblyConfiguration, configurationContext, githubActionsService, fs);
+		var service = new IncrementalDeployService(logFactory, assemblyConfiguration, configurationContext, githubActionsService, FileSystemFactory.RealRead, FileSystemFactory.RealWrite);
 		serviceInvoker.AddCommand(service, (environment, s3BucketName, planFile),
 			static async (s, collector, state, ctx) => await s.Apply(collector, state.environment, state.s3BucketName, state.planFile, ctx)
 		);


### PR DESCRIPTION
## Summary

Alternative to #3021 — fixes the same `ScopedFileSystemException` on `/tmp/` during incremental deploy, but with proper read/write filesystem separation rather than a single-FS swap.

- `IncrementalDeployService` now accepts separate `readFileSystem` and `writeFileSystem` parameters instead of a single `fileSystem` used for both
- `DeployCommands` passes `RealRead` + `RealWrite` to both `Plan` and `Apply` commands
- Each operation uses the correct scoped FS: reads through `readFileSystem`, writes (including plan output and temp staging) through `writeFileSystem`

## Why this over #3021

#3021 swaps `RealRead` → `RealWrite` for the `Apply` command only, still passing a single FS as both the read and write filesystem to `IncrementalDeployService` (and through it to `AssembleContext`). This works but:

1. **Mismatched semantics** — `AssembleContext` has distinct `ReadFileSystem` / `WriteFileSystem` properties, but both point to the same `RealWrite` instance. Future code relying on `ReadFileSystem` having read-scoped permissions (e.g. `.git` access) would silently get the wrong FS.
2. **Plan command unchanged** — `Plan` still uses `RealRead` for writing its output file (`fileSystem.File.Create(@out)`). This happens to work today because the output path is within the working directory scope, but it's using a read FS for a write operation.
3. **Single responsibility** — the service should declare what it needs (a reader and a writer) rather than accepting one FS and hoping the caller picked the right one.

## Test plan

- `dotnet build` passes with 0 errors
- Existing `DocsSyncTests.TestApply` uses separate read/write scoped filesystems and passes
- Deploy apply in CI should no longer throw `ScopedFileSystemException` for `/tmp/` paths

Fixes https://github.com/elastic/docs-internal-workflows/actions/runs/23897412121/job/69685376318


Made with [Cursor](https://cursor.com)