### PR TITLE
[Changelog] Strip dash from title prefix

### DIFF
--- a/docs/cli/changelog/add.md
+++ b/docs/cli/changelog/add.md
@@ -92,10 +92,11 @@ docs-builder changelog add [options...] [-h|--help]
 :   Optional: GitHub repository name (used when `--prs`, `--issues`, or `--release-version` is specified). Falls back to `bundle.repo` in `changelog.yml` when not specified.
 
 `--strip-title-prefix`
-:   Optional: When used with `--prs`, remove square brackets and text within them from the beginning of PR titles, and also remove a colon if it follows the closing bracket.
-:   For example, if a PR title is `"[Attack discovery]: Improves Attack discovery hallucination detection"`, the changelog title will be `"Improves Attack discovery hallucination detection"`.
-:   Multiple square bracket prefixes are also supported (for example `"[Discover][ESQL] Fix filtering by multiline string fields"` becomes `"Fix filtering by multiline string fields"`).
-:   This option applies only when the title is derived from the PR (when `--title` is not explicitly provided).
+:   Optional: When used with `--prs` or `--issues`, remove square brackets and text within them from the beginning of PR or issue titles, remove a colon if it follows the closing bracket, and remove a single ASCII hyphen when it's immediately after that prefix and followed by whitespace.
+:   For example, if a PR title is `"[Discover][ESQL]: Fix filtering by multiline string fields"` it becomes `"Fix filtering by multiline string fields"`.
+:   Likewise `"[Cases] - Enable numerical id service"` becomes `"Enable numerical id service"`.
+:   When a derived title still begins with `-`, `*`, `+`, an en dash, or an em dash, the emitted YAML uses a quoted `title` value so it is valid and unambiguous.
+:   This option applies only when the title is derived from GitHub (when `--title` is not explicitly provided).
 :   By default, the behavior is determined by the `extract.strip_title_prefix` changelog configuration setting (which defaults to `false`).
 
 `--subtype <string?>`
