### PR TITLE
[API Explorer] Fix YamlStaticContext.cs

### DIFF
--- a/src/Elastic.Documentation.Configuration/Serialization/YamlStaticContext.cs
+++ b/src/Elastic.Documentation.Configuration/Serialization/YamlStaticContext.cs
@@ -43,6 +43,8 @@ namespace Elastic.Documentation.Configuration.Serialization;
 [YamlSerializable(typeof(SiteNavigationFile))]
 [YamlSerializable(typeof(PhantomRegistration))]
 [YamlSerializable(typeof(ProductLink))]
+// API configuration (used in DocumentationSetFile.Api Dictionary<string, ApiConfiguration>)
+[YamlSerializable(typeof(ApiConfiguration))]
 // Search configuration
 [YamlSerializable(typeof(SearchConfigDto))]
 [YamlSerializable(typeof(QueryRuleDto))]


### PR DESCRIPTION
This PR is a follow-up for https://github.com/elastic/docs-builder/pull/3121 and https://github.com/elastic/docs-builder/pull/3120

It addresses the following error that I encountered when I ran `docs-builder serve -p ./docs`:

```sh
info ::e.d.c.tionFileProvider:: ConfigurationSource.Local: located /Users/lcawley/Documents/GitHub/docs-builder/config
error::d.b.d.Log             :: Global unhandled exception: Exception during deserialization
(Line: 54, Col: 6, Idx: 1559) - (Line: 54, Col: 6, Idx: 1559): Exception during deserialization
System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter 'Unknown type: System.String')
   at Elastic.Documentation.Configuration.Serialization.StaticObjectFactory.Create(Type) + 0x1bdc
   at YamlDotNet.Serialization.NodeDeserializers.ObjectNodeDeserializer.Deserialize(IParser, Type, Func`3, Object&, ObjectDeserializer) + 0xd8
   at YamlDotNet.Serialization.ValueDeserializers.NodeValueDeserializer.DeserializeValue(IParser, Type, SerializerState, IValueDeserializer) + 0x170 (:0)

	The following errors and warnings were found in the documentation

Exception: Global unhandled exception: Exception during deserialization(Line: 54, Col: 6, Idx: 1559) - (Line: 54, Col: 6, Idx: 1559): Exception during deserializationSystem.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter 'Unknown type: System.String')   at Elastic.Documentation.Configuration.Serialization.StaticObjectFactory.Create(Type) + 0x1bdc   at YamlDotNet.Serialization.NodeDeserializers.ObjectNodeDeserializer.Deserialize(IParser, Type, Func`3, Object&, ObjectDeserializer) + 0xd8   at YamlDotNet.Serialization.ValueDeserializers.NodeValueDeserializer.DeserializeValue(IParser, Type, SerializerState, IValueDeserializer) + 0x170
```