### PR TITLE
Improve changelog render for asciidoc

### DIFF
--- a/docs/cli/changelog/render.md
+++ b/docs/cli/changelog/render.md
@@ -98,6 +98,12 @@ When `--file-type asciidoc` is specified, the command generates a single asciido
 
 The asciidoc output uses attribute references for links (for example, `{repo-pull}NUMBER[#NUMBER]`).
 
+AsciiDoc output ignores the `--dropdowns` flag and always uses a standardized format with the following characteristics:
+
+- Multi-block entries (containing description, Impact, and Action sections) use proper list continuation markers (`+`) to maintain list structure
+- Strong text formatting uses idiomatic single asterisk syntax (`*Impact:*`, `*Action:*`) following AsciiDoc best practices
+- All content blocks are properly attached to their parent list items for correct rendering
+
 ### Multiple PR and issue links
 
 Changelog entries can reference multiple pull requests and issues using the `prs` and `issues` array fields. When an entry has multiple links, all of them are rendered inline for that entry:

--- a/src/services/Elastic.Changelog/Rendering/Asciidoc/AsciidocRendererBase.cs
+++ b/src/services/Elastic.Changelog/Rendering/Asciidoc/AsciidocRendererBase.cs
@@ -61,40 +61,48 @@ public abstract class AsciidocRendererBase
 	}
 
 	/// <summary>
-	/// Renders an entry's description with optional comment handling
+	/// Renders an entry's description with optional comment handling and list continuation
 	/// </summary>
-	private static void RenderEntryDescription(StringBuilder sb, ChangelogEntry entry, bool shouldHide)
+	private static void RenderEntryDescription(StringBuilder sb, ChangelogEntry entry, bool shouldHide, bool needsContinuation = true)
 	{
 		if (string.IsNullOrWhiteSpace(entry.Description))
 			return;
 
 		_ = sb.AppendLine();
-		var indented = ChangelogTextUtilities.Indent(entry.Description);
+
+		// Add list continuation marker for multi-block list items
+		if (needsContinuation)
+		{
+			_ = sb.AppendLine("+");
+		}
+
 		if (shouldHide)
 		{
-			var indentedLines = indented.Split('\n');
-			foreach (var line in indentedLines)
+			var descriptionLines = entry.Description.Split('\n');
+			foreach (var line in descriptionLines)
 				_ = sb.AppendLine(CultureInfo.InvariantCulture, $"// {line}");
 		}
 		else
-			_ = sb.AppendLine(indented);
+			_ = sb.AppendLine(entry.Description);
 	}
 
 	/// <summary>
-	/// Renders Impact and Action fields for breaking changes, deprecations, and known issues
+	/// Renders Impact and Action fields for breaking changes, deprecations, and known issues with list continuation
 	/// </summary>
 	private static void RenderImpactAndAction(StringBuilder sb, ChangelogEntry entry)
 	{
 		if (!string.IsNullOrWhiteSpace(entry.Impact))
 		{
 			_ = sb.AppendLine();
-			_ = sb.AppendLine(CultureInfo.InvariantCulture, $"**Impact:** {entry.Impact}");
+			_ = sb.AppendLine("+");
+			_ = sb.AppendLine(CultureInfo.InvariantCulture, $"*Impact:* {entry.Impact}");
 		}
 
 		if (!string.IsNullOrWhiteSpace(entry.Action))
 		{
 			_ = sb.AppendLine();
-			_ = sb.AppendLine(CultureInfo.InvariantCulture, $"**Action:** {entry.Action}");
+			_ = sb.AppendLine("+");
+			_ = sb.AppendLine(CultureInfo.InvariantCulture, $"*Action:* {entry.Action}");
 		}
 	}
 
@@ -105,7 +113,7 @@ public abstract class AsciidocRendererBase
 	{
 		var (entryRepo, _, hideLinks, shouldHide) = ChangelogRenderUtilities.GetEntryContext(entry, context);
 		RenderEntryTitleAndLinks(sb, entry, entryRepo, hideLinks, shouldHide);
-		RenderEntryDescription(sb, entry, shouldHide);
+		RenderEntryDescription(sb, entry, shouldHide, needsContinuation: !string.IsNullOrWhiteSpace(entry.Description));
 		_ = sb.AppendLine();
 	}
 
