### PR TITLE
Settings: render {applies_to} inline role in descriptions

### DIFF
--- a/docs/syntax/automated_settings.md
+++ b/docs/syntax/automated_settings.md
@@ -73,6 +73,7 @@ It demonstrates:
 - `note`, `tip`, `warning`, `important`, and `deprecation_details`.
 - Nested `settings`.
 - `applies_to` inheritance and override behavior.
+- Inline `{applies_to}` badges inside a setting `description` (for example, to label per-version defaults in a bulleted list).
 - Top-level `page_description`.
 
 ### Result

--- a/docs/syntax/settings-with-applies-example.yml
+++ b/docs/syntax/settings-with-applies-example.yml
@@ -54,6 +54,15 @@ groups:
           xpack.example.mode: strict
           ```
 
+      - setting: xpack.example.defaultModel
+        id: xpack-example-default-model
+        description: |
+          Default model used by the feature. The default varies by version:
+
+          * {applies_to}`stack: ga 9.2` Defaults to `model-v2`.
+          * {applies_to}`stack: ga 9.1` Defaults to `model-v1`.
+        datatype: string
+
   - group: Advanced settings
     id: advanced-settings
     description: |

--- a/src/Elastic.Markdown/Myst/Directives/Settings/SettingsMarkdownNormalizer.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Settings/SettingsMarkdownNormalizer.cs
@@ -17,8 +17,6 @@ internal static class SettingsMarkdownNormalizer
 		var result = markdown.Replace("\r\n", "\n", StringComparison.Ordinal);
 		if (result.Contains("[source,", StringComparison.Ordinal))
 			result = NormalizeAsciiDocSourceBlocks(result);
-		if (result.Contains('{'))
-			result = NormalizeKibanaMarkupArtifacts(result);
 		if (result.Contains("](/", StringComparison.Ordinal)
 			|| result.Contains("](docs-content://", StringComparison.Ordinal)
 			|| result.Contains("(elasticsearch://", StringComparison.Ordinal)
@@ -26,45 +24,6 @@ internal static class SettingsMarkdownNormalizer
 			result = RewriteReferenceLinksForDocset(result, product);
 
 		return result;
-	}
-
-	private static string NormalizeKibanaMarkupArtifacts(string markdown)
-	{
-		var s = markdown.Replace("{applies_to}", "Applies to", StringComparison.Ordinal);
-		return NormalizeAppliesToBacktickArtifacts(s);
-	}
-
-	/// <summary>Kibana-exported blurbs sometimes emit `` `key: value` `` pairs that break markdown code spans.</summary>
-	private static string NormalizeAppliesToBacktickArtifacts(string markdown)
-	{
-		const string prefix = "Applies to`";
-		var idx = 0;
-		var output = new StringBuilder(markdown.Length);
-		while (idx < markdown.Length)
-		{
-			var found = markdown.IndexOf(prefix, idx, StringComparison.OrdinalIgnoreCase);
-			if (found < 0)
-			{
-				_ = output.Append(markdown.AsSpan(idx));
-				break;
-			}
-
-			_ = output.Append(markdown.AsSpan(idx, found - idx));
-			var valueStart = found + prefix.Length;
-			var close = markdown.IndexOf('`', valueStart);
-			if (close < 0)
-			{
-				_ = output.Append(markdown.AsSpan(found));
-				break;
-			}
-
-			_ = output.Append("Applies to (");
-			_ = output.Append(markdown.AsSpan(valueStart, close - valueStart));
-			_ = output.Append(')');
-			idx = close + 1;
-		}
-
-		return output.ToString();
 	}
 
 	/// <summary>

--- a/tests/Elastic.Markdown.Tests/SettingsInclusion/IncludeTests.cs
+++ b/tests/Elastic.Markdown.Tests/SettingsInclusion/IncludeTests.cs
@@ -251,3 +251,35 @@ groups:
 		Html.Should().NotContain("Unavailable");
 	}
 }
+
+public class AppliesToInlineRoleInDescriptionRendersAsBadge(ITestOutputHelper output) : DirectiveTest<SettingsBlock>(output,
+"""
+:::{settings} _settings/applies-to-in-description.yml
+::::
+"""
+)
+{
+	protected override void AddToFileSystem(MockFileSystem fileSystem)
+	{
+		// language=yaml
+		fileSystem.AddFile("docs/_settings/applies-to-in-description.yml", """
+groups:
+  - group: Example
+    settings:
+      - setting: xpack.sample.versioned
+        description: |
+          Behavior depends on version:
+
+          * {applies_to}`stack: ga 9.2` Defaults to `model-a`.
+          * {applies_to}`stack: ga 9.1` Defaults to `model-b`.
+""");
+	}
+
+	[Fact]
+	public void RendersAppliesToRoleAsBadgeNotLiteralText()
+	{
+		Html.Should().Contain("applies-to-popover");
+		Html.Should().NotContain("Applies to (stack: ga 9.2)");
+		Html.Should().NotContain("Applies to (stack: ga 9.1)");
+	}
+}


### PR DESCRIPTION
## Summary

- `SettingsMarkdownNormalizer` was stripping the `{applies_to}` MyST inline role from setting descriptions, turning `{applies_to}\`stack: ga 9.2\`` into the literal text `Applies to (stack: ga 9.2)`. Per-version applicability badges inside bulleted lists (e.g. the Kibana alerting connector defaults in elastic/kibana#259835) rendered as plain text instead of badges.
- Dropped the rewrite so setting descriptions pass through to the MyST parser unchanged, letting the existing `{applies_to}` role render normally.
- Added a regression test (`AppliesToInlineRoleInDescriptionRendersAsBadge`) and extended `docs/syntax/settings-with-applies-example.yml` + `docs/syntax/automated_settings.md` so the live example page demonstrates per-version default labeling.

The other Kibana-artifact cleanups in the normalizer (AsciiDoc `[source,]` blocks, `docs-content://` / `elasticsearch://` / `ecs://` scheme rewrites, repo-root `/reference/` links) are preserved.

## Test plan

- [x] `dotnet test tests/Elastic.Markdown.Tests` — 1609/1609 passing, including the new test
- [x] Verify the docs preview on this PR renders `{applies_to}` badges in the `xpack.example.defaultModel` bullet list on `/syntax/automated_settings`
- [ ] Re-run the Kibana PR #259835 preview to confirm the alerting-settings defaults render as badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)