### PR TITLE
Fix serve crashing when run from a git worktree

### DIFF
--- a/src/Elastic.Documentation.Configuration/FileSystemFactory.cs
+++ b/src/Elastic.Documentation.Configuration/FileSystemFactory.cs
@@ -174,10 +174,28 @@ public static class FileSystemFactory
 	/// </summary>
 	public static ScopedFileSystem RealGitRootForPath(string? path)
 	{
-		if (path is null)
+		var root = path is null ? Paths.WorkingDirectoryRoot.FullName : Paths.FindGitRoot(path);
+		var roots = new List<string> { root, Paths.ApplicationData.FullName };
+
+		// In a git worktree the local .git entry is a file pointing to the main repo's
+		// .git/worktrees/<name> directory. GitCheckoutInformation needs to read config and
+		// HEAD from the main repo's .git dir, which lives outside the worktree root.
+		// Add it as an explicit scope root so those reads are not rejected.
+		var worktreePointer = Path.Join(root, ".git");
+		if (File.Exists(worktreePointer))
+		{
+			var gitdir = File.ReadAllText(worktreePointer).Replace("gitdir:", "").Trim();
+			// gitdir = /main/repo/.git/worktrees/<name> — go up two levels to reach .git
+			var mainGitDir = Path.GetFullPath(Path.Join(gitdir, "..", ".."));
+			if (Directory.Exists(mainGitDir))
+				roots.Add(mainGitDir);
+		}
+
+		// Fast path: no worktree detected and path was null — reuse the pre-built instance
+		if (roots.Count == 2 && path is null)
 			return RealRead;
-		var root = Paths.FindGitRoot(path);
-		return new ScopedFileSystem(new FileSystem(), new ScopedFileSystemOptions([root, Paths.ApplicationData.FullName])
+
+		return new ScopedFileSystem(new FileSystem(), new ScopedFileSystemOptions([.. roots])
 		{
 			AllowedHiddenFolderNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".git", ".artifacts" },
 			AllowedHiddenFileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".git", ".doc.state" }


### PR DESCRIPTION
## Why

Running \`dotnet run --project src/tooling/docs-builder -- serve\` from a git worktree checkout throws a \`ScopedFileSystemException\` and crashes immediately. Worktrees are a common workflow for contributors working on multiple branches simultaneously, so the serve command needs to work from them.

## What

In a git worktree the \`.git\` entry is a **file** (not a directory) that points to the main repo's \`.git/worktrees/<name>\` directory. \`GitCheckoutInformation.Create\` reads \`config\` and \`HEAD\` from the main repo's \`.git\` dir to determine branch and remote — but that directory lives outside the worktree root and was rejected by \`ScopedFileSystem\`.

\`FileSystemFactory.RealGitRootForPath\` now detects the worktree pointer file in both code paths (explicit \`--path\` arg and the default \`WorkingDirectoryRoot\`), resolves the main repo's \`.git\` directory two levels up from the \`worktrees/<name>\` path, and adds it as an explicit scope root. The pre-built \`RealRead\` fast-path is preserved for the common non-worktree case.