@@ -197,7 +198,6 @@ In each of these cases where validation fails, a changelog file is not created.
 
 If the configuration file contains `rules.create` definitions and a PR or issue has a blocking label, that PR is skipped and no changelog file is created for it.
 For more information, refer to [Rules for creation and publishing](/contribute/configure-changelogs.md#rules).
-
 
 ## CI auto-detection [ci-auto-detection]
 

--- a/docs/cli/changelog/evaluate-pr.md
+++ b/docs/cli/changelog/evaluate-pr.md
@@ -51,7 +51,8 @@ docs-builder changelog evaluate-pr [options...] [-h|--help]
 :   Default: `false`
 
 `--strip-title-prefix`
-:   Remove square-bracket prefixes from the PR title (e.g., `[Inference API] Title` becomes `Title`).
+:   Remove square-bracket prefixes from the PR title (for example, `[Inference API] Title` becomes `Title`), strip an optional colon after the prefix, and strip an ASCII ` - `-style separator after the prefix when the hyphen is followed by whitespace.
+:   Titles that still start with `-`, `*`, `+`, an en dash, or an em dash are surrounded by quotes to avoid rendering problems.
 :   Default: `false`
 
 `--bot-name <string>`

--- a/docs/cli/changelog/gh-release.md
+++ b/docs/cli/changelog/gh-release.md
@@ -44,10 +44,11 @@ docs-builder changelog gh-release <repo> [version] [options...] [-h|--help]
 :   If the GitHub release has no published date, falls back to today's date (UTC).
 
 `--strip-title-prefix`
-:   Optional: Remove square brackets and the text within them from the beginning of pull request titles, and also remove a colon if it follows the closing bracket.
-:   For example, `"[Inference API] New embedding model support"` becomes `"New embedding model support"`.
-:   Multiple bracket prefixes are also supported (for example, `"[Discover][ESQL] Fix filtering"` becomes `"Fix filtering"`).
+:   Optional: Remove square brackets and the text within them from the beginning of pull request titles, remove a colon or a single ASCII hyphen if it follows the closing bracket and is followed by whitespace.
+:   Multiple bracket prefixes are also supported (for example, `"[Discover][ESQL] - Fix filtering"` becomes `"Fix filtering"`).
+:   When the title still begins with `-`, `*`, `+`, an en dash, or an em dash, it's surrounded by quotes.
 :   By default, the behavior is determined by the `extract.strip_title_prefix` changelog configuration setting (which defaults to `false`).
+
 `--warn-on-type-mismatch`
 :   Optional: Warn when the type inferred from Release Drafter section headers (for example, "Bug Fixes") doesn't match the type derived from the pull request's labels. Defaults to `true`.
 
@@ -98,10 +99,4 @@ docs-builder changelog gh-release elasticsearch v9.2.0 \
 ```sh
 docs-builder changelog gh-release elasticsearch v9.2.0 \
   --description "Elasticsearch {version} includes new features and fixes. Download: https://github.com/{owner}/{repo}/releases/tag/v{version}"
-```
-
-### Strip component prefixes from titles
-
-```sh
-docs-builder changelog gh-release elasticsearch v9.2.0 --strip-title-prefix
 ```

--- a/docs/contribute/configure-changelogs-ref.md
+++ b/docs/contribute/configure-changelogs-ref.md
@@ -122,7 +122,7 @@ The extracted release note text is used in the changelog `description`.
 
 When `extract.strip_title_prefix` is `true`:
 
-- The separator hyphen is removed only when at least one bracket prefix was stripped; PR titles that intentionally start with `- ` and have no bracket prefix are left unchanged.
+- The separator hyphen is removed only when at least one bracket prefix was stripped; PR titles that intentionally start with `-` followed by whitespace and have no bracket prefix are left unchanged.
 - Titles that still begin with `-`, `*`, `+`, an en dash (U+2013), or an em dash (U+2014) are surrounded in quotes so they're not parsed as list markers.
 - The title cleanup only occurs when the title is derived from GitHub. If you specify `--title` explicitly, that title is used as-is without any prefix stripping.
 

--- a/docs/contribute/configure-changelogs-ref.md
+++ b/docs/contribute/configure-changelogs-ref.md
@@ -104,8 +104,8 @@ Controls how the `changelog add` command extracts information from PR descriptio
 | Setting                      | Description                                                         |
 | ---------------------------- | ------------------------------------------------------------------- |
 | `extract.issues`             | Auto-extract linked issues/PRs from descriptions (default: `true`). |
-| `extract.release_notes`      | Auto-extract descriptions from GitHub (default: `true`).  |
-| `extract.strip_title_prefix` | Remove square-bracket prefixes from PR titles (default: `false`).   |
+| `extract.release_notes`      | Auto-extract descriptions from GitHub (default: `true`). |
+| `extract.strip_title_prefix` | Remove square-bracket prefixes from PR titles; strip a single hyphen separator or colon after the prefix when it is followed by whitespace (default: `false`). |
 
 When `extract.issues` is `true`, the system looks for patterns like "Fixes #123" in PR bodies (when you're creating changelogs from PRs) or "Fixed by #123" in issue bodies (when you're creating changelogs from issues).
 
@@ -120,13 +120,11 @@ When `extract.release_notes` is `true`, the system looks for content like this i
 
 The extracted release note text is used in the changelog `description`.
 
-When `extract.strip_title_prefix` is `true` and PR or issue titles have a prefix in square brackets (such as `[ES|QL]` or `[Security]`), they are automatically removed from the changelog title.
-Multiple square bracket prefixes are also supported (for example `[Discover][ESQL] Title` becomes `Title`).
-If a colon follows the closing bracket, it is also removed.
+When `extract.strip_title_prefix` is `true`:
 
-:::{note}
-The title cleanup only occurs when the title is derived from GitHub. If you specify `--title` explicitly, that title is used as-is without any prefix stripping.
-:::
+- The separator hyphen is removed only when at least one bracket prefix was stripped; PR titles that intentionally start with `- ` and have no bracket prefix are left unchanged.
+- Titles that still begin with `-`, `*`, `+`, an en dash (U+2013), or an em dash (U+2014) are surrounded in quotes so they're not parsed as list markers.
+- The title cleanup only occurs when the title is derived from GitHub. If you specify `--title` explicitly, that title is used as-is without any prefix stripping.
 
 ## Filename [filename]
 

--- a/src/Elastic.Documentation.Configuration/Changelog/ExtractConfiguration.cs
+++ b/src/Elastic.Documentation.Configuration/Changelog/ExtractConfiguration.cs
@@ -23,7 +23,10 @@ public record ExtractConfiguration
 
 	/// <summary>
 	/// Whether to strip square-bracket prefixes from PR titles by default.
-	/// Defaults to false. When enabled, titles like "[ES|QL] Fix bug" become "Fix bug".
+	/// Defaults to false. When enabled, titles like "[ES|QL] Fix bug" become "Fix bug",
+	/// and a single ASCII hyphen used as a team separator after the prefix is removed when it is followed by whitespace
+	/// (for example "[Team] - Do something" becomes "Do something").
+	/// Serialized changelog YAML uses quoted scalars when a title still starts with <c>-</c>, <c>*</c>, <c>+</c>, en dash, or em dash so the value is not parsed as a list marker.
 	/// Can be overridden by CLI --strip-title-prefix flag.
 	/// </summary>
 	public bool StripTitlePrefix { get; init; }

--- a/src/Elastic.Documentation.Configuration/ReleaseNotes/ReleaseNotesSerialization.cs
+++ b/src/Elastic.Documentation.Configuration/ReleaseNotes/ReleaseNotesSerialization.cs
@@ -4,6 +4,7 @@
 
 using System.Globalization;
 using System.IO.Abstractions;
+using System.Text;
 using System.Text.RegularExpressions;
 using Elastic.Documentation.Configuration.Serialization;
 using Elastic.Documentation.ReleaseNotes;
@@ -80,7 +81,8 @@ public static partial class ReleaseNotesSerialization
 	public static string SerializeEntry(ChangelogEntry entry)
 	{
 		var dto = ToDto(entry);
-		return YamlSerializer.Serialize(dto);
+		var yaml = YamlSerializer.Serialize(dto);
+		return ApplyDefensiveTitleQuotingIfNeeded(yaml, entry.Title);
 	}
 
 	/// <summary>
@@ -90,6 +92,55 @@ public static partial class ReleaseNotesSerialization
 	{
 		var dto = ToDto(bundle);
 		return YamlSerializer.Serialize(dto);
+	}
+
+	private static string ApplyDefensiveTitleQuotingIfNeeded(string yaml, string? title)
+	{
+		if (!ChangelogTextUtilities.TitleNeedsDefensiveYamlQuoting(title))
+			return yaml;
+
+		var lines = yaml.Split('\n');
+		for (var i = 0; i < lines.Length; i++)
+		{
+			var line = lines[i];
+			var trimmedStart = line.TrimStart();
+			if (!trimmedStart.StartsWith("title:", StringComparison.Ordinal))
+				continue;
+
+			var colonIdx = line.IndexOf(':');
+			if (colonIdx < 0)
+				continue;
+
+			var valuePart = line[(colonIdx + 1)..].TrimStart();
+			if (valuePart.Length > 0 && (valuePart[0] == '"' || valuePart[0] == '\''))
+				return yaml;
+
+			lines[i] = string.Concat(line.AsSpan(0, colonIdx + 1), " ", ToYamlDoubleQuotedString(title!));
+			break;
+		}
+
+		return string.Join('\n', lines);
+	}
+
+	private static string ToYamlDoubleQuotedString(string s)
+	{
+		var sb = new StringBuilder(s.Length + 2);
+		_ = sb.Append('"');
+		foreach (var c in s)
+		{
+			_ = c switch
+			{
+				'\\' => sb.Append("\\\\"),
+				'"' => sb.Append("\\\""),
+				'\n' => sb.Append("\\n"),
+				'\r' => sb.Append("\\r"),
+				'\t' => sb.Append("\\t"),
+				_ => c < 0x20 ? sb.AppendFormat(CultureInfo.InvariantCulture, "\\u{0:X4}", (int)c) : sb.Append(c),
+			};
+		}
+
+		_ = sb.Append('"');
+		return sb.ToString();
 	}
 
 	#region Manual Mapping Methods

--- a/src/Elastic.Documentation.Configuration/ReleaseNotes/ReleaseNotesSerialization.cs
+++ b/src/Elastic.Documentation.Configuration/ReleaseNotes/ReleaseNotesSerialization.cs
@@ -115,6 +115,10 @@ public static partial class ReleaseNotesSerialization
 			if (valuePart.Length > 0 && (valuePart[0] == '"' || valuePart[0] == '\''))
 				return yaml;
 
+			// Block literals (| / >) span following lines; rewriting only the header orphans continuations.
+			if (valuePart.Length > 0 && (valuePart[0] == '|' || valuePart[0] == '>'))
+				return yaml;
+
 			lines[i] = string.Concat(line.AsSpan(0, colonIdx + 1), " ", ToYamlDoubleQuotedString(title!));
 			break;
 		}

