### PR TITLE
fix(cross-links): use codex path shape in fallback error URL

### DIFF
--- a/src/Elastic.Documentation.Links/CrossLinks/CrossLinkFetcher.cs
+++ b/src/Elastic.Documentation.Links/CrossLinks/CrossLinkFetcher.cs
@@ -29,6 +29,12 @@ public record FetchedCrossLinks
 	public FrozenDictionary<string, string>? RegistryUrlsByRepository { get; init; }
 
 	/// <summary>
+	/// Optional map of repository name to the declared <see cref="DocSetRegistry"/> for that cross-link entry.
+	/// Used to pick the correct links.json path shape in error messages when the index could not be fetched.
+	/// </summary>
+	public FrozenDictionary<string, DocSetRegistry>? RegistryByRepository { get; init; }
+
+	/// <summary>
 	/// Set of repository names that belong to a codex (non-public) registry.
 	/// Used by the URI resolver to generate codex URLs instead of public preview URLs.
 	/// </summary>
@@ -40,6 +46,7 @@ public record FetchedCrossLinks
 		LinkReferences = new Dictionary<string, RepositoryLinks>().ToFrozenDictionary(),
 		LinkIndexEntries = new Dictionary<string, LinkRegistryEntry>().ToFrozenDictionary(),
 		RegistryUrlsByRepository = null,
+		RegistryByRepository = null,
 		CodexRepositories = null
 	};
 }

--- a/src/Elastic.Documentation.Links/CrossLinks/CrossLinkResolver.cs
+++ b/src/Elastic.Documentation.Links/CrossLinks/CrossLinkResolver.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Frozen;
 using System.Diagnostics.CodeAnalysis;
+using Elastic.Documentation.Configuration;
 
 namespace Elastic.Documentation.Links.CrossLinks;
 
@@ -107,7 +108,7 @@ public class CrossLinkResolver(FetchedCrossLinks crossLinks, IUriEnvironmentReso
 		var baseUrl = GetLinksJsonBaseUrl(registryUrl);
 		var linksJson = fetchedCrossLinks.LinkIndexEntries.TryGetValue(crossLinkUri.Scheme, out var indexEntry)
 			? $"{baseUrl}/{indexEntry.Path}"
-			: $"{baseUrl}/elastic/{crossLinkUri.Scheme}/main/links.json";
+			: BuildFallbackLinksJsonUrl(baseUrl, crossLinkUri.Scheme, fetchedCrossLinks);
 
 		errorEmitter($"'{originalLookupPath}' is not a valid link in the '{crossLinkUri.Scheme}' cross link index: {linksJson}");
 		resolvedUri = null;
@@ -256,5 +257,22 @@ public class CrossLinkResolver(FetchedCrossLinks crossLinks, IUriEnvironmentReso
 		if (registryUrl.Contains("/link-index.json", StringComparison.OrdinalIgnoreCase))
 			return registryUrl.Replace("/link-index.json", "", StringComparison.OrdinalIgnoreCase).TrimEnd('/');
 		return registryUrl.TrimEnd('/');
+	}
+
+	/// <summary>
+	/// Builds a best-effort links.json URL to show in error messages when the index could not be fetched
+	/// and no <see cref="LinkRegistryEntry"/> is available. Codex/internal indexes use
+	/// <c>{env}/elastic/{scheme}/links.json</c>; the public S3 index uses <c>elastic/{scheme}/main/links.json</c>.
+	/// </summary>
+	private static string BuildFallbackLinksJsonUrl(string baseUrl, string scheme, FetchedCrossLinks fetchedCrossLinks)
+	{
+		if (fetchedCrossLinks.RegistryByRepository is not null
+			&& fetchedCrossLinks.RegistryByRepository.TryGetValue(scheme, out var registry)
+			&& registry != DocSetRegistry.Public)
+		{
+			return $"{baseUrl}/{registry.ToStringFast(true)}/elastic/{scheme}/links.json";
+		}
+
+		return $"{baseUrl}/elastic/{scheme}/main/links.json";
 	}
 }

