### PR TITLE
Sitemap: Add protocol limit validation

### DIFF
--- a/src/services/Elastic.Documentation.Assembler/Building/AssemblerBuildService.cs
+++ b/src/services/Elastic.Documentation.Assembler/Building/AssemblerBuildService.cs
@@ -138,7 +138,20 @@ public class AssemblerBuildService(
 				.Distinct();
 			var now = DateTimeOffset.UtcNow;
 			var entries = urls.ToDictionary(u => u, _ => now);
-			SitemapBuilder.Generate(entries, assembleContext.WriteFileSystem, assembleContext.OutputWithPathPrefixDirectory);
+
+			if (entries.Count >= SitemapBuilder.WarningEntryThreshold)
+				collector.EmitGlobalWarning(
+					$"Sitemap has {entries.Count:N0} entries, approaching the {SitemapBuilder.MaxEntries:N0} URL protocol limit. " +
+					"Consider implementing sitemap index files."
+				);
+
+			var sitemapResult = SitemapBuilder.Generate(entries, assembleContext.WriteFileSystem, assembleContext.OutputWithPathPrefixDirectory);
+
+			if (sitemapResult.FileSizeBytes >= SitemapBuilder.WarningFileSizeBytes)
+				collector.EmitGlobalWarning(
+					$"Sitemap file size is {sitemapResult.FileSizeBytes / (1024.0 * 1024.0):F1} MB, approaching the 50 MB protocol limit. " +
+					"Consider implementing sitemap index files."
+				);
 		}
 
 		if (exporters.Contains(Exporter.LLMText))

--- a/src/services/Elastic.Documentation.Assembler/Building/AssemblerSitemapService.cs
+++ b/src/services/Elastic.Documentation.Assembler/Building/AssemblerSitemapService.cs
@@ -96,7 +96,19 @@ public class AssemblerSitemapService(
 			return false;
 		}
 
-		SitemapBuilder.Generate(entries, assembleContext.WriteFileSystem, assembleContext.OutputWithPathPrefixDirectory);
+		if (entries.Count >= SitemapBuilder.WarningEntryThreshold)
+			collector.EmitGlobalWarning(
+				$"Sitemap has {entries.Count:N0} entries, approaching the {SitemapBuilder.MaxEntries:N0} URL protocol limit. " +
+				"Consider implementing sitemap index files."
+			);
+
+		var result = SitemapBuilder.Generate(entries, assembleContext.WriteFileSystem, assembleContext.OutputWithPathPrefixDirectory);
+
+		if (result.FileSizeBytes >= SitemapBuilder.WarningFileSizeBytes)
+			collector.EmitGlobalWarning(
+				$"Sitemap file size is {result.FileSizeBytes / (1024.0 * 1024.0):F1} MB, approaching the 50 MB protocol limit. " +
+				"Consider implementing sitemap index files."
+			);
 
 		_logger.LogInformation("Sitemap written to {Path}", assembleContext.OutputWithPathPrefixDirectory.FullName);
 		return true;

--- a/src/services/Elastic.Documentation.Assembler/Building/SitemapBuilder.cs
+++ b/src/services/Elastic.Documentation.Assembler/Building/SitemapBuilder.cs
@@ -56,20 +56,23 @@ public static class SitemapBuilder
 
 		doc.Add(root);
 
-		if (!outputFolder.Exists)
-			_ = fileSystem.Directory.CreateDirectory(outputFolder.FullName);
+		using var buffer = new MemoryStream();
+		doc.Save(buffer);
 
-		var sitemapPath = fileSystem.Path.Join(outputFolder.FullName, "sitemap.xml");
-		using var fileStream = fileSystem.File.Create(sitemapPath);
-		doc.Save(fileStream);
-		fileStream.Flush();
-
-		var fileSize = fileStream.Length;
+		var fileSize = buffer.Length;
 		if (fileSize > MaxFileSizeBytes)
 			throw new InvalidOperationException(
 				$"Sitemap file size is {fileSize / (1024.0 * 1024.0):F1} MB, which exceeds the sitemap protocol limit of 50 MB. " +
 				"Consider implementing sitemap index files to split entries across multiple sitemaps."
 			);
+
+		if (!outputFolder.Exists)
+			_ = fileSystem.Directory.CreateDirectory(outputFolder.FullName);
+
+		var sitemapPath = fileSystem.Path.Join(outputFolder.FullName, "sitemap.xml");
+		using var fileStream = fileSystem.File.Create(sitemapPath);
+		buffer.Position = 0;
+		buffer.CopyTo(fileStream);
 
 		return new SitemapResult(entries.Count, fileSize);
 	}

--- a/src/services/Elastic.Documentation.Assembler/Building/SitemapBuilder.cs
+++ b/src/services/Elastic.Documentation.Assembler/Building/SitemapBuilder.cs
@@ -12,17 +12,30 @@ using Elastic.Markdown.Extensions.DetectionRules;
 
 namespace Elastic.Documentation.Assembler.Building;
 
