### PR TITLE
Skip hidden folders on codex builds

### DIFF
--- a/src/Elastic.Codex/Elastic.Codex.csproj
+++ b/src/Elastic.Codex/Elastic.Codex.csproj
@@ -13,6 +13,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Navigation.Tests"/>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="RazorSlices"/>
   </ItemGroup>
 

--- a/src/Elastic.Codex/Sourcing/CodexCloneService.cs
+++ b/src/Elastic.Codex/Sourcing/CodexCloneService.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System.IO.Abstractions;
+using System.Security;
 using Elastic.Documentation.Configuration.Codex;
 using Elastic.Documentation.Configuration.Toc;
 using Elastic.Documentation.Diagnostics;
@@ -268,9 +269,9 @@ public class CodexCloneService(ILoggerFactory logFactory, ILinkIndexReader linkI
 					return found;
 			}
 		}
-		catch (UnauthorizedAccessException)
+		catch (Exception ex) when (ex is UnauthorizedAccessException or SecurityException)
 		{
-			// Skip directories we can't access
+			// Skip directories we can't access (including ScopedFileSystem-blocked hidden dirs)
 		}
 
 		return null;

--- a/tests/Navigation.Tests/Codex/FindDocsetFileTests.cs
+++ b/tests/Navigation.Tests/Codex/FindDocsetFileTests.cs
@@ -1,0 +1,89 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions.TestingHelpers;
+using AwesomeAssertions;
+using Elastic.Codex.Sourcing;
+using Elastic.Documentation.Configuration;
+using Nullean.ScopedFileSystem;
+
+namespace Elastic.Documentation.Navigation.Tests.Codex;
+
+public class FindDocsetFileTests
+{
+	private static readonly string RepoRoot = Path.Join(Paths.WorkingDirectoryRoot.FullName, "repo");
+
+	private static ScopedFileSystem CreateScopedFs(MockFileSystem mockFs) =>
+		FileSystemFactory.ScopeCurrentWorkingDirectory(mockFs);
+
+	[Fact]
+	public void StandardPath_Found()
+	{
+		var mockFs = new MockFileSystem(new Dictionary<string, MockFileData>
+		{
+			{ Path.Join(RepoRoot, "docs/docset.yml"), new MockFileData("project: test") }
+		});
+
+		var result = CodexCloneService.FindDocsetFile(mockFs, mockFs.DirectoryInfo.New(RepoRoot));
+
+		result.Should().NotBeNull();
+		result.Name.Should().Be("docset.yml");
+	}
+
+	[Fact]
+	public void NonStandardPath_FoundViaRecursion()
+	{
+		var mockFs = new MockFileSystem(new Dictionary<string, MockFileData>
+		{
+			{ Path.Join(RepoRoot, "docs-codex/docset.yml"), new MockFileData("project: test") }
+		});
+
+		var result = CodexCloneService.FindDocsetFile(mockFs, mockFs.DirectoryInfo.New(RepoRoot));
+
+		result.Should().NotBeNull();
+		result.Name.Should().Be("docset.yml");
+	}
+
+	[Fact]
+	public void HiddenDirectory_SkippedByScopedFileSystem()
+	{
+		var mockFs = new MockFileSystem(new Dictionary<string, MockFileData>
+		{
+			{ Path.Join(RepoRoot, ".github/workflows/ci.yml"), new MockFileData("name: CI") },
+			{ Path.Join(RepoRoot, "docs-codex/docset.yml"), new MockFileData("project: test") }
+		});
+		var scopedFs = CreateScopedFs(mockFs);
+
+		var result = CodexCloneService.FindDocsetFile(scopedFs, scopedFs.DirectoryInfo.New(RepoRoot));
+
+		result.Should().NotBeNull();
+		result.Name.Should().Be("docset.yml");
+	}
+
+	[Fact]
+	public void NoDocset_ReturnsNull()
+	{
+		var mockFs = new MockFileSystem(new Dictionary<string, MockFileData>
+		{
+			{ Path.Join(RepoRoot, "src/main.py"), new MockFileData("print('hello')") }
+		});
+
+		var result = CodexCloneService.FindDocsetFile(mockFs, mockFs.DirectoryInfo.New(RepoRoot));
+
+		result.Should().BeNull();
+	}
+
+	[Fact]
+	public void NodeModules_Skipped()
+	{
+		var mockFs = new MockFileSystem(new Dictionary<string, MockFileData>
+		{
+			{ Path.Join(RepoRoot, "node_modules/some-pkg/docset.yml"), new MockFileData("project: fake") }
+		});
+
+		var result = CodexCloneService.FindDocsetFile(mockFs, mockFs.DirectoryInfo.New(RepoRoot));
+
+		result.Should().BeNull();
+	}
+}


### PR DESCRIPTION
This pull request improves the handling and testing of file system access in the `CodexCloneService`, especially around hidden directories and permission issues, and adds comprehensive unit tests for the `FindDocsetFile` method. It also updates project configuration to support internal visibility for testing.

**Testing improvements:**

* Added a new test class `FindDocsetFileTests` in `Navigation.Tests` to cover various scenarios for `CodexCloneService.FindDocsetFile`, including standard and non-standard paths, skipping hidden directories, and handling cases where no docset file is found.
* Updated the project file `Elastic.Codex.csproj` to include `Navigation.Tests` as a friend assembly, allowing tests to access internal members.

**Error handling enhancements:**

* Improved exception handling in `CodexCloneService.FindDocsetFile` to catch both `UnauthorizedAccessException` and `SecurityException`, ensuring directories blocked by the file system (such as hidden directories) are properly skipped.
* Added the necessary `System.Security` namespace import to support the enhanced exception handling.