### PR TITLE
Dependencies: Bump Elastic.Ingest.Elasticsearch to 0.41.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -50,7 +50,7 @@
     <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="9.3.4" />
     <PackageVersion Include="FakeItEasy" Version="9.0.1" />
     <PackageVersion Include="Elastic.Ingest.Elasticsearch" Version="0.41.1" />
-    <PackageVersion Include="Elastic.Mapping" Version="0.41.0" />
+    <PackageVersion Include="Elastic.Mapping" Version="0.41.1" />
     <PackageVersion Include="InMemoryLogger" Version="1.0.66" />
     <PackageVersion Include="MartinCostello.Logging.XUnit.v3" Version="0.7.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -49,7 +49,7 @@
     <PackageVersion Include="Elastic.Aspire.Hosting.Elasticsearch" Version="9.3.0" />
     <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="9.3.4" />
     <PackageVersion Include="FakeItEasy" Version="9.0.1" />
-    <PackageVersion Include="Elastic.Ingest.Elasticsearch" Version="0.41.0" />
+    <PackageVersion Include="Elastic.Ingest.Elasticsearch" Version="0.41.1" />
     <PackageVersion Include="Elastic.Mapping" Version="0.41.0" />
     <PackageVersion Include="InMemoryLogger" Version="1.0.66" />
     <PackageVersion Include="MartinCostello.Logging.XUnit.v3" Version="0.7.1" />


### PR DESCRIPTION
## What
Bump `Elastic.Ingest.Elasticsearch` from 0.41.0 to 0.41.1.

## Why
Pick up the latest release.

## How
Version bump in `Directory.Packages.props`.

## Test plan
- `dotnet restore` and `dotnet build` pass with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)