### PR TITLE
[Findability] Landing page prototype

### DIFF
--- a/src/Elastic.Markdown/Layout/_LandingPage.cshtml
+++ b/src/Elastic.Markdown/Layout/_LandingPage.cshtml
@@ -8,12 +8,10 @@
     --elastic-teal: #00BFB3;
     --elastic-teal-light: #E6FAF8;
     --elastic-pink: #F04E98;
-    --elastic-pink-light: #FDE8F2;
     --elastic-yellow: #FEC514;
     --elastic-green: #00B3A4;
     --bg: #ffffff;
     --bg-alt: #F5F7FA;
-    --bg-warm: #FAFBFC;
     --bg-dark: #1B2638;
     --text-primary: #1B2638;
     --text-secondary: #506477;
@@ -176,13 +174,8 @@
   .quickstart h2 {
     font-size: 18px;
     font-weight: 700;
-    margin-bottom: 4px;
-    letter-spacing: -0.2px;
-  }
-  .quickstart > p {
-    font-size: 14px;
-    color: var(--text-secondary);
     margin-bottom: 16px;
+    letter-spacing: -0.2px;
   }
   .qs-grid {
     display: grid;
@@ -203,7 +196,7 @@
     box-shadow: var(--shadow-sm);
     border-color: var(--elastic-blue);
   }
-  .qs-card h4 {
+  .qs-card h3 {
     font-size: 14px;
     font-weight: 600;
     margin-bottom: 8px;
@@ -253,6 +246,7 @@
   }
   .news-card:hover { border-color: var(--elastic-blue); }
   .news-date {
+    display: block;
     font-size: 11px;
     color: var(--text-tertiary);
     font-weight: 500;
@@ -260,7 +254,7 @@
     letter-spacing: 0.3px;
     margin-bottom: 6px;
   }
-  .news-card h4 { font-size: 13px; font-weight: 600; margin-bottom: 4px; }
+  .news-card h3 { font-size: 13px; font-weight: 600; margin-bottom: 4px; }
   .news-card p { font-size: 12px; color: var(--text-secondary); line-height: 1.45; }
 
   /* ── All products ── */
@@ -270,7 +264,7 @@
     gap: 32px 24px;
     margin-bottom: 52px;
   }