--- a/src/Elastic.Documentation.Links/CrossLinks/DocSetConfigurationCrossLinkFetcher.cs
+++ b/src/Elastic.Documentation.Links/CrossLinks/DocSetConfigurationCrossLinkFetcher.cs
@@ -27,6 +27,7 @@ public class DocSetConfigurationCrossLinkFetcher(
 		var linkReferences = new Dictionary<string, RepositoryLinks>();
 		var linkIndexEntries = new Dictionary<string, LinkRegistryEntry>();
 		var registryUrlsByRepository = new Dictionary<string, string>();
+		var registryByRepository = new Dictionary<string, DocSetRegistry>();
 		var codexRepositories = new HashSet<string>();
 		var declaredRepositories = new HashSet<string>();
 
@@ -36,6 +37,7 @@ public class DocSetConfigurationCrossLinkFetcher(
 		foreach (var entry in configuration.CrossLinkEntries)
 		{
 			_ = declaredRepositories.Add(entry.Repository);
+			registryByRepository[entry.Repository] = entry.Registry;
 			var isCodexEntry = useDualRegistry && entry.Registry != DocSetRegistry.Public;
 			var reader = isCodexEntry ? _codexReader! : publicReader;
 
@@ -85,6 +87,7 @@ public class DocSetConfigurationCrossLinkFetcher(
 			LinkReferences = linkReferences.ToFrozenDictionary(),
 			LinkIndexEntries = linkIndexEntries.ToFrozenDictionary(),
 			RegistryUrlsByRepository = registryUrlsByRepository.ToFrozenDictionary(),
+			RegistryByRepository = registryByRepository.ToFrozenDictionary(),
 			CodexRepositories = codexRepositories.Count > 0 ? codexRepositories.ToFrozenSet() : null,
 		};
 	}

--- a/tests/Elastic.Markdown.Tests/CrossLinks/UriEnvironmentResolverTests.cs
+++ b/tests/Elastic.Markdown.Tests/CrossLinks/UriEnvironmentResolverTests.cs
@@ -4,6 +4,9 @@
 
 using System.Collections.Frozen;
 using AwesomeAssertions;
+using Elastic.Documentation;
+using Elastic.Documentation.Configuration;
+using Elastic.Documentation.Links;
 using Elastic.Documentation.Links.CrossLinks;
 
 namespace Elastic.Markdown.Tests.CrossLinks;
@@ -221,5 +224,82 @@ public class CodexCrossRepoRedirectTests
 		resolvedUri.Should().NotBeNull();
 		resolvedUri.IsAbsoluteUri.Should().BeFalse();
 		resolvedUri.ToString().Should().Be("/r/kibana/get-started");
+	}
+}
+
+public class CrossLinkResolverFallbackUrlTests
+{
+	private static FetchedCrossLinks BuildFallbackOnlyCrossLinks(string repository, string registryUrl, DocSetRegistry registry)
+	{
+		var emptyRepositoryLinks = new RepositoryLinks
+		{
+			Links = [],
+			Origin = new GitCheckoutInformation
+			{
+				Branch = "main",
+				RepositoryName = repository,
+				Remote = "origin",
+				Ref = "refs/heads/main"
+			},
+			UrlPathPrefix = "",
+			CrossLinks = []
+		};
+		return new FetchedCrossLinks
+		{
+			DeclaredRepositories = [repository],
+			LinkReferences = new Dictionary<string, RepositoryLinks> { [repository] = emptyRepositoryLinks }.ToFrozenDictionary(),
+			LinkIndexEntries = new Dictionary<string, LinkRegistryEntry>().ToFrozenDictionary(),
+			RegistryUrlsByRepository = new Dictionary<string, string> { [repository] = registryUrl }.ToFrozenDictionary(),
+			RegistryByRepository = new Dictionary<string, DocSetRegistry> { [repository] = registry }.ToFrozenDictionary()
+		};
+	}
+
+	[Fact]
+	public void InternalRegistry_NoIndexEntry_UsesCodexInternalPath()
+	{
+		var crossLinks = BuildFallbackOnlyCrossLinks(
+			"platform-observability-team",
+			"https://github.com/elastic/codex-link-index",
+			DocSetRegistry.Internal
+		);
+
+		string? emittedError = null;
+		var resolver = new IsolatedBuildEnvironmentUriResolver();
+		var success = CrossLinkResolver.TryResolve(
+			s => emittedError = s,
+			crossLinks,
+			resolver,
+			new Uri("platform-observability-team://index.md", UriKind.Absolute),
+			out _
+		);
+
+		success.Should().BeFalse();
+		emittedError.Should().NotBeNull();
+		emittedError.Should().Contain("https://github.com/elastic/codex-link-index/blob/main/internal/elastic/platform-observability-team/links.json");
+		emittedError.Should().NotContain("/main/links.json");
+	}
+
+	[Fact]
+	public void PublicRegistry_NoIndexEntry_UsesPublicS3Path()
+	{
+		var crossLinks = BuildFallbackOnlyCrossLinks(
+			"docs-content",
+			"https://elastic-docs-link-index.s3.us-east-2.amazonaws.com",
+			DocSetRegistry.Public
+		);
+
+		string? emittedError = null;
+		var resolver = new IsolatedBuildEnvironmentUriResolver();
+		var success = CrossLinkResolver.TryResolve(
+			s => emittedError = s,
+			crossLinks,
+			resolver,
+			new Uri("docs-content://index.md", UriKind.Absolute),
+			out _
+		);
+
+		success.Should().BeFalse();
+		emittedError.Should().NotBeNull();
+		emittedError.Should().Contain("https://elastic-docs-link-index.s3.us-east-2.amazonaws.com/elastic/docs-content/main/links.json");
 	}
 }


