### PR TITLE
fix: applies-switch and tab-set first tab hidden when block contains a comment

### DIFF
--- a/src/Elastic.Markdown/Myst/Directives/AppliesSwitch/AppliesSwitchBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/AppliesSwitch/AppliesSwitchBlock.cs
@@ -52,7 +52,7 @@ public class AppliesItemBlock(DirectiveBlockParser parser, ParserContext context
 			this.EmitError("{applies-item} requires an argument with applies_to definition.");
 
 		AppliesToDefinition = (Arguments ?? "{undefined}").ReplaceSubstitutions(context);
-		Index = Parent!.IndexOf(this);
+		Index = Parent!.OfType<AppliesItemBlock>().ToList().IndexOf(this);
 
 		var appliesSwitch = Parent as AppliesSwitchBlock;
 

--- a/src/Elastic.Markdown/Myst/Directives/Tabs/TabSetBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Tabs/TabSetBlock.cs
@@ -47,7 +47,7 @@ public class TabItemBlock(DirectiveBlockParser parser, ParserContext context)
 			this.EmitError("{tab-item} requires an argument to name the tab.");
 
 		Title = (Arguments ?? "{undefined}").ReplaceSubstitutions(context);
-		Index = Parent!.IndexOf(this);
+		Index = Parent!.OfType<TabItemBlock>().ToList().IndexOf(this);
 
 		var tabSet = Parent as TabSetBlock;
 

--- a/tests/Elastic.Markdown.Tests/Directives/ApplicabilitySwitchTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/ApplicabilitySwitchTests.cs
@@ -46,6 +46,10 @@ This feature has been removed from Elastic Cloud Enterprise.
 	}
 
 	[Fact]
+	public void FirstItemRendersChecked() =>
+		Html.Should().Contain("applies-switch-input\" checked=\"checked\"");
+
+	[Fact]
 	public void ParsesAppliesToDefinitions()
 	{
 		var items = Block!.OfType<AppliesItemBlock>().ToArray();
@@ -62,6 +66,40 @@ This feature has been removed from Elastic Cloud Enterprise.
 		foreach (var item in items)
 			item.Directive.Should().Be("applies-item");
 	}
+}
+
+// Reproduces the real-world case: a % comment block between {applies-switch} and
+// the first {applies-item} previously pushed all item indices to 1, 2, 3.
+public class ApplicabilitySwitchWithCommentTests(ITestOutputHelper output) : DirectiveTest<AppliesSwitchBlock>(output,
+"""
+:::::{applies-switch}
+
+% TODO: some comment here
+
+::::{applies-item} stack: preview 9.1
+Content A
+::::
+
+::::{applies-item} ess: preview 9.1
+Content B
+::::
+
+:::::
+"""
+)
+{
+	[Fact]
+	public void ItemIndicesAreZeroBased()
+	{
+		var items = Block!.OfType<AppliesItemBlock>().ToArray();
+		items.Should().HaveCount(2);
+		for (var i = 0; i < items.Length; i++)
+			items[i].Index.Should().Be(i);
+	}
+
+	[Fact]
+	public void FirstItemRendersChecked() =>
+		Html.Should().Contain("applies-switch-input\" checked=\"checked\"");
 }
 
 public class MultipleApplicabilitySwitchTests(ITestOutputHelper output) : DirectiveTest<AppliesSwitchBlock>(output,


### PR DESCRIPTION
## Why

Any non-item block inside `{applies-switch}` or `{tab-set}` — such as a MyST `%` comment — occupies index 0 in Markdig's child list, pushing all `{applies-item}` / `{tab-item}` blocks to indices 1, 2, 3 …

The Razor templates use `Model.Index == 0` to emit `checked="checked"` on the first radio input, which is what the pure-CSS tab mechanism relies on to show the first panel. When `Index` is never 0, no radio is checked, and all tab content stays hidden until the user clicks a tab.

The real-world trigger was a `% TODO` comment in the [query-logs source](https://raw.githubusercontent.com/elastic/docs-content/refs/heads/main/deploy-manage/monitor/logging-configuration/query-logs.md):

```markdown
::::::{applies-switch}

% TODO: Update ECH and ECE tabs when Cloud UI supports configuring query logging settings directly.

:::::{applies-item} ess:
…
```

This caused https://github.com/elastic/docs-builder/issues/3254.

## What

Changed `AppliesItemBlock` and `TabItemBlock` to compute their index relative to sibling items only, rather than among all children of the parent block:

```csharp
// Before — breaks when any non-item block precedes the first item
Index = Parent!.IndexOf(this);

// After — always yields 0, 1, 2 … regardless of other block types
Index = Parent!.OfType<AppliesItemBlock>().ToList().IndexOf(this);
```

Added a regression test (`ApplicabilitySwitchWithCommentTests`) that places a `%` comment before the first `{applies-item}` and asserts both that indices are 0-based and that the first radio renders with `checked="checked"`.