### PR TITLE
Sitemap: Exclude /docs/api/** URLs

### DIFF
--- a/src/services/Elastic.Documentation.Assembler/Building/SitemapBuilder.cs
+++ b/src/services/Elastic.Documentation.Assembler/Building/SitemapBuilder.cs
@@ -23,6 +23,10 @@ public static class SitemapBuilder
 		IDirectoryInfo outputFolder
 	)
 	{
+		// TODO: Remove this exclusion when API docs are ready for sitemap inclusion
+		var filtered = entries
+			.Where(e => !e.Key.StartsWith("/docs/api/", StringComparison.Ordinal));
+
 		var doc = new XDocument
 		{
 			Declaration = new XDeclaration("1.0", "utf-8", "yes")
@@ -33,7 +37,7 @@ public static class SitemapBuilder
 		var root = new XElement(
 			ns + "urlset",
 			new XAttribute("xmlns", "http://www.sitemaps.org/schemas/sitemap/0.9"),
-			entries
+			filtered
 				.OrderBy(e => e.Key, StringComparer.Ordinal)
 				.Select(e => new XElement(ns + "url", [
 					new XElement(ns + "loc", new Uri(BaseUri, e.Key)),

--- a/tests/Elastic.Documentation.Build.Tests/SitemapTests.cs
+++ b/tests/Elastic.Documentation.Build.Tests/SitemapTests.cs
@@ -95,6 +95,37 @@ public class SitemapTests
 	}
 
 	[Fact]
+	public void Generate_ExcludesApiDocsFromSitemap()
+	{
+		// Arrange
+		var fs = new MockFileSystem();
+		var outputDir = fs.DirectoryInfo.New("/output");
+
+		var now = DateTimeOffset.UtcNow;
+		var entries = new Dictionary<string, DateTimeOffset>
+		{
+			["/docs/elasticsearch/getting-started"] = now,
+			["/docs/api/elasticsearch/rest"] = now,
+			["/docs/api/kibana/actions"] = now,
+			["/docs/kibana/dashboard"] = now,
+		};
+
+		// Act
+		SitemapBuilder.Generate(entries, fs, outputDir);
+
+		// Assert
+		var content = fs.File.ReadAllText(fs.Path.Join("/output", "sitemap.xml"));
+		var doc = XDocument.Parse(content);
+		XNamespace ns = "http://www.sitemaps.org/schemas/sitemap/0.9";
+
+		var locs = doc.Descendants(ns + "loc").Select(e => e.Value).ToList();
+		locs.Should().HaveCount(2);
+		locs.Should().NotContain(l => l.Contains("/docs/api/"));
+		locs.Should().Contain("https://www.elastic.co/docs/elasticsearch/getting-started");
+		locs.Should().Contain("https://www.elastic.co/docs/kibana/dashboard");
+	}
+
+	[Fact]
 	public void BuildSearchBody_FirstPage_HasPitButNoSearchAfter()
 	{
 		// Act


### PR DESCRIPTION
## What
Exclude all `/docs/api/**` URLs from the generated sitemap.

## Why
API docs should not appear in the sitemap for now.

## How
Filter entries with `/docs/api/` prefix in `SitemapBuilder.Generate()` — the single method both the build-time and production sitemap paths funnel through.

## Test plan
- [x] `dotnet test --filter SitemapTests` — all 7 tests pass including new `Generate_ExcludesApiDocsFromSitemap`

## Notes
Marked with a `TODO` comment for easy removal when API docs are ready for sitemap inclusion.