### PR TITLE
fix(site): hide external link arrow when anchor wraps an image

### DIFF
--- a/docs/syntax/links.md
+++ b/docs/syntax/links.md
@@ -118,8 +118,12 @@ External links display an arrow indicator next to the link text.
 Wrap an image in a link to make the image itself clickable. Combine the image syntax with the link syntax:
 
 ```markdown
-[![Deploy to AWS](images/launch-stack.png)](https://console.aws.amazon.com/cloudformation/home)
+[![A bear](/syntax/images/bear.png "bear =300x")](https://example.com)
 ```
+
+Rendered:
+
+[![A bear](/syntax/images/bear.png "bear =300x")](https://example.com)
 
 When an external link wraps an image (for example, a screenshot or badge), the arrow indicator is omitted because the image already conveys the target.
 

--- a/docs/syntax/links.md
+++ b/docs/syntax/links.md
@@ -111,6 +111,8 @@ Link to websites and resources outside the Elastic docs:
 [Elastic Documentation](https://www.elastic.co/guide)
 ```
 
+External links display an arrow indicator next to the link text. The indicator is omitted when the link wraps an image (for example, a screenshot or badge), since the image already conveys the target.
+
 ### Autolinks
 
 Bare `https://` URLs in text are automatically converted to clickable links.

--- a/docs/syntax/links.md
+++ b/docs/syntax/links.md
@@ -111,7 +111,17 @@ Link to websites and resources outside the Elastic docs:
 [Elastic Documentation](https://www.elastic.co/guide)
 ```
 
-External links display an arrow indicator next to the link text. The indicator is omitted when the link wraps an image (for example, a screenshot or badge), since the image already conveys the target.
+External links display an arrow indicator next to the link text.
+
+### Linked images
+
+Wrap an image in a link to make the image itself clickable. Combine the image syntax with the link syntax:
+
+```markdown
+[![Deploy to AWS](images/launch-stack.png)](https://console.aws.amazon.com/cloudformation/home)
+```
+
+When an external link wraps an image (for example, a screenshot or badge), the arrow indicator is omitted because the image already conveys the target.
 
 ### Autolinks
 

--- a/src/Elastic.Documentation.Site/Assets/markdown/typography.css
+++ b/src/Elastic.Documentation.Site/Assets/markdown/typography.css
@@ -51,7 +51,7 @@
 	a {
 		@apply font-body text-blue-elastic hover:text-blue-elastic-100 underline;
 
-		&[target='_blank']::after {
+		&[target='_blank']:not(:has(img))::after {
 			@apply ml-0.5;
 			content: url("data:image/svg+xml; utf8, <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='grey' height='16'><path d='M6.22 8.72a.75.75 0 0 0 1.06 1.06l5.22-5.22v1.69a.75.75 0 0 0 1.5 0v-3.5a.75.75 0 0 0-.75-.75h-3.5a.75.75 0 0 0 0 1.5h1.69L6.22 8.72Z' /><path d='M3.5 6.75c0-.69.56-1.25 1.25-1.25H7A.75.75 0 0 0 7 4H4.75A2.75 2.75 0 0 0 2 6.75v4.5A2.75 2.75 0 0 0 4.75 14h4.5A2.75 2.75 0 0 0 12 11.25V9a.75.75 0 0 0-1.5 0v2.25c0 .69-.56 1.25-1.25 1.25h-4.5c-.69 0-1.25-.56-1.25-1.25v-4.5Z' /></svg>");
 		}


### PR DESCRIPTION
## Summary
- The external-link arrow rendered by `a[target='_blank']::after` in `markdown/typography.css` was appearing next to image-only links (e.g., a "Launch Stack" badge or a screenshot that links out). The indicator is redundant there — the image already conveys the target.
- Scope the pseudo-element to anchors that do not contain an `<img>` via `:not(:has(img))`.
- Add a short note to `docs/syntax/links.md` documenting the behavior.

## Test plan
- [ ] Build the docs site locally and verify an external link with text still shows the arrow.
- [x] Verify an external link wrapping an image (e.g. a markdown `[![alt](img.png)](https://external)`) no longer renders the arrow.
- [x] Confirm existing overrides in `button.css` and `api-docs.css` continue to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)