-  .product-column h4 {
+  .product-column h3 {
     font-size: 13px;
     font-weight: 700;
     color: var(--text-primary);
@@ -294,12 +288,13 @@
     border-radius: var(--radius-md);
     padding: 32px 36px;
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: 1fr;
     gap: 24px;
     margin-bottom: 24px;
+    max-width: 480px;
     border: 1px solid var(--border-light);
   }
-  .help-item h4 {
+  .help-item h3 {
     font-size: 13px;
     font-weight: 600;
     margin-bottom: 4px;
@@ -310,32 +305,11 @@
   }
   .help-item p { font-size: 12px; color: var(--text-secondary); line-height: 1.45; }
 
-  /* ── Footer ── */
-  .landing-footer {
-    background: var(--bg-dark);
-    padding: 44px 40px;
-    color: rgba(255,255,255,0.6);
-    font-family: var(--font);
-  }
-  .landing-footer-inner {
-    max-width: var(--max-w);
-    margin: 0 auto;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 12px;
-    font-size: 13px;
-  }
-  .landing-footer a { color: rgba(255,255,255,0.5); transition: color 0.15s; }
-  .landing-footer a:hover { color: rgba(255,255,255,0.85); }
-
   /* ── Responsive ── */
   @@media (max-width: 900px) {
     .hero-cards { grid-template-columns: 1fr; }
     .all-products-grid { grid-template-columns: repeat(2, 1fr); }
     .news-grid { grid-template-columns: 1fr; }
-    .help-strip { grid-template-columns: 1fr; }
   }
   @@media (max-width: 640px) {
     .landing-hero { padding: 36px 20px 0; }
@@ -349,208 +323,192 @@
 <div hx-select-oob="#main-container" hx-swap="none" class="landing-page w-full max-w-[100vw] relative overflow-x-hidden">
 
   <!-- ── Hero ── -->
-  <section class="landing-hero">
+  <header class="landing-hero" role="banner">
     <div class="landing-hero-inner">
 
       <div class="hero-welcome">
         <h1>Elastic documentation</h1>
-        <p>Official docs for the Elastic Stack, Elastic Cloud, and Elastic solutions.</p>
+        <p>Official docs for the Elastic Stack, Elastic Cloud, and Elastic solutions. Open source, built by Elastic.</p>
       </div>
 
-      <div class="hero-search-wrap">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#8C9BAB" stroke-width="2.5"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>
-        <navigation-search></navigation-search>
-      </div>
+      <search role="search" aria-label="Search documentation">
+        <div class="hero-search-wrap">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#8C9BAB" stroke-width="2.5" aria-hidden="true"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>
+          <navigation-search></navigation-search>
+        </div>
+      </search>
 
-      <div class="hero-cards">
-        <div class="hero-card primary">
+      <section class="hero-cards" aria-label="Popular documentation">
+        <article class="hero-card primary">
           <h2>Learn how to use Elastic</h2>
           <p class="desc">Get started with an overview of Elasticsearch, Kibana, and the rest of the Elastic Stack.</p>
-          <div class="card-links">
+          <nav class="card-links" aria-label="Fundamentals quick links">
             <a href="@Model.Link("/get-started")">What is Elasticsearch?</a>
             <a href="@Model.Link("/get-started")">The Elastic Stack</a>
             <a href="@Model.Link("/manage-data")">Ingest data</a>
             <a href="@Model.Link("/manage-data")">Index basics</a>
-          </div>
+          </nav>
           <a href="@Model.Link("/get-started")" class="card-cta">
             Get started
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
           </a>
-        </div>
-        <div class="hero-card">
+        </article>
+        <article class="hero-card">
           <h2>Elasticsearch</h2>
           <p class="desc">Store, search, and analyze your data with full-text search, vector search, AI search, and more.</p>
-          <div class="card-links">
+          <nav class="card-links" aria-label="Elasticsearch quick links">
             <a href="@Model.Link("/deploy-manage/deploy/self-managed/installing-elasticsearch")">Install</a>
             <a href="https://www.elastic.co/docs/api" target="_blank" rel="noopener noreferrer" hx-disable="true">REST API reference</a>
             <a href="@Model.Link("/reference/query-languages/")">Query DSL</a>
             <a href="@Model.Link("/release-notes/")">Release notes</a>
-          </div>
+          </nav>
           <a href="@Model.Link("/solutions/search")" class="card-cta">
             Elasticsearch docs
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
           </a>
-        </div>
-      </div>
+        </article>
+      </section>
 
     </div>
-  </section>
+  </header>
 
   <!-- ── Main content ── -->
-  <div class="landing-main">
+  <main class="landing-main">
 
     <!-- Quick start -->
-    <div class="quickstart">
+    <section class="quickstart" aria-label="Getting started">
       <h2>New to Elastic? Give it a try.</h2>
       <div class="qs-grid">
-        <div class="qs-card">
-          <h4>Try locally</h4>
+        <article class="qs-card">
+          <h3>Try locally</h3>
           <p>Use Docker to install and run Elasticsearch and Kibana on your local machine.</p>
           <a href="@Model.Link("/get-started")" class="qs-cta">Local installation docs →</a>
-        </div>
-        <div class="qs-card">
-          <h4>Start free Cloud trial</h4>
+        </article>
+        <article class="qs-card">
+          <h3>Start free Cloud trial</h3>
           <p>Evaluate Elastic with a production-ready trial, using real data and use cases.</p>
           <a href="https://cloud.elastic.co/registration?page=docs&placement=docs-body" target="_blank" rel="noopener noreferrer" hx-disable="true" class="qs-cta">Start free trial →</a>
-        </div>
+        </article>
       </div>
-    </div>
+    </section>
 
     <!-- What's new -->
-    <div class="landing-section-header">
-      <h2>What's new</h2>
-      <a href="@Model.Link("/release-notes/")">All release notes →</a>
-    </div>
-    <div class="news-grid">
-      <div class="news-card">
-        <div class="news-date">April 2026</div>
-        <h4>Elasticsearch @Model.CurrentVersion</h4>
-        <p>Improved authentication and upgraded security features.</p>
+    <section aria-label="What's new">
+      <div class="landing-section-header">
+        <h2>What's new</h2>
+        <a href="@Model.Link("/release-notes/")">All release notes →</a>
       </div>
-      <div class="news-card">
-        <div class="news-date">April 2026</div>
-        <h4>Elastic AI Assistant is GA</h4>
-        <p>Ask questions about your data in plain English across Observability and Security.</p>
+      <div class="news-grid">
+        <article class="news-card">
+          <time class="news-date" datetime="2026-04">April 2026</time>
+          <h3>Elasticsearch @Model.CurrentVersion</h3>
+          <p>Improved authentication and upgraded security features.</p>
+        </article>
+        <article class="news-card">
+          <time class="news-date" datetime="2026-04">April 2026</time>
+          <h3>Elastic AI Assistant is GA</h3>
+          <p>Ask questions about your data in plain English across Observability and Security.</p>
+        </article>
+        <article class="news-card">
+          <time class="news-date" datetime="2026-03">March 2026</time>
+          <h3>New Serverless features</h3>
+          <p>Run Elasticsearch without managing infrastructure. New capabilities for search workloads.</p>
+        </article>
       </div>
-      <div class="news-card">
-        <div class="news-date">March 2026</div>
-        <h4>New Serverless features</h4>
-        <p>Run Elasticsearch without managing infrastructure. New capabilities for search workloads.</p>
-      </div>
-    </div>
+    </section>
 
     <!-- All products -->
-    <div class="landing-section-header">
-      <h2>All products</h2>
-    </div>
-    <div class="all-products-grid">
-      <div class="product-column">
-        <h4>Platform</h4>
-        <ul>
-          <li><a href="@Model.Link("/solutions/search")">Elasticsearch</a></li>
-          <li><a href="@Model.Link("/explore-analyze")">Kibana</a></li>
-          <li><a href="@Model.Link("/manage-data")">Logstash</a></li>
-          <li><a href="@Model.Link("/manage-data")">Beats</a></li>
-          <li><a href="@Model.Link("/explore-analyze")">Machine Learning</a></li>
-        </ul>
+    <nav aria-label="Product documentation">
+      <div class="landing-section-header">
+        <h2>All products</h2>
       </div>
-      <div class="product-column">
-        <h4>Solutions</h4>
-        <ul>
-          <li><a href="@Model.Link("/solutions/search")">Elasticsearch</a></li>
-          <li><a href="@Model.Link("/solutions/observability")">Elastic Observability</a></li>
-          <li><a href="@Model.Link("/solutions/security")">Elastic Security</a></li>
-        </ul>
+      <div class="all-products-grid">
+        <div class="product-column">
+          <h3>Platform</h3>
+          <ul>
+            <li><a href="@Model.Link("/solutions/search")">Elasticsearch</a></li>
+            <li><a href="@Model.Link("/explore-analyze")">Kibana</a></li>
+            <li><a href="@Model.Link("/manage-data")">Logstash</a></li>
+            <li><a href="@Model.Link("/manage-data")">Beats</a></li>
+            <li><a href="@Model.Link("/explore-analyze")">Machine Learning</a></li>
+          </ul>
+        </div>
+        <div class="product-column">
+          <h3>Solutions</h3>
+          <ul>
+            <li><a href="@Model.Link("/solutions/search")">Elasticsearch</a></li>
+            <li><a href="@Model.Link("/solutions/observability")">Elastic Observability</a></li>
+            <li><a href="@Model.Link("/solutions/security")">Elastic Security</a></li>
+          </ul>
+        </div>
+        <div class="product-column">
+          <h3>Deploy</h3>
+          <ul>
+            <li><a href="@Model.Link("/deploy-manage")">Elastic Cloud Serverless</a></li>
+            <li><a href="@Model.Link("/deploy-manage")">Elastic Cloud Hosted</a></li>
+            <li><a href="@Model.Link("/deploy-manage")">Self-managed</a></li>
+            <li><a href="@Model.Link("/deploy-manage")">Elastic Cloud Enterprise (ECE)</a></li>
+            <li><a href="@Model.Link("/deploy-manage")">Elastic Cloud on Kubernetes (ECK)</a></li>
+          </ul>
+        </div>
+        <div class="product-column">
+          <h3>Ingest tools</h3>
+          <ul>
+            <li><a href="@Model.Link("/manage-data")">Integrations</a></li>
+            <li><a href="@Model.Link("/reference/opentelemetry/")">Elastic Distributions for OpenTelemetry</a></li>
+            <li><a href="@Model.Link("/manage-data")">Fleet &amp; Elastic Agent</a></li>
+            <li><a href="@Model.Link("/solutions/observability")">APM</a></li>
+            <li><a href="@Model.Link("/solutions/security")">Elastic Defend</a></li>
+            <li><a href="@Model.Link("/manage-data")">Elastic Serverless Forwarder for AWS</a></li>
+            <li><a href="@Model.Link("/manage-data")">Connectors</a></li>
+            <li><a href="@Model.Link("/manage-data")">Web crawler</a></li>
+          </ul>
+        </div>
+        <div class="product-column">
+          <h3>Query languages</h3>
+          <ul>
+            <li><a href="@Model.Link("/reference/query-languages/")">Query DSL</a></li>
+            <li><a href="@Model.Link("/reference/query-languages/")">ES|QL</a></li>
+            <li><a href="@Model.Link("/reference/query-languages/")">KQL</a></li>
+            <li><a href="@Model.Link("/reference/query-languages/")">SQL</a></li>
+            <li><a href="@Model.Link("/reference/query-languages/")">EQL</a></li>
+            <li><a href="@Model.Link("/reference/query-languages/")">Lucene</a></li>
+          </ul>
+        </div>
+        <div class="product-column">
+          <h3>APM agents</h3>
+          <ul>
+            <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Java</a></li>
+            <li><a href="@Model.Link("/reference/elasticsearch-clients/")">&#46;NET</a></li>
+            <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Node.js</a></li>
+            <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Python</a></li>
+            <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Ruby</a></li>
+            <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Go</a></li>
+            <li><a href="@Model.Link("/reference/elasticsearch-clients/")">PHP</a></li>
+          </ul>
+        </div>
+        <div class="product-column">
+          <h3>Developer tools &amp; standards</h3>
+          <ul>
+            <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Elasticsearch clients</a></li>
+            <li><a href="@Model.Link("/reference")">Elastic Common Schema (ECS)</a></li>
+            <li><a href="@Model.Link("/reference")">Search UI</a></li>
+          </ul>
+        </div>
       </div>
-      <div class="product-column">
-        <h4>Deploy</h4>
-        <ul>
-          <li><a href="@Model.Link("/deploy-manage")">Elastic Cloud Serverless</a></li>
-          <li><a href="@Model.Link("/deploy-manage")">Elastic Cloud Hosted</a></li>
-          <li><a href="@Model.Link("/deploy-manage")">Self-managed</a></li>
-          <li><a href="@Model.Link("/deploy-manage")">Elastic Cloud Enterprise (ECE)</a></li>
-          <li><a href="@Model.Link("/deploy-manage")">Elastic Cloud on Kubernetes (ECK)</a></li>
-        </ul>
-      </div>
-      <div class="product-column">
-        <h4>Ingest tools</h4>
-        <ul>
-          <li><a href="@Model.Link("/manage-data")">Integrations</a></li>
-          <li><a href="@Model.Link("/reference/opentelemetry/")">Elastic Distributions for OpenTelemetry</a></li>
-          <li><a href="@Model.Link("/manage-data")">Fleet &amp; Elastic Agent</a></li>
-          <li><a href="@Model.Link("/solutions/observability")">APM</a></li>
-          <li><a href="@Model.Link("/solutions/security")">Elastic Defend</a></li>
-          <li><a href="@Model.Link("/manage-data")">Elastic Serverless Forwarder for AWS</a></li>
-          <li><a href="@Model.Link("/manage-data")">Connectors</a></li>
-          <li><a href="@Model.Link("/manage-data")">Web crawler</a></li>
-        </ul>
-      </div>
-      <div class="product-column">
-        <h4>Query languages</h4>
-        <ul>
-          <li><a href="@Model.Link("/reference/query-languages/")">Query DSL</a></li>
-          <li><a href="@Model.Link("/reference/query-languages/")">ES|QL</a></li>
-          <li><a href="@Model.Link("/reference/query-languages/")">KQL</a></li>
-          <li><a href="@Model.Link("/reference/query-languages/")">SQL</a></li>
-          <li><a href="@Model.Link("/reference/query-languages/")">EQL</a></li>
-          <li><a href="@Model.Link("/reference/query-languages/")">Lucene</a></li>
-        </ul>
-      </div>
-      <div class="product-column">
-        <h4>APM agents</h4>
-        <ul>
-          <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Java</a></li>
-          <li><a href="@Model.Link("/reference/elasticsearch-clients/")">&#46;NET</a></li>
-          <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Node.js</a></li>
-          <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Python</a></li>
-          <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Ruby</a></li>
-          <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Go</a></li>
-          <li><a href="@Model.Link("/reference/elasticsearch-clients/")">PHP</a></li>
-        </ul>
-      </div>
-      <div class="product-column">
-        <h4>Developer tools &amp; standards</h4>
-        <ul>
-          <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Elasticsearch clients</a></li>
-          <li><a href="@Model.Link("/reference")">Elastic Common Schema (ECS)</a></li>
-          <li><a href="@Model.Link("/reference")">Search UI</a></li>
-        </ul>
-      </div>
-    </div>
+    </nav>
 
-    <!-- Help strip -->
-    <div class="help-strip">
+    <!-- Help -->
+    <section class="help-strip" aria-label="Help and community resources">
       <div class="help-item">
-        <h4>
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>
-          Community forums
-        </h4>
-        <p>Ask questions and get help from other Elastic users and engineers.</p>
-      </div>
-      <div class="help-item">
-        <h4>
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 016.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z"/></svg>
-          Training &amp; certification
-        </h4>
-        <p>Free courses and hands-on labs to build your Elastic skills.</p>
-      </div>
-      <div class="help-item">
-        <h4>
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 00-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0020 4.77 5.07 5.07 0 0019.91 1S18.73.65 16 2.48a13.38 13.38 0 00-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 005 4.77a5.44 5.44 0 00-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 009 18.13V22"/></svg>
+        <h3>
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 00-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0020 4.77 5.07 5.07 0 0019.91 1S18.73.65 16 2.48a13.38 13.38 0 00-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 005 4.77a5.44 5.44 0 00-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 009 18.13V22"/></svg>
           Report a docs issue
-        </h4>
-        <p>Found something wrong or confusing? Let us know on GitHub.</p>
+        </h3>
+        <p>Found something wrong or confusing? <a href="@Model.Link("/contribute-docs")">Let us know on GitHub.</a></p>
       </div>
-    </div>
+    </section>
 
-  </div><!-- /.landing-main -->
-
-  <!-- ── Footer ── -->
-  <footer class="landing-footer">
-    <div class="landing-footer-inner">
-      <span>© 2026 Elasticsearch B.V.</span>
-      <span><a href="@Model.Link("/contribute-docs")">Edit this page</a> · <a href="@Model.Link("/contribute-docs")">Report a docs issue</a></span>
-    </div>
-  </footer>
+  </main>
 
 </div>

--- a/src/Elastic.Markdown/Layout/_LandingPage.cshtml
+++ b/src/Elastic.Markdown/Layout/_LandingPage.cshtml
@@ -1,8 +1,8 @@
 @inherits RazorSlice<Elastic.Markdown.MarkdownLayoutViewModel>
 <style>
   /* ── Reset & Base ── */
-  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-  :root {
+  .landing-page, .landing-page * , .landing-page *::before, .landing-page *::after { box-sizing: border-box; }
+  .landing-page {
     --bg: #fafbfc;
     --surface: #ffffff;
     --surface-alt: #f3f5f7;
@@ -29,10 +29,14 @@
     --shadow-lg: 0 4px 20px rgba(0,0,0,0.10);
     --max-w: 1120px;
     --font: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', sans-serif;
+    font-family: var(--font);
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
   }
-  body { font-family: var(--font); background: var(--bg); color: var(--text); line-height: 1.55; -webkit-font-smoothing: antialiased; }
-  a { color: var(--accent); text-decoration: none; transition: color 0.15s; }
-  a:hover { color: var(--accent-hover); }
+  .landing-page a { color: var(--accent); text-decoration: none; transition: color 0.15s; }
+  .landing-page a:hover { color: var(--accent-hover); }
 
   /* ── Hero / Search ── */
   .hero {
@@ -57,7 +61,7 @@
     margin: 0 auto 16px;
     position: relative;
   }
-  .search-wrap svg {
+  .search-wrap > .search-icon {
     position: absolute;
     left: 16px;
     top: 50%;
@@ -370,7 +374,7 @@
   }
 </style>
 
-<div hx-select-oob="#main-container" hx-swap="none" class="w-full max-w-[100vw] relative overflow-x-hidden">
+<div hx-select-oob="#main-container" hx-swap="none" class="landing-page w-full max-w-[100vw] relative overflow-x-hidden">
 
   <!-- ── Version disambiguation ── -->
   <div class="version-banner">
@@ -394,7 +398,7 @@
     <h1>Elastic documentation</h1>
     <p>Find guides, API references, and tutorials for the Elastic Stack.</p>
     <div class="search-wrap">
-      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.35-4.35"/></svg>
+      <svg class="search-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.35-4.35"/></svg>
       <navigation-search></navigation-search>
     </div>
   </div>

--- a/src/Elastic.Markdown/Layout/_LandingPage.cshtml
+++ b/src/Elastic.Markdown/Layout/_LandingPage.cshtml
@@ -1,300 +1,628 @@
 @inherits RazorSlice<Elastic.Markdown.MarkdownLayoutViewModel>
-<div hx-select-oob="#main-container" hx-swap="none" class="w-full max-w-[100vw] text-ink relative text-pretty overflow-x-hidden">
-	<section class="w-full bg-grey-10" id="hero">
-		<div class="container mx-auto pt-28 pb-4 min-[1024px]:pb-28 grid min-[1024px]:grid-cols-[auto_420px] min-[1024px]:justify-between items-center gap-6 min-[1024px]:gap-[74px]">
-			<div class="max-w-165">
-				<h1 class="text-6xl font-bold font-sans text-black">Elastic Docs</h1>
-				<p class="mt-4">Welcome to the technical documentation for <span class="whitespace-nowrap">Elastic Stack 9.0.0</span>
-					and later, and <span class="whitespace-nowrap">Elastic Cloud Serverless</span>. Deploy, operate, and scale with step-by-step guides, API references, examples, and best practices.</p>
-				<p class="mt-4"><strong>Upgrading from an earlier version?</strong> Follow the <a href="@Model.Link("/deploy-manage/upgrade")"
-					class="link">upgrade guide</a> to plan and complete your upgrade. </p>
+<style>
+  /* ── Reset & Base ── */
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  :root {
+    --bg: #fafbfc;
+    --surface: #ffffff;
+    --surface-alt: #f3f5f7;
+    --border: #e2e6ea;
+    --border-light: #eef0f3;
+    --text: #1a1f36;
+    --text-secondary: #4a5270;
+    --text-muted: #8891a4;
+    --accent: #0077cc;
+    --accent-hover: #005fa3;
+    --accent-bg: #e8f4fd;
+    --green: #00bfb3;
+    --green-bg: #e6faf8;
+    --orange: #f5a623;
+    --orange-bg: #fef6e8;
+    --purple: #7b61ff;
+    --purple-bg: #f0edff;
+    --pink: #ff4081;
+    --pink-bg: #fff0f5;
+    --radius: 10px;
+    --radius-sm: 6px;
+    --shadow-sm: 0 1px 3px rgba(0,0,0,0.06);
+    --shadow: 0 2px 8px rgba(0,0,0,0.08);
+    --shadow-lg: 0 4px 20px rgba(0,0,0,0.10);
+    --max-w: 1120px;
+    --font: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', sans-serif;
+  }
+  body { font-family: var(--font); background: var(--bg); color: var(--text); line-height: 1.55; -webkit-font-smoothing: antialiased; }
+  a { color: var(--accent); text-decoration: none; transition: color 0.15s; }
+  a:hover { color: var(--accent-hover); }
 
-				<div class="flex md:inline-flex flex-col gap-6 mt-6">
-					<navigation-search></navigation-search>
-					<div class="flex gap-3">
-						<a href="@Model.Link("/get-started")"
-						   class="grow select-none cursor-pointer text-white text-nowrap bg-blue-elastic hover:bg-blue-elastic-110 focus:ring-4 focus:ring-blue-elastic-50 font-semibold font-sans rounded-sm px-6 py-2 focus:outline-none h-10 flex items-center justify-center">
-							Elastic Fundamentals
-						</a>
-						<a href="https://cloud.elastic.co/registration?page=docs&placement=docs-body"
-						   class="grow cursor-pointer text-blue-elastic hover:text-blue-elastic-100 text-nowrap border-2 border-blue-elastic hover:border-blue-elastic-100 focus:ring-4 focus:outline-none focus:ring-blue-elastic-50 font-semibold font-sans rounded-sm px-6 py-2 text-center h-10 flex items-center justify-center">
-							Start free trial
-						</a>
-					</div>
-				</div>
-				@if (Model.AllVersionsUrl is not null)
-				{
-					<div class="mt-6">
-						<a href="@Model.AllVersionsUrl" class="link">
-							View previous docs versions
-							<svg class="link-arrow"
-							     xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-								<path stroke-linecap="round" stroke-linejoin="round" d="M17.25 8.25 21 12m0 0-3.75 3.75M21 12H3"/>
-							</svg>
-						</a>
-					</div>
-				}
-			</div>
-			<div class="flex flex-col justify-center w-full mt-14 min-[1024px]:mt-0">
-				<div class="rounded-2xl p-8 bg-white flex flex-col gap-4 items-start"
-				     style="border: 2px solid transparent; background: linear-gradient(white, white) padding-box, linear-gradient(-65deg, #BFDBFF 17%, #E2D3FE 83%) border-box; background-clip: padding-box, border-box; background-origin: padding-box, border-box;">
-					<span class="euiBadge euiBadge--primary inline-flex items-center font-sans font-bold text-xs uppercase tracking-wide shrink-0 rounded-full px-2 py-0.5 bg-[#8144CC] text-white">NEW</span>
-					<div class="flex flex-col">
-						<p class="font-sans font-bold text-xl">Elastic skills for AI agents</p>
-						<p class="mt-2">Install official skills that teach AI coding agents how to work with Elasticsearch, Kibana, Fleet, and the rest of the Elastic stack.</p>
-						<div class="grid grid-cols-1 mt-6 gap-2 text-left">
-							<a href="@Model.Link("/explore-analyze/ai-features/agent-skills")" class="link justify-start">
-								Learn more
-								<svg class="link-arrow"
-								     xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-									<path stroke-linecap="round" stroke-linejoin="round" d="M17.25 8.25 21 12m0 0-3.75 3.75M21 12H3"/>
-								</svg>
-							</a>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-	</section>
+  /* ── Hero / Search ── */
+  .hero {
+    max-width: var(--max-w);
+    margin: 0 auto;
+    padding: 48px 24px 0;
+    text-align: center;
+  }
+  .hero h1 {
+    font-size: 28px;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    margin-bottom: 10px;
+  }
+  .hero p {
+    font-size: 15px;
+    color: var(--text-secondary);
+    margin-bottom: 28px;
+  }
+  .search-wrap {
+    max-width: 640px;
+    margin: 0 auto 16px;
+    position: relative;
+  }
+  .search-wrap svg {
+    position: absolute;
+    left: 16px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--text-muted);
+    pointer-events: none;
+  }
+  .search-wrap input {
+    width: 100%;
+    height: 52px;
+    border: 2px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0 16px 0 48px;
+    font-size: 16px;
+    font-family: var(--font);
+    background: var(--surface);
+    color: var(--text);
+    transition: border-color 0.15s, box-shadow 0.15s;
+    outline: none;
+  }
+  .search-wrap input::placeholder { color: var(--text-muted); }
+  .search-wrap input:focus {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px rgba(0,119,204,0.12);
+  }
 
-	<section class="w-full bg-grey-10">
-		<div class="container mx-auto py-10 pb-28">
-			<div class="heading-wrapper" id="solutions-use-cases">
-				<h2 class="font-bold font-sans text-3xl text-ink-dark">
-					<a href="#solutions-use-cases">Solutions and use cases</a>
-				</h2>
-			</div>
-			<div class="grid grid-cols-1 min-[1024px]:grid-cols-2 lg:grid-cols-3 gap-6 mt-6">
-				<div class="rounded-2xl border-1 border-grey-20 p-8 bg-white flex gap-6 items-start">
-					<img loading="lazy" alt="Search logo" src="@Model.Static("elasticsearch-logo-color-64px.svg")" class="size-8"/>
-					<div class="flex flex-col">
-						<p class="font-sans font-bold text-xl">Elasticsearch</p>
-						<p class="mt-2">Build powerful search and RAG applications using Elasticsearch's vector database, AI toolkit, and advanced retrieval capabilities.</p>
-						<div class="grid grid-cols-1 mt-6 gap-2">
-							<a href="@Model.Link("/solutions/search")" class="text-blue-elastic-100 hover:text-blue-elastic-110 font-sans font-semibold">9.0+ (latest @Model.CurrentVersion) docs</a>
-							<a href="https://www.elastic.co/guide/en/elasticsearch/reference/index.html" class="text-sm text-grey-90 hover:text-grey-110 font-sans font-semibold" hx-disable="true">Previous versions</a>
-						</div>
-					</div>
-				</div>
-				<div class="rounded-2xl border-1 border-grey-20 p-8 bg-white flex gap-6 items-start">
-					<img loading="lazy" alt="Observability logo" src="@Model.Static("observability-logo-color-64px.svg")" class="size-8"/>
-					<div class="flex flex-col">
-						<p class="font-sans font-bold text-xl">Observability</p>
-						<p class="mt-2">Resolve problems with open, flexible, and unified observability powered by advanced machine learning and analytics.</p>
-						<div class="grid grid-cols-1 mt-6 gap-2">
-							<a href="@Model.Link("/solutions/observability")" class="text-blue-elastic-100 hover:text-blue-elastic-110 font-sans font-semibold">9.0+ (latest @Model.CurrentVersion) docs</a>
-							<a href="https://www.elastic.co/guide/en/observability/index.html" class="text-sm text-grey-90 hover:text-grey-110 font-sans font-semibold" hx-disable="true">Previous versions</a>
-						</div>
-					</div>
-				</div>
-				<div class="rounded-2xl border-1 border-grey-20 p-8 bg-white flex gap-6 items-start">
-					<img loading="lazy" alt="Security logo" src="@Model.Static("security-logo-color-64px.svg")" class="size-8"/>
-					<div class="flex flex-col">
-						<p class="font-sans font-bold text-xl">Security</p>
-						<p class="mt-2">Detect, investigate, and respond to threats with AI-driven security analytics to protect your organization at scale.</p>
-						<div class="grid grid-cols-1 mt-6 gap-2">
-							<a href="@Model.Link("/solutions/security")" class="text-blue-elastic-100 hover:text-blue-elastic-110 font-sans font-semibold">9.0+ (latest @Model.CurrentVersion) docs</a>
-							<a href="https://www.elastic.co/guide/en/security/index.html" class="text-sm text-grey-90 hover:text-grey-110 font-sans font-semibold" hx-disable="true">Previous versions</a>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-	</section>
+  /* ── Quick destinations ── */
+  .section { max-width: var(--max-w); margin: 0 auto; padding: 40px 24px 0; }
+  .section-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    margin-bottom: 16px;
+  }
+  .section-header h2 { font-size: 17px; font-weight: 700; letter-spacing: -0.01em; }
+  .section-header a { font-size: 13px; font-weight: 500; }
 
-	<section class="w-full">
-		<div class="container mx-auto pt-20 pb-10">
-			<div class="heading-wrapper" id="how-to-guides">
-				<h2 class="font-bold font-sans text-3xl text-ink-dark">
-					<a href="#how-to-guides">
-						How-to guides
-					</a>
-				</h2>
-			</div>
-			<div class="grid grid-cols-1 min-[1024px]:grid-cols-2 lg:grid-cols-4 gap-6 mt-6">
-				<div class="min-h-61 rounded-2xl border-1 border-grey-20 p-8 bg-white flex flex-col gap-6 items-start">
-					<img loading="lazy" alt="Manage data icon" src="@Model.Static("productStreamsWired.svg")" class="size-8"/>
-					<div class="flex flex-col grow">
-						<p class="font-sans font-bold text-xl">Manage data</p>
-						<p class="mt-2 grow">Learn how to ingest, enrich, and manage your data in Elastic.</p>
-						<a href="@Model.Link("/manage-data")" class="text-blue-elastic-100 hover:text-blue-elastic-110 font-sans font-semibold mt-3">View docs</a>
-					</div>
-				</div>
-				<div class="min-h-61 rounded-2xl border-1 border-grey-20 p-8 bg-white flex flex-col gap-6 items-start">
-					<img loading="lazy" alt="Explore and analyze icon" src="@Model.Static("productDashboard.svg")" class="size-8"/>
-					<div class="flex flex-col grow">
-						<p class="font-sans font-bold text-xl">Explore and analyze</p>
-						<p class="mt-2 grow">Discover the tools of Elasticsearch and Kibana.</p>
-						<a href="@Model.Link("/explore-analyze")" class="text-blue-elastic-100 hover:text-blue-elastic-110 font-sans font-semibold mt-3">View docs</a>
-					</div>
-				</div>
-				<div class="min-h-61 rounded-2xl border-1 border-grey-20 p-8 bg-white flex flex-col gap-6 items-start">
-					<img loading="lazy" alt="Deploy and manage icon" src="@Model.Static("storage.svg")" class="size-8"/>
-					<div class="flex flex-col grow">
-						<p class="font-sans font-bold text-xl">Deploy and manage</p>
-						<p class="mt-2 grow">Learn how to deploy and manage all aspects of your Elastic environment.</p>
-						<a href="@Model.Link("/deploy-manage")" class="text-blue-elastic-100 hover:text-blue-elastic-110 font-sans font-semibold mt-3">View docs</a>
-					</div>
-				</div>
-				<div class="min-h-61 rounded-2xl border-1 border-grey-20 p-8 bg-white flex flex-col gap-6 items-start">
-					<img loading="lazy" alt="Manage Cloud account icon" src="@Model.Static("cloud.svg")" class="size-8"/>
-					<div class="flex flex-col grow">
-						<p class="font-sans font-bold text-xl">Manage Cloud account</p>
-						<p class="mt-2 grow">Manage your profile information, preferences, and personal settings.</p>
-						<a href="@Model.Link("/cloud-account")" class="text-blue-elastic-100 hover:text-blue-elastic-110 font-sans font-semibold mt-3">View docs</a>
-					</div>
-				</div>
-			</div>
-		</div>
-	</section>
+  .quick-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 12px;
+  }
+  .quick-card {
+    background: var(--surface);
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius);
+    padding: 18px 20px;
+    display: flex;
+    align-items: flex-start;
+    gap: 14px;
+    transition: box-shadow 0.15s, border-color 0.15s;
+    cursor: pointer;
+    text-decoration: none;
+    color: var(--text);
+  }
+  .quick-card:hover {
+    border-color: var(--accent);
+    box-shadow: var(--shadow);
+    color: var(--text);
+  }
+  .quick-card .icon {
+    width: 40px;
+    height: 40px;
+    border-radius: var(--radius-sm);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    font-size: 18px;
+  }
+  .quick-card .card-text h3 { font-size: 14px; font-weight: 600; margin-bottom: 3px; }
+  .quick-card .card-text p { font-size: 13px; color: var(--text-secondary); line-height: 1.4; }
+  .quick-card .card-text .meta { font-size: 12px; color: var(--text-muted); margin-top: 4px; }
 
-	<section class="w-full">
-		<div class="container mx-auto py-10">
-			<div class="heading-wrapper" id="references">
-				<h2 class="font-bold font-sans text-3xl text-ink-dark">
-					<a href="#references">Reference</a>
-				</h2>
-			</div>
-			<div class="grid grid-cols-1 min-[1024px]:grid-cols-2 lg:grid-cols-4 gap-6 mt-6">
-				<div class="min-h-61 rounded-2xl border-1 border-grey-20 p-8 bg-white flex flex-col items-start">
-					<p class="font-sans font-bold text-xl">Elastic APIs</p>
-					<p class="mt-2 grow">Browse the API docs for Elasticsearch, Kibana, Elastic Cloud, and more.</p>
-					<a href="https://www.elastic.co/docs/api" target="_blank" rel="noopener noreferrer" class="text-blue-elastic-100 hover:text-blue-elastic-110 font-sans font-semibold mt-3">View docs</a>
-				</div>
-				<div class="min-h-61 rounded-2xl border-1 border-grey-20 p-8 bg-white flex flex-col items-start">
-					<p class="font-sans font-bold text-xl">Elasticsearch clients</p>
-					<p class="mt-2 grow">Browse the Elasticsearch client libraries for Java, .Net, Python, and more.</p>
-					<a href="@Model.Link("/reference/elasticsearch-clients/")" class="text-blue-elastic-100 hover:text-blue-elastic-110 font-sans font-semibold mt-3">View docs</a>
-				</div>
-				<div class="min-h-61 rounded-2xl border-1 border-grey-20 p-8 bg-white flex flex-col items-start">
-					<p class="font-sans font-bold text-xl">OpenTelemetry</p>
-					<p class="mt-2 grow">Browse the docs for the Elastic Distributions of OpenTelemetry (EDOT).</p>
-					<a href="@Model.Link("/reference/opentelemetry/")" class="text-blue-elastic-100 hover:text-blue-elastic-110 font-sans font-semibold mt-3">View docs</a>
-				</div>
-				<div class="min-h-61 rounded-2xl border-1 border-grey-20 p-8 bg-white flex flex-col items-start">
-					<p class="font-sans font-bold text-xl">Query languages</p>
-					<p class="mt-2 grow">Browse the docs for Query DSL, <span class="whitespace-nowrap">ES|QL</span>, KQL, and more.</p>
-					<a href="@Model.Link("/reference/query-languages/")" class="text-blue-elastic-100 hover:text-blue-elastic-110 font-sans font-semibold mt-3">View docs</a>
-				</div>
-			</div>
-			<div class="mt-6">
-				<a href="@Model.Link("/reference")" class="link">
-					View all reference docs
-					<svg class="link-arrow"
-					     xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-						<path stroke-linecap="round" stroke-linejoin="round" d="M17.25 8.25 21 12m0 0-3.75 3.75M21 12H3"/>
-					</svg>
-				</a>
-			</div>
-		</div>
-	</section>
+  /* Icon color variants */
+  .icon-blue { background: var(--accent-bg); color: var(--accent); }
+  .icon-green { background: var(--green-bg); color: var(--green); }
+  .icon-orange { background: var(--orange-bg); color: var(--orange); }
+  .icon-purple { background: var(--purple-bg); color: var(--purple); }
+  .icon-pink { background: var(--pink-bg); color: var(--pink); }
 
-	<section class="w-full">
-		<div class="container mx-auto py-10">
-			<div class="heading-wrapper" id="product-resources">
-				<h2 class="font-bold font-sans text-3xl">
-					<a href="#product-resources">
-						Product resources
-					</a>
-				</h2>
-			</div>
-			<div class="grid grid-cols-1 min-[1024px]:grid-cols-2 lg:grid-cols-4 gap-6 mt-6">
-				<div class="min-h-61 rounded-2xl bg-ink-navy border-1 border-grey-20 text-white p-8 flex flex-col items-start">
-					<p class="font-sans font-bold text-xl">Release notes</p>
-					<p class="mt-2 grow">Explore the latest features and changes in Elastic.</p>
-					<a href="@Model.Link("/release-notes/")" class="link mt-3 justify-start text-white hover:text-grey-20">View release notes
-						<svg class="link-arrow"
-						     xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-							<path stroke-linecap="round" stroke-linejoin="round" d="M17.25 8.25 21 12m0 0-3.75 3.75M21 12H3"/>
-						</svg>
-						</a>
-				</div>
-				<div class="min-h-61 rounded-2xl bg-ink-navy border-1 border-grey-20 text-white p-8 flex flex-col items-start">
-					<p class="font-sans font-bold text-xl">Extend and contribute</p>
-					<p class="mt-2 grow">Learn how to contribute to Elastic products and extend capabilities.</p>
-					<a href="@Model.Link("extend/")" class="link mt-3 justify-start text-white hover:text-grey-20">View extend and contribute docs
-						<svg class="link-arrow"
-						     xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-							<path stroke-linecap="round" stroke-linejoin="round" d="M17.25 8.25 21 12m0 0-3.75 3.75M21 12H3"/>
-						</svg>
-						</a>
-				</div>
-				<div class="min-h-61 rounded-2xl bg-ink-navy border-1 border-grey-20 text-white p-8 flex flex-col items-start">
-					<p class="font-sans font-bold text-xl">Troubleshoot</p>
-					<p class="mt-2 grow">Check troubleshooting guides for common fixes.</p>
-					<a href="@Model.Link("/troubleshoot/")" class="link mt-3 justify-start text-white hover:text-grey-20">View troubleshooting docs
-						<svg class="link-arrow"
-						     xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-							<path stroke-linecap="round" stroke-linejoin="round" d="M17.25 8.25 21 12m0 0-3.75 3.75M21 12H3"/>
-						</svg>
-						</a>
-				</div>
-				<div class="min-h-61 rounded-2xl border-1 border-grey-20 bg-white p-8 flex flex-col items-start">
-					<p class="font-sans font-bold text-xl">Previous versions</p>
-					<p class="mt-2 grow">Browse the docs for previous Elastic product versions.</p>
-					<a href="https://www.elastic.co/guide?lang=en" target="_blank" rel="noopener noreferrer" class="link mt-3 justify-start text-blue-elastic-100 hover:text-blue-elastic-110" hx-disable="true">View previous versions
-						<svg class="link-arrow"
-						     xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-							<path stroke-linecap="round" stroke-linejoin="round" d="M17.25 8.25 21 12m0 0-3.75 3.75M21 12H3"/>
-						</svg>
-						</a>
-				</div>
-			</div>
-		</div>
-	</section>
-	
-	@* <section class="w-full bg-grey-10"> *@
-	@* 	<div class="container mx-auto py-10"> *@
-	@* 		<h2 class="font-bold text-3xl text-ink-dark">Instant Elasticsearch</h2> *@
-	@* 		<div class="grid lg:grid-cols-2 gap-6 mt-6"> *@
-	@* 			<div class="lg:basis-[50%]"> *@
-	@* 				<p class="mt-2 font-body">For local testing, use Docker to install and run Elasticsearch.</p> *@
-	@* 			</div> *@
-	@* 			<div class="lg:basis-[50%] rounded-xl border-1 border-grey-20 p-6"> *@
-	@* 				<p class="font-body">Try it locally now:</p> *@
-	@* 				<div class="mt-2"> *@
-	@* 					<div class="highlight-bash notranslate"> *@
-	@* 						<div class="highlight"> *@
-	@* 							<pre> *@
-	@* 								<code class="language-yaml hljs" data-highlighted="yes">curl -fsSL https://elastic.co/start-local | sh</code> *@
-	@* 							</pre> *@
-	@* 						</div> *@
-	@* 					</div> *@
-	@* 				</div> *@
-	@* 			</div> *@
-	@* 		</div> *@
-	@* 	</div> *@
-	@* </section> *@
+  /* ── Version banner ── */
+  .version-banner {
+    max-width: var(--max-w);
+    margin: 40px auto 0;
+    padding: 0 24px;
+  }
+  .version-banner-inner {
+    background: linear-gradient(135deg, #f8f9fb 0%, #eef2f7 100%);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 20px 24px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 20px;
+    flex-wrap: wrap;
+  }
+  .version-banner-inner .vb-text { flex: 1; min-width: 200px; }
+  .version-banner-inner .vb-text h3 { font-size: 14px; font-weight: 600; margin-bottom: 3px; }
+  .version-banner-inner .vb-text p { font-size: 13px; color: var(--text-secondary); }
+  .version-banner-inner .vb-actions { display: flex; gap: 10px; flex-wrap: wrap; }
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 18px;
+    border-radius: var(--radius-sm);
+    font-size: 13px;
+    font-weight: 600;
+    font-family: var(--font);
+    cursor: pointer;
+    transition: background 0.15s, box-shadow 0.15s;
+    border: none;
+    text-decoration: none;
+  }
+  .btn-primary { background: var(--accent); color: #fff; }
+  .btn-primary:hover { background: var(--accent-hover); color: #fff; }
+  .btn-outline { background: var(--surface); color: var(--text-secondary); border: 1px solid var(--border); }
+  .btn-outline:hover { border-color: var(--accent); color: var(--accent); background: var(--accent-bg); }
 
-	<section class="w-full">
-		<div class="container mx-auto py-10">
-			<div class="rounded-xl border-1 border-grey-20 px-12 py-8 grid lg:grid-cols-[1fr_auto] gap-12 items-center text-center lg:text-left">
-				<div>
-					<h2 class="font-semibold font-sans text-3xl text-black leading-[1.2em]">Welcome to our community of developers</h2>
-					<p class="mt-2">Learn from your peers and share code examples.</p>
-				</div>
-				<a href="https://discuss.elastic.co" target="_blank" rel="noopener noreferrer" class="w-full cursor-pointer text-blue-elastic hover:text-blue-elastic-100 text-nowrap border-2 border-blue-elastic hover:border-blue-elastic-100 focus:ring-4 focus:outline-none focus:ring-blue-elastic-50 font-semibold rounded-sm px-6 py-2 text-center h-10 flex items-center justify-center min-w-40 max-w-md lg:max-w-none justify-self-center lg:justify-self-auto">
-					Join now
-				</a>
-			</div>
-		</div>
-	</section>
+  /* ── Product sections ── */
+  .products-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 16px;
+  }
+  @@media (max-width: 800px) {
+    .products-grid { grid-template-columns: 1fr; }
+  }
+  .product-card {
+    background: var(--surface);
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius);
+    padding: 24px;
+    transition: box-shadow 0.15s;
+  }
+  .product-card:hover { box-shadow: var(--shadow); }
+  .product-card h3 {
+    font-size: 16px;
+    font-weight: 700;
+    margin-bottom: 6px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .product-card h3 .dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+  .product-card > p { font-size: 13px; color: var(--text-secondary); margin-bottom: 16px; line-height: 1.5; }
+  .product-card ul { list-style: none; }
+  .product-card ul li { border-top: 1px solid var(--border-light); }
+  .product-card ul li a {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 0;
+    font-size: 14px;
+    color: var(--text);
+    transition: color 0.15s;
+  }
+  .product-card ul li a:hover { color: var(--accent); }
+  .product-card ul li a .arrow { color: var(--text-muted); font-size: 14px; transition: transform 0.15s, color 0.15s; }
+  .product-card ul li a:hover .arrow { transform: translateX(3px); color: var(--accent); }
 
-	<section class="w-full">
-		<div class="container mx-auto pt-10 pb-20">
-			<div class="rounded-2xl overflow-hidden px-12 py-8 bg-blue-elastic bg-no-repeat bg-auto grid lg:grid-cols-[1fr_auto] gap-12 items-center text-center lg:text-left"
-			     style="background-image: url('@Model.Static("elasticon-bg-b.png")'); background-position: center 65%">
-				<div>
-					<h2 class="font-bold font-sans text-3xl text-white">Looking for more?</h2>
-					<p class="mt-2 text-white text-base">We'll show you how to solve toughest challenges with Search AI.
-						Join us at an Elastic{ON} event near you!</p>
-				</div>
-				<a href="https://www.elastic.co/events/elasticon" target="_blank" rel="noopener noreferrer"
-				   class="w-full cursor-pointer text-blue-elastic hover:text-blue-elastic-100 text-nowrap border-2 border-white hover:border-grey-20 bg-white hover:bg-grey-10 focus:ring-4 focus:outline-none focus:ring-blue-elastic-50 font-semibold font-sans rounded-sm px-6 py-2 text-center h-10 flex items-center justify-center min-w-40 max-w-md lg:max-w-none justify-self-center lg:justify-self-auto">
-					Register now
-				</a>
-			</div>
-		</div>
-	</section>
-	
+  /* ── Product index (categorized) ── */
+  .product-index {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 16px;
+  }
+  @@media (max-width: 800px) {
+    .product-index { grid-template-columns: 1fr; }
+  }
+  .pi-category {
+    background: var(--surface);
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius);
+    padding: 18px 20px;
+  }
+  .pi-category h4 {
+    font-size: 12px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    margin-bottom: 10px;
+  }
+  .pi-category ul { list-style: none; }
+  .pi-category ul li + li { border-top: 1px solid var(--border-light); }
+  .pi-category ul li a {
+    display: block;
+    padding: 8px 0;
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--text);
+    text-decoration: none;
+    transition: color 0.12s;
+  }
+  .pi-category ul li a:hover { color: var(--accent); }
+
+  /* ── Reference & API strip ── */
+  .ref-strip {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 12px;
+  }
+  .ref-item {
+    background: var(--surface);
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius-sm);
+    padding: 16px;
+    text-decoration: none;
+    color: var(--text);
+    transition: box-shadow 0.15s, border-color 0.15s;
+  }
+  .ref-item:hover { border-color: var(--accent); box-shadow: var(--shadow-sm); color: var(--text); }
+  .ref-item h4 { font-size: 14px; font-weight: 600; margin-bottom: 3px; }
+  .ref-item p { font-size: 12px; color: var(--text-muted); }
+
+  /* ── Getting started ── */
+  .gs-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 14px;
+  }
+  @@media (max-width: 800px) {
+    .gs-grid { grid-template-columns: 1fr; }
+  }
+  .gs-card {
+    background: var(--surface);
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius);
+    padding: 22px 22px 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    text-decoration: none;
+    color: var(--text);
+    transition: border-color 0.15s, box-shadow 0.15s;
+  }
+  .gs-card:hover { border-color: var(--accent); box-shadow: var(--shadow); color: var(--text); }
+  .gs-card .gs-card-icon {
+    width: 36px;
+    height: 36px;
+    border-radius: var(--radius-sm);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 18px;
+    flex-shrink: 0;
+  }
+  .gs-card h3 { font-size: 15px; font-weight: 700; }
+  .gs-card p { font-size: 13px; color: var(--text-secondary); line-height: 1.45; flex: 1; }
+  .gs-card .gs-cta { font-size: 13px; font-weight: 600; color: var(--accent); }
+
+  /* ── Footer ── */
+  .landing-footer {
+    max-width: var(--max-w);
+    margin: 48px auto 0;
+    padding: 40px 24px;
+    border-top: 1px solid var(--border-light);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 12px;
+    font-size: 13px;
+    color: var(--text-muted);
+  }
+  .landing-footer a { color: var(--text-secondary); }
+
+  /* ── What's new ribbon ── */
+  .whats-new {
+    max-width: var(--max-w);
+    margin: 32px auto 0;
+    padding: 0 24px;
+  }
+  .whats-new-inner {
+    background: linear-gradient(135deg, #eef2ff 0%, #f0edff 100%);
+    border: 1px solid #d8d0ff;
+    border-radius: var(--radius);
+    padding: 14px 20px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-size: 14px;
+  }
+  .whats-new-inner .badge {
+    background: var(--purple);
+    color: #fff;
+    font-size: 11px;
+    font-weight: 700;
+    padding: 3px 10px;
+    border-radius: 20px;
+    white-space: nowrap;
+    letter-spacing: 0.03em;
+  }
+  .whats-new-inner a { font-weight: 500; }
+
+  /* ── Responsive ── */
+  @@media (max-width: 680px) {
+    .hero h1 { font-size: 22px; }
+    .quick-grid { grid-template-columns: 1fr; }
+    .version-banner-inner { flex-direction: column; align-items: flex-start; }
+    .gs-grid { grid-template-columns: 1fr; }
+  }
+</style>
+
+<div hx-select-oob="#main-container" hx-swap="none" class="w-full max-w-[100vw] relative overflow-x-hidden">
+
+  <!-- ── Version disambiguation ── -->
+  <div class="version-banner">
+    <div class="version-banner-inner">
+      <div class="vb-text">
+        <h3>You're viewing docs for Elastic Stack 9.0+ (latest @Model.CurrentVersion)</h3>
+        <p>Need docs for an earlier version?</p>
+      </div>
+      <div class="vb-actions">
+        <a href="https://www.elastic.co/guide" class="btn btn-outline" hx-disable="true">8.x docs (elastic.co/guide) →</a>
+        @if (Model.AllVersionsUrl is not null)
+        {
+          <a href="@Model.AllVersionsUrl" class="btn btn-outline">All versions</a>
+        }
+      </div>
+    </div>
+  </div>
+
+  <!-- ── Hero: Search-first ── -->
+  <div class="hero">
+    <h1>Elastic documentation</h1>
+    <p>Find guides, API references, and tutorials for the Elastic Stack.</p>
+    <div class="search-wrap">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.35-4.35"/></svg>
+      <navigation-search></navigation-search>
+    </div>
+  </div>
+
+  <!-- ── What's new ── -->
+  <div class="whats-new">
+    <div class="whats-new-inner">
+      <span class="badge">NEW</span>
+      <span>Elasticsearch @Model.CurrentVersion is out — <a href="@Model.Link("/release-notes/")">check out what's new →</a></span>
+    </div>
+  </div>
+
+  <!-- ── Popular destinations ── -->
+  <div class="section">
+    <div class="section-header">
+      <h2>Popular destinations</h2>
+    </div>
+    <div class="quick-grid">
+      <a class="quick-card" href="@Model.Link("/solutions/search")">
+        <div class="icon icon-blue">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.35-4.35"/></svg>
+        </div>
+        <div class="card-text">
+          <h3>Elasticsearch</h3>
+          <p>Store, search, and analyze your data</p>
+        </div>
+      </a>
+      <a class="quick-card" href="@Model.Link("/deploy-manage/deploy/self-managed/installing-elasticsearch")">
+        <div class="icon icon-orange">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
+        </div>
+        <div class="card-text">
+          <h3>Install with Docker</h3>
+          <p>Run Elasticsearch in containers</p>
+        </div>
+      </a>
+      <a class="quick-card" href="@Model.Link("/reference/query-languages/")">
+        <div class="icon icon-purple">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M16 18l6-6-6-6"/><path d="M8 6l-6 6 6 6"/></svg>
+        </div>
+        <div class="card-text">
+          <h3>Query DSL</h3>
+          <p>Full-text search, filters, and aggregations</p>
+        </div>
+      </a>
+      <a class="quick-card" href="@Model.Link("/get-started")">
+        <div class="icon icon-green">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>
+        </div>
+        <div class="card-text">
+          <h3>The Elastic Stack</h3>
+          <p>Learn about the open-source tools to search, analyze, and visualize data in real time</p>
+        </div>
+      </a>
+      <a class="quick-card" href="https://www.elastic.co/docs/api" target="_blank" rel="noopener noreferrer" hx-disable="true">
+        <div class="icon icon-pink">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+        </div>
+        <div class="card-text">
+          <h3>Elasticsearch API</h3>
+          <p>REST endpoints</p>
+        </div>
+      </a>
+      <a class="quick-card" href="@Model.Link("/explore-analyze")">
+        <div class="icon icon-orange">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/><path d="M9 21V9"/></svg>
+        </div>
+        <div class="card-text">
+          <h3>Kibana</h3>
+          <p>Visualize your Elasticsearch data</p>
+        </div>
+      </a>
+    </div>
+  </div>
+
+  <!-- ── Get started ── -->
+  <div class="section">
+    <div class="section-header">
+      <h2>Get started</h2>
+    </div>
+    <div class="gs-grid">
+      <a class="gs-card" href="@Model.Link("/get-started")">
+        <div class="gs-card-icon icon-green">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
+        </div>
+        <h3>Try locally</h3>
+        <p>One command. Elasticsearch + Kibana on your machine in under two minutes. No account, no credit card.</p>
+        <span class="gs-cta">Run locally →</span>
+      </a>
+      <a class="gs-card" href="https://cloud.elastic.co/registration?page=docs&placement=docs-body" target="_blank" rel="noopener noreferrer" hx-disable="true">
+        <div class="gs-card-icon icon-blue">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17.5 19H9a7 7 0 1 1 6.71-9h1.79a4.5 4.5 0 1 1 0 9z"/></svg>
+        </div>
+        <h3>Free cloud trial</h3>
+        <p>Fully managed on AWS, GCP, or Azure. Production-ready in minutes. Search, Observability, and Security all included.</p>
+        <span class="gs-cta">Start free trial →</span>
+      </a>
+      <a class="gs-card" href="@Model.Link("/get-started")">
+        <div class="gs-card-icon icon-purple">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
+        </div>
+        <h3>Elastic fundamentals</h3>
+        <p>Learn about Elasticsearch concepts and how to get up and running.</p>
+        <span class="gs-cta">Learn the basics →</span>
+      </a>
+    </div>
+  </div>
+
+  <!-- ── Browse by solution ── -->
+  <div class="section">
+    <div class="section-header">
+      <h2>Browse by solution</h2>
+    </div>
+    <div class="products-grid">
+      <div class="product-card">
+        <h3><span class="dot" style="background:#0077cc"></span> Search</h3>
+        <p>Build search experiences powered by Elasticsearch — from full-text search to vector and hybrid retrieval.</p>
+        <ul>
+          <li><a href="@Model.Link("/solutions/search")">Get started with Search <span class="arrow">→</span></a></li>
+          <li><a href="@Model.Link("/solutions/search")">Semantic &amp; vector search <span class="arrow">→</span></a></li>
+          <li><a href="@Model.Link("/solutions/search")">Search applications <span class="arrow">→</span></a></li>
+          <li><a href="@Model.Link("/solutions/search")">Agent Builder <span class="arrow">→</span></a></li>
+          <li><a href="@Model.Link("/solutions/search")">AI agent skills <span class="arrow">→</span></a></li>
+        </ul>
+      </div>
+      <div class="product-card">
+        <h3><span class="dot" style="background:#00bfb3"></span> Observability</h3>
+        <p>Logs, metrics, APM, and uptime monitoring in a unified platform.</p>
+        <ul>
+          <li><a href="@Model.Link("/solutions/observability")">Get started with Observability <span class="arrow">→</span></a></li>
+          <li><a href="@Model.Link("/solutions/observability")">APM <span class="arrow">→</span></a></li>
+          <li><a href="@Model.Link("/solutions/observability")">Log monitoring <span class="arrow">→</span></a></li>
+          <li><a href="@Model.Link("/solutions/observability")">Synthetics <span class="arrow">→</span></a></li>
+          <li><a href="@Model.Link("/solutions/observability")">Infrastructure monitoring <span class="arrow">→</span></a></li>
+        </ul>
+      </div>
+      <div class="product-card">
+        <h3><span class="dot" style="background:#ff4081"></span> Security</h3>
+        <p>SIEM, endpoint protection, and threat hunting for your organization.</p>
+        <ul>
+          <li><a href="@Model.Link("/solutions/security")">Get started with Security <span class="arrow">→</span></a></li>
+          <li><a href="@Model.Link("/solutions/security")">Detection rules <span class="arrow">→</span></a></li>
+          <li><a href="@Model.Link("/solutions/security")">Endpoint protection <span class="arrow">→</span></a></li>
+          <li><a href="@Model.Link("/solutions/security")">Cases &amp; investigations <span class="arrow">→</span></a></li>
+          <li><a href="@Model.Link("/solutions/security")">Cloud security <span class="arrow">→</span></a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── All products ── -->
+  <div class="section">
+    <div class="section-header">
+      <h2>All products</h2>
+    </div>
+    <div class="product-index">
+      <div class="pi-category">
+        <h4>Elastic Stack</h4>
+        <ul>
+          <li><a href="@Model.Link("/solutions/search")">Elasticsearch</a></li>
+          <li><a href="@Model.Link("/explore-analyze")">Kibana</a></li>
+          <li><a href="@Model.Link("/manage-data")">Logstash</a></li>
+          <li><a href="@Model.Link("/manage-data")">Beats</a></li>
+          <li><a href="@Model.Link("/explore-analyze")">Machine Learning</a></li>
+          <li><a href="@Model.Link("/manage-data")">Elasticsearch for Apache Hadoop &amp; Spark</a></li>
+        </ul>
+      </div>
+      <div class="pi-category">
+        <h4>Cloud &amp; orchestration</h4>
+        <ul>
+          <li><a href="@Model.Link("/deploy-manage")">Elastic Cloud Serverless</a></li>
+          <li><a href="@Model.Link("/deploy-manage")">Elastic Cloud Hosted</a></li>
+          <li><a href="@Model.Link("/deploy-manage")">Elastic Cloud on Kubernetes (ECK)</a></li>
+          <li><a href="@Model.Link("/deploy-manage")">Elastic Cloud Enterprise (ECE)</a></li>
+          <li><a href="@Model.Link("/deploy-manage")">Elastic Cloud control (ecctl)</a></li>
+        </ul>
+      </div>
+      <div class="pi-category">
+        <h4>Ingest tools</h4>
+        <ul>
+          <li><a href="@Model.Link("/manage-data")">Integrations</a></li>
+          <li><a href="@Model.Link("/reference/opentelemetry/")">Elastic Distributions for OpenTelemetry</a></li>
+          <li><a href="@Model.Link("/manage-data")">Fleet &amp; Elastic Agent</a></li>
+          <li><a href="@Model.Link("/solutions/observability")">APM</a></li>
+          <li><a href="@Model.Link("/solutions/security")">Elastic Defend</a></li>
+          <li><a href="@Model.Link("/manage-data")">Elastic Serverless Forwarder for AWS</a></li>
+          <li><a href="@Model.Link("/manage-data")">Connectors</a></li>
+          <li><a href="@Model.Link("/manage-data")">Web crawler</a></li>
+        </ul>
+      </div>
+      <div class="pi-category">
+        <h4>Query languages</h4>
+        <ul>
+          <li><a href="@Model.Link("/reference/query-languages/")">Query DSL</a></li>
+          <li><a href="@Model.Link("/reference/query-languages/")">ES|QL</a></li>
+          <li><a href="@Model.Link("/reference/query-languages/")">KQL</a></li>
+          <li><a href="@Model.Link("/reference/query-languages/")">SQL</a></li>
+          <li><a href="@Model.Link("/reference/query-languages/")">EQL</a></li>
+          <li><a href="@Model.Link("/reference/query-languages/")">Lucene</a></li>
+        </ul>
+      </div>
+      <div class="pi-category">
+        <h4>APM agents</h4>
+        <ul>
+          <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Java Agent</a></li>
+          <li><a href="@Model.Link("/reference/elasticsearch-clients/")">&#46;NET Agent</a></li>
+          <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Node.js Agent</a></li>
+          <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Python Agent</a></li>
+          <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Ruby Agent</a></li>
+          <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Go Agent</a></li>
+          <li><a href="@Model.Link("/reference/elasticsearch-clients/")">PHP Agent</a></li>
+        </ul>
+      </div>
+      <div class="pi-category">
+        <h4>Developer tools &amp; standards</h4>
+        <ul>
+          <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Elasticsearch clients</a></li>
+          <li><a href="@Model.Link("/reference")">Elastic Common Schema (ECS)</a></li>
+          <li><a href="@Model.Link("/reference")">Search UI</a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── Footer ── -->
+  <footer class="landing-footer">
+    <span>© 2026 Elasticsearch B.V.</span>
+    <span><a href="@Model.Link("/contribute-docs")">Edit this page</a> · <a href="@Model.Link("/contribute-docs")">Report a docs issue</a></span>
+  </footer>
+
 </div>

--- a/src/Elastic.Markdown/Layout/_LandingPage.cshtml
+++ b/src/Elastic.Markdown/Layout/_LandingPage.cshtml
@@ -47,11 +47,6 @@
     letter-spacing: -0.02em;
     margin-bottom: 10px;
   }
