### PR TITLE
Propose IA changes to nav-v2

### DIFF
--- a/config/navigation-v2.yml
+++ b/config/navigation-v2.yml
@@ -382,10 +382,6 @@ nav:
         page: docs-content://reference/ingestion-tools/index.md
         children:
         - toc: opentelemetry://reference
-          children:
-          - toc: opentelemetry://reference/motlp
-          - toc: opentelemetry://reference/edot-cloud-forwarder
-          - toc: elastic-agent://reference/edot-collector
         - group: EDOT SDKs
           page: opentelemetry://reference/edot-sdks/index.md
           children:

--- a/config/navigation-v2.yml
+++ b/config/navigation-v2.yml
@@ -382,6 +382,10 @@ nav:
         page: docs-content://reference/ingestion-tools/index.md
         children:
         - toc: opentelemetry://reference
+          children:
+          - toc: opentelemetry://reference/motlp
+          - toc: opentelemetry://reference/edot-cloud-forwarder
+          - toc: elastic-agent://reference/edot-collector
         - group: EDOT SDKs
           page: opentelemetry://reference/edot-sdks/index.md
           children:

--- a/config/navigation-v2.yml
+++ b/config/navigation-v2.yml
@@ -382,17 +382,23 @@ nav:
         page: docs-content://reference/ingestion-tools/index.md
         children:
         - toc: opentelemetry://reference
-        - group: EDOT SDKs
-          page: opentelemetry://reference/edot-sdks/index.md
           children:
-          - toc: apm-agent-android://reference/edot-android
-          - toc: elastic-otel-dotnet://reference/edot-dotnet
-          - toc: apm-agent-ios://reference/edot-ios
-          - toc: elastic-otel-java://reference/edot-java
-          - toc: elastic-otel-node://reference/edot-node
-          - toc: elastic-otel-php://reference/edot-php
-          - toc: elastic-otel-python://reference/edot-python
-          - toc: elastic-otel-rum-js://reference/edot-browser
+          - page: docs-content://solutions/observability/get-started/opentelemetry/quickstart/index.md
+            title: Quickstarts
+          - page: opentelemetry://reference/architecture/index.md
+            title: Reference Architecture
+          - page: docs-content://solutions/observability/get-started/opentelemetry/use-cases/index.md
+            title: Use cases
+          - page: opentelemetry://reference/compatibility/index.md
+            title: Compatibility and support
+          - page: opentelemetry://reference/data-streams.md
+            title: Data streams
+          - page: opentelemetry://reference/central-configuration.md
+            title: Central configuration
+        - toc: opentelemetry://reference/motlp
+        - toc: opentelemetry://reference/edot-cloud-forwarder
+        - toc: elastic-agent://reference/edot-collector
+        - toc: opentelemetry://reference/edot-sdks
         - toc: docs-content://reference/fleet
         - toc: integration-docs://reference
         - toc: elasticsearch://reference/search-connectors

--- a/config/navigation-v2.yml
+++ b/config/navigation-v2.yml
@@ -382,6 +382,17 @@ nav:
         page: docs-content://reference/ingestion-tools/index.md
         children:
         - toc: opentelemetry://reference
+        - group: EDOT SDKs
+          page: opentelemetry://reference/edot-sdks/index.md
+          children:
+          - toc: apm-agent-android://reference/edot-android
+          - toc: elastic-otel-dotnet://reference/edot-dotnet
+          - toc: apm-agent-ios://reference/edot-ios
+          - toc: elastic-otel-java://reference/edot-java
+          - toc: elastic-otel-node://reference/edot-node
+          - toc: elastic-otel-php://reference/edot-php
+          - toc: elastic-otel-python://reference/edot-python
+          - toc: elastic-otel-rum-js://reference/edot-browser
         - toc: docs-content://reference/fleet
         - toc: integration-docs://reference
         - toc: elasticsearch://reference/search-connectors

--- a/config/navigation.yml
+++ b/config/navigation.yml
@@ -474,24 +474,27 @@ toc:
                     path_prefix: reference/opentelemetry/edot-cloud-forwarder/gcp
               - toc: elastic-agent://reference/edot-collector
                 path_prefix: reference/edot-collector
-              - toc: apm-agent-android://reference/edot-android
-                path_prefix: reference/opentelemetry/edot-sdks/android
-              - toc: elastic-otel-dotnet://reference/edot-dotnet
-                path_prefix: reference/opentelemetry/edot-sdks/dotnet
-              - toc: apm-agent-ios://reference/edot-ios
-                path_prefix: reference/opentelemetry/edot-sdks/ios
-              - toc: elastic-otel-java://reference/edot-java
-                path_prefix: reference/opentelemetry/edot-sdks/java
-              - toc: elastic-otel-node://reference/edot-node
-                path_prefix: reference/opentelemetry/edot-sdks/node
-              - toc: elastic-otel-php://reference/edot-php
-                path_prefix: reference/opentelemetry/edot-sdks/php
-              - toc: elastic-otel-python://reference/edot-python
-                path_prefix: reference/opentelemetry/edot-sdks/python
-              # EDOT Browser (RUM)
-              # https://github.com/elastic/elastic-otel-rum-js/blob/main/docs/reference/edot-browser/toc.yml
-              - toc: elastic-otel-rum-js://reference/edot-browser
-                path_prefix: reference/opentelemetry/edot-sdks/browser
+              - toc: opentelemetry://reference/edot-sdks
+                path_prefix: reference/opentelemetry/edot-sdks
+                children:
+                  - toc: apm-agent-android://reference/edot-android
+                    path_prefix: reference/opentelemetry/edot-sdks/android
+                  - toc: elastic-otel-dotnet://reference/edot-dotnet
+                    path_prefix: reference/opentelemetry/edot-sdks/dotnet
+                  - toc: apm-agent-ios://reference/edot-ios
+                    path_prefix: reference/opentelemetry/edot-sdks/ios
+                  - toc: elastic-otel-java://reference/edot-java
+                    path_prefix: reference/opentelemetry/edot-sdks/java
+                  - toc: elastic-otel-node://reference/edot-node
+                    path_prefix: reference/opentelemetry/edot-sdks/node
+                  - toc: elastic-otel-php://reference/edot-php
+                    path_prefix: reference/opentelemetry/edot-sdks/php
+                  - toc: elastic-otel-python://reference/edot-python
+                    path_prefix: reference/opentelemetry/edot-sdks/python
+                  # EDOT Browser (RUM)
+                  # https://github.com/elastic/elastic-otel-rum-js/blob/main/docs/reference/edot-browser/toc.yml
+                  - toc: elastic-otel-rum-js://reference/edot-browser
+                    path_prefix: reference/opentelemetry/edot-sdks/browser
 
           # Elastic Integrations
           # https://github.com/elastic/integration-docs/blob/main/docs/reference/toc.yml

