### PR TITLE
Improve changelog render date handling

### DIFF
--- a/docs/cli/changelog/render.md
+++ b/docs/cli/changelog/render.md
@@ -64,7 +64,7 @@ The `render` command automatically discovers and merges `.amend-*.yaml` files wi
 
 `--title <string?>`
 :   Optional: The title to use for section headers, directories, and anchors in output files.
-:   Defaults to the version in the first bundle.
+:   Defaults to the version in the first bundle. When omitted, ISO date targets are formatted for display the same way as the `{changelog}` directive (e.g., `2026-05-04` becomes "May 4, 2026", `2026-05` becomes "May 2026"), while directory names and heading anchors continue to use the raw target slug.
 :   If the string contains spaces, they are replaced with dashes when used in directory names and anchors.
 
 The `changelog render` command does **not** use `rules.publish` for filtering. Filtering must be done at bundle time using `rules.bundle`. For more information, refer to [](/contribute/publish-changelogs.md). For how the directive differs, see the [{changelog} directive syntax reference](/syntax/changelog.md).

--- a/src/services/Elastic.Changelog/Rendering/ChangelogRenderingService.cs
+++ b/src/services/Elastic.Changelog/Rendering/ChangelogRenderingService.cs
@@ -227,9 +227,23 @@ public class ChangelogRenderingService(
 		if (string.IsNullOrWhiteSpace(input.Title) && version == "unknown")
 			collector.EmitWarning(string.Empty, "No --title option provided and bundle files do not contain 'target' values. Output folder and markdown titles will default to 'unknown'. Consider using --title to specify a custom title.");
 
-		// Use title from input or default to version
-		var title = input.Title ?? version;
-		var titleSlug = ChangelogTextUtilities.TitleToSlug(title);
+		// Determine title and slug
+		string title;
+		string titleSlug;
+
+		if (string.IsNullOrWhiteSpace(input.Title))
+		{
+			// Default title: format dates like the changelog directive
+			title = VersionOrDate.FormatDisplayVersion(version);
+			// Slug always uses raw version to maintain consistent paths/anchors
+			titleSlug = ChangelogTextUtilities.TitleToSlug(version);
+		}
+		else
+		{
+			// Explicit title provided: use as-is for both title and slug
+			title = input.Title;
+			titleSlug = ChangelogTextUtilities.TitleToSlug(input.Title);
+		}
 
 		return new OutputSetup(outputDir, title, titleSlug);
 	}

--- a/tests/Elastic.Changelog.Tests/Changelogs/Render/TitleTargetTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/Render/TitleTargetTests.cs
@@ -132,4 +132,202 @@ public class TitleTargetTests(ITestOutputHelper output) : RenderChangelogTestBas
 			d.Severity == Severity.Warning &&
 			d.Message.Contains("No --title option provided"));
 	}
