### PR TITLE
Restore --exporters aliases and shorthand sets

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -69,9 +69,9 @@
     <PackageVersion Include="FSharp.Core" Version="10.1.201" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Nullean.Argh" Version="0.15.1" />
-    <PackageVersion Include="Nullean.Argh.Hosting" Version="0.15.1" />
-    <PackageVersion Include="Nullean.Argh.Interfaces" Version="0.15.1" />
+    <PackageVersion Include="Nullean.Argh" Version="0.15.4" />
+    <PackageVersion Include="Nullean.Argh.Hosting" Version="0.15.4" />
+    <PackageVersion Include="Nullean.Argh.Interfaces" Version="0.15.4" />
     <PackageVersion Include="Crayon" Version="2.0.69" />
     <PackageVersion Include="DotNet.Glob" Version="3.1.3" />
     <PackageVersion Include="Errata" Version="0.16.0" />

--- a/src/services/Elastic.Documentation.Assembler/Building/AssemblerBuildOptions.cs
+++ b/src/services/Elastic.Documentation.Assembler/Building/AssemblerBuildOptions.cs
@@ -27,7 +27,7 @@ public record AssemblerBuildOptions
 	/// Values: Html, Elasticsearch, Configuration, LinkMetadata, DocumentationState, LLMText, Redirects.
 	/// Default: Html, Configuration, LinkMetadata, DocumentationState, Redirects.
 	/// </summary>
-	[CollectionSyntax(Separator = ",")]
+	[ArgumentParser(typeof(ExporterParser))]
 	public IReadOnlySet<Exporter>? Exporters { get; init; }
 
 	/// <summary>Skip the build step when <c>.artifacts/docs/index.html</c> already exists. Intended for test scenarios only.</summary>

