### PR TITLE
nav-v2: wire in migrate/ as top-level section under "Ingest and manage data"

### DIFF
--- a/config/navigation-v2.yml
+++ b/config/navigation-v2.yml
@@ -367,17 +367,6 @@ nav:
           title: Upload data files
         - page: docs-content://manage-data/ingest/sample-data.md
           title: Sample data
-        - group: Migrating your Elasticsearch data
-          page: docs-content://manage-data/migrate.md
-          children:
-          - page: docs-content://manage-data/migrate/migrate-from-a-self-managed-cluster-with-a-self-signed-certificate-using-remote-reindex.md
-            title: Reindex using a private CA
-          - page: docs-content://manage-data/migrate/migrate-with-logstash.md
-            title: Migrate Elastic Cloud Hosted data to Serverless with Logstash
-          - page: docs-content://manage-data/migrate/migrate-data-between-elasticsearch-clusters-with-minimal-downtime.md
-            title: Minimal-downtime migration using snapshots
-          - page: docs-content://manage-data/migrate/migrate-internal-indices.md
-            title: Migrate system indices
       - group: Ingest tools
         page: docs-content://reference/ingestion-tools/index.md
         children:
@@ -1402,6 +1391,9 @@ nav:
           title: Manage access to AI features
       - page: docs-content://explore-analyze/ai-features/agent-skills.md
         title: AI agent skills for Elastic
+  - label: Migrate your data
+    children:
+    - toc: docs-content://migrate
   - label: Solutions and project types
     children:
     - page: docs-content://solutions/index.md

--- a/config/navigation-v2.yml
+++ b/config/navigation-v2.yml
@@ -278,7 +278,7 @@ nav:
     children:
     - label: Ingest and manage data
       children:
-      - group: "Ingest or migrate: bring your data into Elasticsearch"
+      - group: "Ingest: bring your data into Elasticsearch"
         children:
         - page: docs-content://manage-data/ingest.md
           title: Choose/Plan your ingest method
@@ -367,6 +367,8 @@ nav:
           title: Upload data files
         - page: docs-content://manage-data/ingest/sample-data.md
           title: Sample data
+      - toc: docs-content://migrate
+        title: Migrate your data
       - group: Ingest tools
         page: docs-content://reference/ingestion-tools/index.md
         children:
@@ -1391,9 +1393,6 @@ nav:
           title: Manage access to AI features
       - page: docs-content://explore-analyze/ai-features/agent-skills.md
         title: AI agent skills for Elastic
-  - label: Migrate your data
-    children:
-    - toc: docs-content://migrate
   - label: Solutions and project types
     children:
     - page: docs-content://solutions/index.md

--- a/config/navigation-v2.yml
+++ b/config/navigation-v2.yml
@@ -368,7 +368,7 @@ nav:
         - page: docs-content://manage-data/ingest/sample-data.md
           title: Sample data
       - toc: docs-content://migrate
-        title: Migrate your data
+        title: Move between ingest tools
       - group: Ingest tools
         page: docs-content://reference/ingestion-tools/index.md
         children:

--- a/config/navigation.yml
+++ b/config/navigation.yml
@@ -11,6 +11,7 @@ phantoms:
   - toc: docs-content://release-notes/elasticsearch-clients
   - toc: docs-content://release-notes/apm-agents
   - toc: docs-content://
+  - toc: docs-content://migrate
   - toc: cloud://release-notes
 
 toc:


### PR DESCRIPTION
## Summary

Restructures the **Ingest and manage data** section in `navigation-v2.yml` to decouple migration content from the ingest group:

- Renames `"Ingest or migrate: bring your data into Elasticsearch"` → `"Ingest: bring your data into Elasticsearch"`
- Adds `"Migrate your data"` as a sibling entry (wired to `toc: docs-content://migrate`) directly after the ingest group, at the same level as "Ingest tools", "Data storage and lifecycle", etc.
- Removes the old `manage-data/migrate.md` sub-group from the ingest section (those pages are moving to `migrate/` via [elastic/docs-content#5946](https://github.com/elastic/docs-content/pull/5946))

## Result

Under **INGEST AND MANAGE DATA**:

| Before | After |
|---|---|
| Ingest or migrate: bring your data into Elasticsearch | Ingest: bring your data into Elasticsearch |
| *(migrate content buried inside above)* | **Migrate your data** *(new sibling)* |
| Ingest tools | Ingest tools |
| Data storage and lifecycle | Data storage and lifecycle |
| Transform and enrich data | Transform and enrich data |

## Dependencies

Depends on [elastic/docs-content#5946](https://github.com/elastic/docs-content/pull/5946) merging first (or alongside) for the `docs-content://migrate` toc to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)