### PR TITLE
Changes API: Use content_last_updated instead of last_updated

### DIFF
--- a/src/api/Elastic.Documentation.Api.Core/Changes/ChangesUsecase.cs
+++ b/src/api/Elastic.Documentation.Api.Core/Changes/ChangesUsecase.cs
@@ -82,7 +82,7 @@ public partial class ChangesUsecase(IChangesGateway changesGateway, ILogger<Chan
 		var buffer = new ArrayBufferWriter<byte>();
 		using var writer = new Utf8JsonWriter(buffer);
 		writer.WriteStartArray();
-		writer.WriteNumberValue(cursor.LastUpdatedEpochMs);
+		writer.WriteNumberValue(cursor.ContentLastUpdatedEpochMs);
 		writer.WriteStringValue(cursor.Url);
 		writer.WriteEndArray();
 		writer.Flush();

--- a/src/api/Elastic.Documentation.Api.Core/Changes/IChangesGateway.cs
+++ b/src/api/Elastic.Documentation.Api.Core/Changes/IChangesGateway.cs
@@ -26,7 +26,7 @@ public record ChangesResult
 }
 
 /// <summary>Cursor for search_after pagination over changed pages.</summary>
-public record ChangesPageCursor(long LastUpdatedEpochMs, string Url);
+public record ChangesPageCursor(long ContentLastUpdatedEpochMs, string Url);
 
 /// <summary>Shared defaults for the changes feed.</summary>
 public static class ChangesDefaults

--- a/src/services/Elastic.Documentation.Search/ChangesGateway.cs
+++ b/src/services/Elastic.Documentation.Search/ChangesGateway.cs
@@ -11,7 +11,7 @@ namespace Elastic.Documentation.Search;
 
 /// <summary>
 /// Elasticsearch gateway for the documentation changes feed.
-/// Queries last_updated > since with search_after cursor pagination.
+/// Queries content_last_updated > since with search_after cursor pagination.
 /// Uses a shared Point In Time (PIT) for consistent pagination across requests.
 /// </summary>
 public partial class ChangesGateway(
@@ -67,12 +67,12 @@ public partial class ChangesGateway(
 				.Pit(p => p.Id(pitId).KeepAlive(SharedPointInTimeManager.PitKeepAlive))
 				.Query(q => q.Range(r => r
 					.Date(dr => dr
-						.Field(f => f.LastUpdated)
+						.Field(f => f.ContentLastUpdated)
 						.Gt(request.Since.ToString("O"))
 					)
 				))
 				.Sort(
-					so => so.Field(f => f.LastUpdated, sf => sf.Order(SortOrder.Asc)),
+					so => so.Field(f => f.ContentLastUpdated, sf => sf.Order(SortOrder.Asc)),
 					so => so.Field(f => f.Url, sf => sf.Order(SortOrder.Asc))
 				)
 				.Source(sf => sf
@@ -82,7 +82,7 @@ public partial class ChangesGateway(
 							e => e.Title,
 							e => e.SearchTitle,
 							e => e.Type,
-							e => e.LastUpdated
+							e => e.ContentLastUpdated
 						)
 					)
 				);
@@ -90,7 +90,7 @@ public partial class ChangesGateway(
 			if (request.Cursor is { } cursor)
 			{
 				_ = s.SearchAfter(
-					FieldValue.Long(cursor.LastUpdatedEpochMs),
+					FieldValue.Long(cursor.ContentLastUpdatedEpochMs),
 					FieldValue.String(cursor.Url)
 				);
 			}
@@ -116,7 +116,7 @@ public partial class ChangesGateway(
 				{
 					Url = doc.Url,
 					Title = doc.Title,
-					LastUpdated = doc.LastUpdated
+					LastUpdated = doc.ContentLastUpdated
 				};
 			})
 			.ToList();


### PR DESCRIPTION
## What
Switch the Changes API to query `content_last_updated` instead of `last_updated`.

## Why
After #3016 introduced `content_last_updated`, the Changes API should use it so that metadata-only changes (nav reordering, mapping rollovers) no longer surface in the feed.

## How
- `ChangesGateway` now queries, sorts, and sources `ContentLastUpdated`
- `ChangedPageDto.LastUpdated` still exists with the same JSON name — the mapping just reads from the new field
- Cursor internals renamed to `ContentLastUpdatedEpochMs` (opaque to consumers)

## Test plan
- Query `/changes?since=<date>` and verify only content changes appear
- Verify pagination cursor round-trips correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)