### PR TITLE
ElasticsearchOperations: Add default timeout to async task polling

### DIFF
--- a/src/Elastic.Markdown/Exporters/Elasticsearch/ContentDateEnrichment.cs
+++ b/src/Elastic.Markdown/Exporters/Elasticsearch/ContentDateEnrichment.cs
@@ -101,11 +101,11 @@ public class ContentDateEnrichment(
 		}
 	}.ToJsonString();
 
-	public async Task ResolveContentDatesAsync(string indexAlias, Cancel ct)
+	public async Task ResolveContentDatesAsync(string indexAlias, Cancel ct, TimeSpan? maxDuration = null)
 	{
 		logger.LogInformation("Resolving content dates in {Index} via pipeline {Pipeline}", indexAlias, PipelineName);
 
-		await operations.UpdateByQueryAsync(indexAlias, PostData.String(UnresolvedContentDatesQuery), PipelineName, ct);
+		await operations.UpdateByQueryAsync(indexAlias, PostData.String(UnresolvedContentDatesQuery), PipelineName, ct, maxDuration);
 
 		logger.LogInformation("Content date resolution complete for {Index}", indexAlias);
 	}

--- a/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchOperations.cs
+++ b/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchOperations.cs
@@ -111,7 +111,7 @@ public class ElasticsearchOperations(
 					"Task {TaskId} for {Operation} on '{SourceIndex}' exceeded max duration {MaxDuration} (elapsed: {Elapsed}). Attempting to cancel",
 					taskId, operation, sourceIndex, maxDuration.Value, sw.Elapsed);
 
-				await CancelTaskBestEffortAsync(taskId, operation);
+				await CancelTaskBestEffortAsync(taskId, operation, ct);
 
 				throw new TimeoutException(
 					$"Elasticsearch task {taskId} for {operation} on '{sourceIndex}' did not complete within {maxDuration.Value}");
@@ -123,15 +123,16 @@ public class ElasticsearchOperations(
 		} while (!completed);
 	}
 
-	/// <summary>Attempts to cancel an ES task. Logs on failure but does not throw.</summary>
-	private async Task CancelTaskBestEffortAsync(string taskId, string operation)
+	/// <summary>Attempts to cancel an ES task with a short timeout. Logs on failure but does not throw.</summary>
+	private async Task CancelTaskBestEffortAsync(string taskId, string operation, CancellationToken ct)
 	{
+		using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+		cts.CancelAfter(TimeSpan.FromSeconds(5));
+
 		try
 		{
-			var response = await WithRetryAsync(
-				() => _transport.PostAsync<DynamicResponse>($"/_tasks/{taskId}/_cancel", PostData.Empty, CancellationToken.None),
-				$"POST _tasks/{taskId}/_cancel",
-				CancellationToken.None);
+			var response = await _transport.PostAsync<DynamicResponse>(
+				$"/_tasks/{taskId}/_cancel", PostData.Empty, cts.Token);
 
 			if (response.ApiCallDetails.HasSuccessfulStatusCode)
 				_logger.LogInformation("Successfully requested cancellation of task {TaskId} ({Operation})", taskId, operation);

--- a/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchOperations.cs
+++ b/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchOperations.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Diagnostics;
 using Elastic.Documentation.Diagnostics;
 using Elastic.Transport;
 using Elastic.Transport.Products.Elasticsearch;
@@ -69,8 +70,11 @@ public class ElasticsearchOperations(
 		string operation,
 		string sourceIndex,
 		string? destIndex,
-		CancellationToken ct)
+		CancellationToken ct,
+		TimeSpan? maxDuration = null)
 	{
+		maxDuration ??= TimeSpan.FromMinutes(30);
+		var sw = Stopwatch.StartNew();
 		bool completed;
 		do
 		{
@@ -101,10 +105,45 @@ public class ElasticsearchOperations(
 					operation, sourceIndex, time.ToString(@"hh\:mm\:ss"), total, updated, created, deleted, batches);
 			}
 
+			if (!completed && sw.Elapsed > maxDuration.Value)
+			{
+				_logger.LogWarning(
+					"Task {TaskId} for {Operation} on '{SourceIndex}' exceeded max duration {MaxDuration} (elapsed: {Elapsed}). Attempting to cancel",
+					taskId, operation, sourceIndex, maxDuration.Value, sw.Elapsed);
+
+				await CancelTaskBestEffortAsync(taskId, operation);
+
+				throw new TimeoutException(
+					$"Elasticsearch task {taskId} for {operation} on '{sourceIndex}' did not complete within {maxDuration.Value}");
+			}
+
 			if (!completed)
 				await Task.Delay(TimeSpan.FromSeconds(5), ct);
 
 		} while (!completed);
+	}
+
+	/// <summary>Attempts to cancel an ES task. Logs on failure but does not throw.</summary>
+	private async Task CancelTaskBestEffortAsync(string taskId, string operation)
+	{
+		try
+		{
+			var response = await WithRetryAsync(
+				() => _transport.PostAsync<DynamicResponse>($"/_tasks/{taskId}/_cancel", PostData.Empty, CancellationToken.None),
+				$"POST _tasks/{taskId}/_cancel",
+				CancellationToken.None);
+
+			if (response.ApiCallDetails.HasSuccessfulStatusCode)
+				_logger.LogInformation("Successfully requested cancellation of task {TaskId} ({Operation})", taskId, operation);
+			else
+				_logger.LogWarning(
+					"Cancel request for task {TaskId} ({Operation}) returned status {StatusCode}",
+					taskId, operation, response.ApiCallDetails.HttpStatusCode);
+		}
+		catch (Exception ex)
+		{
+			_logger.LogWarning(ex, "Failed to cancel task {TaskId} ({Operation})", taskId, operation);
+		}
 	}
 
 	/// <summary>
