### PR TITLE
[API explorer] Add support for x-tagGroups

### DIFF
--- a/docs/configure/content-set/api-explorer.md
+++ b/docs/configure/content-set/api-explorer.md
@@ -119,7 +119,7 @@ The API Explorer supports the following OpenAPI specification extensions to enha
 
 ### `x-displayName` for tags
 
-Use the `x-displayName` extension on tag objects to provide user-friendly display names in navigation and landing pages while maintaining stable URLs based on the canonical tag name.
+Use the `x-displayName` extension (from [Redocly](https://redocly.com/docs-legacy/api-reference-docs/specification-extensions/x-display-name)) on tag objects to provide user-friendly display names in navigation and landing pages while maintaining stable URLs based on the canonical tag name.
 
 ```json
 {
@@ -139,7 +139,35 @@ Use the `x-displayName` extension on tag objects to provide user-friendly displa
 ```
 
 **Behavior:**
+
 - When `x-displayName` is present, it's used for navigation titles and section headings in the API Explorer
 - When `x-displayName` is absent, the canonical tag `name` is used as a fallback
 - Navigation URLs and internal references always use the canonical tag `name` for stability
-- This extension follows the [Redocly specification extension pattern](https://redocly.com/docs-legacy/api-reference-docs/specification-extensions/x-display-name)
+
+### `x-tagGroups` for sidebar grouping
+
+Use the document-level `x-tagGroups` extension (from [Redocly](https://redocly.com/docs-legacy/api-reference-docs/specification-extensions/x-tag-groups)) to define how tags are grouped in the API Explorer sidebar. Each group has a display `name` and a list of tag `name` values that belong to it. Group order in the array is the order of top-level sections in the navigation.
+
+```json
+{
+  "openapi": "3.0.3",
+  "info": { "title": "Example", "version": "1.0.0" },
+  "paths": {},
+  "x-tagGroups": [
+    {
+      "name": "Search & Document APIs",
+      "tags": ["search", "document", "eql", "esql", "sql"]
+    },
+    {
+      "name": "Cluster Management",
+      "tags": ["indices", "cluster", "snapshot"]
+    }
+  ]
+}
+```
+
+**Behavior:**
+
+- When `x-tagGroups` is present and valid, the API Explorer uses it as an additional level of grouping in the sidebar.
+- When `x-tagGroups` is absent, tags are listed directly under the API root in a single flat layer.
+- Any operation tag that is not listed under any group is still included: it appears under a fallback section named `unknown`, and the build logs a warning so you can fix the spec.

--- a/src/Elastic.ApiExplorer/OpenApiGenerator.cs
+++ b/src/Elastic.ApiExplorer/OpenApiGenerator.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.IO.Abstractions;
+using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
 using Elastic.ApiExplorer.Landing;
 using Elastic.ApiExplorer.Operations;
@@ -44,6 +45,9 @@ public record ApiEndpoint(List<ApiOperation> Operations, string? Name) : IApiGro
 
 public class OpenApiGenerator(ILoggerFactory logFactory, BuildContext context, IMarkdownStringRenderer markdownStringRenderer)
 {
+	private const string TagOnlyClassificationKey = "__api_explorer_tag_only__";
+	private const string UnknownTagGroupName = "unknown";
+
 	private readonly ILogger _logger = logFactory.CreateLogger<OpenApiGenerator>();
 	private readonly IFileSystem _writeFileSystem = context.WriteFileSystem;
 	private readonly StaticFileContentHashProvider _contentHashProvider = new(new EmbeddedOrPhysicalFileProvider(context));
@@ -56,6 +60,8 @@ public class OpenApiGenerator(ILoggerFactory logFactory, BuildContext context, I
 
 		// Parse x-displayName from OpenAPI tags for user-friendly display names
 		var tagDisplayNames = ParseTagDisplayNames(openApiDocument);
+		var xTagGroups = TryParseXTagGroups(openApiDocument);
+		var orphanTagsLogged = new HashSet<string>(StringComparer.Ordinal);
 
 		var ops = openApiDocument.Paths
 			.SelectMany(p => (p.Value.Operations ?? []).Select(op => (Path: p, Operation: op)))
@@ -70,11 +76,7 @@ public class OpenApiGenerator(ILoggerFactory logFactory, BuildContext context, I
 					? anyApi.Node.GetValue<string>()
 					: null;
 				var tag = op.Value.Tags?.FirstOrDefault()?.Reference.Id;
-				var tagClassification = (extensions?.TryGetValue("x-tag-group", out var g) ?? false) && g is JsonNodeExtension anyTagGroup
-					? anyTagGroup.Node.GetValue<string>()
-					: openApiDocument.Info.Title == "Elasticsearch Request & Response Specification"
-						? ClassifyElasticsearchTag(tag ?? "unknown")
-						: "unknown";
+				var tagClassification = ResolveTagClassification(tag, xTagGroups, orphanTagsLogged);
 
 				var apiString = ns is null
 					? api ?? op.Value.Summary ?? Guid.NewGuid().ToString("N") : $"{ns}.{api}";
@@ -91,11 +93,20 @@ public class OpenApiGenerator(ILoggerFactory logFactory, BuildContext context, I
 
 		// intermediate grouping of models to create the navigation tree
 		// this is two-phased because we need to know if an endpoint has one or more operations
+		var presentClassifications = ops.Select(o => o.Classification).ToHashSet();
+		var orderedClassificationKeys = xTagGroups is null
+			? [TagOnlyClassificationKey]
+			: GetOrderedClassificationKeys(xTagGroups, presentClassifications);
+
 		var classifications = new List<ApiClassification>();
-		foreach (var classGroup in ops.GroupBy(o => o.Classification))
+		foreach (var classKey in orderedClassificationKeys)
 		{
+			var classOps = ops.Where(o => o.Classification == classKey).ToArray();
+			if (classOps.Length == 0)
+				continue;
+
 			var tags = new List<ApiTag>();
-			foreach (var tagGroup in classGroup.GroupBy(o => o.Tag))
+			foreach (var tagGroup in classOps.GroupBy(o => o.Tag))
 			{
 				var apis = new List<ApiEndpoint>();
 				foreach (var apiGroup in tagGroup.GroupBy(o => o.Api))
@@ -119,15 +130,14 @@ public class OpenApiGenerator(ILoggerFactory logFactory, BuildContext context, I
 			// Sort tags alphabetically by display name, fallback to canonical name
 			tags = tags.OrderBy(t => t.DisplayName ?? t.Name, StringComparer.OrdinalIgnoreCase).ToList();
 
-			var classification = new ApiClassification(classGroup.Key, "", tags);
-			classifications.Add(classification);
+			classifications.Add(new ApiClassification(classKey, "", tags));
 		}
 
 		var topLevelNavigationItems = new List<IApiGroupingNavigationItem<IApiGroupingModel, INavigationItem>>();
 		var hasClassifications = classifications.Count > 1;
 		foreach (var classification in classifications)
 		{
-			if (hasClassifications && classification.Name != "common")
+			if (hasClassifications)
 			{
 				var classificationNavigationItem = new ClassificationNavigationItem(classification, rootNavigation, rootNavigation);
 				var tagNavigationItems = new List<IApiGroupingNavigationItem<IApiGroupingModel, INavigationItem>>();
@@ -406,71 +416,94 @@ public class OpenApiGenerator(ILoggerFactory logFactory, BuildContext context, I
 		return parts.Length > 0 ? parts[^1] : schemaId;
 	}
 
-	private static string ClassifyElasticsearchTag(string tag)
+	private string ResolveTagClassification(string? tag, XTagGroupsDocument? xTagGroups, HashSet<string> orphanTagsLogged)
 	{
-#pragma warning disable IDE0066
-		switch (tag)
-#pragma warning restore IDE0066
+		if (xTagGroups is null)
+			return TagOnlyClassificationKey;
+
+		var tagName = tag ?? UnknownTagGroupName;
+		if (xTagGroups.TagToGroup.TryGetValue(tagName, out var group))
+			return group;
+
+		if (orphanTagsLogged.Add(tagName))
 		{
-			case "sql":
-			case "eql":
-			case "esql":
-			case "search":
-			case "document":
-				return "common";
-
-			case "autoscaling":
-			case "ccr":
-			case "indices":
-			case "data stream":
-			case "ilm":
-			case "slm":
-			case "cluster":
-			case "rollup":
-			case "searchable_snapshots":
-			case "shutdown":
-			case "snapshot":
-			case "script":
-			case "search_application":
-			case "connector":
-				return "management";
-
-			case "cat":
-			case "license":
-			case "info":
-			case "tasks":
-			case "xpack":
-			case "health_report":
-			case "features":
-			case "migration":
-			case "watcher":
-				return "info";
-
-
-			case "ml trained model":
-			case "ml anomaly":
-			case "ml data frame":
-			case "ml":
-			case "inference":
-			case "text_structure":
-			case "query_rules":
-			case "analytics":
-			case "graph":
-				return "ai/ml";
-
-			case "ingest":
-			case "enrich":
-			case "transform":
-			case "fleet":
-			case "logstash":
-			case "synonyms":
-				return "ingest";
-
-			case "security":
-				return "security";
+			_logger.LogWarning(
+				"OpenAPI tag '{TagName}' is not listed in any x-tagGroups entry; navigation will group it under '{UnknownGroup}'.",
+				tagName,
+				UnknownTagGroupName);
 		}
-		return "unknown";
+
+		return UnknownTagGroupName;
 	}
+
+	private static List<string> GetOrderedClassificationKeys(XTagGroupsDocument xTagGroups, HashSet<string> presentClassifications)
+	{
+		var ordered = new List<string>();
+		foreach (var g in xTagGroups.OrderedGroupNames)
+		{
+			if (presentClassifications.Contains(g))
+				ordered.Add(g);
+		}
+
+		if (presentClassifications.Contains(UnknownTagGroupName) && !ordered.Contains(UnknownTagGroupName))
+			ordered.Add(UnknownTagGroupName);
+
+		foreach (var c in presentClassifications)
+		{
+			if (!ordered.Contains(c))
+				ordered.Add(c);
+		}
+
+		return ordered;
+	}
+
+	private static XTagGroupsDocument? TryParseXTagGroups(OpenApiDocument openApiDocument)
+	{
+		if (openApiDocument.Extensions?.TryGetValue("x-tagGroups", out var extension) != true || extension is not JsonNodeExtension jsonExt)
+			return null;
+
+		if (jsonExt.Node is not JsonArray array || array.Count == 0)
+			return null;
+
+		var orderedGroupNames = new List<string>();
+		var tagToGroup = new Dictionary<string, string>(StringComparer.Ordinal);
+
+		foreach (var element in array)
+		{
+			if (element is not JsonObject groupObj)
+				continue;
+
+			if (!groupObj.TryGetPropertyValue("name", out var nameNode))
+				continue;
+
+			var groupName = nameNode?.GetValue<string>();
+			if (string.IsNullOrWhiteSpace(groupName))
+				continue;
+
+			if (!orderedGroupNames.Contains(groupName))
+				orderedGroupNames.Add(groupName);
+
+			if (!groupObj.TryGetPropertyValue("tags", out var tagsNode) || tagsNode is not JsonArray tagNames)
+				continue;
+
+			foreach (var tagElement in tagNames)
+			{
+				var tagName = tagElement?.GetValue<string>();
+				if (string.IsNullOrEmpty(tagName))
+					continue;
+
+				if (!tagToGroup.ContainsKey(tagName))
+					tagToGroup[tagName] = groupName;
+			}
+		}
+
+		if (orderedGroupNames.Count == 0 || tagToGroup.Count == 0)
+			return null;
+
+		return new XTagGroupsDocument(orderedGroupNames, tagToGroup);
+	}
+
+	private sealed record XTagGroupsDocument(IReadOnlyList<string> OrderedGroupNames, IReadOnlyDictionary<string, string> TagToGroup);
 
 	/// <summary>
 	/// Parses x-displayName extensions from OpenAPI tag objects to build a mapping of tag names to display names.

--- a/tests/Elastic.ApiExplorer.Tests/TagMetadataTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/TagMetadataTests.cs
@@ -519,7 +519,7 @@ public class TagMetadataTests
 	[Fact]
 	public async Task Tags_WithinClassification_SortedCorrectly()
 	{
-		// Arrange - Elasticsearch spec that creates MULTIPLE classifications so we get classification groups
+		// Arrange - x-tagGroups (Redocly-style) drives classification; sort tags by display name within a group
 		var openApiJson = /*lang=json,strict*/ """
 		{
 		  "openapi": "3.0.3",
@@ -574,6 +574,20 @@ public class TagMetadataTests
 		      "name": "tasks",
 		      "x-displayName": "Task management"
 		    }
+		  ],
+		  "x-tagGroups": [
+		    {
+		      "name": "Search & Document APIs",
+		      "tags": ["search"]
+		    },
+		    {
+		      "name": "Cluster Management",
+		      "tags": ["indices"]
+		    },
+		    {
+		      "name": "Information & Monitoring",
+		      "tags": ["watcher", "tasks"]
+		    }
 		  ]
 		}
 		""";
@@ -583,21 +597,171 @@ public class TagMetadataTests
 		// Act
 		var navigation = generator.CreateNavigation("elasticsearch", openApiDocument);
 
-		// Assert - these should create multiple classifications:
-		// "search" -> "common", "indices" -> "management", "watcher"/"tasks" -> "info" 
-		// We should get classification groups since there are multiple classifications
+		// Assert
 		var classificationItems = navigation.NavigationItems.OfType<ClassificationNavigationItem>().ToList();
-		classificationItems.Should().HaveCountGreaterThan(1, "Should have multiple classification groups");
+		classificationItems.Should().HaveCount(3, "Should have one nav group per x-tagGroups entry that has operations");
 
-		// Find the "info" classification which should contain watcher and tasks
-		var infoClassification = classificationItems.FirstOrDefault(c => c.NavigationTitle == "info");
-		infoClassification.Should().NotBeNull("Should have 'info' classification for watcher and tasks");
+		var infoClassification = classificationItems.First(c => c.NavigationTitle == "Information & Monitoring");
 
 		var tagItems = infoClassification.NavigationItems.OfType<TagNavigationItem>().ToList();
-		tagItems.Should().HaveCount(2, "Info classification should have watcher and tasks");
+		tagItems.Should().HaveCount(2);
 
-		// Expected sort order within info classification: "Task management", "Watcher API" 
 		tagItems[0].NavigationTitle.Should().Be("Task management", "Should sort by displayName");
 		tagItems[1].NavigationTitle.Should().Be("Watcher API", "Should sort by displayName");
+	}
+
+	[Fact]
+	public async Task WithoutXTagGroups_ElasticsearchTitle_UsesFlatTagNavigation()
+	{
+		var openApiJson = /*lang=json,strict*/ """
+		{
+		  "openapi": "3.0.3",
+		  "info": {
+		    "title": "Elasticsearch Request & Response Specification",
+		    "version": "1.0.0"
+		  },
+		  "paths": {
+		    "/search": {
+		      "get": {
+		        "operationId": "search-op",
+		        "tags": ["search"],
+		        "responses": {"200": {"description": "Success"}}
+		      }
+		    },
+		    "/indices": {
+		      "get": {
+		        "operationId": "indices-op",
+		        "tags": ["indices"],
+		        "responses": {"200": {"description": "Success"}}
+		      }
+		    }
+		  },
+		  "tags": [
+		    { "name": "search" },
+		    { "name": "indices" }
+		  ]
+		}
+		""";
+
+		var (generator, openApiDocument) = await CreateGeneratorWithSpec(openApiJson);
+		var navigation = generator.CreateNavigation("elasticsearch", openApiDocument);
+
+		navigation.NavigationItems.OfType<ClassificationNavigationItem>().Should().BeEmpty();
+		navigation.NavigationItems.OfType<TagNavigationItem>().Should().HaveCount(2);
+	}
+
+	[Fact]
+	public async Task XTagGroups_ClassificationOrder_FollowsSpecOrder()
+	{
+		var openApiJson = /*lang=json,strict*/ """
+		{
+		  "openapi": "3.0.3",
+		  "info": { "title": "Order Test", "version": "1.0.0" },
+		  "paths": {
+		    "/z": {
+		      "get": {
+		        "operationId": "z-op",
+		        "tags": ["ztag"],
+		        "responses": {"200": {"description": "Success"}}
+		      }
+		    },
+		    "/a": {
+		      "get": {
+		        "operationId": "a-op",
+		        "tags": ["atag"],
+		        "responses": {"200": {"description": "Success"}}
+		      }
+		    },
+		    "/b": {
+		      "get": {
+		        "operationId": "b-op",
+		        "tags": ["btag"],
+		        "responses": {"200": {"description": "Success"}}
+		      }
+		    }
+		  },
+		  "tags": [
+		    { "name": "ztag" },
+		    { "name": "atag" },
+		    { "name": "btag" }
+		  ],
+		  "x-tagGroups": [
+		    { "name": "Z Group", "tags": ["ztag"] },
+		    { "name": "A Group", "tags": ["atag"] },
+		    { "name": "B Group", "tags": ["btag"] }
+		  ]
+		}
+		""";
+
+		var (generator, openApiDocument) = await CreateGeneratorWithSpec(openApiJson);
+		var navigation = generator.CreateNavigation("test", openApiDocument);
+
+		var titles = navigation.NavigationItems
+			.OfType<ClassificationNavigationItem>()
+			.Select(c => c.NavigationTitle)
+			.ToList();
+
+		titles.Should().Equal("Z Group", "A Group", "B Group");
+	}
+
+	[Fact]
+	public async Task XTagGroups_OrphanTag_AssignsUnknownGroup()
+	{
+		// Two unlisted tags so the "unknown" classification has multiple tags; with a single tag,
+		// CreateTagNavigationItems attaches operations directly to the parent (no TagNavigationItem).
+		var openApiJson = /*lang=json,strict*/ """
+		{
+		  "openapi": "3.0.3",
+		  "info": { "title": "Orphan Test", "version": "1.0.0" },
+		  "paths": {
+		    "/ok": {
+		      "get": {
+		        "operationId": "ok-op",
+		        "tags": ["listed"],
+		        "responses": {"200": {"description": "Success"}}
+		      }
+		    },
+		    "/orphan": {
+		      "get": {
+		        "operationId": "orphan-op",
+		        "tags": ["not_in_any_group"],
+		        "responses": {"200": {"description": "Success"}}
+		      }
+		    },
+		    "/orphan2": {
+		      "get": {
+		        "operationId": "orphan2-op",
+		        "tags": ["other_orphan"],
+		        "responses": {"200": {"description": "Success"}}
+		      }
+		    }
+		  },
+		  "tags": [
+		    { "name": "listed" },
+		    { "name": "not_in_any_group" },
+		    { "name": "other_orphan" }
+		  ],
+		  "x-tagGroups": [
+		    { "name": "Main", "tags": ["listed"] }
+		  ]
+		}
+		""";
+
+		var (generator, openApiDocument) = await CreateGeneratorWithSpec(openApiJson);
+		var navigation = generator.CreateNavigation("test", openApiDocument);
+
+		var classifications = navigation.NavigationItems.OfType<ClassificationNavigationItem>().ToList();
+		classifications.Should().HaveCount(2);
+
+		classifications[0].NavigationTitle.Should().Be("Main");
+		classifications[1].NavigationTitle.Should().Be("unknown");
+
+		var unknownTags = classifications[1].NavigationItems.OfType<TagNavigationItem>().ToList();
+		unknownTags.Should().HaveCount(2);
+		unknownTags
+			.Select(t => t.Index.Model.Name)
+			.OrderBy(name => name, StringComparer.Ordinal)
+			.Should()
+			.Equal("not_in_any_group", "other_orphan");
 	}
 }

--- a/tests/Elastic.ApiExplorer.Tests/TagMetadataTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/TagMetadataTests.cs
@@ -290,9 +290,10 @@ public class TagMetadataTests
 		var settings = new OpenApiReaderSettings { LeaveStreamOpen = false };
 		var result = await OpenApiDocument.LoadAsync(stream, settings: settings);
 
-		if (result.Diagnostic.Errors.Any())
+		var parseErrors = result.Diagnostic?.Errors;
+		if (parseErrors is not null && parseErrors.Any())
 		{
-			throw new InvalidOperationException($"OpenAPI parsing failed: {string.Join(", ", result.Diagnostic.Errors.Select(e => e.Message))}");
+			throw new InvalidOperationException($"OpenAPI parsing failed: {string.Join(", ", parseErrors.Select(e => e.Message))}");
 		}
 
 		return (generator, result.Document!);


### PR DESCRIPTION
This PR builds on https://github.com/elastic/docs-builder/pull/3140 and https://github.com/elastic/elasticsearch-specification/pull/6208
It must be merged after the former, the latter is already merged.
If desired, I can rebase it onto the [api-explorer-improvements](https://github.com/elastic/docs-builder/tree/api-explorer-improvements) branch at that point.

## Summary

Implement document-level `x-tagGroups` extension to replace hard-coded Elasticsearch classification logic with spec-driven grouping metadata.

## Screenshots

This screenshot shows the `x-tagGroups` values picked up from the Elasticsearch OpenAPI document and used in both the lefthand navigation and the automatically generated landing page's sections:

<img width="1819" height="1108" alt="image" src="https://github.com/user-attachments/assets/bcc1c9e6-9514-4ef8-a87b-4b757cc64bd6" />

This screenshot shows the **before** (right) and **After** (left):

<img width="1478" height="1480" alt="image" src="https://github.com/user-attachments/assets/bd353e9f-ef6d-4b4d-b527-20d82b4e79ab" />

There are no changes to the Kibana API, since it doesn't contain x-tagGroups yet. 

## Implementation summary

1. **`OpenApiGenerator`** (`src/Elastic.ApiExplorer/OpenApiGenerator.cs`)  
   - Parses root **`x-tagGroups`** (objects with `name` + `tags` arrays).  
   - **No** `ClassifyElasticsearchTag`, **no** per-operation **`x-tag-group`**.  
   - **Without** `x-tagGroups`: all operations use a single internal bucket so navigation stays **tag-only under the API root** (same idea as a single implicit group).  
   - **With** `x-tagGroups`: grouping follows **spec order**; tags not in any group go to **`unknown`** and trigger a **`LogWarning`** (once per tag name).

2. **Tests** (`tests/Elastic.ApiExplorer.Tests/TagMetadataTests.cs`)  
   - Reworked **`Tags_WithinClassification_SortedCorrectly`** to use **`x-tagGroups`** (aligned with real ES-style group names like `Information & Monitoring`).  
   - Added **`WithoutXTagGroups_ElasticsearchTitle_UsesFlatTagNavigation`**, **`XTagGroups_ClassificationOrder_FollowsSpecOrder`**, **`XTagGroups_OrphanTag_AssignsUnknownGroup`**.

3. **Docs** (`docs/configure/content-set/api-explorer.md`)  
   - New **`x-tagGroups`** section: behavior, orphan/`unknown` policy, Redocly link

## Test procedures

1. Check out a branch in elasticsearch-specification repo that has x-tagGroups implemented, e.g. `experimental-new-docs-output` branch.
2. Run `make contrib` or `make generate` to create the Elasticsearch OpenAPI document.
3. Replace the `docs/elasticsearch-openapi.json` file in the `docs-builder` repo with the new file.
4. Get a new release of docs-builder locally in the `docs-builder` repo:
    ```
    ./build.sh clean
    ./build.sh publishbinaries
    ```
5. Serve up the new content:
    ```
    ./.artifacts/publish/docs-builder/release/docs-builder serve -p ./docs
    ```
6. Preview the new layout in a browser as instructed in the `serve` output. e.g. `/api/elasticsearch` to see the API docs

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
5. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: composer-2