@@ -116,7 +124,11 @@ public abstract class AsciidocRendererBase
 	{
 		var (entryRepo, _, hideLinks, shouldHide) = ChangelogRenderUtilities.GetEntryContext(entry, context);
 		RenderEntryTitleAndLinks(sb, entry, entryRepo, hideLinks, shouldHide);
-		RenderEntryDescription(sb, entry, shouldHide);
+
+		// Description needs continuation when it exists
+		var hasDescription = !string.IsNullOrWhiteSpace(entry.Description);
+		RenderEntryDescription(sb, entry, shouldHide, needsContinuation: hasDescription);
+
 		RenderImpactAndAction(sb, entry);
 		_ = sb.AppendLine();
 	}

--- a/src/services/Elastic.Changelog/Rendering/Asciidoc/BreakingChangesAsciidocRenderer.cs
+++ b/src/services/Elastic.Changelog/Rendering/Asciidoc/BreakingChangesAsciidocRenderer.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Globalization;
 using System.Text;
 using Elastic.Documentation;
 using Elastic.Documentation.ReleaseNotes;
@@ -30,8 +31,17 @@ public class BreakingChangesAsciidocRenderer(StringBuilder sb) : AsciidocRendere
 			if (context.Subsections && !string.IsNullOrWhiteSpace(group.Key))
 			{
 				var header = ChangelogTextUtilities.FormatSubtypeHeader(group.Key);
-				var headerLine = allEntriesHidden ? $"// **{header}**" : $"**{header}**";
-				_ = sb.AppendLine(headerLine);
+
+				if (allEntriesHidden)
+				{
+					_ = sb.AppendLine("// [float]");
+					_ = sb.AppendLine(CultureInfo.InvariantCulture, $"// ==== {header}");
+				}
+				else
+				{
+					_ = sb.AppendLine("[float]");
+					_ = sb.AppendLine(CultureInfo.InvariantCulture, $"==== {header}");
+				}
 				_ = sb.AppendLine();
 			}
 

--- a/src/services/Elastic.Changelog/Rendering/Asciidoc/DeprecationsAsciidocRenderer.cs
+++ b/src/services/Elastic.Changelog/Rendering/Asciidoc/DeprecationsAsciidocRenderer.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Globalization;
 using System.Text;
 using Elastic.Documentation.ReleaseNotes;
 
