### PR TITLE
Update onboarding docs for elastic/docs-actions workflows

### DIFF
--- a/docs/configure/content-sources.md
+++ b/docs/configure/content-sources.md
@@ -48,30 +48,33 @@ To get started:
 
 #### CI configuration
 
-To ensure repositories that use the [tagged branching strategy](#tagged) can be onboarded correctly, our CI integration needs to have appropriate `push`
- branch triggers.
+To ensure repositories that use the [tagged branching strategy](#tagged) can be onboarded correctly, our CI integration needs appropriate `push` branch triggers and matching settings on the reusable workflows in [`elastic/docs-actions`](https://github.com/elastic/docs-actions).
+
+Also add **`docs-deploy.yml`** and **`docs-preview-cleanup.yml`** as described in [How to set up docs previews](../migration/guide/how-to-set-up-docs-previews.md); the snippet below only highlights the tagged-branching-specific parts of **docs-build** (and the same `with:` block must be passed through on your **docs-deploy** consumer job).
 
 ```yml
 name: docs-build
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened]
   push:
     branches:
       - main
       - '\d+.\d+' <1>
-  pull_request_target: ~
   merge_group: ~
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
-  docs-preview:
-    uses: elastic/docs-builder/.github/workflows/preview-build.yml@main
+  build:
+    uses: elastic/docs-actions/.github/workflows/docs-build.yml@v1
     with:
       path-pattern: docs/**
-    permissions:
-      deployments: write
-      id-token: write
-      contents: read
-      pull-requests: write
+      use-release-branches: true <2>
 ```
 
 1. Ensure version branches are built and publish their links ahead of time.
+2. Matches **docs-deploy** `with:` (`path-pattern`, `use-release-branches`) so release-line pushes still produce `links.json` when needed even if `docs/**` is unchanged for a long time.

--- a/docs/contribute/add-repo.md
+++ b/docs/contribute/add-repo.md
@@ -38,10 +38,7 @@ repositories:
 
 ::::{step} Add the workflow actions to the repository
 
-Add the following actions to the `.github/workflows` directory of your repo:
-
-- https://github.com/elastic/docs-builder/blob/main/.github%2Fworkflows%2Fpreview-build.yml
-- https://github.com/elastic/docs-builder/blob/main/.github/workflows/preview-cleanup.yml
+Add the documentation CI workflows to the `.github/workflows` directory. Reusable workflows are maintained in [`elastic/docs-actions`](https://github.com/elastic/docs-actions); consumer repos add **`docs-build.yml`**, **`docs-deploy.yml`**, and **`docs-preview-cleanup.yml`** that call those workflows at `@v1`. Follow [How to set up docs previews](../migration/guide/how-to-set-up-docs-previews.md) for full YAML and permissions.
 
 Then, successfully run a docs build on the `main` branch. This is a requirement. For example, you can merge a docs pull request to `main` after adding the workflow actions.
 

--- a/docs/migration/guide/how-to-set-up-docs-previews.md
+++ b/docs/migration/guide/how-to-set-up-docs-previews.md
@@ -2,19 +2,24 @@
 
 This guide will help you set up docs previews for your GitHub repository.
 
-## GitHub Workflows
+Reusable workflows live in [`elastic/docs-actions`](https://github.com/elastic/docs-actions). Pin them to **`@v1`** so the docs team can ship updates independently of [`elastic/docs-builder`](https://github.com/elastic/docs-builder). Reference repos: [elastic/elastic-otel-rum-js](https://github.com/elastic/elastic-otel-rum-js), [elastic/ecs-logging-nodejs](https://github.com/elastic/ecs-logging-nodejs).
 
-The docs preview system consists of two GitHub Workflows:
-- [`docs-build.yml`](#build): **Build** the docs on a PR
-- [`docs-cleanup.yml`](#cleanup): **Cleanup** the docs after a PR is merged or closed
+## GitHub workflows
+
+The integration uses **three** workflows:
+
+- [`docs-build.yml`](#build) — Required checks: validate and build docs in an unprivileged context (`pull_request`, `push`, `merge_group`).
+- [`docs-deploy.yml`](#deploy) — Runs after `docs-build` completes (`workflow_run`). Handles preview deployment, PR comments, and org checks; never checks out untrusted code before gating.
+- [`docs-preview-cleanup.yml`](#preview-cleanup) — Removes preview artifacts when a PR is closed (`pull_request_target`).
+
+This follows GitHub’s [recommended two-phase approach](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/) for fork PRs: the **build** workflow uses `pull_request` (not `pull_request_target`) for the main validation path.
 
 
 ### Build
 
-This workflow is triggered when a PR is opened. The underlying reusable workflow, builds the documentation and uploads it as an artifact.
-If the `path-pattern` input does not match any changes in the PR, the workflow will skip the build, but still set a green status check.
-This way you only build and deploy the docs when there are changes to the docs and you can still set it as a required status check.
+This workflow runs on pull requests, pushes to your default branch (and optionally release branches), and merge queue events. The reusable workflow builds the documentation and uploads artifacts for the deploy phase.
 
+If the `path-pattern` input does not match any changes in the PR, the workflow can skip the heavy build while still reporting a successful status check, so you can keep **docs-build** as a required check. The default path pattern is `docs/**` (see [optional inputs](#optional-workflow-inputs)).
 
 ::::{tab-set}
 
@@ -25,50 +30,81 @@ This way you only build and deploy the docs when there are changes to the docs a
 name: docs-build
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened]
   push:
-    branches: 
-        - main <1>
-        - '\d+.\d+' <2>
-  pull_request_target: ~
+    branches:
+      - main <1>
+  merge_group: ~
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
-  docs-preview:
-    uses: elastic/docs-builder/.github/workflows/preview-build.yml <3>
-    with:
-      path-pattern: docs/** <4>
-    permissions:
-      id-token: write
-      deployments: write
-      contents: read
-      pull-requests: read
+  build:
+    uses: elastic/docs-actions/.github/workflows/docs-build.yml@v1 <2>
 ```
 
-1. You need to adjust this to your default branch. E.g `main`, `master`, etc.
-2. Optional, a match for the branch you wish to publish to production if different from the first.
-3. Reusable workflow: [elastic/docs-builder/.github/workflows/preview-build.yml](https://github.com/elastic/docs-builder/blob/main/.github/workflows/preview-build.yml)
-4. This should be the path to your `docs` folder.
+1. Adjust to your default branch (`main`, `master`, etc.).
+2. Reusable workflow: [`elastic/docs-actions/.github/workflows/docs-build.yml`](https://github.com/elastic/docs-actions/blob/main/.github/workflows/docs-build.yml)
 
 :::
 
 ::::
 
 
-### Cleanup
+### Deploy
 
-This workflow is triggered when a PR is either merged or closed. The underlying reusable workflow, deletes the docs from the preview environment.
+This workflow runs when **docs-build** finishes. It downloads artifacts, deploys previews, manages GitHub deployments, and may post or update PR comments. It does **not** use `pull_request_target` on the PR head for the same event as the build; it is triggered via `workflow_run` after the build workflow completes.
+
+::::{tab-set}
+
+:::{tab-item} .github/workflows/docs-deploy.yml
+
+```yaml
+---
+name: docs-deploy
+
+on:
+  workflow_run:
+    workflows: [docs-build]
+    types: [completed]
+
+permissions:
+  contents: read
+  deployments: write
+  id-token: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  deploy:
+    uses: elastic/docs-actions/.github/workflows/docs-deploy.yml@v1 <1>
+```
+
+1. Reusable workflow: [`elastic/docs-actions/.github/workflows/docs-deploy.yml`](https://github.com/elastic/docs-actions/blob/main/.github/workflows/docs-deploy.yml)
+
+:::
+
+::::
+
+
+### Preview cleanup
+
+This workflow runs when a PR is **closed** (merged or not). It deletes preview content from the preview environment.
 
 :::{note}
-We are aware of the security implications of using `pull_request_target` as described in [this blog post](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/).
-The workflow never checks out the code and doesn't use any user modifiable inputs (e.g. PR title). 
+Using `pull_request_target` here is intentional. As in GitHub’s guidance, this workflow should **not** check out the PR head for arbitrary code execution with elevated secrets. The reusable cleanup workflow follows that model.
 :::
 
 ::::{tab-set}
 
-:::{tab-item} .github/workflows/docs-cleanup.yml
+:::{tab-item} .github/workflows/docs-preview-cleanup.yml
 
 ```yaml
 ---
-name: docs-cleanup
+name: docs-preview-cleanup
 
 on:
   pull_request_target:
@@ -76,32 +112,59 @@ on:
       - closed
 
 jobs:
-  docs-preview:
-    uses: elastic/docs-builder/.github/workflows/preview-cleanup.yml <1>
+  cleanup:
+    uses: elastic/docs-actions/.github/workflows/docs-preview-cleanup.yml@v1 <1>
     permissions:
       contents: none <2>
       id-token: write
       deployments: write
 ```
 
-1. Reusable workflow: [elastic/docs-builder/.github/workflows/preview-cleanup.yml](https://github.com/elastic/docs-builder/blob/main/.github/workflows/preview-cleanup.yml)
-2. No permissions to read content
+1. Reusable workflow: [`elastic/docs-actions/.github/workflows/docs-preview-cleanup.yml`](https://github.com/elastic/docs-actions/blob/main/.github/workflows/docs-preview-cleanup.yml)
+2. No permission to read repository contents from the workflow token as provided here; adjust only if your org policy requires a different matrix.
 
 :::
 
 ::::
 
-## Required Status Checks
 
-To ensure that the docs are always in a deployable state, we need to set up required status checks.
+### Fork pull requests
 
-In this case only the `docs-build` workflow is required, which will produce a status check named `docs-preview / build`.
+Contributors opening PRs from forks still get **build validation** from **docs-build**. Preview **deploy** for fork PRs may depend on membership checks in the deploy workflow. That logic is implemented in `docs-actions` (for example, [elastic/docs-actions#85](https://github.com/elastic/docs-actions/pull/85) — org membership is verified via the GitHub API; contributors do **not** need to change Elastic org visibility on their public profile for that check).
+
+
+### Optional workflow inputs
+
+Pass `with:` on the **`uses:`** line when you need non-default behavior (for example documentation outside `docs/`, [tagged branching](../../configure/content-sources.md), or Vale). Inputs are defined on each reusable workflow’s `workflow_call` interface — see the files under [`.github/workflows/`](https://github.com/elastic/docs-actions/tree/main/.github/workflows) in `docs-actions`.
+
+Common cases:
+
+- **`path-pattern`** — Glob for which paths count as doc changes (default `docs/**`). If you set it on **docs-build**, use the **same** values on **docs-deploy** so both phases agree.
+- **`use-release-branches`** — Set to `true` on **both** build and deploy when you use semver release branches (for example `8.11`) and need link-index / build behavior on pushes that do not touch `docs/**`. See [CI configuration in *Content sources*](../../configure/content-sources.md).
+
+Example fragment (only the job — combine with triggers and permissions from the tabs above):
+
+```yaml
+jobs:
+  build:
+    uses: elastic/docs-actions/.github/workflows/docs-build.yml@v1
+    with:
+      path-pattern: docs/**
+      use-release-branches: true
+```
+
+
+## Required status checks
+
+To keep docs in a deployable state, enable required status checks for the **docs-build** workflow. The check name is typically **`docs-build / build`** (workflow name + job id).
 
 ![docs-preview required status check](img/docs-preview-required-status-check.png)
 
 
 ## Deployments
 
-If the `docs-build` workflow is successful, the `docs-deploy` workflow will create a deployment visible in the GitHub UI on your PR.
+After **docs-build** succeeds, **docs-deploy** runs and can create or update a deployment in the GitHub UI for the PR.
 
 ![docs-preview deployment](img/docs-preview-deployment.png)
+
+If you previously required **`docs-preview / build`** or **`preview-build`**, update branch protection to require **`docs-build`** / **`docs-build / build`** instead.

--- a/docs/migration/guide/move-ref-docs.md
+++ b/docs/migration/guide/move-ref-docs.md
@@ -103,47 +103,71 @@ Example commit: [#398/commit](https://github.com/elastic/apm-agent-android/pull/
 
 ### Step 3: Add the new CI checks
 
-There are two CI checks to add:
+Add three workflow files from [`elastic/docs-actions`](https://github.com/elastic/docs-actions) (`@v1`). Full copy-paste examples and explanations are in [How to set up docs previews](./how-to-set-up-docs-previews.md).
 
-**`docs-build.yml`**
-Add a file named `docs-build.yml` at `.github/workflows/docs-build.yml`. The contents of this file are below:
+**`docs-build.yml`** — `.github/workflows/docs-build.yml`
 
 ```yml
 name: docs-build
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened]
   push:
     branches:
       - main
       - '\d+.\d+' <1>
-  pull_request_target: ~
   merge_group: ~
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
-  docs-preview:
-    uses: elastic/docs-builder/.github/workflows/preview-build.yml@main
+  build:
+    uses: elastic/docs-actions/.github/workflows/docs-build.yml@v1
     with:
-      path-pattern: docs/**
-    permissions:
-      deployments: write
-      id-token: write
-      contents: read
-      pull-requests: read
+      path-pattern: docs/** <2>
+      use-release-branches: true <3>
 ```
 
-1. Optional match for version branches if you do not wish to publish to production from `main`.
+1. Optional: semver-style branches when docs publish from a release line rather than only `main`.
+2. Update if your Markdown does not live under `docs/`.
+3. Pair with the same flags on **docs-deploy**; set `use-release-branches` only when you use release-line pushes as above.
 
-Learn more about this file: [`docs-build.yml`](./how-to-set-up-docs-previews.md#build).
+[`docs-build.yml`](./how-to-set-up-docs-previews.md#build)
 
-:::{important}
-If the documentation you are adding will not live in the `/docs/*` dir of the repository, you must update the `path-pattern` appropriately. Please reach out in #docs-team if you need help with this.
-:::
-
-**`docs-cleanup.yml`**
-Add a file named `docs-cleanup.yml` at `.github/workflows/docs-cleanup.yml`. The contents of this file are below:
+**`docs-deploy.yml`** — `.github/workflows/docs-deploy.yml`
 
 ```yml
-name: docs-cleanup
+name: docs-deploy
+
+on:
+  workflow_run:
+    workflows: [docs-build]
+    types: [completed]
+
+permissions:
+  contents: read
+  deployments: write
+  id-token: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  deploy:
+    uses: elastic/docs-actions/.github/workflows/docs-deploy.yml@v1
+    with:
+      path-pattern: docs/**
+      use-release-branches: true
+```
+
+[`docs-deploy.yml`](./how-to-set-up-docs-previews.md#deploy)
+
+**`docs-preview-cleanup.yml`** — `.github/workflows/docs-preview-cleanup.yml`
+
+```yml
+name: docs-preview-cleanup
 
 on:
   pull_request_target:
@@ -151,15 +175,23 @@ on:
       - closed
 
 jobs:
-  docs-preview:
-    uses: elastic/docs-builder/.github/workflows/preview-cleanup.yml@main
+  cleanup:
+    uses: elastic/docs-actions/.github/workflows/docs-preview-cleanup.yml@v1
     permissions:
       contents: none
       id-token: write
       deployments: write
 ```
 
-Learn more about this file: [`docs-cleanup.yml`](./how-to-set-up-docs-previews.md#cleanup)
+[`docs-preview-cleanup.yml`](./how-to-set-up-docs-previews.md#preview-cleanup)
+
+:::{important}
+If the documentation you are adding will not live in the `/docs/*` dir of the repository, you must update `path-pattern` on **both** `docs-build` and `docs-deploy` (and adjust `use-release-branches` only if your branching strategy requires it). Please reach out in #docs-team if you need help with this.
+:::
+
+:::{note}
+If you only use continuous deployment from `main` (no release-line branches), omit `\d+.\d+` from `push.branches`, remove `use-release-branches`, and drop the matching `with:` from **docs-deploy** — see the minimal examples in [How to set up docs previews](./how-to-set-up-docs-previews.md).
+:::
 
 Example PR: [#398](https://github.com/elastic/apm-agent-android/pull/398)
 


### PR DESCRIPTION
## Summary

Onboarding and migration guides still described the old reusable workflows under `elastic/docs-builder` (`preview-build` / `preview-cleanup`) and a two-file setup. Documentation CI has moved to [`elastic/docs-actions`](https://github.com/elastic/docs-actions) with a three-workflow consumer pattern (`docs-build`, `docs-deploy`, `docs-preview-cleanup`) pinned at `@v1`.

## Changes

- **How to set up docs previews**: Rewrote for `docs-actions`, two-phase security model (`pull_request` + `workflow_run`), required check `docs-build / build`, optional inputs, and fork PR note pointing to [elastic/docs-actions#85](https://github.com/elastic/docs-actions/pull/85) (API org membership; no public org visibility workaround).
- **Move reference docs**: Step 3 updated with three YAML files and release-branch notes.
- **Add a new repo**: Workflow step now points at `docs-actions` and the how-to guide.
- **Content sources (tagged branching)**: CI snippet updated to `docs-actions` and `use-release-branches`.

## Context

Aligns with examples such as [elastic/elastic-otel-rum-js#55](https://github.com/elastic/elastic-otel-rum-js/pull/55).

Made with [Cursor](https://cursor.com)