### PR TITLE
Docs preview local: path-prefix build

### DIFF
--- a/.github/workflows/docs-preview-local.yml
+++ b/.github/workflows/docs-preview-local.yml
@@ -302,7 +302,7 @@ jobs:
           && needs.check.outputs.any_modified != 'false'
           && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         run: |
-          dotnet run --project src/tooling/docs-builder -- --strict
+          dotnet run --project src/tooling/docs-builder -- --strict --path-prefix "${PATH_PREFIX}"
 
       - name: 'Validate inbound links'
         if: >

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ Elastic Docs V3 is our next-generation documentation platform designed to improv
 ## What do you want to do today?
 
 * [Contribute to Elastic documentation](https://www.elastic.co/docs/contribute-docs/)
+* [Edit and preview this handbook locally](./contribute/locally.md)
 * [Learn about V3 syntax](./syntax/index.md)
 * [Configure content sets in V3](./configure/index.md)
 * [Explore CLI commands](./cli/index.md)


### PR DESCRIPTION
## Summary
Passes `PATH_PREFIX` from **Generate env.PATH_PREFIX** into `dotnet run … docs-builder … --strict` via `--path-prefix "${PATH_PREFIX}"`, so emitted HTML/static URLs match where we sync in S3 (same prefix).

## Problem
Without this, previews under `https://docs-v3-preview.elastic.dev/elastic/docs-builder/tree/...` request `/_static/...` at the bucket root (`404`), so the page renders unstyled.

## Test plan
- [ ] After merge: run Docs preview (local) on `main`.
- [ ] Open preview URL and confirm `/_static/...` requests are under `/elastic/docs-builder/tree/main/_static/...` (200).

Made with [Cursor](https://cursor.com)