-  .hero p {
-    font-size: 15px;
-    color: var(--text-secondary);
-    margin-bottom: 28px;
-  }
   .search-wrap {
     max-width: 640px;
     margin: 0 auto 16px;
@@ -65,26 +60,8 @@
     color: var(--text-muted);
     pointer-events: none;
   }
-  .search-wrap input {
-    width: 100%;
-    height: 52px;
-    border: 2px solid var(--border);
-    border-radius: var(--radius);
-    padding: 0 16px 0 48px;
-    font-size: 16px;
-    font-family: var(--font);
-    background: var(--surface);
-    color: var(--text);
-    transition: border-color 0.15s, box-shadow 0.15s;
-    outline: none;
-  }
-  .search-wrap input::placeholder { color: var(--text-muted); }
-  .search-wrap input:focus {
-    border-color: var(--accent);
-    box-shadow: 0 0 0 3px rgba(0,119,204,0.12);
-  }
 
-  /* ── Quick destinations ── */
+  /* ── Section layout ── */
   .section { max-width: var(--max-w); margin: 0 auto; padding: 40px 24px 0; }
   .section-header {
     display: flex;
@@ -95,43 +72,6 @@
   .section-header h2 { font-size: 17px; font-weight: 700; letter-spacing: -0.01em; }
   .section-header a { font-size: 13px; font-weight: 500; }
 
-  .quick-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-    gap: 12px;
-  }
-  .quick-card {
-    background: var(--surface);
-    border: 1px solid var(--border-light);
-    border-radius: var(--radius);
-    padding: 18px 20px;
-    display: flex;
-    align-items: flex-start;
-    gap: 14px;
-    transition: box-shadow 0.15s, border-color 0.15s;
-    cursor: pointer;
-    text-decoration: none;
-    color: var(--text);
-  }
-  .quick-card:hover {
-    border-color: var(--accent);
-    box-shadow: var(--shadow);
-    color: var(--text);
-  }
-  .quick-card .icon {
-    width: 40px;
-    height: 40px;
-    border-radius: var(--radius-sm);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-shrink: 0;
-    font-size: 18px;
-  }
-  .quick-card .card-text h3 { font-size: 14px; font-weight: 600; margin-bottom: 3px; }
-  .quick-card .card-text p { font-size: 13px; color: var(--text-secondary); line-height: 1.4; }
-  .quick-card .card-text .meta { font-size: 12px; color: var(--text-muted); margin-top: 4px; }
-
   /* Icon color variants */
   .icon-blue { background: var(--accent-bg); color: var(--accent); }
   .icon-green { background: var(--green-bg); color: var(--green); }
