### PR TITLE
Search: Add completion suggest field to ai_questions mapping

### DIFF
--- a/src/Elastic.Documentation/Search/DocumentationMappingConfig.cs
+++ b/src/Elastic.Documentation/Search/DocumentationMappingConfig.cs
@@ -73,7 +73,8 @@ public class LexicalConfig : IConfigureElasticsearch<DocumentationDocument>
 			.MultiField("completion", mf => mf.SearchAsYouType()
 				.Analyzer("synonyms_fixed_analyzer")
 				.SearchAnalyzer("synonyms_analyzer")
-				.IndexOptions("offsets")))
+				.IndexOptions("offsets"))
+			.MultiField("suggest", mf => mf.Completion()))
 		// Keyword fields with multi-fields
 		.Url(f => f
 			.MultiField("match", mf => mf.Text())


### PR DESCRIPTION
## What
Add an FST-based `completion` type multi-field (`ai_questions.suggest`) to the ai_questions mapping for use with the completion suggester API.

## Why
The existing `ai_questions.completion` multi-field is `search_as_you_type` (inverted index with shingles), which is incompatible with the completion suggester API. The completion suggester requires a field of type `completion` (FST).

## How
Added a new `suggest` multi-field with `Completion()` type alongside the existing `completion` SearchAsYouType multi-field.

## Test plan
- Build compiles
- Requires a crawler run to create new indices with the updated mapping

## Notes
Named `suggest` since the `completion` multi-field name is already taken by SearchAsYouType.

🤖 Generated with [Claude Code](https://claude.com/claude-code)