+
+	[Fact]
+	public async Task RenderChangelogs_WithIsoDateTarget_FormatsDateInHeading()
+	{
+		// Arrange
+		var changelogDir = FileSystem.Path.Join(Paths.WorkingDirectoryRoot.FullName, Guid.NewGuid().ToString());
+		FileSystem.Directory.CreateDirectory(changelogDir);
+
+		// Create test changelog file with ISO date target
+		// language=yaml
+		var changelog1 =
+			"""
+			title: Test feature
+			type: feature
+			products:
+			  - product: elasticsearch
+			    target: 2026-05-04
+			prs:
+			- "100"
+			""";
+
+		var changelogFile = FileSystem.Path.Join(changelogDir, "1755268130-test-feature.yaml");
+		await FileSystem.File.WriteAllTextAsync(changelogFile, changelog1, TestContext.Current.CancellationToken);
+
+		// Create bundle file with ISO date target
+		var bundleDir = FileSystem.Path.Join(Paths.WorkingDirectoryRoot.FullName, Guid.NewGuid().ToString());
+		FileSystem.Directory.CreateDirectory(bundleDir);
+
+		var bundleFile = FileSystem.Path.Join(bundleDir, "bundle.yaml");
+		// language=yaml
+		var bundleContent =
+			$"""
+			products:
+			  - product: elasticsearch
+			    target: 2026-05-04
+			entries:
+			  - file:
+			      name: 1755268130-test-feature.yaml
+			      checksum: {ComputeSha1(changelog1)}
+			""";
+		await FileSystem.File.WriteAllTextAsync(bundleFile, bundleContent, TestContext.Current.CancellationToken);
+
+		var outputDir = FileSystem.Path.Join(Paths.WorkingDirectoryRoot.FullName, Guid.NewGuid().ToString());
+
+		var input = new RenderChangelogsArguments
+		{
+			Bundles = [new BundleInput { BundleFile = bundleFile, Directory = changelogDir }],
+			Output = outputDir
+			// Note: Title is not set, should default to formatted date
+		};
+
+		// Act
+		var result = await Service.RenderChangelogs(Collector, input, TestContext.Current.CancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		Collector.Errors.Should().Be(0);
+
+		// Check that output directory uses raw date slug
+		var indexFile = FileSystem.Path.Join(outputDir, "2026-05-04", "index.md");
+		FileSystem.File.Exists(indexFile).Should().BeTrue();
+
+		// Check that heading uses formatted date but anchor uses raw date
+		var indexContent = await FileSystem.File.ReadAllTextAsync(indexFile, TestContext.Current.CancellationToken);
+		indexContent.Should().Contain("## May 4, 2026 [elastic-release-notes-2026-05-04]");
+	}
+
+	[Fact]
+	public async Task RenderChangelogs_WithYearMonthTarget_FormatsDateInHeading()
+	{
+		// Arrange
+		var changelogDir = FileSystem.Path.Join(Paths.WorkingDirectoryRoot.FullName, Guid.NewGuid().ToString());
+		FileSystem.Directory.CreateDirectory(changelogDir);
+
+		// Create test changelog file with year-month target
+		// language=yaml
+		var changelog1 =
+			"""
+			title: Test feature
+			type: feature
+			products:
+			  - product: elasticsearch
+			    target: 2026-05
+			prs:
+			- "100"
+			""";
+
+		var changelogFile = FileSystem.Path.Join(changelogDir, "1755268130-test-feature.yaml");
+		await FileSystem.File.WriteAllTextAsync(changelogFile, changelog1, TestContext.Current.CancellationToken);
+
+		// Create bundle file with year-month target
+		var bundleDir = FileSystem.Path.Join(Paths.WorkingDirectoryRoot.FullName, Guid.NewGuid().ToString());
+		FileSystem.Directory.CreateDirectory(bundleDir);
+
+		var bundleFile = FileSystem.Path.Join(bundleDir, "bundle.yaml");
+		// language=yaml
+		var bundleContent =
+			$"""
+			products:
+			  - product: elasticsearch
+			    target: 2026-05
+			entries:
+			  - file:
+			      name: 1755268130-test-feature.yaml
+			      checksum: {ComputeSha1(changelog1)}
+			""";
+		await FileSystem.File.WriteAllTextAsync(bundleFile, bundleContent, TestContext.Current.CancellationToken);
+
+		var outputDir = FileSystem.Path.Join(Paths.WorkingDirectoryRoot.FullName, Guid.NewGuid().ToString());
+
+		var input = new RenderChangelogsArguments
+		{
+			Bundles = [new BundleInput { BundleFile = bundleFile, Directory = changelogDir }],
+			Output = outputDir
+			// Note: Title is not set, should default to formatted date
+		};
+
+		// Act
+		var result = await Service.RenderChangelogs(Collector, input, TestContext.Current.CancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		Collector.Errors.Should().Be(0);
+
+		// Check that output directory uses raw date slug
+		var indexFile = FileSystem.Path.Join(outputDir, "2026-05", "index.md");
+		FileSystem.File.Exists(indexFile).Should().BeTrue();
+
+		// Check that heading uses formatted date but anchor uses raw date
+		var indexContent = await FileSystem.File.ReadAllTextAsync(indexFile, TestContext.Current.CancellationToken);
+		indexContent.Should().Contain("## May 2026 [elastic-release-notes-2026-05]");
+	}
+
+	[Fact]
+	public async Task RenderChangelogs_WithExplicitDateTitle_DoesNotFormatTitle()
+	{
+		// Arrange
+		var changelogDir = FileSystem.Path.Join(Paths.WorkingDirectoryRoot.FullName, Guid.NewGuid().ToString());
+		FileSystem.Directory.CreateDirectory(changelogDir);
+
+		// Create test changelog file with ISO date target
+		// language=yaml
+		var changelog1 =
+			"""
+			title: Test feature
+			type: feature
+			products:
+			  - product: elasticsearch
+			    target: 2026-05-04
+			prs:
+			- "100"
+			""";
+
+		var changelogFile = FileSystem.Path.Join(changelogDir, "1755268130-test-feature.yaml");
+		await FileSystem.File.WriteAllTextAsync(changelogFile, changelog1, TestContext.Current.CancellationToken);
+
+		// Create bundle file with ISO date target
+		var bundleDir = FileSystem.Path.Join(Paths.WorkingDirectoryRoot.FullName, Guid.NewGuid().ToString());
+		FileSystem.Directory.CreateDirectory(bundleDir);
+
+		var bundleFile = FileSystem.Path.Join(bundleDir, "bundle.yaml");
+		// language=yaml
+		var bundleContent =
+			$"""
+			products:
+			  - product: elasticsearch
+			    target: 2026-05-04
+			entries:
+			  - file:
+			      name: 1755268130-test-feature.yaml
+			      checksum: {ComputeSha1(changelog1)}
+			""";
+		await FileSystem.File.WriteAllTextAsync(bundleFile, bundleContent, TestContext.Current.CancellationToken);
+
+		var outputDir = FileSystem.Path.Join(Paths.WorkingDirectoryRoot.FullName, Guid.NewGuid().ToString());
+
+		var input = new RenderChangelogsArguments
+		{
+			Bundles = [new BundleInput { BundleFile = bundleFile, Directory = changelogDir }],
+			Output = outputDir,
+			Title = "2026-05-04" // Explicit title provided - should stay literal
+		};
+
+		// Act
+		var result = await Service.RenderChangelogs(Collector, input, TestContext.Current.CancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		Collector.Errors.Should().Be(0);
+
+		// Check that output directory uses title slug
+		var indexFile = FileSystem.Path.Join(outputDir, "2026-05-04", "index.md");
+		FileSystem.File.Exists(indexFile).Should().BeTrue();
+
+		// Check that heading uses literal title (no formatting applied)
+		var indexContent = await FileSystem.File.ReadAllTextAsync(indexFile, TestContext.Current.CancellationToken);
+		indexContent.Should().Contain("## 2026-05-04 [elastic-release-notes-2026-05-04]");
+	}
 }


### PR DESCRIPTION
## Summary

Fixes the default handling of date-based release titles in the `docs-builder changelog render` command.

The changelog render command now produces headings like:

```md
## May 4, 2026 [elastic-release-notes-2026-05-04]
```

Instead of:
```md
## 2026-05-04 [elastic-release-notes-2026-05-04]
```
This matches the {changelog} directive behavior exactly!

## AI implementation details

### 1. **Tests Added** (`TitleTargetTests.cs`)
- Added 3 new test methods to verify date formatting behavior:
  - `RenderChangelogs_WithIsoDateTarget_FormatsDateInHeading()` - Tests `2026-05-04` → `May 4, 2026`
  - `RenderChangelogs_WithYearMonthTarget_FormatsDateInHeading()` - Tests `2026-05` → `May 2026` 
  - `RenderChangelogs_WithExplicitDateTitle_DoesNotFormatTitle()` - Tests explicit `--title` stays literal

### 2. **Implementation** (`ChangelogRenderingService.SetupOutput`)
- Updated the title/slug logic to decouple display title from slug:
  - **No `--title`**: Uses `VersionOrDate.FormatDisplayVersion(version)` for title, raw `version` for slug
  - **With `--title`**: Uses literal title for both (unchanged behavior)

### 3. **Documentation** (`docs/cli/changelog/render.md`)  
- Updated `--title` option description to explain the new date formatting behavior

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: composer-2