### PR TITLE
feat(assembler): on-demand assembler serve with live reload and improved frontend DX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           dotnet run --project ../docs-builder/src/tooling/docs-builder -- assembler config init --local 
           dotnet run --project ../docs-builder/src/tooling/docs-builder -- assembler clone -c local --skip-private-repositories
           dotnet run --project ../docs-builder/src/tooling/docs-builder -- assembler build -c local --skip-private-repositories
-          dotnet run --project ../docs-builder/src/tooling/docs-builder -- assembler serve &
+          dotnet run --project ../docs-builder/src/tooling/docs-builder -- assembler serve-static &
         
       - name: Wait for docs
         working-directory: src/Elastic.Documentation.Site

--- a/aspire/AppHost.cs
+++ b/aspire/AppHost.cs
@@ -122,7 +122,7 @@ internal static class AspireHost
 			.WithEnvironment("LLM_GATEWAY_FUNCTION_URL", llmUrl)
 			.WithEnvironment("LLM_GATEWAY_SERVICE_ACCOUNT_KEY_PATH", llmServiceAccountPath)
 			.WithHttpEndpoint(port: 4000, isProxied: false)
-			.WithArgs(["assembler", "serve", .. GlobalArguments])
+			.WithArgs(["assembler", "serve-static", .. GlobalArguments])
 			.WithHttpHealthCheck("/", 200)
 			.WaitForCompletion(buildAll)
 			.WithParentRelationship(cloneAll);

--- a/build/CommandLine.fs
+++ b/build/CommandLine.fs
@@ -43,6 +43,7 @@ type Build =
 
     | [<CliPrefix(CliPrefix.None);SubCommand>] Format of ParseResults<FormatArgs>
     | [<CliPrefix(CliPrefix.None);SubCommand>] Watch
+    | [<CliPrefix(CliPrefix.None);SubCommand>] Watch_Full
 
     | [<CliPrefix(CliPrefix.None);Hidden;SubCommand>] Lint of ParseResults<LintArgs>
     | [<CliPrefix(CliPrefix.None);Hidden;SubCommand>] PristineCheck
@@ -84,6 +85,7 @@ with
             | Format _ -> "runs dotnet format"
 
             | Watch -> "runs dotnet watch to continuous build code/templates and web assets on the fly"
+            | Watch_Full -> "runs assembler serve with dotnet watch — watches checkout dirs and live-reloads assembled docs"
 
             // steps
             | Lint _ -> "runs dotnet format --verify-no-changes"

--- a/build/Targets.fs
+++ b/build/Targets.fs
@@ -42,6 +42,8 @@ let private format (formatArgs: ParseResults<FormatArgs>) =
 
 let private watch _ = exec { run "dotnet" "watch" "--project" "src/tooling/docs-builder" "--configuration" "debug" "--" "serve" "--watch" }
 
+let private watchFull _ = exec { run "dotnet" "watch" "--project" "src/tooling/docs-builder" "--configuration" "debug" "--" "assembler" "serve" }
+
 let private lint (lintArgs: ParseResults<LintArgs>) =
     let includeFiles = lintArgs.TryGetResult LintArgs.Include |> Option.defaultValue []
     let includeArgs = 
@@ -256,6 +258,7 @@ let Setup (parsed:ParseResults<Build>) =
 
         | Format formatArgs -> Build.Step (fun _ -> format formatArgs)
         | Watch -> Build.Step watch
+        | Watch_Full -> Build.Step watchFull
 
         // steps
         | Lint lintArgs -> Build.Step (fun _ -> lint lintArgs)

--- a/docs/cli-schema.json
+++ b/docs/cli-schema.json
@@ -1537,9 +1537,85 @@
             "assembler"
           ],
           "name": "serve",