+public record SitemapResult(int EntryCount, long FileSizeBytes);
+
 public static class SitemapBuilder
 {
+	public const int MaxEntries = 50_000;
+	public const int WarningEntryThreshold = 40_000;
+	public const long MaxFileSizeBytes = 50L * 1024 * 1024;
+	public const long WarningFileSizeBytes = 40L * 1024 * 1024;
+
 	private static readonly Uri BaseUri = new("https://www.elastic.co");
 
 	/// <summary>Generates sitemap.xml with per-URL last_updated dates.</summary>
-	public static void Generate(
+	public static SitemapResult Generate(
 		IReadOnlyDictionary<string, DateTimeOffset> entries,
 		IFileSystem fileSystem,
 		IDirectoryInfo outputFolder
 	)
 	{
+		if (entries.Count > MaxEntries)
+			throw new InvalidOperationException(
+				$"Sitemap contains {entries.Count:N0} URLs, which exceeds the sitemap protocol limit of {MaxEntries:N0}. " +
+				"Consider implementing sitemap index files to split entries across multiple sitemaps."
+			);
+
 		var doc = new XDocument
 		{
 			Declaration = new XDeclaration("1.0", "utf-8", "yes")
@@ -46,8 +59,19 @@ public static class SitemapBuilder
 		if (!outputFolder.Exists)
 			_ = fileSystem.Directory.CreateDirectory(outputFolder.FullName);
 
-		using var fileStream = fileSystem.File.Create(fileSystem.Path.Join(outputFolder.FullName, "sitemap.xml"));
+		var sitemapPath = fileSystem.Path.Join(outputFolder.FullName, "sitemap.xml");
+		using var fileStream = fileSystem.File.Create(sitemapPath);
 		doc.Save(fileStream);
+		fileStream.Flush();
+
+		var fileSize = fileStream.Length;
+		if (fileSize > MaxFileSizeBytes)
+			throw new InvalidOperationException(
+				$"Sitemap file size is {fileSize / (1024.0 * 1024.0):F1} MB, which exceeds the sitemap protocol limit of 50 MB. " +
+				"Consider implementing sitemap index files to split entries across multiple sitemaps."
+			);
+
+		return new SitemapResult(entries.Count, fileSize);
 	}
 }
 

--- a/tests/Elastic.Documentation.Build.Tests/SitemapTests.cs
+++ b/tests/Elastic.Documentation.Build.Tests/SitemapTests.cs
@@ -95,6 +95,62 @@ public class SitemapTests
 	}
 
 	[Fact]
+	public void Generate_ReturnsEntryCountAndFileSize()
+	{
+		// Arrange
+		var fs = new MockFileSystem();
+		var outputDir = fs.DirectoryInfo.New("/output");
+		var now = DateTimeOffset.UtcNow;
+		var entries = new Dictionary<string, DateTimeOffset>
+		{
+			["/docs/page-1"] = now,
+			["/docs/page-2"] = now,
+		};
+
+		// Act
+		var result = SitemapBuilder.Generate(entries, fs, outputDir);
+
+		// Assert
+		result.EntryCount.Should().Be(2);
+		result.FileSizeBytes.Should().BeGreaterThan(0);
+	}
+
+	[Fact]
+	public void Generate_ThrowsWhenEntryCountExceedsLimit()
+	{
+		// Arrange
+		var fs = new MockFileSystem();
+		var outputDir = fs.DirectoryInfo.New("/output");
+		var now = DateTimeOffset.UtcNow;
+		var entries = Enumerable.Range(0, SitemapBuilder.MaxEntries + 1)
+			.ToDictionary(i => $"/docs/page-{i}", _ => now);
+
+		// Act
+		var act = () => SitemapBuilder.Generate(entries, fs, outputDir);
+
+		// Assert
+		act.Should().Throw<InvalidOperationException>()
+			.WithMessage("*exceeds the sitemap protocol limit*");
+	}
+
+	[Fact]
+	public void Generate_DoesNotThrowAtExactLimit()
+	{
+		// Arrange
+		var fs = new MockFileSystem();
+		var outputDir = fs.DirectoryInfo.New("/output");
+		var now = DateTimeOffset.UtcNow;
+		var entries = Enumerable.Range(0, SitemapBuilder.MaxEntries)
+			.ToDictionary(i => $"/docs/page-{i}", _ => now);
+
+		// Act
+		var act = () => SitemapBuilder.Generate(entries, fs, outputDir);
+
+		// Assert
+		act.Should().NotThrow();
+	}
+
+	[Fact]
 	public void BuildSearchBody_FirstPage_HasPitButNoSearchAfter()
 	{
 		// Act


### PR DESCRIPTION
## What
Validate sitemap.xml against the sitemap protocol limits (50,000 URLs and 50 MB file size), throwing on violation and warning early at 80% thresholds.

## Why
The sitemap protocol enforces hard limits. Exceeding them produces an invalid sitemap that search engines will reject. Early warnings at 40k entries / 40 MB give the team time to implement sitemap index files before hitting the wall.

## How
- `SitemapBuilder.Generate()` throws `InvalidOperationException` when entries exceed 50k or file size exceeds 50 MB
- `Generate()` now returns a `SitemapResult(EntryCount, FileSizeBytes)` record
- Both call sites (`AssemblerSitemapService`, `AssemblerBuildService`) emit `EmitGlobalWarning` at 40k entries and 40 MB file size

## Test plan
- `dotnet test --filter SitemapTests` — 9 tests pass including 3 new ones covering the entry count limit and result metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)