--- a/src/Elastic.Documentation/ReleaseNotes/ChangelogTextUtilities.cs
+++ b/src/Elastic.Documentation/ReleaseNotes/ChangelogTextUtilities.cs
@@ -100,7 +100,9 @@ public static partial class ChangelogTextUtilities
 	}
 
 	/// <summary>
-	/// Strips square bracket prefix(es) and optional colon from title (e.g., "[Inference API] Title" -> "Title", "[Discover][ESQL] Title" -> "Title")
+	/// Strips square bracket prefix(es), optional colon, and a single ASCII hyphen used as a team/title separator
+	/// when it is followed by whitespace (e.g. <c>[Cases] - Enable …</c> → <c>Enable …</c>).
+	/// The hyphen is removed only when the prefix strip removed at least one bracket segment.
 	/// </summary>
 	public static string StripSquareBracketPrefix(string title)
 	{
@@ -108,10 +110,12 @@ public static partial class ChangelogTextUtilities
 			return title;
 
 		var span = title.AsSpan();
+		var removedBracketPrefix = false;
 
 		// Keep stripping square bracket prefixes until there are no more at the start
 		while (span.Length > 0 && span[0] == '[')
 		{
+			removedBracketPrefix = true;
 			// Find the matching ']'
 			var closingBracketIndex = span.IndexOf(']');
 			if (closingBracketIndex < 0)
@@ -128,7 +132,34 @@ public static partial class ChangelogTextUtilities
 		if (span.Length > 0 && span[0] == ':')
 			span = span[1..].TrimStart();
 
+		if (removedBracketPrefix &&
+			span.Length >= 2 &&
+			span[0] == '-' &&
+			char.IsWhiteSpace(span[1]))
+			span = span[2..].TrimStart();
+
 		return span.ToString();
+	}
+
+	/// <summary>
+	/// Whether a changelog title should be emitted as an explicitly quoted YAML scalar so unambiguous
+	/// plain scalars are not parsed as list markers. Does not change the semantic title string.
+	/// </summary>
+	public static bool TitleNeedsDefensiveYamlQuoting(string? title)
+	{
+		if (string.IsNullOrEmpty(title))
+			return false;
+
+		var s = title.AsSpan().TrimStart();
+		if (s.IsEmpty)
+			return false;
+
+		return s[0] switch
+		{
+			'-' or '*' or '+' => true,
+			'\u2013' or '\u2014' => true,
+			_ => false
+		};
 	}
 
 	/// <summary>

--- a/tests/Elastic.Changelog.Tests/Changelogs/Create/TitleProcessingTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/Create/TitleProcessingTests.cs
@@ -197,6 +197,63 @@ public class TitleProcessingTests(ITestOutputHelper output) : CreateChangelogTes
 	}
 
 	[Fact]
