### PR TITLE
[API Explorer] Enable code block copy

### DIFF
--- a/src/Elastic.ApiExplorer/ApiCodeBlockModel.cs
+++ b/src/Elastic.ApiExplorer/ApiCodeBlockModel.cs
@@ -1,0 +1,8 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic.ApiExplorer;
+
+/// <summary>Model for the API Explorer code block partial (Myst-style highlight wrappers and copy support).</summary>
+public record ApiCodeBlockModel(string HighlightClass, string Source);

--- a/src/Elastic.ApiExplorer/Operations/OperationView.cshtml
+++ b/src/Elastic.ApiExplorer/Operations/OperationView.cshtml
@@ -1,7 +1,6 @@
 @using Elastic.ApiExplorer.Landing
 @using Elastic.ApiExplorer.Operations
 @using Elastic.ApiExplorer.Schema
-@using Elastic.ApiExplorer.Shared
 @using Microsoft.OpenApi
 @inherits RazorSliceHttpResult<Elastic.ApiExplorer.Operations.OperationViewModel>
 @implements IUsesLayout<Elastic.ApiExplorer._Layout, ApiLayoutViewModel>
@@ -512,7 +511,7 @@
 		</h3>
 		<div class="example-block">
 			<h4>@codeSamples[0].Language</h4>
-			<pre><code class="@codeSamples[0].HighlightClass">@codeSamples[0].Source</code></pre>
+			@(await RenderPartialAsync<_ApiCodeBlock, ApiCodeBlockModel>(new ApiCodeBlockModel(codeSamples[0].HighlightClass, codeSamples[0].Source)))
 		</div>
 	}
 	else if (codeSamples.Count > 1)
@@ -533,7 +532,7 @@
 				<input class="tabs-input" checked="@(i == 0 ? "checked" : "")" id="@tabId" name="code-samples" type="radio" tabindex="0">
 				<label class="tabs-label" data-sync-id="@sample.Language" data-sync-group="api-language" for="@tabId">@sample.Language</label>
 				<div class="tabs-content" tabindex="0">
-					<pre><code class="@sample.HighlightClass">@sample.Source</code></pre>
+					@(await RenderPartialAsync<_ApiCodeBlock, ApiCodeBlockModel>(new ApiCodeBlockModel(sample.HighlightClass, sample.Source)))
 				</div>
 			}
 		</div>
@@ -568,7 +567,7 @@
 				}
 				@if (example.Value?.Value is not null)
 				{
-					<pre><code class="language-json">@example.Value.Value.ToString()</code></pre>
+					@(await RenderPartialAsync<_ApiCodeBlock, ApiCodeBlockModel>(new ApiCodeBlockModel("language-json", example.Value.Value.ToString()!)))
 				}
 				@if (!string.IsNullOrEmpty(example.Value?.ExternalValue))
 				{
@@ -597,7 +596,7 @@
 				}
 				@if (example.Value?.Value is not null)
 				{
-					<pre><code class="language-json">@example.Value.Value.ToString()</code></pre>
+					@(await RenderPartialAsync<_ApiCodeBlock, ApiCodeBlockModel>(new ApiCodeBlockModel("language-json", example.Value.Value.ToString()!)))
 				}
 				@if (!string.IsNullOrEmpty(example.Value?.ExternalValue))
 				{

--- a/src/Elastic.ApiExplorer/Operations/OperationViewModel.cs
+++ b/src/Elastic.ApiExplorer/Operations/OperationViewModel.cs
@@ -25,6 +25,16 @@ public record CodeSample(string Language, string Source, string HighlightClass)
 
 	public static string GetHighlightClass(string language) =>
 		LanguageHighlightMap.GetValueOrDefault(language, $"language-{language.ToLowerInvariant()}");
+
+	/// <summary>Maps a hljs <c>language-*</c> class to the outer Myst-style wrapper, e.g. <c>language-json</c> to <c>highlight-json</c>.</summary>
+	public static string GetHighlightGroupClass(string? highlightClass)
+	{
+		if (string.IsNullOrEmpty(highlightClass) || !highlightClass.StartsWith("language-", StringComparison.Ordinal))
+			return "highlight-plaintext";
+
+		var id = highlightClass["language-".Length..];
+		return string.IsNullOrEmpty(id) ? "highlight-plaintext" : $"highlight-{id}";
+	}
 }
 
 public class OperationViewModel(ApiRenderContext context) : ApiViewModel(context)

--- a/src/Elastic.ApiExplorer/Schemas/SchemaView.cshtml
+++ b/src/Elastic.ApiExplorer/Schemas/SchemaView.cshtml
@@ -1,7 +1,6 @@
 @using Elastic.ApiExplorer.Landing
 @using Elastic.ApiExplorer.Schema
 @using Elastic.ApiExplorer.Schemas
-@using Elastic.ApiExplorer.Shared
 @using Microsoft.OpenApi
 @inherits RazorSliceHttpResult<Elastic.ApiExplorer.Schemas.SchemaViewModel>
 @implements IUsesLayout<Elastic.ApiExplorer._Layout, ApiLayoutViewModel>
@@ -210,6 +209,6 @@
 		<h3 class="section-header" id="example" data-section="example">
 			<span>Example</span>
 		</h3>
