### PR TITLE
Skip redirect validation for docset-excluded paths

### DIFF
--- a/src/authoring/Elastic.Documentation.Refactor/Tracking/LocalChangesService.cs
+++ b/src/authoring/Elastic.Documentation.Refactor/Tracking/LocalChangesService.cs
@@ -68,6 +68,8 @@ public class LocalChangeTrackingService(
 			var lookupPath = change is RenamedGitChange renamed ? renamed.OldFilePath : change.FilePath;
 			var docSetRelativePath = Path.GetRelativePath(buildContext.DocumentationSourceDirectory.FullName, Path.Join(root.FullName, lookupPath));
 			var rootRelativePath = Path.GetRelativePath(root.FullName, Path.Join(root.FullName, lookupPath));
+			if (buildContext.Configuration.IsExcluded(docSetRelativePath.OptionalWindowsReplace()))
+				continue;
 			if (redirects.ContainsKey(docSetRelativePath))
 				continue;
 			if (redirects.ContainsKey(rootRelativePath))

--- a/tests/Elastic.Documentation.Configuration.Tests/ConfigurationFileExcludeTests.cs
+++ b/tests/Elastic.Documentation.Configuration.Tests/ConfigurationFileExcludeTests.cs
@@ -1,0 +1,97 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Collections.Frozen;
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
+using AwesomeAssertions;
+using Elastic.Documentation.Configuration.Builder;
+using Elastic.Documentation.Configuration.Products;
+using Elastic.Documentation.Configuration.Toc;
+using Elastic.Documentation.Configuration.Versions;
+using Elastic.Documentation.Diagnostics;
+using Nullean.ScopedFileSystem;
+
+namespace Elastic.Documentation.Configuration.Tests;
+
+public class ConfigurationFileExcludeTests
+{
+	[Fact]
+	public void IsExcluded_DocsetGlob_MatchesNestedKibanaDocsPath()
+	{
+		var docSet = new DocumentationSetFile
+		{
+			Project = "test",
+			TableOfContents = [],
+			Exclude =
+			[
+				"reference/query-languages/esql/kibana/docs/**"
+			]
+		};
+		var config = CreateConfiguration(docSet);
+
+		config.IsExcluded("reference/query-languages/esql/kibana/docs/functions/mv_slice.md").Should().BeTrue();
+	}
+
+	[Fact]
+	public void IsExcluded_DocsetGlob_DoesNotMatchOutsideTree()
+	{
+		var docSet = new DocumentationSetFile
+		{
+			Project = "test",
+			TableOfContents = [],
+			Exclude =
+			[
+				"reference/query-languages/esql/kibana/docs/**"
+			]
+		};
+		var config = CreateConfiguration(docSet);
+
+		config.IsExcluded("reference/query-languages/esql/guide.md").Should().BeFalse();
+	}
+
+	private static ConfigurationFile CreateConfiguration(DocumentationSetFile docSet)
+	{
+		var collector = new DiagnosticsCollector([]);
+		var root = Paths.WorkingDirectoryRoot.FullName;
+		var configFilePath = Path.Join(root, "docs", "_docset.yml");
+		var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+		{
+			{ configFilePath, new MockFileData("") }
+		}, root);
+
+		var configPath = fileSystem.FileInfo.New(configFilePath);
+		var docsDir = fileSystem.DirectoryInfo.New(Path.Join(root, "docs"));
+
+		var context = new MockDocumentationSetContext(collector, fileSystem, configPath, docsDir);
+		var versionsConfig = new VersionsConfiguration
+		{
+			VersioningSystems = new Dictionary<VersioningSystemId, VersioningSystem>()
+		};
+		var productsConfig = new ProductsConfiguration
+		{
+			Products = new Dictionary<string, Product>().ToFrozenDictionary(),
+			ProductDisplayNames = new Dictionary<string, string>().ToFrozenDictionary()
+		};
+
+		return new ConfigurationFile(docSet, context, versionsConfig, productsConfig);
+	}
+
+	private sealed class MockDocumentationSetContext(
+		IDiagnosticsCollector collector,
+		IFileSystem fileSystem,
+		IFileInfo configurationPath,
+		IDirectoryInfo documentationSourceDirectory)
+		: IDocumentationSetContext
+	{
+		public IDiagnosticsCollector Collector => collector;
+		public ScopedFileSystem ReadFileSystem => WriteFileSystem;
+		public ScopedFileSystem WriteFileSystem { get; } = FileSystemFactory.ScopeCurrentWorkingDirectoryForWrite(fileSystem);
+		public IDirectoryInfo OutputDirectory => fileSystem.DirectoryInfo.New(Path.Join(Paths.WorkingDirectoryRoot.FullName, ".artifacts"));
+		public IFileInfo ConfigurationPath => configurationPath;
+		public BuildType BuildType => BuildType.Isolated;
+		public IDirectoryInfo DocumentationSourceDirectory => documentationSourceDirectory;
+		public GitCheckoutInformation Git => GitCheckoutInformation.Create(documentationSourceDirectory, fileSystem);
+	}
+}


### PR DESCRIPTION
## Summary

`docs-builder validate` (redirect validation) required `redirects.yml` entries for every deleted or renamed Markdown file, without considering `docset.yml` `exclude` globs or folder-level TOC excludes. That caused false positives when paths were never published (for example Elasticsearch excluding generated Kibana ES|QL docs under `reference/query-languages/esql/kibana/docs/**`).

## Changes

- **`LocalChangeTrackingService.ValidateRedirects`**: Before checking `redirects.yml`, skip changes whose docset-relative path matches `Configuration.IsExcluded` (same logic as the Markdown pipeline: docset globs, `FolderExcludedFiles`, and `!` include overrides).
- **Tests**: `ConfigurationFileExcludeTests` covers the Elasticsearch-style glob and a path outside the excluded tree.

## Testing

- `dotnet build`
- `dotnet test tests/Elastic.Documentation.Configuration.Tests/`

Made with [Cursor](https://cursor.com)