@@ -15,22 +16,37 @@ public class DeprecationsAsciidocRenderer(StringBuilder sb) : AsciidocRendererBa
 	/// <inheritdoc />
 	public override void Render(IReadOnlyCollection<ChangelogEntry> entries, ChangelogRenderContext context)
 	{
-		var groupedByArea = entries.GroupBy(e => ChangelogRenderUtilities.GetComponent(e, context)).OrderBy(g => g.Key).ToList();
+		// Group by area if subsections is enabled, otherwise use single group
+		var groupedEntries = context.Subsections
+			? entries.GroupBy(e => ChangelogRenderUtilities.GetComponent(e, context)).OrderBy(g => g.Key).ToList()
+			: [entries.GroupBy(_ => string.Empty).First()];
 
-		foreach (var areaGroup in groupedByArea)
+		foreach (var group in groupedEntries)
 		{
-			// Check if all entries in this area group are hidden
-			var allEntriesHidden = areaGroup.All(entry =>
+			// Check if all entries in this group are hidden
+			var allEntriesHidden = group.All(entry =>
 				ChangelogRenderUtilities.ShouldHideEntry(entry, context.FeatureIdsToHide, context));
 
-			var componentName = !string.IsNullOrWhiteSpace(areaGroup.Key) ? areaGroup.Key : "General";
-			var formattedComponent = ChangelogTextUtilities.FormatAreaHeader(componentName);
+			// Add nested section header when subsections are enabled and group has a name
+			if (context.Subsections && !string.IsNullOrWhiteSpace(group.Key))
+			{
+				var componentName = group.Key != string.Empty ? group.Key : "General";
+				var formattedComponent = ChangelogTextUtilities.FormatAreaHeader(componentName);
 
-			var headerLine = allEntriesHidden ? $"// {formattedComponent}::" : $"{formattedComponent}::";
-			_ = sb.AppendLine(headerLine);
-			_ = sb.AppendLine();
+				if (allEntriesHidden)
+				{
+					_ = sb.AppendLine("// [float]");
+					_ = sb.AppendLine(CultureInfo.InvariantCulture, $"// ==== {formattedComponent}");
+				}
+				else
+				{
+					_ = sb.AppendLine("[float]");
+					_ = sb.AppendLine(CultureInfo.InvariantCulture, $"==== {formattedComponent}");
+				}
+				_ = sb.AppendLine();
+			}
 
-			foreach (var entry in areaGroup)
+			foreach (var entry in group)
 				RenderEntryWithImpactAction(sb, entry, context);
 		}
 	}

--- a/src/services/Elastic.Changelog/Rendering/Asciidoc/EntriesByAreaAsciidocRenderer.cs
+++ b/src/services/Elastic.Changelog/Rendering/Asciidoc/EntriesByAreaAsciidocRenderer.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Globalization;
 using System.Text;
 using Elastic.Documentation.ReleaseNotes;
 
@@ -15,24 +16,37 @@ public class EntriesByAreaAsciidocRenderer(StringBuilder sb) : AsciidocRendererB
 	/// <inheritdoc />
 	public override void Render(IReadOnlyCollection<ChangelogEntry> entries, ChangelogRenderContext context)
 	{
-		var groupedByArea = context.Subsections
+		// Group by area if subsections is enabled, otherwise use single group
+		var groupedEntries = context.Subsections
 			? entries.GroupBy(e => ChangelogRenderUtilities.GetComponent(e, context)).OrderBy(g => g.Key).ToList()
-			: entries.GroupBy(e => ChangelogRenderUtilities.GetComponent(e, context)).ToList();
+			: [entries.GroupBy(_ => string.Empty).First()];
 
-		foreach (var areaGroup in groupedByArea)
+		foreach (var group in groupedEntries)
 		{
-			// Check if all entries in this area group are hidden
-			var allEntriesHidden = areaGroup.All(entry =>
+			// Check if all entries in this group are hidden
+			var allEntriesHidden = group.All(entry =>
 				ChangelogRenderUtilities.ShouldHideEntry(entry, context.FeatureIdsToHide, context));
 
-			var componentName = !string.IsNullOrWhiteSpace(areaGroup.Key) ? areaGroup.Key : "General";
-			var formattedComponent = ChangelogTextUtilities.FormatAreaHeader(componentName);
+			// Add nested section header when subsections are enabled and group has a name
+			if (context.Subsections && !string.IsNullOrWhiteSpace(group.Key))
+			{
+				var componentName = group.Key != string.Empty ? group.Key : "General";
+				var formattedComponent = ChangelogTextUtilities.FormatAreaHeader(componentName);
 
-			var headerLine = allEntriesHidden ? $"// {formattedComponent}::" : $"{formattedComponent}::";
-			_ = sb.AppendLine(headerLine);
-			_ = sb.AppendLine();
+				if (allEntriesHidden)
+				{
+					_ = sb.AppendLine("// [float]");
+					_ = sb.AppendLine(CultureInfo.InvariantCulture, $"// ==== {formattedComponent}");
+				}
+				else
+				{
+					_ = sb.AppendLine("[float]");
+					_ = sb.AppendLine(CultureInfo.InvariantCulture, $"==== {formattedComponent}");
+				}
+				_ = sb.AppendLine();
+			}
 
-			foreach (var entry in areaGroup)
+			foreach (var entry in group)
 				RenderBasicEntry(sb, entry, context);
 		}
 	}

--- a/src/services/Elastic.Changelog/Rendering/Asciidoc/HighlightsAsciidocRenderer.cs
+++ b/src/services/Elastic.Changelog/Rendering/Asciidoc/HighlightsAsciidocRenderer.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Globalization;
 using System.Text;
 using Elastic.Documentation.ReleaseNotes;
 
@@ -15,24 +16,37 @@ public class HighlightsAsciidocRenderer(StringBuilder sb) : AsciidocRendererBase
 	/// <inheritdoc />
 	public override void Render(IReadOnlyCollection<ChangelogEntry> entries, ChangelogRenderContext context)
 	{
-		var groupedByArea = context.Subsections
+		// Group by area if subsections is enabled, otherwise use single group
+		var groupedEntries = context.Subsections
 			? entries.GroupBy(e => ChangelogRenderUtilities.GetComponent(e, context)).OrderBy(g => g.Key).ToList()
-			: entries.GroupBy(e => ChangelogRenderUtilities.GetComponent(e, context)).ToList();
+			: [entries.GroupBy(_ => string.Empty).First()];
 
-		foreach (var areaGroup in groupedByArea)
+		foreach (var group in groupedEntries)
 		{
-			// Check if all entries in this area group are hidden
-			var allEntriesHidden = areaGroup.All(entry =>
+			// Check if all entries in this group are hidden
+			var allEntriesHidden = group.All(entry =>
 				ChangelogRenderUtilities.ShouldHideEntry(entry, context.FeatureIdsToHide, context));
 
-			var componentName = !string.IsNullOrWhiteSpace(areaGroup.Key) ? areaGroup.Key : "General";
-			var formattedComponent = ChangelogTextUtilities.FormatAreaHeader(componentName);
+			// Add nested section header when subsections are enabled and group has a name
+			if (context.Subsections && !string.IsNullOrWhiteSpace(group.Key))
+			{
+				var componentName = group.Key != string.Empty ? group.Key : "General";
+				var formattedComponent = ChangelogTextUtilities.FormatAreaHeader(componentName);
 
-			var headerLine = allEntriesHidden ? $"// {formattedComponent}::" : $"{formattedComponent}::";
-			_ = sb.AppendLine(headerLine);
-			_ = sb.AppendLine();
+				if (allEntriesHidden)
+				{
+					_ = sb.AppendLine("// [float]");
+					_ = sb.AppendLine(CultureInfo.InvariantCulture, $"// ==== {formattedComponent}");
+				}
+				else
+				{
+					_ = sb.AppendLine("[float]");
+					_ = sb.AppendLine(CultureInfo.InvariantCulture, $"==== {formattedComponent}");
+				}
+				_ = sb.AppendLine();
+			}
 
-			foreach (var entry in areaGroup)
+			foreach (var entry in group)
 				RenderBasicEntry(sb, entry, context);
 		}
 	}

--- a/src/services/Elastic.Changelog/Rendering/Asciidoc/KnownIssuesAsciidocRenderer.cs
+++ b/src/services/Elastic.Changelog/Rendering/Asciidoc/KnownIssuesAsciidocRenderer.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Globalization;
 using System.Text;
 using Elastic.Documentation.ReleaseNotes;
 
@@ -15,22 +16,37 @@ public class KnownIssuesAsciidocRenderer(StringBuilder sb) : AsciidocRendererBas
 	/// <inheritdoc />
 	public override void Render(IReadOnlyCollection<ChangelogEntry> entries, ChangelogRenderContext context)
 	{
-		var groupedByArea = entries.GroupBy(e => ChangelogRenderUtilities.GetComponent(e, context)).OrderBy(g => g.Key).ToList();
+		// Group by area if subsections is enabled, otherwise use single group
+		var groupedEntries = context.Subsections
+			? entries.GroupBy(e => ChangelogRenderUtilities.GetComponent(e, context)).OrderBy(g => g.Key).ToList()
+			: [entries.GroupBy(_ => string.Empty).First()];
 
-		foreach (var areaGroup in groupedByArea)
+		foreach (var group in groupedEntries)
 		{
-			// Check if all entries in this area group are hidden
-			var allEntriesHidden = areaGroup.All(entry =>
+			// Check if all entries in this group are hidden
+			var allEntriesHidden = group.All(entry =>
 				ChangelogRenderUtilities.ShouldHideEntry(entry, context.FeatureIdsToHide, context));
 
-			var componentName = !string.IsNullOrWhiteSpace(areaGroup.Key) ? areaGroup.Key : "General";
-			var formattedComponent = ChangelogTextUtilities.FormatAreaHeader(componentName);
+			// Add nested section header when subsections are enabled and group has a name
+			if (context.Subsections && !string.IsNullOrWhiteSpace(group.Key))
+			{
+				var componentName = group.Key != string.Empty ? group.Key : "General";
+				var formattedComponent = ChangelogTextUtilities.FormatAreaHeader(componentName);
 
-			var headerLine = allEntriesHidden ? $"// {formattedComponent}::" : $"{formattedComponent}::";
-			_ = sb.AppendLine(headerLine);
-			_ = sb.AppendLine();
+				if (allEntriesHidden)
+				{
+					_ = sb.AppendLine("// [float]");
+					_ = sb.AppendLine(CultureInfo.InvariantCulture, $"// ==== {formattedComponent}");
+				}
+				else
+				{
+					_ = sb.AppendLine("[float]");
+					_ = sb.AppendLine(CultureInfo.InvariantCulture, $"==== {formattedComponent}");
+				}
+				_ = sb.AppendLine();
+			}
 
-			foreach (var entry in areaGroup)
+			foreach (var entry in group)
 				RenderEntryWithImpactAction(sb, entry, context);
 		}
 	}

--- a/src/services/Elastic.Changelog/Rendering/Markdown/BreakingChangesMarkdownRenderer.cs
+++ b/src/services/Elastic.Changelog/Rendering/Markdown/BreakingChangesMarkdownRenderer.cs
@@ -70,7 +70,7 @@ public class BreakingChangesMarkdownRenderer(ScopedFileSystem fileSystem) : Mark
 						_ = sb.AppendLine(InvariantCulture, $"::::{{dropdown}} {ChangelogTextUtilities.Beautify(entry.Title)}");
 						_ = sb.AppendLine(entry.Description ?? "% Describe the functionality that changed");
 						_ = sb.AppendLine();
-						RenderPrIssueLinks(sb, entry, entryRepo, entryOwner, entryHideLinks);
+						RenderPrIssueLinks(sb, new PrIssueLinkOptions(entry, entryRepo, entryOwner, entryHideLinks));
 
 						_ = sb.AppendLine(!string.IsNullOrWhiteSpace(entry.Impact)
 							? "**Impact**<br>" + entry.Impact
@@ -99,7 +99,7 @@ public class BreakingChangesMarkdownRenderer(ScopedFileSystem fileSystem) : Mark
 						}
 
 						// PR/Issue links with "For more information" pattern - indented for list continuation
-						RenderPrIssueLinks(sb, entry, entryRepo, entryOwner, entryHideLinks, indentForListItem: true);
+						RenderPrIssueLinks(sb, new PrIssueLinkOptions(entry, entryRepo, entryOwner, entryHideLinks, IndentForListItem: true));
 
 						// Impact and Action sections - indented for list continuation
 						if (!string.IsNullOrWhiteSpace(entry.Impact))

--- a/src/services/Elastic.Changelog/Rendering/Markdown/DeprecationsMarkdownRenderer.cs
+++ b/src/services/Elastic.Changelog/Rendering/Markdown/DeprecationsMarkdownRenderer.cs
@@ -67,7 +67,7 @@ public class DeprecationsMarkdownRenderer(ScopedFileSystem fileSystem) : Markdow
 						_ = sb.AppendLine(InvariantCulture, $"::::{{dropdown}} {ChangelogTextUtilities.Beautify(entry.Title)}");
 						_ = sb.AppendLine(entry.Description ?? "% Describe the functionality that was deprecated");
 						_ = sb.AppendLine();
-						RenderPrIssueLinks(sb, entry, entryRepo, entryOwner, entryHideLinks);
+						RenderPrIssueLinks(sb, new PrIssueLinkOptions(entry, entryRepo, entryOwner, entryHideLinks));
 
 						_ = sb.AppendLine(!string.IsNullOrWhiteSpace(entry.Impact)
 							? "**Impact**<br>" + entry.Impact
@@ -96,7 +96,7 @@ public class DeprecationsMarkdownRenderer(ScopedFileSystem fileSystem) : Markdow
 						}
 
 						// PR/Issue links with "For more information" pattern - indented for list continuation
-						RenderPrIssueLinks(sb, entry, entryRepo, entryOwner, entryHideLinks, indentForListItem: true);
+						RenderPrIssueLinks(sb, new PrIssueLinkOptions(entry, entryRepo, entryOwner, entryHideLinks, IndentForListItem: true));
 
 						// Impact and Action sections - indented for list continuation
 						if (!string.IsNullOrWhiteSpace(entry.Impact))

--- a/src/services/Elastic.Changelog/Rendering/Markdown/HighlightsMarkdownRenderer.cs
+++ b/src/services/Elastic.Changelog/Rendering/Markdown/HighlightsMarkdownRenderer.cs
@@ -70,7 +70,7 @@ public class HighlightsMarkdownRenderer(ScopedFileSystem fileSystem) : MarkdownR
 						_ = sb.AppendLine(InvariantCulture, $"::::{{dropdown}} {ChangelogTextUtilities.Beautify(entry.Title)}");
 						_ = sb.AppendLine(entry.Description ?? "% Describe the highlight");
 						_ = sb.AppendLine();
-						RenderPrIssueLinks(sb, entry, entryRepo, entryOwner, entryHideLinks);
+						RenderPrIssueLinks(sb, new PrIssueLinkOptions(entry, entryRepo, entryOwner, entryHideLinks));
 						_ = sb.AppendLine("::::");
 					}
 					else
@@ -88,7 +88,7 @@ public class HighlightsMarkdownRenderer(ScopedFileSystem fileSystem) : MarkdownR
 						}
 
 						// PR/Issue links with "For more information" pattern - indented for list continuation
-						RenderPrIssueLinks(sb, entry, entryRepo, entryOwner, entryHideLinks, indentForListItem: true);
+						RenderPrIssueLinks(sb, new PrIssueLinkOptions(entry, entryRepo, entryOwner, entryHideLinks, IndentForListItem: true));
 					}
 
 					if (shouldHide)

--- a/src/services/Elastic.Changelog/Rendering/Markdown/KnownIssuesMarkdownRenderer.cs
+++ b/src/services/Elastic.Changelog/Rendering/Markdown/KnownIssuesMarkdownRenderer.cs
@@ -67,7 +67,7 @@ public class KnownIssuesMarkdownRenderer(ScopedFileSystem fileSystem) : Markdown
 						_ = sb.AppendLine(InvariantCulture, $"::::{{dropdown}} {ChangelogTextUtilities.Beautify(entry.Title)}");
 						_ = sb.AppendLine(entry.Description ?? "% Describe the known issue");
 						_ = sb.AppendLine();
-						RenderPrIssueLinks(sb, entry, entryRepo, entryOwner, entryHideLinks);
+						RenderPrIssueLinks(sb, new PrIssueLinkOptions(entry, entryRepo, entryOwner, entryHideLinks));
 
 						_ = sb.AppendLine(!string.IsNullOrWhiteSpace(entry.Impact)
 							? "**Impact**<br>" + entry.Impact
@@ -96,7 +96,7 @@ public class KnownIssuesMarkdownRenderer(ScopedFileSystem fileSystem) : Markdown
 						}
 
 						// PR/Issue links with "For more information" pattern - indented for list continuation
-						RenderPrIssueLinks(sb, entry, entryRepo, entryOwner, entryHideLinks, indentForListItem: true);
+						RenderPrIssueLinks(sb, new PrIssueLinkOptions(entry, entryRepo, entryOwner, entryHideLinks, IndentForListItem: true));
 
 						// Impact and Action sections - indented for list continuation
 						if (!string.IsNullOrWhiteSpace(entry.Impact))

--- a/src/services/Elastic.Changelog/Rendering/Markdown/MarkdownRendererBase.cs
+++ b/src/services/Elastic.Changelog/Rendering/Markdown/MarkdownRendererBase.cs
@@ -11,6 +11,17 @@ using Nullean.ScopedFileSystem;
 namespace Elastic.Changelog.Rendering.Markdown;
 
 /// <summary>
+/// Options for rendering PR and issue links
+/// </summary>
+public record PrIssueLinkOptions(
+	ChangelogEntry Entry,
+	string Repo,
+	string Owner,
+	bool HideLinks,
+	bool IndentForListItem = false
+);
+
+/// <summary>
 /// Abstract base class for changelog markdown renderers
 /// </summary>
 public abstract class MarkdownRendererBase(ScopedFileSystem fileSystem) : IChangelogMarkdownRenderer
@@ -37,28 +48,22 @@ public abstract class MarkdownRendererBase(ScopedFileSystem fileSystem) : IChang
 	}
 
 	/// <summary>
