### PR TITLE
[API Explorer] Sort tags by x-displayName

### DIFF
--- a/src/Elastic.ApiExplorer/OpenApiGenerator.cs
+++ b/src/Elastic.ApiExplorer/OpenApiGenerator.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System;
 using System.IO.Abstractions;
 using System.Text.RegularExpressions;
 using Elastic.ApiExplorer.Landing;
@@ -114,6 +115,10 @@ public class OpenApiGenerator(ILoggerFactory logFactory, BuildContext context, I
 				var tag = new ApiTag(tagName, displayName, "", apis);
 				tags.Add(tag);
 			}
+
+			// Sort tags alphabetically by display name, fallback to canonical name
+			tags = tags.OrderBy(t => t.DisplayName ?? t.Name, StringComparer.OrdinalIgnoreCase).ToList();
+
 			var classification = new ApiClassification(classGroup.Key, "", tags);
 			classifications.Add(classification);
 		}

--- a/tests/Elastic.ApiExplorer.Tests/TagMetadataTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/TagMetadataTests.cs
@@ -329,4 +329,274 @@ public class TagMetadataTests
 		// Access the ApiTag model through the Index property
 		return tagItem.Index.Model is ApiTag tag && tag.Name == expectedTagName;
 	}
+
+	[Fact]
+	public async Task Tags_WithMixedDisplayNames_SortedAlphabeticallyByDisplayName()
+	{
+		// Arrange - spec with mixed x-displayName and canonical names
+		var openApiJson = /*lang=json*/ """
+		{
+		  "openapi": "3.0.3",
+		  "info": {
+		    "title": "Test API",
+		    "version": "1.0.0"
+		  },
+		  "paths": {
+		    "/zebra": {
+		      "get": {
+		        "operationId": "zebra-op",
+		        "tags": ["zebra"],
+		        "responses": {"200": {"description": "Success"}}
+		      }
+		    },
+		    "/apple": {
+		      "get": {
+		        "operationId": "apple-op",
+		        "tags": ["apple"],
+		        "responses": {"200": {"description": "Success"}}
+		      }
+		    },
+		    "/charlie": {
+		      "get": {
+		        "operationId": "charlie-op",
+		        "tags": ["charlie"],
+		        "responses": {"200": {"description": "Success"}}
+		      }
+		    }
+		  },
+		  "tags": [
+		    {
+		      "name": "zebra",
+		      "x-displayName": "Animal Zoo"
+		    },
+		    {
+		      "name": "apple",
+		      "x-displayName": "Fruit Store"  
+		    },
+		    {
+		      "name": "charlie"
+		    }
+		  ]
+		}
+		""";
+
+		var (generator, openApiDocument) = await CreateGeneratorWithSpec(openApiJson);
+
+		// Act
+		var navigation = generator.CreateNavigation("test", openApiDocument);
+
+		// Assert - should be sorted alphabetically by display name: "Animal Zoo", "charlie", "Fruit Store"
+		navigation.NavigationItems.Should().HaveCount(3);
+
+		var tagItems = navigation.NavigationItems.OfType<TagNavigationItem>().ToList();
+		tagItems.Should().HaveCount(3);
+
+		// Verify sorted order
+		tagItems[0].NavigationTitle.Should().Be("Animal Zoo", "First tag should be 'Animal Zoo' (zebra with x-displayName)");
+		tagItems[1].NavigationTitle.Should().Be("charlie", "Second tag should be 'charlie' (canonical name, no x-displayName)");
+		tagItems[2].NavigationTitle.Should().Be("Fruit Store", "Third tag should be 'Fruit Store' (apple with x-displayName)");
+	}
+
+	[Fact]
+	public async Task Tags_CaseInsensitiveSorting_WorksCorrectly()
+	{
+		// Arrange - spec with case variations
+		var openApiJson = /*lang=json*/ """
+		{
+		  "openapi": "3.0.3",
+		  "info": {
+		    "title": "Test API",
+		    "version": "1.0.0"
+		  },
+		  "paths": {
+		    "/bravo": {
+		      "get": {
+		        "operationId": "bravo-op",
+		        "tags": ["bravo"],
+		        "responses": {"200": {"description": "Success"}}
+		      }
+		    },
+		    "/alpha": {
+		      "get": {
+		        "operationId": "alpha-op",
+		        "tags": ["alpha"],
+		        "responses": {"200": {"description": "Success"}}
+		      }
+		    }
+		  },
+		  "tags": [
+		    {
+		      "name": "bravo",
+		      "x-displayName": "beta Service"
+		    },
+		    {
+		      "name": "alpha", 
+		      "x-displayName": "Alpha Service"
+		    }
+		  ]
+		}
+		""";
+
+		var (generator, openApiDocument) = await CreateGeneratorWithSpec(openApiJson);
+
+		// Act
+		var navigation = generator.CreateNavigation("test", openApiDocument);
+
+		// Assert - should be sorted case-insensitively: "Alpha Service", "beta Service"
+		var tagItems = navigation.NavigationItems.OfType<TagNavigationItem>().ToList();
+		tagItems.Should().HaveCount(2);
+
+		tagItems[0].NavigationTitle.Should().Be("Alpha Service", "Should sort case-insensitively");
+		tagItems[1].NavigationTitle.Should().Be("beta Service", "Should sort case-insensitively");
+	}
+
+	[Fact]
+	public async Task Tags_OnlyCanonicalNames_SortedAlphabetically()
+	{
+		// Arrange - spec with no x-displayName values
+		var openApiJson = /*lang=json*/ """
+		{
+		  "openapi": "3.0.3",
+		  "info": {
+		    "title": "Test API",
+		    "version": "1.0.0"
+		  },
+		  "paths": {
+		    "/zebra": {
+		      "get": {
+		        "operationId": "zebra-op",
+		        "tags": ["zebra"],
+		        "responses": {"200": {"description": "Success"}}
+		      }
+		    },
+		    "/alpha": {
+		      "get": {
+		        "operationId": "alpha-op",
+		        "tags": ["alpha"],
+		        "responses": {"200": {"description": "Success"}}
+		      }
+		    },
+		    "/mike": {
+		      "get": {
+		        "operationId": "mike-op",
+		        "tags": ["mike"],
+		        "responses": {"200": {"description": "Success"}}
+		      }
+		    }
+		  },
+		  "tags": [
+		    {
+		      "name": "zebra",
+		      "description": "Zebra operations"
+		    },
+		    {
+		      "name": "alpha",
+		      "description": "Alpha operations"
+		    },
+		    {
+		      "name": "mike",
+		      "description": "Mike operations" 
+		    }
+		  ]
+		}
+		""";
+
+		var (generator, openApiDocument) = await CreateGeneratorWithSpec(openApiJson);
+
+		// Act
+		var navigation = generator.CreateNavigation("test", openApiDocument);
+
+		// Assert - should be sorted alphabetically by canonical name: "alpha", "mike", "zebra"
+		var tagItems = navigation.NavigationItems.OfType<TagNavigationItem>().ToList();
+		tagItems.Should().HaveCount(3);
+
+		tagItems[0].NavigationTitle.Should().Be("alpha", "Should sort by canonical name");
+		tagItems[1].NavigationTitle.Should().Be("mike", "Should sort by canonical name");
+		tagItems[2].NavigationTitle.Should().Be("zebra", "Should sort by canonical name");
+	}
+
+	[Fact]
+	public async Task Tags_WithinClassification_SortedCorrectly()
+	{
+		// Arrange - Elasticsearch spec that creates MULTIPLE classifications so we get classification groups
+		var openApiJson = /*lang=json,strict*/ """
+		{
+		  "openapi": "3.0.3",
+		  "info": {
+		    "title": "Elasticsearch Request & Response Specification",
+		    "version": "1.0.0"
+		  },
+		  "paths": {
+		    "/search": {
+		      "get": {
+		        "operationId": "search-op",
+		        "tags": ["search"],
+		        "responses": {"200": {"description": "Success"}}
+		      }
+		    },
+		    "/indices": {
+		      "get": {
+		        "operationId": "indices-op",
+		        "tags": ["indices"],
+		        "responses": {"200": {"description": "Success"}}
+		      }
+		    },
+		    "/watcher": {
+		      "get": {
+		        "operationId": "watcher-op",
+		        "tags": ["watcher"],
+		        "responses": {"200": {"description": "Success"}}
+		      }
+		    },
+		    "/tasks": {
+		      "get": {
+		        "operationId": "tasks-op",
+		        "tags": ["tasks"],
+		        "responses": {"200": {"description": "Success"}}
+		      }
+		    }
+		  },
+		  "tags": [
+		    {
+		      "name": "search",
+		      "x-displayName": "Search API"
+		    },
+		    {
+		      "name": "indices",
+		      "x-displayName": "Indices Management"
+		    },
+		    {
+		      "name": "watcher",
+		      "x-displayName": "Watcher API"
+		    },
+		    {
+		      "name": "tasks",
+		      "x-displayName": "Task management"
+		    }
+		  ]
+		}
+		""";
+
+		var (generator, openApiDocument) = await CreateGeneratorWithSpec(openApiJson);
+
+		// Act
+		var navigation = generator.CreateNavigation("elasticsearch", openApiDocument);
+
+		// Assert - these should create multiple classifications:
+		// "search" -> "common", "indices" -> "management", "watcher"/"tasks" -> "info" 
+		// We should get classification groups since there are multiple classifications
+		var classificationItems = navigation.NavigationItems.OfType<ClassificationNavigationItem>().ToList();
+		classificationItems.Should().HaveCountGreaterThan(1, "Should have multiple classification groups");
+
+		// Find the "info" classification which should contain watcher and tasks
+		var infoClassification = classificationItems.FirstOrDefault(c => c.NavigationTitle == "info");
+		infoClassification.Should().NotBeNull("Should have 'info' classification for watcher and tasks");
+
+		var tagItems = infoClassification.NavigationItems.OfType<TagNavigationItem>().ToList();
+		tagItems.Should().HaveCount(2, "Info classification should have watcher and tasks");
+
+		// Expected sort order within info classification: "Task management", "Watcher API" 
+		tagItems[0].NavigationTitle.Should().Be("Task management", "Should sort by displayName");
+		tagItems[1].NavigationTitle.Should().Be("Watcher API", "Should sort by displayName");
+	}
 }