+          "summary": "Serve assembled documentation with live reload and on-demand per-request rendering. Requires assembler clone to have been run first. No prior build is needed. Pages are rendered on demand; file changes invalidate the repo and trigger a live reload.",
+          "notes": null,
+          "usage": "docs-builder assembler serve [options]",
+          "examples": [],
+          "parameters": [
+            {
+              "role": "flag",
+              "name": "port",
+              "shortName": null,
+              "type": "integer",
+              "required": false,
+              "summary": "Port to listen on. Default: 4000.",
+              "defaultValue": "4000"
+            },
+            {
+              "role": "flag",
+              "name": "environment",
+              "shortName": null,
+              "type": "string",
+              "required": false,
+              "summary": "Named deployment target. Determines which repositories are used."
+            },
+            {
+              "role": "flag",
+              "name": "no-watch-md",
+              "shortName": null,
+              "type": "boolean",
+              "required": false,
+              "summary": "Disable watching checkout directories for markdown changes. Static asset live reload still works. Useful when doing frontend (CSS/JS) work.",
+              "defaultValue": "false"
+            },
+            {
+              "role": "flag",
+              "name": "log-level",
+              "shortName": "l",
+              "type": "enum",
+              "required": false,
+              "summary": "Minimum log level. Default: information",
+              "enumValues": [
+                "trace",
+                "debug",
+                "information",
+                "warning",
+                "error",
+                "critical",
+                "none"
+              ]
+            },
+            {
+              "role": "flag",
+              "name": "config-source",
+              "shortName": "c",
+              "type": "enum",
+              "required": false,
+              "summary": "Override the configuration source: local, remote",
+              "enumValues": [
+                "local",
+                "remote",
+                "embedded"
+              ]
+            },
+            {
+              "role": "flag",
+              "name": "skip-private-repositories",
+              "shortName": null,
+              "type": "boolean",
+              "required": false,
+              "summary": "Skip cloning private repositories"
+            }
+          ]
+        },
+        {
+          "path": [
+            "assembler"
+          ],
+          "name": "serve-static",
           "summary": "Serve the output of a completed assembler build at http://localhost:4000.",
           "notes": "Run after assembler build. Does not watch for file changes.",
-          "usage": "docs-builder assembler serve [options]",
+          "usage": "docs-builder assembler serve-static [options]",
           "examples": [],
           "parameters": [
             {
@@ -1557,7 +1633,7 @@
               "shortName": null,
               "type": "string",
               "required": false,
-              "summary": "Path to the built site. Defaults to .artifacts/docs/.",
+              "summary": "Path to the built site. Defaults to .artifacts/assembly/.",
               "validations": [
                 {
                   "kind": "rejectSymbolicLinks",

--- a/src/Elastic.Documentation.LinkIndex/LinkIndexReader.cs
+++ b/src/Elastic.Documentation.LinkIndex/LinkIndexReader.cs
@@ -9,7 +9,7 @@ using Elastic.Documentation.Links;
 
 namespace Elastic.Documentation.LinkIndex;
 
-public class Aws3LinkIndexReader(IAmazonS3 s3Client, string bucketName = "elastic-docs-link-index", string registryKey = "link-index.json") : ILinkIndexReader
+public class Aws3LinkIndexReader(IAmazonS3 s3Client, string bucketName = "elastic-docs-link-index", string registryKey = "link-index.json") : ILinkIndexReader, IDisposable
 {
 
 	// <summary>
@@ -52,4 +52,10 @@ public class Aws3LinkIndexReader(IAmazonS3 s3Client, string bucketName = "elasti
 	}
 
 	public string RegistryUrl { get; } = $"https://{bucketName}.s3.{s3Client.Config.RegionEndpoint.SystemName}.amazonaws.com/{registryKey}";
+
+	public void Dispose()
+	{
+		s3Client.Dispose();
+		GC.SuppressFinalize(this);
+	}
 }

--- a/src/Elastic.Documentation.Links/CrossLinks/CrossLinkFetcher.cs
+++ b/src/Elastic.Documentation.Links/CrossLinks/CrossLinkFetcher.cs
@@ -57,7 +57,7 @@ public record FetchedCrossLinks
 	};
 }
 
-public abstract class CrossLinkFetcher(ILoggerFactory logFactory, ILinkIndexReader linkIndexProvider, ScopedFileSystem? fileSystem = null) : IDisposable
+public abstract class CrossLinkFetcher(ILoggerFactory logFactory, ILinkIndexReader linkIndexProvider, ScopedFileSystem? fileSystem = null, bool ownsReader = false) : IDisposable
 {
 	protected ILogger Logger { get; } = logFactory.CreateLogger(nameof(CrossLinkFetcher));
 	protected ILinkIndexReader LinkIndexProvider => linkIndexProvider;
@@ -206,9 +206,10 @@ public abstract class CrossLinkFetcher(ILoggerFactory logFactory, ILinkIndexRead
 
 	public void Dispose()
 	{
-		// Dispose the reader only when this fetcher created it (e.g. Aws3LinkIndexReader.CreateAnonymous()).
-		// logFactory is injected and owned by the caller — do not dispose it here.
-		if (linkIndexProvider is IDisposable disposableReader)
+		// Only dispose linkIndexProvider when this fetcher created it (ownsReader = true).
+		// When the reader was injected by the caller, the caller retains ownership and must dispose it.
+		// logFactory is always injected — never disposed here.
+		if (ownsReader && linkIndexProvider is IDisposable disposableReader)
 			disposableReader.Dispose();
 		GC.SuppressFinalize(this);
 	}

--- a/src/Elastic.Documentation.Links/CrossLinks/CrossLinkFetcher.cs
+++ b/src/Elastic.Documentation.Links/CrossLinks/CrossLinkFetcher.cs
@@ -60,6 +60,7 @@ public record FetchedCrossLinks
 public abstract class CrossLinkFetcher(ILoggerFactory logFactory, ILinkIndexReader linkIndexProvider, ScopedFileSystem? fileSystem = null) : IDisposable
 {
 	protected ILogger Logger { get; } = logFactory.CreateLogger(nameof(CrossLinkFetcher));
+	protected ILinkIndexReader LinkIndexProvider => linkIndexProvider;
 	private readonly IFileSystem _fileSystem = fileSystem ?? FileSystemFactory.AppData;
 	private LinkRegistry? _linkIndex;
 
@@ -205,6 +206,8 @@ public abstract class CrossLinkFetcher(ILoggerFactory logFactory, ILinkIndexRead
 
 	public void Dispose()
 	{
+		if (linkIndexProvider is IDisposable disposableReader)
+			disposableReader.Dispose();
 		logFactory.Dispose();
 		GC.SuppressFinalize(this);
 	}

--- a/src/Elastic.Documentation.Links/CrossLinks/CrossLinkFetcher.cs
+++ b/src/Elastic.Documentation.Links/CrossLinks/CrossLinkFetcher.cs
@@ -206,9 +206,10 @@ public abstract class CrossLinkFetcher(ILoggerFactory logFactory, ILinkIndexRead
 
 	public void Dispose()
 	{
+		// Dispose the reader only when this fetcher created it (e.g. Aws3LinkIndexReader.CreateAnonymous()).
+		// logFactory is injected and owned by the caller — do not dispose it here.
 		if (linkIndexProvider is IDisposable disposableReader)
 			disposableReader.Dispose();
-		logFactory.Dispose();
 		GC.SuppressFinalize(this);
 	}
 }

--- a/src/Elastic.Documentation.Links/CrossLinks/DocSetConfigurationCrossLinkFetcher.cs
+++ b/src/Elastic.Documentation.Links/CrossLinks/DocSetConfigurationCrossLinkFetcher.cs
@@ -16,7 +16,7 @@ public class DocSetConfigurationCrossLinkFetcher(
 	ConfigurationFile configuration,
 	ILinkIndexReader? linkIndexProvider = null,
 	ILinkIndexReader? codexLinkIndexReader = null)
-	: CrossLinkFetcher(logFactory, linkIndexProvider ?? Aws3LinkIndexReader.CreateAnonymous())
+	: CrossLinkFetcher(logFactory, linkIndexProvider ?? Aws3LinkIndexReader.CreateAnonymous(), ownsReader: linkIndexProvider is null)
 {
 	private readonly ILogger _logger = logFactory.CreateLogger(nameof(DocSetConfigurationCrossLinkFetcher));
 	private readonly ILinkIndexReader? _codexReader = codexLinkIndexReader;

--- a/src/Elastic.Documentation.Links/CrossLinks/DocSetConfigurationCrossLinkFetcher.cs
+++ b/src/Elastic.Documentation.Links/CrossLinks/DocSetConfigurationCrossLinkFetcher.cs
@@ -19,6 +19,8 @@ public class DocSetConfigurationCrossLinkFetcher(
 	: CrossLinkFetcher(logFactory, linkIndexProvider ?? Aws3LinkIndexReader.CreateAnonymous(), ownsReader: linkIndexProvider is null)
 {
 	private readonly ILogger _logger = logFactory.CreateLogger(nameof(DocSetConfigurationCrossLinkFetcher));
+	// _codexReader is injected by the caller who retains ownership and is responsible for disposal.
+	// ReloadableGeneratorState, the primary caller, disposes it directly in its own Dispose().
 	private readonly ILinkIndexReader? _codexReader = codexLinkIndexReader;
 
 	public override async Task<FetchedCrossLinks> FetchCrossLinks(Cancel ctx)

--- a/src/Elastic.Documentation.Links/CrossLinks/DocSetConfigurationCrossLinkFetcher.cs
+++ b/src/Elastic.Documentation.Links/CrossLinks/DocSetConfigurationCrossLinkFetcher.cs
@@ -31,7 +31,7 @@ public class DocSetConfigurationCrossLinkFetcher(
 		var codexRepositories = new HashSet<string>();
 		var declaredRepositories = new HashSet<string>();
 
-		var publicReader = linkIndexProvider ?? Aws3LinkIndexReader.CreateAnonymous();
+		var publicReader = LinkIndexProvider;
 		var useDualRegistry = configuration.Registry != DocSetRegistry.Public && _codexReader is not null;
 
 		// Fetch each registry once up front so per-repository lookups don't trigger N S3 round-trips.

--- a/src/Elastic.Markdown/IO/DocumentationSet.cs
+++ b/src/Elastic.Markdown/IO/DocumentationSet.cs
@@ -217,6 +217,9 @@ public class DocumentationSet : INavigationTraversable
 	}
 
 	private bool _resolved;
+
+	public void InvalidateResolved() => _resolved = false;
+
 	public async Task ResolveDirectoryTree(Cancel ctx)
 	{
 		if (_resolved)

--- a/src/Elastic.Markdown/IO/DocumentationSet.cs
+++ b/src/Elastic.Markdown/IO/DocumentationSet.cs
@@ -217,17 +217,26 @@ public class DocumentationSet : INavigationTraversable
 	}
 
 	private bool _resolved;
+	private long _version;
 
-	public void InvalidateResolved() => _resolved = false;
+	public void InvalidateResolved()
+	{
+		_ = Interlocked.Increment(ref _version);
+		_resolved = false;
+	}
 
 	public async Task ResolveDirectoryTree(Cancel ctx)
 	{
 		if (_resolved)
 			return;
 
+		// Capture the version before parsing so that if InvalidateResolved() fires
+		// mid-flight we do not incorrectly mark the (now stale) result as resolved.
+		var capturedVersion = Interlocked.Read(ref _version);
 		await Parallel.ForEachAsync(MarkdownFiles, ctx, async (file, token) => await file.MinimalParseAsync(TryFindDocumentByRelativePath, token));
 
-		_resolved = true;
+		if (Interlocked.Read(ref _version) == capturedVersion)
+			_resolved = true;
 	}
 
 	public RepositoryLinks CreateLinkReference()

--- a/src/services/Elastic.Documentation.Assembler/AssembleSources.cs
+++ b/src/services/Elastic.Documentation.Assembler/AssembleSources.cs
@@ -47,7 +47,10 @@ public class AssembleSources
 
 		var sw = System.Diagnostics.Stopwatch.StartNew();
 		FetchedCrossLinks crossLinks;
-		using (var crossLinkFetcher = new AssemblerCrossLinkFetcher(logFactory, context.Configuration, context.Environment, Aws3LinkIndexReader.CreateAnonymous()))
+		// Use a separate using for the reader so ownership is explicit: the caller (this method)
+		// disposes it, not the fetcher (ownsReader stays false/default on AssemblerCrossLinkFetcher).
+		using var linkIndexReader = Aws3LinkIndexReader.CreateAnonymous();
+		using (var crossLinkFetcher = new AssemblerCrossLinkFetcher(logFactory, context.Configuration, context.Environment, linkIndexReader))
 			crossLinks = await crossLinkFetcher.FetchCrossLinks(ctx);
 		var crossLinkResolver = new CrossLinkResolver(crossLinks, uriResolver);
 		logger.LogInformation("  AssembleAsync: FetchCrossLinks in {Elapsed:mm\\:ss\\.fff}", sw.Elapsed);

--- a/src/services/Elastic.Documentation.Assembler/AssembleSources.cs
+++ b/src/services/Elastic.Documentation.Assembler/AssembleSources.cs
@@ -42,13 +42,13 @@ public class AssembleSources
 	{
 		var logger = logFactory.CreateLogger<AssembleSources>();
 
-		var linkIndexProvider = Aws3LinkIndexReader.CreateAnonymous();
 		var navigationTocMappings = GetTocMappings(context);
 		var uriResolver = new PublishEnvironmentUriResolver(navigationTocMappings, context.Environment);
 
 		var sw = System.Diagnostics.Stopwatch.StartNew();
-		var crossLinkFetcher = new AssemblerCrossLinkFetcher(logFactory, context.Configuration, context.Environment, linkIndexProvider);
-		var crossLinks = await crossLinkFetcher.FetchCrossLinks(ctx);
+		FetchedCrossLinks crossLinks;
+		using (var crossLinkFetcher = new AssemblerCrossLinkFetcher(logFactory, context.Configuration, context.Environment, Aws3LinkIndexReader.CreateAnonymous()))
+			crossLinks = await crossLinkFetcher.FetchCrossLinks(ctx);
 		var crossLinkResolver = new CrossLinkResolver(crossLinks, uriResolver);
 		logger.LogInformation("  AssembleAsync: FetchCrossLinks in {Elapsed:mm\\:ss\\.fff}", sw.Elapsed);
 

--- a/src/services/Elastic.Documentation.Assembler/Building/AssemblerBuilder.cs
+++ b/src/services/Elastic.Documentation.Assembler/Building/AssemblerBuilder.cs
@@ -62,14 +62,7 @@ public class AssemblerBuilder(
 				continue;
 			}
 
-			// Create inferrer per-repository with git context
-			var documentInferrer = new DocumentInferrerService(
-				context.ProductsConfiguration,
-				context.VersionsConfiguration,
-				context.LegacyUrlMappings,
-				set.DocumentationSet.Configuration,
-				set.DocumentationSet.Context.Git
-			);
+			var documentInferrer = CreateInferrer(set);
 
 			var stopwatch = Stopwatch.StartNew();
 			try
@@ -157,36 +150,31 @@ public class AssemblerBuilder(
 		}
 	}
 
-	public DocumentationGenerator CreateGenerator(AssemblerDocumentationSet set)
-	{
-		SetFeatureFlags(set);
-		var documentInferrer = new DocumentInferrerService(
+	private DocumentInferrerService CreateInferrer(AssemblerDocumentationSet set) =>
+		new(
 			context.ProductsConfiguration,
 			context.VersionsConfiguration,
 			context.LegacyUrlMappings,
 			set.DocumentationSet.Configuration,
 			set.DocumentationSet.Context.Git
 		);
+
+	public DocumentationGenerator CreateGenerator(AssemblerDocumentationSet set)
+	{
+		SetFeatureFlags(set);
 		return new DocumentationGenerator(
 			set.DocumentationSet,
 			logFactory, NavigationTraversable, HtmlWriter,
 			pathProvider,
 			legacyUrlMapper: LegacyUrlMapper,
-			documentInferrer: documentInferrer
+			documentInferrer: CreateInferrer(set)
 		);
 	}
 
 	public async Task BuildOneAsync(AssemblerDocumentationSet set, Cancel ctx)
 	{
 		await set.DocumentationSet.ResolveDirectoryTree(ctx);
-		var documentInferrer = new DocumentInferrerService(
-			context.ProductsConfiguration,
-			context.VersionsConfiguration,
-			context.LegacyUrlMappings,
-			set.DocumentationSet.Configuration,
-			set.DocumentationSet.Context.Git
-		);
-		_ = await BuildAsync(set, null, documentInferrer, ctx);
+		_ = await BuildAsync(set, null, CreateInferrer(set), ctx);
 	}
 
 	private async Task<GenerationResult> BuildAsync(AssemblerDocumentationSet set, IMarkdownExporter[]? markdownExporters, IDocumentInferrerService documentInferrer, Cancel ctx)

--- a/src/services/Elastic.Documentation.Assembler/Building/AssemblerBuilder.cs
+++ b/src/services/Elastic.Documentation.Assembler/Building/AssemblerBuilder.cs
@@ -157,6 +157,38 @@ public class AssemblerBuilder(
 		}
 	}
 
+	public DocumentationGenerator CreateGenerator(AssemblerDocumentationSet set)
+	{
+		SetFeatureFlags(set);
+		var documentInferrer = new DocumentInferrerService(
+			context.ProductsConfiguration,
+			context.VersionsConfiguration,
+			context.LegacyUrlMappings,
+			set.DocumentationSet.Configuration,
+			set.DocumentationSet.Context.Git
+		);
+		return new DocumentationGenerator(
+			set.DocumentationSet,
+			logFactory, NavigationTraversable, HtmlWriter,
+			pathProvider,
+			legacyUrlMapper: LegacyUrlMapper,
+			documentInferrer: documentInferrer
+		);
+	}
+
+	public async Task BuildOneAsync(AssemblerDocumentationSet set, Cancel ctx)
+	{
+		await set.DocumentationSet.ResolveDirectoryTree(ctx);
+		var documentInferrer = new DocumentInferrerService(
+			context.ProductsConfiguration,
+			context.VersionsConfiguration,
+			context.LegacyUrlMappings,
+			set.DocumentationSet.Configuration,
+			set.DocumentationSet.Context.Git
+		);
+		_ = await BuildAsync(set, null, documentInferrer, ctx);
+	}
+
 	private async Task<GenerationResult> BuildAsync(AssemblerDocumentationSet set, IMarkdownExporter[]? markdownExporters, IDocumentInferrerService documentInferrer, Cancel ctx)
 	{
 		SetFeatureFlags(set);

--- a/src/tooling/docs-builder/Commands/Assembler/AssemblerCommands.cs
+++ b/src/tooling/docs-builder/Commands/Assembler/AssemblerCommands.cs
@@ -168,8 +168,9 @@ internal sealed class AssemblerCommands(
 	/// </summary>
 	/// <param name="port">Port to listen on. Default: 4000.</param>
 	/// <param name="environment">Named deployment target. Determines which repositories are used.</param>
+	/// <param name="noWatchMd">Disable watching checkout directories for markdown changes. Static asset live reload still works. Useful when doing frontend (CSS/JS) work.</param>
 	[NoOptionsInjection]
-	public async Task Serve(int port = 4000, string? environment = null, CancellationToken ct = default)
+	public async Task Serve(int port = 4000, string? environment = null, bool noWatchMd = false, CancellationToken ct = default)
 	{
 		environment ??= "dev";
 		var readFs = FileSystemFactory.RealRead;
@@ -201,7 +202,7 @@ internal sealed class AssemblerCommands(
 		var historyMapper = new PageLegacyUrlMapper(legacyPageChecker, assembleContext.VersionsConfiguration, assembleSources.LegacyUrlMappings);
 		var builder = new AssemblerBuilder(logFactory, assembleContext, navigation, htmlWriter, pathProvider, historyMapper);
 
-		var host = new AssemblerServeWebHost(port, assembleSources, builder, logFactory);
+		var host = new AssemblerServeWebHost(port, assembleSources, builder, logFactory, watchMarkdown: !noWatchMd);
 		await host.RunAsync(ct);
 		await host.StopAsync(ct);
 		await collector.StopAsync(ct);

--- a/src/tooling/docs-builder/Commands/Assembler/AssemblerCommands.cs
+++ b/src/tooling/docs-builder/Commands/Assembler/AssemblerCommands.cs
@@ -6,15 +6,21 @@ using System.IO.Abstractions;
 using Actions.Core.Services;
 using Documentation.Builder.Http;
 using Elastic.Documentation;
+using Elastic.Documentation.Assembler;
 using Elastic.Documentation.Assembler.Building;
+using Elastic.Documentation.Assembler.Navigation;
 using Elastic.Documentation.Assembler.Sourcing;
 using Elastic.Documentation.Configuration;
 using Elastic.Documentation.Configuration.Assembler;
+using Elastic.Documentation.Configuration.Toc;
 using Elastic.Documentation.Diagnostics;
+using Elastic.Documentation.LegacyDocs;
+using Elastic.Documentation.Navigation.Assembler;
 using Elastic.Documentation.Services;
 using Microsoft.Extensions.Logging;
 using Nullean.Argh;
 using Nullean.Argh.Documentation;
+using Nullean.ScopedFileSystem;
 
 namespace Documentation.Builder.Commands.Assembler;
 
@@ -155,13 +161,59 @@ internal sealed class AssemblerCommands(
 		return await serviceInvoker.InvokeAsync(ct);
 	}
 
+	/// <summary>
+	/// Serve assembled documentation with live reload and on-demand per-request rendering.
+	/// Requires <c>assembler clone</c> to have been run first. No prior build is needed.
+	/// Pages are rendered on demand; file changes invalidate the repo and trigger a live reload.
+	/// </summary>
+	/// <param name="port">Port to listen on. Default: 4000.</param>
+	/// <param name="environment">Named deployment target. Determines which repositories are used.</param>
+	[NoOptionsInjection]
+	public async Task Serve(int port = 4000, string? environment = null, CancellationToken ct = default)
+	{
+		environment ??= "dev";
+		var readFs = FileSystemFactory.RealRead;
+		var writeFs = FileSystemFactory.RealWrite;
+
+		var assembleContext = new AssembleContext(assemblyConfiguration, configurationContext, environment, collector, readFs, writeFs, null, null);
+
+		var cloner = new AssemblerRepositorySourcer(logFactory, assembleContext);
+		var checkoutResult = cloner.GetAll();
+		var checkouts = checkoutResult.Checkouts.ToArray();
+
+		if (checkouts.Length == 0)
+			throw new Exception("No checkouts found. Run 'assembler clone' first.");
+
+		var exporters = ExportOptions.Default
+			.Except([Exporter.DocumentationState])
+			.ToHashSet();
+
+		var assembleSources = await AssembleSources.AssembleAsync(logFactory, assembleContext, checkouts, configurationContext, exporters, ct);
+
+		var navigationFileInfo = configurationContext.ConfigurationFileProvider.NavigationFile;
+		var siteNavigationFile = SiteNavigationFile.Deserialize(await readFs.File.ReadAllTextAsync(navigationFileInfo.FullName, ct));
+		var documentationSets = assembleSources.AssembleSets.Values.Select(s => s.DocumentationSet.Navigation).ToArray();
+		var navigation = new SiteNavigation(siteNavigationFile, assembleContext, documentationSets, assembleContext.Environment.PathPrefix);
+
+		var pathProvider = new GlobalNavigationPathProvider(navigation, assembleSources, assembleContext);
+		using var htmlWriter = new GlobalNavigationHtmlWriter(logFactory, navigation, collector);
+		var legacyPageChecker = new LegacyPageService(logFactory);
+		var historyMapper = new PageLegacyUrlMapper(legacyPageChecker, assembleContext.VersionsConfiguration, assembleSources.LegacyUrlMappings);
+		var builder = new AssemblerBuilder(logFactory, assembleContext, navigation, htmlWriter, pathProvider, historyMapper);
+
+		var host = new AssemblerServeWebHost(port, assembleSources, builder, logFactory);
+		await host.RunAsync(ct);
+		await host.StopAsync(ct);
+		await collector.StopAsync(ct);
+	}
+
 	/// <summary>Serve the output of a completed assembler build at <c>http://localhost:4000</c>.</summary>
 	/// <remarks>Run after <c>assembler build</c>. Does not watch for file changes.</remarks>
 	/// <param name="port">Port to listen on. Default: 4000.</param>
-	/// <param name="path">Path to the built site. Defaults to <c>.artifacts/docs/</c>.</param>
-
+	/// <param name="path">Path to the built site. Defaults to <c>.artifacts/assembly/</c>.</param>
 	[NoOptionsInjection]
-	public async Task Serve(int port = 4000, [Existing, ExpandUserProfile, RejectSymbolicLinks] DirectoryInfo? path = null, CancellationToken ct = default)
+	[CommandName("serve-static")]
+	public async Task ServeStatic(int port = 4000, [Existing, ExpandUserProfile, RejectSymbolicLinks] DirectoryInfo? path = null, CancellationToken ct = default)
 	{
 		var host = new StaticWebHost(port, path?.FullName);
 		await host.RunAsync(ct);

--- a/src/tooling/docs-builder/Http/AssemblerReloadService.cs
+++ b/src/tooling/docs-builder/Http/AssemblerReloadService.cs
@@ -2,7 +2,9 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using Elastic.Documentation;
 using Elastic.Documentation.Assembler.Navigation;
+using Elastic.Documentation.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Westwind.AspNetCore.LiveReload;
@@ -11,6 +13,7 @@ namespace Documentation.Builder.Http;
 
 public sealed class AssemblerReloadService(
 	IReadOnlyList<AssemblerDocumentationSet> assemblerSets,
+	bool watchMarkdown,
 	ILogger<AssemblerReloadService> logger
 ) : IHostedService, IDisposable
 {
@@ -22,13 +25,23 @@ public sealed class AssemblerReloadService(
 	{
 		_serviceCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
+		if (watchMarkdown)
+			StartMarkdownWatchers();
+
+		StartStaticAssetsWatcher();
+
+		return Task.CompletedTask;
+	}
+
+	private void StartMarkdownWatchers()
+	{
 		foreach (var set in assemblerSets)
 		{
 			var checkoutDir = set.Checkout.Directory.FullName;
 			if (!Directory.Exists(checkoutDir))
 				continue;
 
-			logger.LogInformation("Start file watch on checkout: {Directory}", checkoutDir);
+			logger.LogInformation("Start markdown watch on checkout: {Directory}", checkoutDir);
 			var watcher = new FileSystemWatcher(checkoutDir)
 			{
 				NotifyFilter = NotifyFilters.Attributes
@@ -46,16 +59,40 @@ public sealed class AssemblerReloadService(
 			watcher.IncludeSubdirectories = true;
 			watcher.EnableRaisingEvents = true;
 
-			watcher.Changed += (_, e) => OnChanged(e.FullPath, set);
-			watcher.Created += (_, e) => OnChanged(e.FullPath, set);
-			watcher.Deleted += (_, e) => OnChanged(e.FullPath, set);
-			watcher.Renamed += (_, e) => OnChanged(e.FullPath, set);
+			watcher.Changed += (_, e) => OnMarkdownChanged(e.FullPath, set);
+			watcher.Created += (_, e) => OnMarkdownChanged(e.FullPath, set);
+			watcher.Deleted += (_, e) => OnMarkdownChanged(e.FullPath, set);
+			watcher.Renamed += (_, e) => OnMarkdownChanged(e.FullPath, set);
 			watcher.Error += (_, e) => logger.LogError(e.GetException(), "File watcher error in {Directory}", checkoutDir);
 
 			_watchers.Add(watcher);
 		}
+	}
 
-		return Task.CompletedTask;
+	private void StartStaticAssetsWatcher()
+	{
+		var solutionRoot = Paths.GetSolutionDirectory();
+		if (solutionRoot is null)
+			return;
+
+		var staticDir = Path.Join(solutionRoot.FullName, "src", "Elastic.Documentation.Site", "_static");
+		if (!Directory.Exists(staticDir))
+			return;
+
+		logger.LogInformation("Start static assets watch on: {Directory}", staticDir);
+		var watcher = new FileSystemWatcher(staticDir)
+		{
+			NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.CreationTime,
+			IncludeSubdirectories = true,
+			EnableRaisingEvents = true
+		};
+
+		watcher.Changed += (_, e) => OnStaticAssetChanged(e.FullPath);
+		watcher.Created += (_, e) => OnStaticAssetChanged(e.FullPath);
+		watcher.Renamed += (_, e) => OnStaticAssetChanged(e.FullPath);
+		watcher.Error += (_, e) => logger.LogError(e.GetException(), "Static assets watcher error in {Directory}", staticDir);
+
+		_watchers.Add(watcher);
 	}
 
 	private static bool ShouldIgnorePath(string path) =>
@@ -63,19 +100,30 @@ public sealed class AssemblerReloadService(
 		path.Contains("/.git/") || path.Contains("\\.git\\") ||
 		path.Contains("/node_modules/") || path.Contains("\\node_modules\\");
 
-	private void OnChanged(string fullPath, AssemblerDocumentationSet set)
+	private void OnMarkdownChanged(string fullPath, AssemblerDocumentationSet set)
 	{
 		if (ShouldIgnorePath(fullPath))
 			return;
 
-		logger.LogInformation("Changed: {FullPath}", fullPath);
+		logger.LogInformation("Markdown changed: {FullPath}", fullPath);
 
 		var token = _serviceCts?.Token ?? Cancel.None;
 		_ = _debouncer.ExecuteAsync(async _ =>
 		{
-			// Invalidate so the next RenderLayout call re-parses the changed files
 			set.DocumentationSet.InvalidateResolved();
 			logger.LogInformation("Invalidated {RepositoryName}, triggering live reload", set.Checkout.Repository.Name);
+			await Task.Run(() => LiveReloadMiddleware.RefreshWebSocketRequest(), CancellationToken.None);
+		}, token);
+	}
+
+	private void OnStaticAssetChanged(string fullPath)
+	{
+		logger.LogInformation("Static asset changed: {FullPath}", fullPath);
+
+		var token = _serviceCts?.Token ?? Cancel.None;
+		_ = _debouncer.ExecuteAsync(async _ =>
+		{
+			logger.LogInformation("Triggering live reload for static asset change");
 			await Task.Run(() => LiveReloadMiddleware.RefreshWebSocketRequest(), CancellationToken.None);
 		}, token);
 	}

--- a/src/tooling/docs-builder/Http/AssemblerReloadService.cs
+++ b/src/tooling/docs-builder/Http/AssemblerReloadService.cs
@@ -1,0 +1,129 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Documentation.Assembler.Navigation;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Westwind.AspNetCore.LiveReload;
+
+namespace Documentation.Builder.Http;
+
+public sealed class AssemblerReloadService(
+	IReadOnlyList<AssemblerDocumentationSet> assemblerSets,
+	ILogger<AssemblerReloadService> logger
+) : IHostedService, IDisposable
+{
+	private readonly List<FileSystemWatcher> _watchers = [];
+	private CancellationTokenSource? _serviceCts;
+	private readonly Debouncer _debouncer = new(TimeSpan.FromMilliseconds(200));
+
+	public Task StartAsync(Cancel cancellationToken)
+	{
+		_serviceCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+		foreach (var set in assemblerSets)
+		{
+			var checkoutDir = set.Checkout.Directory.FullName;
+			if (!Directory.Exists(checkoutDir))
+				continue;
+
+			logger.LogInformation("Start file watch on checkout: {Directory}", checkoutDir);
+			var watcher = new FileSystemWatcher(checkoutDir)
+			{
+				NotifyFilter = NotifyFilters.Attributes
+								| NotifyFilters.CreationTime
+								| NotifyFilters.DirectoryName
+								| NotifyFilters.FileName
+								| NotifyFilters.LastWrite
+								| NotifyFilters.Security
+								| NotifyFilters.Size
+			};
+			watcher.Filters.Add("*.md");
+			watcher.Filters.Add("docset.yml");
+			watcher.Filters.Add("_docset.yml");
+			watcher.Filters.Add("toc.yml");
+			watcher.IncludeSubdirectories = true;
+			watcher.EnableRaisingEvents = true;
+
+			watcher.Changed += (_, e) => OnChanged(e.FullPath, set);
+			watcher.Created += (_, e) => OnChanged(e.FullPath, set);
+			watcher.Deleted += (_, e) => OnChanged(e.FullPath, set);
+			watcher.Renamed += (_, e) => OnChanged(e.FullPath, set);
+			watcher.Error += (_, e) => logger.LogError(e.GetException(), "File watcher error in {Directory}", checkoutDir);
+
+			_watchers.Add(watcher);
+		}
+
+		return Task.CompletedTask;
+	}
+
+	private static bool ShouldIgnorePath(string path) =>
+		path.Contains("/.artifacts/") || path.Contains("\\.artifacts\\") ||
+		path.Contains("/.git/") || path.Contains("\\.git\\") ||
+		path.Contains("/node_modules/") || path.Contains("\\node_modules\\");
+
+	private void OnChanged(string fullPath, AssemblerDocumentationSet set)
+	{
+		if (ShouldIgnorePath(fullPath))
+			return;
+
+		logger.LogInformation("Changed: {FullPath}", fullPath);
+
+		var token = _serviceCts?.Token ?? Cancel.None;
+		_ = _debouncer.ExecuteAsync(async _ =>
+		{
+			// Invalidate so the next RenderLayout call re-parses the changed files
+			set.DocumentationSet.InvalidateResolved();
+			logger.LogInformation("Invalidated {RepositoryName}, triggering live reload", set.Checkout.Repository.Name);
+			await Task.Run(() => LiveReloadMiddleware.RefreshWebSocketRequest(), CancellationToken.None);
+		}, token);
+	}
+
+	public async Task StopAsync(Cancel cancellationToken)
+	{
+		if (_serviceCts is not null)
+		{
+			await _serviceCts.CancelAsync();
+			_serviceCts.Dispose();
+			_serviceCts = null;
+		}
+		foreach (var watcher in _watchers)
+			watcher.Dispose();
+		_watchers.Clear();
+	}
+
+	public void Dispose()
+	{
+		_serviceCts?.Dispose();
+		foreach (var watcher in _watchers)
+			watcher.Dispose();
+		_debouncer.Dispose();
+	}
+
+	private sealed class Debouncer(TimeSpan window) : IDisposable
+	{
+		private readonly SemaphoreSlim _semaphore = new(1, 1);
+		private readonly long _windowInTicks = window.Ticks;
+		private long _nextRun;
+
+		public async Task ExecuteAsync(Func<Cancel, Task> innerAction, Cancel cancellationToken)
+		{
+			var requestStart = DateTime.UtcNow.Ticks;
+			try
+			{
+				await _semaphore.WaitAsync(cancellationToken);
+				if (requestStart <= _nextRun)
+					return;
+				await innerAction(cancellationToken);
+				_nextRun = requestStart + _windowInTicks;
+			}
+			finally
+			{
+				_ = _semaphore.Release();
+			}
+		}
+
+		public void Dispose() => _semaphore.Dispose();
+	}
+}

--- a/src/tooling/docs-builder/Http/AssemblerServeWebHost.cs
+++ b/src/tooling/docs-builder/Http/AssemblerServeWebHost.cs
@@ -10,6 +10,9 @@ using Elastic.Documentation.ServiceDefaults;
 using Elastic.Documentation.Site.FileProviders;
 using Elastic.Markdown;
 using Elastic.Markdown.IO;
+#if DEBUG
+using Elastic.Documentation.Api.Infrastructure;
+#endif
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -52,6 +55,9 @@ public class AssemblerServeWebHost
 		});
 
 		_ = builder.AddDocumentationServiceDefaults();
+#if DEBUG
+		builder.Services.AddElasticDocsApiUsecases("dev");
+#endif
 
 		_ = builder.Logging
 			.AddFilter("Microsoft.AspNetCore.Hosting.Diagnostics", LogLevel.Error)
@@ -151,6 +157,12 @@ public class AssemblerServeWebHost
 		}
 
 		_ = pipeline.UseRouting();
+
+#if DEBUG
+		var apiV1 = _webApplication.MapGroup($"{SystemEnvironmentVariables.Instance.ApiPrefix}/v1");
+		var mapOtlpEndpoints = !string.IsNullOrWhiteSpace(_webApplication.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
+		apiV1.MapElasticDocsApiEndpoints(mapOtlpEndpoints);
+#endif
 
 		_ = _webApplication.MapGet("/", (Cancel ctx) => ServeRoot(ctx));
 		_ = _webApplication.MapGet("{**slug}", (string slug, Cancel ctx) => ServeDocumentationFile(slug, ctx));

--- a/src/tooling/docs-builder/Http/AssemblerServeWebHost.cs
+++ b/src/tooling/docs-builder/Http/AssemblerServeWebHost.cs
@@ -34,7 +34,8 @@ public class AssemblerServeWebHost
 		int port,
 		AssembleSources assembleSources,
 		AssemblerBuilder assemblerBuilder,
-		ILoggerFactory logFactory
+		ILoggerFactory logFactory,
+		bool watchMarkdown = true
 	)
 	{
 		_prefixMap = BuildPrefixMap(assembleSources, assemblerBuilder);
@@ -65,7 +66,7 @@ public class AssemblerServeWebHost
 
 		var sets = assembleSources.AssembleSets.Values.ToList();
 		_ = builder.Services.AddHostedService<AssemblerReloadService>(_ =>
-			new AssemblerReloadService(sets, logFactory.CreateLogger<AssemblerReloadService>())
+			new AssemblerReloadService(sets, watchMarkdown, logFactory.CreateLogger<AssemblerReloadService>())
 		);
 
 		_ = builder.WebHost.UseUrls($"http://localhost:{port}");

--- a/src/tooling/docs-builder/Http/AssemblerServeWebHost.cs
+++ b/src/tooling/docs-builder/Http/AssemblerServeWebHost.cs
@@ -1,0 +1,234 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Documentation.Assembler;
+using Elastic.Documentation.Assembler.Building;
+using Elastic.Documentation.Assembler.Navigation;
+using Elastic.Documentation.Configuration;
+using Elastic.Documentation.ServiceDefaults;
+using Elastic.Documentation.Site.FileProviders;
+using Elastic.Markdown;
+using Elastic.Markdown.IO;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Westwind.AspNetCore.LiveReload;
+
+namespace Documentation.Builder.Http;
+
+public class AssemblerServeWebHost
+{
+	private readonly WebApplication _webApplication;
+
+	// Sorted longest-prefix-first for greedy matching
+	private readonly (string Prefix, string FileSlugBase, AssemblerDocumentationSet Set, DocumentationGenerator Generator)[] _prefixMap;
+
+	// Shortest top-level prefix → first real content section (e.g. "/docs/get-started")
+	private readonly string _rootRedirectUrl;
+
+	public AssemblerServeWebHost(
+		int port,
+		AssembleSources assembleSources,
+		AssemblerBuilder assemblerBuilder,
+		ILoggerFactory logFactory
+	)
+	{
+		_prefixMap = BuildPrefixMap(assembleSources, assemblerBuilder);
+		_rootRedirectUrl = "/" + (_prefixMap
+			.OrderBy(e => e.Prefix.Length)
+			.Select(e => e.Prefix)
+			.FirstOrDefault() ?? assembleSources.AssembleContext.Environment.PathPrefix ?? "");
+
+		var urlPathPrefix = assembleSources.AssembleSets.Values.FirstOrDefault()?.BuildContext.UrlPathPrefix ?? "";
+
+		var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+		{
+			ContentRootPath = Paths.WorkingDirectoryRoot.FullName
+		});
+
+		_ = builder.AddDocumentationServiceDefaults();
+
+		_ = builder.Logging
+			.AddFilter("Microsoft.AspNetCore.Hosting.Diagnostics", LogLevel.Error)
+			.AddFilter("Microsoft.AspNetCore.StaticFiles.StaticFileMiddleware", LogLevel.Error)
+			.AddFilter("Microsoft.Hosting.Lifetime", LogLevel.Information);
+
+		_ = builder.Services.AddAotLiveReload(s =>
+		{
+			s.FolderToMonitor = assembleSources.AssembleContext.CheckoutDirectory.FullName;
+			s.ClientFileExtensions = ".md,.yml";
+		});
+
+		var sets = assembleSources.AssembleSets.Values.ToList();
+		_ = builder.Services.AddHostedService<AssemblerReloadService>(_ =>
+			new AssemblerReloadService(sets, logFactory.CreateLogger<AssemblerReloadService>())
+		);
+
+		_ = builder.WebHost.UseUrls($"http://localhost:{port}");
+
+		_webApplication = builder.Build();
+		SetUpRoutes(assembleSources, urlPathPrefix);
+	}
+
+	public async Task RunAsync(Cancel ctx) => await _webApplication.RunAsync(ctx);
+
+	public async Task StopAsync(Cancel ctx) => await _webApplication.StopAsync(ctx);
+
+	private static (string Prefix, string FileSlugBase, AssemblerDocumentationSet Set, DocumentationGenerator Generator)[] BuildPrefixMap(
+		AssembleSources assembleSources, AssemblerBuilder assemblerBuilder)
+	{
+		var envPathPrefix = assembleSources.AssembleContext.Environment.PathPrefix; // e.g. "docs"
+		var entries = new List<(string, string, AssemblerDocumentationSet, DocumentationGenerator)>();
+		var generatorCache = new Dictionary<string, DocumentationGenerator>();
+
+		foreach (var (uri, mapping) in assembleSources.NavigationTocMappings)
+		{
+			var repoName = uri.Scheme;
+			if (!assembleSources.AssembleSets.TryGetValue(repoName, out var set))
+				continue;
+
+			// Reconstruct the path within SourceDirectory for this TOC mapping.
+			// The URI host is the subfolder of the repo's content root that this TOC covers.
+			var fileSlugBase = Path.Join(uri.Host, uri.AbsolutePath.Trim('/')).TrimStart('/');
+
+			// The URL slug includes the global path prefix (e.g. "docs/release-notes/elasticsearch").
+			// SourcePathPrefix is just the suffix (e.g. "release-notes/elasticsearch"), so prepend.
+			var urlPrefix = string.IsNullOrEmpty(envPathPrefix)
+				? mapping.SourcePathPrefix
+				: string.IsNullOrEmpty(mapping.SourcePathPrefix)
+					? envPathPrefix
+					: $"{envPathPrefix}/{mapping.SourcePathPrefix}";
+
+			// Reuse the same generator for the same repo across multiple TOC entries
+			if (!generatorCache.TryGetValue(repoName, out var generator))
+			{
+				generator = assemblerBuilder.CreateGenerator(set);
+				generatorCache[repoName] = generator;
+			}
+
+			entries.Add((urlPrefix, fileSlugBase, set, generator));
+		}
+		return [.. entries.OrderByDescending(e => e.Item1.Length)];
+	}
+
+	private void SetUpRoutes(AssembleSources assembleSources, string urlPathPrefix)
+	{
+		var firstBuildContext = assembleSources.AssembleSets.Values.FirstOrDefault()?.BuildContext;
+
+		// Static assets MUST come before UseRouting so they're served before the {**slug} catch-all matches
+		var staticRequestPath = string.IsNullOrEmpty(urlPathPrefix) ? "/_static" : $"{urlPathPrefix}/_static";
+		var pipeline = _webApplication
+			.UseLiveReloadWithManualScriptInjection(_webApplication.Lifetime)
+			.UseDeveloperExceptionPage(new DeveloperExceptionPageOptions())
+			.Use(async (context, next) =>
+			{
+				try
+				{
+					await next(context);
+				}
+				catch (Exception ex)
+				{
+					Console.WriteLine($"[UNHANDLED EXCEPTION] {ex.GetType().Name}: {ex.Message}");
+					Console.WriteLine($"[STACK TRACE] {ex.StackTrace}");
+					if (ex.InnerException != null)
+						Console.WriteLine($"[INNER EXCEPTION] {ex.InnerException.GetType().Name}: {ex.InnerException.Message}");
+					throw;
+				}
+			});
+
+		if (firstBuildContext != null)
+		{
+			_ = pipeline.UseStaticFiles(new StaticFileOptions
+			{
+				FileProvider = new EmbeddedOrPhysicalFileProvider(firstBuildContext),
+				RequestPath = staticRequestPath
+			});
+		}
+
+		_ = pipeline.UseRouting();
+
+		_ = _webApplication.MapGet("/", (Cancel ctx) => ServeRoot(ctx));
+		_ = _webApplication.MapGet("{**slug}", (string slug, Cancel ctx) => ServeDocumentationFile(slug, ctx));
+	}
+
+	private Task<IResult> ServeRoot(Cancel _) =>
+		Task.FromResult(Results.Redirect(_rootRedirectUrl));
+
+	private async Task<IResult> ServeDocumentationFile(string slug, Cancel ctx)
+	{
+		if (slug == ".well-known/appspecific/com.chrome.devtools.json")
+			return Results.NotFound();
+
+		// Static asset requests that UseStaticFiles couldn't serve → 404, not a redirect
+		if (slug.Contains("/_static/") || slug.Contains("\\_static\\"))
+			return Results.NotFound();
+
+		var match = FindRepo(slug);
+		if (match is null)
+			return Results.Redirect(_rootRedirectUrl);
+
+		var (set, generator, relFileSlug) = match.Value;
+
+		// Mirror the file lookup logic from DocumentationWebHost.ServeDocumentationFile
+		var s = Path.GetExtension(relFileSlug) == string.Empty
+			? Path.Join(relFileSlug, "index.md")
+			: relFileSlug;
+		var fp = new FilePath(s, generator.DocumentationSet.SourceDirectory);
+
+		if (!generator.DocumentationSet.Files.TryGetValue(fp, out var documentationFile))
+		{
+			s = Path.GetExtension(relFileSlug) == string.Empty
+				? relFileSlug + ".md"
+				: s.Replace($"{Path.DirectorySeparatorChar}index.md", ".md");
+			fp = new FilePath(s, generator.DocumentationSet.SourceDirectory);
+			_ = generator.DocumentationSet.Files.TryGetValue(fp, out documentationFile);
+		}
+
+		switch (documentationFile)
+		{
+			case MarkdownFile markdown:
+				var rendered = await generator.RenderLayout(markdown, ctx);
+				return LiveReloadHtml(rendered.Html);
+			case ImageFile image:
+				return Results.File(image.SourceFile.FullName, image.MimeType);
+			default:
+				// If this is a navigation node (index.md not found), try redirect to first child
+				var fp404 = new FilePath("404.md", generator.DocumentationSet.SourceDirectory);
+				if (generator.DocumentationSet.Files.TryGetValue(fp404, out var notFound) && notFound is MarkdownFile notFoundMd)
+				{
+					var renderedNotFound = await generator.RenderLayout(notFoundMd, ctx);
+					return Results.Content(renderedNotFound.Html, "text/html", null, 404);
+				}
+				return Results.NotFound();
+		}
+	}
+
+	private (AssemblerDocumentationSet Set, DocumentationGenerator Generator, string RelFileSlug)? FindRepo(string slug)
+	{
+		foreach (var (prefix, fileSlugBase, set, generator) in _prefixMap)
+		{
+			if (!slug.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+				continue;
+			var afterPrefix = slug[prefix.Length..].TrimStart('/');
+			var relFileSlug = string.IsNullOrEmpty(fileSlugBase)
+				? afterPrefix
+				: string.IsNullOrEmpty(afterPrefix) ? fileSlugBase : $"{fileSlugBase}/{afterPrefix}";
+			return (set, generator, relFileSlug);
+		}
+		return null;
+	}
+
+	private static IResult LiveReloadHtml(string content)
+	{
+		if (LiveReloadConfiguration.Current.LiveReloadEnabled)
+		{
+			var script = $"\n<script src=\"{LiveReloadConfiguration.Current.LiveReloadScriptUrl}\" defer></script>";
+			content += script;
+		}
+		return Results.Content(content, "text/html");
+	}
+}

--- a/src/tooling/docs-builder/Http/AssemblerServeWebHost.cs
+++ b/src/tooling/docs-builder/Http/AssemblerServeWebHost.cs
@@ -30,8 +30,9 @@ public class AssemblerServeWebHost
 	// Sorted longest-prefix-first for greedy matching
 	private readonly (string Prefix, string FileSlugBase, AssemblerDocumentationSet Set, DocumentationGenerator Generator)[] _prefixMap;
 
-	// Shortest top-level prefix → first real content section (e.g. "/docs/get-started")
-	private readonly string _rootRedirectUrl;
+	// Shortest top-level prefix → first real content section (e.g. "/docs/get-started").
+	// Null when no mappings exist and no path prefix is configured — callers must guard.
+	private readonly string? _rootRedirectUrl;
 
 	public AssemblerServeWebHost(
 		int port,
@@ -42,10 +43,13 @@ public class AssemblerServeWebHost
 	)
 	{
 		_prefixMap = BuildPrefixMap(assembleSources, assemblerBuilder);
-		_rootRedirectUrl = "/" + (_prefixMap
-			.OrderBy(e => e.Prefix.Length)
-			.Select(e => e.Prefix)
-			.FirstOrDefault() ?? assembleSources.AssembleContext.Environment.PathPrefix ?? "");
+		var firstPrefix = _prefixMap.OrderBy(e => e.Prefix.Length).Select(e => e.Prefix).FirstOrDefault();
+		var envPrefix = assembleSources.AssembleContext.Environment.PathPrefix;
+		_rootRedirectUrl = firstPrefix is not null
+			? $"/{firstPrefix}"
+			: envPrefix is { Length: > 0 }
+				? $"/{envPrefix}"
+				: null;
 
 		var urlPathPrefix = assembleSources.AssembleSets.Values.FirstOrDefault()?.BuildContext.UrlPathPrefix ?? "";
 
@@ -67,7 +71,7 @@ public class AssemblerServeWebHost
 		_ = builder.Services.AddAotLiveReload(s =>
 		{
 			s.FolderToMonitor = assembleSources.AssembleContext.CheckoutDirectory.FullName;
-			s.ClientFileExtensions = ".md,.yml";
+			s.ClientFileExtensions = watchMarkdown ? ".md,.yml" : ".css,.js";
 		});
 
 		var sets = assembleSources.AssembleSets.Values.ToList();
@@ -169,7 +173,9 @@ public class AssemblerServeWebHost
 	}
 
 	private Task<IResult> ServeRoot(Cancel _) =>
-		Task.FromResult(Results.Redirect(_rootRedirectUrl));
+		Task.FromResult(_rootRedirectUrl is not null
+			? Results.Redirect(_rootRedirectUrl)
+			: Results.NotFound());
 
 	private async Task<IResult> ServeDocumentationFile(string slug, Cancel ctx)
 	{
@@ -182,7 +188,7 @@ public class AssemblerServeWebHost
 
 		var match = FindRepo(slug);
 		if (match is null)
-			return Results.Redirect(_rootRedirectUrl);
+			return _rootRedirectUrl is not null ? Results.Redirect(_rootRedirectUrl) : Results.NotFound();
 
 		var (set, generator, relFileSlug) = match.Value;
 
@@ -224,7 +230,12 @@ public class AssemblerServeWebHost
 	{
 		foreach (var (prefix, fileSlugBase, set, generator) in _prefixMap)
 		{
-			if (!slug.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+			var matchesPrefix =
+				slug.Equals(prefix, StringComparison.OrdinalIgnoreCase)
+				|| (slug.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+					&& slug.Length > prefix.Length
+					&& slug[prefix.Length] == '/');
+			if (!matchesPrefix)
 				continue;
 			var afterPrefix = slug[prefix.Length..].TrimStart('/');
 			var relFileSlug = string.IsNullOrEmpty(fileSlugBase)

--- a/src/tooling/docs-builder/Http/ReloadableGeneratorState.cs
+++ b/src/tooling/docs-builder/Http/ReloadableGeneratorState.cs
@@ -268,6 +268,9 @@ public class ReloadableGeneratorState : IDisposable
 		_apiGenerationCts?.Cancel();
 		_apiGenerationCts?.Dispose();
 		_apiSemaphore.Dispose();
+		// _crossLinkFetcher owns its internally-created Aws3LinkIndexReader; dispose it.
+		// _codexReader is owned by this class (not by the fetcher); dispose it separately.
+		_crossLinkFetcher.Dispose();
 		(_codexReader as IDisposable)?.Dispose();
 		GC.SuppressFinalize(this);
 	}


### PR DESCRIPTION
## Summary

This PR adds `docs-builder assembler serve` — on-demand page rendering for the full assembled documentation site, with live reload.

### The problem

The full `assembler build` is fast (~30 seconds), which is perfectly fine for CI/CD. However, for local frontend development — iterating on CSS, JavaScript, or templates — even 30 seconds is too slow for a tight feedback loop. As a result, frontend work has always been done against isolated single-repo builds (`docs-builder serve`) rather than the real assembled site with its global navigation, cross-repo links, and assembler-specific styling. This means visual regressions in the assembled layout are only caught after a full build.

### What this adds

#### `docs-builder assembler serve` — on-demand rendering with live reload
After running `assembler clone` (the only prerequisite), the serve command:

- Loads cross-links from S3 and resolves all repository directory trees in memory
- Starts an HTTP server on port 4000 that **renders each page on demand** via `DocumentationGenerator.RenderLayout` — no prior build needed
- Routes incoming requests to the correct repository using `NavigationTocMapping.SourcePathPrefix` (longest-match), then looks up and renders the matching `MarkdownFile`
- Watches all checkout directories for `*.md`, `docset.yml`, and `toc.yml` changes — on any change invalidates the affected repo's directory tree so the next request re-renders from the updated source, then fires a browser live reload via Westwind
- Serves embedded CSS/JS/fonts at `/{pathPrefix}/_static` using `EmbeddedOrPhysicalFileProvider` (which in DEBUG builds serves directly from physical files in `src/Elastic.Documentation.Site/_static/`)

#### `--no-watch-md` flag
Skips setting up the 100+ `FileSystemWatcher` instances on checkout directories. Static-asset live reload still runs. The intended use case: frontend developers who only care about CSS/JS/template changes and don't need markdown change detection.

#### Static-asset live reload (DEBUG only)
In debug mode, `AssemblerReloadService` also watches `src/Elastic.Documentation.Site/_static/` for CSS/JS changes and fires a browser live reload. Combined with `EmbeddedOrPhysicalFileProvider` serving from physical files in debug mode, this gives instant CSS/JS feedback against the fully assembled site.

#### `./build.sh watch-full`
Runs `dotnet watch` over the docs-builder project with `assembler serve` as the command. This is the primary frontend development loop: C# hot reload for template changes, on-demand markdown rendering, and static-asset live reload — all against the real assembled site.

#### `docs-builder assembler serve-static`
The previous `assembler serve` behaviour — serves the pre-built output of `assembler build` as static files with no watching or live reload. Renamed to make room for the new on-demand mode.

### Bug fix: Ctrl+C hang on shutdown

`AmazonS3Client` (AWS SDK) spawns foreground threads for connection-pool management that permanently block process exit unless the client is explicitly disposed. `Aws3LinkIndexReader.CreateAnonymous()` was called in many places and the result was never disposed:

- `Aws3LinkIndexReader` now implements `IDisposable` and forwards to `s3Client.Dispose()`
- `CrossLinkFetcher.Dispose()` now also disposes its `ILinkIndexReader` if it is `IDisposable`
- `AssembleSources.AssembleAsync` wraps the cross-link fetcher in a `using` block so the S3 client is released immediately after the fetch completes
- `DocSetConfigurationCrossLinkFetcher` was creating a brand-new `AmazonS3Client` on **every** `FetchCrossLinks()` call (i.e. on every live-reload cycle in `docs-builder serve`); it now reuses the reader from the base class via the new `protected LinkIndexProvider` property

## Workflow

```bash
# one-time setup
docs-builder assembler clone

# iterate on content — pages render on demand, browser live-reloads on .md changes
docs-builder assembler serve

# frontend work — full assembled site with CSS/JS live reload, no markdown watchers
docs-builder assembler serve --no-watch-md

# full frontend loop with C# hot reload (templates, CSS, JS — all live)
./build.sh watch-full

# serve a previously built assembly as static files (old behaviour)
docs-builder assembler serve-static
```

## Test plan

- [ ] `assembler clone` followed by `assembler serve` starts the server and renders pages on demand without a prior `assembler build`
- [ ] Editing a markdown file in a checkout directory triggers a live reload and the updated content is served on the next request
- [ ] `assembler serve --no-watch-md` starts without checkout directory watchers; static-asset live reload still works in debug mode
- [ ] In debug mode (`dotnet run --configuration debug`), editing a CSS file in `src/Elastic.Documentation.Site/_static/` triggers a browser live reload
- [ ] `assembler serve-static` serves the pre-built `.artifacts/assembly/` directory as before
- [ ] `./build.sh watch-full` starts `dotnet watch` with `assembler serve`
- [ ] Ctrl+C exits cleanly without hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)