+	public async Task CreateChangelog_WithStripTitlePrefix_StripsKibanaStyleTeamHyphenSeparator()
+	{
+		var prInfo = new GitHubPrInfo
+		{
+			Title = "[Cases] - Enable cases numerical id service",
+			Labels = ["type:feature"]
+		};
+
+		A.CallTo(() => MockGitHubService.FetchPrInfoAsync(
+				"https://github.com/elastic/kibana/pull/238555",
+				null,
+				null,
+				A<CancellationToken>._))
+			.Returns(prInfo);
+
+		var configContent =
+			"""
+			pivot:
+			  types:
+			    feature: "type:feature"
+			    bug-fix:
+			    breaking-change:
+			lifecycles:
+			  - preview
+			  - beta
+			  - ga
+			""";
+		var configPath = await CreateConfigDirectory(configContent);
+
+		var service = CreateService();
+
+		var input = new CreateChangelogArguments
+		{
+			Prs = ["https://github.com/elastic/kibana/pull/238555"],
+			Products = [new ProductArgument { Product = "kibana", Target = "9.2.0", Lifecycle = "ga" }],
+			Config = configPath,
+			Output = CreateOutputDirectory(),
+			StripTitlePrefix = true
+		};
+
+		var result = await service.CreateChangelog(Collector, input, TestContext.Current.CancellationToken);
+
+		result.Should().BeTrue();
+		Collector.Errors.Should().Be(0);
+
+		var outputDir = input.Output ?? FileSystem.Directory.GetCurrentDirectory();
+		if (!FileSystem.Directory.Exists(outputDir))
+			FileSystem.Directory.CreateDirectory(outputDir);
+		var files = FileSystem.Directory.GetFiles(outputDir, "*.yaml");
+		files.Should().HaveCount(1);
+
+		var yamlContent = await FileSystem.File.ReadAllTextAsync(files[0], TestContext.Current.CancellationToken);
+		yamlContent.Should().Contain("title: Enable cases numerical id service");
+		yamlContent.Should().NotContain("title: '- Enable");
+	}
+
+	[Fact]
 	public async Task CreateChangelog_WithExplicitTitle_OverridesPrTitle()
 	{
 		// Arrange

--- a/tests/Elastic.Changelog.Tests/Evaluation/ChangelogPrEvaluationServiceTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/ChangelogPrEvaluationServiceTests.cs
@@ -308,6 +308,22 @@ public class ChangelogPrEvaluationServiceTests : ChangelogTestBase
 	}
 
 	[Fact]
