### PR TITLE
Fix API explorer empty navigation for single-tag OpenAPI specs

### DIFF
--- a/docs/_docset.yml
+++ b/docs/_docset.yml
@@ -49,6 +49,7 @@ suppress:
 api:
    elasticsearch: elasticsearch-openapi.json
    kibana: kibana-openapi.json
+   dashboard: dashboard-openapi.json
 
 toc:
   - file: index.md

--- a/docs/dashboard-openapi.json
+++ b/docs/dashboard-openapi.json
@@ -1,0 +1,15783 @@
+{
+  "components": {
+    "schemas": {
+      "byteFormat": {
+        "additionalProperties": false,
+        "properties": {
+          "decimals": {
+            "default": 2,
+            "description": "Number of decimals",
+            "type": "number"
+          },
+          "suffix": {
+            "description": "Suffix",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "bits",
+              "bytes"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "title": "Byte Format",
+        "type": "object"
+      },
+      "categoricalColorMapping": {
+        "additionalProperties": false,
+        "properties": {
+          "mapping": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "color": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/colorFromPalette"
+                    },
+                    {
+                      "$ref": "#/components/schemas/color_code"
+                    }
+                  ]
+                },
+                "values": {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/components/schemas/range_key"
+                      },
+                      {
+                        "$ref": "#/components/schemas/multi_field_key"
+                      }
+                    ]
+                  },
+                  "maxItems": 1000,
+                  "type": "array"
+                }
+              },
+              "required": [
+                "values",
+                "color"
+              ],
+              "type": "object"
+            },
+            "maxItems": 1000,
+            "type": "array"
+          },
+          "mode": {
+            "enum": [
+              "categorical"
+            ],
+            "type": "string"
+          },
+          "palette": {
+            "description": "The palette name to use for color assignment.",
+            "type": "string"
+          },
+          "unassigned": {
+            "$ref": "#/components/schemas/unassignedColorSchema"
+          }
+        },
+        "required": [
+          "mode",
+          "palette",
+          "mapping",
+          "unassigned"
+        ],
+        "title": "Categorical Color Mapping",
+        "type": "object"
+      },
+      "collapseBy": {
+        "description": "Collapse by function description",
+        "enum": [
+          "avg",
+          "sum",
+          "max",
+          "min"
+        ],
+        "title": "collapseBy",
+        "type": "string",
+        "x-oas-optional": true
+      },
+      "colorByValue": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/colorByValueAbsolute"
+          },
+          {
+            "$ref": "#/components/schemas/colorByValuePercentage"
+          },
+          {
+            "$ref": "#/components/schemas/legacyColorByValue"
+          }
+        ],
+        "title": "Color By Value"
+      },
+      "colorByValueAbsolute": {
+        "additionalProperties": false,
+        "description": "Color by absolute value configuration",
+        "properties": {
+          "range": {
+            "enum": [
+              "absolute"
+            ],
+            "type": "string"
+          },
+          "steps": {
+            "description": "Array of ordered color steps defining the range each color is applied.",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "color": {
+                  "description": "The color to use for this step.",
+                  "type": "string"
+                },
+                "gte": {
+                  "description": "The lower bound of range from which this color applies (inclusive).",
+                  "nullable": true,
+                  "type": "number"
+                },
+                "lt": {
+                  "description": "The upper bound of range to which this color applies (exclusive).",
+                  "nullable": true,
+                  "type": "number"
+                },
+                "lte": {
+                  "description": "The upper bound of range to which this color applies (inclusive).",
+                  "nullable": true,
+                  "type": "number"
+                }
+              },
+              "required": [
+                "color"
+              ],
+              "type": "object"
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "type": "array"
+          },
+          "type": {
+            "enum": [
+              "dynamic"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "range",
+          "steps"
+        ],
+        "title": "Color By Value (Absolute)",
+        "type": "object"
+      },
+      "colorByValuePercentage": {
+        "additionalProperties": false,
+        "description": "Color by percentage value configuration",
+        "properties": {
+          "range": {
+            "enum": [
+              "percentage"
+            ],
+            "type": "string"
+          },
+          "steps": {
+            "description": "Array of ordered color steps defining the range each color is applied.",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "color": {
+                  "description": "The color to use for this step.",
+                  "type": "string"
+                },
+                "gte": {
+                  "description": "The lower bound of range from which this color applies (inclusive).",
+                  "nullable": true,
+                  "type": "number"
+                },
+                "lt": {
+                  "description": "The upper bound of range to which this color applies (exclusive).",
+                  "nullable": true,
+                  "type": "number"
+                },
+                "lte": {
+                  "description": "The upper bound of range to which this color applies (inclusive).",
+                  "nullable": true,
+                  "type": "number"
+                }
+              },
+              "required": [
+                "color"
+              ],
+              "type": "object"
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "type": "array"
+          },
+          "type": {
+            "enum": [
+              "dynamic"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "range",
+          "steps"
+        ],
+        "title": "Color By Value (Percentage)",
+        "type": "object"
+      },
+      "colorFromPalette": {
+        "additionalProperties": false,
+        "properties": {
+          "index": {
+            "description": "The index of the color in the palette.",
+            "type": "number"
+          },
+          "palette": {
+            "description": "The palette name to use.",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "from_palette"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "index"
+        ],
+        "title": "Color From Palette",
+        "type": "object"
+      },
+      "colorMapping": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/categoricalColorMapping"
+          },
+          {
+            "$ref": "#/components/schemas/gradientColorMapping"
+          }
+        ],
+        "title": "Color Mapping",
+        "x-oas-optional": true
+      },
+      "color_code": {
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "enum": [
+              "color_code"
+            ],
+            "type": "string"
+          },
+          "value": {
+            "description": "The static color value to use.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "value"
+        ],
+        "title": "Color Code",
+        "type": "object"
+      },
+      "countMetricOperation": {
+        "additionalProperties": false,
+        "properties": {
+          "empty_as_null": {
+            "default": false,
+            "description": "Whether to consider null values as null",
+            "type": "boolean"
+          },
+          "field": {
+            "description": "Field to be used for the metric",
+            "type": "string"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/filterSimple"
+          },
+          "format": {
+            "$ref": "#/components/schemas/formatType"
+          },
+          "label": {
+            "description": "Label for the operation",
+            "type": "string"
+          },
+          "operation": {
+            "enum": [
+              "count"
+            ],
+            "type": "string"
+          },
+          "reduced_time_range": {
+            "description": "Reduced time range",
+            "title": "Operation Reduced Time Range Setting",
+            "type": "string"
+          },
+          "time_scale": {
+            "$ref": "#/components/schemas/operationTimeScaleSetting"
+          },
+          "time_shift": {
+            "description": "Time shift",
+            "title": "Operation Time Shift Setting",
+            "type": "string"
+          }
+        },
+        "required": [
+          "format",
+          "filter",
+          "time_scale",
+          "operation"
+        ],
+        "title": "Count Metric Operation",
+        "type": "object"
+      },
+      "counterRateOperation": {
+        "additionalProperties": false,
+        "properties": {
+          "color": {
+            "$ref": "#/components/schemas/staticColor"
+          },
+          "field": {
+            "description": "Field to be used for the metric",
+            "type": "string"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/filterSimple"
+          },
+          "format": {
+            "$ref": "#/components/schemas/formatType"
+          },
+          "label": {
+            "description": "Label for the operation",
+            "type": "string"
+          },
+          "operation": {
+            "enum": [
+              "counter_rate"
+            ],
+            "type": "string"
+          },
+          "reduced_time_range": {
+            "description": "Reduced time range",
+            "title": "Operation Reduced Time Range Setting",
+            "type": "string"
+          },
+          "time_scale": {
+            "$ref": "#/components/schemas/operationTimeScaleSetting"
+          },
+          "time_shift": {
+            "description": "Time shift",
+            "title": "Operation Time Shift Setting",
+            "type": "string"
+          }
+        },
+        "required": [
+          "format",
+          "filter",
+          "time_scale",
+          "field",
+          "operation",
+          "color"
+        ],
+        "title": "Counter Rate Operation",
+        "type": "object"
+      },
+      "cumulativeSumOperation": {
+        "additionalProperties": false,
+        "properties": {
+          "color": {
+            "$ref": "#/components/schemas/staticColor"
+          },
+          "field": {
+            "description": "Field to be used for the metric",
+            "type": "string"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/filterSimple"
+          },
+          "format": {
+            "$ref": "#/components/schemas/formatType"
+          },
+          "label": {
+            "description": "Label for the operation",
+            "type": "string"
+          },
+          "operation": {
+            "enum": [
+              "cumulative_sum"
+            ],
+            "type": "string"
+          },
+          "reduced_time_range": {
+            "description": "Reduced time range",
+            "title": "Operation Reduced Time Range Setting",
+            "type": "string"
+          },
+          "time_scale": {
+            "$ref": "#/components/schemas/operationTimeScaleSetting"
+          },
+          "time_shift": {
+            "description": "Time shift",
+            "title": "Operation Time Shift Setting",
+            "type": "string"
+          }
+        },
+        "required": [
+          "format",
+          "filter",
+          "time_scale",
+          "field",
+          "operation",
+          "color"
+        ],
+        "title": "Cumulative Sum Operation",
+        "type": "object"
+      },
+      "customFormat": {
+        "additionalProperties": false,
+        "properties": {
+          "pattern": {
+            "description": "Pattern",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "custom"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "pattern"
+        ],
+        "title": "Custom Format",
+        "type": "object"
+      },
+      "datatableDensity": {
+        "additionalProperties": false,
+        "description": "Density configuration for the datatable",
+        "properties": {
+          "height": {
+            "additionalProperties": false,
+            "properties": {
+              "header": {
+                "anyOf": [
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "enum": [
+                          "auto"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "max_lines": {
+                        "default": 3,
+                        "maximum": 5,
+                        "minimum": 1,
+                        "type": "number"
+                      },
+                      "type": {
+                        "enum": [
+                          "custom"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object"
+                  }
+                ],
+                "description": "Maximum number of lines to use before header is truncated"
+              },
+              "value": {
+                "anyOf": [
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "enum": [
+                          "auto"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "lines": {
+                        "default": 1,
+                        "maximum": 20,
+                        "minimum": 1,
+                        "type": "number"
+                      },
+                      "type": {
+                        "enum": [
+                          "custom"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object"
+                  }
+                ],
+                "description": "Number of lines to display per table body cell"
+              }
+            },
+            "type": "object"
+          },
+          "mode": {
+            "description": "Density mode",
+            "enum": [
+              "compact",
+              "default",
+              "expanded"
+            ],
+            "type": "string"
+          }
+        },
+        "title": "datatableDensity",
+        "type": "object",
+        "x-oas-optional": true
+      },
+      "datatableESQL": {
+        "additionalProperties": false,
+        "description": "Datatable state configuration for ES|QL queries",
+        "properties": {
+          "data_source": {
+            "$ref": "#/components/schemas/esqlDataSource"
+          },
+          "density": {
+            "$ref": "#/components/schemas/datatableDensity"
+          },
+          "description": {
+            "type": "string"
+          },
+          "drilldowns": {
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "dashboard_id": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": false,
+                      "description": "When enabled, the dashboard opens in a new browser tab.",
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "dashboard_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "use_filters": {
+                      "default": true,
+                      "description": "When enabled, filters are passed to the opening dashboard.",
+                      "type": "boolean"
+                    },
+                    "use_time_range": {
+                      "default": true,
+                      "description": "When enabled, time range is passed to the opening dashboard.",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "dashboard_id",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "dashboard_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "discover_drilldown"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "discover_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "encode_url": {
+                      "default": true,
+                      "description": "When true, URL is escaped using percent encoding",
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_click_row",
+                        "on_click_value",
+                        "on_open_panel_menu",
+                        "on_select_range"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "url_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "url": {
+                      "description": "Templated Url. Variables documented at https://www.elastic.co/docs/explore-analyze/dashboards/drilldowns#url-template-variable",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "url",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "url_drilldown",
+                  "type": "object"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "filters": {
+            "$ref": "#/components/schemas/lensPanelFilters"
+          },
+          "hide_border": {
+            "type": "boolean"
+          },
+          "hide_title": {
+            "type": "boolean"
+          },
+          "ignore_global_filters": {
+            "default": false,
+            "description": "If true, ignore global filters when fetching data for this layer. Default is false.",
+            "type": "boolean"
+          },
+          "metrics": {
+            "description": "Array of metrics to display as columns in the datatable",
+            "items": {
+              "$ref": "#/components/schemas/datatableESQLMetric"
+            },
+            "maxItems": 1000,
+            "minItems": 1,
+            "type": "array"
+          },
+          "paging": {
+            "description": "Enables pagination and sets the number of rows to display per page",
+            "enum": [
+              10,
+              20,
+              30,
+              50,
+              100
+            ],
+            "type": "integer"
+          },
+          "references": {
+            "items": {
+              "$ref": "#/components/schemas/kbn-content-management-utils-referenceSchema"
+            },
+            "type": "array"
+          },
+          "row_numbers": {
+            "additionalProperties": false,
+            "description": "Configuration for row numbers",
+            "properties": {
+              "visible": {
+                "description": "Show row numbers",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "visible"
+            ],
+            "type": "object"
+          },
+          "rows": {
+            "description": "Array of operations to split the datatable rows by",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "alignment": {
+                  "description": "Alignment of the rows",
+                  "enum": [
+                    "left",
+                    "center",
+                    "right"
+                  ],
+                  "type": "string"
+                },
+                "apply_color_to": {
+                  "description": "Where to apply the color for datatable (value, background, or badge)",
+                  "enum": [
+                    "value",
+                    "background",
+                    "badge"
+                  ],
+                  "type": "string"
+                },
+                "click_filter": {
+                  "description": "Whether to enable the one click filter",
+                  "type": "boolean"
+                },
+                "collapse_by": {
+                  "$ref": "#/components/schemas/collapseBy"
+                },
+                "color": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/colorByValue"
+                    },
+                    {
+                      "$ref": "#/components/schemas/colorMapping"
+                    }
+                  ],
+                  "description": "Color configuration for ESQL datatable rows. Use dynamic coloring for numeric data and categorical/gradient mode for categorical data."
+                },
+                "column": {
+                  "description": "Column to use",
+                  "type": "string"
+                },
+                "format": {
+                  "$ref": "#/components/schemas/formatType"
+                },
+                "label": {
+                  "description": "Label for the operation",
+                  "type": "string"
+                },
+                "visible": {
+                  "type": "boolean"
+                },
+                "width": {
+                  "description": "Column width in pixels",
+                  "minimum": 0,
+                  "type": "number"
+                }
+              },
+              "required": [
+                "column",
+                "format",
+                "collapse_by"
+              ],
+              "type": "object"
+            },
+            "maxItems": 50,
+            "minItems": 1,
+            "type": "array"
+          },
+          "sampling": {
+            "default": 1,
+            "description": "Sampling factor between 0 (no sampling) and 1 (full sampling). Default is 1.",
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "sort_by": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "description": "Sort by a metric or row column",
+                "properties": {
+                  "column_type": {
+                    "description": "Type of column to sort by",
+                    "enum": [
+                      "metric",
+                      "row"
+                    ],
+                    "type": "string"
+                  },
+                  "direction": {
+                    "$ref": "#/components/schemas/vis_api_direction"
+                  },
+                  "index": {
+                    "description": "Index of the column/row to sort by (0-based)",
+                    "minimum": 0,
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "column_type",
+                  "index",
+                  "direction"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "description": "Sort by a pivoted metric column (created when metrics are pivoted by split_metrics_by)",
+                "properties": {
+                  "column_type": {
+                    "enum": [
+                      "pivoted_metric"
+                    ],
+                    "type": "string"
+                  },
+                  "direction": {
+                    "$ref": "#/components/schemas/vis_api_direction"
+                  },
+                  "index": {
+                    "description": "0-based index into the \"metrics\" array for the metric to sort; use \"values\" to identify the pivoted column",
+                    "minimum": 0,
+                    "type": "number"
+                  },
+                  "values": {
+                    "description": "Array of pivot values, one for each split_metrics_by column in order",
+                    "items": {
+                      "type": "string"
+                    },
+                    "maxItems": 20,
+                    "minItems": 1,
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "column_type",
+                  "index",
+                  "values",
+                  "direction"
+                ],
+                "type": "object"
+              }
+            ],
+            "description": "Sorting configuration. Only one column can be sorted at a time. Use \"column_type\" to specify the column type."
+          },
+          "split_metrics_by": {
+            "description": "Array of operations to split the metric columns by",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "column": {
+                  "description": "Column to use",
+                  "type": "string"
+                },
+                "format": {
+                  "$ref": "#/components/schemas/formatType"
+                },
+                "label": {
+                  "description": "Label for the operation",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "column",
+                "format"
+              ],
+              "type": "object"
+            },
+            "maxItems": 20,
+            "minItems": 1,
+            "type": "array"
+          },
+          "time_range": {
+            "$ref": "#/components/schemas/kbn-es-query-server-timeRangeSchema"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "data_table"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "filters",
+          "data_source",
+          "density",
+          "time_range"
+        ],
+        "title": "Datatable (ES|QL)",
+        "type": "object"
+      },
+      "datatableESQLMetric": {
+        "additionalProperties": false,
+        "properties": {
+          "alignment": {
+            "description": "Alignment of the columns",
+            "enum": [
+              "left",
+              "center",
+              "right"
+            ],
+            "type": "string"
+          },
+          "apply_color_to": {
+            "description": "Where to apply the color for datatable (value, background, or badge)",
+            "enum": [
+              "value",
+              "background",
+              "badge"
+            ],
+            "type": "string"
+          },
+          "color": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/colorByValue"
+              },
+              {
+                "$ref": "#/components/schemas/colorMapping"
+              }
+            ],
+            "description": "Color configuration for datatable metrics. Use dynamic coloring for numeric data and categorical/gradient mode for categorical data."
+          },
+          "column": {
+            "description": "Column to use",
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/components/schemas/formatType"
+          },
+          "label": {
+            "description": "Label for the operation",
+            "type": "string"
+          },
+          "summary": {
+            "additionalProperties": false,
+            "description": "Summary row configuration",
+            "properties": {
+              "label": {
+                "description": "Summary row label",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of summary function to apply to the column",
+                "enum": [
+                  "sum",
+                  "avg",
+                  "count",
+                  "min",
+                  "max"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          },
+          "visible": {
+            "type": "boolean"
+          },
+          "width": {
+            "description": "Column width in pixels",
+            "minimum": 0,
+            "type": "number"
+          }
+        },
+        "required": [
+          "column",
+          "format"
+        ],
+        "title": "Datatable Metric (ES|QL)",
+        "type": "object"
+      },
+      "datatableNoESQL": {
+        "additionalProperties": false,
+        "description": "Datatable state configuration for standard queries",
+        "properties": {
+          "data_source": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/kbn-data-view-reference-schema"
+              },
+              {
+                "$ref": "#/components/schemas/kbn-data-view-spec-schema"
+              }
+            ]
+          },
+          "density": {
+            "$ref": "#/components/schemas/datatableDensity"
+          },
+          "description": {
+            "type": "string"
+          },
+          "drilldowns": {
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "dashboard_id": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": false,
+                      "description": "When enabled, the dashboard opens in a new browser tab.",
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "dashboard_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "use_filters": {
+                      "default": true,
+                      "description": "When enabled, filters are passed to the opening dashboard.",
+                      "type": "boolean"
+                    },
+                    "use_time_range": {
+                      "default": true,
+                      "description": "When enabled, time range is passed to the opening dashboard.",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "dashboard_id",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "dashboard_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "discover_drilldown"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "discover_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "encode_url": {
+                      "default": true,
+                      "description": "When true, URL is escaped using percent encoding",
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_click_row",
+                        "on_click_value",
+                        "on_open_panel_menu",
+                        "on_select_range"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "url_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "url": {
+                      "description": "Templated Url. Variables documented at https://www.elastic.co/docs/explore-analyze/dashboards/drilldowns#url-template-variable",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "url",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "url_drilldown",
+                  "type": "object"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "filters": {
+            "$ref": "#/components/schemas/lensPanelFilters"
+          },
+          "hide_border": {
+            "type": "boolean"
+          },
+          "hide_title": {
+            "type": "boolean"
+          },
+          "ignore_global_filters": {
+            "default": false,
+            "description": "If true, ignore global filters when fetching data for this layer. Default is false.",
+            "type": "boolean"
+          },
+          "metrics": {
+            "description": "Array of metrics to display as columns in the datatable",
+            "items": {
+              "anyOf": [
+                {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/countMetricOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/uniqueCountMetricOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/minMaxAvgMedianStdDevMetricOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/sumMetricOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/lastValueOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/percentileOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/percentileRanksOperation"
+                    }
+                  ]
+                },
+                {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/differencesOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/movingAverageOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/cumulativeSumOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/counterRateOperation"
+                    }
+                  ]
+                },
+                {
+                  "$ref": "#/components/schemas/formulaOperation"
+                }
+              ]
+            },
+            "maxItems": 1000,
+            "minItems": 1,
+            "type": "array"
+          },
+          "paging": {
+            "description": "Enables pagination and sets the number of rows to display per page",
+            "enum": [
+              10,
+              20,
+              30,
+              50,
+              100
+            ],
+            "type": "integer"
+          },
+          "query": {
+            "$ref": "#/components/schemas/filterSimple"
+          },
+          "references": {
+            "items": {
+              "$ref": "#/components/schemas/kbn-content-management-utils-referenceSchema"
+            },
+            "type": "array"
+          },
+          "row_numbers": {
+            "additionalProperties": false,
+            "description": "Configuration for row numbers",
+            "properties": {
+              "visible": {
+                "description": "Show row numbers",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "visible"
+            ],
+            "type": "object"
+          },
+          "rows": {
+            "description": "Array of operations to split the datatable rows by",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/dateHistogramOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/termsOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/histogramOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/rangesOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/filtersOperation"
+                }
+              ]
+            },
+            "maxItems": 50,
+            "minItems": 1,
+            "type": "array"
+          },
+          "sampling": {
+            "default": 1,
+            "description": "Sampling factor between 0 (no sampling) and 1 (full sampling). Default is 1.",
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "sort_by": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "description": "Sort by a metric or row column",
+                "properties": {
+                  "column_type": {
+                    "description": "Type of column to sort by",
+                    "enum": [
+                      "metric",
+                      "row"
+                    ],
+                    "type": "string"
+                  },
+                  "direction": {
+                    "$ref": "#/components/schemas/vis_api_direction"
+                  },
+                  "index": {
+                    "description": "Index of the column/row to sort by (0-based)",
+                    "minimum": 0,
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "column_type",
+                  "index",
+                  "direction"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "description": "Sort by a pivoted metric column (created when metrics are pivoted by split_metrics_by)",
+                "properties": {
+                  "column_type": {
+                    "enum": [
+                      "pivoted_metric"
+                    ],
+                    "type": "string"
+                  },
+                  "direction": {
+                    "$ref": "#/components/schemas/vis_api_direction"
+                  },
+                  "index": {
+                    "description": "0-based index into the \"metrics\" array for the metric to sort; use \"values\" to identify the pivoted column",
+                    "minimum": 0,
+                    "type": "number"
+                  },
+                  "values": {
+                    "description": "Array of pivot values, one for each split_metrics_by column in order",
+                    "items": {
+                      "type": "string"
+                    },
+                    "maxItems": 20,
+                    "minItems": 1,
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "column_type",
+                  "index",
+                  "values",
+                  "direction"
+                ],
+                "type": "object"
+              }
+            ],
+            "description": "Sorting configuration. Only one column can be sorted at a time. Use \"column_type\" to specify the column type."
+          },
+          "split_metrics_by": {
+            "description": "Array of operations to split the metric columns by",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/dateHistogramOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/termsOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/histogramOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/rangesOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/filtersOperation"
+                }
+              ]
+            },
+            "maxItems": 20,
+            "minItems": 1,
+            "type": "array"
+          },
+          "time_range": {
+            "$ref": "#/components/schemas/kbn-es-query-server-timeRangeSchema"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "data_table"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "filters",
+          "query",
+          "data_source",
+          "density",
+          "metrics",
+          "time_range"
+        ],
+        "title": "Datatable (DSL)",
+        "type": "object"
+      },
+      "dateHistogramOperation": {
+        "additionalProperties": false,
+        "properties": {
+          "collapse_by": {
+            "$ref": "#/components/schemas/collapseBy"
+          },
+          "color": {
+            "$ref": "#/components/schemas/colorMapping"
+          },
+          "drop_partial_intervals": {
+            "description": "Whether to drop partial intervals",
+            "type": "boolean"
+          },
+          "field": {
+            "description": "Field to be used for the date histogram",
+            "type": "string"
+          },
+          "include_empty_rows": {
+            "default": true,
+            "description": "Whether to include empty rows",
+            "type": "boolean"
+          },
+          "label": {
+            "description": "Label for the operation",
+            "type": "string"
+          },
+          "operation": {
+            "enum": [
+              "date_histogram"
+            ],
+            "type": "string"
+          },
+          "suggested_interval": {
+            "default": "auto",
+            "description": "Suggested interval",
+            "type": "string"
+          },
+          "use_original_time_range": {
+            "default": false,
+            "description": "Whether to use original time range",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "operation",
+          "field",
+          "color",
+          "collapse_by"
+        ],
+        "title": "Date Histogram Operation",
+        "type": "object"
+      },
+      "differencesOperation": {
+        "additionalProperties": false,
+        "properties": {
+          "color": {
+            "$ref": "#/components/schemas/staticColor"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/filterSimple"
+          },
+          "format": {
+            "$ref": "#/components/schemas/formatType"
+          },
+          "label": {
+            "description": "Label for the operation",
+            "type": "string"
+          },
+          "of": {
+            "$ref": "#/components/schemas/fieldMetricOperations"
+          },
+          "operation": {
+            "enum": [
+              "differences"
+            ],
+            "type": "string"
+          },
+          "reduced_time_range": {
+            "description": "Reduced time range",
+            "title": "Operation Reduced Time Range Setting",
+            "type": "string"
+          },
+          "time_scale": {
+            "$ref": "#/components/schemas/operationTimeScaleSetting"
+          },
+          "time_shift": {
+            "description": "Time shift",
+            "title": "Operation Time Shift Setting",
+            "type": "string"
+          }
+        },
+        "required": [
+          "format",
+          "filter",
+          "time_scale",
+          "operation",
+          "of",
+          "color"
+        ],
+        "title": "Differences Operation",
+        "type": "object"
+      },
+      "durationFormat": {
+        "additionalProperties": false,
+        "properties": {
+          "from": {
+            "description": "From",
+            "type": "string"
+          },
+          "suffix": {
+            "description": "Suffix",
+            "type": "string"
+          },
+          "to": {
+            "description": "To",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "duration"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "from",
+          "to"
+        ],
+        "title": "Duration Format",
+        "type": "object"
+      },
+      "esqlDataSource": {
+        "additionalProperties": false,
+        "description": "Uses an ES|QL query as the data source. The query is executed at render time; resulting columns are available as fields.",
+        "properties": {
+          "query": {
+            "description": "An ES|QL query that drives the data source. The query must produce a tabular result set; column names are used as field references. Example: \"FROM logs-* | STATS count = COUNT(*) BY host.name\".",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "esql"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "query"
+        ],
+        "title": "ES|QL Data Source",
+        "type": "object"
+      },
+      "fieldMetricOperations": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/countMetricOperation"
+          },
+          {
+            "$ref": "#/components/schemas/uniqueCountMetricOperation"
+          },
+          {
+            "$ref": "#/components/schemas/minMaxAvgMedianStdDevMetricOperation"
+          },
+          {
+            "$ref": "#/components/schemas/sumMetricOperation"
+          },
+          {
+            "$ref": "#/components/schemas/lastValueOperation"
+          },
+          {
+            "$ref": "#/components/schemas/percentileOperation"
+          },
+          {
+            "$ref": "#/components/schemas/percentileRanksOperation"
+          }
+        ],
+        "title": "Field Metric Operations"
+      },
+      "filterSimple": {
+        "additionalProperties": false,
+        "properties": {
+          "expression": {
+            "description": "A query expression in KQL or Lucene syntax",
+            "type": "string"
+          },
+          "language": {
+            "default": "kql",
+            "enum": [
+              "kql",
+              "lucene"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "expression"
+        ],
+        "title": "Filter",
+        "type": "object"
+      },
+      "filterWithLabel": {
+        "additionalProperties": false,
+        "properties": {
+          "filter": {
+            "$ref": "#/components/schemas/filterSimple"
+          },
+          "label": {
+            "description": "Label for the filter",
+            "type": "string"
+          }
+        },
+        "required": [
+          "filter"
+        ],
+        "title": "Filter with Label",
+        "type": "object"
+      },
+      "filtersOperation": {
+        "additionalProperties": false,
+        "properties": {
+          "collapse_by": {
+            "$ref": "#/components/schemas/collapseBy"
+          },
+          "color": {
+            "$ref": "#/components/schemas/colorMapping"
+          },
+          "filters": {
+            "items": {
+              "$ref": "#/components/schemas/filterWithLabel"
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "label": {
+            "description": "Label for the operation",
+            "type": "string"
+          },
+          "operation": {
+            "enum": [
+              "filters"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "operation",
+          "filters",
+          "color",
+          "collapse_by"
+        ],
+        "title": "Filters Operation",
+        "type": "object"
+      },
+      "formatType": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/numericFormat"
+          },
+          {
+            "$ref": "#/components/schemas/byteFormat"
+          },
+          {
+            "$ref": "#/components/schemas/durationFormat"
+          },
+          {
+            "$ref": "#/components/schemas/customFormat"
+          }
+        ],
+        "title": "Format Type",
+        "x-oas-optional": true
+      },
+      "formulaOperation": {
+        "additionalProperties": false,
+        "properties": {
+          "color": {
+            "$ref": "#/components/schemas/staticColor"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/filterSimple"
+          },
+          "format": {
+            "$ref": "#/components/schemas/formatType"
+          },
+          "formula": {
+            "description": "Formula",
+            "type": "string"
+          },
+          "label": {
+            "description": "Label for the operation",
+            "type": "string"
+          },
+          "operation": {
+            "enum": [
+              "formula"
+            ],
+            "type": "string"
+          },
+          "reduced_time_range": {
+            "description": "Reduced time range",
+            "title": "Operation Reduced Time Range Setting",
+            "type": "string"
+          },
+          "time_scale": {
+            "description": "Time scale",
+            "enum": [
+              "s",
+              "m",
+              "h",
+              "d"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format",
+          "operation",
+          "formula",
+          "filter",
+          "color"
+        ],
+        "title": "Formula Operation",
+        "type": "object"
+      },
+      "gaugeESQL": {
+        "additionalProperties": false,
+        "properties": {
+          "data_source": {
+            "$ref": "#/components/schemas/esqlDataSource"
+          },
+          "description": {
+            "type": "string"
+          },
+          "drilldowns": {
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "dashboard_id": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": false,
+                      "description": "When enabled, the dashboard opens in a new browser tab.",
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "dashboard_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "use_filters": {
+                      "default": true,
+                      "description": "When enabled, filters are passed to the opening dashboard.",
+                      "type": "boolean"
+                    },
+                    "use_time_range": {
+                      "default": true,
+                      "description": "When enabled, time range is passed to the opening dashboard.",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "dashboard_id",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "dashboard_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "discover_drilldown"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "discover_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "encode_url": {
+                      "default": true,
+                      "description": "When true, URL is escaped using percent encoding",
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_click_row",
+                        "on_click_value",
+                        "on_open_panel_menu",
+                        "on_select_range"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "url_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "url": {
+                      "description": "Templated Url. Variables documented at https://www.elastic.co/docs/explore-analyze/dashboards/drilldowns#url-template-variable",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "url",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "url_drilldown",
+                  "type": "object"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "filters": {
+            "$ref": "#/components/schemas/lensPanelFilters"
+          },
+          "hide_border": {
+            "type": "boolean"
+          },
+          "hide_title": {
+            "type": "boolean"
+          },
+          "ignore_global_filters": {
+            "default": false,
+            "description": "If true, ignore global filters when fetching data for this layer. Default is false.",
+            "type": "boolean"
+          },
+          "metric": {
+            "additionalProperties": false,
+            "properties": {
+              "color": {
+                "$ref": "#/components/schemas/colorByValue"
+              },
+              "column": {
+                "description": "Column to use",
+                "type": "string"
+              },
+              "format": {
+                "$ref": "#/components/schemas/formatType"
+              },
+              "goal": {
+                "additionalProperties": false,
+                "properties": {
+                  "column": {
+                    "description": "Column to use",
+                    "type": "string"
+                  },
+                  "label": {
+                    "description": "Label for the operation",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "column"
+                ],
+                "type": "object"
+              },
+              "label": {
+                "description": "Label for the operation",
+                "type": "string"
+              },
+              "max": {
+                "additionalProperties": false,
+                "properties": {
+                  "column": {
+                    "description": "Column to use",
+                    "type": "string"
+                  },
+                  "label": {
+                    "description": "Label for the operation",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "column"
+                ],
+                "type": "object"
+              },
+              "min": {
+                "additionalProperties": false,
+                "properties": {
+                  "column": {
+                    "description": "Column to use",
+                    "type": "string"
+                  },
+                  "label": {
+                    "description": "Label for the operation",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "column"
+                ],
+                "type": "object"
+              },
+              "subtitle": {
+                "description": "Subtitle below the gauge value",
+                "type": "string"
+              },
+              "ticks": {
+                "additionalProperties": false,
+                "description": "Ticks configuration",
+                "properties": {
+                  "mode": {
+                    "description": "Tick placement mode",
+                    "enum": [
+                      "auto",
+                      "bands"
+                    ],
+                    "type": "string"
+                  },
+                  "visible": {
+                    "description": "Show tick marks",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
+              },
+              "title": {
+                "additionalProperties": false,
+                "description": "Title configuration",
+                "properties": {
+                  "text": {
+                    "description": "Title text",
+                    "type": "string"
+                  },
+                  "visible": {
+                    "description": "Show the title",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "required": [
+              "column",
+              "format",
+              "color"
+            ],
+            "type": "object"
+          },
+          "references": {
+            "items": {
+              "$ref": "#/components/schemas/kbn-content-management-utils-referenceSchema"
+            },
+            "type": "array"
+          },
+          "sampling": {
+            "default": 1,
+            "description": "Sampling factor between 0 (no sampling) and 1 (full sampling). Default is 1.",
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "shape": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/gaugeShapeBullet"
+              },
+              {
+                "$ref": "#/components/schemas/gaugeShapeCircular"
+              }
+            ]
+          },
+          "time_range": {
+            "$ref": "#/components/schemas/kbn-es-query-server-timeRangeSchema"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "gauge"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "filters",
+          "data_source",
+          "metric",
+          "time_range"
+        ],
+        "title": "Gauge Chart (ES|QL)",
+        "type": "object"
+      },
+      "gaugeNoESQL": {
+        "additionalProperties": false,
+        "properties": {
+          "data_source": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/kbn-data-view-reference-schema"
+              },
+              {
+                "$ref": "#/components/schemas/kbn-data-view-spec-schema"
+              }
+            ]
+          },
+          "description": {
+            "type": "string"
+          },
+          "drilldowns": {
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "dashboard_id": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": false,
+                      "description": "When enabled, the dashboard opens in a new browser tab.",
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "dashboard_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "use_filters": {
+                      "default": true,
+                      "description": "When enabled, filters are passed to the opening dashboard.",
+                      "type": "boolean"
+                    },
+                    "use_time_range": {
+                      "default": true,
+                      "description": "When enabled, time range is passed to the opening dashboard.",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "dashboard_id",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "dashboard_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "discover_drilldown"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "discover_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "encode_url": {
+                      "default": true,
+                      "description": "When true, URL is escaped using percent encoding",
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_click_row",
+                        "on_click_value",
+                        "on_open_panel_menu",
+                        "on_select_range"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "url_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "url": {
+                      "description": "Templated Url. Variables documented at https://www.elastic.co/docs/explore-analyze/dashboards/drilldowns#url-template-variable",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "url",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "url_drilldown",
+                  "type": "object"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "filters": {
+            "$ref": "#/components/schemas/lensPanelFilters"
+          },
+          "hide_border": {
+            "type": "boolean"
+          },
+          "hide_title": {
+            "type": "boolean"
+          },
+          "ignore_global_filters": {
+            "default": false,
+            "description": "If true, ignore global filters when fetching data for this layer. Default is false.",
+            "type": "boolean"
+          },
+          "metric": {
+            "anyOf": [
+              {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/countMetricOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/uniqueCountMetricOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/minMaxAvgMedianStdDevMetricOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/sumMetricOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/lastValueOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/percentileOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/percentileRanksOperation"
+                  }
+                ]
+              },
+              {
+                "$ref": "#/components/schemas/formulaOperation"
+              }
+            ]
+          },
+          "query": {
+            "$ref": "#/components/schemas/filterSimple"
+          },
+          "references": {
+            "items": {
+              "$ref": "#/components/schemas/kbn-content-management-utils-referenceSchema"
+            },
+            "type": "array"
+          },
+          "sampling": {
+            "default": 1,
+            "description": "Sampling factor between 0 (no sampling) and 1 (full sampling). Default is 1.",
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "shape": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/gaugeShapeBullet"
+              },
+              {
+                "$ref": "#/components/schemas/gaugeShapeCircular"
+              }
+            ]
+          },
+          "time_range": {
+            "$ref": "#/components/schemas/kbn-es-query-server-timeRangeSchema"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "gauge"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "filters",
+          "query",
+          "data_source",
+          "metric",
+          "time_range"
+        ],
+        "title": "Gauge Chart (DSL)",
+        "type": "object"
+      },
+      "gaugeShapeBullet": {
+        "additionalProperties": false,
+        "description": "Bullet gauge shape",
+        "properties": {
+          "orientation": {
+            "$ref": "#/components/schemas/vis_api_simple_orientation"
+          },
+          "type": {
+            "enum": [
+              "bullet"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "orientation"
+        ],
+        "title": "Shape (Bullet)",
+        "type": "object"
+      },
+      "gaugeShapeCircular": {
+        "additionalProperties": false,
+        "description": "Circular gauge shape",
+        "properties": {
+          "type": {
+            "enum": [
+              "circle",
+              "semi_circle",
+              "arc"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "title": "Shape (Circular)",
+        "type": "object"
+      },
+      "gradientColorMapping": {
+        "additionalProperties": false,
+        "properties": {
+          "gradient": {
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/colorFromPalette"
+                },
+                {
+                  "$ref": "#/components/schemas/color_code"
+                }
+              ]
+            },
+            "maxItems": 3,
+            "type": "array"
+          },
+          "mapping": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "values": {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/components/schemas/range_key"
+                      },
+                      {
+                        "$ref": "#/components/schemas/multi_field_key"
+                      }
+                    ]
+                  },
+                  "maxItems": 100,
+                  "type": "array"
+                }
+              },
+              "required": [
+                "values"
+              ],
+              "type": "object"
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "mode": {
+            "enum": [
+              "gradient"
+            ],
+            "type": "string"
+          },
+          "palette": {
+            "description": "The palette name to use for color assignment.",
+            "type": "string"
+          },
+          "sort": {
+            "description": "Sort direction",
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "type": "string"
+          },
+          "unassigned": {
+            "$ref": "#/components/schemas/unassignedColorSchema"
+          }
+        },
+        "required": [
+          "mode",
+          "palette",
+          "unassigned"
+        ],
+        "title": "Gradient Color Mapping",
+        "type": "object"
+      },
+      "heatmapAxes": {
+        "additionalProperties": false,
+        "description": "Axis configuration for X and Y axes",
+        "properties": {
+          "x": {
+            "$ref": "#/components/schemas/heatmapXAxis"
+          },
+          "y": {
+            "$ref": "#/components/schemas/heatmapYAxis"
+          }
+        },
+        "required": [
+          "x",
+          "y"
+        ],
+        "title": "Axes",
+        "type": "object",
+        "x-oas-optional": true
+      },
+      "heatmapCells": {
+        "additionalProperties": false,
+        "description": "Cells configuration",
+        "properties": {
+          "labels": {
+            "additionalProperties": false,
+            "properties": {
+              "visible": {
+                "description": "Show cell labels",
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "title": "Cells",
+        "type": "object",
+        "x-oas-optional": true
+      },
+      "heatmapESQL": {
+        "additionalProperties": false,
+        "properties": {
+          "axes": {
+            "$ref": "#/components/schemas/heatmapAxes"
+          },
+          "cells": {
+            "$ref": "#/components/schemas/heatmapCells"
+          },
+          "data_source": {
+            "$ref": "#/components/schemas/esqlDataSource"
+          },
+          "description": {
+            "type": "string"
+          },
+          "drilldowns": {
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "dashboard_id": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": false,
+                      "description": "When enabled, the dashboard opens in a new browser tab.",
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "dashboard_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "use_filters": {
+                      "default": true,
+                      "description": "When enabled, filters are passed to the opening dashboard.",
+                      "type": "boolean"
+                    },
+                    "use_time_range": {
+                      "default": true,
+                      "description": "When enabled, time range is passed to the opening dashboard.",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "dashboard_id",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "dashboard_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "discover_drilldown"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "discover_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "encode_url": {
+                      "default": true,
+                      "description": "When true, URL is escaped using percent encoding",
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_click_row",
+                        "on_click_value",
+                        "on_open_panel_menu",
+                        "on_select_range"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "url_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "url": {
+                      "description": "Templated Url. Variables documented at https://www.elastic.co/docs/explore-analyze/dashboards/drilldowns#url-template-variable",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "url",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "url_drilldown",
+                  "type": "object"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "filters": {
+            "$ref": "#/components/schemas/lensPanelFilters"
+          },
+          "hide_border": {
+            "type": "boolean"
+          },
+          "hide_title": {
+            "type": "boolean"
+          },
+          "ignore_global_filters": {
+            "default": false,
+            "description": "If true, ignore global filters when fetching data for this layer. Default is false.",
+            "type": "boolean"
+          },
+          "legend": {
+            "$ref": "#/components/schemas/heatmapLegend"
+          },
+          "metric": {
+            "additionalProperties": false,
+            "properties": {
+              "color": {
+                "$ref": "#/components/schemas/colorByValue"
+              },
+              "column": {
+                "description": "Column to use",
+                "type": "string"
+              },
+              "format": {
+                "$ref": "#/components/schemas/formatType"
+              },
+              "label": {
+                "description": "Label for the operation",
+                "type": "string"
+              }
+            },
+            "required": [
+              "column",
+              "format",
+              "color"
+            ],
+            "type": "object"
+          },
+          "references": {
+            "items": {
+              "$ref": "#/components/schemas/kbn-content-management-utils-referenceSchema"
+            },
+            "type": "array"
+          },
+          "sampling": {
+            "default": 1,
+            "description": "Sampling factor between 0 (no sampling) and 1 (full sampling). Default is 1.",
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "time_range": {
+            "$ref": "#/components/schemas/kbn-es-query-server-timeRangeSchema"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "heatmap"
+            ],
+            "type": "string"
+          },
+          "x": {
+            "additionalProperties": false,
+            "properties": {
+              "column": {
+                "description": "Column to use",
+                "type": "string"
+              },
+              "format": {
+                "$ref": "#/components/schemas/formatType"
+              },
+              "label": {
+                "description": "Label for the operation",
+                "type": "string"
+              }
+            },
+            "required": [
+              "column",
+              "format"
+            ],
+            "type": "object"
+          },
+          "y": {
+            "additionalProperties": false,
+            "properties": {
+              "column": {
+                "description": "Column to use",
+                "type": "string"
+              },
+              "format": {
+                "$ref": "#/components/schemas/formatType"
+              },
+              "label": {
+                "description": "Label for the operation",
+                "type": "string"
+              }
+            },
+            "required": [
+              "column",
+              "format"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "type",
+          "legend",
+          "filters",
+          "axes",
+          "cells",
+          "x",
+          "data_source",
+          "metric",
+          "time_range"
+        ],
+        "title": "Heatmap Chart (ES|QL)",
+        "type": "object"
+      },
+      "heatmapLegend": {
+        "additionalProperties": false,
+        "description": "Legend configuration",
+        "properties": {
+          "size": {
+            "$ref": "#/components/schemas/legendSize"
+          },
+          "truncate_after_lines": {
+            "description": "Maximum lines before truncating legend items (1-10)",
+            "maximum": 10,
+            "minimum": 1,
+            "title": "legendTruncateAfterLines",
+            "type": "number"
+          },
+          "visibility": {
+            "description": "Legend visibility",
+            "enum": [
+              "visible",
+              "hidden"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "size"
+        ],
+        "title": "Legend",
+        "type": "object",
+        "x-oas-optional": true
+      },
+      "heatmapNoESQL": {
+        "additionalProperties": false,
+        "properties": {
+          "axes": {
+            "$ref": "#/components/schemas/heatmapAxes"
+          },
+          "cells": {
+            "$ref": "#/components/schemas/heatmapCells"
+          },
+          "data_source": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/kbn-data-view-reference-schema"
+              },
+              {
+                "$ref": "#/components/schemas/kbn-data-view-spec-schema"
+              }
+            ]
+          },
+          "description": {
+            "type": "string"
+          },
+          "drilldowns": {
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "dashboard_id": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": false,
+                      "description": "When enabled, the dashboard opens in a new browser tab.",
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "dashboard_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "use_filters": {
+                      "default": true,
+                      "description": "When enabled, filters are passed to the opening dashboard.",
+                      "type": "boolean"
+                    },
+                    "use_time_range": {
+                      "default": true,
+                      "description": "When enabled, time range is passed to the opening dashboard.",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "dashboard_id",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "dashboard_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "discover_drilldown"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "discover_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "encode_url": {
+                      "default": true,
+                      "description": "When true, URL is escaped using percent encoding",
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_click_row",
+                        "on_click_value",
+                        "on_open_panel_menu",
+                        "on_select_range"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "url_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "url": {
+                      "description": "Templated Url. Variables documented at https://www.elastic.co/docs/explore-analyze/dashboards/drilldowns#url-template-variable",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "url",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "url_drilldown",
+                  "type": "object"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "filters": {
+            "$ref": "#/components/schemas/lensPanelFilters"
+          },
+          "hide_border": {
+            "type": "boolean"
+          },
+          "hide_title": {
+            "type": "boolean"
+          },
+          "ignore_global_filters": {
+            "default": false,
+            "description": "If true, ignore global filters when fetching data for this layer. Default is false.",
+            "type": "boolean"
+          },
+          "legend": {
+            "$ref": "#/components/schemas/heatmapLegend"
+          },
+          "metric": {
+            "anyOf": [
+              {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/countMetricOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/uniqueCountMetricOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/minMaxAvgMedianStdDevMetricOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/sumMetricOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/lastValueOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/percentileOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/percentileRanksOperation"
+                  }
+                ]
+              },
+              {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/differencesOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/movingAverageOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/cumulativeSumOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/counterRateOperation"
+                  }
+                ]
+              },
+              {
+                "$ref": "#/components/schemas/formulaOperation"
+              }
+            ]
+          },
+          "query": {
+            "$ref": "#/components/schemas/filterSimple"
+          },
+          "references": {
+            "items": {
+              "$ref": "#/components/schemas/kbn-content-management-utils-referenceSchema"
+            },
+            "type": "array"
+          },
+          "sampling": {
+            "default": 1,
+            "description": "Sampling factor between 0 (no sampling) and 1 (full sampling). Default is 1.",
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "time_range": {
+            "$ref": "#/components/schemas/kbn-es-query-server-timeRangeSchema"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "heatmap"
+            ],
+            "type": "string"
+          },
+          "x": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/dateHistogramOperation"
+              },
+              {
+                "$ref": "#/components/schemas/termsOperation"
+              },
+              {
+                "$ref": "#/components/schemas/histogramOperation"
+              },
+              {
+                "$ref": "#/components/schemas/rangesOperation"
+              },
+              {
+                "$ref": "#/components/schemas/filtersOperation"
+              }
+            ]
+          },
+          "y": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/dateHistogramOperation"
+              },
+              {
+                "$ref": "#/components/schemas/termsOperation"
+              },
+              {
+                "$ref": "#/components/schemas/histogramOperation"
+              },
+              {
+                "$ref": "#/components/schemas/rangesOperation"
+              },
+              {
+                "$ref": "#/components/schemas/filtersOperation"
+              }
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "legend",
+          "filters",
+          "axes",
+          "cells",
+          "x",
+          "query",
+          "data_source",
+          "metric",
+          "time_range"
+        ],
+        "title": "Heatmap Chart (DSL)",
+        "type": "object"
+      },
+      "heatmapXAxis": {
+        "additionalProperties": false,
+        "description": "X axis configuration",
+        "properties": {
+          "labels": {
+            "additionalProperties": false,
+            "properties": {
+              "orientation": {
+                "$ref": "#/components/schemas/vis_api_orientation"
+              },
+              "visible": {
+                "description": "Show axis labels",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "orientation"
+            ],
+            "type": "object"
+          },
+          "scale": {
+            "description": "X-axis scale type. Use 'temporal' for timestamp/date fields (e.g., @timestamp, DATE_TRUNC results). Use 'ordinal' for categorical/text fields. Use 'linear' for numeric fields.",
+            "enum": [
+              "ordinal",
+              "temporal",
+              "linear"
+            ],
+            "type": "string"
+          },
+          "sort": {
+            "description": "Axis sort order; omit or use undefined for no sorting",
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "type": "string"
+          },
+          "title": {
+            "additionalProperties": false,
+            "properties": {
+              "text": {
+                "description": "Axis title text",
+                "type": "string"
+              },
+              "visible": {
+                "description": "Show the title",
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "required": [
+          "scale"
+        ],
+        "title": "X Axis",
+        "type": "object",
+        "x-oas-optional": true
+      },
+      "heatmapYAxis": {
+        "additionalProperties": false,
+        "description": "Y axis configuration",
+        "properties": {
+          "labels": {
+            "additionalProperties": false,
+            "properties": {
+              "visible": {
+                "description": "Show axis labels",
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "sort": {
+            "description": "Axis sort order; omit or use undefined for no sorting",
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "type": "string"
+          },
+          "title": {
+            "additionalProperties": false,
+            "properties": {
+              "text": {
+                "description": "Axis title text",
+                "type": "string"
+              },
+              "visible": {
+                "description": "Show the title",
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "title": "Y Axis",
+        "type": "object",
+        "x-oas-optional": true
+      },
+      "histogramOperation": {
+        "additionalProperties": false,
+        "properties": {
+          "collapse_by": {
+            "$ref": "#/components/schemas/collapseBy"
+          },
+          "color": {
+            "$ref": "#/components/schemas/colorMapping"
+          },
+          "field": {
+            "description": "Field to be used for the histogram",
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/components/schemas/formatType"
+          },
+          "granularity": {
+            "anyOf": [
+              {
+                "description": "Granularity of the histogram",
+                "maximum": 7,
+                "minimum": 1,
+                "type": "number"
+              },
+              {
+                "enum": [
+                  "auto"
+                ],
+                "type": "string"
+              }
+            ],
+            "default": "auto"
+          },
+          "include_empty_rows": {
+            "default": true,
+            "description": "Whether to include empty rows",
+            "type": "boolean"
+          },
+          "label": {
+            "description": "Label for the operation",
+            "type": "string"
+          },
+          "operation": {
+            "enum": [
+              "histogram"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "operation",
+          "format",
+          "field",
+          "color",
+          "collapse_by"
+        ],
+        "title": "Histogram Operation",
+        "type": "object"
+      },
+      "kbn-as-code-filters-schema_asCodeConditionFilterSchema": {
+        "additionalProperties": false,
+        "description": "Condition filter",
+        "properties": {
+          "condition": {
+            "description": "A filter condition with strict operator/value type matching",
+            "discriminator": {
+              "propertyName": "operator"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/kbn-as-code-filters-schema_condition_is"
+              },
+              {
+                "$ref": "#/components/schemas/kbn-as-code-filters-schema_condition_is_one_of"
+              },
+              {
+                "$ref": "#/components/schemas/kbn-as-code-filters-schema_condition_range"
+              },
+              {
+                "$ref": "#/components/schemas/kbn-as-code-filters-schema_condition_exists"
+              }
+            ]
+          },
+          "controlled_by": {
+            "description": "Optional identifier for the component/plugin managing this filter",
+            "type": "string"
+          },
+          "data_view_id": {
+            "description": "Data view ID that this filter applies to",
+            "type": "string"
+          },
+          "disabled": {
+            "description": "Whether the filter is disabled",
+            "type": "boolean"
+          },
+          "is_multi_index": {
+            "description": "Whether this filter can be applied to multiple indices",
+            "type": "boolean"
+          },
+          "label": {
+            "description": "Human-readable label for the filter",
+            "type": "string"
+          },
+          "negate": {
+            "description": "Whether to negate the filter.",
+            "type": "boolean"
+          },
+          "type": {
+            "enum": [
+              "condition"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "condition"
+        ],
+        "title": "condition",
+        "type": "object"
+      },
+      "kbn-as-code-filters-schema_asCodeDSLFilterSchema": {
+        "additionalProperties": false,
+        "description": "DSL filter",
+        "properties": {
+          "controlled_by": {
+            "description": "Optional identifier for the component/plugin managing this filter",
+            "type": "string"
+          },
+          "data_view_id": {
+            "description": "Data view ID that this filter applies to",
+            "type": "string"
+          },
+          "disabled": {
+            "description": "Whether the filter is disabled",
+            "type": "boolean"
+          },
+          "dsl": {
+            "additionalProperties": {},
+            "description": "Elasticsearch Query DSL object",
+            "type": "object"
+          },
+          "field": {
+            "description": "Field name for scripted filters where field cannot be extracted from query.",
+            "type": "string"
+          },
+          "is_multi_index": {
+            "description": "Whether this filter can be applied to multiple indices",
+            "type": "boolean"
+          },
+          "label": {
+            "description": "Human-readable label for the filter",
+            "type": "string"
+          },
+          "negate": {
+            "description": "Whether to negate the filter.",
+            "type": "boolean"
+          },
+          "params": {},
+          "type": {
+            "enum": [
+              "dsl"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "dsl",
+          "params"
+        ],
+        "title": "dsl",
+        "type": "object"
+      },
+      "kbn-as-code-filters-schema_asCodeGroupFilterSchema": {
+        "additionalProperties": false,
+        "description": "Grouped condition filter",
+        "properties": {
+          "controlled_by": {
+            "description": "Optional identifier for the component/plugin managing this filter",
+            "type": "string"
+          },
+          "data_view_id": {
+            "description": "Data view ID that this filter applies to",
+            "type": "string"
+          },
+          "disabled": {
+            "description": "Whether the filter is disabled",
+            "type": "boolean"
+          },
+          "group": {
+            "$ref": "#/components/schemas/kbn-as-code-filters-schema_groupFilter"
+          },
+          "is_multi_index": {
+            "description": "Whether this filter can be applied to multiple indices",
+            "type": "boolean"
+          },
+          "label": {
+            "description": "Human-readable label for the filter",
+            "type": "string"
+          },
+          "negate": {
+            "description": "Whether to negate the filter.",
+            "type": "boolean"
+          },
+          "type": {
+            "enum": [
+              "group"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "group"
+        ],
+        "title": "group",
+        "type": "object"
+      },
+      "kbn-as-code-filters-schema_asCodeSpatialFilterSchema": {
+        "additionalProperties": false,
+        "description": "Spatial filter",
+        "properties": {
+          "controlled_by": {
+            "description": "Optional identifier for the component/plugin managing this filter",
+            "type": "string"
+          },
+          "data_view_id": {
+            "description": "Data view ID that this filter applies to",
+            "type": "string"
+          },
+          "disabled": {
+            "description": "Whether the filter is disabled",
+            "type": "boolean"
+          },
+          "dsl": {
+            "additionalProperties": {},
+            "description": "Elasticsearch geo query DSL object",
+            "type": "object"
+          },
+          "is_multi_index": {
+            "description": "Whether this filter can be applied to multiple indices",
+            "type": "boolean"
+          },
+          "label": {
+            "description": "Human-readable label for the filter",
+            "type": "string"
+          },
+          "negate": {
+            "description": "Whether to negate the filter.",
+            "type": "boolean"
+          },
+          "type": {
+            "enum": [
+              "spatial"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "dsl"
+        ],
+        "title": "spatial",
+        "type": "object"
+      },
+      "kbn-as-code-filters-schema_condition_exists": {
+        "additionalProperties": false,
+        "description": "Condition: exists",
+        "properties": {
+          "field": {
+            "description": "Field the filter applies to",
+            "type": "string"
+          },
+          "negate": {
+            "description": "Whether to negate the filter.",
+            "type": "boolean"
+          },
+          "operator": {
+            "enum": [
+              "exists"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "field",
+          "operator"
+        ],
+        "title": "exists",
+        "type": "object"
+      },
+      "kbn-as-code-filters-schema_condition_is": {
+        "additionalProperties": false,
+        "description": "Condition: is",
+        "properties": {
+          "field": {
+            "description": "Field the filter applies to",
+            "type": "string"
+          },
+          "negate": {
+            "description": "Whether to negate the filter.",
+            "type": "boolean"
+          },
+          "operator": {
+            "enum": [
+              "is"
+            ],
+            "type": "string"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "title": "value",
+                "type": "string"
+              },
+              {
+                "title": "value",
+                "type": "number"
+              },
+              {
+                "title": "value",
+                "type": "boolean"
+              }
+            ],
+            "description": "Single value for comparison"
+          }
+        },
+        "required": [
+          "field",
+          "operator",
+          "value"
+        ],
+        "title": "is",
+        "type": "object"
+      },
+      "kbn-as-code-filters-schema_condition_is_one_of": {
+        "additionalProperties": false,
+        "description": "Condition: is one of",
+        "properties": {
+          "field": {
+            "description": "Field the filter applies to",
+            "type": "string"
+          },
+          "negate": {
+            "description": "Whether to negate the filter.",
+            "type": "boolean"
+          },
+          "operator": {
+            "enum": [
+              "is_one_of"
+            ],
+            "type": "string"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "maxItems": 10000,
+                "type": "array"
+              },
+              {
+                "items": {
+                  "type": "number"
+                },
+                "maxItems": 10000,
+                "type": "array"
+              },
+              {
+                "items": {
+                  "type": "boolean"
+                },
+                "maxItems": 10000,
+                "type": "array"
+              }
+            ],
+            "description": "Homogeneous array of values"
+          }
+        },
+        "required": [
+          "field",
+          "operator",
+          "value"
+        ],
+        "title": "is_one_of",
+        "type": "object"
+      },
+      "kbn-as-code-filters-schema_condition_range": {
+        "additionalProperties": false,
+        "description": "Condition: range",
+        "properties": {
+          "field": {
+            "description": "Field the filter applies to",
+            "type": "string"
+          },
+          "negate": {
+            "description": "Whether to negate the filter.",
+            "type": "boolean"
+          },
+          "operator": {
+            "enum": [
+              "range"
+            ],
+            "type": "string"
+          },
+          "value": {
+            "additionalProperties": false,
+            "properties": {
+              "format": {
+                "description": "Date format (e.g., strict_date_optional_time, strict_date_optional_time_nanos)",
+                "type": "string"
+              },
+              "gt": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "description": "Greater than"
+              },
+              "gte": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "description": "Greater than or equal to"
+              },
+              "lt": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "description": "Less than"
+              },
+              "lte": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "description": "Less than or equal to"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "required": [
+          "field",
+          "operator",
+          "value"
+        ],
+        "title": "range",
+        "type": "object"
+      },
+      "kbn-as-code-filters-schema_groupFilter": {
+        "additionalProperties": false,
+        "description": "Condition or nested group filter",
+        "properties": {
+          "conditions": {
+            "items": {
+              "anyOf": [
+                {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/kbn-as-code-filters-schema_condition_is"
+                    },
+                    {
+                      "$ref": "#/components/schemas/kbn-as-code-filters-schema_condition_is_one_of"
+                    },
+                    {
+                      "$ref": "#/components/schemas/kbn-as-code-filters-schema_condition_range"
+                    },
+                    {
+                      "$ref": "#/components/schemas/kbn-as-code-filters-schema_condition_exists"
+                    }
+                  ],
+                  "description": "A filter condition with strict operator/value type matching"
+                },
+                {
+                  "$ref": "#/components/schemas/kbn-as-code-filters-schema_groupFilter"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "operator": {
+            "enum": [
+              "and",
+              "or"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "operator",
+          "conditions"
+        ],
+        "title": "kbn-as-code-filters-schema_groupFilter",
+        "type": "object"
+      },
+      "kbn-as-code-meta": {
+        "additionalProperties": false,
+        "properties": {
+          "created_at": {
+            "type": "string"
+          },
+          "created_by": {
+            "type": "string"
+          },
+          "managed": {
+            "type": "boolean"
+          },
+          "owner": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "updated_by": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "title": "kbn-as-code-meta",
+        "type": "object"
+      },
+      "kbn-as-code-query": {
+        "additionalProperties": false,
+        "properties": {
+          "expression": {
+            "description": "A query expression in KQL or Lucene syntax.",
+            "type": "string"
+          },
+          "language": {
+            "description": "Query language. Use `kql` for Kibana Query Language (KQL) or `lucene` for Lucene query syntax.",
+            "enum": [
+              "kql",
+              "lucene"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "expression",
+          "language"
+        ],
+        "title": "kbn-as-code-query",
+        "type": "object",
+        "x-oas-optional": true
+      },
+      "kbn-composite-runtime-field-schema": {
+        "additionalProperties": false,
+        "properties": {
+          "fields": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "custom_description": {
+                  "description": "Add a description to the field. It's displayed next to the field on the Discover, Lens, and Data View Management pages.",
+                  "minLength": 1,
+                  "title": "Custom description",
+                  "type": "string"
+                },
+                "custom_label": {
+                  "description": "Create a label to display in place of the field name in Discover, Maps, Lens, Visualize, and TSVB. Useful for shortening a long field name. Queries and filters use the original field name.",
+                  "minLength": 1,
+                  "title": "Custom label",
+                  "type": "string"
+                },
+                "format": {
+                  "$ref": "#/components/schemas/kbn-runtime-field-format"
+                },
+                "name": {
+                  "description": "The name of the runtime subfield, it gets appended to the parent field name. Example: \"parent_name.my_runtime_subfield\".",
+                  "maxLength": 1000,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "type": {
+                  "$ref": "#/components/schemas/kbn-runtime-field-type"
+                }
+              },
+              "required": [
+                "name",
+                "type",
+                "format"
+              ],
+              "type": "object"
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "name": {
+            "description": "The name of the runtime field. Example: \"my_runtime_field\".",
+            "maxLength": 1000,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          },
+          "script": {
+            "description": "The script that defines the runtime field. This should be a painless script that computes the field value at query time. Runtime fields without a script retrieve values from _source. If the field doesn't exist in _source, a search request returns no value.",
+            "minLength": 1,
+            "title": "Script",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "composite"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "fields",
+          "name"
+        ],
+        "title": "Composite runtime field",
+        "type": "object"
+      },
+      "kbn-content-management-utils-referenceSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "type",
+          "id"
+        ],
+        "title": "kbn-content-management-utils-referenceSchema",
+        "type": "object"
+      },
+      "kbn-controls-schemas-controls-group-schema-esql-control": {
+        "additionalProperties": false,
+        "properties": {
+          "config": {
+            "discriminator": {
+              "propertyName": "control_type"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/kbn-controls-schemas-options-list-esql-control-schema-static-values"
+              },
+              {
+                "$ref": "#/components/schemas/kbn-controls-schemas-options-list-esql-control-schema-values-from-query"
+              }
+            ]
+          },
+          "grow": {
+            "default": false,
+            "description": "Expand width of the control panel to fit available space.",
+            "type": "boolean"
+          },
+          "id": {
+            "description": "The unique ID of the control",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "esql_control"
+            ],
+            "type": "string"
+          },
+          "width": {
+            "default": "medium",
+            "description": "Minimum width of the control panel in the control group.",
+            "enum": [
+              "small",
+              "medium",
+              "large"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "config"
+        ],
+        "title": "esql_control",
+        "type": "object"
+      },
+      "kbn-controls-schemas-controls-group-schema-options-list-control": {
+        "additionalProperties": false,
+        "properties": {
+          "config": {
+            "additionalProperties": false,
+            "properties": {
+              "data_view_id": {
+                "description": "The ID of the data view that the control is tied to",
+                "type": "string"
+              },
+              "display_settings": {
+                "additionalProperties": false,
+                "properties": {
+                  "hide_action_bar": {
+                    "type": "boolean"
+                  },
+                  "hide_exclude": {
+                    "type": "boolean"
+                  },
+                  "hide_exists": {
+                    "type": "boolean"
+                  },
+                  "hide_sort": {
+                    "type": "boolean"
+                  },
+                  "placeholder": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "exclude": {
+                "default": false,
+                "type": "boolean"
+              },
+              "exists_selected": {
+                "default": false,
+                "type": "boolean"
+              },
+              "field_name": {
+                "description": "The name of the field in the data view that the control is tied to",
+                "type": "string"
+              },
+              "ignore_validations": {
+                "default": false,
+                "type": "boolean"
+              },
+              "run_past_timeout": {
+                "default": false,
+                "type": "boolean"
+              },
+              "search_technique": {
+                "default": "wildcard",
+                "enum": [
+                  "prefix",
+                  "wildcard",
+                  "exact"
+                ],
+                "type": "string"
+              },
+              "selected_options": {
+                "default": [],
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
+                },
+                "maxItems": 10000,
+                "type": "array"
+              },
+              "single_select": {
+                "default": false,
+                "type": "boolean"
+              },
+              "sort": {
+                "additionalProperties": false,
+                "default": {
+                  "by": "_count",
+                  "direction": "desc"
+                },
+                "properties": {
+                  "by": {
+                    "enum": [
+                      "_count",
+                      "_key"
+                    ],
+                    "type": "string"
+                  },
+                  "direction": {
+                    "enum": [
+                      "asc",
+                      "desc"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "by",
+                  "direction"
+                ],
+                "type": "object"
+              },
+              "title": {
+                "description": "A human-readable title for the control",
+                "type": "string"
+              },
+              "use_global_filters": {
+                "default": true,
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "data_view_id",
+              "field_name"
+            ],
+            "type": "object"
+          },
+          "grow": {
+            "default": false,
+            "description": "Expand width of the control panel to fit available space.",
+            "type": "boolean"
+          },
+          "id": {
+            "description": "The unique ID of the control",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "options_list_control"
+            ],
+            "type": "string"
+          },
+          "width": {
+            "default": "medium",
+            "description": "Minimum width of the control panel in the control group.",
+            "enum": [
+              "small",
+              "medium",
+              "large"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "config"
+        ],
+        "title": "options_list_control",
+        "type": "object"
+      },
+      "kbn-controls-schemas-controls-group-schema-range-slider-control": {
+        "additionalProperties": false,
+        "properties": {
+          "config": {
+            "additionalProperties": false,
+            "properties": {
+              "data_view_id": {
+                "description": "The ID of the data view that the control is tied to",
+                "type": "string"
+              },
+              "field_name": {
+                "description": "The name of the field in the data view that the control is tied to",
+                "type": "string"
+              },
+              "ignore_validations": {
+                "default": false,
+                "type": "boolean"
+              },
+              "step": {
+                "default": 1,
+                "minimum": 0,
+                "type": "number"
+              },
+              "title": {
+                "description": "A human-readable title for the control",
+                "type": "string"
+              },
+              "use_global_filters": {
+                "default": true,
+                "type": "boolean"
+              },
+              "value": {
+                "items": {
+                  "type": "string"
+                },
+                "maxItems": 2,
+                "minItems": 2,
+                "type": "array"
+              }
+            },
+            "required": [
+              "data_view_id",
+              "field_name"
+            ],
+            "type": "object"
+          },
+          "grow": {
+            "default": false,
+            "description": "Expand width of the control panel to fit available space.",
+            "type": "boolean"
+          },
+          "id": {
+            "description": "The unique ID of the control",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "range_slider_control"
+            ],
+            "type": "string"
+          },
+          "width": {
+            "default": "medium",
+            "description": "Minimum width of the control panel in the control group.",
+            "enum": [
+              "small",
+              "medium",
+              "large"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "config"
+        ],
+        "title": "range_slider_control",
+        "type": "object"
+      },
+      "kbn-controls-schemas-controls-group-schema-time-slider-control": {
+        "additionalProperties": false,
+        "properties": {
+          "config": {
+            "additionalProperties": false,
+            "properties": {
+              "end_percentage_of_time_range": {
+                "default": 1,
+                "maximum": 1,
+                "minimum": 0,
+                "type": "number"
+              },
+              "is_anchored": {
+                "default": false,
+                "type": "boolean"
+              },
+              "start_percentage_of_time_range": {
+                "default": 0,
+                "maximum": 1,
+                "minimum": 0,
+                "type": "number"
+              }
+            },
+            "type": "object"
+          },
+          "grow": {
+            "default": false,
+            "description": "Expand width of the control panel to fit available space.",
+            "type": "boolean"
+          },
+          "id": {
+            "description": "The unique ID of the control",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "time_slider_control"
+            ],
+            "type": "string"
+          },
+          "width": {
+            "default": "medium",
+            "description": "Minimum width of the control panel in the control group.",
+            "enum": [
+              "small",
+              "medium",
+              "large"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "config"
+        ],
+        "title": "time_slider_control",
+        "type": "object"
+      },
+      "kbn-controls-schemas-options-list-esql-control-schema-static-values": {
+        "additionalProperties": false,
+        "properties": {
+          "available_options": {
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 1000,
+            "type": "array"
+          },
+          "control_type": {
+            "enum": [
+              "STATIC_VALUES"
+            ],
+            "type": "string"
+          },
+          "display_settings": {
+            "additionalProperties": false,
+            "properties": {
+              "hide_action_bar": {
+                "type": "boolean"
+              },
+              "hide_exclude": {
+                "type": "boolean"
+              },
+              "hide_exists": {
+                "type": "boolean"
+              },
+              "hide_sort": {
+                "type": "boolean"
+              },
+              "placeholder": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "selected_options": {
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 10000,
+            "type": "array"
+          },
+          "single_select": {
+            "default": true,
+            "type": "boolean"
+          },
+          "title": {
+            "description": "A human-readable title for the control",
+            "type": "string"
+          },
+          "variable_name": {
+            "type": "string"
+          },
+          "variable_type": {
+            "enum": [
+              "fields",
+              "values",
+              "functions",
+              "time_literal",
+              "multi_values"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "selected_options",
+          "variable_name",
+          "variable_type",
+          "control_type",
+          "available_options"
+        ],
+        "title": "kbn-controls-schemas-options-list-esql-control-schema-static-values",
+        "type": "object"
+      },
+      "kbn-controls-schemas-options-list-esql-control-schema-values-from-query": {
+        "additionalProperties": false,
+        "properties": {
+          "control_type": {
+            "enum": [
+              "VALUES_FROM_QUERY"
+            ],
+            "type": "string"
+          },
+          "display_settings": {
+            "additionalProperties": false,
+            "properties": {
+              "hide_action_bar": {
+                "type": "boolean"
+              },
+              "hide_exclude": {
+                "type": "boolean"
+              },
+              "hide_exists": {
+                "type": "boolean"
+              },
+              "hide_sort": {
+                "type": "boolean"
+              },
+              "placeholder": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "esql_query": {
+            "type": "string"
+          },
+          "selected_options": {
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 10000,
+            "type": "array"
+          },
+          "single_select": {
+            "default": true,
+            "type": "boolean"
+          },
+          "title": {
+            "description": "A human-readable title for the control",
+            "type": "string"
+          },
+          "variable_name": {
+            "type": "string"
+          },
+          "variable_type": {
+            "enum": [
+              "fields",
+              "values",
+              "functions",
+              "time_literal",
+              "multi_values"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "selected_options",
+          "variable_name",
+          "variable_type",
+          "control_type",
+          "esql_query"
+        ],
+        "title": "kbn-controls-schemas-options-list-esql-control-schema-values-from-query",
+        "type": "object"
+      },
+      "kbn-dashboard-data": {
+        "additionalProperties": false,
+        "properties": {
+          "access_control": {
+            "additionalProperties": false,
+            "properties": {
+              "access_mode": {
+                "enum": [
+                  "write_restricted",
+                  "default"
+                ],
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "description": {
+            "description": "A short description.",
+            "type": "string"
+          },
+          "filters": {
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/kbn-as-code-filters-schema_asCodeConditionFilterSchema"
+                },
+                {
+                  "$ref": "#/components/schemas/kbn-as-code-filters-schema_asCodeGroupFilterSchema"
+                },
+                {
+                  "$ref": "#/components/schemas/kbn-as-code-filters-schema_asCodeDSLFilterSchema"
+                },
+                {
+                  "$ref": "#/components/schemas/kbn-as-code-filters-schema_asCodeSpatialFilterSchema"
+                }
+              ],
+              "description": "A filter which can be a condition, group, DSL, or spatial"
+            },
+            "maxItems": 500,
+            "type": "array"
+          },
+          "options": {
+            "$ref": "#/components/schemas/kbn-dashboard-options"
+          },
+          "panels": {
+            "default": [],
+            "items": {
+              "anyOf": [
+                {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/kbn-dashboard-panel-type-discover_session"
+                    },
+                    {
+                      "$ref": "#/components/schemas/kbn-dashboard-panel-type-esql_control"
+                    },
+                    {
+                      "$ref": "#/components/schemas/kbn-dashboard-panel-type-image"
+                    },
+                    {
+                      "$ref": "#/components/schemas/kbn-dashboard-panel-type-markdown"
+                    },
+                    {
+                      "$ref": "#/components/schemas/kbn-dashboard-panel-type-options_list_control"
+                    },
+                    {
+                      "$ref": "#/components/schemas/kbn-dashboard-panel-type-range_slider_control"
+                    },
+                    {
+                      "$ref": "#/components/schemas/kbn-dashboard-panel-type-slo_alerts"
+                    },
+                    {
+                      "$ref": "#/components/schemas/kbn-dashboard-panel-type-slo_burn_rate"
+                    },
+                    {
+                      "$ref": "#/components/schemas/kbn-dashboard-panel-type-slo_error_budget"
+                    },
+                    {
+                      "$ref": "#/components/schemas/kbn-dashboard-panel-type-slo_overview"
+                    },
+                    {
+                      "$ref": "#/components/schemas/kbn-dashboard-panel-type-synthetics_monitors"
+                    },
+                    {
+                      "$ref": "#/components/schemas/kbn-dashboard-panel-type-synthetics_stats_overview"
+                    },
+                    {
+                      "$ref": "#/components/schemas/kbn-dashboard-panel-type-time_slider_control"
+                    },
+                    {
+                      "$ref": "#/components/schemas/kbn-dashboard-panel-type-vis"
+                    }
+                  ]
+                },
+                {
+                  "$ref": "#/components/schemas/kbn-dashboard-section"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "pinned_panels": {
+            "default": [],
+            "description": "An array of control panels and their state in the control group.",
+            "items": {
+              "discriminator": {
+                "propertyName": "type"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/kbn-controls-schemas-controls-group-schema-esql-control"
+                },
+                {
+                  "$ref": "#/components/schemas/kbn-controls-schemas-controls-group-schema-options-list-control"
+                },
+                {
+                  "$ref": "#/components/schemas/kbn-controls-schemas-controls-group-schema-range-slider-control"
+                },
+                {
+                  "$ref": "#/components/schemas/kbn-controls-schemas-controls-group-schema-time-slider-control"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "project_routing": {
+            "type": "string"
+          },
+          "query": {
+            "$ref": "#/components/schemas/kbn-as-code-query"
+          },
+          "refresh_interval": {
+            "$ref": "#/components/schemas/kbn-data-service-server-refreshIntervalSchema"
+          },
+          "tags": {
+            "items": {
+              "description": "An array of tags ids applied to this dashboard",
+              "type": "string"
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "time_range": {
+            "$ref": "#/components/schemas/kbn-es-query-server-timeRangeSchema"
+          },
+          "title": {
+            "description": "A human-readable title for the dashboard",
+            "type": "string"
+          }
+        },
+        "required": [
+          "options",
+          "query",
+          "refresh_interval",
+          "time_range",
+          "title"
+        ],
+        "title": "kbn-dashboard-data",
+        "type": "object"
+      },
+      "kbn-dashboard-dropped-panel-warning": {
+        "additionalProperties": false,
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "panel_config": {
+            "additionalProperties": true,
+            "properties": {},
+            "type": "object"
+          },
+          "panel_references": {
+            "items": {
+              "$ref": "#/components/schemas/kbn-content-management-utils-referenceSchema"
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "panel_type": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "dropped_panel"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "message",
+          "panel_type",
+          "panel_config"
+        ],
+        "title": "kbn-dashboard-dropped-panel-warning",
+        "type": "object"
+      },
+      "kbn-dashboard-options": {
+        "additionalProperties": false,
+        "default": {
+          "auto_apply_filters": true,
+          "hide_panel_borders": false,
+          "hide_panel_titles": false,
+          "sync_colors": false,
+          "sync_cursor": true,
+          "sync_tooltips": false,
+          "use_margins": true
+        },
+        "properties": {
+          "auto_apply_filters": {
+            "default": true,
+            "description": "Auto apply control filters.",
+            "type": "boolean"
+          },
+          "hide_panel_borders": {
+            "default": false,
+            "description": "Hide the panel borders in the dashboard.",
+            "type": "boolean"
+          },
+          "hide_panel_titles": {
+            "default": false,
+            "description": "Hide the panel titles in the dashboard.",
+            "type": "boolean"
+          },
+          "sync_colors": {
+            "default": false,
+            "description": "Synchronize colors between related panels in the dashboard.",
+            "type": "boolean"
+          },
+          "sync_cursor": {
+            "default": true,
+            "description": "Synchronize cursor position between related panels in the dashboard.",
+            "type": "boolean"
+          },
+          "sync_tooltips": {
+            "default": false,
+            "description": "Synchronize tooltips between related panels in the dashboard.",
+            "type": "boolean"
+          },
+          "use_margins": {
+            "default": true,
+            "description": "Show margins between panels in the dashboard layout.",
+            "type": "boolean"
+          }
+        },
+        "title": "kbn-dashboard-options",
+        "type": "object"
+      },
+      "kbn-dashboard-panel-grid": {
+        "additionalProperties": false,
+        "properties": {
+          "h": {
+            "default": 15,
+            "description": "The height of the panel in grid units",
+            "minimum": 1,
+            "type": "number"
+          },
+          "w": {
+            "default": 24,
+            "description": "The width of the panel in grid units",
+            "maximum": 48,
+            "minimum": 1,
+            "type": "number"
+          },
+          "x": {
+            "description": "The x coordinate of the panel in grid units",
+            "type": "number"
+          },
+          "y": {
+            "description": "The y coordinate of the panel in grid units",
+            "type": "number"
+          }
+        },
+        "required": [
+          "x",
+          "y"
+        ],
+        "title": "kbn-dashboard-panel-grid",
+        "type": "object"
+      },
+      "kbn-dashboard-panel-type-discover_session": {
+        "additionalProperties": false,
+        "properties": {
+          "config": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "description": "Panel configuration stored inline",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "drilldowns": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "encode_url": {
+                          "default": true,
+                          "description": "When true, URL is escaped using percent encoding",
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "open_in_new_tab": {
+                          "default": true,
+                          "type": "boolean"
+                        },
+                        "trigger": {
+                          "enum": [
+                            "on_open_panel_menu"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "enum": [
+                            "url_drilldown"
+                          ],
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "Templated Url. Variables documented at https://www.elastic.co/docs/explore-analyze/dashboards/drilldowns#url-template-variable",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "url",
+                        "label",
+                        "trigger",
+                        "type"
+                      ],
+                      "title": "url_drilldown",
+                      "type": "object"
+                    },
+                    "maxItems": 100,
+                    "type": "array"
+                  },
+                  "hide_border": {
+                    "type": "boolean"
+                  },
+                  "hide_title": {
+                    "type": "boolean"
+                  },
+                  "tabs": {
+                    "description": "Inline tab configuration. Used when no `ref_id` is set. Currently supports one tab.",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "column_order": {
+                              "description": "Ordered list of field names to display in the data table. If omitted, defaults to the advanced setting \"defaultColumns\" or the referenced saved object.",
+                              "items": {
+                                "description": "Field name of a column in display order.",
+                                "type": "string"
+                              },
+                              "maxItems": 100,
+                              "type": "array"
+                            },
+                            "column_settings": {
+                              "additionalProperties": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "width": {
+                                    "description": "Optional width of the column in pixels.",
+                                    "minimum": 0,
+                                    "type": "number"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "description": "Per-column presentation settings keyed by field name (e.g. widths). Keys should correspond to entries in `column_order` when both are set.",
+                              "type": "object"
+                            },
+                            "data_source": {
+                              "discriminator": {
+                                "propertyName": "type"
+                              },
+                              "oneOf": [
+                                {
+                                  "$ref": "#/components/schemas/kbn-data-view-reference-schema"
+                                },
+                                {
+                                  "$ref": "#/components/schemas/kbn-data-view-spec-schema"
+                                }
+                              ]
+                            },
+                            "density": {
+                              "description": "Data grid density. Choose \"compact\", \"expanded\", or \"normal\" for row spacing. If omitted, defaults to Discover or embeddable defaults (e.g. user preference / local storage).",
+                              "enum": [
+                                "compact",
+                                "expanded",
+                                "normal"
+                              ],
+                              "type": "string"
+                            },
+                            "filters": {
+                              "default": [],
+                              "description": "List of filters to apply to the data in the tab.",
+                              "items": {
+                                "description": "A filter which can be a condition, group, DSL, or spatial",
+                                "discriminator": {
+                                  "propertyName": "type"
+                                },
+                                "oneOf": [
+                                  {
+                                    "$ref": "#/components/schemas/kbn-as-code-filters-schema_asCodeConditionFilterSchema"
+                                  },
+                                  {
+                                    "$ref": "#/components/schemas/kbn-as-code-filters-schema_asCodeGroupFilterSchema"
+                                  },
+                                  {
+                                    "$ref": "#/components/schemas/kbn-as-code-filters-schema_asCodeDSLFilterSchema"
+                                  },
+                                  {
+                                    "$ref": "#/components/schemas/kbn-as-code-filters-schema_asCodeSpatialFilterSchema"
+                                  }
+                                ]
+                              },
+                              "maxItems": 100,
+                              "type": "array"
+                            },
+                            "header_row_height": {
+                              "anyOf": [
+                                {
+                                  "maximum": 5,
+                                  "minimum": 1,
+                                  "type": "number"
+                                },
+                                {
+                                  "enum": [
+                                    "auto"
+                                  ],
+                                  "type": "string"
+                                }
+                              ],
+                              "description": "Header row height. Use a number (1–5) or \"auto\" to size based on content. If omitted, defaults to Discover or embeddable defaults (e.g. user preference / local storage)."
+                            },
+                            "query": {
+                              "$ref": "#/components/schemas/kbn-as-code-query"
+                            },
+                            "row_height": {
+                              "anyOf": [
+                                {
+                                  "maximum": 20,
+                                  "minimum": 1,
+                                  "type": "number"
+                                },
+                                {
+                                  "enum": [
+                                    "auto"
+                                  ],
+                                  "type": "string"
+                                }
+                              ],
+                              "description": "Data row height. Use a number (1–20) or \"auto\" to size based on content. If omitted, defaults to the advanced setting \"discover:rowHeightOption\"."
+                            },
+                            "rows_per_page": {
+                              "description": "The number of rows to display per page in the data table. If omitted, defaults to the advanced setting \"discover:sampleRowsPerPage\".",
+                              "maximum": 10000,
+                              "minimum": 1,
+                              "type": "number"
+                            },
+                            "sample_size": {
+                              "description": "The number of documents to sample for the data table. If omitted, defaults to the advanced setting \"discover:sampleSize\".",
+                              "maximum": 10000,
+                              "minimum": 10,
+                              "type": "number"
+                            },
+                            "sort": {
+                              "default": [],
+                              "description": "Sort configuration for the data table (field and direction).",
+                              "items": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "direction": {
+                                    "description": "The direction to sort the field by: Use \"asc\" for ascending or \"desc\" for descending.",
+                                    "enum": [
+                                      "asc",
+                                      "desc"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "The name of the field to sort by.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "direction"
+                                ],
+                                "type": "object"
+                              },
+                              "maxItems": 100,
+                              "type": "array"
+                            },
+                            "view_mode": {
+                              "default": "documents",
+                              "description": "Discover view mode. Choose \"documents\" (search hits), \"patterns\" (pattern analysis), or \"aggregated\" (field statistics).",
+                              "enum": [
+                                "documents",
+                                "patterns",
+                                "aggregated"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "query",
+                            "data_source"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "column_order": {
+                              "description": "Ordered list of field names to display in the data table. If omitted, defaults to the advanced setting \"defaultColumns\" or the referenced saved object.",
+                              "items": {
+                                "description": "Field name of a column in display order.",
+                                "type": "string"
+                              },
+                              "maxItems": 100,
+                              "type": "array"
+                            },
+                            "column_settings": {
+                              "additionalProperties": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "width": {
+                                    "description": "Optional width of the column in pixels.",
+                                    "minimum": 0,
+                                    "type": "number"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "description": "Per-column presentation settings keyed by field name (e.g. widths). Keys should correspond to entries in `column_order` when both are set.",
+                              "type": "object"
+                            },
+                            "data_source": {
+                              "$ref": "#/components/schemas/esqlDataSource"
+                            },
+                            "density": {
+                              "description": "Data grid density. Choose \"compact\", \"expanded\", or \"normal\" for row spacing. If omitted, defaults to Discover or embeddable defaults (e.g. user preference / local storage).",
+                              "enum": [
+                                "compact",
+                                "expanded",
+                                "normal"
+                              ],
+                              "type": "string"
+                            },
+                            "header_row_height": {
+                              "anyOf": [
+                                {
+                                  "maximum": 5,
+                                  "minimum": 1,
+                                  "type": "number"
+                                },
+                                {
+                                  "enum": [
+                                    "auto"
+                                  ],
+                                  "type": "string"
+                                }
+                              ],
+                              "description": "Header row height. Use a number (1–5) or \"auto\" to size based on content. If omitted, defaults to Discover or embeddable defaults (e.g. user preference / local storage)."
+                            },
+                            "row_height": {
+                              "anyOf": [
+                                {
+                                  "maximum": 20,
+                                  "minimum": 1,
+                                  "type": "number"
+                                },
+                                {
+                                  "enum": [
+                                    "auto"
+                                  ],
+                                  "type": "string"
+                                }
+                              ],
+                              "description": "Data row height. Use a number (1–20) or \"auto\" to size based on content. If omitted, defaults to the advanced setting \"discover:rowHeightOption\"."
+                            },
+                            "sort": {
+                              "default": [],
+                              "description": "Sort configuration for the data table (field and direction).",
+                              "items": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "direction": {
+                                    "description": "The direction to sort the field by: Use \"asc\" for ascending or \"desc\" for descending.",
+                                    "enum": [
+                                      "asc",
+                                      "desc"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "The name of the field to sort by.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "direction"
+                                ],
+                                "type": "object"
+                              },
+                              "maxItems": 100,
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "data_source"
+                          ],
+                          "type": "object"
+                        }
+                      ]
+                    },
+                    "maxItems": 1,
+                    "minItems": 1,
+                    "type": "array"
+                  },
+                  "time_range": {
+                    "$ref": "#/components/schemas/kbn-es-query-server-timeRangeSchema"
+                  },
+                  "title": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "time_range",
+                  "tabs"
+                ],
+                "title": "By value",
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "description": "Panel configuration stored in a linked library item",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "drilldowns": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "encode_url": {
+                          "default": true,
+                          "description": "When true, URL is escaped using percent encoding",
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "open_in_new_tab": {
+                          "default": true,
+                          "type": "boolean"
+                        },
+                        "trigger": {
+                          "enum": [
+                            "on_open_panel_menu"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "enum": [
+                            "url_drilldown"
+                          ],
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "Templated Url. Variables documented at https://www.elastic.co/docs/explore-analyze/dashboards/drilldowns#url-template-variable",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "url",
+                        "label",
+                        "trigger",
+                        "type"
+                      ],
+                      "title": "url_drilldown",
+                      "type": "object"
+                    },
+                    "maxItems": 100,
+                    "type": "array"
+                  },
+                  "hide_border": {
+                    "type": "boolean"
+                  },
+                  "hide_title": {
+                    "type": "boolean"
+                  },
+                  "overrides": {
+                    "additionalProperties": false,
+                    "default": {},
+                    "properties": {
+                      "column_order": {
+                        "description": "When set, overrides column order for the data table relative to the referenced saved object (`ref_id`) or the inline tab in `tabs`. If omitted, the source configuration is used.",
+                        "items": {
+                          "description": "Field name of a column in display order.",
+                          "type": "string"
+                        },
+                        "maxItems": 100,
+                        "type": "array"
+                      },
+                      "column_settings": {
+                        "additionalProperties": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "width": {
+                              "description": "Optional width of the column in pixels.",
+                              "minimum": 0,
+                              "type": "number"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "description": "Per-column presentation overrides (e.g. widths) keyed by field name. When set, merges with the source configuration for the referenced session or inline tab.",
+                        "type": "object"
+                      },
+                      "density": {
+                        "description": "Data grid row spacing: `compact`, `expanded`, or `normal`. When set, overrides the referenced saved object or the inline tab config in `tabs`. If omitted, the source configuration is used.",
+                        "enum": [
+                          "compact",
+                          "expanded",
+                          "normal"
+                        ],
+                        "type": "string"
+                      },
+                      "header_row_height": {
+                        "anyOf": [
+                          {
+                            "maximum": 5,
+                            "minimum": 1,
+                            "type": "number"
+                          },
+                          {
+                            "enum": [
+                              "auto"
+                            ],
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Header row height: number (1–5) or `auto`. When set, overrides the referenced saved object or the inline tab config in `tabs`. If omitted, the source configuration is used."
+                      },
+                      "row_height": {
+                        "anyOf": [
+                          {
+                            "maximum": 20,
+                            "minimum": 1,
+                            "type": "number"
+                          },
+                          {
+                            "enum": [
+                              "auto"
+                            ],
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Data row height: number (1–20) or `auto`. When set, overrides the referenced saved object or the inline tab config in `tabs`. If omitted, falls back to the source or to the advanced setting \"discover:rowHeightOption\"."
+                      },
+                      "rows_per_page": {
+                        "description": "Number of rows per page. When set, overrides the referenced saved object or the inline tab config in `tabs`. If omitted, falls back to the source or to the advanced setting \"discover:sampleRowsPerPage\".",
+                        "maximum": 10000,
+                        "minimum": 1,
+                        "type": "number"
+                      },
+                      "sample_size": {
+                        "description": "Number of documents to sample. When set, overrides the referenced saved object or the inline tab config in `tabs`. If omitted, falls back to the source or to the advanced setting \"discover:sampleSize\".",
+                        "maximum": 10000,
+                        "minimum": 10,
+                        "type": "number"
+                      },
+                      "sort": {
+                        "description": "Sort configuration (field and direction) for the data table. When set, overrides the referenced saved object or the inline tab config in `tabs`. If omitted, the source configuration is used.",
+                        "items": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "direction": {
+                              "description": "The direction to sort the field by: Use \"asc\" for ascending or \"desc\" for descending.",
+                              "enum": [
+                                "asc",
+                                "desc"
+                              ],
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "The name of the field to sort by.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "direction"
+                          ],
+                          "type": "object"
+                        },
+                        "maxItems": 100,
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "ref_id": {
+                    "type": "string"
+                  },
+                  "selected_tab_id": {
+                    "description": "Tab to select from the referenced saved object. If omitted, defaults to the first tab.",
+                    "type": "string"
+                  },
+                  "time_range": {
+                    "$ref": "#/components/schemas/kbn-es-query-server-timeRangeSchema"
+                  },
+                  "title": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "time_range",
+                  "ref_id"
+                ],
+                "title": "By reference",
+                "type": "object"
+              }
+            ]
+          },
+          "grid": {
+            "$ref": "#/components/schemas/kbn-dashboard-panel-grid"
+          },
+          "id": {
+            "description": "The unique ID of the panel.",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "discover_session"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "grid",
+          "type",
+          "config"
+        ],
+        "title": "discover_session",
+        "type": "object"
+      },
+      "kbn-dashboard-panel-type-esql_control": {
+        "additionalProperties": false,
+        "properties": {
+          "config": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/kbn-controls-schemas-options-list-esql-control-schema-static-values"
+              },
+              {
+                "$ref": "#/components/schemas/kbn-controls-schemas-options-list-esql-control-schema-values-from-query"
+              }
+            ]
+          },
+          "grid": {
+            "$ref": "#/components/schemas/kbn-dashboard-panel-grid"
+          },
+          "id": {
+            "description": "The unique ID of the panel.",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "esql_control"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "grid",
+          "type",
+          "config"
+        ],
+        "title": "esql_control",
+        "type": "object"
+      },
+      "kbn-dashboard-panel-type-image": {
+        "additionalProperties": false,
+        "properties": {
+          "config": {
+            "additionalProperties": false,
+            "description": "Image embeddable schema",
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "drilldowns": {
+                "items": {
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "dashboard_id": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "open_in_new_tab": {
+                          "default": false,
+                          "description": "When enabled, the dashboard opens in a new browser tab.",
+                          "type": "boolean"
+                        },
+                        "trigger": {
+                          "enum": [
+                            "on_click_image"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "enum": [
+                            "dashboard_drilldown"
+                          ],
+                          "type": "string"
+                        },
+                        "use_filters": {
+                          "default": true,
+                          "description": "When enabled, filters are passed to the opening dashboard.",
+                          "type": "boolean"
+                        },
+                        "use_time_range": {
+                          "default": true,
+                          "description": "When enabled, time range is passed to the opening dashboard.",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "dashboard_id",
+                        "label",
+                        "trigger",
+                        "type"
+                      ],
+                      "title": "dashboard_drilldown",
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "encode_url": {
+                          "default": true,
+                          "description": "When true, URL is escaped using percent encoding",
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "open_in_new_tab": {
+                          "default": true,
+                          "type": "boolean"
+                        },
+                        "trigger": {
+                          "enum": [
+                            "on_click_image",
+                            "on_open_panel_menu"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "enum": [
+                            "url_drilldown"
+                          ],
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "Templated Url. Variables documented at https://www.elastic.co/docs/explore-analyze/dashboards/drilldowns#url-template-variable",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "url",
+                        "label",
+                        "trigger",
+                        "type"
+                      ],
+                      "title": "url_drilldown",
+                      "type": "object"
+                    }
+                  ]
+                },
+                "maxItems": 100,
+                "type": "array"
+              },
+              "hide_border": {
+                "type": "boolean"
+              },
+              "hide_title": {
+                "type": "boolean"
+              },
+              "image_config": {
+                "additionalProperties": false,
+                "properties": {
+                  "alt_text": {
+                    "type": "string"
+                  },
+                  "background_color": {
+                    "type": "string"
+                  },
+                  "object_fit": {
+                    "default": "contain",
+                    "description": "How the image should be sized within its container",
+                    "enum": [
+                      "fill",
+                      "contain",
+                      "cover",
+                      "none"
+                    ],
+                    "type": "string"
+                  },
+                  "src": {
+                    "anyOf": [
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "file_id": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "enum": [
+                              "file"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "file_id"
+                        ],
+                        "title": "file",
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "type": {
+                            "enum": [
+                              "url"
+                            ],
+                            "type": "string"
+                          },
+                          "url": {
+                            "description": "URL of the image",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "url"
+                        ],
+                        "title": "url",
+                        "type": "object"
+                      }
+                    ],
+                    "description": "Image source"
+                  }
+                },
+                "required": [
+                  "src"
+                ],
+                "type": "object"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "image_config"
+            ],
+            "type": "object"
+          },
+          "grid": {
+            "$ref": "#/components/schemas/kbn-dashboard-panel-grid"
+          },
+          "id": {
+            "description": "The unique ID of the panel.",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "image"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "grid",
+          "type",
+          "config"
+        ],
+        "title": "image",
+        "type": "object"
+      },
+      "kbn-dashboard-panel-type-markdown": {
+        "additionalProperties": false,
+        "properties": {
+          "config": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "description": "Panel configuration stored inline",
+                "properties": {
+                  "content": {
+                    "default": "",
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "hide_border": {
+                    "type": "boolean"
+                  },
+                  "hide_title": {
+                    "type": "boolean"
+                  },
+                  "settings": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "open_links_in_new_tab": {
+                        "default": true,
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "title": {
+                    "type": "string"
+                  }
+                },
+                "title": "By value",
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "description": "Panel configuration stored in a linked library item",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "hide_border": {
+                    "type": "boolean"
+                  },
+                  "hide_title": {
+                    "type": "boolean"
+                  },
+                  "ref_id": {
+                    "description": "The unique identifier of the markdown library item.",
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "ref_id"
+                ],
+                "title": "By reference",
+                "type": "object"
+              }
+            ],
+            "default": {
+              "content": "",
+              "settings": {
+                "open_links_in_new_tab": true
+              }
+            },
+            "description": "Markdown panel config"
+          },
+          "grid": {
+            "$ref": "#/components/schemas/kbn-dashboard-panel-grid"
+          },
+          "id": {
+            "description": "The unique ID of the panel.",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "markdown"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "grid",
+          "type"
+        ],
+        "title": "markdown",
+        "type": "object"
+      },
+      "kbn-dashboard-panel-type-options_list_control": {
+        "additionalProperties": false,
+        "properties": {
+          "config": {
+            "additionalProperties": false,
+            "properties": {
+              "data_view_id": {
+                "description": "The ID of the data view that the control is tied to",
+                "type": "string"
+              },
+              "display_settings": {
+                "additionalProperties": false,
+                "properties": {
+                  "hide_action_bar": {
+                    "type": "boolean"
+                  },
+                  "hide_exclude": {
+                    "type": "boolean"
+                  },
+                  "hide_exists": {
+                    "type": "boolean"
+                  },
+                  "hide_sort": {
+                    "type": "boolean"
+                  },
+                  "placeholder": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "exclude": {
+                "default": false,
+                "type": "boolean"
+              },
+              "exists_selected": {
+                "default": false,
+                "type": "boolean"
+              },
+              "field_name": {
+                "description": "The name of the field in the data view that the control is tied to",
+                "type": "string"
+              },
+              "ignore_validations": {
+                "default": false,
+                "type": "boolean"
+              },
+              "run_past_timeout": {
+                "default": false,
+                "type": "boolean"
+              },
+              "search_technique": {
+                "default": "wildcard",
+                "enum": [
+                  "prefix",
+                  "wildcard",
+                  "exact"
+                ],
+                "type": "string"
+              },
+              "selected_options": {
+                "default": [],
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
+                },
+                "maxItems": 10000,
+                "type": "array"
+              },
+              "single_select": {
+                "default": false,
+                "type": "boolean"
+              },
+              "sort": {
+                "additionalProperties": false,
+                "default": {
+                  "by": "_count",
+                  "direction": "desc"
+                },
+                "properties": {
+                  "by": {
+                    "enum": [
+                      "_count",
+                      "_key"
+                    ],
+                    "type": "string"
+                  },
+                  "direction": {
+                    "enum": [
+                      "asc",
+                      "desc"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "by",
+                  "direction"
+                ],
+                "type": "object"
+              },
+              "title": {
+                "description": "A human-readable title for the control",
+                "type": "string"
+              },
+              "use_global_filters": {
+                "default": true,
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "data_view_id",
+              "field_name"
+            ],
+            "type": "object"
+          },
+          "grid": {
+            "$ref": "#/components/schemas/kbn-dashboard-panel-grid"
+          },
+          "id": {
+            "description": "The unique ID of the panel.",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "options_list_control"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "grid",
+          "type",
+          "config"
+        ],
+        "title": "options_list_control",
+        "type": "object"
+      },
+      "kbn-dashboard-panel-type-range_slider_control": {
+        "additionalProperties": false,
+        "properties": {
+          "config": {
+            "additionalProperties": false,
+            "properties": {
+              "data_view_id": {
+                "description": "The ID of the data view that the control is tied to",
+                "type": "string"
+              },
+              "field_name": {
+                "description": "The name of the field in the data view that the control is tied to",
+                "type": "string"
+              },
+              "ignore_validations": {
+                "default": false,
+                "type": "boolean"
+              },
+              "step": {
+                "default": 1,
+                "minimum": 0,
+                "type": "number"
+              },
+              "title": {
+                "description": "A human-readable title for the control",
+                "type": "string"
+              },
+              "use_global_filters": {
+                "default": true,
+                "type": "boolean"
+              },
+              "value": {
+                "items": {
+                  "type": "string"
+                },
+                "maxItems": 2,
+                "minItems": 2,
+                "type": "array"
+              }
+            },
+            "required": [
+              "data_view_id",
+              "field_name"
+            ],
+            "type": "object"
+          },
+          "grid": {
+            "$ref": "#/components/schemas/kbn-dashboard-panel-grid"
+          },
+          "id": {
+            "description": "The unique ID of the panel.",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "range_slider_control"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "grid",
+          "type",
+          "config"
+        ],
+        "title": "range_slider_control",
+        "type": "object"
+      },
+      "kbn-dashboard-panel-type-slo_alerts": {
+        "additionalProperties": false,
+        "properties": {
+          "config": {
+            "$ref": "#/components/schemas/slo-alerts-embeddable"
+          },
+          "grid": {
+            "$ref": "#/components/schemas/kbn-dashboard-panel-grid"
+          },
+          "id": {
+            "description": "The unique ID of the panel.",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "slo_alerts"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "grid",
+          "type",
+          "config"
+        ],
+        "title": "slo_alerts",
+        "type": "object"
+      },
+      "kbn-dashboard-panel-type-slo_burn_rate": {
+        "additionalProperties": false,
+        "properties": {
+          "config": {
+            "$ref": "#/components/schemas/slo-burn-rate-embeddable"
+          },
+          "grid": {
+            "$ref": "#/components/schemas/kbn-dashboard-panel-grid"
+          },
+          "id": {
+            "description": "The unique ID of the panel.",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "slo_burn_rate"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "grid",
+          "type",
+          "config"
+        ],
+        "title": "slo_burn_rate",
+        "type": "object"
+      },
+      "kbn-dashboard-panel-type-slo_error_budget": {
+        "additionalProperties": false,
+        "properties": {
+          "config": {
+            "$ref": "#/components/schemas/slo-error-budget-embeddable"
+          },
+          "grid": {
+            "$ref": "#/components/schemas/kbn-dashboard-panel-grid"
+          },
+          "id": {
+            "description": "The unique ID of the panel.",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "slo_error_budget"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "grid",
+          "type",
+          "config"
+        ],
+        "title": "slo_error_budget",
+        "type": "object"
+      },
+      "kbn-dashboard-panel-type-slo_overview": {
+        "additionalProperties": false,
+        "properties": {
+          "config": {
+            "description": "SLO Overview embeddable schema",
+            "discriminator": {
+              "propertyName": "overview_mode"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/slo-single-overview-embeddable"
+              },
+              {
+                "$ref": "#/components/schemas/slo-group-overview-embeddable"
+              }
+            ]
+          },
+          "grid": {
+            "$ref": "#/components/schemas/kbn-dashboard-panel-grid"
+          },
+          "id": {
+            "description": "The unique ID of the panel.",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "slo_overview"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "grid",
+          "type",
+          "config"
+        ],
+        "title": "slo_overview",
+        "type": "object"
+      },
+      "kbn-dashboard-panel-type-synthetics_monitors": {
+        "additionalProperties": false,
+        "properties": {
+          "config": {
+            "additionalProperties": false,
+            "description": "Synthetics monitors embeddable schema",
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "filters": {
+                "additionalProperties": false,
+                "properties": {
+                  "locations": {
+                    "description": "Filter by monitor locations",
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "label": {
+                          "description": "Display label for the filter option",
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Value for the filter option",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 100,
+                    "type": "array"
+                  },
+                  "monitor_ids": {
+                    "description": "Filter by monitor IDs",
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "label": {
+                          "description": "Display label for the filter option",
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Value for the filter option",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 5000,
+                    "type": "array"
+                  },
+                  "monitor_types": {
+                    "description": "Filter by monitor types",
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "label": {
+                          "description": "Display label for the filter option",
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Value for the filter option",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 10,
+                    "type": "array"
+                  },
+                  "projects": {
+                    "description": "Filter by project",
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "label": {
+                          "description": "Display label for the filter option",
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Value for the filter option",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 100,
+                    "type": "array"
+                  },
+                  "tags": {
+                    "description": "Filter by tags",
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "label": {
+                          "description": "Display label for the filter option",
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Value for the filter option",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 100,
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "hide_border": {
+                "type": "boolean"
+              },
+              "hide_title": {
+                "type": "boolean"
+              },
+              "title": {
+                "type": "string"
+              },
+              "view": {
+                "description": "View mode for the monitors embeddable (defaults to cardView)",
+                "enum": [
+                  "cardView",
+                  "compactView"
+                ],
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "grid": {
+            "$ref": "#/components/schemas/kbn-dashboard-panel-grid"
+          },
+          "id": {
+            "description": "The unique ID of the panel.",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "synthetics_monitors"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "grid",
+          "type",
+          "config"
+        ],
+        "title": "synthetics_monitors",
+        "type": "object"
+      },
+      "kbn-dashboard-panel-type-synthetics_stats_overview": {
+        "additionalProperties": false,
+        "properties": {
+          "config": {
+            "additionalProperties": false,
+            "description": "Synthetics stats overview embeddable schema",
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "drilldowns": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "encode_url": {
+                      "default": true,
+                      "description": "When true, URL is escaped using percent encoding",
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_open_panel_menu"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "url_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "url": {
+                      "description": "Templated Url. Variables documented at https://www.elastic.co/docs/explore-analyze/dashboards/drilldowns#url-template-variable",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "url",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "url_drilldown",
+                  "type": "object"
+                },
+                "maxItems": 100,
+                "type": "array"
+              },
+              "filters": {
+                "additionalProperties": false,
+                "properties": {
+                  "locations": {
+                    "description": "Filter by monitor locations",
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "label": {
+                          "description": "Display label for the filter option",
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Value for the filter option",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 100,
+                    "type": "array"
+                  },
+                  "monitor_ids": {
+                    "description": "Filter by monitor IDs",
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "label": {
+                          "description": "Display label for the filter option",
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Value for the filter option",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 5000,
+                    "type": "array"
+                  },
+                  "monitor_types": {
+                    "description": "Filter by monitor types",
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "label": {
+                          "description": "Display label for the filter option",
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Value for the filter option",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 10,
+                    "type": "array"
+                  },
+                  "projects": {
+                    "description": "Filter by project",
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "label": {
+                          "description": "Display label for the filter option",
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Value for the filter option",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 100,
+                    "type": "array"
+                  },
+                  "tags": {
+                    "description": "Filter by tags",
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "label": {
+                          "description": "Display label for the filter option",
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Value for the filter option",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "label",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 100,
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "hide_border": {
+                "type": "boolean"
+              },
+              "hide_title": {
+                "type": "boolean"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "grid": {
+            "$ref": "#/components/schemas/kbn-dashboard-panel-grid"
+          },
+          "id": {
+            "description": "The unique ID of the panel.",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "synthetics_stats_overview"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "grid",
+          "type",
+          "config"
+        ],
+        "title": "synthetics_stats_overview",
+        "type": "object"
+      },
+      "kbn-dashboard-panel-type-time_slider_control": {
+        "additionalProperties": false,
+        "properties": {
+          "config": {
+            "additionalProperties": false,
+            "properties": {
+              "end_percentage_of_time_range": {
+                "default": 1,
+                "maximum": 1,
+                "minimum": 0,
+                "type": "number"
+              },
+              "is_anchored": {
+                "default": false,
+                "type": "boolean"
+              },
+              "start_percentage_of_time_range": {
+                "default": 0,
+                "maximum": 1,
+                "minimum": 0,
+                "type": "number"
+              }
+            },
+            "type": "object"
+          },
+          "grid": {
+            "$ref": "#/components/schemas/kbn-dashboard-panel-grid"
+          },
+          "id": {
+            "description": "The unique ID of the panel.",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "time_slider_control"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "grid",
+          "type",
+          "config"
+        ],
+        "title": "time_slider_control",
+        "type": "object"
+      },
+      "kbn-dashboard-panel-type-vis": {
+        "additionalProperties": false,
+        "properties": {
+          "config": {
+            "anyOf": [
+              {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/metricNoESQL"
+                  },
+                  {
+                    "$ref": "#/components/schemas/metricESQL"
+                  },
+                  {
+                    "$ref": "#/components/schemas/legacyMetricNoESQL"
+                  },
+                  {
+                    "$ref": "#/components/schemas/xyChartNoESQL"
+                  },
+                  {
+                    "$ref": "#/components/schemas/xyChartESQL"
+                  },
+                  {
+                    "$ref": "#/components/schemas/gaugeNoESQL"
+                  },
+                  {
+                    "$ref": "#/components/schemas/gaugeESQL"
+                  },
+                  {
+                    "$ref": "#/components/schemas/heatmapNoESQL"
+                  },
+                  {
+                    "$ref": "#/components/schemas/heatmapESQL"
+                  },
+                  {
+                    "$ref": "#/components/schemas/tagcloudNoESQL"
+                  },
+                  {
+                    "$ref": "#/components/schemas/tagcloudESQL"
+                  },
+                  {
+                    "$ref": "#/components/schemas/regionMapNoESQL"
+                  },
+                  {
+                    "$ref": "#/components/schemas/regionMapESQL"
+                  },
+                  {
+                    "$ref": "#/components/schemas/datatableNoESQL"
+                  },
+                  {
+                    "$ref": "#/components/schemas/datatableESQL"
+                  },
+                  {
+                    "$ref": "#/components/schemas/pieNoESQL"
+                  },
+                  {
+                    "$ref": "#/components/schemas/pieESQL"
+                  },
+                  {
+                    "$ref": "#/components/schemas/mosaicNoESQL"
+                  },
+                  {
+                    "$ref": "#/components/schemas/mosaicESQL"
+                  },
+                  {
+                    "$ref": "#/components/schemas/treemapNoESQL"
+                  },
+                  {
+                    "$ref": "#/components/schemas/treemapESQL"
+                  },
+                  {
+                    "$ref": "#/components/schemas/waffleNoESQL"
+                  },
+                  {
+                    "$ref": "#/components/schemas/waffleESQL"
+                  }
+                ],
+                "description": "Panel configuration stored inline",
+                "title": "By value"
+              },
+              {
+                "additionalProperties": false,
+                "description": "Panel configuration stored in a linked library item",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "drilldowns": {
+                    "items": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "dashboard_id": {
+                              "type": "string"
+                            },
+                            "label": {
+                              "type": "string"
+                            },
+                            "open_in_new_tab": {
+                              "default": false,
+                              "description": "When enabled, the dashboard opens in a new browser tab.",
+                              "type": "boolean"
+                            },
+                            "trigger": {
+                              "enum": [
+                                "on_apply_filter"
+                              ],
+                              "type": "string"
+                            },
+                            "type": {
+                              "enum": [
+                                "dashboard_drilldown"
+                              ],
+                              "type": "string"
+                            },
+                            "use_filters": {
+                              "default": true,
+                              "description": "When enabled, filters are passed to the opening dashboard.",
+                              "type": "boolean"
+                            },
+                            "use_time_range": {
+                              "default": true,
+                              "description": "When enabled, time range is passed to the opening dashboard.",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "dashboard_id",
+                            "label",
+                            "trigger",
+                            "type"
+                          ],
+                          "title": "dashboard_drilldown",
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "label": {
+                              "type": "string"
+                            },
+                            "open_in_new_tab": {
+                              "default": true,
+                              "type": "boolean"
+                            },
+                            "trigger": {
+                              "enum": [
+                                "on_apply_filter"
+                              ],
+                              "type": "string"
+                            },
+                            "type": {
+                              "enum": [
+                                "discover_drilldown"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "label",
+                            "trigger",
+                            "type"
+                          ],
+                          "title": "discover_drilldown",
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "encode_url": {
+                              "default": true,
+                              "description": "When true, URL is escaped using percent encoding",
+                              "type": "boolean"
+                            },
+                            "label": {
+                              "type": "string"
+                            },
+                            "open_in_new_tab": {
+                              "default": true,
+                              "type": "boolean"
+                            },
+                            "trigger": {
+                              "enum": [
+                                "on_click_row",
+                                "on_click_value",
+                                "on_open_panel_menu",
+                                "on_select_range"
+                              ],
+                              "type": "string"
+                            },
+                            "type": {
+                              "enum": [
+                                "url_drilldown"
+                              ],
+                              "type": "string"
+                            },
+                            "url": {
+                              "description": "Templated Url. Variables documented at https://www.elastic.co/docs/explore-analyze/dashboards/drilldowns#url-template-variable",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "url",
+                            "label",
+                            "trigger",
+                            "type"
+                          ],
+                          "title": "url_drilldown",
+                          "type": "object"
+                        }
+                      ]
+                    },
+                    "maxItems": 100,
+                    "type": "array"
+                  },
+                  "hide_border": {
+                    "type": "boolean"
+                  },
+                  "hide_title": {
+                    "type": "boolean"
+                  },
+                  "ref_id": {
+                    "type": "string"
+                  },
+                  "references": {
+                    "items": {
+                      "$ref": "#/components/schemas/kbn-content-management-utils-referenceSchema"
+                    },
+                    "type": "array"
+                  },
+                  "time_range": {
+                    "$ref": "#/components/schemas/kbn-es-query-server-timeRangeSchema"
+                  },
+                  "title": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "ref_id",
+                  "time_range"
+                ],
+                "title": "By reference",
+                "type": "object"
+              }
+            ],
+            "description": "Lens embeddable schema"
+          },
+          "grid": {
+            "$ref": "#/components/schemas/kbn-dashboard-panel-grid"
+          },
+          "id": {
+            "description": "The unique ID of the panel.",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "vis"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "grid",
+          "type",
+          "config"
+        ],
+        "title": "vis",
+        "type": "object"
+      },
+      "kbn-dashboard-section": {
+        "additionalProperties": false,
+        "description": "Collapsable section",
+        "properties": {
+          "collapsed": {
+            "default": false,
+            "description": "The collapsed state of the section.",
+            "type": "boolean"
+          },
+          "grid": {
+            "additionalProperties": false,
+            "properties": {
+              "y": {
+                "description": "The y coordinate of the section in grid units",
+                "type": "number"
+              }
+            },
+            "required": [
+              "y"
+            ],
+            "type": "object"
+          },
+          "id": {
+            "description": "The unique ID of the section.",
+            "type": "string"
+          },
+          "panels": {
+            "default": [],
+            "description": "The panels that belong to the section.",
+            "items": {
+              "discriminator": {
+                "propertyName": "type"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/kbn-dashboard-panel-type-discover_session"
+                },
+                {
+                  "$ref": "#/components/schemas/kbn-dashboard-panel-type-esql_control"
+                },
+                {
+                  "$ref": "#/components/schemas/kbn-dashboard-panel-type-image"
+                },
+                {
+                  "$ref": "#/components/schemas/kbn-dashboard-panel-type-markdown"
+                },
+                {
+                  "$ref": "#/components/schemas/kbn-dashboard-panel-type-options_list_control"
+                },
+                {
+                  "$ref": "#/components/schemas/kbn-dashboard-panel-type-range_slider_control"
+                },
+                {
+                  "$ref": "#/components/schemas/kbn-dashboard-panel-type-slo_alerts"
+                },
+                {
+                  "$ref": "#/components/schemas/kbn-dashboard-panel-type-slo_burn_rate"
+                },
+                {
+                  "$ref": "#/components/schemas/kbn-dashboard-panel-type-slo_error_budget"
+                },
+                {
+                  "$ref": "#/components/schemas/kbn-dashboard-panel-type-slo_overview"
+                },
+                {
+                  "$ref": "#/components/schemas/kbn-dashboard-panel-type-synthetics_monitors"
+                },
+                {
+                  "$ref": "#/components/schemas/kbn-dashboard-panel-type-synthetics_stats_overview"
+                },
+                {
+                  "$ref": "#/components/schemas/kbn-dashboard-panel-type-time_slider_control"
+                },
+                {
+                  "$ref": "#/components/schemas/kbn-dashboard-panel-type-vis"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "title": {
+            "description": "The title of the section.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "grid"
+        ],
+        "title": "section",
+        "type": "object"
+      },
+      "kbn-data-service-server-refreshIntervalSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "pause": {
+            "description": "Set to false to auto-refresh data on an interval.",
+            "type": "boolean"
+          },
+          "value": {
+            "description": "A numeric value indicating refresh frequency in milliseconds.",
+            "type": "number"
+          }
+        },
+        "required": [
+          "pause",
+          "value"
+        ],
+        "title": "kbn-data-service-server-refreshIntervalSchema",
+        "type": "object",
+        "x-oas-optional": true
+      },
+      "kbn-data-view-reference-schema": {
+        "additionalProperties": false,
+        "properties": {
+          "ref_id": {
+            "description": "The id of the Kibana data view to use as the data source. Example: \"my-data-view\".",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "data_view_reference"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "ref_id"
+        ],
+        "title": "Data view reference",
+        "type": "object"
+      },
+      "kbn-data-view-spec-schema": {
+        "additionalProperties": false,
+        "properties": {
+          "index_pattern": {
+            "description": "The index pattern (Elasticsearch index expression) to use as the data source. Example: \"my-index-*\".",
+            "type": "string"
+          },
+          "runtime_fields": {
+            "items": {
+              "discriminator": {
+                "propertyName": "type"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/kbn-composite-runtime-field-schema"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "time_field": {
+            "description": "The name of the time field in the index. Used for time-based filtering. Example: \"@timestamp\".",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "data_view_spec"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "index_pattern"
+        ],
+        "title": "Data view inline spec",
+        "type": "object"
+      },
+      "kbn-es-query-server-timeRangeSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "from": {
+            "type": "string"
+          },
+          "mode": {
+            "enum": [
+              "absolute",
+              "relative"
+            ],
+            "type": "string"
+          },
+          "to": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "from",
+          "to"
+        ],
+        "title": "kbn-es-query-server-timeRangeSchema",
+        "type": "object",
+        "x-oas-optional": true
+      },
+      "kbn-runtime-field-format": {
+        "additionalProperties": false,
+        "description": "Set your preferred format for displaying the value. Changing the format can affect the value and prevent highlighting in Discover.",
+        "properties": {
+          "params": {},
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "params"
+        ],
+        "title": "Format",
+        "type": "object",
+        "x-oas-optional": true
+      },
+      "kbn-runtime-field-schema": {
+        "additionalProperties": false,
+        "properties": {
+          "custom_description": {
+            "description": "Add a description to the field. It's displayed next to the field on the Discover, Lens, and Data View Management pages.",
+            "minLength": 1,
+            "title": "Custom description",
+            "type": "string"
+          },
+          "custom_label": {
+            "description": "Create a label to display in place of the field name in Discover, Maps, Lens, Visualize, and TSVB. Useful for shortening a long field name. Queries and filters use the original field name.",
+            "minLength": 1,
+            "title": "Custom label",
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/components/schemas/kbn-runtime-field-format"
+          },
+          "name": {
+            "description": "The name of the runtime field. Example: \"my_runtime_field\".",
+            "maxLength": 1000,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          },
+          "script": {
+            "description": "The script that defines the runtime field. This should be a painless script that computes the field value at query time. Runtime fields without a script retrieve values from _source. If the field doesn't exist in _source, a search request returns no value.",
+            "minLength": 1,
+            "title": "Script",
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/kbn-runtime-field-type"
+          }
+        },
+        "required": [
+          "type",
+          "format",
+          "name"
+        ],
+        "title": "Runtime field",
+        "type": "object",
+        "x-oas-discriminator-default-case": true
+      },
+      "kbn-runtime-field-type": {
+        "description": "The type of the runtime field (e.g., \"keyword\", \"long\", \"date\").",
+        "enum": [
+          "keyword",
+          "long",
+          "double",
+          "date",
+          "ip",
+          "boolean",
+          "geo_point"
+        ],
+        "title": "Type",
+        "type": "string"
+      },
+      "lastValueOperation": {
+        "additionalProperties": false,
+        "properties": {
+          "field": {
+            "description": "Field to be used for the metric",
+            "type": "string"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/filterSimple"
+          },
+          "format": {
+            "$ref": "#/components/schemas/formatType"
+          },
+          "label": {
+            "description": "Label for the operation",
+            "type": "string"
+          },
+          "multi_value": {
+            "default": false,
+            "description": "Whether to return all values for multi-value fields. Only affects data table and metric charts; other charts use the last value from the array.",
+            "type": "boolean"
+          },
+          "operation": {
+            "enum": [
+              "last_value"
+            ],
+            "type": "string"
+          },
+          "reduced_time_range": {
+            "description": "Reduced time range",
+            "title": "Operation Reduced Time Range Setting",
+            "type": "string"
+          },
+          "time_field": {
+            "description": "Time field used to determine document recency",
+            "type": "string"
+          },
+          "time_scale": {
+            "$ref": "#/components/schemas/operationTimeScaleSetting"
+          },
+          "time_shift": {
+            "description": "Time shift",
+            "title": "Operation Time Shift Setting",
+            "type": "string"
+          }
+        },
+        "required": [
+          "format",
+          "filter",
+          "time_scale",
+          "field",
+          "operation",
+          "time_field"
+        ],
+        "title": "Last Value Operation",
+        "type": "object"
+      },
+      "legacyColorByValue": {
+        "additionalProperties": false,
+        "deprecated": true,
+        "description": "Legacy color by value configuration",
+        "properties": {
+          "palette": {
+            "description": "The legacy palette name.",
+            "type": "string"
+          },
+          "range": {
+            "description": "Determines whether the range is interpreted as absolute or as a percentage of the data.",
+            "enum": [
+              "absolute",
+              "percentage"
+            ],
+            "type": "string"
+          },
+          "shift": {
+            "description": "Whether to shift the palette.",
+            "type": "boolean"
+          },
+          "steps": {
+            "description": "Array of ordered color steps defining the range each color is applied.",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "color": {
+                  "description": "The color to use for this step.",
+                  "type": "string"
+                },
+                "gte": {
+                  "description": "The lower bound of range from which this color applies (inclusive).",
+                  "nullable": true,
+                  "type": "number"
+                },
+                "lt": {
+                  "description": "The upper bound of range to which this color applies (exclusive).",
+                  "nullable": true,
+                  "type": "number"
+                },
+                "lte": {
+                  "description": "The upper bound of range to which this color applies (inclusive).",
+                  "nullable": true,
+                  "type": "number"
+                }
+              },
+              "required": [
+                "color"
+              ],
+              "type": "object"
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "type": "array"
+          },
+          "type": {
+            "enum": [
+              "legacy_dynamic"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "range",
+          "steps",
+          "palette",
+          "shift"
+        ],
+        "title": "Legacy color by value",
+        "type": "object"
+      },
+      "legacyColorByValueAbsolute": {
+        "additionalProperties": false,
+        "deprecated": true,
+        "description": "Legacy color by absolute value configuration",
+        "properties": {
+          "palette": {
+            "description": "The legacy palette name.",
+            "type": "string"
+          },
+          "range": {
+            "enum": [
+              "absolute"
+            ],
+            "type": "string"
+          },
+          "shift": {
+            "description": "Whether to shift the palette.",
+            "type": "boolean"
+          },
+          "steps": {
+            "description": "Array of ordered color steps defining the range each color is applied.",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "color": {
+                  "description": "The color to use for this step.",
+                  "type": "string"
+                },
+                "gte": {
+                  "description": "The lower bound of range from which this color applies (inclusive).",
+                  "nullable": true,
+                  "type": "number"
+                },
+                "lt": {
+                  "description": "The upper bound of range to which this color applies (exclusive).",
+                  "nullable": true,
+                  "type": "number"
+                },
+                "lte": {
+                  "description": "The upper bound of range to which this color applies (inclusive).",
+                  "nullable": true,
+                  "type": "number"
+                }
+              },
+              "required": [
+                "color"
+              ],
+              "type": "object"
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "type": "array"
+          },
+          "type": {
+            "enum": [
+              "legacy_dynamic"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "range",
+          "steps",
+          "palette",
+          "shift"
+        ],
+        "title": "Legacy color by value (absolute)",
+        "type": "object"
+      },
+      "legacyMetricNoESQL": {
+        "additionalProperties": false,
+        "properties": {
+          "data_source": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/kbn-data-view-reference-schema"
+              },
+              {
+                "$ref": "#/components/schemas/kbn-data-view-spec-schema"
+              }
+            ]
+          },
+          "description": {
+            "type": "string"
+          },
+          "drilldowns": {
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "dashboard_id": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": false,
+                      "description": "When enabled, the dashboard opens in a new browser tab.",
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "dashboard_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "use_filters": {
+                      "default": true,
+                      "description": "When enabled, filters are passed to the opening dashboard.",
+                      "type": "boolean"
+                    },
+                    "use_time_range": {
+                      "default": true,
+                      "description": "When enabled, time range is passed to the opening dashboard.",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "dashboard_id",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "dashboard_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "discover_drilldown"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "discover_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "encode_url": {
+                      "default": true,
+                      "description": "When true, URL is escaped using percent encoding",
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_click_row",
+                        "on_click_value",
+                        "on_open_panel_menu",
+                        "on_select_range"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "url_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "url": {
+                      "description": "Templated Url. Variables documented at https://www.elastic.co/docs/explore-analyze/dashboards/drilldowns#url-template-variable",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "url",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "url_drilldown",
+                  "type": "object"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "filters": {
+            "$ref": "#/components/schemas/lensPanelFilters"
+          },
+          "hide_border": {
+            "type": "boolean"
+          },
+          "hide_title": {
+            "type": "boolean"
+          },
+          "ignore_global_filters": {
+            "default": false,
+            "description": "If true, ignore global filters when fetching data for this layer. Default is false.",
+            "type": "boolean"
+          },
+          "metric": {
+            "anyOf": [
+              {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/countMetricOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/uniqueCountMetricOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/minMaxAvgMedianStdDevMetricOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/sumMetricOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/lastValueOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/percentileOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/percentileRanksOperation"
+                  }
+                ]
+              },
+              {
+                "$ref": "#/components/schemas/formulaOperation"
+              }
+            ]
+          },
+          "query": {
+            "$ref": "#/components/schemas/filterSimple"
+          },
+          "references": {
+            "items": {
+              "$ref": "#/components/schemas/kbn-content-management-utils-referenceSchema"
+            },
+            "type": "array"
+          },
+          "sampling": {
+            "default": 1,
+            "description": "Sampling factor between 0 (no sampling) and 1 (full sampling). Default is 1.",
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "time_range": {
+            "$ref": "#/components/schemas/kbn-es-query-server-timeRangeSchema"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "legacy_metric"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "filters",
+          "query",
+          "data_source",
+          "metric",
+          "time_range"
+        ],
+        "title": "Legacy Metric Chart (DSL)",
+        "type": "object"
+      },
+      "legendSize": {
+        "description": "Legend size",
+        "enum": [
+          "auto",
+          "s",
+          "m",
+          "l",
+          "xl"
+        ],
+        "title": "Legend Size",
+        "type": "string",
+        "x-oas-optional": true
+      },
+      "lensPanelFilters": {
+        "description": "Filters applied to the panel",
+        "items": {
+          "anyOf": [
+            {
+              "$ref": "#/components/schemas/kbn-as-code-filters-schema_asCodeConditionFilterSchema"
+            },
+            {
+              "$ref": "#/components/schemas/kbn-as-code-filters-schema_asCodeGroupFilterSchema"
+            },
+            {
+              "$ref": "#/components/schemas/kbn-as-code-filters-schema_asCodeDSLFilterSchema"
+            },
+            {
+              "$ref": "#/components/schemas/kbn-as-code-filters-schema_asCodeSpatialFilterSchema"
+            }
+          ],
+          "description": "A filter which can be a condition, group, DSL, or spatial"
+        },
+        "maxItems": 100,
+        "title": "lensPanelFilters",
+        "type": "array",
+        "x-oas-optional": true
+      },
+      "metricCompareToBaseline": {
+        "additionalProperties": false,
+        "properties": {
+          "baseline": {
+            "default": 0,
+            "description": "Baseline value",
+            "type": "number"
+          },
+          "icon": {
+            "description": "Show icon",
+            "type": "boolean"
+          },
+          "palette": {
+            "description": "Palette",
+            "type": "string"
+          },
+          "to": {
+            "enum": [
+              "baseline"
+            ],
+            "type": "string"
+          },
+          "value": {
+            "description": "Show value",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "to"
+        ],
+        "title": "Compare To Baseline",
+        "type": "object"
+      },
+      "metricCompareToPrimary": {
+        "additionalProperties": false,
+        "properties": {
+          "icon": {
+            "description": "Show icon",
+            "type": "boolean"
+          },
+          "palette": {
+            "description": "Palette",
+            "type": "string"
+          },
+          "to": {
+            "enum": [
+              "primary"
+            ],
+            "type": "string"
+          },
+          "value": {
+            "description": "Show value",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "to"
+        ],
+        "title": "Compare To Primary",
+        "type": "object"
+      },
+      "metricComplementaryBar": {
+        "additionalProperties": false,
+        "properties": {
+          "max_value": {
+            "additionalProperties": false,
+            "properties": {
+              "column": {
+                "description": "Column to use",
+                "type": "string"
+              },
+              "label": {
+                "description": "Label for the operation",
+                "type": "string"
+              }
+            },
+            "required": [
+              "column"
+            ],
+            "type": "object"
+          },
+          "orientation": {
+            "$ref": "#/components/schemas/vis_api_simple_orientation"
+          },
+          "type": {
+            "enum": [
+              "bar"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "orientation",
+          "max_value"
+        ],
+        "title": "Complementary Bar",
+        "type": "object",
+        "x-oas-optional": true
+      },
+      "metricESQL": {
+        "additionalProperties": false,
+        "description": "Metric chart configuration for ES|QL queries",
+        "properties": {
+          "breakdown_by": {
+            "additionalProperties": false,
+            "properties": {
+              "collapse_by": {
+                "$ref": "#/components/schemas/collapseBy"
+              },
+              "column": {
+                "description": "Column to use",
+                "type": "string"
+              },
+              "columns": {
+                "default": 3,
+                "description": "Number of columns",
+                "type": "number"
+              },
+              "format": {
+                "$ref": "#/components/schemas/formatType"
+              },
+              "label": {
+                "description": "Label for the operation",
+                "type": "string"
+              }
+            },
+            "required": [
+              "column",
+              "format",
+              "collapse_by"
+            ],
+            "type": "object"
+          },
+          "data_source": {
+            "$ref": "#/components/schemas/esqlDataSource"
+          },
+          "description": {
+            "type": "string"
+          },
+          "drilldowns": {
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "dashboard_id": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": false,
+                      "description": "When enabled, the dashboard opens in a new browser tab.",
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "dashboard_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "use_filters": {
+                      "default": true,
+                      "description": "When enabled, filters are passed to the opening dashboard.",
+                      "type": "boolean"
+                    },
+                    "use_time_range": {
+                      "default": true,
+                      "description": "When enabled, time range is passed to the opening dashboard.",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "dashboard_id",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "dashboard_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "discover_drilldown"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "discover_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "encode_url": {
+                      "default": true,
+                      "description": "When true, URL is escaped using percent encoding",
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_click_row",
+                        "on_click_value",
+                        "on_open_panel_menu",
+                        "on_select_range"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "url_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "url": {
+                      "description": "Templated Url. Variables documented at https://www.elastic.co/docs/explore-analyze/dashboards/drilldowns#url-template-variable",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "url",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "url_drilldown",
+                  "type": "object"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "filters": {
+            "$ref": "#/components/schemas/lensPanelFilters"
+          },
+          "hide_border": {
+            "type": "boolean"
+          },
+          "hide_title": {
+            "type": "boolean"
+          },
+          "ignore_global_filters": {
+            "default": false,
+            "description": "If true, ignore global filters when fetching data for this layer. Default is false.",
+            "type": "boolean"
+          },
+          "metrics": {
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "apply_color_to": {
+                      "description": "Where to apply the color",
+                      "enum": [
+                        "value",
+                        "background"
+                      ],
+                      "type": "string"
+                    },
+                    "background_chart": {
+                      "$ref": "#/components/schemas/metricComplementaryBar"
+                    },
+                    "color": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/components/schemas/colorByValue"
+                        },
+                        {
+                          "$ref": "#/components/schemas/staticColor"
+                        }
+                      ]
+                    },
+                    "column": {
+                      "description": "Column to use",
+                      "type": "string"
+                    },
+                    "format": {
+                      "$ref": "#/components/schemas/formatType"
+                    },
+                    "label": {
+                      "description": "Label for the operation",
+                      "type": "string"
+                    },
+                    "subtitle": {
+                      "description": "Subtitle below the primary metric value",
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "primary"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "column",
+                    "format",
+                    "type",
+                    "background_chart"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "color": {
+                      "$ref": "#/components/schemas/staticColor"
+                    },
+                    "column": {
+                      "description": "Column to use",
+                      "type": "string"
+                    },
+                    "compare": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/components/schemas/metricCompareToBaseline"
+                        },
+                        {
+                          "$ref": "#/components/schemas/metricCompareToPrimary"
+                        }
+                      ]
+                    },
+                    "format": {
+                      "$ref": "#/components/schemas/formatType"
+                    },
+                    "label": {
+                      "description": "Label for the operation",
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "secondary"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "column",
+                    "format",
+                    "type",
+                    "color"
+                  ],
+                  "type": "object"
+                }
+              ]
+            },
+            "maxItems": 2,
+            "minItems": 1,
+            "type": "array"
+          },
+          "references": {
+            "items": {
+              "$ref": "#/components/schemas/kbn-content-management-utils-referenceSchema"
+            },
+            "type": "array"
+          },
+          "sampling": {
+            "default": 1,
+            "description": "Sampling factor between 0 (no sampling) and 1 (full sampling). Default is 1.",
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "styling": {
+            "$ref": "#/components/schemas/metricStyling"
+          },
+          "time_range": {
+            "$ref": "#/components/schemas/kbn-es-query-server-timeRangeSchema"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "metric"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "filters",
+          "data_source",
+          "styling",
+          "metrics",
+          "time_range"
+        ],
+        "title": "Metric Chart (ES|QL)",
+        "type": "object"
+      },
+      "metricIconConfig": {
+        "additionalProperties": false,
+        "description": "Icon configuration for the primary metric",
+        "properties": {
+          "alignment": {
+            "description": "Icon alignment",
+            "enum": [
+              "left",
+              "right"
+            ],
+            "type": "string"
+          },
+          "name": {
+            "description": "Icon name",
+            "enum": [
+              "alert",
+              "asterisk",
+              "bell",
+              "bolt",
+              "bug",
+              "compute",
+              "editor_comment",
+              "flag",
+              "globe",
+              "heart",
+              "map_marker",
+              "pin",
+              "sort_down",
+              "sort_up",
+              "star_empty",
+              "tag",
+              "temperature"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "Icon Configuration",
+        "type": "object",
+        "x-oas-optional": true
+      },
+      "metricNoESQL": {
+        "additionalProperties": false,
+        "description": "Metric chart configuration for standard queries",
+        "properties": {
+          "breakdown_by": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/dateHistogramOperation"
+              },
+              {
+                "$ref": "#/components/schemas/termsOperation"
+              },
+              {
+                "$ref": "#/components/schemas/histogramOperation"
+              },
+              {
+                "$ref": "#/components/schemas/rangesOperation"
+              },
+              {
+                "$ref": "#/components/schemas/filtersOperation"
+              }
+            ]
+          },
+          "data_source": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/kbn-data-view-reference-schema"
+              },
+              {
+                "$ref": "#/components/schemas/kbn-data-view-spec-schema"
+              }
+            ]
+          },
+          "description": {
+            "type": "string"
+          },
+          "drilldowns": {
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "dashboard_id": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": false,
+                      "description": "When enabled, the dashboard opens in a new browser tab.",
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "dashboard_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "use_filters": {
+                      "default": true,
+                      "description": "When enabled, filters are passed to the opening dashboard.",
+                      "type": "boolean"
+                    },
+                    "use_time_range": {
+                      "default": true,
+                      "description": "When enabled, time range is passed to the opening dashboard.",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "dashboard_id",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "dashboard_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "discover_drilldown"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "discover_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "encode_url": {
+                      "default": true,
+                      "description": "When true, URL is escaped using percent encoding",
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_click_row",
+                        "on_click_value",
+                        "on_open_panel_menu",
+                        "on_select_range"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "url_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "url": {
+                      "description": "Templated Url. Variables documented at https://www.elastic.co/docs/explore-analyze/dashboards/drilldowns#url-template-variable",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "url",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "url_drilldown",
+                  "type": "object"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "filters": {
+            "$ref": "#/components/schemas/lensPanelFilters"
+          },
+          "hide_border": {
+            "type": "boolean"
+          },
+          "hide_title": {
+            "type": "boolean"
+          },
+          "ignore_global_filters": {
+            "default": false,
+            "description": "If true, ignore global filters when fetching data for this layer. Default is false.",
+            "type": "boolean"
+          },
+          "metrics": {
+            "items": {
+              "anyOf": [
+                {
+                  "anyOf": [
+                    {
+                      "anyOf": [
+                        {
+                          "$ref": "#/components/schemas/countMetricOperation"
+                        },
+                        {
+                          "$ref": "#/components/schemas/uniqueCountMetricOperation"
+                        },
+                        {
+                          "$ref": "#/components/schemas/minMaxAvgMedianStdDevMetricOperation"
+                        },
+                        {
+                          "$ref": "#/components/schemas/sumMetricOperation"
+                        },
+                        {
+                          "$ref": "#/components/schemas/lastValueOperation"
+                        },
+                        {
+                          "$ref": "#/components/schemas/percentileOperation"
+                        },
+                        {
+                          "$ref": "#/components/schemas/percentileRanksOperation"
+                        }
+                      ]
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "$ref": "#/components/schemas/differencesOperation"
+                        },
+                        {
+                          "$ref": "#/components/schemas/movingAverageOperation"
+                        },
+                        {
+                          "$ref": "#/components/schemas/cumulativeSumOperation"
+                        },
+                        {
+                          "$ref": "#/components/schemas/counterRateOperation"
+                        }
+                      ]
+                    },
+                    {
+                      "$ref": "#/components/schemas/formulaOperation"
+                    }
+                  ]
+                },
+                {
+                  "anyOf": [
+                    {
+                      "anyOf": [
+                        {
+                          "$ref": "#/components/schemas/countMetricOperation"
+                        },
+                        {
+                          "$ref": "#/components/schemas/uniqueCountMetricOperation"
+                        },
+                        {
+                          "$ref": "#/components/schemas/minMaxAvgMedianStdDevMetricOperation"
+                        },
+                        {
+                          "$ref": "#/components/schemas/sumMetricOperation"
+                        },
+                        {
+                          "$ref": "#/components/schemas/lastValueOperation"
+                        },
+                        {
+                          "$ref": "#/components/schemas/percentileOperation"
+                        },
+                        {
+                          "$ref": "#/components/schemas/percentileRanksOperation"
+                        }
+                      ]
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "$ref": "#/components/schemas/differencesOperation"
+                        },
+                        {
+                          "$ref": "#/components/schemas/movingAverageOperation"
+                        },
+                        {
+                          "$ref": "#/components/schemas/cumulativeSumOperation"
+                        },
+                        {
+                          "$ref": "#/components/schemas/counterRateOperation"
+                        }
+                      ]
+                    },
+                    {
+                      "$ref": "#/components/schemas/formulaOperation"
+                    }
+                  ]
+                }
+              ]
+            },
+            "maxItems": 2,
+            "minItems": 1,
+            "type": "array"
+          },
+          "query": {
+            "$ref": "#/components/schemas/filterSimple"
+          },
+          "references": {
+            "items": {
+              "$ref": "#/components/schemas/kbn-content-management-utils-referenceSchema"
+            },
+            "type": "array"
+          },
+          "sampling": {
+            "default": 1,
+            "description": "Sampling factor between 0 (no sampling) and 1 (full sampling). Default is 1.",
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "styling": {
+            "$ref": "#/components/schemas/metricStyling"
+          },
+          "time_range": {
+            "$ref": "#/components/schemas/kbn-es-query-server-timeRangeSchema"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "metric"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "filters",
+          "query",
+          "data_source",
+          "styling",
+          "metrics",
+          "time_range"
+        ],
+        "title": "Metric Chart (DSL)",
+        "type": "object"
+      },
+      "metricStyling": {
+        "additionalProperties": false,
+        "description": "Visual styling options for the chart",
+        "properties": {
+          "primary": {
+            "additionalProperties": false,
+            "properties": {
+              "icon": {
+                "$ref": "#/components/schemas/metricIconConfig"
+              },
+              "labels": {
+                "additionalProperties": false,
+                "description": "Labels (title and subtitle) configuration",
+                "properties": {
+                  "alignment": {
+                    "description": "Horizontal alignment for the title and subtitle text (left, center or right)",
+                    "enum": [
+                      "left",
+                      "center",
+                      "right"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "position": {
+                "description": "Position of the primary metric value (top, middle, or bottom)",
+                "enum": [
+                  "top",
+                  "middle",
+                  "bottom"
+                ],
+                "type": "string"
+              },
+              "value": {
+                "additionalProperties": false,
+                "description": "Primary metric value configuration",
+                "properties": {
+                  "alignment": {
+                    "description": "Alignment for the primary metric value (left, center or right)",
+                    "enum": [
+                      "left",
+                      "center",
+                      "right"
+                    ],
+                    "type": "string"
+                  },
+                  "sizing": {
+                    "description": "Controls how the primary value text is sized within the panel. 'auto' selects a font size from predefined breakpoints based on panel height, then shrinks if the text overflows horizontally. 'fill' scales the text to be as large as possible, filling all available space.",
+                    "enum": [
+                      "auto",
+                      "fill"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "required": [
+              "icon"
+            ],
+            "type": "object"
+          },
+          "secondary": {
+            "additionalProperties": false,
+            "properties": {
+              "label": {
+                "additionalProperties": false,
+                "properties": {
+                  "placement": {
+                    "description": "Label placement relative to the secondary metric value (before or after)",
+                    "enum": [
+                      "before",
+                      "after"
+                    ],
+                    "type": "string"
+                  },
+                  "visible": {
+                    "description": "Whether to display the label",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
+              },
+              "value": {
+                "additionalProperties": false,
+                "description": "Secondary metric value configuration",
+                "properties": {
+                  "alignment": {
+                    "description": "Alignment for secondary values (left, center or right)",
+                    "enum": [
+                      "left",
+                      "center",
+                      "right"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "title": "metricStyling",
+        "type": "object",
+        "x-oas-optional": true
+      },
+      "minMaxAvgMedianStdDevMetricOperation": {
+        "additionalProperties": false,
+        "properties": {
+          "field": {
+            "description": "Field to be used for the metric",
+            "type": "string"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/filterSimple"
+          },
+          "format": {
+            "$ref": "#/components/schemas/formatType"
+          },
+          "label": {
+            "description": "Label for the operation",
+            "type": "string"
+          },
+          "operation": {
+            "enum": [
+              "min",
+              "max",
+              "average",
+              "median",
+              "standard_deviation"
+            ],
+            "type": "string"
+          },
+          "reduced_time_range": {
+            "description": "Reduced time range",
+            "title": "Operation Reduced Time Range Setting",
+            "type": "string"
+          },
+          "time_scale": {
+            "$ref": "#/components/schemas/operationTimeScaleSetting"
+          },
+          "time_shift": {
+            "description": "Time shift",
+            "title": "Operation Time Shift Setting",
+            "type": "string"
+          }
+        },
+        "required": [
+          "format",
+          "filter",
+          "time_scale",
+          "field",
+          "operation"
+        ],
+        "title": "Stats Metric Operation",
+        "type": "object"
+      },
+      "mosaicESQL": {
+        "additionalProperties": false,
+        "description": "Mosaic chart configuration schema for ES|QL queries, defining metrics and breakdown dimensions using column-based configuration",
+        "properties": {
+          "data_source": {
+            "$ref": "#/components/schemas/esqlDataSource"
+          },
+          "description": {
+            "type": "string"
+          },
+          "drilldowns": {
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "dashboard_id": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": false,
+                      "description": "When enabled, the dashboard opens in a new browser tab.",
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "dashboard_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "use_filters": {
+                      "default": true,
+                      "description": "When enabled, filters are passed to the opening dashboard.",
+                      "type": "boolean"
+                    },
+                    "use_time_range": {
+                      "default": true,
+                      "description": "When enabled, time range is passed to the opening dashboard.",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "dashboard_id",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "dashboard_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "discover_drilldown"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "discover_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "encode_url": {
+                      "default": true,
+                      "description": "When true, URL is escaped using percent encoding",
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_click_row",
+                        "on_click_value",
+                        "on_open_panel_menu",
+                        "on_select_range"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "url_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "url": {
+                      "description": "Templated Url. Variables documented at https://www.elastic.co/docs/explore-analyze/dashboards/drilldowns#url-template-variable",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "url",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "url_drilldown",
+                  "type": "object"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "filters": {
+            "$ref": "#/components/schemas/lensPanelFilters"
+          },
+          "group_breakdown_by": {
+            "description": "Array of group breakdown dimensions (minimum 1)",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "collapse_by": {
+                  "$ref": "#/components/schemas/collapseBy"
+                },
+                "color": {
+                  "$ref": "#/components/schemas/colorMapping"
+                },
+                "column": {
+                  "description": "Column to use",
+                  "type": "string"
+                },
+                "format": {
+                  "$ref": "#/components/schemas/formatType"
+                },
+                "label": {
+                  "description": "Label for the operation",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "column",
+                "format",
+                "color",
+                "collapse_by"
+              ],
+              "type": "object"
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "type": "array"
+          },
+          "group_by": {
+            "description": "Array of breakdown dimensions (minimum 1)",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "collapse_by": {
+                  "$ref": "#/components/schemas/collapseBy"
+                },
+                "color": {
+                  "$ref": "#/components/schemas/colorMapping"
+                },
+                "column": {
+                  "description": "Column to use",
+                  "type": "string"
+                },
+                "format": {
+                  "$ref": "#/components/schemas/formatType"
+                },
+                "label": {
+                  "description": "Label for the operation",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "column",
+                "format",
+                "color",
+                "collapse_by"
+              ],
+              "type": "object"
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "type": "array"
+          },
+          "hide_border": {
+            "type": "boolean"
+          },
+          "hide_title": {
+            "type": "boolean"
+          },
+          "ignore_global_filters": {
+            "default": false,
+            "description": "If true, ignore global filters when fetching data for this layer. Default is false.",
+            "type": "boolean"
+          },
+          "legend": {
+            "$ref": "#/components/schemas/mosaicLegend"
+          },
+          "metric": {
+            "additionalProperties": false,
+            "description": "Metric configuration for ES|QL mode, combining generic options, primary metric options, and column selection",
+            "properties": {
+              "column": {
+                "description": "Column to use",
+                "type": "string"
+              },
+              "format": {
+                "$ref": "#/components/schemas/formatType"
+              },
+              "label": {
+                "description": "Label for the operation",
+                "type": "string"
+              }
+            },
+            "required": [
+              "column",
+              "format"
+            ],
+            "type": "object"
+          },
+          "references": {
+            "items": {
+              "$ref": "#/components/schemas/kbn-content-management-utils-referenceSchema"
+            },
+            "type": "array"
+          },
+          "sampling": {
+            "default": 1,
+            "description": "Sampling factor between 0 (no sampling) and 1 (full sampling). Default is 1.",
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "time_range": {
+            "$ref": "#/components/schemas/kbn-es-query-server-timeRangeSchema"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "mosaic"
+            ],
+            "type": "string"
+          },
+          "values": {
+            "$ref": "#/components/schemas/valueDisplay"
+          }
+        },
+        "required": [
+          "type",
+          "filters",
+          "data_source",
+          "legend",
+          "values",
+          "metric",
+          "time_range"
+        ],
+        "title": "Mosaic Chart (ES|QL)",
+        "type": "object"
+      },
+      "mosaicLegend": {
+        "additionalProperties": false,
+        "description": "Legend configuration for mosaic chart appearance and behavior",
+        "properties": {
+          "nested": {
+            "description": "Show nested legend with hierarchical breakdown levels",
+            "type": "boolean"
+          },
+          "size": {
+            "$ref": "#/components/schemas/legendSize"
+          },
+          "truncate_after_lines": {
+            "description": "Maximum lines before truncating legend items (1-10)",
+            "maximum": 10,
+            "minimum": 1,
+            "title": "legendTruncateAfterLines",
+            "type": "number"
+          },
+          "visibility": {
+            "description": "Legend visibility",
+            "enum": [
+              "auto",
+              "visible",
+              "hidden"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "size"
+        ],
+        "title": "Legend",
+        "type": "object",
+        "x-oas-optional": true
+      },
+      "mosaicNoESQL": {
+        "additionalProperties": false,
+        "description": "Mosaic chart configuration schema for data source queries (non-ES|QL mode), defining metrics and breakdown dimensions",
+        "properties": {
+          "data_source": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/kbn-data-view-reference-schema"
+              },
+              {
+                "$ref": "#/components/schemas/kbn-data-view-spec-schema"
+              }
+            ]
+          },
+          "description": {
+            "type": "string"
+          },
+          "drilldowns": {
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "dashboard_id": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": false,
+                      "description": "When enabled, the dashboard opens in a new browser tab.",
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "dashboard_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "use_filters": {
+                      "default": true,
+                      "description": "When enabled, filters are passed to the opening dashboard.",
+                      "type": "boolean"
+                    },
+                    "use_time_range": {
+                      "default": true,
+                      "description": "When enabled, time range is passed to the opening dashboard.",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "dashboard_id",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "dashboard_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "discover_drilldown"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "discover_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "encode_url": {
+                      "default": true,
+                      "description": "When true, URL is escaped using percent encoding",
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_click_row",
+                        "on_click_value",
+                        "on_open_panel_menu",
+                        "on_select_range"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "url_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "url": {
+                      "description": "Templated Url. Variables documented at https://www.elastic.co/docs/explore-analyze/dashboards/drilldowns#url-template-variable",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "url",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "url_drilldown",
+                  "type": "object"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "filters": {
+            "$ref": "#/components/schemas/lensPanelFilters"
+          },
+          "group_breakdown_by": {
+            "description": "Array of group breakdown dimensions (minimum 1)",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/dateHistogramOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/termsOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/histogramOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/rangesOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/filtersOperation"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "type": "array"
+          },
+          "group_by": {
+            "description": "Array of breakdown dimensions (minimum 1)",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/dateHistogramOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/termsOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/histogramOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/rangesOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/filtersOperation"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "type": "array"
+          },
+          "hide_border": {
+            "type": "boolean"
+          },
+          "hide_title": {
+            "type": "boolean"
+          },
+          "ignore_global_filters": {
+            "default": false,
+            "description": "If true, ignore global filters when fetching data for this layer. Default is false.",
+            "type": "boolean"
+          },
+          "legend": {
+            "$ref": "#/components/schemas/mosaicLegend"
+          },
+          "metric": {
+            "anyOf": [
+              {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/countMetricOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/uniqueCountMetricOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/minMaxAvgMedianStdDevMetricOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/sumMetricOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/lastValueOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/percentileOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/percentileRanksOperation"
+                  }
+                ]
+              },
+              {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/differencesOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/movingAverageOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/cumulativeSumOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/counterRateOperation"
+                  }
+                ]
+              },
+              {
+                "$ref": "#/components/schemas/formulaOperation"
+              }
+            ]
+          },
+          "query": {
+            "$ref": "#/components/schemas/filterSimple"
+          },
+          "references": {
+            "items": {
+              "$ref": "#/components/schemas/kbn-content-management-utils-referenceSchema"
+            },
+            "type": "array"
+          },
+          "sampling": {
+            "default": 1,
+            "description": "Sampling factor between 0 (no sampling) and 1 (full sampling). Default is 1.",
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "time_range": {
+            "$ref": "#/components/schemas/kbn-es-query-server-timeRangeSchema"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "mosaic"
+            ],
+            "type": "string"
+          },
+          "values": {
+            "$ref": "#/components/schemas/valueDisplay"
+          }
+        },
+        "required": [
+          "type",
+          "filters",
+          "data_source",
+          "query",
+          "legend",
+          "values",
+          "metric",
+          "time_range"
+        ],
+        "title": "Mosaic Chart (DSL)",
+        "type": "object"
+      },
+      "movingAverageOperation": {
+        "additionalProperties": false,
+        "properties": {
+          "color": {
+            "$ref": "#/components/schemas/staticColor"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/filterSimple"
+          },
+          "format": {
+            "$ref": "#/components/schemas/formatType"
+          },
+          "label": {
+            "description": "Label for the operation",
+            "type": "string"
+          },
+          "of": {
+            "$ref": "#/components/schemas/fieldMetricOperations"
+          },
+          "operation": {
+            "enum": [
+              "moving_average"
+            ],
+            "type": "string"
+          },
+          "reduced_time_range": {
+            "description": "Reduced time range",
+            "title": "Operation Reduced Time Range Setting",
+            "type": "string"
+          },
+          "time_scale": {
+            "$ref": "#/components/schemas/operationTimeScaleSetting"
+          },
+          "time_shift": {
+            "description": "Time shift",
+            "title": "Operation Time Shift Setting",
+            "type": "string"
+          },
+          "window": {
+            "default": 5,
+            "description": "Window",
+            "type": "number"
+          }
+        },
+        "required": [
+          "format",
+          "filter",
+          "time_scale",
+          "operation",
+          "of",
+          "color"
+        ],
+        "title": "Moving Average Operation",
+        "type": "object"
+      },
+      "multi_field_key": {
+        "additionalProperties": false,
+        "properties": {
+          "keys": {
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "type": {
+            "enum": [
+              "multi_field_key"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "keys"
+        ],
+        "title": "Multi Field Key",
+        "type": "object"
+      },
+      "numericFormat": {
+        "additionalProperties": false,
+        "properties": {
+          "compact": {
+            "default": false,
+            "description": "Whether to use compact notation",
+            "type": "boolean"
+          },
+          "decimals": {
+            "default": 2,
+            "description": "Number of decimals",
+            "type": "number"
+          },
+          "suffix": {
+            "description": "Suffix",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "number",
+              "percent"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "title": "Numeric Format",
+        "type": "object"
+      },
+      "operationTimeScaleSetting": {
+        "description": "Time scale",
+        "enum": [
+          "s",
+          "m",
+          "h",
+          "d"
+        ],
+        "title": "Operation Time Scale Setting",
+        "type": "string",
+        "x-oas-optional": true
+      },
+      "percentileOperation": {
+        "additionalProperties": false,
+        "properties": {
+          "field": {
+            "description": "Field to be used for the metric",
+            "type": "string"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/filterSimple"
+          },
+          "format": {
+            "$ref": "#/components/schemas/formatType"
+          },
+          "label": {
+            "description": "Label for the operation",
+            "type": "string"
+          },
+          "operation": {
+            "enum": [
+              "percentile"
+            ],
+            "type": "string"
+          },
+          "percentile": {
+            "default": 95,
+            "description": "Percentile",
+            "type": "number"
+          },
+          "reduced_time_range": {
+            "description": "Reduced time range",
+            "title": "Operation Reduced Time Range Setting",
+            "type": "string"
+          },
+          "time_scale": {
+            "$ref": "#/components/schemas/operationTimeScaleSetting"
+          },
+          "time_shift": {
+            "description": "Time shift",
+            "title": "Operation Time Shift Setting",
+            "type": "string"
+          }
+        },
+        "required": [
+          "format",
+          "filter",
+          "time_scale",
+          "field",
+          "operation"
+        ],
+        "title": "Percentile Operation",
+        "type": "object"
+      },
+      "percentileRanksOperation": {
+        "additionalProperties": false,
+        "properties": {
+          "field": {
+            "description": "Field to be used for the metric",
+            "type": "string"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/filterSimple"
+          },
+          "format": {
+            "$ref": "#/components/schemas/formatType"
+          },
+          "label": {
+            "description": "Label for the operation",
+            "type": "string"
+          },
+          "operation": {
+            "enum": [
+              "percentile_rank"
+            ],
+            "type": "string"
+          },
+          "rank": {
+            "default": 0,
+            "description": "Percentile Rank",
+            "type": "number"
+          },
+          "reduced_time_range": {
+            "description": "Reduced time range",
+            "title": "Operation Reduced Time Range Setting",
+            "type": "string"
+          },
+          "time_scale": {
+            "$ref": "#/components/schemas/operationTimeScaleSetting"
+          },
+          "time_shift": {
+            "description": "Time shift",
+            "title": "Operation Time Shift Setting",
+            "type": "string"
+          }
+        },
+        "required": [
+          "format",
+          "filter",
+          "time_scale",
+          "field",
+          "operation"
+        ],
+        "title": "Percentile Ranks Operation",
+        "type": "object"
+      },
+      "pieESQL": {
+        "additionalProperties": false,
+        "description": "Pie chart configuration for ES|QL queries",
+        "properties": {
+          "data_source": {
+            "$ref": "#/components/schemas/esqlDataSource"
+          },
+          "description": {
+            "type": "string"
+          },
+          "donut_hole": {
+            "description": "Donut hole size: none (pie), or s/m/l",
+            "enum": [
+              "none",
+              "s",
+              "m",
+              "l"
+            ],
+            "type": "string"
+          },
+          "drilldowns": {
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "dashboard_id": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": false,
+                      "description": "When enabled, the dashboard opens in a new browser tab.",
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "dashboard_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "use_filters": {
+                      "default": true,
+                      "description": "When enabled, filters are passed to the opening dashboard.",
+                      "type": "boolean"
+                    },
+                    "use_time_range": {
+                      "default": true,
+                      "description": "When enabled, time range is passed to the opening dashboard.",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "dashboard_id",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "dashboard_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "discover_drilldown"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "discover_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "encode_url": {
+                      "default": true,
+                      "description": "When true, URL is escaped using percent encoding",
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_click_row",
+                        "on_click_value",
+                        "on_open_panel_menu",
+                        "on_select_range"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "url_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "url": {
+                      "description": "Templated Url. Variables documented at https://www.elastic.co/docs/explore-analyze/dashboards/drilldowns#url-template-variable",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "url",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "url_drilldown",
+                  "type": "object"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "filters": {
+            "$ref": "#/components/schemas/lensPanelFilters"
+          },
+          "group_by": {
+            "description": "Array of breakdown dimensions (minimum 1)",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "collapse_by": {
+                  "$ref": "#/components/schemas/collapseBy"
+                },
+                "color": {
+                  "$ref": "#/components/schemas/colorMapping"
+                },
+                "column": {
+                  "description": "Column to use",
+                  "type": "string"
+                },
+                "format": {
+                  "$ref": "#/components/schemas/formatType"
+                },
+                "label": {
+                  "description": "Label for the operation",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "column",
+                "format",
+                "color",
+                "collapse_by"
+              ],
+              "type": "object"
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "type": "array"
+          },
+          "hide_border": {
+            "type": "boolean"
+          },
+          "hide_title": {
+            "type": "boolean"
+          },
+          "ignore_global_filters": {
+            "default": false,
+            "description": "If true, ignore global filters when fetching data for this layer. Default is false.",
+            "type": "boolean"
+          },
+          "labels": {
+            "additionalProperties": false,
+            "description": "Label configuration for pie chart slice labels inside or outside the pie",
+            "properties": {
+              "position": {
+                "description": "Renders pie chart slice labels inside or outside the pie",
+                "enum": [
+                  "inside",
+                  "outside"
+                ],
+                "type": "string"
+              },
+              "visible": {
+                "description": "Show slice labels",
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "legend": {
+            "$ref": "#/components/schemas/pieLegend"
+          },
+          "metrics": {
+            "description": "Array of metric configurations (minimum 1)",
+            "items": {
+              "additionalProperties": false,
+              "description": "ES|QL column reference for primary metric",
+              "properties": {
+                "color": {
+                  "$ref": "#/components/schemas/staticColor"
+                },
+                "column": {
+                  "description": "Column to use",
+                  "type": "string"
+                },
+                "format": {
+                  "$ref": "#/components/schemas/formatType"
+                },
+                "label": {
+                  "description": "Label for the operation",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "column",
+                "format",
+                "color"
+              ],
+              "type": "object"
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "type": "array"
+          },
+          "references": {
+            "items": {
+              "$ref": "#/components/schemas/kbn-content-management-utils-referenceSchema"
+            },
+            "type": "array"
+          },
+          "sampling": {
+            "default": 1,
+            "description": "Sampling factor between 0 (no sampling) and 1 (full sampling). Default is 1.",
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "time_range": {
+            "$ref": "#/components/schemas/kbn-es-query-server-timeRangeSchema"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "pie"
+            ],
+            "type": "string"
+          },
+          "values": {
+            "$ref": "#/components/schemas/valueDisplay"
+          }
+        },
+        "required": [
+          "type",
+          "filters",
+          "data_source",
+          "legend",
+          "values",
+          "metrics",
+          "time_range"
+        ],
+        "title": "Pie Chart (ES|QL)",
+        "type": "object"
+      },
+      "pieLegend": {
+        "additionalProperties": false,
+        "description": "Legend configuration for pie chart",
+        "properties": {
+          "nested": {
+            "description": "Show nested legend with hierarchical breakdown levels",
+            "type": "boolean"
+          },
+          "size": {
+            "$ref": "#/components/schemas/legendSize"
+          },
+          "truncate_after_lines": {
+            "description": "Maximum lines before truncating legend items (1-10)",
+            "maximum": 10,
+            "minimum": 1,
+            "title": "legendTruncateAfterLines",
+            "type": "number"
+          },
+          "visibility": {
+            "description": "Legend visibility",
+            "enum": [
+              "auto",
+              "visible",
+              "hidden"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "size"
+        ],
+        "title": "Legend",
+        "type": "object",
+        "x-oas-optional": true
+      },
+      "pieNoESQL": {
+        "additionalProperties": false,
+        "description": "Pie chart configuration for standard queries",
+        "properties": {
+          "data_source": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/kbn-data-view-reference-schema"
+              },
+              {
+                "$ref": "#/components/schemas/kbn-data-view-spec-schema"
+              }
+            ]
+          },
+          "description": {
+            "type": "string"
+          },
+          "donut_hole": {
+            "description": "Donut hole size: none (pie), or s/m/l",
+            "enum": [
+              "none",
+              "s",
+              "m",
+              "l"
+            ],
+            "type": "string"
+          },
+          "drilldowns": {
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "dashboard_id": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": false,
+                      "description": "When enabled, the dashboard opens in a new browser tab.",
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "dashboard_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "use_filters": {
+                      "default": true,
+                      "description": "When enabled, filters are passed to the opening dashboard.",
+                      "type": "boolean"
+                    },
+                    "use_time_range": {
+                      "default": true,
+                      "description": "When enabled, time range is passed to the opening dashboard.",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "dashboard_id",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "dashboard_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "discover_drilldown"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "discover_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "encode_url": {
+                      "default": true,
+                      "description": "When true, URL is escaped using percent encoding",
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_click_row",
+                        "on_click_value",
+                        "on_open_panel_menu",
+                        "on_select_range"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "url_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "url": {
+                      "description": "Templated Url. Variables documented at https://www.elastic.co/docs/explore-analyze/dashboards/drilldowns#url-template-variable",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "url",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "url_drilldown",
+                  "type": "object"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "filters": {
+            "$ref": "#/components/schemas/lensPanelFilters"
+          },
+          "group_by": {
+            "description": "Array of breakdown dimensions (minimum 1)",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/dateHistogramOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/termsOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/histogramOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/rangesOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/filtersOperation"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "type": "array"
+          },
+          "hide_border": {
+            "type": "boolean"
+          },
+          "hide_title": {
+            "type": "boolean"
+          },
+          "ignore_global_filters": {
+            "default": false,
+            "description": "If true, ignore global filters when fetching data for this layer. Default is false.",
+            "type": "boolean"
+          },
+          "labels": {
+            "additionalProperties": false,
+            "description": "Label configuration for pie chart slice labels inside or outside the pie",
+            "properties": {
+              "position": {
+                "description": "Renders pie chart slice labels inside or outside the pie",
+                "enum": [
+                  "inside",
+                  "outside"
+                ],
+                "type": "string"
+              },
+              "visible": {
+                "description": "Show slice labels",
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "legend": {
+            "$ref": "#/components/schemas/pieLegend"
+          },
+          "metrics": {
+            "description": "Array of metric configurations (minimum 1)",
+            "items": {
+              "anyOf": [
+                {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/countMetricOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/uniqueCountMetricOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/minMaxAvgMedianStdDevMetricOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/sumMetricOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/lastValueOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/percentileOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/percentileRanksOperation"
+                    }
+                  ]
+                },
+                {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/differencesOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/movingAverageOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/cumulativeSumOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/counterRateOperation"
+                    }
+                  ]
+                },
+                {
+                  "$ref": "#/components/schemas/formulaOperation"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "type": "array"
+          },
+          "query": {
+            "$ref": "#/components/schemas/filterSimple"
+          },
+          "references": {
+            "items": {
+              "$ref": "#/components/schemas/kbn-content-management-utils-referenceSchema"
+            },
+            "type": "array"
+          },
+          "sampling": {
+            "default": 1,
+            "description": "Sampling factor between 0 (no sampling) and 1 (full sampling). Default is 1.",
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "time_range": {
+            "$ref": "#/components/schemas/kbn-es-query-server-timeRangeSchema"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "pie"
+            ],
+            "type": "string"
+          },
+          "values": {
+            "$ref": "#/components/schemas/valueDisplay"
+          }
+        },
+        "required": [
+          "type",
+          "filters",
+          "data_source",
+          "query",
+          "legend",
+          "values",
+          "metrics",
+          "time_range"
+        ],
+        "title": "Pie Chart (DSL)",
+        "type": "object"
+      },
+      "range_key": {
+        "additionalProperties": false,
+        "properties": {
+          "from": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          },
+          "ranges": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "from": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
+                },
+                "label": {
+                  "type": "string"
+                },
+                "to": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "from",
+                "to",
+                "label"
+              ],
+              "type": "object"
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "to": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          },
+          "type": {
+            "enum": [
+              "range_key"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "from",
+          "to",
+          "ranges"
+        ],
+        "title": "Range Key",
+        "type": "object"
+      },
+      "rangesOperation": {
+        "additionalProperties": false,
+        "properties": {
+          "collapse_by": {
+            "$ref": "#/components/schemas/collapseBy"
+          },
+          "color": {
+            "$ref": "#/components/schemas/colorMapping"
+          },
+          "field": {
+            "description": "Field to be used for the range",
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/components/schemas/formatType"
+          },
+          "label": {
+            "description": "Label for the operation",
+            "type": "string"
+          },
+          "operation": {
+            "enum": [
+              "range"
+            ],
+            "type": "string"
+          },
+          "ranges": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "gt": {
+                  "description": "Greater than",
+                  "type": "number"
+                },
+                "label": {
+                  "description": "Label",
+                  "type": "string"
+                },
+                "lte": {
+                  "description": "Less than or equal to",
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            "maxItems": 100,
+            "type": "array"
+          }
+        },
+        "required": [
+          "operation",
+          "format",
+          "field",
+          "ranges",
+          "color",
+          "collapse_by"
+        ],
+        "title": "Ranges Operation",
+        "type": "object"
+      },
+      "regionMapESQL": {
+        "additionalProperties": false,
+        "properties": {
+          "data_source": {
+            "$ref": "#/components/schemas/esqlDataSource"
+          },
+          "description": {
+            "type": "string"
+          },
+          "drilldowns": {
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "dashboard_id": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": false,
+                      "description": "When enabled, the dashboard opens in a new browser tab.",
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "dashboard_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "use_filters": {
+                      "default": true,
+                      "description": "When enabled, filters are passed to the opening dashboard.",
+                      "type": "boolean"
+                    },
+                    "use_time_range": {
+                      "default": true,
+                      "description": "When enabled, time range is passed to the opening dashboard.",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "dashboard_id",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "dashboard_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "discover_drilldown"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "discover_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "encode_url": {
+                      "default": true,
+                      "description": "When true, URL is escaped using percent encoding",
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_click_row",
+                        "on_click_value",
+                        "on_open_panel_menu",
+                        "on_select_range"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "url_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "url": {
+                      "description": "Templated Url. Variables documented at https://www.elastic.co/docs/explore-analyze/dashboards/drilldowns#url-template-variable",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "url",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "url_drilldown",
+                  "type": "object"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "filters": {
+            "$ref": "#/components/schemas/lensPanelFilters"
+          },
+          "hide_border": {
+            "type": "boolean"
+          },
+          "hide_title": {
+            "type": "boolean"
+          },
+          "ignore_global_filters": {
+            "default": false,
+            "description": "If true, ignore global filters when fetching data for this layer. Default is false.",
+            "type": "boolean"
+          },
+          "metric": {
+            "additionalProperties": false,
+            "properties": {
+              "column": {
+                "description": "Column to use",
+                "type": "string"
+              },
+              "format": {
+                "$ref": "#/components/schemas/formatType"
+              },
+              "label": {
+                "description": "Label for the operation",
+                "type": "string"
+              }
+            },
+            "required": [
+              "column",
+              "format"
+            ],
+            "type": "object"
+          },
+          "references": {
+            "items": {
+              "$ref": "#/components/schemas/kbn-content-management-utils-referenceSchema"
+            },
+            "type": "array"
+          },
+          "region": {
+            "additionalProperties": false,
+            "properties": {
+              "column": {
+                "description": "Column to use",
+                "type": "string"
+              },
+              "ems": {
+                "additionalProperties": false,
+                "properties": {
+                  "boundaries": {
+                    "description": "EMS boundaries",
+                    "type": "string"
+                  },
+                  "join": {
+                    "description": "EMS join field",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "boundaries",
+                  "join"
+                ],
+                "type": "object"
+              },
+              "label": {
+                "description": "Label for the operation",
+                "type": "string"
+              }
+            },
+            "required": [
+              "column"
+            ],
+            "type": "object"
+          },
+          "sampling": {
+            "default": 1,
+            "description": "Sampling factor between 0 (no sampling) and 1 (full sampling). Default is 1.",
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "time_range": {
+            "$ref": "#/components/schemas/kbn-es-query-server-timeRangeSchema"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "region_map"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "filters",
+          "data_source",
+          "metric",
+          "region",
+          "time_range"
+        ],
+        "title": "Region Map (ES|QL)",
+        "type": "object"
+      },
+      "regionMapNoESQL": {
+        "additionalProperties": false,
+        "properties": {
+          "data_source": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/kbn-data-view-reference-schema"
+              },
+              {
+                "$ref": "#/components/schemas/kbn-data-view-spec-schema"
+              }
+            ]
+          },
+          "description": {
+            "type": "string"
+          },
+          "drilldowns": {
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "dashboard_id": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": false,
+                      "description": "When enabled, the dashboard opens in a new browser tab.",
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "dashboard_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "use_filters": {
+                      "default": true,
+                      "description": "When enabled, filters are passed to the opening dashboard.",
+                      "type": "boolean"
+                    },
+                    "use_time_range": {
+                      "default": true,
+                      "description": "When enabled, time range is passed to the opening dashboard.",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "dashboard_id",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "dashboard_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "discover_drilldown"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "discover_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "encode_url": {
+                      "default": true,
+                      "description": "When true, URL is escaped using percent encoding",
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_click_row",
+                        "on_click_value",
+                        "on_open_panel_menu",
+                        "on_select_range"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "url_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "url": {
+                      "description": "Templated Url. Variables documented at https://www.elastic.co/docs/explore-analyze/dashboards/drilldowns#url-template-variable",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "url",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "url_drilldown",
+                  "type": "object"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "filters": {
+            "$ref": "#/components/schemas/lensPanelFilters"
+          },
+          "hide_border": {
+            "type": "boolean"
+          },
+          "hide_title": {
+            "type": "boolean"
+          },
+          "ignore_global_filters": {
+            "default": false,
+            "description": "If true, ignore global filters when fetching data for this layer. Default is false.",
+            "type": "boolean"
+          },
+          "metric": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/fieldMetricOperations"
+              },
+              {
+                "$ref": "#/components/schemas/formulaOperation"
+              }
+            ]
+          },
+          "query": {
+            "$ref": "#/components/schemas/filterSimple"
+          },
+          "references": {
+            "items": {
+              "$ref": "#/components/schemas/kbn-content-management-utils-referenceSchema"
+            },
+            "type": "array"
+          },
+          "region": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/dateHistogramOperation"
+              },
+              {
+                "$ref": "#/components/schemas/termsOperation"
+              },
+              {
+                "$ref": "#/components/schemas/histogramOperation"
+              },
+              {
+                "$ref": "#/components/schemas/rangesOperation"
+              },
+              {
+                "$ref": "#/components/schemas/filtersOperation"
+              }
+            ]
+          },
+          "sampling": {
+            "default": 1,
+            "description": "Sampling factor between 0 (no sampling) and 1 (full sampling). Default is 1.",
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "time_range": {
+            "$ref": "#/components/schemas/kbn-es-query-server-timeRangeSchema"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "region_map"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "filters",
+          "query",
+          "data_source",
+          "metric",
+          "region",
+          "time_range"
+        ],
+        "title": "Region Map (DSL)",
+        "type": "object"
+      },
+      "slo-alerts-embeddable": {
+        "additionalProperties": false,
+        "description": "SLO Alerts embeddable schema",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "drilldowns": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "encode_url": {
+                  "default": true,
+                  "description": "When true, URL is escaped using percent encoding",
+                  "type": "boolean"
+                },
+                "label": {
+                  "type": "string"
+                },
+                "open_in_new_tab": {
+                  "default": true,
+                  "type": "boolean"
+                },
+                "trigger": {
+                  "enum": [
+                    "on_open_panel_menu"
+                  ],
+                  "type": "string"
+                },
+                "type": {
+                  "enum": [
+                    "url_drilldown"
+                  ],
+                  "type": "string"
+                },
+                "url": {
+                  "description": "Templated Url. Variables documented at https://www.elastic.co/docs/explore-analyze/dashboards/drilldowns#url-template-variable",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "url",
+                "label",
+                "trigger",
+                "type"
+              ],
+              "title": "url_drilldown",
+              "type": "object"
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "hide_border": {
+            "type": "boolean"
+          },
+          "hide_title": {
+            "type": "boolean"
+          },
+          "slos": {
+            "default": [],
+            "description": "List of SLOs to display alerts for",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "slo_id": {
+                  "description": "SLO ID",
+                  "type": "string"
+                },
+                "slo_instance_id": {
+                  "default": "*",
+                  "description": "SLO instance ID",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "slo_id"
+              ],
+              "type": "object"
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "title": "slo-alerts-embeddable",
+        "type": "object"
+      },
+      "slo-burn-rate-embeddable": {
+        "additionalProperties": false,
+        "description": "SLO Burn Rate embeddable schema",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "drilldowns": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "encode_url": {
+                  "default": true,
+                  "description": "When true, URL is escaped using percent encoding",
+                  "type": "boolean"
+                },
+                "label": {
+                  "type": "string"
+                },
+                "open_in_new_tab": {
+                  "default": true,
+                  "type": "boolean"
+                },
+                "trigger": {
+                  "enum": [
+                    "on_open_panel_menu"
+                  ],
+                  "type": "string"
+                },
+                "type": {
+                  "enum": [
+                    "url_drilldown"
+                  ],
+                  "type": "string"
+                },
+                "url": {
+                  "description": "Templated Url. Variables documented at https://www.elastic.co/docs/explore-analyze/dashboards/drilldowns#url-template-variable",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "url",
+                "label",
+                "trigger",
+                "type"
+              ],
+              "title": "url_drilldown",
+              "type": "object"
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "duration": {
+            "description": "Duration for the burn rate chart in the format [value][unit], e.g. 5m, 3h, or 6d",
+            "type": "string"
+          },
+          "hide_border": {
+            "type": "boolean"
+          },
+          "hide_title": {
+            "type": "boolean"
+          },
+          "slo_id": {
+            "description": "The ID of the SLO to display the burn rate for",
+            "type": "string"
+          },
+          "slo_instance_id": {
+            "default": "*",
+            "description": "ID of the SLO instance. Set when the SLO uses group_by; identifies which instance to show. Defaults to * (all instances).",
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "slo_id",
+          "duration"
+        ],
+        "title": "slo-burn-rate-embeddable",
+        "type": "object"
+      },
+      "slo-error-budget-embeddable": {
+        "additionalProperties": false,
+        "description": "SLO Error Budget embeddable schema",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "drilldowns": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "encode_url": {
+                  "default": true,
+                  "description": "When true, URL is escaped using percent encoding",
+                  "type": "boolean"
+                },
+                "label": {
+                  "type": "string"
+                },
+                "open_in_new_tab": {
+                  "default": true,
+                  "type": "boolean"
+                },
+                "trigger": {
+                  "enum": [
+                    "on_open_panel_menu"
+                  ],
+                  "type": "string"
+                },
+                "type": {
+                  "enum": [
+                    "url_drilldown"
+                  ],
+                  "type": "string"
+                },
+                "url": {
+                  "description": "Templated Url. Variables documented at https://www.elastic.co/docs/explore-analyze/dashboards/drilldowns#url-template-variable",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "url",
+                "label",
+                "trigger",
+                "type"
+              ],
+              "title": "url_drilldown",
+              "type": "object"
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "hide_border": {
+            "type": "boolean"
+          },
+          "hide_title": {
+            "type": "boolean"
+          },
+          "slo_id": {
+            "description": "The ID of the SLO to display the error budget for",
+            "type": "string"
+          },
+          "slo_instance_id": {
+            "default": "*",
+            "description": "ID of the SLO instance. Set when the SLO uses group_by; identifies which instance to show. Defaults to * (all instances).",
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "slo_id"
+        ],
+        "title": "slo-error-budget-embeddable",
+        "type": "object"
+      },
+      "slo-group-overview-embeddable": {
+        "additionalProperties": false,
+        "description": "SLO Group Overview embeddable schema",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "drilldowns": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "encode_url": {
+                  "default": true,
+                  "description": "When true, URL is escaped using percent encoding",
+                  "type": "boolean"
+                },
+                "label": {
+                  "type": "string"
+                },
+                "open_in_new_tab": {
+                  "default": true,
+                  "type": "boolean"
+                },
+                "trigger": {
+                  "enum": [
+                    "on_open_panel_menu"
+                  ],
+                  "type": "string"
+                },
+                "type": {
+                  "enum": [
+                    "url_drilldown"
+                  ],
+                  "type": "string"
+                },
+                "url": {
+                  "description": "Templated Url. Variables documented at https://www.elastic.co/docs/explore-analyze/dashboards/drilldowns#url-template-variable",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "url",
+                "label",
+                "trigger",
+                "type"
+              ],
+              "title": "url_drilldown",
+              "type": "object"
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "group_filters": {
+            "additionalProperties": false,
+            "default": {
+              "group_by": "status"
+            },
+            "properties": {
+              "filters": {
+                "items": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/kbn-as-code-filters-schema_asCodeConditionFilterSchema"
+                    },
+                    {
+                      "$ref": "#/components/schemas/kbn-as-code-filters-schema_asCodeGroupFilterSchema"
+                    },
+                    {
+                      "$ref": "#/components/schemas/kbn-as-code-filters-schema_asCodeDSLFilterSchema"
+                    },
+                    {
+                      "$ref": "#/components/schemas/kbn-as-code-filters-schema_asCodeSpatialFilterSchema"
+                    }
+                  ],
+                  "description": "A filter which can be a condition, group, DSL, or spatial"
+                },
+                "maxItems": 500,
+                "type": "array"
+              },
+              "group_by": {
+                "default": "status",
+                "enum": [
+                  "slo.tags",
+                  "status",
+                  "slo.indicator.type",
+                  "_index"
+                ],
+                "type": "string"
+              },
+              "groups": {
+                "items": {
+                  "type": "string"
+                },
+                "maxItems": 100,
+                "type": "array"
+              },
+              "kql_query": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "hide_border": {
+            "type": "boolean"
+          },
+          "hide_title": {
+            "type": "boolean"
+          },
+          "overview_mode": {
+            "enum": [
+              "groups"
+            ],
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "overview_mode"
+        ],
+        "title": "slo-group-overview-embeddable",
+        "type": "object"
+      },
+      "slo-single-overview-embeddable": {
+        "additionalProperties": false,
+        "description": "SLO Single Overview embeddable schema",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "drilldowns": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "encode_url": {
+                  "default": true,
+                  "description": "When true, URL is escaped using percent encoding",
+                  "type": "boolean"
+                },
+                "label": {
+                  "type": "string"
+                },
+                "open_in_new_tab": {
+                  "default": true,
+                  "type": "boolean"
+                },
+                "trigger": {
+                  "enum": [
+                    "on_open_panel_menu"
+                  ],
+                  "type": "string"
+                },
+                "type": {
+                  "enum": [
+                    "url_drilldown"
+                  ],
+                  "type": "string"
+                },
+                "url": {
+                  "description": "Templated Url. Variables documented at https://www.elastic.co/docs/explore-analyze/dashboards/drilldowns#url-template-variable",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "url",
+                "label",
+                "trigger",
+                "type"
+              ],
+              "title": "url_drilldown",
+              "type": "object"
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "hide_border": {
+            "type": "boolean"
+          },
+          "hide_title": {
+            "type": "boolean"
+          },
+          "overview_mode": {
+            "enum": [
+              "single"
+            ],
+            "type": "string"
+          },
+          "remote_name": {
+            "description": "The name of the remote SLO",
+            "type": "string"
+          },
+          "slo_id": {
+            "description": "The ID of the SLO",
+            "type": "string"
+          },
+          "slo_instance_id": {
+            "default": "*",
+            "description": "ID of the SLO instance. Set when the SLO uses group_by; identifies which instance to show. Defaults to * (all instances).",
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "slo_id",
+          "overview_mode"
+        ],
+        "title": "slo-single-overview-embeddable",
+        "type": "object"
+      },
+      "staticColor": {
+        "additionalProperties": false,
+        "properties": {
+          "color": {
+            "description": "The static color to be used for all values.",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "static"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "color"
+        ],
+        "title": "Static Color",
+        "type": "object",
+        "x-oas-optional": true
+      },
+      "staticOperationDefinition": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "$ref": "#/components/schemas/formatType"
+          },
+          "label": {
+            "description": "Label for the operation",
+            "type": "string"
+          },
+          "operation": {
+            "enum": [
+              "static_value"
+            ],
+            "type": "string"
+          },
+          "value": {
+            "default": 100,
+            "description": "Static value",
+            "type": "number"
+          }
+        },
+        "required": [
+          "format",
+          "operation"
+        ],
+        "title": "Static Operation Definition",
+        "type": "object"
+      },
+      "sumMetricOperation": {
+        "additionalProperties": false,
+        "properties": {
+          "empty_as_null": {
+            "default": false,
+            "description": "Whether to consider null values as null",
+            "type": "boolean"
+          },
+          "field": {
+            "description": "Field to be used for the metric",
+            "type": "string"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/filterSimple"
+          },
+          "format": {
+            "$ref": "#/components/schemas/formatType"
+          },
+          "label": {
+            "description": "Label for the operation",
+            "type": "string"
+          },
+          "operation": {
+            "enum": [
+              "sum"
+            ],
+            "type": "string"
+          },
+          "reduced_time_range": {
+            "description": "Reduced time range",
+            "title": "Operation Reduced Time Range Setting",
+            "type": "string"
+          },
+          "time_scale": {
+            "$ref": "#/components/schemas/operationTimeScaleSetting"
+          },
+          "time_shift": {
+            "description": "Time shift",
+            "title": "Operation Time Shift Setting",
+            "type": "string"
+          }
+        },
+        "required": [
+          "format",
+          "filter",
+          "time_scale",
+          "field",
+          "operation"
+        ],
+        "title": "Sum Metric Operation",
+        "type": "object"
+      },
+      "tagcloudESQL": {
+        "additionalProperties": false,
+        "properties": {
+          "caption": {
+            "additionalProperties": false,
+            "description": "Caption configuration representing the metric and the tag_by operations labels",
+            "properties": {
+              "visible": {
+                "default": true,
+                "description": "Show caption",
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "data_source": {
+            "$ref": "#/components/schemas/esqlDataSource"
+          },
+          "description": {
+            "type": "string"
+          },
+          "drilldowns": {
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "dashboard_id": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": false,
+                      "description": "When enabled, the dashboard opens in a new browser tab.",
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "dashboard_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "use_filters": {
+                      "default": true,
+                      "description": "When enabled, filters are passed to the opening dashboard.",
+                      "type": "boolean"
+                    },
+                    "use_time_range": {
+                      "default": true,
+                      "description": "When enabled, time range is passed to the opening dashboard.",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "dashboard_id",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "dashboard_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "discover_drilldown"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "discover_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "encode_url": {
+                      "default": true,
+                      "description": "When true, URL is escaped using percent encoding",
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_click_row",
+                        "on_click_value",
+                        "on_open_panel_menu",
+                        "on_select_range"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "url_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "url": {
+                      "description": "Templated Url. Variables documented at https://www.elastic.co/docs/explore-analyze/dashboards/drilldowns#url-template-variable",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "url",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "url_drilldown",
+                  "type": "object"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "filters": {
+            "$ref": "#/components/schemas/lensPanelFilters"
+          },
+          "font_size": {
+            "additionalProperties": false,
+            "description": "Minimum and maximum font size for the tags",
+            "properties": {
+              "max": {
+                "default": 72,
+                "description": "Maximum font size",
+                "maximum": 120,
+                "type": "number"
+              },
+              "min": {
+                "default": 18,
+                "description": "Minimum font size",
+                "minimum": 1,
+                "type": "number"
+              }
+            },
+            "type": "object"
+          },
+          "hide_border": {
+            "type": "boolean"
+          },
+          "hide_title": {
+            "type": "boolean"
+          },
+          "ignore_global_filters": {
+            "default": false,
+            "description": "If true, ignore global filters when fetching data for this layer. Default is false.",
+            "type": "boolean"
+          },
+          "metric": {
+            "additionalProperties": false,
+            "properties": {
+              "column": {
+                "description": "Column to use",
+                "type": "string"
+              },
+              "format": {
+                "$ref": "#/components/schemas/formatType"
+              },
+              "label": {
+                "description": "Label for the operation",
+                "type": "string"
+              }
+            },
+            "required": [
+              "column",
+              "format"
+            ],
+            "type": "object"
+          },
+          "orientation": {
+            "$ref": "#/components/schemas/vis_api_orientation"
+          },
+          "references": {
+            "items": {
+              "$ref": "#/components/schemas/kbn-content-management-utils-referenceSchema"
+            },
+            "type": "array"
+          },
+          "sampling": {
+            "default": 1,
+            "description": "Sampling factor between 0 (no sampling) and 1 (full sampling). Default is 1.",
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "tag_by": {
+            "additionalProperties": false,
+            "properties": {
+              "color": {
+                "$ref": "#/components/schemas/colorMapping"
+              },
+              "column": {
+                "description": "Column to use",
+                "type": "string"
+              },
+              "format": {
+                "$ref": "#/components/schemas/formatType"
+              },
+              "label": {
+                "description": "Label for the operation",
+                "type": "string"
+              }
+            },
+            "required": [
+              "column",
+              "format",
+              "color"
+            ],
+            "type": "object"
+          },
+          "time_range": {
+            "$ref": "#/components/schemas/kbn-es-query-server-timeRangeSchema"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "tag_cloud"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "filters",
+          "data_source",
+          "orientation",
+          "metric",
+          "tag_by",
+          "time_range"
+        ],
+        "title": "Tag Cloud Chart (ES|QL)",
+        "type": "object"
+      },
+      "tagcloudNoESQL": {
+        "additionalProperties": false,
+        "properties": {
+          "caption": {
+            "additionalProperties": false,
+            "description": "Caption configuration representing the metric and the tag_by operations labels",
+            "properties": {
+              "visible": {
+                "default": true,
+                "description": "Show caption",
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "data_source": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/kbn-data-view-reference-schema"
+              },
+              {
+                "$ref": "#/components/schemas/kbn-data-view-spec-schema"
+              }
+            ]
+          },
+          "description": {
+            "type": "string"
+          },
+          "drilldowns": {
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "dashboard_id": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": false,
+                      "description": "When enabled, the dashboard opens in a new browser tab.",
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "dashboard_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "use_filters": {
+                      "default": true,
+                      "description": "When enabled, filters are passed to the opening dashboard.",
+                      "type": "boolean"
+                    },
+                    "use_time_range": {
+                      "default": true,
+                      "description": "When enabled, time range is passed to the opening dashboard.",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "dashboard_id",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "dashboard_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "discover_drilldown"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "discover_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "encode_url": {
+                      "default": true,
+                      "description": "When true, URL is escaped using percent encoding",
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_click_row",
+                        "on_click_value",
+                        "on_open_panel_menu",
+                        "on_select_range"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "url_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "url": {
+                      "description": "Templated Url. Variables documented at https://www.elastic.co/docs/explore-analyze/dashboards/drilldowns#url-template-variable",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "url",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "url_drilldown",
+                  "type": "object"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "filters": {
+            "$ref": "#/components/schemas/lensPanelFilters"
+          },
+          "font_size": {
+            "additionalProperties": false,
+            "description": "Minimum and maximum font size for the tags",
+            "properties": {
+              "max": {
+                "default": 72,
+                "description": "Maximum font size",
+                "maximum": 120,
+                "type": "number"
+              },
+              "min": {
+                "default": 18,
+                "description": "Minimum font size",
+                "minimum": 1,
+                "type": "number"
+              }
+            },
+            "type": "object"
+          },
+          "hide_border": {
+            "type": "boolean"
+          },
+          "hide_title": {
+            "type": "boolean"
+          },
+          "ignore_global_filters": {
+            "default": false,
+            "description": "If true, ignore global filters when fetching data for this layer. Default is false.",
+            "type": "boolean"
+          },
+          "metric": {
+            "anyOf": [
+              {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/countMetricOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/uniqueCountMetricOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/minMaxAvgMedianStdDevMetricOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/sumMetricOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/lastValueOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/percentileOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/percentileRanksOperation"
+                  }
+                ]
+              },
+              {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/differencesOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/movingAverageOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/cumulativeSumOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/counterRateOperation"
+                  }
+                ]
+              },
+              {
+                "$ref": "#/components/schemas/formulaOperation"
+              }
+            ]
+          },
+          "orientation": {
+            "$ref": "#/components/schemas/vis_api_orientation"
+          },
+          "query": {
+            "$ref": "#/components/schemas/filterSimple"
+          },
+          "references": {
+            "items": {
+              "$ref": "#/components/schemas/kbn-content-management-utils-referenceSchema"
+            },
+            "type": "array"
+          },
+          "sampling": {
+            "default": 1,
+            "description": "Sampling factor between 0 (no sampling) and 1 (full sampling). Default is 1.",
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "tag_by": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/dateHistogramOperation"
+              },
+              {
+                "$ref": "#/components/schemas/termsOperation"
+              },
+              {
+                "$ref": "#/components/schemas/histogramOperation"
+              },
+              {
+                "$ref": "#/components/schemas/rangesOperation"
+              },
+              {
+                "$ref": "#/components/schemas/filtersOperation"
+              }
+            ]
+          },
+          "time_range": {
+            "$ref": "#/components/schemas/kbn-es-query-server-timeRangeSchema"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "tag_cloud"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "filters",
+          "query",
+          "data_source",
+          "orientation",
+          "metric",
+          "tag_by",
+          "time_range"
+        ],
+        "title": "Tag Cloud Chart (DSL)",
+        "type": "object"
+      },
+      "termsOperation": {
+        "additionalProperties": false,
+        "properties": {
+          "collapse_by": {
+            "$ref": "#/components/schemas/collapseBy"
+          },
+          "color": {
+            "$ref": "#/components/schemas/colorMapping"
+          },
+          "excludes": {
+            "additionalProperties": false,
+            "properties": {
+              "as_regex": {
+                "description": "Whether to use regex",
+                "type": "boolean"
+              },
+              "values": {
+                "items": {
+                  "description": "Values to exclude",
+                  "type": "string"
+                },
+                "maxItems": 100,
+                "type": "array"
+              }
+            },
+            "required": [
+              "values"
+            ],
+            "type": "object"
+          },
+          "fields": {
+            "items": {
+              "description": "Fields to be used for the terms",
+              "type": "string"
+            },
+            "maxItems": 4,
+            "minItems": 1,
+            "type": "array"
+          },
+          "format": {
+            "$ref": "#/components/schemas/formatType"
+          },
+          "includes": {
+            "additionalProperties": false,
+            "properties": {
+              "as_regex": {
+                "description": "Whether to use regex",
+                "type": "boolean"
+              },
+              "values": {
+                "items": {
+                  "description": "Values to include",
+                  "type": "string"
+                },
+                "maxItems": 100,
+                "type": "array"
+              }
+            },
+            "required": [
+              "values"
+            ],
+            "type": "object"
+          },
+          "increase_accuracy": {
+            "description": "Whether to increase accuracy",
+            "type": "boolean"
+          },
+          "label": {
+            "description": "Label for the operation",
+            "type": "string"
+          },
+          "limit": {
+            "default": 5,
+            "description": "Maximum number of terms",
+            "type": "number"
+          },
+          "operation": {
+            "enum": [
+              "terms"
+            ],
+            "type": "string"
+          },
+          "other_bucket": {
+            "additionalProperties": false,
+            "properties": {
+              "include_documents_without_field": {
+                "description": "Whether to include documents without field",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "include_documents_without_field"
+            ],
+            "type": "object"
+          },
+          "rank_by": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "direction": {
+                    "$ref": "#/components/schemas/termsRankByAlphabeticalDirection"
+                  },
+                  "type": {
+                    "enum": [
+                      "alphabetical"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "direction"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "max": {
+                    "description": "Maximum number of rare terms",
+                    "type": "number"
+                  },
+                  "type": {
+                    "enum": [
+                      "rare"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "max"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "type": {
+                    "enum": [
+                      "significant"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "direction": {
+                    "$ref": "#/components/schemas/termsRankByMetricDirection"
+                  },
+                  "metric_index": {
+                    "default": 0,
+                    "description": "0-based index into the metrics array (layer's metrics array if XY chart) identifying which metric to rank by. Defaults to 0 (first metric).",
+                    "minimum": 0,
+                    "type": "number"
+                  },
+                  "type": {
+                    "enum": [
+                      "metric"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "direction"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "direction": {
+                    "$ref": "#/components/schemas/termsRankByCustomDirection"
+                  },
+                  "field": {
+                    "description": "Numeric field to be used for the custom operation",
+                    "type": "string"
+                  },
+                  "operation": {
+                    "enum": [
+                      "min",
+                      "max",
+                      "average",
+                      "median",
+                      "standard_deviation",
+                      "unique_count",
+                      "count",
+                      "sum",
+                      "last_value"
+                    ],
+                    "type": "string"
+                  },
+                  "type": {
+                    "enum": [
+                      "custom"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "field",
+                  "direction",
+                  "operation"
+                ],
+                "type": "object"
+              },
+              {
+                "$ref": "#/components/schemas/termsRankByPercentileOperation"
+              },
+              {
+                "$ref": "#/components/schemas/termsRankByPercentileRankOperation"
+              }
+            ]
+          }
+        },
+        "required": [
+          "operation",
+          "format",
+          "fields",
+          "color",
+          "collapse_by"
+        ],
+        "title": "Terms Operation",
+        "type": "object"
+      },
+      "termsRankByAlphabeticalDirection": {
+        "description": "Sort direction for alphabetical ranking",
+        "enum": [
+          "asc",
+          "desc"
+        ],
+        "title": "termsRankByAlphabeticalDirection",
+        "type": "string"
+      },
+      "termsRankByCustomDirection": {
+        "description": "Sort direction for custom ranking",
+        "enum": [
+          "asc",
+          "desc"
+        ],
+        "title": "termsRankByCustomDirection",
+        "type": "string"
+      },
+      "termsRankByMetricDirection": {
+        "description": "Sort direction for metric-based ranking",
+        "enum": [
+          "asc",
+          "desc"
+        ],
+        "title": "termsRankByMetricDirection",
+        "type": "string"
+      },
+      "termsRankByPercentileOperation": {
+        "additionalProperties": false,
+        "description": "Ranks terms by a percentile value of a numeric field (e.g. the 95th percentile of response time).",
+        "properties": {
+          "direction": {
+            "$ref": "#/components/schemas/termsRankByCustomDirection"
+          },
+          "field": {
+            "description": "Numeric field to be used for the custom operation",
+            "type": "string"
+          },
+          "operation": {
+            "enum": [
+              "percentile"
+            ],
+            "type": "string"
+          },
+          "percentile": {
+            "default": 95,
+            "description": "The percentile threshold (0–100) at which to compute the field value used for ranking terms.",
+            "type": "number"
+          },
+          "type": {
+            "enum": [
+              "custom"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "field",
+          "direction",
+          "operation"
+        ],
+        "title": "Terms Rank By Percentile Operation",
+        "type": "object"
+      },
+      "termsRankByPercentileRankOperation": {
+        "additionalProperties": false,
+        "description": "Ranks terms by the percentile rank of a single value — the proportion of field values at or below that value.",
+        "properties": {
+          "direction": {
+            "$ref": "#/components/schemas/termsRankByCustomDirection"
+          },
+          "field": {
+            "description": "Numeric field to be used for the custom operation",
+            "type": "string"
+          },
+          "operation": {
+            "enum": [
+              "percentile_rank"
+            ],
+            "type": "string"
+          },
+          "rank": {
+            "default": 0,
+            "description": "The numeric value for which to compute the percentile rank (the percentage of field values at or below this value).",
+            "type": "number"
+          },
+          "type": {
+            "enum": [
+              "custom"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "field",
+          "direction",
+          "operation"
+        ],
+        "title": "Terms Rank By Percentile Rank Operation",
+        "type": "object"
+      },
+      "treemapESQL": {
+        "additionalProperties": false,
+        "description": "Treemap chart configuration schema for ES|QL queries, defining metrics and breakdown dimensions using column-based configuration",
+        "properties": {
+          "data_source": {
+            "$ref": "#/components/schemas/esqlDataSource"
+          },
+          "description": {
+            "type": "string"
+          },
+          "drilldowns": {
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "dashboard_id": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": false,
+                      "description": "When enabled, the dashboard opens in a new browser tab.",
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "dashboard_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "use_filters": {
+                      "default": true,
+                      "description": "When enabled, filters are passed to the opening dashboard.",
+                      "type": "boolean"
+                    },
+                    "use_time_range": {
+                      "default": true,
+                      "description": "When enabled, time range is passed to the opening dashboard.",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "dashboard_id",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "dashboard_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "discover_drilldown"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "discover_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "encode_url": {
+                      "default": true,
+                      "description": "When true, URL is escaped using percent encoding",
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_click_row",
+                        "on_click_value",
+                        "on_open_panel_menu",
+                        "on_select_range"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "url_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "url": {
+                      "description": "Templated Url. Variables documented at https://www.elastic.co/docs/explore-analyze/dashboards/drilldowns#url-template-variable",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "url",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "url_drilldown",
+                  "type": "object"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "filters": {
+            "$ref": "#/components/schemas/lensPanelFilters"
+          },
+          "group_by": {
+            "description": "Array of breakdown dimensions (minimum 1)",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "collapse_by": {
+                  "$ref": "#/components/schemas/collapseBy"
+                },
+                "color": {
+                  "$ref": "#/components/schemas/colorMapping"
+                },
+                "column": {
+                  "description": "Column to use",
+                  "type": "string"
+                },
+                "format": {
+                  "$ref": "#/components/schemas/formatType"
+                },
+                "label": {
+                  "description": "Label for the operation",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "column",
+                "format",
+                "color",
+                "collapse_by"
+              ],
+              "type": "object"
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "type": "array"
+          },
+          "hide_border": {
+            "type": "boolean"
+          },
+          "hide_title": {
+            "type": "boolean"
+          },
+          "ignore_global_filters": {
+            "default": false,
+            "description": "If true, ignore global filters when fetching data for this layer. Default is false.",
+            "type": "boolean"
+          },
+          "labels": {
+            "additionalProperties": false,
+            "description": "Labels configuration",
+            "properties": {
+              "visible": {
+                "description": "Show category labels",
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "legend": {
+            "$ref": "#/components/schemas/treemapLegend"
+          },
+          "metrics": {
+            "description": "Array of metric configurations (minimum 1)",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "color": {
+                  "$ref": "#/components/schemas/staticColor"
+                },
+                "column": {
+                  "description": "Column to use",
+                  "type": "string"
+                },
+                "format": {
+                  "$ref": "#/components/schemas/formatType"
+                },
+                "label": {
+                  "description": "Label for the operation",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "column",
+                "format",
+                "color"
+              ],
+              "type": "object"
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "type": "array"
+          },
+          "references": {
+            "items": {
+              "$ref": "#/components/schemas/kbn-content-management-utils-referenceSchema"
+            },
+            "type": "array"
+          },
+          "sampling": {
+            "default": 1,
+            "description": "Sampling factor between 0 (no sampling) and 1 (full sampling). Default is 1.",
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "time_range": {
+            "$ref": "#/components/schemas/kbn-es-query-server-timeRangeSchema"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "treemap"
+            ],
+            "type": "string"
+          },
+          "values": {
+            "$ref": "#/components/schemas/valueDisplay"
+          }
+        },
+        "required": [
+          "type",
+          "filters",
+          "data_source",
+          "legend",
+          "values",
+          "metrics",
+          "time_range"
+        ],
+        "title": "Treemap Chart (ES|QL)",
+        "type": "object"
+      },
+      "treemapLegend": {
+        "additionalProperties": false,
+        "description": "Configuration for the treemap chart legend appearance and behavior",
+        "properties": {
+          "nested": {
+            "description": "Show nested legend with hierarchical breakdown levels",
+            "type": "boolean"
+          },
+          "size": {
+            "$ref": "#/components/schemas/legendSize"
+          },
+          "truncate_after_lines": {
+            "description": "Maximum lines before truncating legend items (1-10)",
+            "maximum": 10,
+            "minimum": 1,
+            "title": "legendTruncateAfterLines",
+            "type": "number"
+          },
+          "visibility": {
+            "description": "Legend visibility",
+            "enum": [
+              "auto",
+              "visible",
+              "hidden"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "size"
+        ],
+        "title": "Legend",
+        "type": "object",
+        "x-oas-optional": true
+      },
+      "treemapNoESQL": {
+        "additionalProperties": false,
+        "description": "Treemap chart configuration schema for data source queries (non-ES|QL mode), defining metrics and breakdown dimensions",
+        "properties": {
+          "data_source": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/kbn-data-view-reference-schema"
+              },
+              {
+                "$ref": "#/components/schemas/kbn-data-view-spec-schema"
+              }
+            ]
+          },
+          "description": {
+            "type": "string"
+          },
+          "drilldowns": {
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "dashboard_id": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": false,
+                      "description": "When enabled, the dashboard opens in a new browser tab.",
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "dashboard_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "use_filters": {
+                      "default": true,
+                      "description": "When enabled, filters are passed to the opening dashboard.",
+                      "type": "boolean"
+                    },
+                    "use_time_range": {
+                      "default": true,
+                      "description": "When enabled, time range is passed to the opening dashboard.",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "dashboard_id",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "dashboard_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "discover_drilldown"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "discover_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "encode_url": {
+                      "default": true,
+                      "description": "When true, URL is escaped using percent encoding",
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_click_row",
+                        "on_click_value",
+                        "on_open_panel_menu",
+                        "on_select_range"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "url_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "url": {
+                      "description": "Templated Url. Variables documented at https://www.elastic.co/docs/explore-analyze/dashboards/drilldowns#url-template-variable",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "url",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "url_drilldown",
+                  "type": "object"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "filters": {
+            "$ref": "#/components/schemas/lensPanelFilters"
+          },
+          "group_by": {
+            "description": "Array of breakdown dimensions (minimum 1)",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/dateHistogramOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/termsOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/histogramOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/rangesOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/filtersOperation"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "type": "array"
+          },
+          "hide_border": {
+            "type": "boolean"
+          },
+          "hide_title": {
+            "type": "boolean"
+          },
+          "ignore_global_filters": {
+            "default": false,
+            "description": "If true, ignore global filters when fetching data for this layer. Default is false.",
+            "type": "boolean"
+          },
+          "labels": {
+            "additionalProperties": false,
+            "description": "Labels configuration",
+            "properties": {
+              "visible": {
+                "description": "Show category labels",
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "legend": {
+            "$ref": "#/components/schemas/treemapLegend"
+          },
+          "metrics": {
+            "description": "Array of metric configurations (minimum 1)",
+            "items": {
+              "anyOf": [
+                {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/countMetricOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/uniqueCountMetricOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/minMaxAvgMedianStdDevMetricOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/sumMetricOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/lastValueOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/percentileOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/percentileRanksOperation"
+                    }
+                  ]
+                },
+                {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/differencesOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/movingAverageOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/cumulativeSumOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/counterRateOperation"
+                    }
+                  ]
+                },
+                {
+                  "$ref": "#/components/schemas/formulaOperation"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "type": "array"
+          },
+          "query": {
+            "$ref": "#/components/schemas/filterSimple"
+          },
+          "references": {
+            "items": {
+              "$ref": "#/components/schemas/kbn-content-management-utils-referenceSchema"
+            },
+            "type": "array"
+          },
+          "sampling": {
+            "default": 1,
+            "description": "Sampling factor between 0 (no sampling) and 1 (full sampling). Default is 1.",
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "time_range": {
+            "$ref": "#/components/schemas/kbn-es-query-server-timeRangeSchema"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "treemap"
+            ],
+            "type": "string"
+          },
+          "values": {
+            "$ref": "#/components/schemas/valueDisplay"
+          }
+        },
+        "required": [
+          "type",
+          "filters",
+          "data_source",
+          "query",
+          "legend",
+          "values",
+          "metrics",
+          "time_range"
+        ],
+        "title": "Treemap Chart (DSL)",
+        "type": "object"
+      },
+      "unassignedColorSchema": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/colorFromPalette"
+          },
+          {
+            "$ref": "#/components/schemas/color_code"
+          }
+        ],
+        "description": "The color to use for unassigned values.",
+        "title": "unassignedColorSchema",
+        "x-oas-optional": true
+      },
+      "uniqueCountMetricOperation": {
+        "additionalProperties": false,
+        "properties": {
+          "empty_as_null": {
+            "default": false,
+            "description": "Whether to consider null values as null",
+            "type": "boolean"
+          },
+          "field": {
+            "description": "Field to be used for the metric",
+            "type": "string"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/filterSimple"
+          },
+          "format": {
+            "$ref": "#/components/schemas/formatType"
+          },
+          "label": {
+            "description": "Label for the operation",
+            "type": "string"
+          },
+          "operation": {
+            "enum": [
+              "unique_count"
+            ],
+            "type": "string"
+          },
+          "reduced_time_range": {
+            "description": "Reduced time range",
+            "title": "Operation Reduced Time Range Setting",
+            "type": "string"
+          },
+          "time_scale": {
+            "$ref": "#/components/schemas/operationTimeScaleSetting"
+          },
+          "time_shift": {
+            "description": "Time shift",
+            "title": "Operation Time Shift Setting",
+            "type": "string"
+          }
+        },
+        "required": [
+          "format",
+          "filter",
+          "time_scale",
+          "field",
+          "operation"
+        ],
+        "title": "Unique Count Metric Operation",
+        "type": "object"
+      },
+      "valueDisplay": {
+        "additionalProperties": false,
+        "description": "Configure the visibility and the format of the values rendered on each chart partition section",
+        "properties": {
+          "mode": {
+            "description": "How to format values when visible.",
+            "enum": [
+              "absolute",
+              "percentage"
+            ],
+            "type": "string"
+          },
+          "percent_decimals": {
+            "description": "Decimal places for percentage display (0-10)",
+            "maximum": 10,
+            "minimum": 0,
+            "type": "number"
+          },
+          "visible": {
+            "description": "Show metric values on the chart",
+            "type": "boolean"
+          }
+        },
+        "title": "valueDisplay",
+        "type": "object",
+        "x-oas-optional": true
+      },
+      "vis_api_direction": {
+        "description": "Sort direction",
+        "enum": [
+          "asc",
+          "desc"
+        ],
+        "title": "vis_api_direction",
+        "type": "string"
+      },
+      "vis_api_domain_custom": {
+        "additionalProperties": false,
+        "description": "Uses explicitly provided domain bounds (min and max).",
+        "properties": {
+          "max": {
+            "description": "Max domain value",
+            "type": "number"
+          },
+          "min": {
+            "description": "Min domain value",
+            "type": "number"
+          },
+          "rounding": {
+            "description": "Whether to round axis domain bounds outward to readable “nice” values (for example 1, 5, 10, 100) instead of exact data min/max.",
+            "title": "vis_api_domain_rounding",
+            "type": "boolean"
+          },
+          "type": {
+            "enum": [
+              "custom"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "min",
+          "max"
+        ],
+        "title": "vis_api_domain_custom",
+        "type": "object"
+      },
+      "vis_api_domain_fit": {
+        "additionalProperties": false,
+        "description": "Uses tight domain bounds from the observed data minimum to maximum, without baseline expansion.",
+        "properties": {
+          "rounding": {
+            "description": "Whether to round axis domain bounds outward to readable “nice” values (for example 1, 5, 10, 100) instead of exact data min/max.",
+            "title": "vis_api_domain_rounding",
+            "type": "boolean"
+          },
+          "type": {
+            "enum": [
+              "fit"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "title": "vis_api_domain_fit",
+        "type": "object"
+      },
+      "vis_api_domain_full": {
+        "additionalProperties": false,
+        "description": "Uses the full chart domain, including baseline expansion when applicable (for example, includes zero for bar-like series).",
+        "properties": {
+          "rounding": {
+            "description": "Whether to round axis domain bounds outward to readable “nice” values (for example 1, 5, 10, 100) instead of exact data min/max.",
+            "title": "vis_api_domain_rounding",
+            "type": "boolean"
+          },
+          "type": {
+            "enum": [
+              "full"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "title": "vis_api_domain_full",
+        "type": "object"
+      },
+      "vis_api_orientation": {
+        "description": "Orientation of the tagcloud",
+        "enum": [
+          "horizontal",
+          "vertical",
+          "angled"
+        ],
+        "title": "vis_api_orientation",
+        "type": "string",
+        "x-oas-optional": true
+      },
+      "vis_api_simple_orientation": {
+        "default": "horizontal",
+        "description": "Orientation",
+        "enum": [
+          "horizontal",
+          "vertical"
+        ],
+        "title": "vis_api_simple_orientation",
+        "type": "string"
+      },
+      "vis_api_xy_axis_config": {
+        "additionalProperties": false,
+        "description": "Axis configuration for X, primary Y, and secondary Y axes. The primary Y axis defaults to the start (leading) side, and the secondary Y axis defaults to the end (trailing) side.",
+        "properties": {
+          "secondary_y": {
+            "additionalProperties": false,
+            "description": "Y-axis configuration with optional anchor, scale, and bounds. The anchor controls which side of the chart the axis renders on.",
+            "properties": {
+              "anchor": {
+                "description": "Position of the Y-axis relative to the chart orientation: start places it on the leading side (left in vertical charts), end on the trailing side (right in vertical charts).",
+                "enum": [
+                  "start",
+                  "end"
+                ],
+                "type": "string"
+              },
+              "domain": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/vis_api_domain_full"
+                  },
+                  {
+                    "$ref": "#/components/schemas/vis_api_domain_fit"
+                  },
+                  {
+                    "$ref": "#/components/schemas/vis_api_domain_custom"
+                  }
+                ],
+                "description": "Y-axis domain configuration"
+              },
+              "grid": {
+                "additionalProperties": false,
+                "description": "Axis grid lines configuration",
+                "properties": {
+                  "visible": {
+                    "description": "Show grid lines for this axis",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "visible"
+                ],
+                "type": "object"
+              },
+              "labels": {
+                "additionalProperties": false,
+                "description": "Label configuration",
+                "properties": {
+                  "orientation": {
+                    "$ref": "#/components/schemas/vis_api_orientation"
+                  }
+                },
+                "required": [
+                  "orientation"
+                ],
+                "type": "object"
+              },
+              "scale": {
+                "description": "Y-axis scale type for data transformation",
+                "enum": [
+                  "linear",
+                  "log",
+                  "sqrt"
+                ],
+                "type": "string"
+              },
+              "ticks": {
+                "additionalProperties": false,
+                "description": "Axis tick marks configuration",
+                "properties": {
+                  "visible": {
+                    "description": "Show tick marks on the axis",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "visible"
+                ],
+                "type": "object"
+              },
+              "title": {
+                "additionalProperties": false,
+                "description": "Axis title configuration",
+                "properties": {
+                  "text": {
+                    "description": "Axis title text",
+                    "type": "string"
+                  },
+                  "visible": {
+                    "description": "Show the title",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "required": [
+              "domain"
+            ],
+            "type": "object"
+          },
+          "x": {
+            "additionalProperties": false,
+            "description": "X-axis configuration",
+            "properties": {
+              "domain": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/vis_api_domain_fit"
+                  },
+                  {
+                    "$ref": "#/components/schemas/vis_api_domain_custom"
+                  }
+                ],
+                "description": "X-axis domain configuration"
+              },
+              "grid": {
+                "additionalProperties": false,
+                "description": "Axis grid lines configuration",
+                "properties": {
+                  "visible": {
+                    "description": "Show grid lines for this axis",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "visible"
+                ],
+                "type": "object"
+              },
+              "labels": {
+                "additionalProperties": false,
+                "description": "Label configuration",
+                "properties": {
+                  "orientation": {
+                    "$ref": "#/components/schemas/vis_api_orientation"
+                  }
+                },
+                "required": [
+                  "orientation"
+                ],
+                "type": "object"
+              },
+              "scale": {
+                "description": "X-axis scale type. Use 'temporal' for timestamp/date fields (e.g., @timestamp, DATE_TRUNC results). Use 'ordinal' for categorical/text fields. Use 'linear' for numeric fields.",
+                "enum": [
+                  "ordinal",
+                  "temporal",
+                  "linear"
+                ],
+                "type": "string"
+              },
+              "ticks": {
+                "additionalProperties": false,
+                "description": "Axis tick marks configuration",
+                "properties": {
+                  "visible": {
+                    "description": "Show tick marks on the axis",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "visible"
+                ],
+                "type": "object"
+              },
+              "title": {
+                "additionalProperties": false,
+                "description": "Axis title configuration",
+                "properties": {
+                  "text": {
+                    "description": "Axis title text",
+                    "type": "string"
+                  },
+                  "visible": {
+                    "description": "Show the title",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "y": {
+            "additionalProperties": false,
+            "description": "Y-axis configuration with optional anchor, scale, and bounds. The anchor controls which side of the chart the axis renders on.",
+            "properties": {
+              "anchor": {
+                "description": "Position of the Y-axis relative to the chart orientation: start places it on the leading side (left in vertical charts), end on the trailing side (right in vertical charts).",
+                "enum": [
+                  "start",
+                  "end"
+                ],
+                "type": "string"
+              },
+              "domain": {
+                "description": "Y-axis domain configuration",
+                "discriminator": {
+                  "propertyName": "type"
+                },
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/vis_api_domain_full"
+                  },
+                  {
+                    "$ref": "#/components/schemas/vis_api_domain_fit"
+                  },
+                  {
+                    "$ref": "#/components/schemas/vis_api_domain_custom"
+                  }
+                ]
+              },
+              "grid": {
+                "additionalProperties": false,
+                "description": "Axis grid lines configuration",
+                "properties": {
+                  "visible": {
+                    "description": "Show grid lines for this axis",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "visible"
+                ],
+                "type": "object"
+              },
+              "labels": {
+                "additionalProperties": false,
+                "description": "Label configuration",
+                "properties": {
+                  "orientation": {
+                    "$ref": "#/components/schemas/vis_api_orientation"
+                  }
+                },
+                "required": [
+                  "orientation"
+                ],
+                "type": "object"
+              },
+              "scale": {
+                "description": "Y-axis scale type for data transformation",
+                "enum": [
+                  "linear",
+                  "log",
+                  "sqrt"
+                ],
+                "type": "string"
+              },
+              "ticks": {
+                "additionalProperties": false,
+                "description": "Axis tick marks configuration",
+                "properties": {
+                  "visible": {
+                    "description": "Show tick marks on the axis",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "visible"
+                ],
+                "type": "object"
+              },
+              "title": {
+                "additionalProperties": false,
+                "description": "Axis title configuration",
+                "properties": {
+                  "text": {
+                    "description": "Axis title text",
+                    "type": "string"
+                  },
+                  "visible": {
+                    "description": "Show the title",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "required": [
+              "domain"
+            ],
+            "type": "object"
+          }
+        },
+        "title": "Axis",
+        "type": "object",
+        "x-oas-optional": true
+      },
+      "waffleESQL": {
+        "additionalProperties": false,
+        "description": "Waffle chart configuration for ES|QL queries",
+        "properties": {
+          "data_source": {
+            "$ref": "#/components/schemas/esqlDataSource"
+          },
+          "description": {
+            "type": "string"
+          },
+          "drilldowns": {
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "dashboard_id": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": false,
+                      "description": "When enabled, the dashboard opens in a new browser tab.",
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "dashboard_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "use_filters": {
+                      "default": true,
+                      "description": "When enabled, filters are passed to the opening dashboard.",
+                      "type": "boolean"
+                    },
+                    "use_time_range": {
+                      "default": true,
+                      "description": "When enabled, time range is passed to the opening dashboard.",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "dashboard_id",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "dashboard_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "discover_drilldown"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "discover_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "encode_url": {
+                      "default": true,
+                      "description": "When true, URL is escaped using percent encoding",
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_click_row",
+                        "on_click_value",
+                        "on_open_panel_menu",
+                        "on_select_range"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "url_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "url": {
+                      "description": "Templated Url. Variables documented at https://www.elastic.co/docs/explore-analyze/dashboards/drilldowns#url-template-variable",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "url",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "url_drilldown",
+                  "type": "object"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "filters": {
+            "$ref": "#/components/schemas/lensPanelFilters"
+          },
+          "group_by": {
+            "description": "Array of ES|QL breakdown columns (minimum 1)",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "collapse_by": {
+                  "$ref": "#/components/schemas/collapseBy"
+                },
+                "color": {
+                  "$ref": "#/components/schemas/colorMapping"
+                },
+                "column": {
+                  "description": "Column to use",
+                  "type": "string"
+                },
+                "format": {
+                  "$ref": "#/components/schemas/formatType"
+                },
+                "label": {
+                  "description": "Label for the operation",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "column",
+                "format",
+                "color",
+                "collapse_by"
+              ],
+              "type": "object"
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "type": "array"
+          },
+          "hide_border": {
+            "type": "boolean"
+          },
+          "hide_title": {
+            "type": "boolean"
+          },
+          "ignore_global_filters": {
+            "default": false,
+            "description": "If true, ignore global filters when fetching data for this layer. Default is false.",
+            "type": "boolean"
+          },
+          "legend": {
+            "$ref": "#/components/schemas/waffleLegend"
+          },
+          "metrics": {
+            "description": "Array of metric configurations (minimum 1)",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "color": {
+                  "$ref": "#/components/schemas/staticColor"
+                },
+                "column": {
+                  "description": "Column to use",
+                  "type": "string"
+                },
+                "format": {
+                  "$ref": "#/components/schemas/formatType"
+                },
+                "label": {
+                  "description": "Label for the operation",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "column",
+                "format",
+                "color"
+              ],
+              "type": "object"
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "type": "array"
+          },
+          "references": {
+            "items": {
+              "$ref": "#/components/schemas/kbn-content-management-utils-referenceSchema"
+            },
+            "type": "array"
+          },
+          "sampling": {
+            "default": 1,
+            "description": "Sampling factor between 0 (no sampling) and 1 (full sampling). Default is 1.",
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "time_range": {
+            "$ref": "#/components/schemas/kbn-es-query-server-timeRangeSchema"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "waffle"
+            ],
+            "type": "string"
+          },
+          "values": {
+            "$ref": "#/components/schemas/valueDisplay"
+          }
+        },
+        "required": [
+          "type",
+          "filters",
+          "data_source",
+          "legend",
+          "values",
+          "metrics",
+          "time_range"
+        ],
+        "title": "Waffle Chart (ES|QL)",
+        "type": "object"
+      },
+      "waffleLegend": {
+        "additionalProperties": false,
+        "description": "Legend configuration for waffle chart",
+        "properties": {
+          "size": {
+            "$ref": "#/components/schemas/legendSize"
+          },
+          "truncate_after_lines": {
+            "description": "Maximum lines before truncating legend items (1-10)",
+            "maximum": 10,
+            "minimum": 1,
+            "title": "legendTruncateAfterLines",
+            "type": "number"
+          },
+          "values": {
+            "items": {
+              "description": "Legend value display mode: absolute (show raw metric values in legend)",
+              "enum": [
+                "absolute"
+              ],
+              "type": "string"
+            },
+            "maxItems": 1,
+            "minItems": 1,
+            "type": "array"
+          },
+          "visibility": {
+            "description": "Legend visibility",
+            "enum": [
+              "auto",
+              "visible",
+              "hidden"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "size"
+        ],
+        "title": "Legend",
+        "type": "object",
+        "x-oas-optional": true
+      },
+      "waffleNoESQL": {
+        "additionalProperties": false,
+        "description": "Waffle chart configuration for standard queries",
+        "properties": {
+          "data_source": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/kbn-data-view-reference-schema"
+              },
+              {
+                "$ref": "#/components/schemas/kbn-data-view-spec-schema"
+              }
+            ]
+          },
+          "description": {
+            "type": "string"
+          },
+          "drilldowns": {
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "dashboard_id": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": false,
+                      "description": "When enabled, the dashboard opens in a new browser tab.",
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "dashboard_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "use_filters": {
+                      "default": true,
+                      "description": "When enabled, filters are passed to the opening dashboard.",
+                      "type": "boolean"
+                    },
+                    "use_time_range": {
+                      "default": true,
+                      "description": "When enabled, time range is passed to the opening dashboard.",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "dashboard_id",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "dashboard_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "discover_drilldown"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "discover_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "encode_url": {
+                      "default": true,
+                      "description": "When true, URL is escaped using percent encoding",
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_click_row",
+                        "on_click_value",
+                        "on_open_panel_menu",
+                        "on_select_range"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "url_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "url": {
+                      "description": "Templated Url. Variables documented at https://www.elastic.co/docs/explore-analyze/dashboards/drilldowns#url-template-variable",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "url",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "url_drilldown",
+                  "type": "object"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "filters": {
+            "$ref": "#/components/schemas/lensPanelFilters"
+          },
+          "group_by": {
+            "description": "Array of breakdown dimensions (minimum 1)",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/dateHistogramOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/termsOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/histogramOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/rangesOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/filtersOperation"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "type": "array"
+          },
+          "hide_border": {
+            "type": "boolean"
+          },
+          "hide_title": {
+            "type": "boolean"
+          },
+          "ignore_global_filters": {
+            "default": false,
+            "description": "If true, ignore global filters when fetching data for this layer. Default is false.",
+            "type": "boolean"
+          },
+          "legend": {
+            "$ref": "#/components/schemas/waffleLegend"
+          },
+          "metrics": {
+            "description": "Array of metric configurations (minimum 1)",
+            "items": {
+              "anyOf": [
+                {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/countMetricOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/uniqueCountMetricOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/minMaxAvgMedianStdDevMetricOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/sumMetricOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/lastValueOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/percentileOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/percentileRanksOperation"
+                    }
+                  ]
+                },
+                {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/differencesOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/movingAverageOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/cumulativeSumOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/counterRateOperation"
+                    }
+                  ]
+                },
+                {
+                  "$ref": "#/components/schemas/formulaOperation"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "type": "array"
+          },
+          "query": {
+            "$ref": "#/components/schemas/filterSimple"
+          },
+          "references": {
+            "items": {
+              "$ref": "#/components/schemas/kbn-content-management-utils-referenceSchema"
+            },
+            "type": "array"
+          },
+          "sampling": {
+            "default": 1,
+            "description": "Sampling factor between 0 (no sampling) and 1 (full sampling). Default is 1.",
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "time_range": {
+            "$ref": "#/components/schemas/kbn-es-query-server-timeRangeSchema"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "waffle"
+            ],
+            "type": "string"
+          },
+          "values": {
+            "$ref": "#/components/schemas/valueDisplay"
+          }
+        },
+        "required": [
+          "type",
+          "filters",
+          "data_source",
+          "query",
+          "legend",
+          "values",
+          "metrics",
+          "time_range"
+        ],
+        "title": "Waffle Chart (DSL)",
+        "type": "object"
+      },
+      "xyAnnotationByRefLayer": {
+        "additionalProperties": false,
+        "description": "Reference to a library annotation group",
+        "properties": {
+          "group_id": {
+            "description": "ID of the linked annotation group from the library",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "annotation_group"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "group_id"
+        ],
+        "title": "xyAnnotationByRefLayer",
+        "type": "object"
+      },
+      "xyAnnotationLayerNoESQL": {
+        "additionalProperties": false,
+        "description": "Layer containing annotations (query-based, points, and ranges)",
+        "properties": {
+          "data_source": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/kbn-data-view-reference-schema"
+              },
+              {
+                "$ref": "#/components/schemas/kbn-data-view-spec-schema"
+              }
+            ]
+          },
+          "events": {
+            "description": "Array of annotation configurations",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/xyAnnotationQuery"
+                },
+                {
+                  "$ref": "#/components/schemas/xyAnnotationManualEvent"
+                },
+                {
+                  "$ref": "#/components/schemas/xyAnnotationManualRange"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "type": "array"
+          },
+          "ignore_global_filters": {
+            "default": false,
+            "description": "If true, ignore global filters when fetching data for this layer. Default is false.",
+            "type": "boolean"
+          },
+          "type": {
+            "enum": [
+              "annotations"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "data_source",
+          "events"
+        ],
+        "title": "Annotation Layer (DSL)",
+        "type": "object"
+      },
+      "xyAnnotationManualEvent": {
+        "additionalProperties": false,
+        "description": "Manual point annotation at specific timestamp",
+        "properties": {
+          "color": {
+            "$ref": "#/components/schemas/staticColor"
+          },
+          "icon": {
+            "description": "Icon to display at the annotation point",
+            "enum": [
+              "asterisk",
+              "alert",
+              "bell",
+              "bolt",
+              "bug",
+              "circle",
+              "editor_comment",
+              "flag",
+              "heart",
+              "map_marker",
+              "pin_filled",
+              "star_empty",
+              "star_filled",
+              "tag",
+              "triangle"
+            ],
+            "type": "string"
+          },
+          "label": {
+            "description": "Label text for the annotation",
+            "type": "string"
+          },
+          "line": {
+            "additionalProperties": false,
+            "description": "Vertical line configuration for point annotation",
+            "properties": {
+              "stroke_dash": {
+                "description": "Vertical line style",
+                "enum": [
+                  "solid",
+                  "dashed",
+                  "dotted"
+                ],
+                "type": "string"
+              },
+              "stroke_width": {
+                "description": "Vertical line width in pixels",
+                "maximum": 10,
+                "minimum": 1,
+                "type": "number"
+              }
+            },
+            "required": [
+              "stroke_width",
+              "stroke_dash"
+            ],
+            "type": "object"
+          },
+          "text": {
+            "additionalProperties": false,
+            "description": "Annotation text label visibility",
+            "properties": {
+              "visible": {
+                "description": "Show text label on the annotation",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "visible"
+            ],
+            "type": "object"
+          },
+          "timestamp": {
+            "anyOf": [
+              {
+                "description": "Unix timestamp in milliseconds",
+                "type": "number"
+              },
+              {
+                "description": "ISO date string",
+                "type": "string"
+              }
+            ]
+          },
+          "type": {
+            "enum": [
+              "point"
+            ],
+            "type": "string"
+          },
+          "visible": {
+            "description": "Show the annotation",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "color",
+          "type",
+          "timestamp"
+        ],
+        "title": "xyAnnotationManualEvent",
+        "type": "object"
+      },
+      "xyAnnotationManualRange": {
+        "additionalProperties": false,
+        "description": "Manual range annotation spanning time interval",
+        "properties": {
+          "color": {
+            "$ref": "#/components/schemas/staticColor"
+          },
+          "fill": {
+            "description": "Fill direction for range",
+            "enum": [
+              "inside",
+              "outside"
+            ],
+            "type": "string"
+          },
+          "interval": {
+            "additionalProperties": false,
+            "description": "Time range for annotation",
+            "properties": {
+              "from": {
+                "anyOf": [
+                  {
+                    "description": "Unix timestamp in milliseconds",
+                    "type": "number"
+                  },
+                  {
+                    "description": "ISO date string",
+                    "type": "string"
+                  }
+                ]
+              },
+              "to": {
+                "anyOf": [
+                  {
+                    "description": "Unix timestamp in milliseconds",
+                    "type": "number"
+                  },
+                  {
+                    "description": "ISO date string",
+                    "type": "string"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "from",
+              "to"
+            ],
+            "type": "object"
+          },
+          "label": {
+            "description": "Label text for the annotation",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "range"
+            ],
+            "type": "string"
+          },
+          "visible": {
+            "description": "Show the annotation",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "color",
+          "type",
+          "interval"
+        ],
+        "title": "xyAnnotationManualRange",
+        "type": "object"
+      },
+      "xyAnnotationQuery": {
+        "additionalProperties": false,
+        "description": "Annotation from query results matching a filter",
+        "properties": {
+          "color": {
+            "$ref": "#/components/schemas/staticColor"
+          },
+          "extra_fields": {
+            "description": "Additional fields for annotation tooltip",
+            "items": {
+              "description": "Additional field to include in tooltip",
+              "type": "string"
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "icon": {
+            "description": "Icon to display at the annotation point",
+            "enum": [
+              "asterisk",
+              "alert",
+              "bell",
+              "bolt",
+              "bug",
+              "circle",
+              "editor_comment",
+              "flag",
+              "heart",
+              "map_marker",
+              "pin_filled",
+              "star_empty",
+              "star_filled",
+              "tag",
+              "triangle"
+            ],
+            "type": "string"
+          },
+          "label": {
+            "description": "Label text for the annotation",
+            "type": "string"
+          },
+          "line": {
+            "additionalProperties": false,
+            "description": "Vertical line configuration for point annotation",
+            "properties": {
+              "stroke_dash": {
+                "description": "Vertical line style",
+                "enum": [
+                  "solid",
+                  "dashed",
+                  "dotted"
+                ],
+                "type": "string"
+              },
+              "stroke_width": {
+                "description": "Vertical line width in pixels",
+                "maximum": 10,
+                "minimum": 1,
+                "type": "number"
+              }
+            },
+            "required": [
+              "stroke_width",
+              "stroke_dash"
+            ],
+            "type": "object"
+          },
+          "query": {
+            "$ref": "#/components/schemas/filterSimple"
+          },
+          "text": {
+            "additionalProperties": false,
+            "description": "Annotation text label configuration",
+            "properties": {
+              "field": {
+                "description": "Field name for text label source",
+                "type": "string"
+              },
+              "visible": {
+                "description": "Show text label on the annotation",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "visible"
+            ],
+            "type": "object"
+          },
+          "time_field": {
+            "description": "Field containing the timestamp",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "query"
+            ],
+            "type": "string"
+          },
+          "visible": {
+            "description": "Show the annotation",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "color",
+          "type",
+          "query",
+          "time_field"
+        ],
+        "title": "xyAnnotationQuery",
+        "type": "object"
+      },
+      "xyChartESQL": {
+        "additionalProperties": false,
+        "description": "XY chart configuration for ES|QL queries",
+        "properties": {
+          "axis": {
+            "$ref": "#/components/schemas/vis_api_xy_axis_config"
+          },
+          "description": {
+            "type": "string"
+          },
+          "drilldowns": {
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "dashboard_id": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": false,
+                      "description": "When enabled, the dashboard opens in a new browser tab.",
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "dashboard_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "use_filters": {
+                      "default": true,
+                      "description": "When enabled, filters are passed to the opening dashboard.",
+                      "type": "boolean"
+                    },
+                    "use_time_range": {
+                      "default": true,
+                      "description": "When enabled, time range is passed to the opening dashboard.",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "dashboard_id",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "dashboard_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "discover_drilldown"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "discover_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "encode_url": {
+                      "default": true,
+                      "description": "When true, URL is escaped using percent encoding",
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_click_row",
+                        "on_click_value",
+                        "on_open_panel_menu",
+                        "on_select_range"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "url_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "url": {
+                      "description": "Templated Url. Variables documented at https://www.elastic.co/docs/explore-analyze/dashboards/drilldowns#url-template-variable",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "url",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "url_drilldown",
+                  "type": "object"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "filters": {
+            "$ref": "#/components/schemas/lensPanelFilters"
+          },
+          "hide_border": {
+            "type": "boolean"
+          },
+          "hide_title": {
+            "type": "boolean"
+          },
+          "layers": {
+            "description": "ES|QL chart layers",
+            "items": {
+              "$ref": "#/components/schemas/xyLayersESQL"
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "type": "array"
+          },
+          "legend": {
+            "$ref": "#/components/schemas/xyLegend"
+          },
+          "references": {
+            "items": {
+              "$ref": "#/components/schemas/kbn-content-management-utils-referenceSchema"
+            },
+            "type": "array"
+          },
+          "styling": {
+            "$ref": "#/components/schemas/xyStyling"
+          },
+          "time_range": {
+            "$ref": "#/components/schemas/kbn-es-query-server-timeRangeSchema"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "xy"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "filters",
+          "legend",
+          "axis",
+          "styling",
+          "layers",
+          "time_range"
+        ],
+        "title": "XY Chart (ES|QL)",
+        "type": "object"
+      },
+      "xyChartNoESQL": {
+        "additionalProperties": false,
+        "description": "XY chart configuration for DSL queries",
+        "properties": {
+          "axis": {
+            "$ref": "#/components/schemas/vis_api_xy_axis_config"
+          },
+          "description": {
+            "type": "string"
+          },
+          "drilldowns": {
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "dashboard_id": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": false,
+                      "description": "When enabled, the dashboard opens in a new browser tab.",
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "dashboard_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "use_filters": {
+                      "default": true,
+                      "description": "When enabled, filters are passed to the opening dashboard.",
+                      "type": "boolean"
+                    },
+                    "use_time_range": {
+                      "default": true,
+                      "description": "When enabled, time range is passed to the opening dashboard.",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "dashboard_id",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "dashboard_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_apply_filter"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "discover_drilldown"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "discover_drilldown",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "encode_url": {
+                      "default": true,
+                      "description": "When true, URL is escaped using percent encoding",
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "open_in_new_tab": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "trigger": {
+                      "enum": [
+                        "on_click_row",
+                        "on_click_value",
+                        "on_open_panel_menu",
+                        "on_select_range"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "url_drilldown"
+                      ],
+                      "type": "string"
+                    },
+                    "url": {
+                      "description": "Templated Url. Variables documented at https://www.elastic.co/docs/explore-analyze/dashboards/drilldowns#url-template-variable",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "url",
+                    "label",
+                    "trigger",
+                    "type"
+                  ],
+                  "title": "url_drilldown",
+                  "type": "object"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "type": "array"
+          },
+          "filters": {
+            "$ref": "#/components/schemas/lensPanelFilters"
+          },
+          "hide_border": {
+            "type": "boolean"
+          },
+          "hide_title": {
+            "type": "boolean"
+          },
+          "layers": {
+            "description": "Chart layers",
+            "items": {
+              "$ref": "#/components/schemas/xyLayersNoESQL"
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "type": "array"
+          },
+          "legend": {
+            "$ref": "#/components/schemas/xyLegend"
+          },
+          "query": {
+            "$ref": "#/components/schemas/filterSimple"
+          },
+          "references": {
+            "items": {
+              "$ref": "#/components/schemas/kbn-content-management-utils-referenceSchema"
+            },
+            "type": "array"
+          },
+          "styling": {
+            "$ref": "#/components/schemas/xyStyling"
+          },
+          "time_range": {
+            "$ref": "#/components/schemas/kbn-es-query-server-timeRangeSchema"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "xy"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "filters",
+          "legend",
+          "axis",
+          "styling",
+          "query",
+          "layers",
+          "time_range"
+        ],
+        "title": "XY Chart (DSL)",
+        "type": "object"
+      },
+      "xyFitting": {
+        "additionalProperties": false,
+        "description": "Missing data interpolation configuration for line and area series",
+        "properties": {
+          "emphasize": {
+            "description": "Visually distinguish fitted segments with a dashed line style and reduced area opacity",
+            "type": "boolean"
+          },
+          "extend": {
+            "description": "How to render line and area edges when data does not cover the full X domain",
+            "enum": [
+              "none",
+              "zero",
+              "nearest"
+            ],
+            "type": "string"
+          },
+          "type": {
+            "description": "Fitting function type for missing data",
+            "enum": [
+              "none",
+              "zero",
+              "linear",
+              "carry",
+              "lookahead",
+              "average",
+              "nearest"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "title": "xyFitting",
+        "type": "object",
+        "x-oas-optional": true
+      },
+      "xyLayerESQL": {
+        "additionalProperties": false,
+        "description": "Data layer for ES|QL queries with column references",
+        "properties": {
+          "breakdown_by": {
+            "additionalProperties": false,
+            "description": "ES|QL column for breakdown",
+            "properties": {
+              "collapse_by": {
+                "$ref": "#/components/schemas/collapseBy"
+              },
+              "color": {
+                "$ref": "#/components/schemas/colorMapping"
+              },
+              "column": {
+                "description": "Column to use",
+                "type": "string"
+              },
+              "format": {
+                "$ref": "#/components/schemas/formatType"
+              },
+              "label": {
+                "description": "Label for the operation",
+                "type": "string"
+              }
+            },
+            "required": [
+              "column",
+              "format",
+              "color",
+              "collapse_by"
+            ],
+            "type": "object"
+          },
+          "data_source": {
+            "$ref": "#/components/schemas/esqlDataSource"
+          },
+          "ignore_global_filters": {
+            "default": false,
+            "description": "If true, ignore global filters when fetching data for this layer. Default is false.",
+            "type": "boolean"
+          },
+          "sampling": {
+            "default": 1,
+            "description": "Sampling factor between 0 (no sampling) and 1 (full sampling). Default is 1.",
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "type": {
+            "description": "Chart type for the data layer",
+            "enum": [
+              "area",
+              "area_percentage",
+              "area_stacked",
+              "bar",
+              "bar_horizontal",
+              "bar_horizontal_stacked",
+              "bar_horizontal_percentage",
+              "bar_percentage",
+              "bar_stacked",
+              "line"
+            ],
+            "type": "string"
+          },
+          "x": {
+            "additionalProperties": false,
+            "properties": {
+              "column": {
+                "description": "Column to use",
+                "type": "string"
+              },
+              "format": {
+                "$ref": "#/components/schemas/formatType"
+              },
+              "label": {
+                "description": "Label for the operation",
+                "type": "string"
+              }
+            },
+            "required": [
+              "column",
+              "format"
+            ],
+            "type": "object"
+          },
+          "y": {
+            "description": "Array of ES|QL columns for Y-axis metrics",
+            "items": {
+              "additionalProperties": false,
+              "description": "ES|QL column for Y-axis metric",
+              "properties": {
+                "axis_id": {
+                  "description": "ID of the axis definition this Y metric is bound to; links the metric to the matching axis configuration in axis.y or axis.secondary_y. If omitted, the metric is bound to the primary Y axis.",
+                  "enum": [
+                    "y",
+                    "secondary_y"
+                  ],
+                  "type": "string"
+                },
+                "color": {
+                  "$ref": "#/components/schemas/staticColor"
+                },
+                "column": {
+                  "description": "Column to use",
+                  "type": "string"
+                },
+                "format": {
+                  "$ref": "#/components/schemas/formatType"
+                },
+                "label": {
+                  "description": "Label for the operation",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "column",
+                "format",
+                "color"
+              ],
+              "type": "object"
+            },
+            "maxItems": 100,
+            "type": "array"
+          }
+        },
+        "required": [
+          "data_source",
+          "type",
+          "y"
+        ],
+        "title": "Layer (ES|QL)",
+        "type": "object"
+      },
+      "xyLayerNoESQL": {
+        "additionalProperties": false,
+        "description": "Data layer for standard queries with metrics and buckets",
+        "properties": {
+          "breakdown_by": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/dateHistogramOperation"
+              },
+              {
+                "$ref": "#/components/schemas/termsOperation"
+              },
+              {
+                "$ref": "#/components/schemas/histogramOperation"
+              },
+              {
+                "$ref": "#/components/schemas/rangesOperation"
+              },
+              {
+                "$ref": "#/components/schemas/filtersOperation"
+              }
+            ]
+          },
+          "data_source": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/kbn-data-view-reference-schema"
+              },
+              {
+                "$ref": "#/components/schemas/kbn-data-view-spec-schema"
+              }
+            ]
+          },
+          "ignore_global_filters": {
+            "default": false,
+            "description": "If true, ignore global filters when fetching data for this layer. Default is false.",
+            "type": "boolean"
+          },
+          "sampling": {
+            "default": 1,
+            "description": "Sampling factor between 0 (no sampling) and 1 (full sampling). Default is 1.",
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "type": {
+            "description": "Chart type for the data layer",
+            "enum": [
+              "area",
+              "area_percentage",
+              "area_stacked",
+              "bar",
+              "bar_horizontal",
+              "bar_horizontal_stacked",
+              "bar_horizontal_percentage",
+              "bar_percentage",
+              "bar_stacked",
+              "line"
+            ],
+            "type": "string"
+          },
+          "x": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/dateHistogramOperation"
+              },
+              {
+                "$ref": "#/components/schemas/termsOperation"
+              },
+              {
+                "$ref": "#/components/schemas/histogramOperation"
+              },
+              {
+                "$ref": "#/components/schemas/rangesOperation"
+              },
+              {
+                "$ref": "#/components/schemas/filtersOperation"
+              }
+            ]
+          },
+          "y": {
+            "description": "Array of metrics to display on Y-axis",
+            "items": {
+              "anyOf": [
+                {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/countMetricOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/uniqueCountMetricOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/minMaxAvgMedianStdDevMetricOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/sumMetricOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/lastValueOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/percentileOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/percentileRanksOperation"
+                    }
+                  ]
+                },
+                {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/differencesOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/movingAverageOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/cumulativeSumOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/counterRateOperation"
+                    }
+                  ]
+                },
+                {
+                  "$ref": "#/components/schemas/formulaOperation"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "type": "array"
+          }
+        },
+        "required": [
+          "type",
+          "data_source",
+          "y"
+        ],
+        "title": "Layer (DSL)",
+        "type": "object"
+      },
+      "xyLayersESQL": {
+        "$ref": "#/components/schemas/xyLayerESQL",
+        "description": "XY chart layer types for ES|QL queries",
+        "title": "xyLayersESQL"
+      },
+      "xyLayersNoESQL": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/xyLayerNoESQL"
+          },
+          {
+            "$ref": "#/components/schemas/xyReferenceLineLayerNoESQL"
+          },
+          {
+            "$ref": "#/components/schemas/xyAnnotationLayerNoESQL"
+          },
+          {
+            "$ref": "#/components/schemas/xyAnnotationByRefLayer"
+          }
+        ],
+        "description": "XY chart layer types for DSL queries",
+        "title": "xyLayersNoESQL"
+      },
+      "xyLegend": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/xyLegendOutsideHorizontal"
+          },
+          {
+            "$ref": "#/components/schemas/xyLegendOutsideVertical"
+          },
+          {
+            "$ref": "#/components/schemas/xyLegendInside"
+          }
+        ],
+        "description": "Legend configuration for XY chart",
+        "title": "Legend",
+        "x-oas-optional": true
+      },
+      "xyLegendInside": {
+        "additionalProperties": false,
+        "description": "Inside legend",
+        "properties": {
+          "columns": {
+            "description": "Number of legend columns",
+            "maximum": 5,
+            "minimum": 1,
+            "type": "number"
+          },
+          "layout": {
+            "additionalProperties": false,
+            "properties": {
+              "truncate": {
+                "additionalProperties": false,
+                "properties": {
+                  "enabled": {
+                    "description": "Enable truncation of legend items",
+                    "type": "boolean"
+                  },
+                  "max_lines": {
+                    "description": "Maximum lines before truncating legend items (1-10)",
+                    "maximum": 10,
+                    "minimum": 1,
+                    "title": "legendTruncateAfterLines",
+                    "type": "number"
+                  }
+                },
+                "type": "object"
+              },
+              "type": {
+                "enum": [
+                  "grid"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          },
+          "placement": {
+            "enum": [
+              "inside"
+            ],
+            "type": "string"
+          },
+          "position": {
+            "description": "Legend position inside the chart",
+            "enum": [
+              "top_left",
+              "top_right",
+              "bottom_left",
+              "bottom_right"
+            ],
+            "type": "string"
+          },
+          "statistics": {
+            "description": "Statistics to display in legend",
+            "items": {
+              "description": "Statistical functions that can be displayed in chart legend for data series",
+              "enum": [
+                "min",
+                "max",
+                "avg",
+                "median",
+                "range",
+                "last_value",
+                "last_non_null_value",
+                "first_value",
+                "first_non_null_value",
+                "difference",
+                "difference_percentage",
+                "count",
+                "total",
+                "standard_deviation",
+                "variance",
+                "distinct_count",
+                "current_and_last_value"
+              ],
+              "type": "string"
+            },
+            "maxItems": 17,
+            "type": "array"
+          },
+          "visibility": {
+            "description": "Legend visibility",
+            "enum": [
+              "auto",
+              "visible",
+              "hidden"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "placement"
+        ],
+        "title": "Inside",
+        "type": "object"
+      },
+      "xyLegendOutsideHorizontal": {
+        "additionalProperties": false,
+        "description": "Outside legend positioned horizontal (top/bottom) of the chart",
+        "properties": {
+          "layout": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "truncate": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "enabled": {
+                        "description": "Enable truncation of legend items",
+                        "type": "boolean"
+                      },
+                      "max_lines": {
+                        "description": "Maximum lines before truncating legend items (1-10)",
+                        "maximum": 10,
+                        "minimum": 1,
+                        "title": "legendTruncateAfterLines",
+                        "type": "number"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": {
+                    "enum": [
+                      "grid"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "type": {
+                    "enum": [
+                      "list"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          "placement": {
+            "enum": [
+              "outside"
+            ],
+            "type": "string"
+          },
+          "position": {
+            "enum": [
+              "top",
+              "bottom"
+            ],
+            "type": "string"
+          },
+          "statistics": {
+            "description": "Statistics to display in legend",
+            "items": {
+              "description": "Statistical functions that can be displayed in chart legend for data series",
+              "enum": [
+                "min",
+                "max",
+                "avg",
+                "median",
+                "range",
+                "last_value",
+                "last_non_null_value",
+                "first_value",
+                "first_non_null_value",
+                "difference",
+                "difference_percentage",
+                "count",
+                "total",
+                "standard_deviation",
+                "variance",
+                "distinct_count",
+                "current_and_last_value"
+              ],
+              "type": "string"
+            },
+            "maxItems": 17,
+            "type": "array"
+          },
+          "visibility": {
+            "description": "Legend visibility",
+            "enum": [
+              "auto",
+              "visible",
+              "hidden"
+            ],
+            "type": "string"
+          }
+        },
+        "title": "Outside horizontal",
+        "type": "object"
+      },
+      "xyLegendOutsideVertical": {
+        "additionalProperties": false,
+        "description": "Outside legend positioned vertical (left/right) of the chart",
+        "properties": {
+          "layout": {
+            "additionalProperties": false,
+            "properties": {
+              "truncate": {
+                "additionalProperties": false,
+                "properties": {
+                  "enabled": {
+                    "description": "Enable truncation of legend items",
+                    "type": "boolean"
+                  },
+                  "max_lines": {
+                    "description": "Maximum lines before truncating legend items (1-10)",
+                    "maximum": 10,
+                    "minimum": 1,
+                    "title": "legendTruncateAfterLines",
+                    "type": "number"
+                  }
+                },
+                "type": "object"
+              },
+              "type": {
+                "enum": [
+                  "grid"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          },
+          "placement": {
+            "enum": [
+              "outside"
+            ],
+            "type": "string"
+          },
+          "position": {
+            "enum": [
+              "left",
+              "right"
+            ],
+            "type": "string"
+          },
+          "size": {
+            "$ref": "#/components/schemas/legendSize"
+          },
+          "statistics": {
+            "description": "Statistics to display in legend",
+            "items": {
+              "description": "Statistical functions that can be displayed in chart legend for data series",
+              "enum": [
+                "min",
+                "max",
+                "avg",
+                "median",
+                "range",
+                "last_value",
+                "last_non_null_value",
+                "first_value",
+                "first_non_null_value",
+                "difference",
+                "difference_percentage",
+                "count",
+                "total",
+                "standard_deviation",
+                "variance",
+                "distinct_count",
+                "current_and_last_value"
+              ],
+              "type": "string"
+            },
+            "maxItems": 17,
+            "type": "array"
+          },
+          "visibility": {
+            "description": "Legend visibility",
+            "enum": [
+              "auto",
+              "visible",
+              "hidden"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "size"
+        ],
+        "title": "Outside vertical",
+        "type": "object"
+      },
+      "xyReferenceLineLayerNoESQL": {
+        "additionalProperties": false,
+        "description": "Reference line layer for standard queries",
+        "properties": {
+          "data_source": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/kbn-data-view-reference-schema"
+              },
+              {
+                "$ref": "#/components/schemas/kbn-data-view-spec-schema"
+              }
+            ]
+          },
+          "ignore_global_filters": {
+            "default": false,
+            "description": "If true, ignore global filters when fetching data for this layer. Default is false.",
+            "type": "boolean"
+          },
+          "sampling": {
+            "default": 1,
+            "description": "Sampling factor between 0 (no sampling) and 1 (full sampling). Default is 1.",
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "thresholds": {
+            "description": "Array of reference line thresholds",
+            "items": {
+              "anyOf": [
+                {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/countMetricOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/uniqueCountMetricOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/minMaxAvgMedianStdDevMetricOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/sumMetricOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/lastValueOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/percentileOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/percentileRanksOperation"
+                    }
+                  ]
+                },
+                {
+                  "$ref": "#/components/schemas/staticOperationDefinition"
+                },
+                {
+                  "$ref": "#/components/schemas/formulaOperation"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "type": "array"
+          },
+          "type": {
+            "enum": [
+              "reference_lines"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "data_source",
+          "thresholds"
+        ],
+        "title": "Reference Line Layer (DSL)",
+        "type": "object"
+      },
+      "xyStyling": {
+        "additionalProperties": false,
+        "description": "Visual styling options for the chart",
+        "properties": {
+          "areas": {
+            "$ref": "#/components/schemas/xyStylingAreas"
+          },
+          "bars": {
+            "$ref": "#/components/schemas/xyStylingBars"
+          },
+          "fitting": {
+            "$ref": "#/components/schemas/xyFitting"
+          },
+          "interpolation": {
+            "description": "Curve interpolation method for line and area series",
+            "enum": [
+              "linear",
+              "smooth",
+              "stepped"
+            ],
+            "type": "string"
+          },
+          "overlays": {
+            "$ref": "#/components/schemas/xyStylingOverlays"
+          },
+          "points": {
+            "$ref": "#/components/schemas/xyStylingPoints"
+          }
+        },
+        "required": [
+          "overlays",
+          "fitting",
+          "points",
+          "areas",
+          "bars"
+        ],
+        "title": "xyStyling",
+        "type": "object",
+        "x-oas-optional": true
+      },
+      "xyStylingAreas": {
+        "additionalProperties": false,
+        "description": "Area-specific rendering settings",
+        "properties": {
+          "fill_opacity": {
+            "description": "Area fill opacity (0-1 typical, max 2 for legacy)",
+            "maximum": 2,
+            "minimum": 0,
+            "type": "number"
+          }
+        },
+        "title": "xyStylingAreas",
+        "type": "object",
+        "x-oas-optional": true
+      },
+      "xyStylingBars": {
+        "additionalProperties": false,
+        "description": "Bar-specific rendering settings",
+        "properties": {
+          "data_labels": {
+            "additionalProperties": false,
+            "description": "Data label configuration for bar series",
+            "properties": {
+              "visible": {
+                "default": false,
+                "description": "Display value labels on bar data points",
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "minimum_height": {
+            "description": "Minimum bar height in pixels",
+            "minimum": 0,
+            "type": "number"
+          }
+        },
+        "title": "xyStylingBars",
+        "type": "object",
+        "x-oas-optional": true
+      },
+      "xyStylingOverlays": {
+        "additionalProperties": false,
+        "description": "Visual overlays drawn on top of the chart canvas",
+        "properties": {
+          "current_time_marker": {
+            "additionalProperties": false,
+            "description": "Current time marker configuration",
+            "properties": {
+              "visible": {
+                "default": false,
+                "description": "Show current time marker line",
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "partial_buckets": {
+            "additionalProperties": false,
+            "description": "Partial (incomplete) bucket indicator configuration",
+            "properties": {
+              "visible": {
+                "default": false,
+                "description": "Show partial bucket indicators at time range edges",
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "title": "xyStylingOverlays",
+        "type": "object",
+        "x-oas-optional": true
+      },
+      "xyStylingPoints": {
+        "additionalProperties": false,
+        "description": "Data point marker settings for line and area series",
+        "properties": {
+          "visibility": {
+            "description": "Data point marker visibility on line and area series",
+            "enum": [
+              "auto",
+              "visible",
+              "hidden"
+            ],
+            "type": "string"
+          }
+        },
+        "title": "xyStylingPoints",
+        "type": "object",
+        "x-oas-optional": true
+      }
+    },
+    "securitySchemes": {
+      "apiKeyAuth": {
+        "in": "header",
+        "name": "Authorization",
+        "type": "apiKey"
+      },
+      "basicAuth": {
+        "scheme": "basic",
+        "type": "http"
+      }
+    }
+  },
+  "info": {
+    "title": "Kibana HTTP APIs",
+    "version": "0.0.0"
+  },
+  "openapi": "3.0.0",
+  "paths": {
+    "/api/dashboards": {
+      "get": {
+        "description": "This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.",
+        "operationId": "get-dashboards",
+        "parameters": [
+          {
+            "description": "The page of dashboards to return",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "The number of dashboards to return per page",
+            "in": "query",
+            "name": "per_page",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "An Elasticsearch simple_query_string query that filters the dashboards in the response by \"title\" and \"description\"",
+            "in": "query",
+            "name": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "A tag ID to include. Accepts a single tag ID or multiple tag IDs. When multiple are specified, dashboards matching ANY of the tag IDs are included.",
+            "in": "query",
+            "name": "tags",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "maxItems": 100,
+              "type": "array"
+            }
+          },
+          {
+            "description": "A tag ID to exclude. Accepts a single tag ID or multiple tag IDs. When multiple are specified, dashboards matching ANY of the tag IDs are excluded.",
+            "in": "query",
+            "name": "excluded_tags",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "maxItems": 100,
+              "type": "array"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "dashboards": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "data": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "access_control": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "access_mode": {
+                                    "enum": [
+                                      "write_restricted",
+                                      "default"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "description": {
+                                "type": "string"
+                              },
+                              "tags": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "time_range": {
+                                "$ref": "#/components/schemas/kbn-es-query-server-timeRangeSchema"
+                              },
+                              "title": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "time_range",
+                              "title"
+                            ],
+                            "type": "object"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "meta": {
+                            "$ref": "#/components/schemas/kbn-as-code-meta"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "data",
+                          "meta"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "page": {
+                      "type": "number"
+                    },
+                    "total": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "dashboards",
+                    "total",
+                    "page"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "403": {
+            "description": "forbidden"
+          }
+        },
+        "summary": "Search dashboards",
+        "tags": [
+          "Dashboards"
+        ],
+        "x-state": "Technical Preview; added in 9.4.0"
+      },
+      "post": {
+        "description": "This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.",
+        "operationId": "post-dashboards",
+        "parameters": [
+          {
+            "description": "A required header to protect against CSRF attacks",
+            "in": "header",
+            "name": "kbn-xsrf",
+            "required": true,
+            "schema": {
+              "example": "true",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/kbn-dashboard-data"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/kbn-dashboard-data"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/kbn-as-code-meta"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "data",
+                    "meta"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "created"
+          },
+          "400": {
+            "description": "invalid request"
+          },
+          "403": {
+            "description": "forbidden"
+          }
+        },
+        "summary": "Create a dashboard",
+        "tags": [
+          "Dashboards"
+        ],
+        "x-state": "Technical Preview; added in 9.4.0"
+      }
+    },
+    "/api/dashboards/{id}": {
+      "delete": {
+        "description": "This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.",
+        "operationId": "delete-dashboards-id",
+        "parameters": [
+          {
+            "description": "A required header to protect against CSRF attacks",
+            "in": "header",
+            "name": "kbn-xsrf",
+            "required": true,
+            "schema": {
+              "example": "true",
+              "type": "string"
+            }
+          },
+          {
+            "description": "A unique identifier for the dashboard.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "deleted"
+          },
+          "403": {
+            "description": "forbidden"
+          },
+          "404": {
+            "description": "not found"
+          }
+        },
+        "summary": "Delete a dashboard",
+        "tags": [
+          "Dashboards"
+        ],
+        "x-state": "Technical Preview; added in 9.4.0"
+      },
+      "get": {
+        "description": "This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.",
+        "operationId": "get-dashboards-id",
+        "parameters": [
+          {
+            "description": "A unique identifier for the dashboard.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/kbn-dashboard-data"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/kbn-as-code-meta"
+                    },
+                    "warnings": {
+                      "items": {
+                        "$ref": "#/components/schemas/kbn-dashboard-dropped-panel-warning"
+                      },
+                      "maxItems": 100,
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "data",
+                    "meta"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "403": {
+            "description": "forbidden"
+          },
+          "404": {
+            "description": "not found"
+          }
+        },
+        "summary": "Get a dashboard",
+        "tags": [
+          "Dashboards"
+        ],
+        "x-state": "Technical Preview; added in 9.4.0"
+      },
+      "put": {
+        "description": "This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.",
+        "operationId": "put-dashboards-id",
+        "parameters": [
+          {
+            "description": "A required header to protect against CSRF attacks",
+            "in": "header",
+            "name": "kbn-xsrf",
+            "required": true,
+            "schema": {
+              "example": "true",
+              "type": "string"
+            }
+          },
+          {
+            "description": "A unique identifier. Must contain only lowercase letters, numbers, hyphens, and underscores.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "maxLength": 250,
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "description": {
+                    "description": "A short description.",
+                    "type": "string"
+                  },
+                  "filters": {
+                    "items": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/components/schemas/kbn-as-code-filters-schema_asCodeConditionFilterSchema"
+                        },
+                        {
+                          "$ref": "#/components/schemas/kbn-as-code-filters-schema_asCodeGroupFilterSchema"
+                        },
+                        {
+                          "$ref": "#/components/schemas/kbn-as-code-filters-schema_asCodeDSLFilterSchema"
+                        },
+                        {
+                          "$ref": "#/components/schemas/kbn-as-code-filters-schema_asCodeSpatialFilterSchema"
+                        }
+                      ],
+                      "description": "A filter which can be a condition, group, DSL, or spatial"
+                    },
+                    "maxItems": 500,
+                    "type": "array"
+                  },
+                  "options": {
+                    "$ref": "#/components/schemas/kbn-dashboard-options"
+                  },
+                  "panels": {
+                    "default": [],
+                    "items": {
+                      "anyOf": [
+                        {
+                          "anyOf": [
+                            {
+                              "$ref": "#/components/schemas/kbn-dashboard-panel-type-discover_session"
+                            },
+                            {
+                              "$ref": "#/components/schemas/kbn-dashboard-panel-type-esql_control"
+                            },
+                            {
+                              "$ref": "#/components/schemas/kbn-dashboard-panel-type-image"
+                            },
+                            {
+                              "$ref": "#/components/schemas/kbn-dashboard-panel-type-markdown"
+                            },
+                            {
+                              "$ref": "#/components/schemas/kbn-dashboard-panel-type-options_list_control"
+                            },
+                            {
+                              "$ref": "#/components/schemas/kbn-dashboard-panel-type-range_slider_control"
+                            },
+                            {
+                              "$ref": "#/components/schemas/kbn-dashboard-panel-type-slo_alerts"
+                            },
+                            {
+                              "$ref": "#/components/schemas/kbn-dashboard-panel-type-slo_burn_rate"
+                            },
+                            {
+                              "$ref": "#/components/schemas/kbn-dashboard-panel-type-slo_error_budget"
+                            },
+                            {
+                              "$ref": "#/components/schemas/kbn-dashboard-panel-type-slo_overview"
+                            },
+                            {
+                              "$ref": "#/components/schemas/kbn-dashboard-panel-type-synthetics_monitors"
+                            },
+                            {
+                              "$ref": "#/components/schemas/kbn-dashboard-panel-type-synthetics_stats_overview"
+                            },
+                            {
+                              "$ref": "#/components/schemas/kbn-dashboard-panel-type-time_slider_control"
+                            },
+                            {
+                              "$ref": "#/components/schemas/kbn-dashboard-panel-type-vis"
+                            }
+                          ]
+                        },
+                        {
+                          "$ref": "#/components/schemas/kbn-dashboard-section"
+                        }
+                      ]
+                    },
+                    "maxItems": 100,
+                    "type": "array"
+                  },
+                  "pinned_panels": {
+                    "default": [],
+                    "description": "An array of control panels and their state in the control group.",
+                    "items": {
+                      "discriminator": {
+                        "propertyName": "type"
+                      },
+                      "oneOf": [
+                        {
+                          "$ref": "#/components/schemas/kbn-controls-schemas-controls-group-schema-esql-control"
+                        },
+                        {
+                          "$ref": "#/components/schemas/kbn-controls-schemas-controls-group-schema-options-list-control"
+                        },
+                        {
+                          "$ref": "#/components/schemas/kbn-controls-schemas-controls-group-schema-range-slider-control"
+                        },
+                        {
+                          "$ref": "#/components/schemas/kbn-controls-schemas-controls-group-schema-time-slider-control"
+                        }
+                      ]
+                    },
+                    "maxItems": 100,
+                    "type": "array"
+                  },
+                  "project_routing": {
+                    "type": "string"
+                  },
+                  "query": {
+                    "$ref": "#/components/schemas/kbn-as-code-query"
+                  },
+                  "refresh_interval": {
+                    "$ref": "#/components/schemas/kbn-data-service-server-refreshIntervalSchema"
+                  },
+                  "tags": {
+                    "items": {
+                      "description": "An array of tags ids applied to this dashboard",
+                      "type": "string"
+                    },
+                    "maxItems": 100,
+                    "type": "array"
+                  },
+                  "time_range": {
+                    "$ref": "#/components/schemas/kbn-es-query-server-timeRangeSchema"
+                  },
+                  "title": {
+                    "description": "A human-readable title for the dashboard",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "options",
+                  "query",
+                  "refresh_interval",
+                  "time_range",
+                  "title"
+                ],
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/kbn-dashboard-data"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/kbn-as-code-meta"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "data",
+                    "meta"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "updated"
+          },
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/kbn-dashboard-data"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/kbn-as-code-meta"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "data",
+                    "meta"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "created"
+          },
+          "400": {
+            "description": "invalid request"
+          },
+          "403": {
+            "description": "forbidden"
+          }
+        },
+        "summary": "Upsert dashboard",
+        "tags": [
+          "Dashboards"
+        ],
+        "x-state": "Technical Preview; added in 9.4.0"
+      }
+    }
+  },
+  "security": [
+    {
+      "basicAuth": []
+    }
+  ],
+  "servers": [
+    {
+      "url": "http://localhost:5622"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Dashboards"
+    }
+  ]
+}

--- a/src/Elastic.ApiExplorer/OpenApiGenerator.cs
+++ b/src/Elastic.ApiExplorer/OpenApiGenerator.cs
@@ -82,63 +82,16 @@ public class OpenApiGenerator(ILoggerFactory logFactory, BuildContext context, I
 			})
 			.ToArray();
 
-		var nestedGrouping =
-			(
-				from op in ops
-				group op by op.Classification
-				into classificationGroup
-				from tagGroup in
-				from op in classificationGroup
-				group op by op.Tag
-				into apiGroups
-				from apiGroup in
-				from op in apiGroups
-				group op by op.Api
-				group apiGroup by apiGroups.Key
-				group tagGroup by classificationGroup.Key
-			).ToArray();
-
-
-		/*
-		var grouped = openApiDocument.Paths
-			.Select(p =>
-			{
-				var op = p.Value.Operations.First();
-				var extensions = op.Value.Extensions;
-				var ns = (extensions?.TryGetValue("x-namespace", out var n) ?? false) && n is OpenApiAny anyNs
-					? anyNs.Node.GetValue<string>()
-					: null;
-				var api = (extensions?.TryGetValue("x-api-name", out var a) ?? false) && a is OpenApiAny anyApi
-					? anyApi.Node.GetValue<string>()
-					: null;
-				var tag = op.Value.Tags?.FirstOrDefault()?.Reference.Id;
-				var classification = openApiDocument.Info.Title == "Elasticsearch Request & Response Specification"
-					? ClassifyElasticsearchTag(tag ?? "unknown")
-					: "unknown";
-
-				var apiString = ns is null ? api ?? Guid.NewGuid().ToString("N") : $"{ns}.{api}";
-				return new
-				{
-					Classification = classification,
-					Api = apiString,
-					Tag = tag,
-					Path = p
-				};
-			})
-			.GroupBy(g => g.Classification)
-			.ToArray();
-		*/
-
 		// intermediate grouping of models to create the navigation tree
 		// this is two-phased because we need to know if an endpoint has one or more operations
 		var classifications = new List<ApiClassification>();
-		foreach (var classificationGroup in nestedGrouping)
+		foreach (var classGroup in ops.GroupBy(o => o.Classification))
 		{
 			var tags = new List<ApiTag>();
-			foreach (var tagGroup in classificationGroup)
+			foreach (var tagGroup in classGroup.GroupBy(o => o.Tag))
 			{
 				var apis = new List<ApiEndpoint>();
-				foreach (var apiGroup in tagGroup)
+				foreach (var apiGroup in tagGroup.GroupBy(o => o.Api))
 				{
 					var operations = new List<ApiOperation>();
 					foreach (var api in apiGroup)
@@ -153,7 +106,7 @@ public class OpenApiGenerator(ILoggerFactory logFactory, BuildContext context, I
 				var tag = new ApiTag(tagGroup.Key ?? "unknown", "", apis);
 				tags.Add(tag);
 			}
-			var classification = new ApiClassification(classificationGroup.Key, "", tags);
+			var classification = new ApiClassification(classGroup.Key, "", tags);
 			classifications.Add(classification);
 		}
 
@@ -178,7 +131,13 @@ public class OpenApiGenerator(ILoggerFactory logFactory, BuildContext context, I
 		// Add schema type pages for shared types
 		CreateSchemaNavigationItems(apiUrlSuffix, openApiDocument, rootNavigation, topLevelNavigationItems);
 
-		rootNavigation.NavigationItems = topLevelNavigationItems;
+		// Multi-tag / multi-classification builds into topLevelNavigationItems; single-tag writes endpoints
+		// directly onto root. Assigning topLevel here must not wipe root when that list is still empty.
+		if (topLevelNavigationItems.Count > 0 && rootNavigation.NavigationItems.Count == 0)
+			rootNavigation.NavigationItems = topLevelNavigationItems;
+		else if (topLevelNavigationItems.Count > 0 && rootNavigation.NavigationItems.Count > 0)
+			rootNavigation.NavigationItems = [.. rootNavigation.NavigationItems, .. topLevelNavigationItems];
+
 		return rootNavigation;
 	}
 

--- a/tests/Elastic.ApiExplorer.Tests/DashboardOpenApiNavigationTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/DashboardOpenApiNavigationTests.cs
@@ -1,0 +1,38 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions;
+using AwesomeAssertions;
+using Elastic.Documentation;
+using Elastic.Documentation.Configuration;
+using Elastic.Documentation.Diagnostics;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nullean.ScopedFileSystem;
+
+namespace Elastic.ApiExplorer.Tests;
+
+public class DashboardOpenApiNavigationTests
+{
+	/// <summary>
+	/// Dashboard OpenAPI (single tag for all operations) must populate the API explorer nav.
+	/// Regression: grouped navigation overwrote root items with an empty top-level list.
+	/// </summary>
+	[Fact]
+	public async Task CreateNavigation_SingleTagOpenApiSpec_HasSidebarItems()
+	{
+		var configurationContext = TestHelpers.CreateConfigurationContext(new FileSystem());
+		var context = new BuildContext(new DiagnosticsCollector([]), FileSystemFactory.RealRead, configurationContext);
+		var fs = new FileSystem();
+		var path = fs.Path.Combine(Paths.WorkingDirectoryRoot.FullName, "docs", "dashboard-openapi.json");
+		var fi = fs.FileInfo.New(path);
+		var doc = await OpenApiReader.Create(fi);
+
+		doc.Should().NotBeNull();
+
+		var generator = new OpenApiGenerator(NullLoggerFactory.Instance, context, NoopMarkdownStringRenderer.Instance);
+		var navigation = generator.CreateNavigation("dashboard", doc);
+
+		navigation.NavigationItems.Should().NotBeEmpty();
+	}
+}

--- a/tests/Elastic.Documentation.Configuration.Tests/PhysicalDocsetTests.cs
+++ b/tests/Elastic.Documentation.Configuration.Tests/PhysicalDocsetTests.cs
@@ -36,9 +36,10 @@ public class PhysicalDocsetTests
 		docSet.Subs.Should().ContainKey("dbuild").WhoseValue.Should().Be("docs-builder");
 
 		// Assert API configuration
-		docSet.Api.Should().HaveCount(2);
+		docSet.Api.Should().HaveCount(3);
 		docSet.Api.Should().ContainKey("elasticsearch").WhoseValue.Should().Be("elasticsearch-openapi.json");
 		docSet.Api.Should().ContainKey("kibana").WhoseValue.Should().Be("kibana-openapi.json");
+		docSet.Api.Should().ContainKey("dashboard").WhoseValue.Should().Be("dashboard-openapi.json");
 
 		// Assert TOC structure
 		docSet.TableOfContents.Should().NotBeEmpty();


### PR DESCRIPTION
## Summary

The local API explorer showed a shell page (title and layout) but an empty sidebar and overview for OpenAPI documents where every operation shares a single tag (for example the Kibana HTTP dashboard spec).

## Root cause

1. **Grouping**: The previous LINQ comprehension did not reliably build classification → tag → API groups, so no navigation tree was produced for some specs.
2. **Single-tag overwrite**: When all operations use one tag, endpoints are attached directly to the root `LandingNavigationItem`. The code then assigned `rootNavigation.NavigationItems = topLevelNavigationItems` even when that list was still empty, which cleared the sidebar.

## Changes

- Rebuild operation grouping with explicit nested `GroupBy` calls.
- Only assign or merge from `topLevelNavigationItems` when appropriate so single-tag specs keep their endpoints; merge when both operation nav and schema sections exist.
- Add `DashboardOpenApiNavigationTests` using `docs/dashboard-openapi.json`.
- Register `dashboard` in `docs/_docset.yml` and align `PhysicalDocsetTests` with the third API entry.

## Testing

- `dotnet test` on `Elastic.ApiExplorer.Tests` and the PhysicalDocset deserialization test.

Made with [Cursor](https://cursor.com)