### PR TITLE
Dependencies: Bump Elastic.Ingest.Elasticsearch to 0.41.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -49,8 +49,8 @@
     <PackageVersion Include="Elastic.Aspire.Hosting.Elasticsearch" Version="9.3.0" />
     <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="9.3.4" />
     <PackageVersion Include="FakeItEasy" Version="9.0.1" />
-    <PackageVersion Include="Elastic.Ingest.Elasticsearch" Version="0.41.1" />
-    <PackageVersion Include="Elastic.Mapping" Version="0.41.1" />
+    <PackageVersion Include="Elastic.Ingest.Elasticsearch" Version="0.41.2" />
+    <PackageVersion Include="Elastic.Mapping" Version="0.41.2" />
     <PackageVersion Include="InMemoryLogger" Version="1.0.66" />
     <PackageVersion Include="MartinCostello.Logging.XUnit.v3" Version="0.7.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />


### PR DESCRIPTION
## What
Bump `Elastic.Ingest.Elasticsearch` and `Elastic.Mapping` from 0.41.1 to 0.41.2.

## Why
Keep dependencies up to date with the latest patch release.

## How
Version bump in `Directory.Packages.props`.

## Test plan
- `dotnet restore` succeeds
- CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)