### PR TITLE
Harden branding image symlink check to cover ancestor directories

### DIFF
--- a/src/Elastic.Documentation.Configuration/Builder/ConfigurationFile.cs
+++ b/src/Elastic.Documentation.Configuration/Builder/ConfigurationFile.cs
@@ -11,6 +11,7 @@ using Elastic.Documentation.Configuration.Versions;
 using Elastic.Documentation.Diagnostics;
 using Elastic.Documentation.Extensions;
 using Elastic.Documentation.Links;
+using static Elastic.Documentation.Configuration.SymlinkValidator;
 
 namespace Elastic.Documentation.Configuration.Builder;
 
@@ -330,10 +331,11 @@ public record ConfigurationFile
 			return null;
 		}
 
-		if (resolved.LinkTarget is not null)
+		var symlinkError = ValidateFileAccess(resolved, context.DocumentationSourceDirectory);
+		if (symlinkError is not null)
 		{
 			context.EmitError(context.ConfigurationPath,
-				$"'{fieldName}' path '{imagePath}' is a symbolic link, which is not allowed for branding images.");
+				$"'{fieldName}' path '{imagePath}' is unsafe: {symlinkError}");
 			return null;
 		}
 


### PR DESCRIPTION
## Why

The previous symlink check on `branding.icon` and `branding.og-image` only tested whether the image file itself was a symlink. A symlinked parent directory (e.g. `assets/` → `/etc/`) would pass the check and allow an attacker to read arbitrary files outside the documentation source directory.

However we still validate the file itself is an image.

## What

Replaces the bare `resolved.LinkTarget is not null` check with `ValidateFileAccess`, which walks ancestor directories up to the doc root and rejects any symlinked or hidden intermediate directory — the same protection already used for `docset.yml` and `toc.yml`.