### PR DESCRIPTION
## Summary
- When the codex link index can't be fetched (e.g. CI without credentials to reach the private `elastic/codex-link-index` repo), the cross-link resolver falls through to an error message containing a best-effort URL to the repo's `links.json`.
- That fallback was hardcoded to the public-S3 layout `elastic/{scheme}/main/links.json`, so errors against a codex/internal registry pointed at a non-existent path under `codex-link-index` (e.g. `https://github.com/elastic/codex-link-index/blob/main/elastic/platform-observability-team/main/links.json`), making the error message misleading.
- This PR threads the per-repo `DocSetRegistry` through `FetchedCrossLinks` and picks the codex layout (`{env}/elastic/{scheme}/links.json`, e.g. `internal/elastic/platform-observability-team/links.json`) when the entry is non-public, keeping the existing S3 layout for public entries.

## Context
Surfaced while debugging [elastic/platform-capacity-team#1328](https://github.com/elastic/platform-capacity-team/pull/1328), whose preview build fails because its runner can't clone the private `codex-link-index` repo. That credentials failure (exit 128) is the primary blocker there and isn't addressed here — the consuming workflow needs a token with access to `codex-link-index`. But whenever the fetch fails for any reason (rate-limit, rotated token, etc.), the error URL should at least point at a path that exists.

Locally the bug almost never surfaces because `CrossLinkFetcher.TryGetCachedLinkReference` short-circuits to a cached `links.json` and the git reader is never invoked.

## Changes
- Add optional `FrozenDictionary<string, DocSetRegistry>? RegistryByRepository` to `FetchedCrossLinks`.
- Populate it in `DocSetConfigurationCrossLinkFetcher` from each `CrossLinkEntry.Registry`.
- Switch `CrossLinkResolver.TryResolve` fallback onto registry type via a small `BuildFallbackLinksJsonUrl` helper.
- Add unit tests covering both the codex/internal and public fallback shapes.

## Test plan
- [x] `dotnet test tests/Elastic.Markdown.Tests/Elastic.Markdown.Tests.csproj --filter CrossLinks|Codex` — 35/35 pass, including the two new `CrossLinkResolverFallbackUrlTests`.
- [x] `dotnet test tests/Elastic.Documentation.Configuration.Tests` — 353/353 pass.
- [ ] Reviewer: confirm the codex path shape (`{env}/elastic/{scheme}/links.json`) still matches the current layout of `elastic/codex-link-index`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)