--- a/src/Elastic.Documentation.Navigation/V2/SiteNavigationV2.cs
+++ b/src/Elastic.Documentation.Navigation/V2/SiteNavigationV2.cs
@@ -56,11 +56,49 @@ public class SiteNavigationV2 : SiteNavigation
 		{
 			LabelNavV2Item label => CreateLabel(label, nodes, parent, sitePrefix),
 			GroupNavV2Item group => CreateGroup(group, nodes, parent, sitePrefix),
-			TocNavV2Item toc => nodes.TryGetValue(toc.Source, out var node) ? node : null,
+			TocNavV2Item toc => CreateToc(toc, nodes, parent, sitePrefix),
 			PageNavV2Item { Page: null, Title: var title } => new PlaceholderNavigationLeaf(title ?? "Untitled", sitePrefix, parent),
 			PageNavV2Item { Page: var page, Title: var title } => new PageCrossLinkLeaf(page, title ?? page.ToString(), sitePrefix, parent),
 			_ => null
 		};
+
+	private static INavigationItem? CreateToc(
+		TocNavV2Item toc,
+		IReadOnlyDictionary<Uri, IRootNavigationItem<IDocumentationFile, INavigationItem>> nodes,
+		INodeNavigationItem<INavigationModel, INavigationItem> parent,
+		string sitePrefix
+	)
+	{
+		if (!nodes.TryGetValue(toc.Source, out var node))
+			return null;
+		if (toc.Children.Count == 0)
+			return node;
+		var children = BuildV2Items(toc.Children, nodes, parent, sitePrefix);
+		return new TocOverrideNode(node, children, parent.NavigationRoot, parent);
+	}
+
+	/// <summary>
+	/// Wraps an existing toc node but replaces its children with a V2-specified subset.
+	/// Used when a <c>toc:</c> entry in <c>navigation-v2.yml</c> declares explicit children,
+	/// so we can show fewer items without mutating the shared V1 node.
+	/// </summary>
+	private sealed class TocOverrideNode(
+		IRootNavigationItem<IDocumentationFile, INavigationItem> source,
+		IReadOnlyList<INavigationItem> children,
+		IRootNavigationItem<INavigationModel, INavigationItem> navigationRoot,
+		INodeNavigationItem<INavigationModel, INavigationItem> parent
+	) : INodeNavigationItem<INavigationModel, INavigationItem>
+	{
+		public string Id => source.Id;
+		public string Url => source.Url;
+		public string NavigationTitle => source.NavigationTitle;
+		public IRootNavigationItem<INavigationModel, INavigationItem> NavigationRoot => navigationRoot;
+		public INodeNavigationItem<INavigationModel, INavigationItem>? Parent { get; set; } = parent;
+		public bool Hidden => source.Hidden;
+		public int NavigationIndex { get; set; }
+		public ILeafNavigationItem<INavigationModel> Index => source.Index;
+		public IReadOnlyCollection<INavigationItem> NavigationItems => children;
+	}
 
 	private static LabelNavigationNode CreateLabel(
 		LabelNavV2Item label,


### PR DESCRIPTION
> [!NOTE]
> This is a proposal on top of elastic/docs-builder#2927 — open to discussion on naming and ordering.

Closes https://github.com/elastic/docs-content/issues/5748

## Summary

Restructures the EDOT section in `navigation-v2.yml` and `navigation.yml` to give EDOT sub-tools first-class visibility in the Ingest tools group.

**Changes:**

- Extracts mOTLP, EDOT Cloud Forwarder, EDOT Collector, and EDOT SDKs from inside the EDOT group to sit as siblings alongside Fleet, APM, Beats, etc.
- The EDOT group retains only the core reference content (architecture, compatibility, data streams, central configuration)
- Adds `opentelemetry://reference/edot-sdks` as a proper named toc node in `navigation.yml` so it resolves correctly
- Adds `toc: opentelemetry://reference/edot-sdks` to "Ingest data from applications" under Manage data
- Implements child overrides for `toc:` entries in nav-v2 (`TocOverrideNode`) so EDOT's nav-v2 children don't duplicate the full V1 SDK list

**Depends on:** elastic/opentelemetry#574 (changes `file: edot-sdks/index.md` → `toc: edot-sdks` in the EDOT reference toc)

## Result

```
Ingest tools
├── Elastic Distributions of OpenTelemetry (EDOT)  ← core content only
├── mOTLP
├── EDOT Cloud Forwarder
├── EDOT Collector
├── EDOT SDKs                                       ← all language SDKs
├── Fleet and Elastic Agent
├── APM
├── Beats
└── ...
```