### PR TITLE
Search: Remove shard/replica settings for serverless compatibility

### DIFF
--- a/src/Elastic.Markdown/Exporters/Elasticsearch/ContentDateEnrichment.cs
+++ b/src/Elastic.Markdown/Exporters/Elasticsearch/ContentDateEnrichment.cs
@@ -71,7 +71,6 @@ public class ContentDateEnrichment(
 
 		var mapping = new JsonObject
 		{
-			["settings"] = new JsonObject { ["number_of_shards"] = 1, ["number_of_replicas"] = 0 },
 			["mappings"] = new JsonObject
 			{
 				["properties"] = new JsonObject


### PR DESCRIPTION
## What
Remove `number_of_shards` and `number_of_replicas` settings from the content date lookup index creation request.

## Why
Elasticsearch serverless mode does not support these settings — the platform manages shard/replica counts automatically. Including them causes a 400 error on index creation, breaking the assembler index pipeline.

## How
Removed the `settings` block from the PUT index request in `ContentDateEnrichment.EnsureLookupIndexAsync`. The mappings-only request is sufficient.

## Test plan
- Verify the assembler index CI job passes against the serverless cluster
- Confirm the `docs-assembler-content-dates-edge` index is created successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)