+	public async Task EvaluatePr_StripTitlePrefix_RemovesKibanaStyleTeamHyphenSeparator()
+	{
+		await WriteMinimalConfig();
+		var service = CreateService();
+		var args = DefaultArgs(prTitle: "[Cases] - Enable cases numerical id service") with
+		{
+			StripTitlePrefix = true
+		};
+
+		var result = await service.EvaluatePr(Collector, args, CancellationToken.None);
+
+		result.Should().BeTrue();
+		VerifyOutputSet("title", "Enable cases numerical id service");
+	}
+
+	[Fact]
 	public async Task EvaluatePr_NoConfig_UsesDefaults()
 	{
 		var service = CreateService();

--- a/tests/Elastic.Documentation.Configuration.Tests/ReleaseNotes/ChangelogTextUtilitiesTests.cs
+++ b/tests/Elastic.Documentation.Configuration.Tests/ReleaseNotes/ChangelogTextUtilitiesTests.cs
@@ -52,10 +52,30 @@ public class ChangelogTextUtilitiesTests
 	[InlineData("[Test] Title", "Title")]
 	[InlineData("No bracket prefix", "No bracket prefix")]
 	[InlineData("[Unclosed bracket", "[Unclosed bracket")]
+	[InlineData("[Cases] - Enable cases numerical id service", "Enable cases numerical id service")]
+	[InlineData("[Team] - Leading", "Leading")]
+	[InlineData("- Leading dash without brackets", "- Leading dash without brackets")]
+	[InlineData("[Team]-NoSpace", "-NoSpace")]
 	public void StripSquareBracketPrefix_RemovesPrefix(string input, string expected)
 	{
 		var result = ChangelogTextUtilities.StripSquareBracketPrefix(input);
 		result.Should().Be(expected);
+	}
+
+	[Theory]
+	[InlineData(null, false)]
+	[InlineData("", false)]
+	[InlineData("  ", false)]
+	[InlineData("Plain title", false)]
+	[InlineData("- Leading dash", true)]
+	[InlineData("  - Leading dash", true)]
+	[InlineData("* Star", true)]
+	[InlineData("+ Plus", true)]
+	[InlineData("\u2013 En dash", true)]
+	[InlineData("\u2014 Em dash", true)]
+	public void TitleNeedsDefensiveYamlQuoting_DetectsBulletLikeScalars(string? input, bool expected)
+	{
+		ChangelogTextUtilities.TitleNeedsDefensiveYamlQuoting(input).Should().Be(expected);
 	}
 
 	[Theory]

--- a/tests/Elastic.Documentation.Configuration.Tests/ReleaseNotes/ReleaseNotesSerializationTests.cs
+++ b/tests/Elastic.Documentation.Configuration.Tests/ReleaseNotes/ReleaseNotesSerializationTests.cs
@@ -51,4 +51,23 @@ public class ReleaseNotesSerializationTests
 		yaml.Should().Contain("title: Enable numerical id service");
 		yaml.Should().NotContain("title: \"Enable numerical id service\"");
 	}
