### PR TITLE
Add multi-language code sample tabs to API Explorer

### DIFF
--- a/docs/configure/content-set/api-explorer.md
+++ b/docs/configure/content-set/api-explorer.md
@@ -91,6 +91,6 @@ The `x-codeSamples` extension is a JSON array of objects, each with a `lang` and
 ]
 ```
 
-When multiple languages are available, they appear as tabs inside the Request Examples section, replacing the JSON code block of the first request example. The example's description text is preserved above the tabs. The selected language persists across operations and page navigations. When only one language is available, the example renders without a tab selector.
+The code samples appear in a standalone "Code Examples" section on every operation page that has the extension, regardless of HTTP method. This means GET, DELETE, and other operations without a request body also display language tabs when `x-codeSamples` are present. When multiple languages are available, they appear as tabs. The selected language persists across operations and page navigations. When only one language is available, the example renders without a tab selector.
 
-Console is treated as the default language and appears first in the tab order when present. If an operation has no `x-codeSamples`, request examples render as JSON code blocks as before.
+Console is treated as the default language and appears first in the tab order when present.

--- a/docs/configure/content-set/api-explorer.md
+++ b/docs/configure/content-set/api-explorer.md
@@ -76,3 +76,21 @@ The API Explorer generates the following types of pages from your OpenAPI spec:
 - **Landing page**: An overview of the API grouped by tag
 - **Operation pages**: One page per API operation, with the HTTP method, path, parameters, request body, response schemas, and examples
 - **Schema type pages**: Dedicated pages for complex shared types such as `QueryContainer` and `AggregationContainer`
+
+## Multi-language code examples
+
+When an OpenAPI operation includes the `x-codeSamples` extension, the API Explorer renders the code samples with a language selector tab. This lets users switch between available languages such as Console, cURL, Python, JavaScript, Ruby, PHP, and Java.
+
+The `x-codeSamples` extension is a JSON array of objects, each with a `lang` and `source` field:
+
+```json
+"x-codeSamples": [
+  { "lang": "Console", "source": "GET /_search" },
+  { "lang": "curl", "source": "curl -X GET ..." },
+  { "lang": "Python", "source": "resp = client.search()" }
+]
+```
+
+When multiple languages are available, they appear as tabs inside the Request Examples section, replacing the JSON code block of the first request example. The example's description text is preserved above the tabs. The selected language persists across operations and page navigations. When only one language is available, the example renders without a tab selector.
+
+Console is treated as the default language and appears first in the tab order when present. If an operation has no `x-codeSamples`, request examples render as JSON code blocks as before.

--- a/src/Elastic.ApiExplorer/Operations/OperationView.cshtml
+++ b/src/Elastic.ApiExplorer/Operations/OperationView.cshtml
@@ -486,6 +486,8 @@
 		var successResponse = operation.Responses?.FirstOrDefault(r => r.Key.StartsWith("2")).Value;
 		var responseContent = successResponse?.Content?.FirstOrDefault().Value;
 		var responseExamples = responseContent?.Examples;
+
+		var codeSamples = Model.CodeSamples;
 	}
 	@if (requestExamples is { Count: > 0 })
 	{
@@ -497,6 +499,7 @@
 				<button class="section-nav-btn" data-dir="down" title="Next section">&#x25BC;</button>
 			</span>
 		</h3>
+		var exampleIndex = 0;
 		@foreach (var example in requestExamples)
 		{
 			<div class="example-block">
@@ -505,15 +508,38 @@
 				{
 					<div class="example-description">@Model.RenderMarkdown(example.Value.Description)</div>
 				}
-				@if (example.Value?.Value is not null)
+				@if (exampleIndex == 0 && codeSamples.Count > 1)
 				{
-					<pre><code class="language-json">@example.Value.Value.ToString()</code></pre>
+					<div class="tabs">
+						@for (var i = 0; i < codeSamples.Count; i++)
+						{
+							var sample = codeSamples[i];
+							var tabId = $"code-sample-{i}";
+							<input class="tabs-input" checked="@(i == 0 ? "checked" : "")" id="@tabId" name="code-samples" type="radio" tabindex="0">
+							<label class="tabs-label" data-sync-id="@sample.Language" data-sync-group="api-language" for="@tabId">@sample.Language</label>
+							<div class="tabs-content" tabindex="0">
+								<pre><code class="@sample.HighlightClass">@sample.Source</code></pre>
+							</div>
+						}
+					</div>
+				}
+				else if (exampleIndex == 0 && codeSamples.Count == 1)
+				{
+					<pre><code class="@codeSamples[0].HighlightClass">@codeSamples[0].Source</code></pre>
+				}
+				else
+				{
+					@if (example.Value?.Value is not null)
+					{
+						<pre><code class="language-json">@example.Value.Value.ToString()</code></pre>
+					}
 				}
 				@if (!string.IsNullOrEmpty(example.Value?.ExternalValue))
 				{
 					<p class="external-example">External example: <a href="@example.Value.ExternalValue">@example.Value.ExternalValue</a></p>
 				}
 			</div>
+			exampleIndex++;
 		}
 	}
 	@if (responseExamples is { Count: > 0 })

--- a/src/Elastic.ApiExplorer/Operations/OperationView.cshtml
+++ b/src/Elastic.ApiExplorer/Operations/OperationView.cshtml
@@ -478,6 +478,47 @@
 		}
 	}
 	@{
+		var codeSamples = Model.CodeSamples;
+	}
+	@if (codeSamples.Count == 1)
+	{
+		<h3 class="section-header" id="code-examples" data-section="code-examples">
+			<span>Code Examples</span>
+			<span class="section-nav">
+				<span class="section-path">@Model.Operation.Route</span>
+				<button class="section-nav-btn" data-dir="up" title="Previous section">&#x25B2;</button>
+				<button class="section-nav-btn" data-dir="down" title="Next section">&#x25BC;</button>
+			</span>
+		</h3>
+		<div class="example-block">
+			<h4>@codeSamples[0].Language</h4>
+			<pre><code class="@codeSamples[0].HighlightClass">@codeSamples[0].Source</code></pre>
+		</div>
+	}
+	else if (codeSamples.Count > 1)
+	{
+		<h3 class="section-header" id="code-examples" data-section="code-examples">
+			<span>Code Examples</span>
+			<span class="section-nav">
+				<span class="section-path">@Model.Operation.Route</span>
+				<button class="section-nav-btn" data-dir="up" title="Previous section">&#x25B2;</button>
+				<button class="section-nav-btn" data-dir="down" title="Next section">&#x25BC;</button>
+			</span>
+		</h3>
+		<div class="tabs">
+			@for (var i = 0; i < codeSamples.Count; i++)
+			{
+				var sample = codeSamples[i];
+				var tabId = $"code-sample-{i}";
+				<input class="tabs-input" checked="@(i == 0 ? "checked" : "")" id="@tabId" name="code-samples" type="radio" tabindex="0">
+				<label class="tabs-label" data-sync-id="@sample.Language" data-sync-group="api-language" for="@tabId">@sample.Language</label>
+				<div class="tabs-content" tabindex="0">
+					<pre><code class="@sample.HighlightClass">@sample.Source</code></pre>
+				</div>
+			}
+		</div>
+	}
+	@{
 		// Check for examples in request body
 		var requestBodyContent = operation.RequestBody?.Content?.FirstOrDefault().Value;
 		var requestExamples = requestBodyContent?.Examples;
@@ -486,8 +527,6 @@
 		var successResponse = operation.Responses?.FirstOrDefault(r => r.Key.StartsWith("2")).Value;
 		var responseContent = successResponse?.Content?.FirstOrDefault().Value;
 		var responseExamples = responseContent?.Examples;
-
-		var codeSamples = Model.CodeSamples;
 	}
 	@if (requestExamples is { Count: > 0 })
 	{
@@ -499,7 +538,6 @@
 				<button class="section-nav-btn" data-dir="down" title="Next section">&#x25BC;</button>
 			</span>
 		</h3>
-		var exampleIndex = 0;
 		@foreach (var example in requestExamples)
 		{
 			<div class="example-block">
@@ -508,38 +546,15 @@
 				{
 					<div class="example-description">@Model.RenderMarkdown(example.Value.Description)</div>
 				}
-				@if (exampleIndex == 0 && codeSamples.Count > 1)
+				@if (example.Value?.Value is not null)
 				{
-					<div class="tabs">
-						@for (var i = 0; i < codeSamples.Count; i++)
-						{
-							var sample = codeSamples[i];
-							var tabId = $"code-sample-{i}";
-							<input class="tabs-input" checked="@(i == 0 ? "checked" : "")" id="@tabId" name="code-samples" type="radio" tabindex="0">
-							<label class="tabs-label" data-sync-id="@sample.Language" data-sync-group="api-language" for="@tabId">@sample.Language</label>
-							<div class="tabs-content" tabindex="0">
-								<pre><code class="@sample.HighlightClass">@sample.Source</code></pre>
-							</div>
-						}
-					</div>
-				}
-				else if (exampleIndex == 0 && codeSamples.Count == 1)
-				{
-					<pre><code class="@codeSamples[0].HighlightClass">@codeSamples[0].Source</code></pre>
-				}
-				else
-				{
-					@if (example.Value?.Value is not null)
-					{
-						<pre><code class="language-json">@example.Value.Value.ToString()</code></pre>
-					}
+					<pre><code class="language-json">@example.Value.Value.ToString()</code></pre>
 				}
 				@if (!string.IsNullOrEmpty(example.Value?.ExternalValue))
 				{
 					<p class="external-example">External example: <a href="@example.Value.ExternalValue">@example.Value.ExternalValue</a></p>
 				}
 			</div>
-			exampleIndex++;
 		}
 	}
 	@if (responseExamples is { Count: > 0 })
@@ -572,8 +587,10 @@
 		}
 	}
 	@{
-		var hasExamples = requestExamples is { Count: > 0 } || responseExamples is { Count: > 0 };
-		var examplesAnchor = requestExamples is { Count: > 0 } ? "request-examples" : "response-examples";
+		var hasExamples = codeSamples.Count > 0 || requestExamples is { Count: > 0 } || responseExamples is { Count: > 0 };
+		var examplesAnchor = codeSamples.Count > 0 ? "code-examples"
+			: requestExamples is { Count: > 0 } ? "request-examples"
+			: "response-examples";
 	}
 	@if (hasExamples)
 	{

--- a/src/Elastic.ApiExplorer/Operations/OperationView.cshtml
+++ b/src/Elastic.ApiExplorer/Operations/OperationView.cshtml
@@ -528,7 +528,7 @@
 		var responseContent = successResponse?.Content?.FirstOrDefault().Value;
 		var responseExamples = responseContent?.Examples;
 	}
-	@if (requestExamples is { Count: > 0 })
+	@if (requestExamples is { Count: > 0 } && !(requestExamples.Count == 1 && codeSamples.Count > 0))
 	{
 		<h3 class="section-header" id="request-examples" data-section="request-examples">
 			<span>Request Examples</span>

--- a/src/Elastic.ApiExplorer/Operations/OperationViewModel.cs
+++ b/src/Elastic.ApiExplorer/Operations/OperationViewModel.cs
@@ -71,7 +71,7 @@ public class OperationViewModel(ApiRenderContext context) : ApiViewModel(context
 		return tocItems;
 	}
 
-	internal static IReadOnlyList<CodeSample> ParseCodeSamples(OpenApiOperation operation)
+	public static IReadOnlyList<CodeSample> ParseCodeSamples(OpenApiOperation operation)
 	{
 		if (operation.Extensions?.TryGetValue("x-codeSamples", out var ext) != true
 			|| ext is not JsonNodeExtension jsonExt

--- a/src/Elastic.ApiExplorer/Operations/OperationViewModel.cs
+++ b/src/Elastic.ApiExplorer/Operations/OperationViewModel.cs
@@ -57,6 +57,9 @@ public class OperationViewModel(ApiRenderContext context) : ApiViewModel(context
 		if (operation.Responses is { Count: > 0 })
 			tocItems.Add(new ApiTocItem(operation.Responses.Count == 1 ? "Response" : "Responses", "responses"));
 
+		if (CodeSamples.Count > 0)
+			tocItems.Add(new ApiTocItem("Code Examples", "code-examples"));
+
 		// Request body examples
 		var reqContent = operation.RequestBody?.Content?.FirstOrDefault().Value;
 		if (reqContent?.Examples is { Count: > 0 })

--- a/src/Elastic.ApiExplorer/Operations/OperationViewModel.cs
+++ b/src/Elastic.ApiExplorer/Operations/OperationViewModel.cs
@@ -2,16 +2,45 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Text.Json.Nodes;
 using Microsoft.OpenApi;
 
 namespace Elastic.ApiExplorer.Operations;
+
+/// <summary>
+/// A single code sample extracted from the x-codeSamples OpenAPI extension.
+/// </summary>
+public record CodeSample(string Language, string Source, string HighlightClass)
+{
+	private static readonly Dictionary<string, string> LanguageHighlightMap = new(StringComparer.OrdinalIgnoreCase)
+	{
+		["Console"] = "language-console",
+		["curl"] = "language-bash",
+		["Python"] = "language-python",
+		["JavaScript"] = "language-javascript",
+		["Ruby"] = "language-ruby",
+		["PHP"] = "language-php",
+		["Java"] = "language-java",
+	};
+
+	public static string GetHighlightClass(string language) =>
+		LanguageHighlightMap.GetValueOrDefault(language, $"language-{language.ToLowerInvariant()}");
+}
 
 public class OperationViewModel(ApiRenderContext context) : ApiViewModel(context)
 {
 	public required ApiOperation Operation { get; init; }
 
+	/// <summary>
+	/// Code samples parsed from the x-codeSamples extension, ordered with Console first.
+	/// Populated during <see cref="GetTocItems"/>, which runs before the template body.
+	/// </summary>
+	public IReadOnlyList<CodeSample> CodeSamples { get; private set; } = [];
+
 	protected override IReadOnlyList<ApiTocItem> GetTocItems()
 	{
+		CodeSamples = ParseCodeSamples(Operation.Operation);
+
 		var operation = Operation.Operation;
 		var tocItems = new List<ApiTocItem> { new("Paths", "paths") };
 
@@ -40,5 +69,42 @@ public class OperationViewModel(ApiRenderContext context) : ApiViewModel(context
 			tocItems.Add(new ApiTocItem("Response Examples", "response-examples"));
 
 		return tocItems;
+	}
+
+	internal static IReadOnlyList<CodeSample> ParseCodeSamples(OpenApiOperation operation)
+	{
+		if (operation.Extensions?.TryGetValue("x-codeSamples", out var ext) != true
+			|| ext is not JsonNodeExtension jsonExt
+			|| jsonExt.Node is not JsonArray samplesArray)
+			return [];
+
+		var samples = new List<CodeSample>();
+		foreach (var item in samplesArray)
+		{
+			if (item is not JsonObject obj)
+				continue;
+
+			var lang = obj["lang"]?.GetValue<string>();
+			var source = obj["source"]?.GetValue<string>();
+
+			if (string.IsNullOrEmpty(lang) || string.IsNullOrEmpty(source))
+				continue;
+
+			samples.Add(new CodeSample(lang, source, CodeSample.GetHighlightClass(lang)));
+		}
+
+		// Console first when present, then preserve spec order
+		samples.Sort((a, b) =>
+		{
+			var aIsConsole = string.Equals(a.Language, "Console", StringComparison.OrdinalIgnoreCase);
+			var bIsConsole = string.Equals(b.Language, "Console", StringComparison.OrdinalIgnoreCase);
+			if (aIsConsole && !bIsConsole)
+				return -1;
+			if (!aIsConsole && bIsConsole)
+				return 1;
+			return 0;
+		});
+
+		return samples;
 	}
 }

--- a/src/Elastic.ApiExplorer/Operations/OperationViewModel.cs
+++ b/src/Elastic.ApiExplorer/Operations/OperationViewModel.cs
@@ -60,9 +60,9 @@ public class OperationViewModel(ApiRenderContext context) : ApiViewModel(context
 		if (CodeSamples.Count > 0)
 			tocItems.Add(new ApiTocItem("Code Examples", "code-examples"));
 
-		// Request body examples
+		// Request body examples (skip when single example duplicates code samples)
 		var reqContent = operation.RequestBody?.Content?.FirstOrDefault().Value;
-		if (reqContent?.Examples is { Count: > 0 })
+		if (reqContent?.Examples is { Count: > 0 } && !(reqContent.Examples.Count == 1 && CodeSamples.Count > 0))
 			tocItems.Add(new ApiTocItem("Request Examples", "request-examples"));
 
 		// Response examples

--- a/tests/Elastic.ApiExplorer.Tests/CodeSampleTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/CodeSampleTests.cs
@@ -1,0 +1,154 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text.Json.Nodes;
+using AwesomeAssertions;
+using Elastic.ApiExplorer.Operations;
+using Microsoft.OpenApi;
+
+namespace Elastic.ApiExplorer.Tests;
+
+public class CodeSampleTests
+{
+	private static OpenApiOperation CreateOperationWithCodeSamples(JsonArray samplesArray)
+	{
+		var operation = new OpenApiOperation();
+		operation.Extensions ??= new Dictionary<string, IOpenApiExtension>();
+		operation.Extensions["x-codeSamples"] = new JsonNodeExtension(samplesArray);
+		return operation;
+	}
+
+	[Fact]
+	public void CodeSamples_ReturnsEmptyList_WhenExtensionIsMissing()
+	{
+		var operation = new OpenApiOperation();
+
+		var result = OperationViewModel.ParseCodeSamples(operation);
+
+		result.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void CodeSamples_ParsesValidSamples()
+	{
+		var samples = new JsonArray(
+			new JsonObject { ["lang"] = "Console", ["source"] = "GET /_search" },
+			new JsonObject { ["lang"] = "curl", ["source"] = "curl -X GET ..." }
+		);
+		var operation = CreateOperationWithCodeSamples(samples);
+
+		var result = OperationViewModel.ParseCodeSamples(operation);
+
+		result.Should().HaveCount(2);
+		result[0].Language.Should().Be("Console");
+		result[0].Source.Should().Be("GET /_search");
+		result[1].Language.Should().Be("curl");
+		result[1].Source.Should().Be("curl -X GET ...");
+	}
+
+	[Fact]
+	public void CodeSamples_OrdersConsoleFirst()
+	{
+		var samples = new JsonArray(
+			new JsonObject { ["lang"] = "Python", ["source"] = "resp = client.search()" },
+			new JsonObject { ["lang"] = "curl", ["source"] = "curl -X GET ..." },
+			new JsonObject { ["lang"] = "Console", ["source"] = "GET /_search" },
+			new JsonObject { ["lang"] = "Java", ["source"] = "client.search()" }
+		);
+		var operation = CreateOperationWithCodeSamples(samples);
+
+		var result = OperationViewModel.ParseCodeSamples(operation);
+
+		result[0].Language.Should().Be("Console");
+	}
+
+	[Fact]
+	public void CodeSamples_PreservesOrderForNonConsole()
+	{
+		var samples = new JsonArray(
+			new JsonObject { ["lang"] = "Python", ["source"] = "resp = client.search()" },
+			new JsonObject { ["lang"] = "curl", ["source"] = "curl -X GET ..." },
+			new JsonObject { ["lang"] = "Console", ["source"] = "GET /_search" },
+			new JsonObject { ["lang"] = "Ruby", ["source"] = "response = client.search" }
+		);
+		var operation = CreateOperationWithCodeSamples(samples);
+
+		var result = OperationViewModel.ParseCodeSamples(operation);
+
+		result[0].Language.Should().Be("Console");
+		result[1].Language.Should().Be("Python");
+		result[2].Language.Should().Be("curl");
+		result[3].Language.Should().Be("Ruby");
+	}
+
+	[Fact]
+	public void CodeSamples_SkipsEntriesWithMissingSource()
+	{
+		var samples = new JsonArray(
+			new JsonObject { ["lang"] = "Console", ["source"] = "GET /_search" },
+			new JsonObject { ["lang"] = "Python" },
+			new JsonObject { ["lang"] = "curl", ["source"] = "" }
+		);
+		var operation = CreateOperationWithCodeSamples(samples);
+
+		var result = OperationViewModel.ParseCodeSamples(operation);
+
+		result.Should().HaveCount(1);
+		result[0].Language.Should().Be("Console");
+	}
+
+	[Fact]
+	public void CodeSamples_SkipsEntriesWithMissingLang()
+	{
+		var samples = new JsonArray(
+			new JsonObject { ["source"] = "GET /_search" },
+			new JsonObject { ["lang"] = "Console", ["source"] = "GET /_search" }
+		);
+		var operation = CreateOperationWithCodeSamples(samples);
+
+		var result = OperationViewModel.ParseCodeSamples(operation);
+
+		result.Should().HaveCount(1);
+		result[0].Language.Should().Be("Console");
+	}
+
+	[Fact]
+	public void CodeSamples_HandlesEmptyArray()
+	{
+		var samples = new JsonArray();
+		var operation = CreateOperationWithCodeSamples(samples);
+
+		var result = OperationViewModel.ParseCodeSamples(operation);
+
+		result.Should().BeEmpty();
+	}
+
+	[Theory]
+	[InlineData("Console", "language-console")]
+	[InlineData("curl", "language-bash")]
+	[InlineData("Python", "language-python")]
+	[InlineData("JavaScript", "language-javascript")]
+	[InlineData("Ruby", "language-ruby")]
+	[InlineData("PHP", "language-php")]
+	[InlineData("Java", "language-java")]
+	[InlineData("Go", "language-go")]
+	[InlineData("TypeScript", "language-typescript")]
+	public void GetHighlightClass_MapsLanguagesCorrectly(string language, string expected)
+	{
+		CodeSample.GetHighlightClass(language).Should().Be(expected);
+	}
+
+	[Fact]
+	public void CodeSamples_SetsCorrectHighlightClass()
+	{
+		var samples = new JsonArray(
+			new JsonObject { ["lang"] = "curl", ["source"] = "curl -X GET ..." }
+		);
+		var operation = CreateOperationWithCodeSamples(samples);
+
+		var result = OperationViewModel.ParseCodeSamples(operation);
+
+		result[0].HighlightClass.Should().Be("language-bash");
+	}
+}


### PR DESCRIPTION
## Summary

- Parses `x-codeSamples` from OpenAPI operations and renders them as language-selectable tabs (Console, cURL, Python, JavaScript, Ruby, PHP, Java)
- Renders a standalone **Code Examples** section on every operation page that has `x-codeSamples`, regardless of HTTP method (GET, DELETE, PUT, POST, etc.)
- Reuses the existing `tabs.css` / `tabs.ts` infrastructure with `data-sync-group="api-language"` so the selected language persists across operations and page loads
- Leaves Request Examples and Response Examples sections unchanged

## Changes

| File | Change |
|------|--------|
| `OperationViewModel.cs` | `CodeSample` record, `ParseCodeSamples` static method, highlight-class mapping, TOC entry |
| `OperationView.cshtml` | Standalone Code Examples section with language tabs for all operations |
| `CodeSampleTests.cs` | 9 unit tests (parsing, ordering, edge cases, highlight mapping) |
| `api-explorer.md` | Documentation for multi-language examples |
