### PR TITLE
Enable docs-preview-local S3 uploads

### DIFF
--- a/.github/workflows/docs-preview-local.yml
+++ b/.github/workflows/docs-preview-local.yml
@@ -258,11 +258,9 @@ jobs:
 
       - name: Generate env.PATH_PREFIX
         id: generate-path-prefix
-        # disabled: preview path prefix is not needed on this branch
         if: >
-          false
-          && env.MATCH == 'true'
-          && steps.deployment.outputs.result
+          env.MATCH == 'true'
+          && needs.check.outputs.any_modified != 'false'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
@@ -336,13 +334,10 @@ jobs:
 
       - name: Upload to S3
         id: s3-upload
-        # disabled: preview uploads are not enabled on this branch
         if: >
-          false
-          && env.MATCH == 'true'
+          env.MATCH == 'true'
           && !cancelled()
           && steps.internal-docs-build.outputs.skip != 'true'
-          && steps.deployment.outputs.result
           && steps.internal-docs-build.outcome == 'success'
         env:
           AWS_RETRY_MODE: standard

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,5 +11,6 @@ Elastic Docs V3 is our next-generation documentation platform designed to improv
 * [Contribute to Elastic documentation](https://www.elastic.co/docs/contribute-docs/)
 * [Learn about V3 syntax](./syntax/index.md)
 * [Configure content sets in V3](./configure/index.md)
+* [Explore CLI commands](./cli/index.md)
 * [Contribute to V3 (developer guide)](./development/index.md)
 * [Learn about migration to Elastic Docs V3](./migration/index.md)


### PR DESCRIPTION
## Summary
- remove the hard `false` gate from the `Upload to S3` step in `.github/workflows/docs-preview-local.yml`
- enable `Generate env.PATH_PREFIX` when matching docs changes are present, without requiring deployment outputs
- touch `docs/index.md` so the merge includes a docs change and triggers the upload path

## Test plan
- [ ] Merge this PR into `main`
- [ ] Confirm `Docs preview (local)` runs on the merge commit
- [ ] Verify `Upload to S3` executes (not skipped)

Made with [Cursor](https://cursor.com)