### PR TITLE
feat(cli): support llm exporter alias with argh EnumValue

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -69,9 +69,9 @@
     <PackageVersion Include="FSharp.Core" Version="10.1.201" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Nullean.Argh" Version="0.15.1" />
-    <PackageVersion Include="Nullean.Argh.Hosting" Version="0.15.1" />
-    <PackageVersion Include="Nullean.Argh.Interfaces" Version="0.15.1" />
+    <PackageVersion Include="Nullean.Argh" Version="0.15.3" />
+    <PackageVersion Include="Nullean.Argh.Hosting" Version="0.15.3" />
+    <PackageVersion Include="Nullean.Argh.Interfaces" Version="0.15.3" />
     <PackageVersion Include="Crayon" Version="2.0.69" />
     <PackageVersion Include="DotNet.Glob" Version="3.1.3" />
     <PackageVersion Include="Errata" Version="0.16.0" />

--- a/src/Elastic.Documentation/Elastic.Documentation.csproj
+++ b/src/Elastic.Documentation/Elastic.Documentation.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging"/>
     <PackageReference Include="NetEscapades.EnumGenerators"/>
+    <PackageReference Include="Nullean.Argh.Interfaces" />
     <PackageReference Include="Proc" />
     <PackageReference Include="SoftCircuits.IniFileParser" />
     <PackageReference Include="Nullean.ScopedFileSystem" />

--- a/src/Elastic.Documentation/Exporter.cs
+++ b/src/Elastic.Documentation/Exporter.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using Nullean.Argh;
 using static Elastic.Documentation.Exporter;
 
 namespace Elastic.Documentation;
@@ -9,6 +10,7 @@ namespace Elastic.Documentation;
 public enum Exporter
 {
 	Html,
+	[EnumValue("llm")]
 	LLMText,
 	Elasticsearch,
 	Configuration,

--- a/src/services/Elastic.Documentation.Assembler/Building/AssemblerBuildOptions.cs
+++ b/src/services/Elastic.Documentation.Assembler/Building/AssemblerBuildOptions.cs
@@ -24,7 +24,7 @@ public record AssemblerBuildOptions
 
 	/// <summary>
 	/// Comma-separated list of exporters to run.
-	/// Values: Html, Elasticsearch, Configuration, LinkMetadata, DocumentationState, LLMText, Redirects.
+	/// Values: Html, Elasticsearch, Configuration, LinkMetadata, DocumentationState, llm, Redirects.
 	/// Default: Html, Configuration, LinkMetadata, DocumentationState, Redirects.
 	/// </summary>
 	[CollectionSyntax(Separator = ",")]

--- a/src/services/Elastic.Documentation.Assembler/Building/AssemblerBuildOptions.cs
+++ b/src/services/Elastic.Documentation.Assembler/Building/AssemblerBuildOptions.cs
@@ -24,8 +24,6 @@ public record AssemblerBuildOptions
 
 	/// <summary>
 	/// Comma-separated list of exporters to run.
-	/// Values: Html, Elasticsearch, Configuration, LinkMetadata, DocumentationState, llm, Redirects.
-	/// Default: Html, Configuration, LinkMetadata, DocumentationState, Redirects.
 	/// </summary>
 	[CollectionSyntax(Separator = ",")]
 	public IReadOnlySet<Exporter>? Exporters { get; init; }

--- a/src/services/Elastic.Documentation.Isolated/IsolatedBuildOptions.cs
+++ b/src/services/Elastic.Documentation.Isolated/IsolatedBuildOptions.cs
@@ -35,8 +35,6 @@ public record IsolatedBuildOptions
 
 	/// <summary>
 	/// Comma-separated list of exporters to run.
-	/// Values: html, elasticsearch, configuration, linkmetadata, documentationstate, llm, redirects.
-	/// Default: html, configuration, linkmetadata, documentationstate, redirects.
 	/// </summary>
 	[CollectionSyntax(Separator = ",")]
 	public IReadOnlySet<Exporter>? Exporters { get; init; }

--- a/src/services/Elastic.Documentation.Isolated/IsolatedBuildOptions.cs
+++ b/src/services/Elastic.Documentation.Isolated/IsolatedBuildOptions.cs
@@ -35,7 +35,8 @@ public record IsolatedBuildOptions
 
 	/// <summary>
 	/// Comma-separated list of exporters to run.
-	/// Default: html, configuration, linkmetadata, documentationState, dedirects.
+	/// Values: html, elasticsearch, configuration, linkmetadata, documentationstate, llm, redirects.
+	/// Default: html, configuration, linkmetadata, documentationstate, redirects.
 	/// </summary>
 	[CollectionSyntax(Separator = ",")]
 	public IReadOnlySet<Exporter>? Exporters { get; init; }


### PR DESCRIPTION
## Why

The exporter enum needed a stable CLI token of `llm` for `LLMText`, but previous argh versions could not express per-enum-member CLI values. This made it impossible to keep the existing C# enum naming while exposing the desired command-line value.

## What

Upgraded to the latest `Nullean.Argh` packages and applied PR #48 support by annotating `Exporter.LLMText` with `EnumValue(\"llm\")`. The CLI now accepts and advertises `llm` for exporter selection, and the option help text was aligned with the generated behavior.

Made with [Cursor](https://cursor.com)