### PR TITLE
Add a configurable ceiling path to FindGitRoot and regression tests

### DIFF
--- a/src/Elastic.Documentation.Configuration/BuildContext.cs
+++ b/src/Elastic.Documentation.Configuration/BuildContext.cs
@@ -108,7 +108,7 @@ public record BuildContext : IDocumentationSetContext, IDocumentationConfigurati
 
 		(DocumentationSourceDirectory, ConfigurationPath) = Paths.FindDocsFolderFromRoot(ReadFileSystem, rootFolder);
 
-		DocumentationCheckoutDirectory = Paths.FindGitRoot(DocumentationSourceDirectory);
+		DocumentationCheckoutDirectory = Paths.FindGitRoot(DocumentationSourceDirectory, ceiling: rootFolder);
 
 		OutputDirectory = !string.IsNullOrWhiteSpace(output)
 			? WriteFileSystem.DirectoryInfo.New(output)

--- a/src/Elastic.Documentation.Configuration/Paths.cs
+++ b/src/Elastic.Documentation.Configuration/Paths.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.IO.Abstractions;
+using Elastic.Documentation.Extensions;
 
 namespace Elastic.Documentation.Configuration;
 
@@ -58,17 +59,32 @@ public static class Paths
 	/// a <c>.git</c> directory or file (worktree pointer) is found.
 	/// Returns <see langword="null"/> if no git root is found within the allowed depth.
 	/// </summary>