-	/// Renders PR and issue links for dropdown entries
+	/// Renders PR and issue links with configurable formatting options
 	/// </summary>
-	protected static void RenderPrIssueLinks(StringBuilder sb, ChangelogEntry entry, string entryRepo, string entryOwner, bool entryHideLinks)
-		=> RenderPrIssueLinks(sb, entry, entryRepo, entryOwner, entryHideLinks, indentForListItem: false);
-
-	/// <summary>
-	/// Renders PR and issue links with optional indentation for flattened list items
-	/// </summary>
-	protected static void RenderPrIssueLinks(StringBuilder sb, ChangelogEntry entry, string entryRepo, string entryOwner, bool entryHideLinks, bool indentForListItem)
+	protected static void RenderPrIssueLinks(StringBuilder sb, PrIssueLinkOptions options)
 	{
 		var prParts = new List<string>();
-		foreach (var pr in entry.Prs ?? [])
+		foreach (var pr in options.Entry.Prs ?? [])
 		{
-			var s = ChangelogTextUtilities.FormatPrLink(pr, entryRepo, entryHideLinks, entryOwner);
+			var s = ChangelogTextUtilities.FormatPrLink(pr, options.Repo, options.HideLinks, options.Owner);
 			if (!string.IsNullOrEmpty(s))
 				prParts.Add(s);
 		}
 
 		var issueParts = new List<string>();
-		foreach (var issue in entry.Issues ?? [])
+		foreach (var issue in options.Entry.Issues ?? [])
 		{
-			var s = ChangelogTextUtilities.FormatIssueLink(issue, entryRepo, entryHideLinks, entryOwner);
+			var s = ChangelogTextUtilities.FormatIssueLink(issue, options.Repo, options.HideLinks, options.Owner);
 			if (!string.IsNullOrEmpty(s))
 				issueParts.Add(s);
 		}
@@ -66,21 +71,21 @@ public abstract class MarkdownRendererBase(ScopedFileSystem fileSystem) : IChang
 		if (prParts.Count == 0 && issueParts.Count == 0)
 			return;
 
-		if (entryHideLinks)
+		if (options.HideLinks)
 		{
 			foreach (var s in prParts)
 			{
-				var line = indentForListItem ? ChangelogTextUtilities.Indent(s) : s;
+				var line = options.IndentForListItem ? ChangelogTextUtilities.Indent(s) : s;
 				_ = sb.AppendLine(line);
 			}
 			foreach (var s in issueParts)
 			{
-				var line = indentForListItem ? ChangelogTextUtilities.Indent(s) : s;
+				var line = options.IndentForListItem ? ChangelogTextUtilities.Indent(s) : s;
 				_ = sb.AppendLine(line);
 			}
 
 			var infoLine = "For more information, check the pull request or issue above.";
-			_ = sb.AppendLine(indentForListItem ? ChangelogTextUtilities.Indent(infoLine) : infoLine);
+			_ = sb.AppendLine(options.IndentForListItem ? ChangelogTextUtilities.Indent(infoLine) : infoLine);
 		}
 		else
 		{
@@ -89,7 +94,7 @@ public abstract class MarkdownRendererBase(ScopedFileSystem fileSystem) : IChang
 			lineParts.AddRange(issueParts);
 
 			var fullLine = string.Join(" ", lineParts) + ".";
-			_ = sb.AppendLine(indentForListItem ? ChangelogTextUtilities.Indent(fullLine) : fullLine);
+			_ = sb.AppendLine(options.IndentForListItem ? ChangelogTextUtilities.Indent(fullLine) : fullLine);
 		}
 
 		_ = sb.AppendLine();

--- a/tests/Elastic.Changelog.Tests/Changelogs/Render/DropdownRenderTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/Render/DropdownRenderTests.cs
@@ -418,8 +418,8 @@ public class DropdownRenderTests(ITestOutputHelper output) : RenderChangelogTest
 
 			// AsciiDoc should always use bullet format regardless of dropdowns flag
 			content.Should().Contain("* Breaking API change");
-			content.Should().Contain("**Impact:** Existing API calls will fail");
-			content.Should().Contain("**Action:** Update your code");
+			content.Should().Contain("*Impact:* Existing API calls will fail");
+			content.Should().Contain("*Action:* Update your code");
 
 			// Should never contain MyST dropdown syntax
 			content.Should().NotContain("::::{dropdown}");


### PR DESCRIPTION
This PR builds on https://github.com/elastic/docs-builder/pull/3244 (and addresses https://github.com/elastic/docs-builder/pull/3244#discussion_r3197765083).

It fixes formatting issues that were apparent while testing the `docs-builder changelog render` command with `--format-type asciidoc`. For example:

- No list continuation: Multi-block list items (description + Impact + Action) don't use `+` continuation syntax
- Wrong strong formatting: used **Impact:** and **Action:** instead of idiomatic *Impact:*
- Broken list structure: Additional paragraphs terminate the list item instead of continuing it
- Inconsistent subsections handling: Some renderers ignore the --subsections flag and always add "General::" headers
- Definition lists break list continuation: AsciiDoc definition list syntax (General::) doesn't work with list continuation markers (+)

## Screenshots

### Before

- Lists with paragraphs and *no* `--subsections` aren't aligned well and inject an unexpected "general" area:
    <img width="1570" height="905" alt="image" src="https://github.com/user-attachments/assets/c3c18803-c230-4835-aa97-e92ccba5bf2d" />

- Lists with paragraphs and `--subsections` are smushed together in definition lists
    <img width="1849" height="552" alt="image" src="https://github.com/user-attachments/assets/c2e1144e-470a-4157-b7b7-934c482c3e80" />


### After

- Lists with paragraphs and *no* `--subsections` work:
   <img width="1557" height="1358" alt="image" src="https://github.com/user-attachments/assets/c57d3d5a-450a-4ee2-815c-daea8e7963a3" />
 
- Lists with paragraphs and `--subsections` work by moving away from fragile definition lists:
    <img width="1867" height="719" alt="image" src="https://github.com/user-attachments/assets/66750654-37da-4ef2-9938-f59880f91fa5" />

NOTE: Since there are teams who have already said they don't want the descriptions published, I've created https://github.com/elastic/docs-builder/pull/3263 as a follow-on too.

## AI Summary

Improves `changelog render` **AsciiDoc** output for multi-block list items (description, Impact, Action), aligns **Markdown** PR/issue link rendering with analyzer-friendly options, fixes **AsciiDoc subsection** behavior versus `--subsections`, replaces **definition lists** with **nested sections** where grouping is intended, and documents AsciiDoc behavior in the CLI reference.

### AsciiDoc

- **`AsciidocRendererBase`**
  - Emits **[list continuation](https://docs.asciidoctor.org/asciidoc/latest/lists/continuation/#list-continuation)** (`+`) before description text (when continuation applies) and before Impact/Action blocks so bullets stay attached to the list item.
  - Drops two-space indentation of full description blobs; emits the raw description (hidden entries still prefixed with `//` per line).
  - Uses **constrained bold** `*Impact:*` / `*Action:*` instead of `**Impact:**` / `**Action:**`.
- **Section / grouping** (`975b4200`)
  - **Deprecations, Known Issues, Highlights, Entries-by-area**: respect **`Subsections`**; when `--subsections` is **off**, collapse to a single group **without** a `General`-style wrapper.
  - When `--subsections` is **on**, replace `Component::` **definition lists** with **`[float]` + `==== Title`** nested sections (and commented-out equivalents when all entries in the group are hidden).
  - **Breaking changes**: subtype headers use the same nested-section style instead of bold-only lines; hidden groups get commented `// [float]` / `// ==== …`.
- **CA1305 / globalization**: interpolated section titles use `AppendLine(CultureInfo.InvariantCulture, …)` where applicable (per second commit diff).

### Markdown

- Introduces **`PrIssueLinkOptions`** and a single **`RenderPrIssueLinks(StringBuilder, PrIssueLinkOptions)`** API (avoids long parameter lists / adjacent booleans).
- Call sites updated in breaking changes, deprecations, known issues, and highlights renderers.

### Docs & tests

- **`docs/cli/changelog/render.md`**: clarifies that AsciiDoc ignores `--dropdowns`, and briefly describes list continuation, `*Impact:*` / `*Action:*`, and attachment of blocks to list items.
- **`DropdownRenderTests`**: AsciiDoc expectations updated for `*Impact:*` / `*Action:*`.

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: composer-2, claude-4-sonnet-thinking