### PR TITLE
Return exit code 1 on CTRL+C cancellation

### DIFF
--- a/src/tooling/docs-builder/Middleware/CatchExceptionMiddleware.cs
+++ b/src/tooling/docs-builder/Middleware/CatchExceptionMiddleware.cs
@@ -31,6 +31,7 @@ internal sealed class CatchExceptionMiddleware(ILogger<CatchExceptionMiddleware>
 			if (ex is OperationCanceledException && context.CancellationToken.IsCancellationRequested && _cancelKeyPressed)
 			{
 				logger.LogInformation("Cancellation requested, exiting.");
+				context.ExitCode = 1;
 				return;
 			}
 			_ = collector.StartAsync(context.CancellationToken);


### PR DESCRIPTION
## Why

When a user presses CTRL+C, the process was exiting with code 0, making it indistinguishable from a successful run. This caused CI pipelines and shell scripts to silently swallow user-initiated cancellations as if the build had succeeded.

## What

`CatchExceptionMiddleware` now sets `context.ExitCode = 1` before returning on the CTRL+C path, so cancellation always signals failure to the caller — without emitting a spurious global error log entry.