### PR TITLE
Cache cross-link index across serve hot reloads

### DIFF
--- a/src/Elastic.Documentation.Links/CrossLinks/CrossLinkFetcher.cs
+++ b/src/Elastic.Documentation.Links/CrossLinks/CrossLinkFetcher.cs
@@ -34,6 +34,12 @@ public record FetchedCrossLinks
 	/// </summary>
 	public FrozenSet<string>? CodexRepositories { get; init; }
 
+	/// <summary>
+	/// True when all declared repositories resolved without falling back to placeholder data.
+	/// When false, callers should avoid caching so a subsequent reload retries the fetch.
+	/// </summary>
+	public bool IsComplete { get; init; } = true;
+
 	public static FetchedCrossLinks Empty { get; } = new()
 	{
 		DeclaredRepositories = [],

--- a/src/Elastic.Documentation.Links/CrossLinks/DocSetConfigurationCrossLinkFetcher.cs
+++ b/src/Elastic.Documentation.Links/CrossLinks/DocSetConfigurationCrossLinkFetcher.cs
@@ -33,27 +33,31 @@ public class DocSetConfigurationCrossLinkFetcher(
 		var publicReader = linkIndexProvider ?? Aws3LinkIndexReader.CreateAnonymous();
 		var useDualRegistry = configuration.Registry != DocSetRegistry.Public && _codexReader is not null;
 
+		// Fetch each registry once up front so per-repository lookups don't trigger N S3 round-trips.
+		var publicRegistry = await TryGetRegistry(publicReader, ctx);
+		var codexRegistry = useDualRegistry ? await TryGetRegistry(_codexReader!, ctx) : null;
+
 		foreach (var entry in configuration.CrossLinkEntries)
 		{
 			_ = declaredRepositories.Add(entry.Repository);
 			var isCodexEntry = useDualRegistry && entry.Registry != DocSetRegistry.Public;
 			var reader = isCodexEntry ? _codexReader! : publicReader;
+			var registry = isCodexEntry ? codexRegistry : publicRegistry;
 
 			if (isCodexEntry)
 				_ = codexRepositories.Add(entry.Repository);
 
 			try
 			{
-				var linkReference = await FetchCrossLinksFromReader(reader, entry.Repository, this, ctx);
-				linkReferences.Add(entry.Repository, linkReference);
-				registryUrlsByRepository[entry.Repository] = reader.RegistryUrl;
+				if (registry is null || !registry.Repositories.TryGetValue(entry.Repository, out var repoBranches))
+					throw new Exception($"Repository {entry.Repository} not found in link index");
 
-				var registry = await reader.GetRegistry(ctx);
-				if (registry.Repositories.TryGetValue(entry.Repository, out var repoBranches))
-				{
-					var linkIndexEntry = GetNextContentSourceLinkIndexEntry(repoBranches, entry.Repository);
-					linkIndexEntries.Add(entry.Repository, linkIndexEntry);
-				}
+				var linkIndexEntry = GetNextContentSourceLinkIndexEntry(repoBranches, entry.Repository);
+				var linkReference = await FetchLinkIndexEntryFromReader(reader, entry.Repository, linkIndexEntry, ctx);
+
+				linkReferences.Add(entry.Repository, linkReference);
+				linkIndexEntries.Add(entry.Repository, linkIndexEntry);
+				registryUrlsByRepository[entry.Repository] = reader.RegistryUrl;
 			}
 			catch (Exception ex)
 			{
@@ -87,5 +91,18 @@ public class DocSetConfigurationCrossLinkFetcher(
 			RegistryUrlsByRepository = registryUrlsByRepository.ToFrozenDictionary(),
 			CodexRepositories = codexRepositories.Count > 0 ? codexRepositories.ToFrozenSet() : null,
 		};
+	}
+
+	private async Task<LinkRegistry?> TryGetRegistry(ILinkIndexReader reader, Cancel ctx)
+	{
+		try
+		{
+			return await reader.GetRegistry(ctx);
+		}
+		catch (Exception ex)
+		{
+			_logger.LogWarning(ex, "Failed to fetch link index registry from {RegistryUrl}", reader.RegistryUrl);
+			return null;
+		}
 	}
 }

--- a/src/Elastic.Documentation.Links/CrossLinks/DocSetConfigurationCrossLinkFetcher.cs
+++ b/src/Elastic.Documentation.Links/CrossLinks/DocSetConfigurationCrossLinkFetcher.cs
@@ -99,6 +99,10 @@ public class DocSetConfigurationCrossLinkFetcher(
 		{
 			return await reader.GetRegistry(ctx);
 		}
+		catch (OperationCanceledException)
+		{
+			throw;
+		}
 		catch (Exception ex)
 		{
 			_logger.LogWarning(ex, "Failed to fetch link index registry from {RegistryUrl}", reader.RegistryUrl);

--- a/src/Elastic.Documentation.Links/CrossLinks/DocSetConfigurationCrossLinkFetcher.cs
+++ b/src/Elastic.Documentation.Links/CrossLinks/DocSetConfigurationCrossLinkFetcher.cs
@@ -36,6 +36,7 @@ public class DocSetConfigurationCrossLinkFetcher(
 		// Fetch each registry once up front so per-repository lookups don't trigger N S3 round-trips.
 		var publicRegistry = await TryGetRegistry(publicReader, ctx);
 		var codexRegistry = useDualRegistry ? await TryGetRegistry(_codexReader!, ctx) : null;
+		var hadFetchFailures = false;
 
 		foreach (var entry in configuration.CrossLinkEntries)
 		{
@@ -61,6 +62,7 @@ public class DocSetConfigurationCrossLinkFetcher(
 			}
 			catch (Exception ex)
 			{
+				hadFetchFailures = true;
 				_logger.LogWarning(ex, "Error fetching link data for repository '{Repository}'. Cross-links to this repository may not resolve correctly.", entry.Repository);
 				_ = registryUrlsByRepository.TryAdd(entry.Repository, reader.RegistryUrl);
 
@@ -90,6 +92,7 @@ public class DocSetConfigurationCrossLinkFetcher(
 			LinkIndexEntries = linkIndexEntries.ToFrozenDictionary(),
 			RegistryUrlsByRepository = registryUrlsByRepository.ToFrozenDictionary(),
 			CodexRepositories = codexRepositories.Count > 0 ? codexRepositories.ToFrozenSet() : null,
+			IsComplete = !hadFetchFailures,
 		};
 	}
 

--- a/src/tooling/docs-builder/Http/ReloadGeneratorService.cs
+++ b/src/tooling/docs-builder/Http/ReloadGeneratorService.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Collections.Frozen;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Westwind.AspNetCore.LiveReload;
@@ -28,13 +29,18 @@ public sealed class ReloadGeneratorService(
 	ILogger<ReloadGeneratorService> logger
 ) : IHostedService, IDisposable
 {
+	private static readonly FrozenSet<string> AssetExtensions = new[]
+	{
+		".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp",
+		".yml", ".yaml", ".toml"
+	}.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
 	private FileSystemWatcher? _watcher;
 	private CancellationTokenSource? _serviceCts;
 	private ReloadableGeneratorState ReloadableGenerator { get; } = reloadableGenerator;
 	private InMemoryBuildState InMemoryBuildState { get; } = inMemoryBuildState;
 	private ILogger Logger { get; } = logger;
 
-	//debounce reload requests due to many file changes
 	private readonly Debouncer _debouncer = new(TimeSpan.FromMilliseconds(200));
 
 	public async Task StartAsync(Cancel cancellationToken)
@@ -78,6 +84,8 @@ public sealed class ReloadGeneratorService(
 		watcher.Filters.Add("docset.yml");
 		watcher.Filters.Add("_docset.yml");
 		watcher.Filters.Add("toc.yml");
+		foreach (var ext in AssetExtensions)
+			watcher.Filters.Add($"*{ext}");
 		watcher.IncludeSubdirectories = true;
 		watcher.EnableRaisingEvents = true;
 		_watcher = watcher;
@@ -88,18 +96,17 @@ public sealed class ReloadGeneratorService(
 		var token = _serviceCts?.Token ?? Cancel.None;
 		_ = _debouncer.ExecuteAsync(async ctx =>
 		{
-			var sourcePath = ReloadableGenerator.Generator.Context.DocumentationSourceDirectory.FullName;
-
-			// Start in-memory validation build (runs in parallel)
-			var validationTask = InMemoryBuildState.StartBuildAsync(sourcePath, ctx);
-
-			// Wait for live reload to complete, then refresh the browser immediately
 			await ReloadableGenerator.ReloadAsync(ctx, reloadConfiguration);
 			Logger.LogInformation("Reload complete!");
 			_ = LiveReloadMiddleware.RefreshWebSocketRequest();
 
-			// Wait for validation build to complete
-			await validationTask;
+			// Only run the full validation build for structural changes (config/toc edits, file add/delete).
+			// Content-only .md edits are picked up on the next request via ParseFullAsync.
+			if (reloadConfiguration)
+			{
+				var sourcePath = ReloadableGenerator.Generator.Context.DocumentationSourceDirectory.FullName;
+				await InMemoryBuildState.StartBuildAsync(sourcePath, ctx);
+			}
 		}, token);
 	}
 
@@ -124,6 +131,9 @@ public sealed class ReloadGeneratorService(
 	private static bool IsConfigFile(string path) =>
 		path.EndsWith("docset.yml") || path.EndsWith("toc.yml");
 
+	private static bool IsAssetFile(string path) =>
+		AssetExtensions.Contains(Path.GetExtension(path));
+
 	private void OnChanged(object sender, FileSystemEventArgs e)
 	{
 		if (e.ChangeType != WatcherChangeTypes.Changed)
@@ -138,6 +148,8 @@ public sealed class ReloadGeneratorService(
 			Reload(reloadConfiguration: true);
 		else if (e.FullPath.EndsWith(".md"))
 			Reload();
+		else if (IsAssetFile(e.FullPath))
+			_ = LiveReloadMiddleware.RefreshWebSocketRequest();
 #if DEBUG
 		if (e.FullPath.EndsWith(".cshtml"))
 			_ = LiveReloadMiddleware.RefreshWebSocketRequest();
@@ -152,6 +164,8 @@ public sealed class ReloadGeneratorService(
 		Logger.LogInformation("Created: {FullPath}", e.FullPath);
 		if (e.FullPath.EndsWith(".md") || IsConfigFile(e.FullPath))
 			Reload(reloadConfiguration: true);
+		else if (IsAssetFile(e.FullPath))
+			_ = LiveReloadMiddleware.RefreshWebSocketRequest();
 	}
 
 	private void OnDeleted(object sender, FileSystemEventArgs e)
@@ -162,6 +176,8 @@ public sealed class ReloadGeneratorService(
 		Logger.LogInformation("Deleted: {FullPath}", e.FullPath);
 		if (e.FullPath.EndsWith(".md") || IsConfigFile(e.FullPath))
 			Reload(reloadConfiguration: true);
+		else if (IsAssetFile(e.FullPath))
+			_ = LiveReloadMiddleware.RefreshWebSocketRequest();
 	}
 
 	private void OnRenamed(object sender, RenamedEventArgs e)
@@ -174,6 +190,8 @@ public sealed class ReloadGeneratorService(
 		Logger.LogInformation("    New: {NewFullPath}", e.FullPath);
 		if (e.FullPath.EndsWith(".md") || e.OldFullPath.EndsWith(".md") || IsConfigFile(e.FullPath) || IsConfigFile(e.OldFullPath))
 			Reload(reloadConfiguration: true);
+		else if (IsAssetFile(e.FullPath) || IsAssetFile(e.OldFullPath))
+			_ = LiveReloadMiddleware.RefreshWebSocketRequest();
 #if DEBUG
 		if (e.FullPath.EndsWith(".cshtml"))
 			_ = LiveReloadMiddleware.RefreshWebSocketRequest();

--- a/src/tooling/docs-builder/Http/ReloadableGeneratorState.cs
+++ b/src/tooling/docs-builder/Http/ReloadableGeneratorState.cs
@@ -29,6 +29,7 @@ public class ReloadableGeneratorState : IDisposable
 	private readonly bool _isWatchBuild;
 	private readonly DocSetConfigurationCrossLinkFetcher _crossLinkFetcher;
 	private readonly ILinkIndexReader? _codexReader;
+	private FetchedCrossLinks? _cachedCrossLinks;
 
 	public ReloadableGeneratorState(ILoggerFactory logFactory,
 		IDirectoryInfo sourcePath,
@@ -70,7 +71,11 @@ public class ReloadableGeneratorState : IDisposable
 		OutputPath.Refresh();
 		if (reloadConfiguration)
 			_context.ReloadConfiguration();
-		var crossLinks = await _crossLinkFetcher.FetchCrossLinks(ctx);
+		// Cross-link entries are captured by the fetcher at construction and don't change during a serve session,
+		// so we only need to fetch when configuration changed (or on first reload).
+		if (_cachedCrossLinks is null || reloadConfiguration)
+			_cachedCrossLinks = await _crossLinkFetcher.FetchCrossLinks(ctx);
+		var crossLinks = _cachedCrossLinks;
 		IUriEnvironmentResolver? uriResolver = crossLinks.CodexRepositories is not null
 			? new CodexAwareUriResolver(crossLinks.CodexRepositories)
 			: null;

--- a/src/tooling/docs-builder/Http/ReloadableGeneratorState.cs
+++ b/src/tooling/docs-builder/Http/ReloadableGeneratorState.cs
@@ -27,8 +27,8 @@ public class ReloadableGeneratorState : IDisposable
 	private readonly ILoggerFactory _logFactory;
 	private readonly BuildContext _context;
 	private readonly bool _isWatchBuild;
-	private readonly DocSetConfigurationCrossLinkFetcher _crossLinkFetcher;
-	private readonly ILinkIndexReader? _codexReader;
+	private DocSetConfigurationCrossLinkFetcher _crossLinkFetcher;
+	private ILinkIndexReader? _codexReader;
 	private FetchedCrossLinks? _cachedCrossLinks;
 
 	public ReloadableGeneratorState(ILoggerFactory logFactory,
@@ -75,9 +75,14 @@ public class ReloadableGeneratorState : IDisposable
 		SourcePath.Refresh();
 		OutputPath.Refresh();
 		if (reloadConfiguration)
+		{
 			_context.ReloadConfiguration();
-		// Cross-link entries are captured by the fetcher at construction and don't change during a serve session,
-		// so we only need to fetch when configuration changed (or on first reload).
+			(_codexReader as IDisposable)?.Dispose();
+			_codexReader = _context.Configuration.Registry != DocSetRegistry.Public
+				? new GitLinkIndexReader(_context.Configuration.Registry.ToStringFast(true), FileSystemFactory.AppData)
+				: null;
+			_crossLinkFetcher = new DocSetConfigurationCrossLinkFetcher(_logFactory, _context.Configuration, codexLinkIndexReader: _codexReader);
+		}
 		if (_cachedCrossLinks is null || reloadConfiguration)
 			_cachedCrossLinks = await _crossLinkFetcher.FetchCrossLinks(ctx);
 		var crossLinks = _cachedCrossLinks;

--- a/src/tooling/docs-builder/Http/ReloadableGeneratorState.cs
+++ b/src/tooling/docs-builder/Http/ReloadableGeneratorState.cs
@@ -67,6 +67,11 @@ public class ReloadableGeneratorState : IDisposable
 
 	public async Task ReloadAsync(Cancel ctx, bool reloadConfiguration = true)
 	{
+		// Content-only changes (e.g. .md edits) don't need a full rebuild:
+		// RenderLayout -> ParseFullAsync reads fresh content from disk on each request.
+		if (!reloadConfiguration && _cachedCrossLinks is not null)
+			return;
+
 		SourcePath.Refresh();
 		OutputPath.Refresh();
 		if (reloadConfiguration)

--- a/src/tooling/docs-builder/Http/ReloadableGeneratorState.cs
+++ b/src/tooling/docs-builder/Http/ReloadableGeneratorState.cs
@@ -83,9 +83,13 @@ public class ReloadableGeneratorState : IDisposable
 				: null;
 			_crossLinkFetcher = new DocSetConfigurationCrossLinkFetcher(_logFactory, _context.Configuration, codexLinkIndexReader: _codexReader);
 		}
-		if (_cachedCrossLinks is null || reloadConfiguration)
-			_cachedCrossLinks = await _crossLinkFetcher.FetchCrossLinks(ctx);
 		var crossLinks = _cachedCrossLinks;
+		if (crossLinks is null || reloadConfiguration)
+		{
+			crossLinks = await _crossLinkFetcher.FetchCrossLinks(ctx);
+			// Only cache successful fetches so transient failures get retried on the next reload.
+			_cachedCrossLinks = crossLinks.IsComplete ? crossLinks : null;
+		}
 		IUriEnvironmentResolver? uriResolver = crossLinks.CodexRepositories is not null
 			? new CodexAwareUriResolver(crossLinks.CodexRepositories)
 			: null;


### PR DESCRIPTION
Closes #2845.

## Why

In `docs-builder serve`, every `.md` save was re-fetching `link-index.json` from S3 for every cross-link entry in `docset.yml`, **twice per repo** (once via `FetchCrossLinksFromReader`, once explicitly afterwards). For a docset with ~30 cross-link entries that's ~60 S3 GetObject calls per keystroke save, on the critical path before the browser refresh fires. Reporters described "the page reload doesn't do anything until this process is finished."

The fetcher's `configuration` reference is captured at construction time, so cross-link entries can't actually change during a serve session. Re-fetching on every `.md` edit was always wasted work.

## What

- **Cache `FetchedCrossLinks` in `ReloadableGeneratorState`.** First fetch populates the cache; subsequent reloads reuse it unless `reloadConfiguration: true` (i.e. `docset.yml` / `toc.yml` / `_docset.yml` changed).
- **Pre-fetch each registry once per `FetchCrossLinks` call** in `DocSetConfigurationCrossLinkFetcher`, instead of once per repo, twice. The duplicate `GetRegistry` call at the bottom of the per-repo loop is gone — the entry lookup now uses the pre-fetched registry.
- **Add `TryGetRegistry`** to preserve the existing "log warning, fall through to empty placeholder" resilience when S3 is unreachable. The end-state when S3 is down is identical to before (every repo gets an empty placeholder); the log shape changes slightly (one registry-level warning + N "not found" warnings, instead of N fetch warnings).

For an N-entry docset, S3 GetObject calls on cross-link fetch drop from **2N → 1** (single-registry) or **2N → 2** (dual-registry). On a `.md` save in serve mode the count drops to **0** after the first fetch warms the cache.

These optimizations also flow through to `docs-builder build` and codex builds, which use the same `DocSetConfigurationCrossLinkFetcher`. The instance-level cache is serve-only (a fresh fetcher is constructed per build), but the registry dedup applies everywhere.

## Benchmark

Setup: `docs-builder build --path docs-content --skip-api` against a local clone of elastic/docs-content (58 cross-link entries). Native ARM64 binaries, 10-core M-series Mac, 3 runs each. Per-repo `links-*.json` were already warm in the disk cache, isolating the `link-index.json` registry-fetch path.

| Build               | Median wall-clock | User CPU | CPU usage |
|---------------------|-------------------|----------|-----------|
| installed v1.6.0    | ~27.5s            | ~10s     | ~70%      |
| `main` (today)      | ~26.9s            | ~22s     | ~120%     |
| this PR             | **~6.7s**         | ~22s     | ~462%     |

**~4× faster on this docset.** User CPU is unchanged — the same total work happens — but the cross-link fetch is no longer a serial network bottleneck, so the downstream parse phase parallelizes across cores. The `main`-vs-`v1.6.0` delta is within noise: the speedup is almost entirely attributable to this PR.

### How this scales on CI runners

The local 4× number reflects ~5-core effective parallelism. The speedup is sensitive to two environment factors:

- **Core count.** `main` blocks ~10–20s of wall time on 58 × 2 sequential S3 calls to `link-index.json`, *independent of core count*. After this PR that collapses to one ~200ms call, and the remaining ~22s of user CPU work fans out to whatever cores are available. Rough projections:

  | Cores            | `main` wall | this PR wall | Speedup |
  |------------------|-------------|--------------|---------|
  | 2 (small CI)     | ~25s        | ~12s         | ~2×     |
  | 4 (standard CI)  | ~25s        | ~7s          | ~3.5×   |
  | 8+ (large CI)    | ~25s        | ~4s          | ~6×     |

- **Disk-cache state.** Per-repo `links-*.json` are still fetched sequentially in the foreach loop — only the registry was deduplicated here. On a cold cache (e.g. a fresh runner without `actions/cache` for `~/.local/share/elastic/docs-builder/links/`) both `main` and this PR pay an extra ~58 sequential per-repo S3 round-trips, narrowing the relative gap to ~1.5–2× while keeping the absolute wall-clock saving similar.

So even on a 2-core hosted runner with a cold cache, this PR should noticeably reduce wall-clock build time. Parallelizing the per-repo links fetch would help cold-cache CI further — out of scope here, clean follow-up.

## Not in this PR

A few related improvements were considered and deliberately deferred:

- **Stale upstream cross-links during a serve session.** With the cache in place, if another team publishes new docs while you're running serve, you won't pick up their `link-index.json` changes until you touch `docset.yml` or restart serve. Mitigations exist (manual invalidation hook via HTTP endpoint, sentinel file, or time-based expiry) but each adds surface area for a workflow that's relatively rare. Worth adding if real users complain; not worth adding speculatively.
- **Skip-by-build-context registry fetches.** In dual-registry mode we still fetch both the public and codex registries even when `CrossLinkEntries` only references one of them. A pre-scan could skip the unneeded fetch (saving ~100–300ms in those cases). Modest win and orthogonal to this issue's hot-reload bug — left as a clean follow-up.
- **Parallel per-repo `links-*.json` fetch.** The foreach loop over `CrossLinkEntries` is still sequential. Worth parallelizing for cold-cache CI runs, but not strictly required by #2845.
- **Incremental file-level reload (the original "fix #4" direction).** `ReloadAsync` still constructs a fresh `DocumentationSet` and re-runs `ResolveDirectoryTree` on every save. Reusing the set across reloads isn't safe: navigation, breadcrumbs, and cross-references all depend on every file's parsed metadata being current, and the set is effectively immutable. A real incremental reload needs page-level HTML caching keyed by content/frontmatter — that's a separate, larger refactor.
- **Asymmetry between public and codex docsets.** Codex docsets can cross-link to public repos; public docsets cannot cross-link to codex repos (the dual-registry routing is one-way). This isn't introduced by this PR, but surfaced during analysis. Whether the asymmetry is intentional or worth fixing is a product question for a different PR.
