### PR TITLE
Search: Fall back to last_updated in sitemap reader

### DIFF
--- a/src/services/Elastic.Documentation.Assembler/Building/EsSitemapReader.cs
+++ b/src/services/Elastic.Documentation.Assembler/Building/EsSitemapReader.cs
@@ -61,7 +61,8 @@ public class EsSitemapReader(DistributedTransport transport, ILogger logger, str
 							continue;
 
 						var url = source["url"]?.GetValue<string>();
-						var lastUpdatedStr = source["content_last_updated"]?.GetValue<string>();
+						var lastUpdatedStr = source["content_last_updated"]?.GetValue<string>()
+							?? source["last_updated"]?.GetValue<string>();
 
 						if (url is null || lastUpdatedStr is null)
 							continue;
@@ -131,7 +132,7 @@ public class EsSitemapReader(DistributedTransport transport, ILogger logger, str
 		var body = new JsonObject
 		{
 			["size"] = PageSize,
-			["_source"] = new JsonArray("url", "content_last_updated"),
+			["_source"] = new JsonArray("url", "content_last_updated", "last_updated"),
 			["query"] = new JsonObject
 			{
 				["bool"] = new JsonObject


### PR DESCRIPTION
## What
Fall back to `last_updated` when `content_last_updated` is missing in the sitemap reader.

## Why
Documents indexed before the content date pipeline existed don't have `content_last_updated`, causing the sitemap reader to skip every hit and fail with "No documents found."

## How
The sitemap reader now tries `content_last_updated` first, then falls back to `last_updated`. The `_source` filter fetches both fields.

## Test plan
- [ ] Verify sitemap generation succeeds against an index with documents that only have `last_updated`

🤖 Generated with [Claude Code](https://claude.com/claude-code)