### PR TITLE
[API Explorer] Use ES spec with code samples

### DIFF
--- a/docs/_docset.yml
+++ b/docs/_docset.yml
@@ -47,7 +47,7 @@ suppress:
   - DeepLinkingVirtualFile
 
 api:
-   elasticsearch: elasticsearch-openapi.json
+   elasticsearch: elasticsearch-openapi-docs.json
    kibana:
      - file: kibana-api-overview.md
      - spec: kibana-openapi.json


### PR DESCRIPTION
This PR checks in the Elasticsearch OpenAPI document that contains the `x-codeSamples` so that they're visible in this branch.

It's derived from the https://github.com/elastic/elasticsearch-specification/tree/experimental-new-docs-output branch and the `make transform-to-openapi-for-docs` command. The previous file was the output from the `make transform-to-openapi` command.