### PR DESCRIPTION
This builds on https://github.com/elastic/docs-builder/pull/3140

## Summary

Adds a tag sorting feature for the API Explorer, where the left-hand navigation is sorted by the tag x-displayNames when they exist.

NOTE: This PR does not change the sorting of the bespoke categories in the Elasticsearch API.

## Screenshots

**Before**

<img width="853" height="822" alt="image" src="https://github.com/user-attachments/assets/a9040647-30fc-4572-a298-80b23ae8b7ab" />

In this case "Alerting" appeared after "Cases".

**After**

<img width="926" height="705" alt="image" src="https://github.com/user-attachments/assets/cbf82399-6827-40ef-a3b1-dc4473479a87" />


## ✅ Implementation Complete

### Changes Made

**1. Core Sorting Logic** - [`src/Elastic.ApiExplorer/OpenApiGenerator.cs`](src/Elastic.ApiExplorer/OpenApiGenerator.cs)

- Added alphabetical sorting of tags within each classification
- Uses case-insensitive comparison with `StringComparer.OrdinalIgnoreCase` 
- Primary sort key: `DisplayName` (from `x-displayName`)
- Fallback sort key: canonical `Name` when no display name exists
- Added `using System;` import for `StringComparer` access

**2. Comprehensive Test Coverage** - 
[`tests/Elastic.ApiExplorer.Tests/TagMetadataTests.cs`](tests/Elastic.ApiExplorer.Tests/TagMetadataTests.cs)

Added 4 new test cases covering:
- **Mixed scenarios**: Tags with both `x-displayName` and canonical names
- **Case-insensitive sorting**: Verifies proper alphabetical ordering regardless of case
- **Canonical-only**: Tags without `x-displayName` sort by canonical name
- **Within classifications**: Sorting works correctly in multi-classification Elasticsearch specs

### Key Features

✅ **Alphabetical sorting** by user-friendly display names (e.g., "Task management" before "Watcher API")  
✅ **Fallback handling** to canonical names when no `x-displayName` exists  
✅ **Case-insensitive** ordering for consistent results  
✅ **Preserved existing functionality** - all Phase 1 features (display names, stable IDs) work unchanged  
✅ **Works in all scenarios** - single tags, classification groups, mixed API specs  

### Test Results

- ✅ All new tag sorting tests pass
- ✅ All existing TagMetadata tests pass (no regressions) 
- ✅ Complete ApiExplorer test suite passes

The implementation provides users with predictable, alphabetical navigation ordering while maintaining all existing API Explorer functionality. Tags now appear in a consistent, user-friendly order based on their display names across all API specifications.

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: composer-2, claude-4-sonnet-thinking