-	/// <remarks>Same depth protection as <see cref="FindGitRoot(string)"/>.</remarks>
-	public static IDirectoryInfo? FindGitRoot(IDirectoryInfo startDirectory)
+	/// <param name="startDirectory">Directory to start the upward search from.</param>
+	/// <param name="ceiling">
+	/// Optional upper bound for the search. When provided, the walk may reach <paramref name="ceiling"/>
+	/// but never goes above it, replacing the fixed depth limit with a directory boundary.
+	/// When <see langword="null"/>, the original depth-1 limit applies.
+	/// </param>
+	/// <remarks>
+	/// Without a ceiling the same depth protection as <see cref="FindGitRoot(string)"/> applies.
+	/// With a ceiling the caller guarantees the boundary is trustworthy (e.g. the working directory
+	/// root), so any <c>.git</c> found at or below it is accepted regardless of depth.
+	/// </remarks>
+	public static IDirectoryInfo? FindGitRoot(IDirectoryInfo startDirectory, IDirectoryInfo? ceiling = null)
 	{
 		var directory = startDirectory;
 		var depth = 0;
 		while (directory != null)
 		{
+			if (ceiling is not null && !directory.IsSubPathOf(ceiling))
+				return null;
+
 			var hasGit = directory.GetDirectories(".git").Length > 0
 					  || directory.GetFiles(".git").Length > 0;
 			if (hasGit)
 			{
+				if (ceiling is not null)
+					return directory;
 #if DEBUG
 				if (depth <= 1 || directory.GetFiles("*.slnx").Length > 0)
 					return directory;

--- a/tests/Elastic.Documentation.Configuration.Tests/FindGitRootTests.cs
+++ b/tests/Elastic.Documentation.Configuration.Tests/FindGitRootTests.cs
@@ -1,0 +1,152 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions.TestingHelpers;
+using AwesomeAssertions;
+
+namespace Elastic.Documentation.Configuration.Tests;
+
+public class FindGitRootTests
+{
+	[Fact]
+	public void DocsAtRoot_FindsGitRoot()
+	{
+		var fs = new MockFileSystem();
+		fs.AddDirectory("/repo/.git");
+		fs.AddFile("/repo/docset.yml", new("toc: []"));
+
+		var start = fs.DirectoryInfo.New("/repo");
+
+		var result = Paths.FindGitRoot(start, ceiling: start);
+
+		result.Should().NotBeNull();
+		result!.FullName.Should().Be("/repo");
+	}
+
+	[Fact]
+	public void DocsInDocsFolder_FindsGitRoot()
+	{
+		var fs = new MockFileSystem();
+		fs.AddDirectory("/repo/.git");
+		fs.AddFile("/repo/docs/docset.yml", new("toc: []"));
+
+		var ceiling = fs.DirectoryInfo.New("/repo");
+		var start = fs.DirectoryInfo.New("/repo/docs");
+
+		var result = Paths.FindGitRoot(start, ceiling: ceiling);
+
+		result.Should().NotBeNull();
+		result!.FullName.Should().Be("/repo");
+	}
+
+	[Fact]
+	public void DocsNestedTwoLevels_FindsGitRoot()
+	{
+		var fs = new MockFileSystem();
+		fs.AddDirectory("/repo/.git");
+		fs.AddFile("/repo/docs/resilience-team/docset.yml", new("toc: []"));
+
+		var ceiling = fs.DirectoryInfo.New("/repo");
+		var start = fs.DirectoryInfo.New("/repo/docs/resilience-team");
+
+		var result = Paths.FindGitRoot(start, ceiling: ceiling);
+
+		result.Should().NotBeNull();
+		result!.FullName.Should().Be("/repo");
+	}
+
+	[Fact]
+	public void DocsNestedTwoLevels_WithoutCeiling_ReturnsNull()
+	{
+		var fs = new MockFileSystem();
+		fs.AddDirectory("/repo/.git");
+		fs.AddFile("/repo/docs/resilience-team/docset.yml", new("toc: []"));
+
+		var start = fs.DirectoryInfo.New("/repo/docs/resilience-team");
+
+		var result = Paths.FindGitRoot(start);
+
+		result.Should().BeNull();
+	}
+
+	[Fact]
+	public void CeilingPreventsEscapingToParentRepo()
+	{
+		var fs = new MockFileSystem();
+		fs.AddDirectory("/parent-repo/.git");
+		fs.AddDirectory("/parent-repo/checkout");
+		fs.AddFile("/parent-repo/checkout/docs/docset.yml", new("toc: []"));
+
+		var ceiling = fs.DirectoryInfo.New("/parent-repo/checkout");
+		var start = fs.DirectoryInfo.New("/parent-repo/checkout/docs");
+
+		var result = Paths.FindGitRoot(start, ceiling: ceiling);
+
+		result.Should().BeNull("the .git is above the ceiling and must not be reached");
+	}
+
+	[Fact]
+	public void CeilingPreventsEscapingToParentRepo_DeeplyNested()
+	{
+		var fs = new MockFileSystem();
+		fs.AddDirectory("/workspace/projects/other-repo/.git");
+		fs.AddDirectory("/workspace/projects/other-repo/subrepo/docs/team");
+		fs.AddFile("/workspace/projects/other-repo/subrepo/docs/team/docset.yml", new("toc: []"));
+
+		var ceiling = fs.DirectoryInfo.New("/workspace/projects/other-repo/subrepo");
+		var start = fs.DirectoryInfo.New("/workspace/projects/other-repo/subrepo/docs/team");
+
+		var result = Paths.FindGitRoot(start, ceiling: ceiling);
+
+		result.Should().BeNull("the .git belongs to a parent repo outside the ceiling");
+	}
+
+	[Fact]
+	public void GitRootInsideCeiling_IsAccepted()
+	{
+		var fs = new MockFileSystem();
+		fs.AddDirectory("/workspace/.git");
+		fs.AddDirectory("/workspace/docs/a/b/c");
+		fs.AddFile("/workspace/docs/a/b/c/docset.yml", new("toc: []"));
+
+		var ceiling = fs.DirectoryInfo.New("/workspace");
+		var start = fs.DirectoryInfo.New("/workspace/docs/a/b/c");
+
+		var result = Paths.FindGitRoot(start, ceiling: ceiling);
+
+		result.Should().NotBeNull();
+		result!.FullName.Should().Be("/workspace");
+	}
+
+	[Fact]
+	public void NoGitDirectory_ReturnsNull()
+	{
+		var fs = new MockFileSystem();
+		fs.AddDirectory("/repo/docs");
+		fs.AddFile("/repo/docs/docset.yml", new("toc: []"));
+
+		var ceiling = fs.DirectoryInfo.New("/repo");
+		var start = fs.DirectoryInfo.New("/repo/docs");
+
+		var result = Paths.FindGitRoot(start, ceiling: ceiling);
+
+		result.Should().BeNull();
+	}
+
+	[Fact]
+	public void WorktreeGitFile_InsideCeiling_IsAccepted()
+	{
+		var fs = new MockFileSystem();
+		fs.AddFile("/repo/.git", new("gitdir: /main/.git/worktrees/repo"));
+		fs.AddFile("/repo/docs/team/docset.yml", new("toc: []"));
+
+		var ceiling = fs.DirectoryInfo.New("/repo");
+		var start = fs.DirectoryInfo.New("/repo/docs/team");
+
+		var result = Paths.FindGitRoot(start, ceiling: ceiling);
+
+		result.Should().NotBeNull();
+		result!.FullName.Should().Be("/repo");
+	}
+}

--- a/tests/Elastic.Documentation.Configuration.Tests/FindGitRootTests.cs
+++ b/tests/Elastic.Documentation.Configuration.Tests/FindGitRootTests.cs
@@ -17,11 +17,12 @@ public class FindGitRootTests
 		fs.AddFile("/repo/docset.yml", new("toc: []"));
 
 		var start = fs.DirectoryInfo.New("/repo");
+		var expected = start.FullName;
 
 		var result = Paths.FindGitRoot(start, ceiling: start);
 
 		result.Should().NotBeNull();
-		result!.FullName.Should().Be("/repo");
+		result.FullName.Should().Be(expected);
 	}
 
 	[Fact]
@@ -37,7 +38,7 @@ public class FindGitRootTests
 		var result = Paths.FindGitRoot(start, ceiling: ceiling);
 
 		result.Should().NotBeNull();
-		result!.FullName.Should().Be("/repo");
+		result.FullName.Should().Be(ceiling.FullName);
 	}
 
 	[Fact]
@@ -53,7 +54,7 @@ public class FindGitRootTests
 		var result = Paths.FindGitRoot(start, ceiling: ceiling);
 
 		result.Should().NotBeNull();
-		result!.FullName.Should().Be("/repo");
+		result.FullName.Should().Be(ceiling.FullName);
 	}
 
 	[Fact]
