### PR TITLE
Fix Codex DocumentationCheckoutDirectory so edit links render

### DIFF
--- a/src/Elastic.Codex/Building/CodexBuildService.cs
+++ b/src/Elastic.Codex/Building/CodexBuildService.cs
@@ -178,14 +178,16 @@ public class CodexBuildService(
 				? parsed
 				: null;
 
-			// Create build context for this documentation set
+			// Repository clone root must be BuildContext `source`: FindGitRoot(..., ceiling: rootFolder) only
+			// discovers .git inside that ceiling (#3115). Using DocsDirectory alone would cap the ceiling
+			// at the docs subtree and return null above repo/.git, breaking GithubEditUrl generation.
 			var buildContext = new BuildContext(
 				context.Collector,
 				fileSystem,
 				fileSystem,
 				configurationContext,
 				ExportOptions.Default,
-				checkout.DocsDirectory.FullName,
+				checkout.RepositoryDirectory.FullName,
 				outputPath,
 				git)
 			{

--- a/tests/Elastic.Markdown.Tests/BuildContextDocumentationCheckoutDirectoryTests.cs
+++ b/tests/Elastic.Markdown.Tests/BuildContextDocumentationCheckoutDirectoryTests.cs
@@ -1,0 +1,75 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions.TestingHelpers;
+using AwesomeAssertions;
+using Elastic.Documentation;
+using Elastic.Documentation.Configuration;
+using Elastic.Documentation.Configuration.Builder;
+using Nullean.ScopedFileSystem;
+using Xunit;
+
+namespace Elastic.Markdown.Tests;
+
+/// <summary>
+/// Regression: Codex must pass the repository clone root as <see cref="BuildContext"/> <c>source</c>
+/// so <c>FindGitRoot(..., ceiling: rootFolder)</c> can see <c>.git</c> under the ceiling (#3115).
+/// Prior bug used <c>DocsDirectory</c> only, capping the ceiling at the docs subtree.
+/// </summary>
+public class BuildContextDocumentationCheckoutDirectoryTests(ITestOutputHelper output)
+{
+	[Fact]
+	public void SourceAsRepositoryRoot_SetsDocumentationCheckoutDirectory()
+	{
+		var root = Paths.WorkingDirectoryRoot.FullName;
+		var repoPath = Path.Combine(root, "codex-checkout-dir-test");
+		var fs = new MockFileSystem(new MockFileSystemOptions { CurrentDirectory = root });
+		fs.AddDirectory(Path.Combine(repoPath, ".git"));
+		fs.AddFile(Path.Combine(repoPath, "docs", "docset.yml"), new MockFileData("toc: []\n"));
+
+		var readFs = FileSystemFactory.ScopeCurrentWorkingDirectory(fs);
+		var writeFs = FileSystemFactory.ScopeCurrentWorkingDirectory(fs);
+		var collector = new TestDiagnosticsCollector(output);
+		_ = collector.StartAsync(TestContext.Current.CancellationToken);
+		var configurationContext = TestHelpers.CreateConfigurationContext(fs);
+		var context = new BuildContext(
+			collector,
+			readFs,
+			writeFs,
+			configurationContext,
+			ExportOptions.Default,
+			source: repoPath,
+			output: Path.Combine(root, "codex-checkout-dir-test-out"));
+
+		Assert.NotNull(context.DocumentationCheckoutDirectory);
+		context.DocumentationCheckoutDirectory.FullName.Should().Be(repoPath);
+	}
+
+	[Fact]
+	public void SourceAsDocsSubtreeOnly_LeavesDocumentationCheckoutDirectoryNull()
+	{
+		var root = Paths.WorkingDirectoryRoot.FullName;
+		var repoPath = Path.Combine(root, "codex-docs-only-test");
+		var docsPath = Path.Combine(repoPath, "docs");
+		var fs = new MockFileSystem(new MockFileSystemOptions { CurrentDirectory = root });
+		fs.AddDirectory(Path.Combine(repoPath, ".git"));
+		fs.AddFile(Path.Combine(docsPath, "docset.yml"), new MockFileData("toc: []\n"));
+
+		var readFs = FileSystemFactory.ScopeCurrentWorkingDirectory(fs);
+		var writeFs = FileSystemFactory.ScopeCurrentWorkingDirectory(fs);
+		var collector = new TestDiagnosticsCollector(output);
+		_ = collector.StartAsync(TestContext.Current.CancellationToken);
+		var configurationContext = TestHelpers.CreateConfigurationContext(fs);
+		var context = new BuildContext(
+			collector,
+			readFs,
+			writeFs,
+			configurationContext,
+			ExportOptions.Default,
+			source: docsPath,
+			output: Path.Combine(root, "codex-docs-only-test-out"));
+
+		context.DocumentationCheckoutDirectory.Should().BeNull();
+	}
+}


### PR DESCRIPTION
## Why

After #3115, `FindGitRoot` uses `ceiling: rootFolder` where `rootFolder` comes from `BuildContext` `source`. Codex passed `checkout.DocsDirectory` only, so the ceiling sat at the docs subtree and the walk could not reach `repo/.git` above it. `DocumentationCheckoutDirectory` stayed null, `GithubEditUrl` was never built in `HtmlWriter`, and "Edit this page" did not appear on codex.elastic.dev (including with `?edit`).

## What

Codex now passes `checkout.RepositoryDirectory` (clone root containing `.git`) as `BuildContext` `source`, matching the contract exercised by `FindGitRootTests` (ceiling must include the checkout). Regression tests assert repository-root versus docs-only `source` behavior for `DocumentationCheckoutDirectory`.


Made with [Cursor](https://cursor.com)