+
+	[Fact]
+	public void SerializeEntry_MultilineTitleStartingWithDash_RoundTrips()
+	{
+		var entry = new ChangelogEntry
+		{
+			Title = "- line1\nline2",
+			Type = ChangelogEntryType.Feature,
+			Products =
+			[
+				new ProductReference { ProductId = "kibana", Lifecycle = Lifecycle.Ga }
+			]
+		};
+
+		var yaml = ReleaseNotesSerialization.SerializeEntry(entry);
+
+		var roundTrip = ReleaseNotesSerialization.DeserializeEntry(yaml);
+		roundTrip.Title.Should().Be("- line1\nline2");
+	}
 }

--- a/tests/Elastic.Documentation.Configuration.Tests/ReleaseNotes/ReleaseNotesSerializationTests.cs
+++ b/tests/Elastic.Documentation.Configuration.Tests/ReleaseNotes/ReleaseNotesSerializationTests.cs
@@ -1,0 +1,54 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using AwesomeAssertions;
+using Elastic.Documentation.Configuration.ReleaseNotes;
+using Elastic.Documentation.ReleaseNotes;
+
+namespace Elastic.Documentation.Configuration.Tests.ReleaseNotes;
+
+public class ReleaseNotesSerializationTests
+{
+	[Fact]
+	public void SerializeEntry_TitleStartingWithDash_EmitsDoubleQuotedTitleAndRoundTrips()
+	{
+		var entry = new ChangelogEntry
+		{
+			Title = "- Manual leading dash",
+			Type = ChangelogEntryType.Feature,
+			Products =
+			[
+				new ProductReference { ProductId = "kibana", Lifecycle = Lifecycle.Ga }
+			]
+		};
+
+		var yaml = ReleaseNotesSerialization.SerializeEntry(entry);
+
+		(yaml.Contains("title: \"- Manual leading dash\"", StringComparison.Ordinal) ||
+			yaml.Contains("title: '- Manual leading dash'", StringComparison.Ordinal))
+			.Should().BeTrue("title must be a quoted YAML scalar so '-' is not parsed as a list marker");
+
+		var roundTrip = ReleaseNotesSerialization.DeserializeEntry(yaml);
+		roundTrip.Title.Should().Be("- Manual leading dash");
+	}
+
+	[Fact]
+	public void SerializeEntry_PlainTitle_DoesNotForceDoubleQuotes()
+	{
+		var entry = new ChangelogEntry
+		{
+			Title = "Enable numerical id service",
+			Type = ChangelogEntryType.Feature,
+			Products =
+			[
+				new ProductReference { ProductId = "kibana", Lifecycle = Lifecycle.Ga }
+			]
+		};
+
+		var yaml = ReleaseNotesSerialization.SerializeEntry(entry);
+
+		yaml.Should().Contain("title: Enable numerical id service");
+		yaml.Should().NotContain("title: \"Enable numerical id service\"");
+	}
+}


