### PR TITLE
Update ECS version per 9.4 release

### DIFF
--- a/config/assembler.yml
+++ b/config/assembler.yml
@@ -99,7 +99,7 @@ references:
   apm-aws-lambda:
   apm-k8s-attacher:
   ecs:
-    current: 9.3 # releases do not always align with the Stack version
+    current: 9.4 # releases do not always align with the Stack version
     next: main
   ecs-dotnet:
   ecs-logging-go-logrus:

--- a/config/versions.yml
+++ b/config/versions.yml
@@ -23,7 +23,7 @@ versioning_systems:
   ess: *all
   ecs:
     base: 9.0
-    current: 9.3.0
+    current: 9.4.0
   self: *stack
   ecctl:
     base: 1.0


### PR DESCRIPTION
~~In preparation for the ECS 9.4.0 release, bumping the versions for docs-builder.~~
~~Do not merge automatically, will merge on release day.~~
~~(referenced previous release PR here: https://github.com/elastic/docs-builder/pull/2564)~~

(accidentally created on fork, see here for correct PR: https://github.com/elastic/docs-builder/pull/3252)