@@ -116,7 +117,7 @@ public class FindGitRootTests
 		var result = Paths.FindGitRoot(start, ceiling: ceiling);
 
 		result.Should().NotBeNull();
-		result!.FullName.Should().Be("/workspace");
+		result.FullName.Should().Be(ceiling.FullName);
 	}
 
 	[Fact]
@@ -147,6 +148,6 @@ public class FindGitRootTests
 		var result = Paths.FindGitRoot(start, ceiling: ceiling);
 
 		result.Should().NotBeNull();
-		result!.FullName.Should().Be("/repo");
+		result.FullName.Should().Be(ceiling.FullName);
 	}
 }


### PR DESCRIPTION
This pull request enhances the logic for finding the Git root directory in the documentation configuration system by introducing a "ceiling" boundary to restrict the search scope. It also adds comprehensive tests to verify the new behavior and ensures the codebase uses the updated method consistently.

**Enhancements to Git root detection:**

* The `Paths.FindGitRoot` method now accepts an optional `ceiling` parameter, which acts as an upper boundary for the search. The search for a `.git` directory or file will not traverse above this ceiling, preventing accidental detection of parent repositories outside the intended scope.
* The `BuildContext` constructor is updated to pass the repository root as the ceiling when locating the documentation checkout directory, ensuring the search stays within the expected project boundaries.

**Testing improvements:**

* A new test suite `FindGitRootTests` is added, covering scenarios such as finding the Git root at various directory levels, respecting the ceiling boundary, handling worktree files, and ensuring no false positives when no `.git` exists within the ceiling.

**Codebase maintenance:**

* The `Elastic.Documentation.Extensions` namespace is imported to support the new path logic.