### PR TITLE
[Stack 9.3.4] Bump versions.yml stack.current

### DIFF
--- a/config/versions.yml
+++ b/config/versions.yml
@@ -3,7 +3,7 @@ versioning_systems:
   # Updates for Stack versions are manual
   stack: &stack
     base: 9.0
-    current: 9.3.3
+    current: 9.3.4
 
   # Using an unlikely high version
   # So that our logic that would display "planned" doesn't trigger


### PR DESCRIPTION
## Summary

Set `versioning_systems.stack.current` to **9.3.4**.

Do not merge until release day

## Refs

- https://github.com/elastic/dev/issues/3501

Made with [Cursor](https://cursor.com)