### PR DESCRIPTION
## Summary

This PR fixes the `docs-builder changelog add` command's `--strip-title-prefix` option (and matching config file option) so that it handles titles like: `[Cases] - Enable cases numerical id service`.  When creating changelogs, the square brackets are stripped but the hyphen remained and was ultimately renadered as a bullet point.

## Screenshots

Before:

```yaml
prs:
- https://github.com/elastic/kibana/pull/238555
...
title: '- Enable cases numerical id service'
```

<img width="619" height="241" alt="Image" src="https://github.com/user-attachments/assets/c8a26137-6806-48fc-8b54-2585739ef01f" />

After:

```yaml
prs:
- https://github.com/elastic/kibana/pull/238555
...
title: Enable cases numerical id service
```

## AI implementation details

### Layer 1 — `StripSquareBracketPrefix` ([`ChangelogTextUtilities.cs`](src/Elastic.Documentation/ReleaseNotes/ChangelogTextUtilities.cs))
- Tracks whether any `[...]` prefix was removed.
- After the existing colon handling, if so, removes **one** ASCII `-` when the next character is whitespace (e.g. `[Cases] - Enable …` → `Enable …`).
- Leaves titles like `- No brackets` unchanged (no bracket strip).
- Leaves `[Team]-NoSpace` as `-NoSpace` (no space after `-`, so the separator rule does not run).

### Layer 2 — Defensive YAML ([`ReleaseNotesSerialization.cs`](src/Elastic.Documentation.Configuration/ReleaseNotes/ReleaseNotesSerialization.cs))
- `SerializeEntry` runs `ApplyDefensiveTitleQuotingIfNeeded` after YamlDotNet serialization.
- New helpers: `TitleNeedsDefensiveYamlQuoting` in [`ChangelogTextUtilities.cs`](src/Elastic.Documentation/ReleaseNotes/ChangelogTextUtilities.cs) for `-`, `*`, `+`, en dash, em dash.
- If the title needs quoting but the `title:` line is **unquoted**, it is rewritten with a **double-quoted** scalar (`ToYamlDoubleQuotedString`). If YamlDotNet already used `'` or `"`, the YAML is left as-is.

### Tests
- [`ChangelogTextUtilitiesTests.cs`](tests/Elastic.Documentation.Configuration.Tests/ReleaseNotes/ChangelogTextUtilitiesTests.cs) — strip + quoting detector.
- [`ReleaseNotesSerializationTests.cs`](tests/Elastic.Documentation.Configuration.Tests/ReleaseNotes/ReleaseNotesSerializationTests.cs) — dash title quoted + round-trip; plain title unquoted.
- [`TitleProcessingTests.cs`](tests/Elastic.Changelog.Tests/Changelogs/Create/TitleProcessingTests.cs) — Kibana-style PR title end-to-end.
- [`ChangelogPrEvaluationServiceTests.cs`](tests/Elastic.Changelog.Tests/Evaluation/ChangelogPrEvaluationServiceTests.cs) — `evaluate-pr` strips `[Cases] - …`.

### Docs & config
- [`docs/cli/changelog/add.md`](docs/cli/changelog/add.md), [`gh-release.md`](docs/cli/changelog/gh-release.md), [`evaluate-pr.md`](docs/cli/changelog/evaluate-pr.md), [`configure-changelogs-ref.md`](docs/contribute/configure-changelogs-ref.md)

`dotnet format` was applied to `ChangelogTextUtilities.cs`. Targeted tests in `Elastic.Documentation.Configuration.Tests` and `Elastic.Changelog.Tests` pass.

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: composer-2, claude-4-sonnet-thinking