### PR TITLE
bump edot-cf-azure base version to 0.7.1

### DIFF
--- a/config/versions.yml
+++ b/config/versions.yml
@@ -102,7 +102,7 @@ versioning_systems:
     base: 1.0
     current: 1.5.0
   edot-cf-azure:
-    base: 0.1
+    base: 0.7.1
     current: 0.7.1
   edot-cf-gcp:
     base: 0.1


### PR DESCRIPTION
Bumps the `base` version for `edot-cf-azure` from `0.1` to `0.7.1`, making it the first publicly visible tech preview version.