@@ -154,11 +193,12 @@ public class ElasticsearchOperations(
 	public async Task DeleteByQueryAsync(
 		string index,
 		PostData query,
-		CancellationToken ct)
+		CancellationToken ct,
+		TimeSpan? maxDuration = null)
 	{
 		var taskId = await DeleteByQueryFireAndForgetAsync(index, query, ct)
 			?? throw new InvalidOperationException($"Failed to start _delete_by_query on {index}");
-		await PollTaskUntilCompleteAsync(taskId, "_delete_by_query", index, null, ct);
+		await PollTaskUntilCompleteAsync(taskId, "_delete_by_query", index, null, ct, maxDuration);
 	}
 
 	/// <summary>
@@ -168,12 +208,13 @@ public class ElasticsearchOperations(
 		string sourceIndex,
 		PostData request,
 		string destIndex,
-		CancellationToken ct)
+		CancellationToken ct,
+		TimeSpan? maxDuration = null)
 	{
 		var url = "/_reindex?wait_for_completion=false";
 		var taskId = await PostAsyncTaskAsync(url, request, $"POST _reindex ({sourceIndex} => {destIndex})", ct)
 			?? throw new InvalidOperationException($"Failed to start _reindex ({sourceIndex} => {destIndex})");
-		await PollTaskUntilCompleteAsync(taskId, "_reindex", sourceIndex, destIndex, ct);
+		await PollTaskUntilCompleteAsync(taskId, "_reindex", sourceIndex, destIndex, ct, maxDuration);
 	}
 
 	/// <summary>
@@ -183,12 +224,13 @@ public class ElasticsearchOperations(
 		string index,
 		PostData query,
 		string? pipeline,
-		CancellationToken ct)
+		CancellationToken ct,
+		TimeSpan? maxDuration = null)
 	{
 		var pipelineParam = pipeline is not null ? $"&pipeline={pipeline}" : "";
 		var url = $"/{index}/_update_by_query?wait_for_completion=false{pipelineParam}";
 		var taskId = await PostAsyncTaskAsync(url, query, $"POST {index}/_update_by_query", ct)
 			?? throw new InvalidOperationException($"Failed to start _update_by_query on {index}");
-		await PollTaskUntilCompleteAsync(taskId, "_update_by_query", index, null, ct);
+		await PollTaskUntilCompleteAsync(taskId, "_update_by_query", index, null, ct, maxDuration);
 	}
 }


### PR DESCRIPTION
## What
Add a 30-minute default timeout to `PollTaskUntilCompleteAsync` so ES async tasks (delete_by_query, reindex, update_by_query) can't hang the process indefinitely.

## Why
The content date `_update_by_query` sometimes stalls and never completes, blocking the entire pipeline with no escape.

## How
- `PollTaskUntilCompleteAsync` now tracks elapsed time via `Stopwatch` and throws `TimeoutException` after `maxDuration` (default 30 min)
- Before timing out, best-effort cancels the ES task via `POST _tasks/{id}/_cancel`
- All public async-task methods (`DeleteByQueryAsync`, `ReindexAsync`, `UpdateByQueryAsync`) and `ContentDateEnrichment.ResolveContentDatesAsync` accept an optional `maxDuration` override

## Test plan
- [x] `dotnet build` passes with 0 warnings/errors
- [x] Integration test project compiles unchanged (default `null` → 30 min)
- [ ] Verify normal content date resolution completes well under 30 minutes in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)