-		<pre><code class="language-json">@openApiSchema.Example</code></pre>
+		@(await RenderPartialAsync<_ApiCodeBlock, ApiCodeBlockModel>(new ApiCodeBlockModel("language-json", openApiSchema.Example!.ToString()!)))
 	}
 </section>

--- a/src/Elastic.ApiExplorer/Shared/_ApiCodeBlock.cshtml
+++ b/src/Elastic.ApiExplorer/Shared/_ApiCodeBlock.cshtml
@@ -1,0 +1,10 @@
+@using Elastic.ApiExplorer.Operations
+@inherits RazorSlice<ApiCodeBlockModel>
+@{
+	var highlightGroupClass = CodeSample.GetHighlightGroupClass(Model.HighlightClass);
+}
+<div class="@highlightGroupClass notranslate">
+	<div class="highlight">
+		<pre><code class="@Model.HighlightClass">@Model.Source</code></pre>
+	</div>
+</div>

--- a/tests/Elastic.ApiExplorer.Tests/CodeSampleTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/CodeSampleTests.cs
@@ -151,4 +151,24 @@ public class CodeSampleTests
 
 		result[0].HighlightClass.Should().Be("language-bash");
 	}
+
+	[Theory]
+	[InlineData("language-json", "highlight-json")]
+	[InlineData("language-bash", "highlight-bash")]
+	[InlineData("language-console", "highlight-console")]
+	[InlineData("language-python", "highlight-python")]
+	public void GetHighlightGroupClass_MapsLanguageClassToHighlightClass(string input, string expected) =>
+		CodeSample.GetHighlightGroupClass(input).Should().Be(expected);
+
+	[Fact]
+	public void GetHighlightGroupClass_HandlesNonLanguageClass() =>
+		CodeSample.GetHighlightGroupClass("some-other-class").Should().Be("highlight-plaintext");
+
+	[Fact]
+	public void GetHighlightGroupClass_HandlesEmptyInput() =>
+		CodeSample.GetHighlightGroupClass("").Should().Be("highlight-plaintext");
+
+	[Fact]
+	public void GetHighlightGroupClass_HandlesLanguagePrefixOnly() =>
+		CodeSample.GetHighlightGroupClass("language-").Should().Be("highlight-plaintext");
 }


### PR DESCRIPTION
## Summary

The code blocks in the API Explorer were missing the "Copy" option, like what exists for narrative docs per https://elastic.github.io/docs-builder/syntax/code/

This PR addresses that missing functionality.

## Screenshots

### Before

No copy button:

<img width="2558" height="733" alt="image" src="https://github.com/user-attachments/assets/3177cf16-ca34-4252-863b-22b8aa996a59" />

### After

`x-codeSamples`:

<img width="2051" height="800" alt="image" src="https://github.com/user-attachments/assets/6da44d6b-0c82-41f5-8f4a-484202dcb4c9" />

Request body examples:

<img width="2280" height="746" alt="image" src="https://github.com/user-attachments/assets/a1ec4220-42d7-4095-91f7-948af86f3e3a" />

Response body examples:

<img width="2354" height="729" alt="image" src="https://github.com/user-attachments/assets/90156e81-d28b-4a8b-8aa4-7207ab611a22" />


## Cause

API Explorer examples (`x-codeSamples`, request/response `examples`, schema JSON example) were plain `<pre><code>` blocks. The site’s copy control targets **`.highlight pre`** and relies on a **`div.highlight`** wrapper (see `copybutton.ts` / `copybutton.css`) and the same **Myst-style** structure as `Code.cshtml`, so those samples had **no copy button** and didn’t match regular docs code blocks.

## Implementation details

This PR aligns API Explorer code markup with that pattern:  
`div.highlight-{lang} notranslate` → `div.highlight` → `pre` → `code.language-*`, so **existing** `initCopyButton` and styling apply without new JS.

What changed:

- **`CodeSample.GetHighlightGroupClass`**: maps a hljs `language-*` class to the outer wrapper (e.g. `language-json` → `highlight-json`); `highlight-plaintext` for invalid/empty input.
- **`ApiCodeBlockModel`** + **`Shared/_ApiCodeBlock.cshtml`**: single partial for the wrapper + encoded body; shared by operation and schema pages.
- **`OperationView.cshtml`**: uses the partial for (1) single and (2) tabbed `x-codeSamples`, (3) request `examples`, (4) success response `examples`.
- **`SchemaView.cshtml`**: uses the partial for the inline **Example** block (with null-forgiving on `openApiSchema.Example` where required).
- **`CodeSampleTests`**: tests for `GetHighlightGroupClass` (mapping, non-`language-*`, empty, `language-` only).

**Project hygiene**

- `ApiCodeBlockModel` lives at **`src/Elastic.ApiExplorer/ApiCodeBlockModel.cs`** (root of project) in **`namespace Elastic.ApiExplorer`** to satisfy **IDE0130** and avoid **CA1716** on a C# `namespace` segment named `Shared`.
- **`_ViewImports.cshtml`**: keeps `@using Elastic.ApiExplorer.Shared` so **Razor Slices** partial types (`_PropertyList`, `_SchemaType`, etc.) still resolve; this is unrelated to the C# type’s namespace and was required after an earlier import-only change broke the build.

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: composer-2