### PR TITLE
Sitemap: Read from semantic index for content_last_updated

### DIFF
--- a/src/services/Elastic.Documentation.Assembler/Building/AssemblerSitemapService.cs
+++ b/src/services/Elastic.Documentation.Assembler/Building/AssemblerSitemapService.cs
@@ -76,7 +76,7 @@ public class AssemblerSitemapService(
 
 		var transport = ElasticsearchTransportFactory.Create(cfg);
 
-		var indexName = DocumentationMappingContext.DocumentationDocument
+		var indexName = DocumentationMappingContext.DocumentationDocumentSemantic
 			.CreateContext(type: "assembler", env: environment)
 			.ResolveReadTarget();
 

--- a/src/services/Elastic.Documentation.Assembler/Building/EsSitemapReader.cs
+++ b/src/services/Elastic.Documentation.Assembler/Building/EsSitemapReader.cs
@@ -13,7 +13,7 @@ namespace Elastic.Documentation.Assembler.Building;
 
 public record SitemapEntry(string Url, DateTimeOffset LastUpdated);
 
-/// <summary>Reads all url + content_last_updated pairs from the ES lexical index using search_after with PIT.</summary>
+/// <summary>Reads all url + content_last_updated pairs from the ES semantic index using search_after with PIT.</summary>
 public class EsSitemapReader(DistributedTransport transport, ILogger logger, string indexName)
 {
 	private const int PageSize = 1000;


### PR DESCRIPTION
## What
Switch sitemap generation to query the semantic index instead of the lexical index.

## Why
The `content_last_updated` field is only populated in the semantic index (`docs-assembler.semantic-{env}-latest`). The sitemap command was querying the lexical index, which doesn't have this field, causing it to fail.

## How
Changed `DocumentationMappingContext.DocumentationDocument` to `DocumentationMappingContext.DocumentationDocumentSemantic` in `AssemblerSitemapService`.

## Test plan
- Run `assembler sitemap` against an environment with the semantic index populated
- Verify the generated sitemap.xml contains correct `<lastmod>` dates

## Notes
The Changes API already reads from the semantic index via `ElasticsearchClientAccessor` — no change needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)