--- a/src/services/Elastic.Documentation.Assembler/Building/ExporterParser.cs
+++ b/src/services/Elastic.Documentation.Assembler/Building/ExporterParser.cs
@@ -1,0 +1,74 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Nullean.Argh.Parsing;
+
+namespace Elastic.Documentation.Assembler.Building;
+
+/// <summary>
+/// Parses a comma-separated list of exporter names into <see cref="IReadOnlySet{Exporter}"/>.
+/// Supports short aliases and the shorthands <c>default</c> and <c>metadata</c>.
+/// </summary>
+/// <remarks>
+/// Aliases: llm/llmtext, es/elasticsearch, html, config/configuration,
+///          links/linkmetadata, state/documentationstate, redirect/redirects,
+///          default (expands to <see cref="ExportOptions.Default"/>),
+///          metadata (expands to <see cref="ExportOptions.MetadataOnly"/>),
+///          none (empty set).
+/// </remarks>
+public class ExporterParser : IArgumentParser<IReadOnlySet<Exporter>>
+{
+	public bool TryParse(string raw, out IReadOnlySet<Exporter> result)
+	{
+		var set = new HashSet<Exporter>();
+		foreach (var token in raw.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+		{
+			switch (token.ToLowerInvariant())
+			{
+				case "llm":
+				case "llmtext":
+					_ = set.Add(Exporter.LLMText);
+					break;
+				case "es":
+				case "elasticsearch":
+					_ = set.Add(Exporter.Elasticsearch);
+					break;
+				case "html":
+					_ = set.Add(Exporter.Html);
+					break;
+				case "config":
+				case "configuration":
+					_ = set.Add(Exporter.Configuration);
+					break;
+				case "links":
+				case "linkmetadata":
+					_ = set.Add(Exporter.LinkMetadata);
+					break;
+				case "state":
+				case "documentationstate":
+					_ = set.Add(Exporter.DocumentationState);
+					break;
+				case "redirect":
+				case "redirects":
+					_ = set.Add(Exporter.Redirects);
+					break;
+				case "none":
+					break;
+				case "default":
+					foreach (var e in ExportOptions.Default)
+						_ = set.Add(e);
+					break;
+				case "metadata":
+					foreach (var e in ExportOptions.MetadataOnly)
+						_ = set.Add(e);
+					break;
+				default:
+					throw new ArgumentException(
+						$"Unknown exporter '{token}'. Valid values: html, llm, es, config, links, state, redirects, default, metadata, none.");
+			}
+		}
+		result = set;
+		return true;
+	}
+}

--- a/src/services/Elastic.Documentation.Isolated/ExporterParser.cs
+++ b/src/services/Elastic.Documentation.Isolated/ExporterParser.cs
@@ -1,0 +1,74 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Nullean.Argh.Parsing;
+
+namespace Elastic.Documentation.Isolated;
+
+/// <summary>
+/// Parses a comma-separated list of exporter names into <see cref="IReadOnlySet{Exporter}"/>.
+/// Supports short aliases and the shorthands <c>default</c> and <c>metadata</c>.
+/// </summary>
+/// <remarks>
+/// Aliases: llm/llmtext, es/elasticsearch, html, config/configuration,
+///          links/linkmetadata, state/documentationstate, redirect/redirects,
+///          default (expands to <see cref="ExportOptions.Default"/>),
+///          metadata (expands to <see cref="ExportOptions.MetadataOnly"/>),
+///          none (empty set).
+/// </remarks>
+public class ExporterParser : IArgumentParser<IReadOnlySet<Exporter>>
+{
+	public bool TryParse(string raw, out IReadOnlySet<Exporter> result)
+	{
+		var set = new HashSet<Exporter>();
+		foreach (var token in raw.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+		{
+			switch (token.ToLowerInvariant())
+			{
+				case "llm":
+				case "llmtext":
+					_ = set.Add(Exporter.LLMText);
+					break;
+				case "es":
+				case "elasticsearch":
+					_ = set.Add(Exporter.Elasticsearch);
+					break;
+				case "html":
+					_ = set.Add(Exporter.Html);
+					break;
+				case "config":
+				case "configuration":
+					_ = set.Add(Exporter.Configuration);
+					break;
+				case "links":
+				case "linkmetadata":
+					_ = set.Add(Exporter.LinkMetadata);
+					break;
+				case "state":
+				case "documentationstate":
+					_ = set.Add(Exporter.DocumentationState);
+					break;
+				case "redirect":
+				case "redirects":
+					_ = set.Add(Exporter.Redirects);
+					break;
+				case "none":
+					break;
+				case "default":
+					foreach (var e in ExportOptions.Default)
+						_ = set.Add(e);
+					break;
+				case "metadata":
+					foreach (var e in ExportOptions.MetadataOnly)
+						_ = set.Add(e);
+					break;
+				default:
+					throw new ArgumentException(
+						$"Unknown exporter '{token}'. Valid values: html, llm, es, config, links, state, redirects, default, metadata, none.");
+			}
+		}
+		result = set;
+		return true;
+	}
+}

--- a/src/services/Elastic.Documentation.Isolated/IsolatedBuildOptions.cs
+++ b/src/services/Elastic.Documentation.Isolated/IsolatedBuildOptions.cs
@@ -37,7 +37,7 @@ public record IsolatedBuildOptions
 	/// Comma-separated list of exporters to run.
 	/// Default: html, configuration, linkmetadata, documentationState, dedirects.
 	/// </summary>
-	[CollectionSyntax(Separator = ",")]
+	[ArgumentParser(typeof(ExporterParser))]
 	public IReadOnlySet<Exporter>? Exporters { get; init; }
 
 	/// <summary>Base URL written into <c>&lt;link rel=canonical&gt;</c> tags.</summary>

--- a/src/tooling/docs-builder/Middleware/CatchExceptionMiddleware.cs
+++ b/src/tooling/docs-builder/Middleware/CatchExceptionMiddleware.cs
@@ -31,6 +31,7 @@ internal sealed class CatchExceptionMiddleware(ILogger<CatchExceptionMiddleware>
 			if (ex is OperationCanceledException && context.CancellationToken.IsCancellationRequested && _cancelKeyPressed)
 			{
 				logger.LogInformation("Cancellation requested, exiting.");
+				context.ExitCode = 1;
 				return;
 			}
 			_ = collector.StartAsync(context.CancellationToken);


### PR DESCRIPTION
## Why

When the CLI was migrated from ConsoleAppFramework to Nullean.Argh, the custom `ExporterParser` was lost. Users lost the ability to use short aliases (`llm`, `es`, `config`, `links`, `state`, `redirect`) and the convenience shorthands `default`, `metadata`, and `none` for `--exporters`. Only exact enum names worked after the migration.

## What

Restores `ExporterParser` (implementing `IArgumentParser<IReadOnlySet<Exporter>>`) in both the isolated build and assembler service projects, and wires it up via `[ArgumentParser(typeof(ExporterParser))]` on the `Exporters` property in `IsolatedBuildOptions` and `AssemblerBuildOptions`.

Also bumps Nullean.Argh to 0.15.4, which adds support for `[ArgumentParser]` on record properties (previously only valid on method parameters).

## How

argh 0.15.4 now correctly detects when `[ArgumentParser]` on an `IReadOnlySet<T>` property has a parser whose return type matches the full collection type, and emits a single-value parse call rather than an element-accumulation loop.