@@ -139,147 +79,86 @@
   .icon-purple { background: var(--purple-bg); color: var(--purple); }
   .icon-pink { background: var(--pink-bg); color: var(--pink); }
 
-  /* ── Version banner ── */
-  .version-banner {
-    max-width: var(--max-w);
-    margin: 40px auto 0;
-    padding: 0 24px;
-  }
-  .version-banner-inner {
-    background: linear-gradient(135deg, #f8f9fb 0%, #eef2f7 100%);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    padding: 20px 24px;
+  /* ── Tabbed products ── */
+  .tabs-nav {
     display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 20px;
-    flex-wrap: wrap;
+    gap: 0;
+    border-bottom: 2px solid var(--border);
+    margin-bottom: 20px;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
   }
-  .version-banner-inner .vb-text { flex: 1; min-width: 200px; }
-  .version-banner-inner .vb-text h3 { font-size: 14px; font-weight: 600; margin-bottom: 3px; }
-  .version-banner-inner .vb-text p { font-size: 13px; color: var(--text-secondary); }
-  .version-banner-inner .vb-actions { display: flex; gap: 10px; flex-wrap: wrap; }
-  .btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    padding: 8px 18px;
-    border-radius: var(--radius-sm);
+  .tabs-nav button {
+    background: none;
+    border: none;
+    border-bottom: 2px solid transparent;
+    margin-bottom: -2px;
+    padding: 10px 18px;
+    font-family: var(--font);
     font-size: 13px;
     font-weight: 600;
-    font-family: var(--font);
-    cursor: pointer;
-    transition: background 0.15s, box-shadow 0.15s;
-    border: none;
-    text-decoration: none;
-  }
-  .btn-primary { background: var(--accent); color: #fff; }
-  .btn-primary:hover { background: var(--accent-hover); color: #fff; }
-  .btn-outline { background: var(--surface); color: var(--text-secondary); border: 1px solid var(--border); }
-  .btn-outline:hover { border-color: var(--accent); color: var(--accent); background: var(--accent-bg); }
-
-  /* ── Product sections ── */
-  .products-grid {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 16px;
-  }
-  @@media (max-width: 800px) {
-    .products-grid { grid-template-columns: 1fr; }
-  }
-  .product-card {
-    background: var(--surface);
-    border: 1px solid var(--border-light);
-    border-radius: var(--radius);
-    padding: 24px;
-    transition: box-shadow 0.15s;
-  }
-  .product-card:hover { box-shadow: var(--shadow); }
-  .product-card h3 {
-    font-size: 16px;
-    font-weight: 700;
-    margin-bottom: 6px;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
-  .product-card h3 .dot {
-    width: 10px;
-    height: 10px;
-    border-radius: 50%;
-    flex-shrink: 0;
-  }
-  .product-card > p { font-size: 13px; color: var(--text-secondary); margin-bottom: 16px; line-height: 1.5; }
-  .product-card ul { list-style: none; }
-  .product-card ul li { border-top: 1px solid var(--border-light); }
-  .product-card ul li a {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 10px 0;
-    font-size: 14px;
-    color: var(--text);
-    transition: color 0.15s;
-  }
-  .product-card ul li a:hover { color: var(--accent); }
-  .product-card ul li a .arrow { color: var(--text-muted); font-size: 14px; transition: transform 0.15s, color 0.15s; }
-  .product-card ul li a:hover .arrow { transform: translateX(3px); color: var(--accent); }
-
-  /* ── Product index (categorized) ── */
-  .product-index {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 16px;
-  }
-  @@media (max-width: 800px) {
-    .product-index { grid-template-columns: 1fr; }
-  }
-  .pi-category {
-    background: var(--surface);
-    border: 1px solid var(--border-light);
-    border-radius: var(--radius);
-    padding: 18px 20px;
-  }
-  .pi-category h4 {
-    font-size: 12px;
-    font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 0.06em;
+    letter-spacing: 0.04em;
     color: var(--text-muted);
+    cursor: pointer;
+    white-space: nowrap;
+    transition: color 0.15s, border-color 0.15s;
+  }
+  .tabs-nav button:hover { color: var(--text-secondary); }
+  .tabs-nav button.active {
+    color: var(--accent);
+    border-bottom-color: var(--accent);
+  }
+  .tab-panel { display: none; }
+  .tab-panel.active { display: flex; flex-wrap: wrap; gap: 10px; }
+
+  /* Tab cards */
+  .tab-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 14px;
+    width: 100%;
+  }
+  .tab-card {
+    background: var(--surface);
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius);
+    padding: 20px;
+    transition: box-shadow 0.15s, border-color 0.15s;
+  }
+  .tab-card:hover { border-color: var(--border); box-shadow: var(--shadow-sm); }
+  .tab-card h4 {
+    font-size: 15px;
+    font-weight: 700;
     margin-bottom: 10px;
   }
-  .pi-category ul { list-style: none; }
-  .pi-category ul li + li { border-top: 1px solid var(--border-light); }
-  .pi-category ul li a {
+  .tab-card ul { list-style: none; }
+  .tab-card ul li + li { border-top: 1px solid var(--border-light); }
+  .tab-card ul li a {
     display: block;
-    padding: 8px 0;
-    font-size: 14px;
-    font-weight: 500;
-    color: var(--text);
+    padding: 7px 0;
+    font-size: 13px;
+    color: var(--accent);
     text-decoration: none;
     transition: color 0.12s;
   }
-  .pi-category ul li a:hover { color: var(--accent); }
+  .tab-card ul li a:hover { color: var(--accent-hover); }
 
-  /* ── Reference & API strip ── */
-  .ref-strip {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-    gap: 12px;
+  /* ── Top tabs (below search) ── */
+  .top-tabs {
+    max-width: var(--max-w);
+    margin: 0 auto;
+    padding: 0 24px 8px;
   }
-  .ref-item {
-    background: var(--surface);
-    border: 1px solid var(--border-light);
-    border-radius: var(--radius-sm);
-    padding: 16px;
-    text-decoration: none;
-    color: var(--text);
-    transition: box-shadow 0.15s, border-color 0.15s;
+  .top-tabs .tabs-nav { margin-bottom: 20px; justify-content: center; }
+
+  /* ── Page layout ── */
+  .page-layout {
+    max-width: var(--max-w);
+    margin: 0 auto;
+    padding: 0 24px;
   }
-  .ref-item:hover { border-color: var(--accent); box-shadow: var(--shadow-sm); color: var(--text); }
-  .ref-item h4 { font-size: 14px; font-weight: 600; margin-bottom: 3px; }
-  .ref-item p { font-size: 12px; color: var(--text-muted); }
+  .page-main .section { padding: 40px 0 0; max-width: none; margin: 0; }
 
   /* ── Getting started ── */
   .gs-grid {
@@ -314,8 +193,33 @@
     flex-shrink: 0;
   }
   .gs-card h3 { font-size: 15px; font-weight: 700; }
-  .gs-card p { font-size: 13px; color: var(--text-secondary); line-height: 1.45; flex: 1; }
-  .gs-card .gs-cta { font-size: 13px; font-weight: 600; color: var(--accent); }
+
+  /* ── All products (categorized list) ── */
+  .all-products-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 28px 40px;
+  }
+  .all-products-grid .cat-heading {
+    font-size: 12px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    margin-bottom: 10px;
+  }
+  .all-products-grid .cat-list { list-style: none; }
+  .all-products-grid .cat-list li + li { margin-top: 2px; }
+  .all-products-grid .cat-list a {
+    display: block;
+    padding: 5px 0;
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--text);
+    text-decoration: none;
+    transition: color 0.15s;
+  }
+  .all-products-grid .cat-list a:hover { color: var(--accent); }
 
   /* ── Footer ── */
   .landing-footer {
@@ -333,291 +237,275 @@
   }
   .landing-footer a { color: var(--text-secondary); }
 
-  /* ── What's new ribbon ── */
-  .whats-new {
-    max-width: var(--max-w);
-    margin: 32px auto 0;
-    padding: 0 24px;
-  }
-  .whats-new-inner {
-    background: linear-gradient(135deg, #eef2ff 0%, #f0edff 100%);
-    border: 1px solid #d8d0ff;
-    border-radius: var(--radius);
-    padding: 14px 20px;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    font-size: 14px;
-  }
-  .whats-new-inner .badge {
-    background: var(--purple);
-    color: #fff;
-    font-size: 11px;
-    font-weight: 700;
-    padding: 3px 10px;
-    border-radius: 20px;
-    white-space: nowrap;
-    letter-spacing: 0.03em;
-  }
-  .whats-new-inner a { font-weight: 500; }
-
   /* ── Responsive ── */
   @@media (max-width: 680px) {
     .hero h1 { font-size: 22px; }
-    .quick-grid { grid-template-columns: 1fr; }
-    .version-banner-inner { flex-direction: column; align-items: flex-start; }
-    .gs-grid { grid-template-columns: 1fr; }
   }
 </style>
 
 <div hx-select-oob="#main-container" hx-swap="none" class="w-full max-w-[100vw] relative overflow-x-hidden">
 
-  <!-- ── Version disambiguation ── -->
-  <div class="version-banner">
-    <div class="version-banner-inner">
-      <div class="vb-text">
-        <h3>You're viewing docs for Elastic Stack 9.0+ (latest @Model.CurrentVersion)</h3>
-        <p>Need docs for an earlier version?</p>
-      </div>
-      <div class="vb-actions">
-        <a href="https://www.elastic.co/guide" class="btn btn-outline" hx-disable="true">8.x docs (elastic.co/guide) →</a>
-        @if (Model.AllVersionsUrl is not null)
-        {
-          <a href="@Model.AllVersionsUrl" class="btn btn-outline">All versions</a>
-        }
-      </div>
-    </div>
-  </div>
-
   <!-- ── Hero: Search-first ── -->
   <div class="hero">
     <h1>Elastic documentation</h1>
-    <p>Find guides, API references, and tutorials for the Elastic Stack.</p>
     <div class="search-wrap">
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.35-4.35"/></svg>
       <navigation-search></navigation-search>
     </div>
   </div>
 
-  <!-- ── What's new ── -->
-  <div class="whats-new">
-    <div class="whats-new-inner">
-      <span class="badge">NEW</span>
-      <span>Elasticsearch @Model.CurrentVersion is out — <a href="@Model.Link("/release-notes/")">check out what's new →</a></span>
+  <!-- ── Top tabs: Platform / Solutions / Deploy ── -->
+  <div class="top-tabs">
+    <div class="tabs-nav">
+      <button class="active" onclick="switchTopTab(event, 'top-tab-platform')">Platform</button>
+      <button onclick="switchTopTab(event, 'top-tab-solutions')">Solutions</button>
+      <button onclick="switchTopTab(event, 'top-tab-deploy')">Deploy</button>
     </div>
-  </div>
 
-  <!-- ── Popular destinations ── -->
-  <div class="section">
-    <div class="section-header">
-      <h2>Popular destinations</h2>
-    </div>
-    <div class="quick-grid">
-      <a class="quick-card" href="@Model.Link("/solutions/search")">
-        <div class="icon icon-blue">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.35-4.35"/></svg>
+    <div id="top-tab-platform" class="tab-panel active">
+      <div class="tab-cards">
+        <div class="tab-card">
+          <h4>Elasticsearch</h4>
+          <ul>
+            <li><a href="@Model.Link("/deploy-manage/deploy/self-managed/installing-elasticsearch")">Install Elasticsearch →</a></li>
+            <li><a href="https://www.elastic.co/docs/api" target="_blank" rel="noopener noreferrer" hx-disable="true">REST APIs →</a></li>
+            <li><a href="@Model.Link("/reference/query-languages/")">Query DSL →</a></li>
+            <li><a href="@Model.Link("/reference/query-languages/")">Aggregations →</a></li>
+            <li><a href="@Model.Link("/manage-data")">Index management →</a></li>
+          </ul>
         </div>
-        <div class="card-text">
-          <h3>Elasticsearch</h3>
-          <p>Store, search, and analyze your data</p>
+        <div class="tab-card">
+          <h4>Kibana</h4>
+          <ul>
+            <li><a href="@Model.Link("/deploy-manage")">Install Kibana →</a></li>
+            <li><a href="@Model.Link("/explore-analyze")">Dashboards →</a></li>
+            <li><a href="@Model.Link("/explore-analyze")">Visualizations →</a></li>
+            <li><a href="@Model.Link("/explore-analyze")">Discover →</a></li>
+            <li><a href="@Model.Link("/explore-analyze")">Alerting →</a></li>
+          </ul>
         </div>
-      </a>
-      <a class="quick-card" href="@Model.Link("/deploy-manage/deploy/self-managed/installing-elasticsearch")">
-        <div class="icon icon-orange">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
+        <div class="tab-card">
+          <h4>Logstash</h4>
+          <ul>
+            <li><a href="@Model.Link("/manage-data")">Getting started →</a></li>
+            <li><a href="@Model.Link("/manage-data")">Input plugins →</a></li>
+            <li><a href="@Model.Link("/manage-data")">Filter plugins →</a></li>
+            <li><a href="@Model.Link("/manage-data")">Output plugins →</a></li>
+            <li><a href="@Model.Link("/manage-data")">Pipeline configuration →</a></li>
+          </ul>
         </div>
-        <div class="card-text">
-          <h3>Install with Docker</h3>
-          <p>Run Elasticsearch in containers</p>
+        <div class="tab-card">
+          <h4>Beats</h4>
+          <ul>
+            <li><a href="@Model.Link("/manage-data")">Filebeat →</a></li>
+            <li><a href="@Model.Link("/manage-data")">Metricbeat →</a></li>
+            <li><a href="@Model.Link("/manage-data")">Packetbeat →</a></li>
+            <li><a href="@Model.Link("/manage-data")">Heartbeat →</a></li>
+            <li><a href="@Model.Link("/manage-data")">Auditbeat →</a></li>
+          </ul>
         </div>
-      </a>
-      <a class="quick-card" href="@Model.Link("/reference/query-languages/")">
-        <div class="icon icon-purple">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M16 18l6-6-6-6"/><path d="M8 6l-6 6 6 6"/></svg>
-        </div>
-        <div class="card-text">
-          <h3>Query DSL</h3>
-          <p>Full-text search, filters, and aggregations</p>
-        </div>
-      </a>
-      <a class="quick-card" href="@Model.Link("/get-started")">
-        <div class="icon icon-green">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>
-        </div>
-        <div class="card-text">
-          <h3>The Elastic Stack</h3>
-          <p>Learn about the open-source tools to search, analyze, and visualize data in real time</p>
-        </div>
-      </a>
-      <a class="quick-card" href="https://www.elastic.co/docs/api" target="_blank" rel="noopener noreferrer" hx-disable="true">
-        <div class="icon icon-pink">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
-        </div>
-        <div class="card-text">
-          <h3>Elasticsearch API</h3>
-          <p>REST endpoints</p>
-        </div>
-      </a>
-      <a class="quick-card" href="@Model.Link("/explore-analyze")">
-        <div class="icon icon-orange">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/><path d="M9 21V9"/></svg>
-        </div>
-        <div class="card-text">
-          <h3>Kibana</h3>
-          <p>Visualize your Elasticsearch data</p>
-        </div>
-      </a>
-    </div>
-  </div>
-
-  <!-- ── Get started ── -->
-  <div class="section">
-    <div class="section-header">
-      <h2>Get started</h2>
-    </div>
-    <div class="gs-grid">
-      <a class="gs-card" href="@Model.Link("/get-started")">
-        <div class="gs-card-icon icon-green">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
-        </div>
-        <h3>Try locally</h3>
-        <p>One command. Elasticsearch + Kibana on your machine in under two minutes. No account, no credit card.</p>
-        <span class="gs-cta">Run locally →</span>
-      </a>
-      <a class="gs-card" href="https://cloud.elastic.co/registration?page=docs&placement=docs-body" target="_blank" rel="noopener noreferrer" hx-disable="true">
-        <div class="gs-card-icon icon-blue">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17.5 19H9a7 7 0 1 1 6.71-9h1.79a4.5 4.5 0 1 1 0 9z"/></svg>
-        </div>
-        <h3>Free cloud trial</h3>
-        <p>Fully managed on AWS, GCP, or Azure. Production-ready in minutes. Search, Observability, and Security all included.</p>
-        <span class="gs-cta">Start free trial →</span>
-      </a>
-      <a class="gs-card" href="@Model.Link("/get-started")">
-        <div class="gs-card-icon icon-purple">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
-        </div>
-        <h3>Elastic fundamentals</h3>
-        <p>Learn about Elasticsearch concepts and how to get up and running.</p>
-        <span class="gs-cta">Learn the basics →</span>
-      </a>
-    </div>
-  </div>
-
-  <!-- ── Browse by solution ── -->
-  <div class="section">
-    <div class="section-header">
-      <h2>Browse by solution</h2>
-    </div>
-    <div class="products-grid">
-      <div class="product-card">
-        <h3><span class="dot" style="background:#0077cc"></span> Search</h3>
-        <p>Build search experiences powered by Elasticsearch — from full-text search to vector and hybrid retrieval.</p>
-        <ul>
-          <li><a href="@Model.Link("/solutions/search")">Get started with Search <span class="arrow">→</span></a></li>
-          <li><a href="@Model.Link("/solutions/search")">Semantic &amp; vector search <span class="arrow">→</span></a></li>
-          <li><a href="@Model.Link("/solutions/search")">Search applications <span class="arrow">→</span></a></li>
-          <li><a href="@Model.Link("/solutions/search")">Agent Builder <span class="arrow">→</span></a></li>
-          <li><a href="@Model.Link("/solutions/search")">AI agent skills <span class="arrow">→</span></a></li>
-        </ul>
       </div>
-      <div class="product-card">
-        <h3><span class="dot" style="background:#00bfb3"></span> Observability</h3>
-        <p>Logs, metrics, APM, and uptime monitoring in a unified platform.</p>
-        <ul>
-          <li><a href="@Model.Link("/solutions/observability")">Get started with Observability <span class="arrow">→</span></a></li>
-          <li><a href="@Model.Link("/solutions/observability")">APM <span class="arrow">→</span></a></li>
-          <li><a href="@Model.Link("/solutions/observability")">Log monitoring <span class="arrow">→</span></a></li>
-          <li><a href="@Model.Link("/solutions/observability")">Synthetics <span class="arrow">→</span></a></li>
-          <li><a href="@Model.Link("/solutions/observability")">Infrastructure monitoring <span class="arrow">→</span></a></li>
-        </ul>
+    </div>
+
+    <div id="top-tab-solutions" class="tab-panel">
+      <div class="tab-cards">
+        <div class="tab-card">
+          <h4>Elasticsearch</h4>
+          <ul>
+            <li><a href="@Model.Link("/solutions/search")">Get started with Search →</a></li>
+            <li><a href="@Model.Link("/solutions/search")">Semantic &amp; vector search →</a></li>
+            <li><a href="@Model.Link("/solutions/search")">Search applications →</a></li>
+            <li><a href="@Model.Link("/solutions/search")">Agent Builder →</a></li>
+            <li><a href="@Model.Link("/solutions/search")">AI agent skills →</a></li>
+          </ul>
+        </div>
+        <div class="tab-card">
+          <h4>Elastic Observability</h4>
+          <ul>
+            <li><a href="@Model.Link("/solutions/observability")">Get started with Observability →</a></li>
+            <li><a href="@Model.Link("/solutions/observability")">APM →</a></li>
+            <li><a href="@Model.Link("/solutions/observability")">Log monitoring →</a></li>
+            <li><a href="@Model.Link("/solutions/observability")">Infrastructure monitoring →</a></li>
+            <li><a href="@Model.Link("/solutions/observability")">Synthetics →</a></li>
+          </ul>
+        </div>
+        <div class="tab-card">
+          <h4>Elastic Security</h4>
+          <ul>
+            <li><a href="@Model.Link("/solutions/security")">Get started with Security →</a></li>
+            <li><a href="@Model.Link("/solutions/security")">Detection rules →</a></li>
+            <li><a href="@Model.Link("/solutions/security")">Endpoint protection →</a></li>
+            <li><a href="@Model.Link("/solutions/security")">Cases &amp; investigations →</a></li>
+            <li><a href="@Model.Link("/solutions/security")">Cloud security →</a></li>
+          </ul>
+        </div>
       </div>
-      <div class="product-card">
-        <h3><span class="dot" style="background:#ff4081"></span> Security</h3>
-        <p>SIEM, endpoint protection, and threat hunting for your organization.</p>
-        <ul>
-          <li><a href="@Model.Link("/solutions/security")">Get started with Security <span class="arrow">→</span></a></li>
-          <li><a href="@Model.Link("/solutions/security")">Detection rules <span class="arrow">→</span></a></li>
-          <li><a href="@Model.Link("/solutions/security")">Endpoint protection <span class="arrow">→</span></a></li>
-          <li><a href="@Model.Link("/solutions/security")">Cases &amp; investigations <span class="arrow">→</span></a></li>
-          <li><a href="@Model.Link("/solutions/security")">Cloud security <span class="arrow">→</span></a></li>
-        </ul>
+    </div>
+
+    <div id="top-tab-deploy" class="tab-panel">
+      <div class="tab-cards">
+        <div class="tab-card">
+          <h4>Elastic Cloud Serverless</h4>
+          <ul>
+            <li><a href="@Model.Link("/deploy-manage")">Getting started →</a></li>
+            <li><a href="@Model.Link("/deploy-manage")">Project management →</a></li>
+            <li><a href="@Model.Link("/cloud-account")">Billing &amp; usage →</a></li>
+          </ul>
+        </div>
+        <div class="tab-card">
+          <h4>Elastic Cloud Hosted</h4>
+          <ul>
+            <li><a href="@Model.Link("/deploy-manage")">Getting started →</a></li>
+            <li><a href="@Model.Link("/deploy-manage")">Deployment management →</a></li>
+            <li><a href="@Model.Link("/deploy-manage")">Monitoring →</a></li>
+            <li><a href="@Model.Link("/cloud-account")">Billing →</a></li>
+          </ul>
+        </div>
+        <div class="tab-card">
+          <h4>Self-managed</h4>
+          <ul>
+            <li><a href="@Model.Link("/deploy-manage/deploy/self-managed/installing-elasticsearch")">Install Elasticsearch →</a></li>
+            <li><a href="@Model.Link("/deploy-manage")">Install Kibana →</a></li>
+            <li><a href="@Model.Link("/deploy-manage")">Configure →</a></li>
+            <li><a href="@Model.Link("/deploy-manage")">Secure a cluster →</a></li>
+            <li><a href="@Model.Link("/deploy-manage/upgrade")">Upgrade →</a></li>
+          </ul>
+        </div>
+        <div class="tab-card">
+          <h4>Elastic Cloud Enterprise (ECE)</h4>
+          <ul>
+            <li><a href="@Model.Link("/deploy-manage")">Install ECE →</a></li>
+            <li><a href="@Model.Link("/deploy-manage")">Manage deployments →</a></li>
+            <li><a href="@Model.Link("/deploy-manage")">Security &amp; users →</a></li>
+            <li><a href="@Model.Link("/deploy-manage/upgrade")">Upgrade →</a></li>
+          </ul>
+        </div>
+        <div class="tab-card">
+          <h4>Elastic Cloud on Kubernetes (ECK)</h4>
+          <ul>
+            <li><a href="@Model.Link("/deploy-manage")">Quickstart →</a></li>
+            <li><a href="@Model.Link("/deploy-manage")">Operator configuration →</a></li>
+            <li><a href="@Model.Link("/deploy-manage")">Manage resources →</a></li>
+            <li><a href="@Model.Link("/deploy-manage/upgrade")">Upgrade →</a></li>
+          </ul>
+        </div>
       </div>
     </div>
   </div>
 
-  <!-- ── All products ── -->
-  <div class="section">
-    <div class="section-header">
-      <h2>All products</h2>
-    </div>
-    <div class="product-index">
-      <div class="pi-category">
-        <h4>Elastic Stack</h4>
-        <ul>
-          <li><a href="@Model.Link("/solutions/search")">Elasticsearch</a></li>
-          <li><a href="@Model.Link("/explore-analyze")">Kibana</a></li>
-          <li><a href="@Model.Link("/manage-data")">Logstash</a></li>
-          <li><a href="@Model.Link("/manage-data")">Beats</a></li>
-          <li><a href="@Model.Link("/explore-analyze")">Machine Learning</a></li>
-          <li><a href="@Model.Link("/manage-data")">Elasticsearch for Apache Hadoop &amp; Spark</a></li>
-        </ul>
+  <div class="page-layout">
+    <div class="page-main">
+
+      <!-- ── Get started ── -->
+      <div class="section">
+        <div class="section-header">
+          <h2>Get started</h2>
+        </div>
+        <div class="gs-grid">
+          <a class="gs-card" href="@Model.Link("/get-started")">
+            <div class="gs-card-icon icon-purple">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
+            </div>
+            <h3>Elasticsearch concepts</h3>
+          </a>
+          <a class="gs-card" href="@Model.Link("/get-started")">
+            <div class="gs-card-icon icon-green">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>
+            </div>
+            <h3>Try locally</h3>
+          </a>
+          <a class="gs-card" href="https://cloud.elastic.co/registration?page=docs&placement=docs-body" target="_blank" rel="noopener noreferrer" hx-disable="true">
+            <div class="gs-card-icon icon-blue">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17.5 19H9a7 7 0 1 1 6.71-9h1.79a4.5 4.5 0 1 1 0 9z"/></svg>
+            </div>
+            <h3>Start free trial</h3>
+          </a>
+        </div>
       </div>
-      <div class="pi-category">
-        <h4>Cloud &amp; orchestration</h4>
-        <ul>
-          <li><a href="@Model.Link("/deploy-manage")">Elastic Cloud Serverless</a></li>
-          <li><a href="@Model.Link("/deploy-manage")">Elastic Cloud Hosted</a></li>
-          <li><a href="@Model.Link("/deploy-manage")">Elastic Cloud on Kubernetes (ECK)</a></li>
-          <li><a href="@Model.Link("/deploy-manage")">Elastic Cloud Enterprise (ECE)</a></li>
-          <li><a href="@Model.Link("/deploy-manage")">Elastic Cloud control (ecctl)</a></li>
-        </ul>
+
+      <!-- ── All products ── -->
+      <div class="section">
+        <div class="section-header">
+          <h2>All products</h2>
+        </div>
+        <div class="all-products-grid">
+          <div>
+            <h3 class="cat-heading">Platform</h3>
+            <ul class="cat-list">
+              <li><a href="@Model.Link("/solutions/search")">Elasticsearch</a></li>
+              <li><a href="@Model.Link("/explore-analyze")">Kibana</a></li>
+              <li><a href="@Model.Link("/manage-data")">Logstash</a></li>
+              <li><a href="@Model.Link("/manage-data")">Beats</a></li>
+              <li><a href="@Model.Link("/explore-analyze")">Machine Learning</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="cat-heading">Solutions</h3>
+            <ul class="cat-list">
+              <li><a href="@Model.Link("/solutions/search")">Elasticsearch</a></li>
+              <li><a href="@Model.Link("/solutions/observability")">Elastic Observability</a></li>
+              <li><a href="@Model.Link("/solutions/security")">Elastic Security</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="cat-heading">Deploy</h3>
+            <ul class="cat-list">
+              <li><a href="@Model.Link("/deploy-manage")">Elastic Cloud Serverless</a></li>
+              <li><a href="@Model.Link("/deploy-manage")">Elastic Cloud Hosted</a></li>
+              <li><a href="@Model.Link("/deploy-manage")">Self-managed</a></li>
+              <li><a href="@Model.Link("/deploy-manage")">Elastic Cloud Enterprise (ECE)</a></li>
+              <li><a href="@Model.Link("/deploy-manage")">Elastic Cloud on Kubernetes (ECK)</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="cat-heading">Ingest tools</h3>
+            <ul class="cat-list">
+              <li><a href="@Model.Link("/manage-data")">Integrations</a></li>
+              <li><a href="@Model.Link("/reference/opentelemetry/")">Elastic Distributions for OpenTelemetry</a></li>
+              <li><a href="@Model.Link("/manage-data")">Fleet &amp; Elastic Agent</a></li>
+              <li><a href="@Model.Link("/solutions/observability")">APM</a></li>
+              <li><a href="@Model.Link("/solutions/security")">Elastic Defend</a></li>
+              <li><a href="@Model.Link("/manage-data")">Elastic Serverless Forwarder for AWS</a></li>
+              <li><a href="@Model.Link("/manage-data")">Connectors</a></li>
+              <li><a href="@Model.Link("/manage-data")">Web crawler</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="cat-heading">Query languages</h3>
+            <ul class="cat-list">
+              <li><a href="@Model.Link("/reference/query-languages/")">Query DSL</a></li>
+              <li><a href="@Model.Link("/reference/query-languages/")">ES|QL</a></li>
+              <li><a href="@Model.Link("/reference/query-languages/")">KQL</a></li>
+              <li><a href="@Model.Link("/reference/query-languages/")">SQL</a></li>
+              <li><a href="@Model.Link("/reference/query-languages/")">EQL</a></li>
+              <li><a href="@Model.Link("/reference/query-languages/")">Lucene</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="cat-heading">APM agents</h3>
+            <ul class="cat-list">
+              <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Java</a></li>
+              <li><a href="@Model.Link("/reference/elasticsearch-clients/")">&#46;NET</a></li>
+              <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Node.js</a></li>
+              <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Python</a></li>
+              <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Ruby</a></li>
+              <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Go</a></li>
+              <li><a href="@Model.Link("/reference/elasticsearch-clients/")">PHP</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="cat-heading">Developer tools &amp; standards</h3>
+            <ul class="cat-list">
+              <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Elasticsearch clients</a></li>
+              <li><a href="@Model.Link("/reference")">Elastic Common Schema (ECS)</a></li>
+              <li><a href="@Model.Link("/reference")">Search UI</a></li>
+            </ul>
+          </div>
+        </div>
       </div>
-      <div class="pi-category">
-        <h4>Ingest tools</h4>
-        <ul>
-          <li><a href="@Model.Link("/manage-data")">Integrations</a></li>
-          <li><a href="@Model.Link("/reference/opentelemetry/")">Elastic Distributions for OpenTelemetry</a></li>
-          <li><a href="@Model.Link("/manage-data")">Fleet &amp; Elastic Agent</a></li>
-          <li><a href="@Model.Link("/solutions/observability")">APM</a></li>
-          <li><a href="@Model.Link("/solutions/security")">Elastic Defend</a></li>
-          <li><a href="@Model.Link("/manage-data")">Elastic Serverless Forwarder for AWS</a></li>
-          <li><a href="@Model.Link("/manage-data")">Connectors</a></li>
-          <li><a href="@Model.Link("/manage-data")">Web crawler</a></li>
-        </ul>
-      </div>
-      <div class="pi-category">
-        <h4>Query languages</h4>
-        <ul>
-          <li><a href="@Model.Link("/reference/query-languages/")">Query DSL</a></li>
-          <li><a href="@Model.Link("/reference/query-languages/")">ES|QL</a></li>
-          <li><a href="@Model.Link("/reference/query-languages/")">KQL</a></li>
-          <li><a href="@Model.Link("/reference/query-languages/")">SQL</a></li>
-          <li><a href="@Model.Link("/reference/query-languages/")">EQL</a></li>
-          <li><a href="@Model.Link("/reference/query-languages/")">Lucene</a></li>
-        </ul>
-      </div>
-      <div class="pi-category">
-        <h4>APM agents</h4>
-        <ul>
-          <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Java Agent</a></li>
-          <li><a href="@Model.Link("/reference/elasticsearch-clients/")">&#46;NET Agent</a></li>
-          <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Node.js Agent</a></li>
-          <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Python Agent</a></li>
-          <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Ruby Agent</a></li>
-          <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Go Agent</a></li>
-          <li><a href="@Model.Link("/reference/elasticsearch-clients/")">PHP Agent</a></li>
-        </ul>
-      </div>
-      <div class="pi-category">
-        <h4>Developer tools &amp; standards</h4>
-        <ul>
-          <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Elasticsearch clients</a></li>
-          <li><a href="@Model.Link("/reference")">Elastic Common Schema (ECS)</a></li>
-          <li><a href="@Model.Link("/reference")">Search UI</a></li>
-        </ul>
-      </div>
-    </div>
-  </div>
+
+    </div><!-- /.page-main -->
+  </div><!-- /.page-layout -->
 
   <!-- ── Footer ── -->
   <footer class="landing-footer">
@@ -626,3 +514,13 @@
   </footer>
 
 </div>
+
+<script>
+  function switchTopTab(e, tabId) {
+    var container = e.currentTarget.closest('.top-tabs');
+    container.querySelectorAll('.tab-panel').forEach(function(p) { p.classList.remove('active'); });
+    container.querySelectorAll('.tabs-nav button').forEach(function(b) { b.classList.remove('active'); });
+    document.getElementById(tabId).classList.add('active');
+    e.currentTarget.classList.add('active');
+  }
+</script>

--- a/src/Elastic.Markdown/Layout/_LandingPage.cshtml
+++ b/src/Elastic.Markdown/Layout/_LandingPage.cshtml
@@ -1,530 +1,556 @@
 @inherits RazorSlice<Elastic.Markdown.MarkdownLayoutViewModel>
 <style>
   /* ── Reset & Base ── */
-  .landing-page, .landing-page * , .landing-page *::before, .landing-page *::after { box-sizing: border-box; }
+  .landing-page, .landing-page *, .landing-page *::before, .landing-page *::after { box-sizing: border-box; }
   .landing-page {
-    --bg: #fafbfc;
-    --surface: #ffffff;
-    --surface-alt: #f3f5f7;
-    --border: #e2e6ea;
-    --border-light: #eef0f3;
-    --text: #1a1f36;
-    --text-secondary: #4a5270;
-    --text-muted: #8891a4;
-    --accent: #0077cc;
-    --accent-hover: #005fa3;
-    --accent-bg: #e8f4fd;
-    --green: #00bfb3;
-    --green-bg: #e6faf8;
-    --orange: #f5a623;
-    --orange-bg: #fef6e8;
-    --purple: #7b61ff;
-    --purple-bg: #f0edff;
-    --pink: #ff4081;
-    --pink-bg: #fff0f5;
-    --radius: 10px;
-    --radius-sm: 6px;
+    --elastic-blue: #0077CC;
+    --elastic-blue-light: #E8F4FD;
+    --elastic-teal: #00BFB3;
+    --elastic-teal-light: #E6FAF8;
+    --elastic-pink: #F04E98;
+    --elastic-pink-light: #FDE8F2;
+    --elastic-yellow: #FEC514;
+    --elastic-green: #00B3A4;
+    --bg: #ffffff;
+    --bg-alt: #F5F7FA;
+    --bg-warm: #FAFBFC;
+    --bg-dark: #1B2638;
+    --text-primary: #1B2638;
+    --text-secondary: #506477;
+    --text-tertiary: #8C9BAB;
+    --border: #E1E7EE;
+    --border-light: #EEF2F7;
     --shadow-sm: 0 1px 3px rgba(0,0,0,0.06);
-    --shadow: 0 2px 8px rgba(0,0,0,0.08);
-    --shadow-lg: 0 4px 20px rgba(0,0,0,0.10);
+    --shadow-md: 0 4px 12px rgba(0,0,0,0.08);
+    --shadow-lg: 0 8px 30px rgba(0,0,0,0.1);
+    --radius-sm: 8px;
+    --radius-md: 12px;
+    --radius-lg: 16px;
     --max-w: 1120px;
-    --font: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', sans-serif;
+    --font: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
     font-family: var(--font);
     background: var(--bg);
-    color: var(--text);
-    line-height: 1.55;
+    color: var(--text-primary);
+    line-height: 1.5;
     -webkit-font-smoothing: antialiased;
   }
-  .landing-page a { color: var(--accent); text-decoration: none; transition: color 0.15s; }
-  .landing-page a:hover { color: var(--accent-hover); }
+  .landing-page a { color: var(--elastic-blue); text-decoration: none; transition: color 0.15s; }
+  .landing-page a:hover { color: #005fa3; }
 
-  /* ── Hero / Search ── */
-  .hero {
+  /* ── Hero ── */
+  .landing-hero {
+    background: linear-gradient(180deg, #EEF4FF 0%, #F7FAFF 60%, #FFFFFF 100%);
+    padding: 52px 40px 0;
+    border-bottom: 1px solid var(--border-light);
+  }
+  .landing-hero-inner {
     max-width: var(--max-w);
     margin: 0 auto;
-    padding: 48px 24px 0;
-    text-align: center;
   }
-  .hero h1 {
-    font-size: 28px;
-    font-weight: 700;
-    letter-spacing: -0.02em;
-    margin-bottom: 10px;
+  .hero-welcome {
+    max-width: 620px;
+    margin-bottom: 36px;
   }
-  .search-wrap {
-    max-width: 640px;
-    margin: 0 auto 16px;
-    position: relative;
+  .hero-welcome h1 {
+    font-size: 36px;
+    font-weight: 800;
+    color: var(--text-primary);
+    margin-bottom: 12px;
+    letter-spacing: -0.7px;
+    line-height: 1.15;
   }
-  .search-wrap > .search-icon {
-    position: absolute;
-    left: 16px;
-    top: 50%;
-    transform: translateY(-50%);
-    color: var(--text-muted);
-    pointer-events: none;
+  .hero-welcome p {
+    font-size: 17px;
+    color: var(--text-secondary);
+    line-height: 1.6;
   }
 
-  /* ── Section layout ── */
-  .section { max-width: var(--max-w); margin: 0 auto; padding: 40px 24px 0; }
-  .section-header {
+  /* Hero search */
+  .hero-search-wrap {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    background: #fff;
+    border: 1.5px solid var(--border);
+    border-radius: 10px;
+    padding: 14px 20px;
+    margin-bottom: 24px;
+    max-width: 640px;
+    cursor: pointer;
+    transition: border-color 0.2s, box-shadow 0.2s;
+  }
+  .hero-search-wrap:focus-within {
+    border-color: var(--elastic-blue);
+    box-shadow: var(--shadow-sm);
+  }
+
+  /* Hero cards */
+  .hero-cards {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
+    padding-bottom: 48px;
+  }
+  .hero-card {
+    background: #fff;
+    border-radius: var(--radius-md);
+    padding: 28px 28px 24px;
+    border: 1.5px solid var(--border);
+    box-shadow: var(--shadow-sm);
+    transition: box-shadow 0.2s, border-color 0.2s, transform 0.15s;
+    position: relative;
+    overflow: hidden;
+  }
+  .hero-card:hover {
+    box-shadow: var(--shadow-md);
+    border-color: var(--elastic-blue);
+    transform: translateY(-2px);
+  }
+  .hero-card.primary {
+    border-color: var(--elastic-blue);
+    box-shadow: var(--shadow-md), 0 0 0 1px rgba(0,119,204,0.08);
+  }
+  .hero-card.primary::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0;
+    height: 3px;
+    background: linear-gradient(90deg, var(--elastic-blue), var(--elastic-teal));
+  }
+  .hero-card h2 {
+    font-size: 19px;
+    font-weight: 700;
+    margin-bottom: 10px;
+    color: var(--text-primary);
+  }
+  .hero-card .desc {
+    font-size: 14px;
+    color: var(--text-secondary);
+    line-height: 1.6;
+    margin-bottom: 18px;
+  }
+  .card-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 6px;
+  }
+  .card-links a {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--elastic-blue);
+    padding: 4px 10px;
+    background: rgba(0,119,204,0.04);
+    border-radius: 6px;
+    transition: background 0.15s;
+  }
+  .card-links a:hover { background: rgba(0,119,204,0.1); }
+  .card-cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--elastic-blue);
+    text-decoration: none;
+    margin-top: 12px;
+  }
+  .card-cta svg { transition: transform 0.15s; }
+  .hero-card:hover .card-cta svg { transform: translateX(3px); }
+
+  /* ── Main content ── */
+  .landing-main {
+    max-width: var(--max-w);
+    margin: 0 auto;
+    padding: 0 40px 80px;
+  }
+
+  /* ── Quick start ── */
+  .quickstart {
+    background: var(--bg-alt);
+    border-radius: var(--radius-lg);
+    padding: 24px 28px;
+    margin: 40px 0;
+    border: 1px solid var(--border-light);
+  }
+  .quickstart h2 {
+    font-size: 18px;
+    font-weight: 700;
+    margin-bottom: 4px;
+    letter-spacing: -0.2px;
+  }
+  .quickstart > p {
+    font-size: 14px;
+    color: var(--text-secondary);
+    margin-bottom: 16px;
+  }
+  .qs-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 12px;
+  }
+  .qs-card {
+    background: #fff;
+    border-radius: var(--radius-sm);
+    padding: 16px;
+    border: 1px solid var(--border-light);
+    cursor: pointer;
+    transition: box-shadow 0.15s, border-color 0.15s;
+    display: flex;
+    flex-direction: column;
+  }
+  .qs-card:hover {
+    box-shadow: var(--shadow-sm);
+    border-color: var(--elastic-blue);
+  }
+  .qs-card h4 {
+    font-size: 14px;
+    font-weight: 600;
+    margin-bottom: 8px;
+  }
+  .qs-card > p {
+    font-size: 12.5px;
+    color: var(--text-secondary);
+    line-height: 1.5;
+    flex: 1;
+  }
+  .qs-cta {
+    font-size: 12px;
+    margin-top: 12px;
+    color: var(--elastic-blue);
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    text-decoration: none;
+  }
+
+  /* ── Section header ── */
+  .landing-section-header {
     display: flex;
     align-items: baseline;
     justify-content: space-between;
-    margin-bottom: 16px;
-  }
-  .section-header h2 { font-size: 17px; font-weight: 700; letter-spacing: -0.01em; }
-  .section-header a { font-size: 13px; font-weight: 500; }
-
-  /* Icon color variants */
-  .icon-blue { background: var(--accent-bg); color: var(--accent); }
-  .icon-green { background: var(--green-bg); color: var(--green); }
-  .icon-orange { background: var(--orange-bg); color: var(--orange); }
-  .icon-purple { background: var(--purple-bg); color: var(--purple); }
-  .icon-pink { background: var(--pink-bg); color: var(--pink); }
-
-  /* ── Tabbed products ── */
-  .tabs-nav {
-    display: flex;
-    gap: 0;
-    border-bottom: 2px solid var(--border);
     margin-bottom: 20px;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
+    padding-bottom: 12px;
+    border-bottom: 1px solid var(--border-light);
   }
-  .tabs-nav button {
-    background: none;
-    border: none;
-    border-bottom: 2px solid transparent;
-    margin-bottom: -2px;
-    padding: 10px 18px;
-    font-family: var(--font);
-    font-size: 13px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    color: var(--text-muted);
-    cursor: pointer;
-    white-space: nowrap;
-    transition: color 0.15s, border-color 0.15s;
-  }
-  .tabs-nav button:hover { color: var(--text-secondary); }
-  .tabs-nav button.active {
-    color: var(--accent);
-    border-bottom-color: var(--accent);
-  }
-  .tab-panel { display: none; }
-  .tab-panel.active { display: flex; flex-wrap: wrap; gap: 10px; }
+  .landing-section-header h2 { font-size: 18px; font-weight: 700; }
+  .landing-section-header a { font-size: 13px; font-weight: 500; }
 
-  /* Tab cards */
-  .tab-cards {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-    gap: 14px;
-    width: 100%;
-  }
-  .tab-card {
-    background: var(--surface);
-    border: 1px solid var(--border-light);
-    border-radius: var(--radius);
-    padding: 20px;
-    transition: box-shadow 0.15s, border-color 0.15s;
-  }
-  .tab-card:hover { border-color: var(--border); box-shadow: var(--shadow-sm); }
-  .tab-card h4 {
-    font-size: 15px;
-    font-weight: 700;
-    margin-bottom: 10px;
-  }
-  .tab-card ul { list-style: none; }
-  .tab-card ul li + li { border-top: 1px solid var(--border-light); }
-  .tab-card ul li a {
-    display: block;
-    padding: 7px 0;
-    font-size: 13px;
-    color: var(--accent);
-    text-decoration: none;
-    transition: color 0.12s;
-  }
-  .tab-card ul li a:hover { color: var(--accent-hover); }
-
-  /* ── Top tabs (below search) ── */
-  .top-tabs {
-    max-width: var(--max-w);
-    margin: 0 auto;
-    padding: 0 24px 8px;
-  }
-  .top-tabs .tabs-nav { margin-bottom: 20px; justify-content: center; }
-
-  /* ── Page layout ── */
-  .page-layout {
-    max-width: var(--max-w);
-    margin: 0 auto;
-    padding: 0 24px;
-  }
-  .page-main .section { padding: 40px 0 0; max-width: none; margin: 0; }
-
-  /* ── Getting started ── */
-  .gs-grid {
+  /* ── What's new ── */
+  .news-grid {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
-    gap: 14px;
+    gap: 16px;
+    margin-bottom: 52px;
   }
-  @@media (max-width: 800px) {
-    .gs-grid { grid-template-columns: 1fr; }
-  }
-  .gs-card {
-    background: var(--surface);
-    border: 1px solid var(--border-light);
-    border-radius: var(--radius);
-    padding: 22px 22px 20px;
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    text-decoration: none;
-    color: var(--text);
-    transition: border-color 0.15s, box-shadow 0.15s;
-  }
-  .gs-card:hover { border-color: var(--accent); box-shadow: var(--shadow); color: var(--text); }
-  .gs-card .gs-card-icon {
-    width: 36px;
-    height: 36px;
+  .news-card {
+    padding: 18px 20px;
+    background: #fff;
+    border: 1px solid var(--border);
     border-radius: var(--radius-sm);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 18px;
-    flex-shrink: 0;
+    transition: border-color 0.15s;
   }
-  .gs-card h3 { font-size: 15px; font-weight: 700; }
+  .news-card:hover { border-color: var(--elastic-blue); }
+  .news-date {
+    font-size: 11px;
+    color: var(--text-tertiary);
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+    margin-bottom: 6px;
+  }
+  .news-card h4 { font-size: 13px; font-weight: 600; margin-bottom: 4px; }
+  .news-card p { font-size: 12px; color: var(--text-secondary); line-height: 1.45; }
 
-  /* ── All products (categorized list) ── */
+  /* ── All products ── */
   .all-products-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-    gap: 28px 40px;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 32px 24px;
+    margin-bottom: 52px;
   }
-  .all-products-grid .cat-heading {
-    font-size: 12px;
+  .product-column h4 {
+    font-size: 13px;
     font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    color: var(--text-muted);
+    color: var(--text-primary);
     margin-bottom: 10px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--border-light);
   }
-  .all-products-grid .cat-list { list-style: none; }
-  .all-products-grid .cat-list li + li { margin-top: 2px; }
-  .all-products-grid .cat-list a {
-    display: block;
-    padding: 5px 0;
-    font-size: 14px;
-    font-weight: 500;
-    color: var(--text);
+  .product-column ul { list-style: none; }
+  .product-column li { margin-bottom: 6px; }
+  .product-column a {
+    font-size: 13px;
+    color: var(--elastic-blue);
     text-decoration: none;
     transition: color 0.15s;
   }
-  .all-products-grid .cat-list a:hover { color: var(--accent); }
+  .product-column a:hover { color: #005fa3; text-decoration: underline; }
+
+  /* ── Help strip ── */
+  .help-strip {
+    background: var(--bg-alt);
+    border-radius: var(--radius-md);
+    padding: 32px 36px;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 24px;
+    margin-bottom: 24px;
+    border: 1px solid var(--border-light);
+  }
+  .help-item h4 {
+    font-size: 13px;
+    font-weight: 600;
+    margin-bottom: 4px;
+    color: var(--text-primary);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .help-item p { font-size: 12px; color: var(--text-secondary); line-height: 1.45; }
 
   /* ── Footer ── */
   .landing-footer {
+    background: var(--bg-dark);
+    padding: 44px 40px;
+    color: rgba(255,255,255,0.6);
+    font-family: var(--font);
+  }
+  .landing-footer-inner {
     max-width: var(--max-w);
-    margin: 48px auto 0;
-    padding: 40px 24px;
-    border-top: 1px solid var(--border-light);
+    margin: 0 auto;
     display: flex;
     justify-content: space-between;
     align-items: center;
     flex-wrap: wrap;
     gap: 12px;
     font-size: 13px;
-    color: var(--text-muted);
   }
-  .landing-footer a { color: var(--text-secondary); }
+  .landing-footer a { color: rgba(255,255,255,0.5); transition: color 0.15s; }
+  .landing-footer a:hover { color: rgba(255,255,255,0.85); }
 
   /* ── Responsive ── */
-  @@media (max-width: 680px) {
-    .hero h1 { font-size: 22px; }
+  @@media (max-width: 900px) {
+    .hero-cards { grid-template-columns: 1fr; }
+    .all-products-grid { grid-template-columns: repeat(2, 1fr); }
+    .news-grid { grid-template-columns: 1fr; }
+    .help-strip { grid-template-columns: 1fr; }
+  }
+  @@media (max-width: 640px) {
+    .landing-hero { padding: 36px 20px 0; }
+    .hero-welcome h1 { font-size: 26px; }
+    .landing-main { padding: 0 20px 60px; }
+    .qs-grid { grid-template-columns: 1fr; }
+    .all-products-grid { grid-template-columns: 1fr; }
   }
 </style>
 
 <div hx-select-oob="#main-container" hx-swap="none" class="landing-page w-full max-w-[100vw] relative overflow-x-hidden">
 
-  <!-- ── Hero: Search-first ── -->
-  <div class="hero">
-    <h1>Elastic documentation</h1>
-    <div class="search-wrap">
-      <svg class="search-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.35-4.35"/></svg>
-      <navigation-search></navigation-search>
-    </div>
-  </div>
+  <!-- ── Hero ── -->
+  <section class="landing-hero">
+    <div class="landing-hero-inner">
 
-  <!-- ── Top tabs: Platform / Solutions / Deploy ── -->
-  <div class="top-tabs">
-    <div class="tabs-nav">
-      <button class="active" onclick="switchTopTab(event, 'top-tab-platform')">Platform</button>
-      <button onclick="switchTopTab(event, 'top-tab-solutions')">Solutions</button>
-      <button onclick="switchTopTab(event, 'top-tab-deploy')">Deploy</button>
-    </div>
-
-    <div id="top-tab-platform" class="tab-panel active">
-      <div class="tab-cards">
-        <div class="tab-card">
-          <h4>Elasticsearch</h4>
-          <ul>
-            <li><a href="@Model.Link("/deploy-manage/deploy/self-managed/installing-elasticsearch")">Install Elasticsearch →</a></li>
-            <li><a href="https://www.elastic.co/docs/api" target="_blank" rel="noopener noreferrer" hx-disable="true">REST APIs →</a></li>
-            <li><a href="@Model.Link("/reference/query-languages/")">Query DSL →</a></li>
-            <li><a href="@Model.Link("/reference/query-languages/")">Aggregations →</a></li>
-            <li><a href="@Model.Link("/manage-data")">Index management →</a></li>
-          </ul>
-        </div>
-        <div class="tab-card">
-          <h4>Kibana</h4>
-          <ul>
-            <li><a href="@Model.Link("/deploy-manage")">Install Kibana →</a></li>
-            <li><a href="@Model.Link("/explore-analyze")">Dashboards →</a></li>
-            <li><a href="@Model.Link("/explore-analyze")">Visualizations →</a></li>
-            <li><a href="@Model.Link("/explore-analyze")">Discover →</a></li>
-            <li><a href="@Model.Link("/explore-analyze")">Alerting →</a></li>
-          </ul>
-        </div>
-        <div class="tab-card">
-          <h4>Logstash</h4>
-          <ul>
-            <li><a href="@Model.Link("/manage-data")">Getting started →</a></li>
-            <li><a href="@Model.Link("/manage-data")">Input plugins →</a></li>
-            <li><a href="@Model.Link("/manage-data")">Filter plugins →</a></li>
-            <li><a href="@Model.Link("/manage-data")">Output plugins →</a></li>
-            <li><a href="@Model.Link("/manage-data")">Pipeline configuration →</a></li>
-          </ul>
-        </div>
-        <div class="tab-card">
-          <h4>Beats</h4>
-          <ul>
-            <li><a href="@Model.Link("/manage-data")">Filebeat →</a></li>
-            <li><a href="@Model.Link("/manage-data")">Metricbeat →</a></li>
-            <li><a href="@Model.Link("/manage-data")">Packetbeat →</a></li>
-            <li><a href="@Model.Link("/manage-data")">Heartbeat →</a></li>
-            <li><a href="@Model.Link("/manage-data")">Auditbeat →</a></li>
-          </ul>
-        </div>
+      <div class="hero-welcome">
+        <h1>Elastic documentation</h1>
+        <p>Official docs for the Elastic Stack, Elastic Cloud, and Elastic solutions.</p>
       </div>
-    </div>
 
-    <div id="top-tab-solutions" class="tab-panel">
-      <div class="tab-cards">
-        <div class="tab-card">
-          <h4>Elasticsearch</h4>
-          <ul>
-            <li><a href="@Model.Link("/solutions/search")">Get started with Search →</a></li>
-            <li><a href="@Model.Link("/solutions/search")">Semantic &amp; vector search →</a></li>
-            <li><a href="@Model.Link("/solutions/search")">Search applications →</a></li>
-            <li><a href="@Model.Link("/solutions/search")">Agent Builder →</a></li>
-            <li><a href="@Model.Link("/solutions/search")">AI agent skills →</a></li>
-          </ul>
-        </div>
-        <div class="tab-card">
-          <h4>Elastic Observability</h4>
-          <ul>
-            <li><a href="@Model.Link("/solutions/observability")">Get started with Observability →</a></li>
-            <li><a href="@Model.Link("/solutions/observability")">APM →</a></li>
-            <li><a href="@Model.Link("/solutions/observability")">Log monitoring →</a></li>
-            <li><a href="@Model.Link("/solutions/observability")">Infrastructure monitoring →</a></li>
-            <li><a href="@Model.Link("/solutions/observability")">Synthetics →</a></li>
-          </ul>
-        </div>
-        <div class="tab-card">
-          <h4>Elastic Security</h4>
-          <ul>
-            <li><a href="@Model.Link("/solutions/security")">Get started with Security →</a></li>
-            <li><a href="@Model.Link("/solutions/security")">Detection rules →</a></li>
-            <li><a href="@Model.Link("/solutions/security")">Endpoint protection →</a></li>
-            <li><a href="@Model.Link("/solutions/security")">Cases &amp; investigations →</a></li>
-            <li><a href="@Model.Link("/solutions/security")">Cloud security →</a></li>
-          </ul>
-        </div>
+      <div class="hero-search-wrap">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#8C9BAB" stroke-width="2.5"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>
+        <navigation-search></navigation-search>
       </div>
-    </div>
 
-    <div id="top-tab-deploy" class="tab-panel">
-      <div class="tab-cards">
-        <div class="tab-card">
-          <h4>Elastic Cloud Serverless</h4>
-          <ul>
-            <li><a href="@Model.Link("/deploy-manage")">Getting started →</a></li>
-            <li><a href="@Model.Link("/deploy-manage")">Project management →</a></li>
-            <li><a href="@Model.Link("/cloud-account")">Billing &amp; usage →</a></li>
-          </ul>
-        </div>
-        <div class="tab-card">
-          <h4>Elastic Cloud Hosted</h4>
-          <ul>
-            <li><a href="@Model.Link("/deploy-manage")">Getting started →</a></li>
-            <li><a href="@Model.Link("/deploy-manage")">Deployment management →</a></li>
-            <li><a href="@Model.Link("/deploy-manage")">Monitoring →</a></li>
-            <li><a href="@Model.Link("/cloud-account")">Billing →</a></li>
-          </ul>
-        </div>
-        <div class="tab-card">
-          <h4>Self-managed</h4>
-          <ul>
-            <li><a href="@Model.Link("/deploy-manage/deploy/self-managed/installing-elasticsearch")">Install Elasticsearch →</a></li>
-            <li><a href="@Model.Link("/deploy-manage")">Install Kibana →</a></li>
-            <li><a href="@Model.Link("/deploy-manage")">Configure →</a></li>
-            <li><a href="@Model.Link("/deploy-manage")">Secure a cluster →</a></li>
-            <li><a href="@Model.Link("/deploy-manage/upgrade")">Upgrade →</a></li>
-          </ul>
-        </div>
-        <div class="tab-card">
-          <h4>Elastic Cloud Enterprise (ECE)</h4>
-          <ul>
-            <li><a href="@Model.Link("/deploy-manage")">Install ECE →</a></li>
-            <li><a href="@Model.Link("/deploy-manage")">Manage deployments →</a></li>
-            <li><a href="@Model.Link("/deploy-manage")">Security &amp; users →</a></li>
-            <li><a href="@Model.Link("/deploy-manage/upgrade")">Upgrade →</a></li>
-          </ul>
-        </div>
-        <div class="tab-card">
-          <h4>Elastic Cloud on Kubernetes (ECK)</h4>
-          <ul>
-            <li><a href="@Model.Link("/deploy-manage")">Quickstart →</a></li>
-            <li><a href="@Model.Link("/deploy-manage")">Operator configuration →</a></li>
-            <li><a href="@Model.Link("/deploy-manage")">Manage resources →</a></li>
-            <li><a href="@Model.Link("/deploy-manage/upgrade")">Upgrade →</a></li>
-          </ul>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <div class="page-layout">
-    <div class="page-main">
-
-      <!-- ── Get started ── -->
-      <div class="section">
-        <div class="section-header">
-          <h2>Get started</h2>
-        </div>
-        <div class="gs-grid">
-          <a class="gs-card" href="@Model.Link("/get-started")">
-            <div class="gs-card-icon icon-purple">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
-            </div>
-            <h3>Elasticsearch concepts</h3>
+      <div class="hero-cards">
+        <div class="hero-card primary">
+          <h2>Learn how to use Elastic</h2>
+          <p class="desc">Get started with an overview of Elasticsearch, Kibana, and the rest of the Elastic Stack.</p>
+          <div class="card-links">
+            <a href="@Model.Link("/get-started")">What is Elasticsearch?</a>
+            <a href="@Model.Link("/get-started")">The Elastic Stack</a>
+            <a href="@Model.Link("/manage-data")">Ingest data</a>
+            <a href="@Model.Link("/manage-data")">Index basics</a>
+          </div>
+          <a href="@Model.Link("/get-started")" class="card-cta">
+            Get started
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
           </a>
-          <a class="gs-card" href="@Model.Link("/get-started")">
-            <div class="gs-card-icon icon-green">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>
-            </div>
-            <h3>Try locally</h3>
-          </a>
-          <a class="gs-card" href="https://cloud.elastic.co/registration?page=docs&placement=docs-body" target="_blank" rel="noopener noreferrer" hx-disable="true">
-            <div class="gs-card-icon icon-blue">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17.5 19H9a7 7 0 1 1 6.71-9h1.79a4.5 4.5 0 1 1 0 9z"/></svg>
-            </div>
-            <h3>Start free trial</h3>
+        </div>
+        <div class="hero-card">
+          <h2>Elasticsearch</h2>
+          <p class="desc">Store, search, and analyze your data with full-text search, vector search, AI search, and more.</p>
+          <div class="card-links">
+            <a href="@Model.Link("/deploy-manage/deploy/self-managed/installing-elasticsearch")">Install</a>
+            <a href="https://www.elastic.co/docs/api" target="_blank" rel="noopener noreferrer" hx-disable="true">REST API reference</a>
+            <a href="@Model.Link("/reference/query-languages/")">Query DSL</a>
+            <a href="@Model.Link("/release-notes/")">Release notes</a>
+          </div>
+          <a href="@Model.Link("/solutions/search")" class="card-cta">
+            Elasticsearch docs
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
           </a>
         </div>
       </div>
 
-      <!-- ── All products ── -->
-      <div class="section">
-        <div class="section-header">
-          <h2>All products</h2>
+    </div>
+  </section>
+
+  <!-- ── Main content ── -->
+  <div class="landing-main">
+
+    <!-- Quick start -->
+    <div class="quickstart">
+      <h2>New to Elastic? Give it a try.</h2>
+      <div class="qs-grid">
+        <div class="qs-card">
+          <h4>Try locally</h4>
+          <p>Use Docker to install and run Elasticsearch and Kibana on your local machine.</p>
+          <a href="@Model.Link("/get-started")" class="qs-cta">Local installation docs →</a>
         </div>
-        <div class="all-products-grid">
-          <div>
-            <h3 class="cat-heading">Platform</h3>
-            <ul class="cat-list">
-              <li><a href="@Model.Link("/solutions/search")">Elasticsearch</a></li>
-              <li><a href="@Model.Link("/explore-analyze")">Kibana</a></li>
-              <li><a href="@Model.Link("/manage-data")">Logstash</a></li>
-              <li><a href="@Model.Link("/manage-data")">Beats</a></li>
-              <li><a href="@Model.Link("/explore-analyze")">Machine Learning</a></li>
-            </ul>
-          </div>
-          <div>
-            <h3 class="cat-heading">Solutions</h3>
-            <ul class="cat-list">
-              <li><a href="@Model.Link("/solutions/search")">Elasticsearch</a></li>
-              <li><a href="@Model.Link("/solutions/observability")">Elastic Observability</a></li>
-              <li><a href="@Model.Link("/solutions/security")">Elastic Security</a></li>
-            </ul>
-          </div>
-          <div>
-            <h3 class="cat-heading">Deploy</h3>
-            <ul class="cat-list">
-              <li><a href="@Model.Link("/deploy-manage")">Elastic Cloud Serverless</a></li>
-              <li><a href="@Model.Link("/deploy-manage")">Elastic Cloud Hosted</a></li>
-              <li><a href="@Model.Link("/deploy-manage")">Self-managed</a></li>
-              <li><a href="@Model.Link("/deploy-manage")">Elastic Cloud Enterprise (ECE)</a></li>
-              <li><a href="@Model.Link("/deploy-manage")">Elastic Cloud on Kubernetes (ECK)</a></li>
-            </ul>
-          </div>
-          <div>
-            <h3 class="cat-heading">Ingest tools</h3>
-            <ul class="cat-list">
-              <li><a href="@Model.Link("/manage-data")">Integrations</a></li>
-              <li><a href="@Model.Link("/reference/opentelemetry/")">Elastic Distributions for OpenTelemetry</a></li>
-              <li><a href="@Model.Link("/manage-data")">Fleet &amp; Elastic Agent</a></li>
-              <li><a href="@Model.Link("/solutions/observability")">APM</a></li>
-              <li><a href="@Model.Link("/solutions/security")">Elastic Defend</a></li>
-              <li><a href="@Model.Link("/manage-data")">Elastic Serverless Forwarder for AWS</a></li>
-              <li><a href="@Model.Link("/manage-data")">Connectors</a></li>
-              <li><a href="@Model.Link("/manage-data")">Web crawler</a></li>
-            </ul>
-          </div>
-          <div>
-            <h3 class="cat-heading">Query languages</h3>
-            <ul class="cat-list">
-              <li><a href="@Model.Link("/reference/query-languages/")">Query DSL</a></li>
-              <li><a href="@Model.Link("/reference/query-languages/")">ES|QL</a></li>
-              <li><a href="@Model.Link("/reference/query-languages/")">KQL</a></li>
-              <li><a href="@Model.Link("/reference/query-languages/")">SQL</a></li>
-              <li><a href="@Model.Link("/reference/query-languages/")">EQL</a></li>
-              <li><a href="@Model.Link("/reference/query-languages/")">Lucene</a></li>
-            </ul>
-          </div>
-          <div>
-            <h3 class="cat-heading">APM agents</h3>
-            <ul class="cat-list">
-              <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Java</a></li>
-              <li><a href="@Model.Link("/reference/elasticsearch-clients/")">&#46;NET</a></li>
-              <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Node.js</a></li>
-              <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Python</a></li>
-              <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Ruby</a></li>
-              <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Go</a></li>
-              <li><a href="@Model.Link("/reference/elasticsearch-clients/")">PHP</a></li>
-            </ul>
-          </div>
-          <div>
-            <h3 class="cat-heading">Developer tools &amp; standards</h3>
-            <ul class="cat-list">
-              <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Elasticsearch clients</a></li>
-              <li><a href="@Model.Link("/reference")">Elastic Common Schema (ECS)</a></li>
-              <li><a href="@Model.Link("/reference")">Search UI</a></li>
-            </ul>
-          </div>
+        <div class="qs-card">
+          <h4>Start free Cloud trial</h4>
+          <p>Evaluate Elastic with a production-ready trial, using real data and use cases.</p>
+          <a href="https://cloud.elastic.co/registration?page=docs&placement=docs-body" target="_blank" rel="noopener noreferrer" hx-disable="true" class="qs-cta">Start free trial →</a>
         </div>
       </div>
+    </div>
 
-    </div><!-- /.page-main -->
-  </div><!-- /.page-layout -->
+    <!-- What's new -->
+    <div class="landing-section-header">
+      <h2>What's new</h2>
+      <a href="@Model.Link("/release-notes/")">All release notes →</a>
+    </div>
+    <div class="news-grid">
+      <div class="news-card">
+        <div class="news-date">April 2026</div>
+        <h4>Elasticsearch @Model.CurrentVersion</h4>
+        <p>Improved authentication and upgraded security features.</p>
+      </div>
+      <div class="news-card">
+        <div class="news-date">April 2026</div>
+        <h4>Elastic AI Assistant is GA</h4>
+        <p>Ask questions about your data in plain English across Observability and Security.</p>
+      </div>
+      <div class="news-card">
+        <div class="news-date">March 2026</div>
+        <h4>New Serverless features</h4>
+        <p>Run Elasticsearch without managing infrastructure. New capabilities for search workloads.</p>
+      </div>
+    </div>
+
+    <!-- All products -->
+    <div class="landing-section-header">
+      <h2>All products</h2>
+    </div>
+    <div class="all-products-grid">
+      <div class="product-column">
+        <h4>Platform</h4>
+        <ul>
+          <li><a href="@Model.Link("/solutions/search")">Elasticsearch</a></li>
+          <li><a href="@Model.Link("/explore-analyze")">Kibana</a></li>
+          <li><a href="@Model.Link("/manage-data")">Logstash</a></li>
+          <li><a href="@Model.Link("/manage-data")">Beats</a></li>
+          <li><a href="@Model.Link("/explore-analyze")">Machine Learning</a></li>
+        </ul>
+      </div>
+      <div class="product-column">
+        <h4>Solutions</h4>
+        <ul>
+          <li><a href="@Model.Link("/solutions/search")">Elasticsearch</a></li>
+          <li><a href="@Model.Link("/solutions/observability")">Elastic Observability</a></li>
+          <li><a href="@Model.Link("/solutions/security")">Elastic Security</a></li>
+        </ul>
+      </div>
+      <div class="product-column">
+        <h4>Deploy</h4>
+        <ul>
+          <li><a href="@Model.Link("/deploy-manage")">Elastic Cloud Serverless</a></li>
+          <li><a href="@Model.Link("/deploy-manage")">Elastic Cloud Hosted</a></li>
+          <li><a href="@Model.Link("/deploy-manage")">Self-managed</a></li>
+          <li><a href="@Model.Link("/deploy-manage")">Elastic Cloud Enterprise (ECE)</a></li>
+          <li><a href="@Model.Link("/deploy-manage")">Elastic Cloud on Kubernetes (ECK)</a></li>
+        </ul>
+      </div>
+      <div class="product-column">
+        <h4>Ingest tools</h4>
+        <ul>
+          <li><a href="@Model.Link("/manage-data")">Integrations</a></li>
+          <li><a href="@Model.Link("/reference/opentelemetry/")">Elastic Distributions for OpenTelemetry</a></li>
+          <li><a href="@Model.Link("/manage-data")">Fleet &amp; Elastic Agent</a></li>
+          <li><a href="@Model.Link("/solutions/observability")">APM</a></li>
+          <li><a href="@Model.Link("/solutions/security")">Elastic Defend</a></li>
+          <li><a href="@Model.Link("/manage-data")">Elastic Serverless Forwarder for AWS</a></li>
+          <li><a href="@Model.Link("/manage-data")">Connectors</a></li>
+          <li><a href="@Model.Link("/manage-data")">Web crawler</a></li>
+        </ul>
+      </div>
+      <div class="product-column">
+        <h4>Query languages</h4>
+        <ul>
+          <li><a href="@Model.Link("/reference/query-languages/")">Query DSL</a></li>
+          <li><a href="@Model.Link("/reference/query-languages/")">ES|QL</a></li>
+          <li><a href="@Model.Link("/reference/query-languages/")">KQL</a></li>
+          <li><a href="@Model.Link("/reference/query-languages/")">SQL</a></li>
+          <li><a href="@Model.Link("/reference/query-languages/")">EQL</a></li>
+          <li><a href="@Model.Link("/reference/query-languages/")">Lucene</a></li>
+        </ul>
+      </div>
+      <div class="product-column">
+        <h4>APM agents</h4>
+        <ul>
+          <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Java</a></li>
+          <li><a href="@Model.Link("/reference/elasticsearch-clients/")">&#46;NET</a></li>
+          <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Node.js</a></li>
+          <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Python</a></li>
+          <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Ruby</a></li>
+          <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Go</a></li>
+          <li><a href="@Model.Link("/reference/elasticsearch-clients/")">PHP</a></li>
+        </ul>
+      </div>
+      <div class="product-column">
+        <h4>Developer tools &amp; standards</h4>
+        <ul>
+          <li><a href="@Model.Link("/reference/elasticsearch-clients/")">Elasticsearch clients</a></li>
+          <li><a href="@Model.Link("/reference")">Elastic Common Schema (ECS)</a></li>
+          <li><a href="@Model.Link("/reference")">Search UI</a></li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- Help strip -->
+    <div class="help-strip">
+      <div class="help-item">
+        <h4>
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>
+          Community forums
+        </h4>
+        <p>Ask questions and get help from other Elastic users and engineers.</p>
+      </div>
+      <div class="help-item">
+        <h4>
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 016.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z"/></svg>
+          Training &amp; certification
+        </h4>
+        <p>Free courses and hands-on labs to build your Elastic skills.</p>
+      </div>
+      <div class="help-item">
+        <h4>
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 00-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0020 4.77 5.07 5.07 0 0019.91 1S18.73.65 16 2.48a13.38 13.38 0 00-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 005 4.77a5.44 5.44 0 00-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 009 18.13V22"/></svg>
+          Report a docs issue
+        </h4>
+        <p>Found something wrong or confusing? Let us know on GitHub.</p>
+      </div>
+    </div>
+
+  </div><!-- /.landing-main -->
 
   <!-- ── Footer ── -->
   <footer class="landing-footer">
-    <span>© 2026 Elasticsearch B.V.</span>
-    <span><a href="@Model.Link("/contribute-docs")">Edit this page</a> · <a href="@Model.Link("/contribute-docs")">Report a docs issue</a></span>
+    <div class="landing-footer-inner">
+      <span>© 2026 Elasticsearch B.V.</span>
+      <span><a href="@Model.Link("/contribute-docs")">Edit this page</a> · <a href="@Model.Link("/contribute-docs")">Report a docs issue</a></span>
+    </div>
   </footer>
 
 </div>
-
-<script>
-  function switchTopTab(e, tabId) {
-    var container = e.currentTarget.closest('.top-tabs');
-    container.querySelectorAll('.tab-panel').forEach(function(p) { p.classList.remove('active'); });
-    container.querySelectorAll('.tabs-nav button').forEach(function(b) { b.classList.remove('active'); });
-    document.getElementById(tabId).classList.add('active');
-    e.currentTarget.classList.add('active');
-  }
-</script>


### PR DESCRIPTION
Closes https://github.com/elastic/docs-content-internal/issues/1018. 

Demo: https://docs-v3-preview.elastic.dev/elastic/docs-builder/docs/3250

## Summary of changes
- Prominent search bar above the fold
- Two primary destination cards: "Learn how to use Elastic" (fundamentals) and "Elasticsearch", which are the two highest-traffic destinations, accounting for ~50% of all landing page clicks
- "New to Elastic?" section with local install and Cloud trial paths
- What's New section with recent release highlights
- Full product index categorized by platform, solutions, deploy, ingest tools, query languages, APM agents, and developer tools & standards
- Support link for reporting docs issues 
- Optimizations for machine reading
- Scoped CSS replacing Tailwind utility classes

## Guiding principles for changes
Most landing page guidance is written for marketing and ecommerce contexts, which primarily focus on conversion funnels, single CTAs, social proof, and urgency. That advice doesn't translate cleanly to documentation.
A documentation landing page has a different job. Users aren't being persuaded because they've already decided to use the product. They arrive with a specific task in mind, at varying levels of familiarity with the docs site structure. The landing page succeeds when it gets them to the right content as quickly as possible, and fails when it makes them work to find it.

### Principle 1: Serve task-focused users first
The majority of users landing on the Elastic Docs homepage are focused on completing a specific task. They know what they want and they want to reach it in one click. They are not browsing or evaluating whether to use Elastic.
This prototype is designed for this user first. Every element that isn't a direct route to content is friction.

What this means in practice:
- **Lead with search.** The search bar is the most important element on the page. It should be above the fold, visually prominent, and fast to load. For users that want to complete a specific task, it replaces the entire page structure.
- **Surface the most visited pages directly.** The current Elastic Docs landing page is designed by product, task category, and internal team structure. These are reasonable starting points, but they're not the same as what users actually need. Our search queries and pageview data tell us what users came for. We should use them. The CTAs on the landing page are data-informed. We know where users are going, and we don't want to make them rediscover the pages they need through navigation.
- **Minimize decorative content.** Introductory copy, product descriptions, and feature callouts serve discovery-based users, not task-focused users. 

### Principle 2: Acknowledge multiple user intents without serving all of them equally

The Elastic Docs landing page typically serves at least three distinct user types:

- Task-focused users — Returning users who know what they want
- Getting started users — New users who need orientation and a clear first step
- Discovery-focused users — Users evaluating Elastic, exploring what's possible, or looking for features they don't know exist yet. 

If we design for all three of these user types equally,  we'll produce a cluttered page that serves none of them well.

This design prioritizes in this order: 
- Task-focused
- Getting started
- Discovery-focused (what's new, feature highlights, use case showcases should be present, but lightweight)

If you cover the search bar with your hand and ask whether the remaining page structure routes a new user to the right starting point in one click, the getting started content is doing its job. If you ask whether a returning user looking for a specific reference page can find it without thinking, the task-focused routing is also doing its job.

### Principle 3: Distinguish between navigation and content
The Elastic Docs landing page is navigation infrastructure, not content. Its job is to route users to content, not to contain it. This distinction matters because it shapes what belongs on the page. Landing pages that try to contain content (summarizing every product area, explaining what Elasticsearch is, describing use cases) become long, hard to maintain, and slow to scan.

What belongs on a docs landing page:
- Search
- Routes to high-traffic content (most visited pages, getting-started paths, installation guides)
- Product/topic navigation (where the product surface area is large enough to need it)
- A lightweight signal for discovery-mode users (what's new)

What doesn't belong on a docs landing page:
- Marketing copy or product descriptions
- Detailed feature explanations
- Tutorial content
- Community links (unless analytics show significant demand)
- Anything that requires maintenance to stay accurate at the content level

### Principle 4: Make the page readable by machines, not just people
An increasing share of documentation traffic comes through AI intermediaries, including LLM-powered search, coding assistants, support bots. These agents need semantic HTML, structured metadata, and a machine-readable site index to route users to the right content. If an AI agent can't parse the page hierarchy or understand what each section contains, it will hallucinate answers instead of linking to the right docs.

### Principle 5: Name things the way users name them
The landing page uses task-based terms that don't always match how users search. This creates a gap between the landing page labels and the search terms users arrive with.

🤖 Generated with Claude Code.