### PR TITLE
add js esql dsl

### DIFF
--- a/config/assembler.yml
+++ b/config/assembler.yml
@@ -184,6 +184,7 @@ references:
 
   # @elastic/developer-docs
   eland:
+  elasticsearch-dsl-js:
   elasticsearch-hadoop:
   elasticsearch-java:
   elasticsearch-js:

--- a/config/navigation.yml
+++ b/config/navigation.yml
@@ -276,6 +276,11 @@ toc:
                 path_prefix: reference/elasticsearch/clients/javascript
                 # Children include the entire AsciiDoc book
 
+              # JavaScript/TypeScript DSL
+              # https://github.com/elastic/elasticsearch-dsl-js/blob/main/docs/reference/toc.yml
+              - toc: elasticsearch-dsl-js://reference
+                path_prefix: reference/elasticsearch/clients/javascript-dsl
+
               # .NET
               # https://github.com/elastic/elasticsearch-net/blob/main/docs/reference/toc.yml
               - toc: elasticsearch-net://reference


### PR DESCRIPTION
Adding elasticsearch-esql-dsl following https://elastic.github.io/docs-builder/contribute/add-repo/
steps 1 & 2 are done 
https://github.com/elastic/elasticsearch-dsl-js