### PR TITLE
Allow .plan extension for assembler deploy apply

### DIFF
--- a/src/tooling/docs-builder/Commands/Assembler/DeployCommands.cs
+++ b/src/tooling/docs-builder/Commands/Assembler/DeployCommands.cs
@@ -51,7 +51,7 @@ internal sealed class DeployCommands(
 	/// <param name="s3BucketName">S3 bucket to deploy to.</param>
 	/// <param name="planFile">Path to the plan file produced by <c>assembler deploy plan</c>.</param>
 	[NoOptionsInjection]
-	public async Task<int> Apply(string environment, string s3BucketName, [Existing, ExpandUserProfile, RejectSymbolicLinks, FileExtensions(Extensions = "json")] FileInfo planFile, CancellationToken ct = default)
+	public async Task<int> Apply(string environment, string s3BucketName, [Existing, ExpandUserProfile, RejectSymbolicLinks, FileExtensions(Extensions = "json,plan")] FileInfo planFile, CancellationToken ct = default)
 	{
 		await using var serviceInvoker = new ServiceInvoker(collector);
 


### PR DESCRIPTION
## Why

The `assembler deploy plan` command writes plan files with a `.plan` extension, but `assembler deploy apply --plan-file` only accepted `.json`. This caused CI to fail with: `extension must be one of: json`.

## What

Added `plan` to the allowed extensions on the `--plan-file` parameter of `assembler deploy apply`.