### PR TITLE
Search: Add completion multi-field to ai_questions

### DIFF
--- a/src/Elastic.Documentation/Search/DocumentationMappingConfig.cs
+++ b/src/Elastic.Documentation/Search/DocumentationMappingConfig.cs
@@ -63,10 +63,17 @@ public class LexicalConfig : IConfigureElasticsearch<DocumentationDocument>
 		.Headings(f => f
 			.Analyzer("synonyms_fixed_analyzer")
 			.SearchAnalyzer("synonyms_analyzer"))
-		// AI field with custom analyzers not on the attribute
+		// AI fields with custom analyzers not on the attribute
 		.AddField("ai_rag_optimized_summary", f => f.Text()
 			.Analyzer("synonyms_fixed_analyzer")
 			.SearchAnalyzer("synonyms_analyzer"))
+		.AddField("ai_questions", f => f.Text()
+			.Analyzer("synonyms_fixed_analyzer")
+			.SearchAnalyzer("synonyms_analyzer")
+			.MultiField("completion", mf => mf.SearchAsYouType()
+				.Analyzer("synonyms_fixed_analyzer")
+				.SearchAnalyzer("synonyms_analyzer")
+				.IndexOptions("offsets")))
 		// Keyword fields with multi-fields
 		.Url(f => f
 			.MultiField("match", mf => mf.Text())


### PR DESCRIPTION
## What
Add a `completion` (SearchAsYouType) multi-field to the `ai_questions` mapping in the documentation index.

## Why
Enable autocomplete support for website search using the AI-generated questions field.

## How
Added `ai_questions` to `ConfigureCommonMappings` with a `completion` multi-field using synonym analyzers, matching the existing `search_title.completion` pattern.

## Test plan
- [ ] Verify the index mapping includes `ai_questions.completion` as a `search_as_you_type` field
- [ ] Confirm existing search functionality is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)