### PR TITLE
Wire most of nav v1 content into nav v2

### DIFF
--- a/config/navigation-v2.yml
+++ b/config/navigation-v2.yml
@@ -63,10 +63,50 @@ nav:
           - group: Production guidance
             page: docs-content://deploy-manage/production-guidance.md
             children:
-            - page: docs-content://deploy-manage/production-guidance/elasticsearch-in-production-environments.md
-              title: Run Elasticsearch in production
-            - page: docs-content://deploy-manage/production-guidance/kibana-in-production-environments.md
-              title: Run Kibana in production
+            - group: Run Elasticsearch in production
+              page: docs-content://deploy-manage/production-guidance/elasticsearch-in-production-environments.md
+              children:
+              - group: Design for resilience
+                page: docs-content://deploy-manage/production-guidance/availability-and-resilience.md
+                children:
+                - page: docs-content://deploy-manage/production-guidance/availability-and-resilience/resilience-in-small-clusters.md
+                  title: Resilience in small clusters
+                - page: docs-content://deploy-manage/production-guidance/availability-and-resilience/resilience-in-larger-clusters.md
+                  title: Resilience in larger clusters
+                - page: docs-content://deploy-manage/production-guidance/availability-and-resilience/resilience-in-ech.md
+                  title: Resilience in ECH and ECE
+              - page: docs-content://deploy-manage/production-guidance/scaling-considerations.md
+                title: Scaling considerations
+              - group: Performance optimizations
+                page: docs-content://deploy-manage/production-guidance/optimize-performance.md
+                children:
+                - page: docs-content://deploy-manage/production-guidance/general-recommendations.md
+                  title: General recommendations
+                - page: docs-content://deploy-manage/production-guidance/optimize-performance/indexing-speed.md
+                  title: Tune for indexing speed
+                - page: docs-content://deploy-manage/production-guidance/optimize-performance/search-speed.md
+                  title: Tune for search speed
+                - page: docs-content://deploy-manage/production-guidance/optimize-performance/approximate-knn-search.md
+                  title: Tune approximate kNN search
+                - page: docs-content://deploy-manage/production-guidance/optimize-performance/disk-usage.md
+                  title: Tune for disk usage
+                - page: docs-content://deploy-manage/production-guidance/optimize-performance/size-shards.md
+                  title: Size your shards
+            - group: Run Kibana in production
+              page: docs-content://deploy-manage/production-guidance/kibana-in-production-environments.md
+              children:
+              - page: docs-content://deploy-manage/production-guidance/kibana-load-balance-traffic.md
+                title: High availability and load balancing
+              - page: docs-content://deploy-manage/production-guidance/kibana-configure-memory.md
+                title: Configure memory
+              - page: docs-content://deploy-manage/production-guidance/kibana-task-manager-scaling-considerations.md
+                title: Manage background tasks
+              - page: docs-content://deploy-manage/production-guidance/kibana-traffic-scaling-considerations.md
+                title: Traffic scaling considerations
+              - page: docs-content://deploy-manage/production-guidance/kibana-alerting-production-considerations.md
+                title: Optimize alerting performance
+              - page: docs-content://deploy-manage/production-guidance/kibana-reporting-production-considerations.md
+                title: Reporting production considerations
         - group: Install and deploy Elasticsearch
           page: docs-content://deploy-manage/deploy.md
           children:

--- a/config/navigation-v2.yml
+++ b/config/navigation-v2.yml
@@ -697,26 +697,561 @@ nav:
           - label: ───
           - group: Security and encryption
             page: docs-content://deploy-manage/security.md
+            children:
+            - page: docs-content://deploy-manage/security/secure-hosting-environment.md
+              children:
+              - page: docs-content://deploy-manage/security/secure-your-elastic-cloud-enterprise-installation.md
+                title: "{{ece}}"
+                children:
+                - page: docs-content://deploy-manage/security/secure-your-elastic-cloud-enterprise-installation/manage-security-certificates.md
+                - page: docs-content://deploy-manage/security/secure-your-elastic-cloud-enterprise-installation/allow-x509-certificates-signed-with-sha-1.md
+                - page: docs-content://deploy-manage/security/secure-your-elastic-cloud-enterprise-installation/configure-tls-version.md
+                - page: docs-content://deploy-manage/security/secure-your-elastic-cloud-enterprise-installation/migrate-ece-on-podman-hosts-to-selinux-enforce.md
+              - page: docs-content://deploy-manage/security/secure-your-eck-installation.md
+                title: "{{eck}}"
+            - page: docs-content://deploy-manage/security/secure-your-cluster-deployment.md
+              children:
+              - page: docs-content://deploy-manage/security/self-setup.md
+                title: "Self-managed security setup"
+                children:
+                - page: docs-content://deploy-manage/security/self-auto-setup.md
+                  title: "Automatic security setup"
+                - page: docs-content://deploy-manage/security/set-up-minimal-security.md
+                  title: "Minimal security setup"
+                - page: docs-content://deploy-manage/security/set-up-basic-security.md
+                  title: "Set up transport TLS"
+                - page: docs-content://deploy-manage/security/set-up-basic-security-plus-https.md
+                  title: "Set up HTTPS"
+                - page: docs-content://deploy-manage/security/using-kibana-with-security.md
+              - page: docs-content://deploy-manage/security/secure-cluster-communications.md
+                title: "Manage TLS encryption"
+                children:
+                - page: docs-content://deploy-manage/security/self-tls.md
+                  title: "Self-managed"
+                  children:
+                  - page: docs-content://deploy-manage/security/updating-certificates.md
+                    title: "Update TLS certificates"
+                    children:
+                    - page: docs-content://deploy-manage/security/same-ca.md
+                      title: "With the same CA"
+                    - page: docs-content://deploy-manage/security/different-ca.md
+                      title: "With a different CA"
+                  - page: docs-content://deploy-manage/security/kibana-es-mutual-tls.md
+                    title: "Mutual authentication"
+                  - page: docs-content://deploy-manage/security/supported-ssltls-versions-by-jdk-version.md
+                  - page: docs-content://deploy-manage/security/enabling-cipher-suites-for-stronger-encryption.md
+                - page: docs-content://deploy-manage/security/eck-tls.md
+                  title: "ECK"
+                  children:
+                  - page: docs-content://deploy-manage/security/k8s-https-settings.md
+                  - page: docs-content://deploy-manage/security/k8s-transport-settings.md
+                - page: docs-content://deploy-manage/security/external-ca-transport.md
+                  title: "External CA for TLS"
+              - page: docs-content://deploy-manage/security/network-security.md
+                title: "Network security"
+                children:
+                - page: docs-content://deploy-manage/security/network-security-policies.md
+                  title: "How network security policies work in Cloud"
+                - page: docs-content://deploy-manage/security/ece-filter-rules.md
+                  title: "How IP filtering rules work in ECE"
+                - page: docs-content://deploy-manage/security/ip-filtering.md
+                  title: "Add IP filters"
+                  children:
+                  - page: docs-content://deploy-manage/security/ip-filtering-cloud.md
+                    title: "In ECH or Serverless"
+                  - page: docs-content://deploy-manage/security/ip-filtering-ece.md
+                    title: "In ECE"
+                  - page: docs-content://deploy-manage/security/ip-filtering-basic.md
+                    title: "In ECK and Self Managed"
+                - page: docs-content://deploy-manage/security/remote-cluster-filtering.md
+                  title: "Remote cluster filters"
+                - page: docs-content://deploy-manage/security/private-connectivity.md
+                  children:
+                  - page: docs-content://deploy-manage/security/private-connectivity-aws.md
+                    title: "AWS PrivateLink"
+                  - page: docs-content://deploy-manage/security/private-connectivity-azure.md
+                    title: "Azure Private Link"
+                  - page: docs-content://deploy-manage/security/private-connectivity-gcp.md
+                    title: "GCP Private Service Connect"
+                  - page: docs-content://deploy-manage/security/claim-private-connection-api.md
+                - page: docs-content://deploy-manage/security/network-security-api.md
+                  title: "Through the API"
+                - page: docs-content://deploy-manage/security/k8s-network-policies.md
+              - page: docs-content://deploy-manage/security/elastic-cloud-static-ips.md
+              - page: docs-content://deploy-manage/security/kibana-session-management.md
+              - page: docs-content://deploy-manage/security/data-security.md
+                children:
+                - page: docs-content://deploy-manage/security/encrypt-deployment-with-customer-managed-encryption-key.md
+              - page: docs-content://deploy-manage/security/secure-settings.md
+                children:
+                - page: docs-content://deploy-manage/security/k8s-secure-settings.md
+              - page: docs-content://deploy-manage/security/secure-saved-objects.md
+              - page: docs-content://deploy-manage/security/logging-configuration/security-event-audit-logging.md
+                children:
+                - page: docs-content://deploy-manage/security/logging-configuration/enabling-audit-logs.md
+                - page: docs-content://deploy-manage/security/logging-configuration/configuring-audit-logs.md
+                  children:
+                  - page: docs-content://deploy-manage/security/logging-configuration/logfile-audit-events-ignore-policies.md
+                    title: "Elasticsearch audit events ignore policies"
+                  - page: docs-content://deploy-manage/security/logging-configuration/logfile-audit-output.md
+                    title: "Elasticsearch logfile output"
+                - page: docs-content://deploy-manage/security/logging-configuration/auditing-search-queries.md
+                - page: docs-content://deploy-manage/security/logging-configuration/correlating-kibana-elasticsearch-audit-logs.md
+                  title: "Correlate audit events"
+            - page: docs-content://deploy-manage/security/secure-clients-integrations.md
+            - page: docs-content://deploy-manage/security/httprest-clients-security.md
+            - page: docs-content://deploy-manage/security/limitations.md
+              title: "Limitations"
+            - page: docs-content://deploy-manage/security/fips.md
+              children:
+              - page: docs-content://deploy-manage/security/fips-es.md
+              - page: docs-content://deploy-manage/security/fips-kib.md
+              - page: docs-content://deploy-manage/security/fips-ingest.md
           - group: Authentication and authorization
             page: docs-content://deploy-manage/users-roles.md
+            children:
+            - page: docs-content://deploy-manage/users-roles/cloud-organization.md
+              title: "Cloud organization"
+              children:
+              - page: docs-content://deploy-manage/users-roles/cloud-organization/manage-users.md
+              - page: docs-content://deploy-manage/users-roles/cloud-organization/user-roles.md
+              - page: docs-content://deploy-manage/users-roles/cloud-organization/configure-saml-authentication.md
+                title: "Configure SAML SSO"
+                children:
+                - page: docs-content://deploy-manage/users-roles/cloud-organization/register-elastic-cloud-saml-in-okta.md
+                  title: "Okta"
+                - page: docs-content://deploy-manage/users-roles/cloud-organization/register-elastic-cloud-saml-in-microsoft-entra-id.md
+                  title: "Microsoft Entra ID"
+            - page: docs-content://deploy-manage/users-roles/cloud-enterprise-orchestrator.md
+              title: "ECE orchestrator"
+              children:
+              - page: docs-content://deploy-manage/users-roles/cloud-enterprise-orchestrator/manage-system-passwords.md
+              - page: docs-content://deploy-manage/users-roles/cloud-enterprise-orchestrator/manage-users-roles.md
+                children:
+                - page: docs-content://deploy-manage/users-roles/cloud-enterprise-orchestrator/native-user-authentication.md
+                - page: docs-content://deploy-manage/users-roles/cloud-enterprise-orchestrator/active-directory.md
+                - page: docs-content://deploy-manage/users-roles/cloud-enterprise-orchestrator/ldap.md
+                - page: docs-content://deploy-manage/users-roles/cloud-enterprise-orchestrator/saml.md
+              - page: docs-content://deploy-manage/users-roles/cloud-enterprise-orchestrator/configure-sso-for-deployments.md
+            - page: docs-content://deploy-manage/users-roles/serverless-custom-roles.md
+            - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth.md
+              title: "Cluster or deployment"
+              children:
+              - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/quickstart.md
+                title: "Quickstart"
+              - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/user-authentication.md
+                children:
+                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/authentication-realms.md
+                  children:
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/realm-chains.md
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/security-domains.md
+                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/internal-authentication.md
+                  children:
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/native.md
+                    title: "Native"
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/file-based.md
+                    title: "File-based"
+                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/external-authentication.md
+                  children:
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/active-directory.md
+                    title: "Active Directory"
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/jwt.md
+                    title: "JWT"
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/kerberos.md
+                    title: "Kerberos"
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/ldap.md
+                    title: "LDAP"
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/openid-connect.md
+                    title: "OpenID Connect"
+                    children:
+                    - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/oidc-examples.md
+                      title: "With Azure, Google, or Okta"
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/saml.md
+                    title: "SAML"
+                    children:
+                    - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/saml-entra.md
+                      title: "With Microsoft Entra ID"
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/pki.md
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/custom.md
+                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/built-in-users.md
+                  title: "Built-in users"
+                  children:
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/built-in-sm.md
+                    title: "Change passwords"
+                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/orchestrator-managed-users-overview.md
+                  title: "Orchestrator-managed users"
+                  children:
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/manage-elastic-user-cloud.md
+                    title: "ECH and ECE"
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/managed-credentials-eck.md
+                    title: "ECK managed credentials"
+                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/kibana-authentication.md
+                  title: "{{kib}} authentication"
+                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/access-agreement.md
+                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/anonymous-access.md
+                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/token-based-authentication-services.md
+                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/service-accounts.md
+                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/internal-users.md
+                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/operator-privileges.md
+                  children:
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/configure-operator-privileges.md
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/operator-only-functionality.md
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/operator-privileges-for-snapshot-restore.md
+                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/user-profiles.md
+                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/looking-up-users-without-authentication.md
+                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/controlling-user-cache.md
+                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/manage-authentication-for-multiple-clusters.md
+              - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/user-roles.md
+                children:
+                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/defining-roles.md
+                  children:
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/role-structure.md
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/granting-privileges-for-data-streams-aliases.md
+                    title: "For data streams and aliases"
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/kibana-role-management.md
+                    title: "Using Kibana"
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/role-restriction.md
+                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/kibana-privileges.md
+                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/mapping-users-groups-to-roles.md
+                  title: "Map users and groups to roles"
+                  children:
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/role-mapping-resources.md
+                    title: "Role mapping properties"
+                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/authorization-delegation.md
+                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/authorization-plugins.md
+                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/controlling-access-at-document-field-level.md
+                  title: "Control access at the document and field level"
+                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/submitting-requests-on-behalf-of-other-users.md
+                  title: "Submit requests on behalf of other users"
           - group: API keys
             page: docs-content://deploy-manage/api-keys.md
+            children:
+            - page: docs-content://deploy-manage/api-keys/elasticsearch-api-keys.md
+            - page: docs-content://deploy-manage/api-keys/serverless-project-api-keys.md
+            - page: docs-content://deploy-manage/api-keys/elastic-cloud-api-keys.md
+            - page: docs-content://deploy-manage/api-keys/elastic-cloud-enterprise-api-keys.md
           - group: Spaces
             page: docs-content://deploy-manage/manage-spaces.md
           - group: Monitoring
             page: docs-content://deploy-manage/monitor.md
+            children:
+            - page: docs-content://deploy-manage/monitor/autoops.md
+              children:
+              - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-how-to-access.md
+                title: "For {{ech}}"
+              - page: docs-content://deploy-manage/monitor/autoops/autoops-for-serverless.md
+                title: "For {{serverless-full}}"
+                children:
+                - page: docs-content://deploy-manage/monitor/autoops/access-autoops-for-serverless.md
+                  title: "Access AutoOps in your project"
+                - page: docs-content://deploy-manage/monitor/autoops/search-tier-view-autoops-serverless.md
+                  title: "Search Tier view"
+                - page: docs-content://deploy-manage/monitor/autoops/indexing-tier-view-autoops-serverless.md
+                  title: "Indexing Tier view"
+                - page: docs-content://deploy-manage/monitor/autoops/search-ai-lake-view-autoops-serverless.md
+                  title: "Search AI Lake view"
+              - page: docs-content://deploy-manage/monitor/autoops/cc-autoops-as-cloud-connected.md
+                title: "For ECE, ECK, and self-managed clusters"
+                children:
+                - page: docs-content://deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md
+                  title: "Connect your cluster"
+                - page: docs-content://deploy-manage/monitor/autoops/cc-connect-local-dev-to-autoops.md
+                  title: "Connect your local development cluster"
+                - page: docs-content://deploy-manage/monitor/autoops/autoops-sm-custom-certification.md
+                  title: "Configure Elastic agent with custom certificate"
+                - page: docs-content://deploy-manage/monitor/autoops/autoops-disable-metrics-collection.md
+                  title: "Disable certain types of data collection"
+                - page: docs-content://deploy-manage/monitor/autoops/cc-manage-users.md
+                  title: "Manage connected cluster users"
+                - page: docs-content://deploy-manage/monitor/autoops/cc-cloud-connect-autoops-troubleshooting.md
+                  title: "Troubleshooting"
+                  children:
+                  - page: docs-content://deploy-manage/monitor/autoops/autoops-connectivity-check.md
+                    title: "Run the Connectivity Check"
+                  - page: docs-content://deploy-manage/monitor/autoops/autoops-sm-troubleshoot-firewalls.md
+                    title: "Firewalls blocking {{agent}}"
+                  - page: docs-content://deploy-manage/monitor/autoops/autoops-sm-troubleshoot-eck-no-clusters.md
+                    title: "Connected clusters not appearing with ECK"
+              - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-regions.md
+                title: "Regions"
+              - page: docs-content://deploy-manage/monitor/autoops/views.md
+                title: "Views"
+                children:
+                - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-overview-view.md
+                  title: "Overview"
+                - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-deployment-view.md
+                  title: "Deployment or Cluster"
+                - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-nodes-view.md
+                  title: "Nodes"
+                - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-index-view.md
+                  title: "Indices"
+                - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-shards-view.md
+                  title: "Shards"
+                - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-template-optimizer.md
+                  title: "Template Optimizer"
+              - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-events.md
+                title: "Events"
+                children:
+                - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-event-settings.md
+                - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-notifications-settings.md
+              - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-faq.md
+                title: "FAQ"
+            - page: docs-content://deploy-manage/monitor/stack-monitoring.md
+              children:
+              - page: docs-content://deploy-manage/monitor/stack-monitoring/ece-ech-stack-monitoring.md
+                title: "Enable on ECH and ECE"
+              - page: docs-content://deploy-manage/monitor/stack-monitoring/eck-stack-monitoring.md
+                title: "Enable on ECK"
+              - page: docs-content://deploy-manage/monitor/stack-monitoring/elasticsearch-monitoring-self-managed.md
+                title: "Self-managed: {{es}}"
+                children:
+                - page: docs-content://deploy-manage/monitor/stack-monitoring/collecting-monitoring-data-with-elastic-agent.md
+                  title: "Collecting monitoring data with {{agent}}"
+                - page: docs-content://deploy-manage/monitor/stack-monitoring/collecting-monitoring-data-with-metricbeat.md
+                  title: "Collecting monitoring data with {{metricbeat}}"
+                - page: docs-content://deploy-manage/monitor/stack-monitoring/collecting-log-data-with-filebeat.md
+                  title: "Collecting log data with {{filebeat}}"
+                - page: docs-content://deploy-manage/monitor/stack-monitoring/es-self-monitoring-prod.md
+                - page: docs-content://deploy-manage/monitor/stack-monitoring/es-legacy-collection-methods.md
+                  title: "Legacy collection methods"
+                  children:
+                  - page: docs-content://deploy-manage/monitor/stack-monitoring/es-monitoring-collectors.md
+                  - page: docs-content://deploy-manage/monitor/stack-monitoring/es-monitoring-exporters.md
+                  - page: docs-content://deploy-manage/monitor/stack-monitoring/es-local-exporter.md
+                  - page: docs-content://deploy-manage/monitor/stack-monitoring/es-http-exporter.md
+                  - page: docs-content://deploy-manage/monitor/stack-monitoring/es-pause-export.md
+              - page: docs-content://deploy-manage/monitor/stack-monitoring/kibana-monitoring-self-managed.md
+                title: "Self-managed: {{kib}}"
+                children:
+                - page: docs-content://deploy-manage/monitor/stack-monitoring/kibana-monitoring-elastic-agent.md
+                  title: "Collect monitoring data with {{agent}}"
+                - page: docs-content://deploy-manage/monitor/stack-monitoring/kibana-monitoring-metricbeat.md
+                  title: "Collect monitoring data with {{metricbeat}}"
+                - page: docs-content://deploy-manage/monitor/stack-monitoring/kibana-monitoring-legacy.md
+                  title: "Legacy collection methods"
+              - page: docs-content://deploy-manage/monitor/stack-monitoring/kibana-monitoring-data.md
+              - page: docs-content://deploy-manage/monitor/monitoring-data/visualizing-monitoring-data.md
+                children:
+                - page: docs-content://deploy-manage/monitor/monitoring-data/beats-page.md
+                - page: docs-content://deploy-manage/monitor/monitoring-data/elasticsearch-metrics.md
+                - page: docs-content://deploy-manage/monitor/monitoring-data/kibana-page.md
+                - page: docs-content://deploy-manage/monitor/monitoring-data/integrations-server-page.md
+                - page: docs-content://deploy-manage/monitor/monitoring-data/logstash-page.md
+                - page: docs-content://deploy-manage/monitor/monitoring-data/monitor-troubleshooting.md
+                  title: "Troubleshooting"
+              - page: docs-content://deploy-manage/monitor/monitoring-data/configure-stack-monitoring-alerts.md
+              - page: docs-content://deploy-manage/monitor/monitoring-data/configuring-data-streamsindices-for-monitoring.md
+                children:
+                - page: docs-content://deploy-manage/monitor/monitoring-data/config-monitoring-data-streams-elastic-agent.md
+                - page: docs-content://deploy-manage/monitor/monitoring-data/config-monitoring-data-streams-metricbeat-8.md
+                - page: docs-content://deploy-manage/monitor/monitoring-data/config-monitoring-indices-metricbeat-7-internal-collection.md
+            - page: docs-content://deploy-manage/monitor/autoops-vs-stack-monitoring.md
+              title: "AutoOps vs. Stack Monitoring"
+            - page: docs-content://deploy-manage/monitor/cloud-health-perf.md
+              title: "Cloud deployment health"
+              children:
+              - page: docs-content://deploy-manage/monitor/access-performance-metrics-on-elastic-cloud.md
+              - page: docs-content://deploy-manage/monitor/ec-memory-pressure.md
+            - page: docs-content://deploy-manage/monitor/kibana-task-manager-health-monitoring.md
+              title: "{{kib}} task manager monitoring"
+            - page: docs-content://deploy-manage/monitor/orchestrators.md
+              children:
+              - page: docs-content://deploy-manage/monitor/orchestrators/eck-metrics-configuration.md
+                children:
+                - page: docs-content://deploy-manage/monitor/orchestrators/k8s-enabling-metrics-endpoint.md
+                - page: docs-content://deploy-manage/monitor/orchestrators/k8s-securing-metrics-endpoint.md
+                - page: docs-content://deploy-manage/monitor/orchestrators/k8s-prometheus-requirements.md
+              - page: docs-content://deploy-manage/monitor/orchestrators/ece-platform-monitoring.md
+                children:
+                - page: docs-content://deploy-manage/monitor/orchestrators/ece-monitoring-ece-access.md
+                - page: docs-content://deploy-manage/monitor/orchestrators/ece-proxy-log-fields.md
+                - page: docs-content://deploy-manage/monitor/orchestrators/ece-monitoring-ece-set-retention.md
+            - page: docs-content://deploy-manage/monitor/logging-configuration.md
+              children:
+              - page: docs-content://deploy-manage/monitor/logging-configuration/elasticsearch-log4j-configuration-self-managed.md
+              - page: docs-content://deploy-manage/monitor/logging-configuration/update-elasticsearch-logging-levels.md
+              - page: docs-content://deploy-manage/monitor/logging-configuration/elasticsearch-deprecation-logs.md
+              - page: docs-content://deploy-manage/monitor/logging-configuration/slow-logs.md
+              - page: docs-content://deploy-manage/monitor/logging-configuration/kibana-logging.md
+                children:
+                - page: docs-content://deploy-manage/monitor/logging-configuration/kibana-log-levels.md
+                - page: docs-content://deploy-manage/monitor/logging-configuration/kib-advanced-logging.md
+                  children:
+                  - page: docs-content://deploy-manage/monitor/logging-configuration/kibana-log-settings-examples.md
+                    title: "Examples"
           - page: docs-content://deploy-manage/kibana-reporting-configuration.md
             title: Configure Kibana reporting
           - group: Backup, high availability, and resilience tools
             page: docs-content://deploy-manage/tools.md
+            children:
+            - page: docs-content://deploy-manage/tools/snapshot-and-restore.md
+              children:
+              - page: docs-content://deploy-manage/tools/snapshot-and-restore/manage-snapshot-repositories.md
+                children:
+                - page: docs-content://deploy-manage/tools/snapshot-and-restore/self-managed.md
+                  title: "Self-managed"
+                  children:
+                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/azure-repository.md
+                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/google-cloud-storage-repository.md
+                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/s3-repository.md
+                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/shared-file-system-repository.md
+                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/read-only-url-repository.md
+                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/source-only-repository.md
+                - page: docs-content://deploy-manage/tools/snapshot-and-restore/elastic-cloud-hosted.md
+                  title: "{{ech}}"
+                  children:
+                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/ec-aws-custom-repository.md
+                    title: "AWS S3"
+                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/ec-gcs-snapshotting.md
+                    title: "Google Cloud Storage"
+                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/ec-azure-snapshotting.md
+                    title: "Azure Blob Storage"
+                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/access-isolation-for-found-snapshots-repository.md
+                    children:
+                    - page: docs-content://deploy-manage/tools/snapshot-and-restore/repository-isolation-on-azure.md
+                      title: "Azure"
+                    - page: docs-content://deploy-manage/tools/snapshot-and-restore/repository-isolation-on-aws-gcp.md
+                      title: "AWS and GCP"
+                - page: docs-content://deploy-manage/tools/snapshot-and-restore/cloud-enterprise.md
+                  title: "{{ece}}"
+                  children:
+                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/ece-aws-custom-repository.md
+                    title: "AWS S3"
+                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/google-cloud-storage-gcs-repository.md
+                    title: "Google Cloud Storage"
+                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/azure-storage-repository.md
+                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/minio-on-premise-repository.md
+                - page: docs-content://deploy-manage/tools/snapshot-and-restore/cloud-on-k8s.md
+                  title: "{{eck}}"
+              - page: docs-content://deploy-manage/tools/snapshot-and-restore/create-snapshots.md
+              - page: docs-content://deploy-manage/tools/snapshot-and-restore/restore-snapshot.md
+                children:
+                - page: docs-content://deploy-manage/tools/snapshot-and-restore/ece-restore-across-clusters.md
+                  children:
+                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/ece-restore-snapshots-into-new-deployment.md
+                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/ece-restore-snapshots-into-existing-deployment.md
+                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/ece-restore-snapshots-containing-searchable-snapshots-indices-across-clusters.md
+              - page: docs-content://deploy-manage/tools/snapshot-and-restore/searchable-snapshots.md
+            - page: docs-content://deploy-manage/tools/cross-cluster-replication.md
+              children:
+              - page: docs-content://deploy-manage/tools/cross-cluster-replication/set-up-cross-cluster-replication.md
+                title: "Set up cross-cluster replication"
+                children:
+                - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-getting-started-prerequisites.md
+                  title: "Prerequisites"
+                - page: docs-content://deploy-manage/tools/cross-cluster-replication/_connect_to_a_remote_cluster.md
+                - page: docs-content://deploy-manage/tools/cross-cluster-replication/_configure_privileges_for_cross_cluster_replication_2.md
+                - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-getting-started-follower-index.md
+                - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-getting-started-auto-follow.md
+              - page: docs-content://deploy-manage/tools/cross-cluster-replication/manage-cross-cluster-replication.md
+                children:
+                - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-inspect-progress.md
+                - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-pause-replication.md
+                - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-recreate-follower-index.md
+                - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-terminate-replication.md
+              - page: docs-content://deploy-manage/tools/cross-cluster-replication/manage-auto-follow-patterns.md
+                children:
+                - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-auto-follow-create.md
+                - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-auto-follow-retrieve.md
+                - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-auto-follow-pause.md
+                - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-auto-follow-delete.md
+              - page: docs-content://deploy-manage/tools/cross-cluster-replication/upgrading-clusters.md
+                title: "Upgrading clusters"
+                children:
+                - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-uni-directional-upgrade.md
+                - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-bi-directional-upgrade.md
+              - page: docs-content://deploy-manage/tools/cross-cluster-replication/uni-directional-disaster-recovery.md
+                title: "Uni-directional disaster recovery"
+                children:
+                - page: docs-content://deploy-manage/tools/cross-cluster-replication/_prerequisites_14.md
+                  title: "Prerequisites"
+                - page: docs-content://deploy-manage/tools/cross-cluster-replication/_failover_when_clustera_is_down.md
+                  title: "Failover when clusterA is down"
+                - page: docs-content://deploy-manage/tools/cross-cluster-replication/_failback_when_clustera_comes_back.md
+                  title: "Failback when clusterA comes back"
+              - page: docs-content://deploy-manage/tools/cross-cluster-replication/bi-directional-disaster-recovery.md
+                title: "Bi-directional disaster recovery"
+                children:
+                - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-tutorial-initial-setup.md
+                - page: docs-content://deploy-manage/tools/cross-cluster-replication/_failover_when_clustera_is_down_2.md
+                  title: "Failover when clusterA is down"
+                - page: docs-content://deploy-manage/tools/cross-cluster-replication/_failback_when_clustera_comes_back_2.md
+                  title: "Failback when clusterA comes back"
+                - page: docs-content://deploy-manage/tools/cross-cluster-replication/_perform_update_or_delete_by_query.md
           - group: Autoscaling
             page: docs-content://deploy-manage/autoscaling.md
+            children:
+            - page: docs-content://deploy-manage/autoscaling/autoscaling-in-ece-and-ech.md
+              title: "In ECE and ECH"
+            - page: docs-content://deploy-manage/autoscaling/autoscaling-in-eck.md
+              title: "In ECK"
+            - page: docs-content://deploy-manage/autoscaling/autoscaling-deciders.md
+            - page: docs-content://deploy-manage/autoscaling/trained-model-autoscaling.md
           - page: docs-content://deploy-manage/stack-settings.md
             title: Stack settings
           - page: docs-content://deploy-manage/manage-connectors.md
             title: Connectors
           - group: Remote clusters
             page: docs-content://deploy-manage/remote-clusters.md
+            children:
+            - page: docs-content://deploy-manage/remote-clusters/security-models.md
+              title: "Security models"
+            - page: docs-content://deploy-manage/remote-clusters/connection-modes.md
+              title: "Connection modes"
+            - page: docs-content://deploy-manage/remote-clusters/ec-enable-ccs.md
+              title: "On Elastic Cloud Hosted"
+              children:
+              - page: docs-content://deploy-manage/remote-clusters/ec-remote-cluster-same-ess.md
+                title: "To the same {{ecloud}} organization"
+              - page: docs-content://deploy-manage/remote-clusters/ec-remote-cluster-other-ess.md
+                title: "To a different {{ecloud}} organization"
+              - page: docs-content://deploy-manage/remote-clusters/ec-remote-cluster-ece.md
+                title: "To {{ece}}"
+              - page: docs-content://deploy-manage/remote-clusters/ec-remote-cluster-self-managed.md
+                title: "To a self-managed cluster"
+              - page: docs-content://deploy-manage/remote-clusters/ec-enable-ccs-for-eck.md
+                title: "To {{eck}}"
+              - page: docs-content://deploy-manage/remote-clusters/ec-remote-cluster-strong-identity.md
+                title: "Strong identity verification"
+              - page: docs-content://deploy-manage/remote-clusters/ec-edit-remove-trusted-environment.md
+                title: "Manage trusted environments"
+              - page: docs-content://deploy-manage/remote-clusters/ec-migrate-ccs.md
+                title: "Migrate from the CCS deployment template"
+            - page: docs-content://deploy-manage/remote-clusters/ece-enable-ccs.md
+              title: "On Elastic Cloud Enterprise"
+              children:
+              - page: docs-content://deploy-manage/remote-clusters/ece-remote-cluster-same-ece.md
+                title: "To the same ECE environment"
+              - page: docs-content://deploy-manage/remote-clusters/ece-remote-cluster-other-ece.md
+                title: "To a different ECE environment"
+              - page: docs-content://deploy-manage/remote-clusters/ece-remote-cluster-ece-ess.md
+                title: "To {{ecloud}}"
+              - page: docs-content://deploy-manage/remote-clusters/ece-remote-cluster-self-managed.md
+                title: "To a self-managed cluster"
+              - page: docs-content://deploy-manage/remote-clusters/ece-enable-ccs-for-eck.md
+                title: "To {{eck}}"
+              - page: docs-content://deploy-manage/remote-clusters/ece-edit-remove-trusted-environment.md
+                title: "Manage trusted environments"
+              - page: docs-content://deploy-manage/remote-clusters/ece-migrate-ccs.md
+                title: "Migrate from the CCS deployment template"
+            - page: docs-content://deploy-manage/remote-clusters/remote-clusters-self-managed.md
+              title: "On self-managed {{stack}}"
+              children:
+              - page: docs-content://deploy-manage/remote-clusters/remote-clusters-api-key.md
+              - page: docs-content://deploy-manage/remote-clusters/remote-clusters-cert.md
+              - page: docs-content://deploy-manage/remote-clusters/self-remote-cluster-eck.md
+                title: "To {{eck}}"
+              - page: docs-content://deploy-manage/remote-clusters/remote-clusters-migrate.md
+                title: "Migrate from certificate to API key authentication"
+            - page: docs-content://deploy-manage/remote-clusters/eck-remote-clusters-landing.md
+              title: "On Elastic Cloud on Kubernetes"
+              children:
+              - page: docs-content://deploy-manage/remote-clusters/eck-remote-clusters.md
+                title: "To the same ECK environment"
+              - page: docs-content://deploy-manage/remote-clusters/eck-remote-clusters-to-other-eck.md
+                title: "To a different ECK environment"
+              - page: docs-content://deploy-manage/remote-clusters/eck-remote-clusters-to-external.md
+                title: "To an external cluster or deployment"
           - group: Cross-project search
             page: docs-content://deploy-manage/cross-project-search-config.md
             children:
@@ -729,14 +1264,115 @@ nav:
           - label: ───
           - group: Maintenance
             page: docs-content://deploy-manage/maintenance.md
+            children:
+            - page: docs-content://deploy-manage/maintenance/ece.md
+              children:
+              - page: docs-content://deploy-manage/maintenance/ece/deployments-maintenance.md
+                children:
+                - page: docs-content://deploy-manage/maintenance/ece/pause-instance.md
+              - page: docs-content://deploy-manage/maintenance/ece/maintenance-activities.md
+                children:
+                - page: docs-content://deploy-manage/maintenance/ece/enable-maintenance-mode.md
+                - page: docs-content://deploy-manage/maintenance/ece/scale-out-installation.md
+                - page: docs-content://deploy-manage/maintenance/ece/move-nodes-instances-from-allocators.md
+                - page: docs-content://deploy-manage/maintenance/ece/perform-ece-hosts-maintenance.md
+                - page: docs-content://deploy-manage/maintenance/ece/delete-ece-hosts.md
+            - page: docs-content://deploy-manage/maintenance/start-stop-services.md
+              children:
+              - page: docs-content://deploy-manage/maintenance/start-stop-services/start-stop-elasticsearch.md
+              - page: docs-content://deploy-manage/maintenance/start-stop-services/start-stop-kibana.md
+              - page: docs-content://deploy-manage/maintenance/start-stop-services/restart-cloud-hosted-deployment.md
+              - page: docs-content://deploy-manage/maintenance/start-stop-services/restart-an-ece-deployment.md
+              - page: docs-content://deploy-manage/maintenance/start-stop-services/full-cluster-restart-rolling-restart-procedures.md
+            - page: docs-content://deploy-manage/maintenance/start-stop-routing-requests.md
+            - page: docs-content://deploy-manage/maintenance/add-and-remove-elasticsearch-nodes.md
           - group: Upgrade
             page: docs-content://deploy-manage/upgrade.md
+            children:
+            - page: docs-content://deploy-manage/upgrade/plan-upgrade.md
+            - page: docs-content://deploy-manage/upgrade/prepare-to-upgrade.md
+              title: "Preparation steps"
+              children:
+              - page: docs-content://deploy-manage/upgrade/prepare-to-upgrade/upgrade-assistant.md
+            - page: docs-content://deploy-manage/upgrade/deployment-or-cluster.md
+              children:
+              - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/upgrade-717.md
+              - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/upgrade-on-ech.md
+                title: "Upgrade on {{ech}}"
+              - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/upgrade-on-ece.md
+                title: "Upgrade on {{ece}}"
+              - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/upgrade-on-eck.md
+                title: "Upgrade on {{eck}}"
+              - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/self-managed.md
+                title: "Upgrade Elastic on a self-managed cluster"
+                children:
+                - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/elasticsearch.md
+                - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/upgrade-elasticsearch-docker.md
+                  title: "Upgrade Elasticsearch running on Docker"
+                - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/kibana.md
+                  children:
+                  - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/saved-object-migrations.md
+                  - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/kibana-roll-back.md
+                    title: "Roll back to a previous version"
+              - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/archived-settings.md
+                title: "Archived settings"
+              - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/reading-indices-from-older-elasticsearch-versions.md
+                title: "Reading indices from older versions"
+              - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/enterprise-search.md
+            - page: docs-content://deploy-manage/upgrade/ingest-components.md
+            - page: docs-content://deploy-manage/upgrade/orchestrator.md
+              title: "Upgrade your ECE or ECK orchestrator"
+              children:
+              - page: docs-content://deploy-manage/upgrade/orchestrator/upgrade-cloud-enterprise.md
+                children:
+                - page: docs-content://deploy-manage/upgrade/orchestrator/re-running-the-ece-upgrade.md
+              - page: docs-content://deploy-manage/upgrade/orchestrator/upgrade-cloud-on-k8s.md
           - group: Uninstall
             page: docs-content://deploy-manage/uninstall.md
+            children:
+            - page: docs-content://deploy-manage/uninstall/uninstall-elastic-cloud-enterprise.md
+            - page: docs-content://deploy-manage/uninstall/uninstall-elastic-cloud-on-kubernetes.md
+            - page: docs-content://deploy-manage/uninstall/delete-a-cloud-deployment.md
+              title: "Delete an orchestrated deployment"
           - group: Licenses and subscriptions
             page: docs-content://deploy-manage/license.md
+            children:
+            - page: docs-content://deploy-manage/license/manage-your-license-in-ece.md
+              title: "{{ece}}"
+            - page: docs-content://deploy-manage/license/manage-your-license-in-eck.md
+              title: "{{eck}}"
+            - page: docs-content://deploy-manage/license/manage-your-license-in-self-managed-cluster.md
+              title: "Self-managed cluster"
           - group: Manage your Cloud organization
             page: docs-content://deploy-manage/cloud-organization.md
+            children:
+            - page: docs-content://deploy-manage/cloud-organization/billing.md
+              children:
+              - page: docs-content://deploy-manage/cloud-organization/billing/cloud-hosted-deployment-billing-dimensions.md
+                title: "Hosted billing dimensions"
+              - page: docs-content://deploy-manage/cloud-organization/billing/serverless-project-billing-dimensions.md
+                title: "Serverless billing dimensions"
+                children:
+                - page: docs-content://deploy-manage/cloud-organization/billing/elasticsearch-billing-dimensions.md
+                  title: "Elasticsearch projects"
+                - page: docs-content://deploy-manage/cloud-organization/billing/elastic-observability-billing-dimensions.md
+                  title: "Observability projects"
+                - page: docs-content://deploy-manage/cloud-organization/billing/security-billing-dimensions.md
+                  title: "Security projects"
+              - page: docs-content://deploy-manage/cloud-organization/billing/billing-models.md
+              - page: docs-content://deploy-manage/cloud-organization/billing/add-billing-details.md
+              - page: docs-content://deploy-manage/cloud-organization/billing/view-billing-history.md
+              - page: docs-content://deploy-manage/cloud-organization/billing/manage-billing-notifications.md
+                title: "Manage notifications"
+              - page: docs-content://deploy-manage/cloud-organization/billing/manage-subscription.md
+              - page: docs-content://deploy-manage/cloud-organization/billing/monitor-analyze-usage.md
+              - page: docs-content://deploy-manage/cloud-organization/billing/ecu.md
+              - page: docs-content://deploy-manage/cloud-organization/billing/billing-faq.md
+            - page: docs-content://deploy-manage/cloud-organization/operational-emails.md
+            - page: docs-content://deploy-manage/cloud-organization/billing/update-billing-operational-contacts.md
+            - page: docs-content://deploy-manage/cloud-organization/service-status.md
+            - page: docs-content://deploy-manage/cloud-organization/tools-and-apis.md
+              title: "Tools and APIs"
         - group: Deployment and administration tools
           children:
           - toc: ecctl://reference
@@ -1112,35 +1748,215 @@ nav:
             title: Calculate ingest lag metadata
       - label: Search, visualize and analyze
         children:
+        # =======================================================================
+        # SEARCH AND QUERY
+        # Narrative arc: get started → approaches → ingest → querying → cross-cluster → integrate
+        # Pages pulled from solutions/search/ and explore-analyze/ at current paths.
+        # [from E&A] = page currently lives in explore-analyze/
+        # [TODO] = placeholder, page not yet written
+        # =======================================================================
         - group: Search and query
+          page: docs-content://solutions/search.md
           children:
+
+          # -----------------------------------------------------------------------
+          # 1. GET STARTED
+          # -----------------------------------------------------------------------
           - group: Get started with search
+            page: docs-content://solutions/search/get-started.md
             children:
-            - title: APIs and tools for search
-          - group: Search strategies
+            - group: Quickstarts
+              page: docs-content://solutions/search/get-started/quickstarts.md
+              children:
+              - page: docs-content://solutions/search/get-started/index-basics.md
+                title: Index basics
+              - page: docs-content://solutions/search/get-started/keyword-search-python.md
+                title: Keyword search with Python
+              - page: docs-content://solutions/search/get-started/semantic-search.md
+                title: Semantic search
+
+          # -----------------------------------------------------------------------
+          # 2. SEARCH APPROACHES
+          # What kind of search do I need?
+          # FTS is the foundation — everything else layers on top.
+          # -----------------------------------------------------------------------
+          - group: Search approaches
+            page: docs-content://solutions/search/search-approaches.md
             children:
-            - title: Full-text search
-            - title: AI-powered search
-            - title: Hybrid search
-            - title: Ranking and reranking
-          - group: Build search queries with APIs and query languages and search templates
+            # Full-text is core to every deployment, not just one option
+            - group: Full-text search
+              page: docs-content://solutions/search/full-text.md
+              children:
+              - page: docs-content://solutions/search/full-text/how-full-text-works.md
+                title: How full-text search works
+              - page: docs-content://solutions/search/full-text/text-analysis-during-search.md
+                title: Text analysis during search
+              - group: Search relevance
+                page: docs-content://solutions/search/full-text/search-relevance.md
+                children:
+                - page: docs-content://solutions/search/full-text/search-relevance/mixing-exact-search-with-stemming.md
+                  title: Mix exact search with stemming
+                - page: docs-content://solutions/search/full-text/search-relevance/consistent-scoring.md
+                  title: Consistent scoring
+                - page: docs-content://solutions/search/full-text/search-relevance/static-scoring-signals.md
+                  title: Static scoring signals
+              - group: Synonyms
+                page: docs-content://solutions/search/full-text/search-with-synonyms.md
+                children:
+                - page: docs-content://solutions/search/full-text/create-update-synonyms-api-example.md
+                  title: Create and update synonyms via API
+            # Vector search — formerly "AI search"
+            - group: Vector search
+              page: docs-content://solutions/search/ai-search/ai-search.md
+              children:
+              - group: Dense vector search
+                page: docs-content://solutions/search/vector/dense-vector.md
+                children:
+                - page: docs-content://solutions/search/vector/knn.md
+                  title: k-nearest neighbor (kNN)
+                - page: docs-content://solutions/search/vector/bring-own-vectors.md
+                  title: Bring your own vectors
+              - page: docs-content://solutions/search/vector/sparse-vector.md
+                title: Sparse vector search
+              - page: docs-content://solutions/search/vector/dense-versus-sparse-ingest-pipelines.md
+                title: Dense vs sparse ingest pipelines
+              - group: Semantic search
+                page: docs-content://solutions/search/semantic-search.md
+                children:
+                - page: docs-content://solutions/search/semantic-search/semantic-search-semantic-text.md
+                  title: Semantic search with semantic_text
+                - page: docs-content://solutions/search/semantic-search/semantic-search-inference.md
+                  title: Semantic search with the inference API
+                - page: docs-content://solutions/search/semantic-search/semantic-search-elser-ingest-pipelines.md
+                  title: Semantic search with ELSER
+                - page: docs-content://solutions/search/semantic-search/cohere-es.md
+                  title: Semantic search with Cohere
+              - page: docs-content://solutions/search/using-openai-compatible-models.md
+                title: Using OpenAI-compatible models
+            - group: Hybrid search
+              page: docs-content://solutions/search/hybrid-search.md
+              children:
+              - page: docs-content://solutions/search/hybrid-semantic-text.md
+                title: Hybrid search with semantic_text
+            # Ranking — semantic reranking is a lightweight upgrade on top of FTS
+            - group: Ranking and reranking
+              page: docs-content://solutions/search/ranking.md
+              children:
+              - page: docs-content://solutions/search/ranking/semantic-reranking.md
+                title: Semantic reranking
+              - group: Learning to rank
+                page: docs-content://solutions/search/ranking/learning-to-rank-ltr.md
+                children:
+                - page: docs-content://solutions/search/ranking/learning-to-rank-model-training.md
+                  title: Train an LTR model
+                - page: docs-content://solutions/search/ranking/learning-to-rank-search-usage.md
+                  title: Use LTR in search
+
+          # -----------------------------------------------------------------------
+          # 3. INGEST FOR SEARCH
+          # After approaches — the approach decision shapes what your pipeline needs.
+          # -----------------------------------------------------------------------
+          - group: Ingest for search
+            page: docs-content://solutions/search/ingest-for-search.md
             children:
-            - title: ES|QL
-            - title: Query DSL
-            - title: "..."
+            - page: docs-content://solutions/search/search-pipelines.md
+              title: Search pipelines
+
+          # -----------------------------------------------------------------------
+          # 4. QUERYING
+          # How do I express and execute my search?
+          # Two dimensions: what language? what interface?
+          # -----------------------------------------------------------------------
+          - group: Build search queries
+            page: docs-content://solutions/search/querying-for-search.md
+            children:
+            - group: The search API
+              page: docs-content://solutions/search/the-search-api.md
+              children:
+              - page: docs-content://solutions/search/search-templates.md
+                title: Search templates
+              - group: Aggregations
+                page: docs-content://explore-analyze/query-filter/aggregations.md # [from E&A]
+                children:
+                - page: docs-content://explore-analyze/query-filter/aggregations/tutorial-analyze-ecommerce-data-with-aggregations-using-query-dsl.md
+                  title: Tutorial — analyze e-commerce data
+            - page: docs-content://solutions/search/retrievers-overview.md
+              title: Retrievers
+            - page: docs-content://solutions/search/esql-for-search.md
+              title: ES|QL for search
+            - page: docs-content://solutions/search/async-search-api.md
+              title: Async search
+            # Language narrative pages — "understand and decide" layer
+            # These sit above the bulk reference toc further down.
+            - group: Query languages
+              page: docs-content://explore-analyze/query-filter/languages.md # [from E&A] comparison table landing
+              children:
+              - page: docs-content://explore-analyze/query-filter/languages/querydsl.md # [from E&A]
+                title: Query DSL
+              - page: docs-content://explore-analyze/query-filter/languages/kql.md # [from E&A]
+                title: KQL
+              - group: EQL
+                page: docs-content://explore-analyze/query-filter/languages/eql.md # [from E&A]
+                children:
+                - page: docs-content://explore-analyze/query-filter/languages/example-detect-threats-with-eql.md
+                  title: Detect threats with EQL
+              # [THIN] sql.md is a hollow intro + link list that duplicates the reference toc below.
+              # Candidate for removal — redirect to elasticsearch://reference/query-languages/sql.md
+              - page: docs-content://explore-analyze/query-filter/languages/sql.md # [from E&A]
+                title: SQL
+              # [THIN] lucene-query-syntax.md is a single paragraph pointing users to the Kibana UI toggle.
+              # Candidate for removal — redirect to elasticsearch://reference/query-languages/query-dsl/query-dsl-query-string-query.md
+              - page: docs-content://explore-analyze/query-filter/languages/lucene-query-syntax.md # [from E&A]
+                title: Lucene query syntax
+            # Query language reference — bulk toc, cannot interleave with narrative pages above
+            - toc: elasticsearch://reference/query-languages
+            # Developer tools — for running and testing queries
+            - group: Developer tools
+              page: docs-content://explore-analyze/query-filter/tools.md # [from E&A]
+              children:
+              - page: docs-content://explore-analyze/query-filter/tools/console.md
+                title: Console
+              - page: docs-content://explore-analyze/query-filter/tools/search-profiler.md
+                title: Search Profiler
+              - page: docs-content://explore-analyze/query-filter/tools/saved-queries.md
+                title: Saved queries
+
+          # -----------------------------------------------------------------------
+          # 5. SEARCH ACROSS CLUSTERS AND PROJECTS
+          # End-of-journey scaling topic: "my data spans multiple clusters"
+          # -----------------------------------------------------------------------
+          - group: Cross-cluster search
+            page: docs-content://explore-analyze/cross-cluster-search.md # [from E&A]
+            children:
+            - page: docs-content://explore-analyze/cross-cluster-search/using-resolve-cluster-endpoint-before-cross-cluster-search.md
+              title: Using the resolve cluster endpoint
+          # Cross-project search — serverless only, pages are hidden in toc
           - group: Cross-project search
+            page: docs-content://explore-analyze/cross-project-search.md # [from E&A]
             children:
-            - title: Link projects for cross-project search
-            - title: Using project routing to limit search scope
-            - title: How search works in CPS
-            - title: Using tags to control search
-          - title: Cross-cluster search
-          - title: Add search to your site or app
-          - group: Querying and filtering in Kibana
+            - page: docs-content://explore-analyze/cross-project-search/cross-project-search-link-projects.md
+              title: Link projects
+            - page: docs-content://explore-analyze/cross-project-search/cross-project-search-search.md
+              title: Search across projects
+            - page: docs-content://explore-analyze/cross-project-search/cross-project-search-tags.md
+              title: Using tags to control search
+            - page: docs-content://explore-analyze/cross-project-search/cross-project-search-project-routing.md
+              title: Project routing
+
+          # -----------------------------------------------------------------------
+          # 6. INTEGRATE WITH YOUR APP
+          # Wire search into your application code.
+          # [TODO] site-or-app.md → integrate.md rename deferred to docs-content work
+          # -----------------------------------------------------------------------
+          - group: Integrate with your app
+            page: docs-content://solutions/search/site-or-app.md
             children:
-            - title: Filtering in Kibana
-            - title: Query languages
-            - title: Query tools
+            - page: docs-content://solutions/search/site-or-app/clients.md
+              title: Client libraries
+            - page: docs-content://solutions/search/site-or-app/search-ui.md
+              title: Search UI
+            - page: docs-content://solutions/search/apis-and-tools.md
+              title: APIs and tools
         - group: Explore and visualize
           page: docs-content://explore-analyze/explore-and-visualize.md
           children:
@@ -3143,147 +3959,6 @@ nav:
           title: Serverless feature tiers
         - page: docs-content://solutions/security/apis.md
           title: APIs
-  #  - label: Reference
-  #    children:
-  #    - toc: elasticsearch://reference/elasticsearch
-  #    - toc: kibana://reference
-  #    - group: Cloud
-  #      children:
-  #      - toc: cloud://reference
-  #      - toc: cloud-on-k8s://reference
-  #    - toc: docs-content://reference/security
-  #    - toc: docs-content://reference/observability
-  #    - toc: ecs://reference
-  #    - toc: docs-content://reference/machine-learning
-  #    - toc: search-ui://reference
-  #    - toc: elasticsearch://reference/aggregations
-  #    - toc: ecctl://reference
-  #    - toc: docs-content://reference/elasticsearch-clients
-  #    - toc: elasticsearch://reference/enrich-processor
-  #    - toc: elasticsearch://reference/query-languages
-  #    - toc: elasticsearch://reference/scripting-languages
-  #    - page: docs-content://explore-analyze/numeral-formatting.md
-  #      title: Numeral formatting
-  #    - toc: elasticsearch://reference/text-analysis
-  #    - toc: docs-content://reference/glossary
-  #  - label: Troubleshooting
-  #    children:
-  #    - group: Troubleshoot Elasticsearch
-  #      children:
-  #      - page: docs-content://troubleshoot/elasticsearch/add-repository.md
-  #        title: Troubleshoot broken repositories
-  #      - page: docs-content://troubleshoot/elasticsearch/add-tier.md
-  #        title: Add a preferred data tier
-  #      - page: docs-content://troubleshoot/elasticsearch/allow-all-cluster-allocation.md
-  #        title: Allow cluster-wide shard allocation
-  #      - page: docs-content://troubleshoot/elasticsearch/allow-all-index-allocation.md
-  #        title: Allow index shard allocation
-  #      - page: docs-content://troubleshoot/elasticsearch/cluster-allocation-api-examples.md
-  #        title: Using the cluster allocation API
-  #      - page: docs-content://troubleshoot/elasticsearch/corruption-troubleshooting.md
-  #        title: Troubleshoot data corruption
-  #      - page: docs-content://troubleshoot/elasticsearch/discovery-troubleshooting.md
-  #        title: Troubleshoot discovery
-  #      - page: docs-content://troubleshoot/elasticsearch/file-based-recovery.md
-  #        title: File-based access recovery
-  #      - page: docs-content://troubleshoot/elasticsearch/fix-common-cluster-issues.md
-  #        title: Fix common cluster issues
-  #      - page: docs-content://troubleshoot/elasticsearch/fix-data-node-out-of-disk.md
-  #        title: Fix data nodes out of disk
-  #      - page: docs-content://troubleshoot/elasticsearch/fix-master-node-out-of-disk.md
-  #        title: Fix master nodes out of disk
-  #      - page: docs-content://troubleshoot/elasticsearch/fix-other-node-out-of-disk.md
-  #        title: Fix other role nodes out of disk
-  #      - page: docs-content://troubleshoot/elasticsearch/fix-watermark-errors.md
-  #        title: Watermark errors
-  #      - page: docs-content://troubleshoot/elasticsearch/increase-cluster-shard-limit.md
-  #        title: Total shards per node has been reached
-  #      - page: docs-content://troubleshoot/elasticsearch/increase-shard-limit.md
-  #        title: Total shards for an index exceeded
-  #      - page: docs-content://troubleshoot/elasticsearch/diagnose-unassigned-shards.md
-  #        title: Not enough nodes to allocate shard replicas
-  #      - page: docs-content://troubleshoot/elasticsearch/index-lifecycle-management-errors.md
-  #        title: Fix index lifecycle management errors
-  #      - page: docs-content://troubleshoot/elasticsearch/monitoring-troubleshooting.md
-  #        title: Troubleshoot monitoring
-  #      - page: docs-content://troubleshoot/elasticsearch/remote-clusters.md
-  #        title: Troubleshoot remote clusters
-  #      - page: docs-content://troubleshoot/elasticsearch/repeated-snapshot-failures.md
-  #        title: Fix repeated snapshot policy failures
-  #      - page: docs-content://troubleshoot/elasticsearch/restore-from-snapshot.md
-  #        title: Restore from snapshot
-  #      - page: docs-content://troubleshoot/elasticsearch/start-ilm.md
-  #        title: Troubleshoot snapshot and ILM
-  #      - page: docs-content://troubleshoot/elasticsearch/transform-troubleshooting.md
-  #        title: Troubleshoot transforms
-  #      - page: docs-content://troubleshoot/elasticsearch/troubleshoot-ingest-pipelines.md
-  #        title: Troubleshoot ingest pipelines
-  #      - page: docs-content://troubleshoot/elasticsearch/troubleshoot-migrate-to-tiers.md
-  #        title: Troubleshoot incomplete migration to data tiers
-  #      - page: docs-content://troubleshoot/elasticsearch/troubleshooting-searches.md
-  #        title: Troubleshoot searches
-  #      - page: docs-content://troubleshoot/elasticsearch/troubleshooting-shards-capacity-issues.md
-  #        title: Troubleshoot shard capacity health issues
-  #      - page: docs-content://troubleshoot/elasticsearch/troubleshooting-unbalanced-cluster.md
-  #        title: Troubleshoot an unbalanced cluster
-  #      - page: docs-content://troubleshoot/elasticsearch/troubleshooting-unstable-cluster.md
-  #        title: Troubleshoot an unstable cluster
-  #      - page: docs-content://troubleshoot/elasticsearch/watcher-troubleshooting.md
-  #        title: Troubleshoot Watcher
-  #    - group: Troubleshoot Kibana
-  #      children:
-  #      - page: docs-content://troubleshoot/kibana/access.md
-  #        title: Check Kibana server status
-  #      - page: docs-content://troubleshoot/kibana/alerts.md
-  #        title: Troubleshoot Kibana alerts
-  #      - page: docs-content://troubleshoot/kibana/capturing-diagnostics.md
-  #        title: Capture Kibana diagnostics
-  #      - page: docs-content://troubleshoot/kibana/error-server-not-ready.md
-  #        title: "Error: Kibana server is not ready yet"
-  #      - page: docs-content://troubleshoot/kibana/graph.md
-  #        title: Troubleshoot graph analytics
-  #      - page: docs-content://troubleshoot/kibana/maps.md
-  #        title: Troubleshoot Kibana Maps
-  #      - page: docs-content://troubleshoot/kibana/migration-failures.md
-  #        title: Troubleshoot Kibana migration and upgrades
-  #      - page: docs-content://troubleshoot/kibana/monitoring.md
-  #        title: Troubleshoot Kibana monitoring
-  #      - page: docs-content://troubleshoot/kibana/reporting.md
-  #        title: Troubleshoot Kibana reporting
-  #      - page: docs-content://troubleshoot/kibana/task-manager.md
-  #        title: Troubleshoot Kibana Task Manager
-  #      - page: docs-content://troubleshoot/kibana/trace-elasticsearch-query-to-the-origin-in-kibana.md
-  #        title: Trace an Elasticsearch query in Kibana
-  #      - page: docs-content://troubleshoot/kibana/using-kibana-server-logs.md
-  #        title: Using Kibana server logs
-  #    - group: Troubleshoot Observability
-  #      children:
-  #      - page: docs-content://troubleshoot/observability/explore-data.md
-  #        title: Explore data
-  #      - page: docs-content://troubleshoot/observability/inspect.md
-  #        title: Inspect
-  #    - group: Troubleshoot Security
-  #      children:
-  #      - page: docs-content://troubleshoot/security/agentless-integrations.md
-  #        title: Troubleshoot agentless integrations
-  #      - page: docs-content://troubleshoot/security/detection-rules.md
-  #        title: Troubleshoot detection rules
-  #      - page: docs-content://troubleshoot/security/elastic-defend.md
-  #        title: Troubleshoot Elastic Defend
-  #      - page: docs-content://troubleshoot/security/indicators-of-compromise.md
-  #        title: Troubleshoot indicators of compromise
-  #    - group: Troubleshoot ingestion tools
-  #      children:
-  #      - page: docs-content://troubleshoot/ingest/beats-loggingplugin/elastic-logging-plugin-for-docker.md
-  #        title: Beats logging plugin
-  #      - page: docs-content://troubleshoot/ingest/elastic-serverless-forwarder.md
-  #        title: Troubleshoot Elastic Serverless Forwarder
-  #      - page: docs-content://troubleshoot/ingest/fleet/fleet-elastic-agent.md
-  #        title: Troubleshoot Fleet
-  #      - page: docs-content://troubleshoot/ingest/logstash.md
-  #        title: Troubleshoot Logstash
-  #      - page: docs-content://troubleshoot/ingest/opentelemetry/index.md
-  #        title: Troubleshoot EDOT
 
   - section: Products
     url: /products/
@@ -3302,6 +3977,86 @@ nav:
     url: /reference/
     children:
     - toc: docs-content://reference
+    - toc: elasticsearch://reference/elasticsearch
+    - toc: elasticsearch://reference/elasticsearch-plugins
+    - toc: elasticsearch://reference/community-contributed
+    - toc: kibana://reference
+    - group: Cloud
+      children:
+      - toc: cloud://reference
+      - toc: cloud-on-k8s://reference
+    - group: Elasticsearch clients
+      children:
+      - toc: elasticsearch-java://reference
+      - toc: elasticsearch-js://reference
+      - toc: elasticsearch-dsl-js://reference
+      - toc: elasticsearch-net://reference
+      - toc: elasticsearch-php://reference
+      - toc: elasticsearch-py://reference
+      - toc: elasticsearch-ruby://reference
+      - toc: elasticsearch-rs://reference
+      - toc: eland://reference
+      - toc: go-elasticsearch://reference
+      - toc: curator://reference
+    - group: APM
+      children:
+      - toc: apm-k8s-attacher://reference
+      - toc: apm-aws-lambda://reference
+      - toc: apm-agent-dotnet://reference
+      - toc: apm-agent-go://reference
+      - toc: apm-agent-java://reference
+      - toc: apm-agent-nodejs://reference
+      - toc: apm-agent-php://reference
+      - toc: apm-agent-python://reference
+      - toc: apm-agent-ruby://reference
+      - toc: apm-agent-rum-js://reference
+    - group: OpenTelemetry
+      children:
+      - toc: opentelemetry://reference
+        children:
+        - toc: opentelemetry://reference/motlp
+        - toc: opentelemetry://reference/edot-cloud-forwarder
+          children:
+          - toc: edot-cloud-forwarder-aws://reference/edot-cf-aws
+          - toc: edot-cloud-forwarder-azure://reference/edot-cf-azure
+          - toc: opentelemetry://reference/edot-cloud-forwarder/gcp
+      - toc: elastic-agent://reference/edot-collector
+      - toc: apm-agent-android://reference/edot-android
+      - toc: elastic-otel-dotnet://reference/edot-dotnet
+      - toc: apm-agent-ios://reference/edot-ios
+      - toc: elastic-otel-java://reference/edot-java
+      - toc: elastic-otel-node://reference/edot-node
+      - toc: elastic-otel-php://reference/edot-php
+      - toc: elastic-otel-python://reference/edot-python
+      - toc: elastic-otel-rum-js://reference/edot-browser
+    - group: ECS Logging
+      children:
+      - toc: ecs-logging://reference
+        children:
+        - toc: ecs-dotnet://reference
+        - toc: ecs-logging-go-logrus://reference
+        - toc: ecs-logging-go-zap://reference
+        - toc: ecs-logging-go-zerolog://reference
+        - toc: ecs-logging-java://reference
+        - toc: ecs-logging-nodejs://reference
+        - toc: ecs-logging-php://reference
+        - toc: ecs-logging-python://reference
+        - toc: ecs-logging-ruby://reference
+    - toc: beats://reference
+    - toc: logstash://reference
+    - toc: integration-docs://reference
+    - toc: elasticsearch-hadoop://reference
+    - toc: elastic-serverless-forwarder://reference
+    - toc: ecs://reference
+    - toc: search-ui://reference
+    - toc: elasticsearch://reference/aggregations
+    - toc: ecctl://reference
+    - toc: elasticsearch://reference/enrich-processor
+    - toc: elasticsearch://reference/query-languages
+    - toc: elasticsearch://reference/scripting-languages
+    - page: docs-content://explore-analyze/numeral-formatting.md
+      title: Numeral formatting
+    - toc: elasticsearch://reference/text-analysis
     - island: Logstash plugins
       toc: logstash-docs-md://lsr
     - island: Logstash versioned plugins
@@ -3311,6 +4066,69 @@ nav:
     url: /release-notes/
     children:
     - toc: docs-content://release-notes/intro
+      children:
+        # Elasticsearch
+        - toc: elasticsearch://release-notes
+          children:
+            # Elasticsearch Clients
+            - toc: elasticsearch-java://release-notes
+            - toc: elasticsearch-js://release-notes
+            - toc: elasticsearch-net://release-notes
+            - toc: elasticsearch-php://release-notes
+            - toc: elasticsearch-py://release-notes
+            - toc: elasticsearch-ruby://release-notes
+            # Elasticsearch Hadoop
+            - toc: elasticsearch-hadoop://release-notes
+        # Kibana
+        - toc: kibana://release-notes
+        # Elastic Agent
+        - toc: elastic-agent://release-notes
+        # Fleet Server
+        - toc: fleet-server://release-notes
+        # Logstash
+        - toc: logstash://release-notes
+        # Beats
+        - toc: beats://release-notes
+        # Serverless
+        - toc: docs-content://release-notes/elastic-cloud-serverless
+        # Cloud Hosted
+        - toc: cloud://release-notes/cloud-hosted
+        # Cloud Enterprise
+        - toc: cloud://release-notes/cloud-enterprise
+        # Cloud on Kubernetes
+        - toc: cloud-on-k8s://release-notes
+        # Observability
+        - toc: docs-content://release-notes/elastic-observability
+          children:
+            # EDOT SDKs
+            - toc: apm-agent-android://release-notes
+            - toc: edot-cloud-forwarder-aws://release-notes
+            - toc: apm-agent-ios://release-notes
+            - toc: elastic-otel-java://release-notes
+            - toc: elastic-otel-dotnet://release-notes
+            - toc: elastic-otel-node://release-notes
+            - toc: elastic-otel-python://release-notes
+            - toc: elastic-otel-php://release-notes
+            - toc: elastic-otel-rum-js://release-notes
+            # APM
+            - toc: apm-server://release-notes
+            # APM agents
+            - toc: apm-agent-dotnet://release-notes
+            - toc: apm-agent-go://release-notes
+            - toc: apm-agent-java://release-notes
+            - toc: apm-agent-nodejs://release-notes
+            - toc: apm-agent-php://release-notes
+            - toc: apm-agent-python://release-notes
+            - toc: apm-agent-ruby://release-notes
+            - toc: apm-agent-rum-js://release-notes
+            # APM AWS Lambda Extension
+            - toc: apm-aws-lambda://release-notes
+        # Security
+        - toc: docs-content://release-notes/elastic-security
+        # ECS
+        - toc: ecs://release-notes
+        # ECCTL
+        - toc: ecctl://release-notes
 
   - section: Troubleshoot
     url: /troubleshoot/

--- a/config/navigation-v2.yml
+++ b/config/navigation-v2.yml
@@ -205,8 +205,6 @@ nav:
             children:
             - page: docs-content://deploy-manage/deploy/cloud-enterprise/ece-architecture.md
               title: Service-oriented architecture
-            - page: docs-content://deploy-manage/deploy/cloud-enterprise/deploy-an-orchestrator.md
-              title: Deploy an orchestrator
             - group: Prepare your environment
               page: docs-content://deploy-manage/deploy/cloud-enterprise/prepare-environment.md
               children:
@@ -288,10 +286,8 @@ nav:
             page: docs-content://deploy-manage/deploy/cloud-on-k8s.md
             children:
             - group: Deploy an orchestrator
-              page: docs-content://deploy-manage/deploy/cloud-on-k8s/deploy-an-orchestrator.md
+              page: docs-content://deploy-manage/deploy/cloud-on-k8s/install.md
               children:
-              - page: docs-content://deploy-manage/deploy/cloud-on-k8s/install.md
-                title: Install ECK
               - page: docs-content://deploy-manage/deploy/cloud-on-k8s/install-using-yaml-manifest-quickstart.md
                 title: YAML manifests
               - page: docs-content://deploy-manage/deploy/cloud-on-k8s/install-using-helm-chart.md
@@ -767,17 +763,23 @@ nav:
             page: docs-content://deploy-manage/security.md
             children:
             - page: docs-content://deploy-manage/security/secure-hosting-environment.md
+              title: "Secure your orchestrator"
               children:
               - page: docs-content://deploy-manage/security/secure-your-elastic-cloud-enterprise-installation.md
-                title: "{{ece}}"
+                title: "Elastic Cloud Enterprise"
                 children:
                 - page: docs-content://deploy-manage/security/secure-your-elastic-cloud-enterprise-installation/manage-security-certificates.md
+                  title: "Manage security certificates"
                 - page: docs-content://deploy-manage/security/secure-your-elastic-cloud-enterprise-installation/allow-x509-certificates-signed-with-sha-1.md
+                  title: "Allow X.509 certificates signed with SHA-1"
                 - page: docs-content://deploy-manage/security/secure-your-elastic-cloud-enterprise-installation/configure-tls-version.md
+                  title: "Configure the TLS version"
                 - page: docs-content://deploy-manage/security/secure-your-elastic-cloud-enterprise-installation/migrate-ece-on-podman-hosts-to-selinux-enforce.md
+                  title: "Migrate ECE on Podman hosts to SELinux enforce"
               - page: docs-content://deploy-manage/security/secure-your-eck-installation.md
-                title: "{{eck}}"
+                title: "Elastic Cloud on Kubernetes"
             - page: docs-content://deploy-manage/security/secure-your-cluster-deployment.md
+              title: "Secure your cluster, deployment, or project"
               children:
               - page: docs-content://deploy-manage/security/self-setup.md
                 title: "Self-managed security setup"
@@ -791,6 +793,7 @@ nav:
                 - page: docs-content://deploy-manage/security/set-up-basic-security-plus-https.md
                   title: "Set up HTTPS"
                 - page: docs-content://deploy-manage/security/using-kibana-with-security.md
+                  title: "Configure security in Kibana"
               - page: docs-content://deploy-manage/security/secure-cluster-communications.md
                 title: "Manage TLS encryption"
                 children:
@@ -807,12 +810,18 @@ nav:
                   - page: docs-content://deploy-manage/security/kibana-es-mutual-tls.md
                     title: "Mutual authentication"
                   - page: docs-content://deploy-manage/security/supported-ssltls-versions-by-jdk-version.md
+                    title: "Supported SSL/TLS versions by JDK version"
                   - page: docs-content://deploy-manage/security/enabling-cipher-suites-for-stronger-encryption.md
+                    title: "Enabling cipher suites for stronger encryption"
                 - page: docs-content://deploy-manage/security/eck-tls.md
                   title: "ECK"
                   children:
                   - page: docs-content://deploy-manage/security/k8s-https-settings.md
+                    title: "Manage HTTP certificates on ECK"
                   - page: docs-content://deploy-manage/security/k8s-transport-settings.md
+                    title: Manage transport certificates on ECK
+                  - page: docs-content://deploy-manage/security/k8s-es-client-certificate-auth.md
+                    title: "Client certificate authentication"
                 - page: docs-content://deploy-manage/security/external-ca-transport.md
                   title: "External CA for TLS"
               - page: docs-content://deploy-manage/security/network-security.md
@@ -834,6 +843,7 @@ nav:
                 - page: docs-content://deploy-manage/security/remote-cluster-filtering.md
                   title: "Remote cluster filters"
                 - page: docs-content://deploy-manage/security/private-connectivity.md
+                  title: "Private connectivity"
                   children:
                   - page: docs-content://deploy-manage/security/private-connectivity-aws.md
                     title: "AWS PrivateLink"
@@ -842,39 +852,58 @@ nav:
                   - page: docs-content://deploy-manage/security/private-connectivity-gcp.md
                     title: "GCP Private Service Connect"
                   - page: docs-content://deploy-manage/security/claim-private-connection-api.md
+                    title: "Claim private connection ownership"
                 - page: docs-content://deploy-manage/security/network-security-api.md
                   title: "Through the API"
                 - page: docs-content://deploy-manage/security/k8s-network-policies.md
+                  title: "Kubernetes network policies"
               - page: docs-content://deploy-manage/security/elastic-cloud-static-ips.md
+                title: "Elastic Cloud static IPs"
               - page: docs-content://deploy-manage/security/kibana-session-management.md
+                title: "Kibana session management"
               - page: docs-content://deploy-manage/security/data-security.md
+                title: "Encrypt your deployment data"
                 children:
                 - page: docs-content://deploy-manage/security/encrypt-deployment-with-customer-managed-encryption-key.md
+                  title: "Use a customer-managed encryption key"
               - page: docs-content://deploy-manage/security/secure-settings.md
+                title: "Secure your settings"
                 children:
                 - page: docs-content://deploy-manage/security/k8s-secure-settings.md
+                  title: "Secure settings on ECK"
               - page: docs-content://deploy-manage/security/secure-saved-objects.md
+                title: "Secure Kibana saved objects"
               - page: docs-content://deploy-manage/security/logging-configuration/security-event-audit-logging.md
+                title: "Security event audit logging"
                 children:
                 - page: docs-content://deploy-manage/security/logging-configuration/enabling-audit-logs.md
+                  title: "Enable audit logging"
                 - page: docs-content://deploy-manage/security/logging-configuration/configuring-audit-logs.md
+                  title: Configure audit logging
                   children:
                   - page: docs-content://deploy-manage/security/logging-configuration/logfile-audit-events-ignore-policies.md
                     title: "Elasticsearch audit events ignore policies"
                   - page: docs-content://deploy-manage/security/logging-configuration/logfile-audit-output.md
                     title: "Elasticsearch logfile output"
                 - page: docs-content://deploy-manage/security/logging-configuration/auditing-search-queries.md
+                  title: Audit Elasticsearch search queries
                 - page: docs-content://deploy-manage/security/logging-configuration/correlating-kibana-elasticsearch-audit-logs.md
                   title: "Correlate audit events"
             - page: docs-content://deploy-manage/security/secure-clients-integrations.md
+              title: Secure other Elastic Stack components
             - page: docs-content://deploy-manage/security/httprest-clients-security.md
+              title: Securing HTTP client applications
             - page: docs-content://deploy-manage/security/limitations.md
               title: "Limitations"
             - page: docs-content://deploy-manage/security/fips.md
+              title: FIPS compliance
               children:
               - page: docs-content://deploy-manage/security/fips-es.md
+                title: FIPS compliance for Elasticsearch
               - page: docs-content://deploy-manage/security/fips-kib.md
+                title: FIPS compliance for Kibana
               - page: docs-content://deploy-manage/security/fips-ingest.md
+                title: FIPS mode for Ingest tools
           - group: Authentication and authorization
             page: docs-content://deploy-manage/users-roles.md
             children:
@@ -882,7 +911,9 @@ nav:
               title: "Cloud organization"
               children:
               - page: docs-content://deploy-manage/users-roles/cloud-organization/manage-users.md
+                title: Manage users
               - page: docs-content://deploy-manage/users-roles/cloud-organization/user-roles.md
+                title: User roles and privileges
               - page: docs-content://deploy-manage/users-roles/cloud-organization/configure-saml-authentication.md
                 title: "Configure SAML SSO"
                 children:
@@ -894,32 +925,46 @@ nav:
               title: "ECE orchestrator"
               children:
               - page: docs-content://deploy-manage/users-roles/cloud-enterprise-orchestrator/manage-system-passwords.md
+                title: Manage system passwords
               - page: docs-content://deploy-manage/users-roles/cloud-enterprise-orchestrator/manage-users-roles.md
+                title: Manage users and roles
                 children:
                 - page: docs-content://deploy-manage/users-roles/cloud-enterprise-orchestrator/native-user-authentication.md
+                  title: Native users
                 - page: docs-content://deploy-manage/users-roles/cloud-enterprise-orchestrator/active-directory.md
+                  title: Active Directory
                 - page: docs-content://deploy-manage/users-roles/cloud-enterprise-orchestrator/ldap.md
+                  title: LDAP
                 - page: docs-content://deploy-manage/users-roles/cloud-enterprise-orchestrator/saml.md
+                  title: SAML
               - page: docs-content://deploy-manage/users-roles/cloud-enterprise-orchestrator/configure-sso-for-deployments.md
+                title: Configure SSO for deployments
             - page: docs-content://deploy-manage/users-roles/serverless-custom-roles.md
+              title: Serverless project custom roles
             - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth.md
               title: "Cluster or deployment"
               children:
               - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/quickstart.md
                 title: "Quickstart"
               - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/user-authentication.md
+                title: User authentication
                 children:
                 - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/authentication-realms.md
+                  title: Authentication realms
                   children:
                   - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/realm-chains.md
+                    title: Realm chains
                   - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/security-domains.md
+                    title: Security domains
                 - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/internal-authentication.md
+                  title: Internal authentication
                   children:
                   - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/native.md
                     title: "Native"
                   - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/file-based.md
                     title: "File-based"
                 - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/external-authentication.md
+                  title: External authentication
                   children:
                   - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/active-directory.md
                     title: "Active Directory"
@@ -940,7 +985,9 @@ nav:
                     - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/saml-entra.md
                       title: "With Microsoft Entra ID"
                   - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/pki.md
+                    title: PKI
                   - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/custom.md
+                    title: Custom realms
                 - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/built-in-users.md
                   title: "Built-in users"
                   children:
@@ -954,39 +1001,59 @@ nav:
                   - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/managed-credentials-eck.md
                     title: "ECK managed credentials"
                 - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/kibana-authentication.md
-                  title: "{{kib}} authentication"
+                  title: "Kibana authentication"
                 - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/access-agreement.md
+                  title: Kibana access agreement
                 - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/anonymous-access.md
+                  title: Anonymous access
                 - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/token-based-authentication-services.md
+                  title: Token-based authentication services
                 - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/service-accounts.md
+                  title: Service accounts
                 - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/internal-users.md
+                  title: Internal users
                 - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/operator-privileges.md
+                  title: Operator privileges
                   children:
                   - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/configure-operator-privileges.md
+                    title: Configure operator privileges
                   - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/operator-only-functionality.md
+                    title: Operator-only functionality
                   - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/operator-privileges-for-snapshot-restore.md
+                    title: Operator privileges for snapshot and restore
                 - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/user-profiles.md
+                  title: User profiles
                 - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/looking-up-users-without-authentication.md
+                  title: Looking up users without authentication
                 - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/controlling-user-cache.md
+                  title: Controlling the user cache
                 - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/manage-authentication-for-multiple-clusters.md
+                  title: Manage authentication for multiple clusters
               - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/user-roles.md
+                title: User roles
                 children:
                 - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/defining-roles.md
+                  title: Defining roles
                   children:
                   - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/role-structure.md
+                    title: Role structure
                   - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/granting-privileges-for-data-streams-aliases.md
                     title: "For data streams and aliases"
                   - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/kibana-role-management.md
                     title: "Using Kibana"
                   - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/role-restriction.md
+                    title: Role restriction
                 - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/kibana-privileges.md
+                  title: Kibana privileges
                 - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/mapping-users-groups-to-roles.md
                   title: "Map users and groups to roles"
                   children:
                   - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/role-mapping-resources.md
                     title: "Role mapping properties"
                 - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/authorization-delegation.md
+                  title: Authorization delegation
                 - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/authorization-plugins.md
+                  title: Authorization plugins
                 - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/controlling-access-at-document-field-level.md
                   title: "Control access at the document and field level"
                 - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/submitting-requests-on-behalf-of-other-users.md
@@ -995,20 +1062,25 @@ nav:
             page: docs-content://deploy-manage/api-keys.md
             children:
             - page: docs-content://deploy-manage/api-keys/elasticsearch-api-keys.md
+              title: Elasticsearch API keys
             - page: docs-content://deploy-manage/api-keys/serverless-project-api-keys.md
+              title: Serverless project API keys
             - page: docs-content://deploy-manage/api-keys/elastic-cloud-api-keys.md
+              title: Elastic Cloud API keys
             - page: docs-content://deploy-manage/api-keys/elastic-cloud-enterprise-api-keys.md
+              title: Elastic Cloud Enterprise API keys
           - group: Spaces
             page: docs-content://deploy-manage/manage-spaces.md
           - group: Monitoring
             page: docs-content://deploy-manage/monitor.md
             children:
             - page: docs-content://deploy-manage/monitor/autoops.md
+              title: AutoOps
               children:
               - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-how-to-access.md
-                title: "For {{ech}}"
+                title: "For Elastic Cloud Hosted"
               - page: docs-content://deploy-manage/monitor/autoops/autoops-for-serverless.md
-                title: "For {{serverless-full}}"
+                title: "For Elastic Cloud Serverless"
                 children:
                 - page: docs-content://deploy-manage/monitor/autoops/access-autoops-for-serverless.md
                   title: "Access AutoOps in your project"
@@ -1037,7 +1109,7 @@ nav:
                   - page: docs-content://deploy-manage/monitor/autoops/autoops-connectivity-check.md
                     title: "Run the Connectivity Check"
                   - page: docs-content://deploy-manage/monitor/autoops/autoops-sm-troubleshoot-firewalls.md
-                    title: "Firewalls blocking {{agent}}"
+                    title: "Firewalls blocking Elastic Agent"
                   - page: docs-content://deploy-manage/monitor/autoops/autoops-sm-troubleshoot-eck-no-clusters.md
                     title: "Connected clusters not appearing with ECK"
               - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-regions.md
@@ -1061,89 +1133,129 @@ nav:
                 title: "Events"
                 children:
                 - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-event-settings.md
+                  title: Event Settings
                 - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-notifications-settings.md
+                  title: Notifications Settings
               - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-faq.md
                 title: "FAQ"
             - page: docs-content://deploy-manage/monitor/stack-monitoring.md
+              title: Stack monitoring
               children:
               - page: docs-content://deploy-manage/monitor/stack-monitoring/ece-ech-stack-monitoring.md
                 title: "Enable on ECH and ECE"
               - page: docs-content://deploy-manage/monitor/stack-monitoring/eck-stack-monitoring.md
                 title: "Enable on ECK"
               - page: docs-content://deploy-manage/monitor/stack-monitoring/elasticsearch-monitoring-self-managed.md
-                title: "Self-managed: {{es}}"
+                title: "Self-managed: Elasticsearch"
                 children:
                 - page: docs-content://deploy-manage/monitor/stack-monitoring/collecting-monitoring-data-with-elastic-agent.md
-                  title: "Collecting monitoring data with {{agent}}"
+                  title: "Collecting monitoring data with Elastic Agent"
                 - page: docs-content://deploy-manage/monitor/stack-monitoring/collecting-monitoring-data-with-metricbeat.md
-                  title: "Collecting monitoring data with {{metricbeat}}"
+                  title: "Collecting monitoring data with Metricbeat"
                 - page: docs-content://deploy-manage/monitor/stack-monitoring/collecting-log-data-with-filebeat.md
-                  title: "Collecting log data with {{filebeat}}"
+                  title: "Collecting log data with Filebeat"
                 - page: docs-content://deploy-manage/monitor/stack-monitoring/es-self-monitoring-prod.md
+                  title: Monitoring in a production environment
                 - page: docs-content://deploy-manage/monitor/stack-monitoring/es-legacy-collection-methods.md
                   title: "Legacy collection methods"
                   children:
                   - page: docs-content://deploy-manage/monitor/stack-monitoring/es-monitoring-collectors.md
+                    title: Collectors
                   - page: docs-content://deploy-manage/monitor/stack-monitoring/es-monitoring-exporters.md
+                    title: Exporters
                   - page: docs-content://deploy-manage/monitor/stack-monitoring/es-local-exporter.md
+                    title: Local exporters
                   - page: docs-content://deploy-manage/monitor/stack-monitoring/es-http-exporter.md
+                    title: HTTP exporters
                   - page: docs-content://deploy-manage/monitor/stack-monitoring/es-pause-export.md
+                    title: Pausing data collection
               - page: docs-content://deploy-manage/monitor/stack-monitoring/kibana-monitoring-self-managed.md
-                title: "Self-managed: {{kib}}"
+                title: "Self-managed: Kibana"
                 children:
                 - page: docs-content://deploy-manage/monitor/stack-monitoring/kibana-monitoring-elastic-agent.md
-                  title: "Collect monitoring data with {{agent}}"
+                  title: "Collect monitoring data with Elastic Agent"
                 - page: docs-content://deploy-manage/monitor/stack-monitoring/kibana-monitoring-metricbeat.md
-                  title: "Collect monitoring data with {{metricbeat}}"
+                  title: "Collect monitoring data with Metricbeat"
                 - page: docs-content://deploy-manage/monitor/stack-monitoring/kibana-monitoring-legacy.md
                   title: "Legacy collection methods"
               - page: docs-content://deploy-manage/monitor/stack-monitoring/kibana-monitoring-data.md
+                title: Access monitoring data in Kibana
               - page: docs-content://deploy-manage/monitor/monitoring-data/visualizing-monitoring-data.md
+                title: Visualizing monitoring data
                 children:
                 - page: docs-content://deploy-manage/monitor/monitoring-data/beats-page.md
+                  title: Beats metrics
                 - page: docs-content://deploy-manage/monitor/monitoring-data/elasticsearch-metrics.md
+                  title: Elasticsearch metrics
                 - page: docs-content://deploy-manage/monitor/monitoring-data/kibana-page.md
+                  title: Kibana metrics
                 - page: docs-content://deploy-manage/monitor/monitoring-data/integrations-server-page.md
+                  title: Integrations Server metrics
                 - page: docs-content://deploy-manage/monitor/monitoring-data/logstash-page.md
+                  title: Logstash metrics
                 - page: docs-content://deploy-manage/monitor/monitoring-data/monitor-troubleshooting.md
                   title: "Troubleshooting"
               - page: docs-content://deploy-manage/monitor/monitoring-data/configure-stack-monitoring-alerts.md
+                title: Stack monitoring alerts
               - page: docs-content://deploy-manage/monitor/monitoring-data/configuring-data-streamsindices-for-monitoring.md
+                title: Configuring monitoring data streams and indices
                 children:
                 - page: docs-content://deploy-manage/monitor/monitoring-data/config-monitoring-data-streams-elastic-agent.md
+                  title: Configuring data streams created by Elastic Agent
                 - page: docs-content://deploy-manage/monitor/monitoring-data/config-monitoring-data-streams-metricbeat-8.md
+                  title: Configuring data streams created by Metricbeat 8
                 - page: docs-content://deploy-manage/monitor/monitoring-data/config-monitoring-indices-metricbeat-7-internal-collection.md
+                  title: Configuring indices created by Metricbeat 7 or internal collection
             - page: docs-content://deploy-manage/monitor/autoops-vs-stack-monitoring.md
               title: "AutoOps vs. Stack Monitoring"
             - page: docs-content://deploy-manage/monitor/cloud-health-perf.md
               title: "Cloud deployment health"
               children:
               - page: docs-content://deploy-manage/monitor/access-performance-metrics-on-elastic-cloud.md
+                title: Performance metrics on Elastic Cloud
               - page: docs-content://deploy-manage/monitor/ec-memory-pressure.md
+                title: JVM memory pressure indicator
             - page: docs-content://deploy-manage/monitor/kibana-task-manager-health-monitoring.md
-              title: "{{kib}} task manager monitoring"
+              title: "Kibana task manager monitoring"
             - page: docs-content://deploy-manage/monitor/orchestrators.md
+              title: Monitoring orchestrators
               children:
               - page: docs-content://deploy-manage/monitor/orchestrators/eck-metrics-configuration.md
+                title: ECK operator metrics
                 children:
                 - page: docs-content://deploy-manage/monitor/orchestrators/k8s-enabling-metrics-endpoint.md
+                  title: Enabling the metrics endpoint
                 - page: docs-content://deploy-manage/monitor/orchestrators/k8s-securing-metrics-endpoint.md
+                  title: Securing the metrics endpoint
                 - page: docs-content://deploy-manage/monitor/orchestrators/k8s-prometheus-requirements.md
+                  title: Prometheus requirements
               - page: docs-content://deploy-manage/monitor/orchestrators/ece-platform-monitoring.md
+                title: ECE platform monitoring
                 children:
                 - page: docs-content://deploy-manage/monitor/orchestrators/ece-monitoring-ece-access.md
+                  title: Platform monitoring deployment logs and metrics
                 - page: docs-content://deploy-manage/monitor/orchestrators/ece-proxy-log-fields.md
+                  title: Proxy log fields
                 - page: docs-content://deploy-manage/monitor/orchestrators/ece-monitoring-ece-set-retention.md
+                  title: Set the retention period for logging and metrics indices
             - page: docs-content://deploy-manage/monitor/logging-configuration.md
+              title: Logging
               children:
               - page: docs-content://deploy-manage/monitor/logging-configuration/elasticsearch-log4j-configuration-self-managed.md
+                title: Elasticsearch log4j configuration
               - page: docs-content://deploy-manage/monitor/logging-configuration/update-elasticsearch-logging-levels.md
+                title: Update Elasticsearch logging levels
               - page: docs-content://deploy-manage/monitor/logging-configuration/elasticsearch-deprecation-logs.md
+                title: Elasticsearch deprecation logs
               - page: docs-content://deploy-manage/monitor/logging-configuration/slow-logs.md
+                title: Slow query and index logging
               - page: docs-content://deploy-manage/monitor/logging-configuration/kibana-logging.md
+                title: Kibana logging
                 children:
                 - page: docs-content://deploy-manage/monitor/logging-configuration/kibana-log-levels.md
+                  title: Set global log levels for Kibana
                 - page: docs-content://deploy-manage/monitor/logging-configuration/kib-advanced-logging.md
+                  title: Advanced Kibana logging settings
                   children:
                   - page: docs-content://deploy-manage/monitor/logging-configuration/kibana-log-settings-examples.md
                     title: "Examples"
@@ -1153,20 +1265,28 @@ nav:
             page: docs-content://deploy-manage/tools.md
             children:
             - page: docs-content://deploy-manage/tools/snapshot-and-restore.md
+              title: Snapshot and restore
               children:
               - page: docs-content://deploy-manage/tools/snapshot-and-restore/manage-snapshot-repositories.md
+                title: Manage snapshot repositories
                 children:
                 - page: docs-content://deploy-manage/tools/snapshot-and-restore/self-managed.md
                   title: "Self-managed"
                   children:
                   - page: docs-content://deploy-manage/tools/snapshot-and-restore/azure-repository.md
+                    title: Azure repository
                   - page: docs-content://deploy-manage/tools/snapshot-and-restore/google-cloud-storage-repository.md
+                    title: Google Cloud Storage repository
                   - page: docs-content://deploy-manage/tools/snapshot-and-restore/s3-repository.md
+                    title: S3 repository
                   - page: docs-content://deploy-manage/tools/snapshot-and-restore/shared-file-system-repository.md
+                    title: Shared file system repository
                   - page: docs-content://deploy-manage/tools/snapshot-and-restore/read-only-url-repository.md
+                    title: Read-only URL repository
                   - page: docs-content://deploy-manage/tools/snapshot-and-restore/source-only-repository.md
+                    title: Source-only repository
                 - page: docs-content://deploy-manage/tools/snapshot-and-restore/elastic-cloud-hosted.md
-                  title: "{{ech}}"
+                  title: "Elastic Cloud Hosted"
                   children:
                   - page: docs-content://deploy-manage/tools/snapshot-and-restore/ec-aws-custom-repository.md
                     title: "AWS S3"
@@ -1175,32 +1295,43 @@ nav:
                   - page: docs-content://deploy-manage/tools/snapshot-and-restore/ec-azure-snapshotting.md
                     title: "Azure Blob Storage"
                   - page: docs-content://deploy-manage/tools/snapshot-and-restore/access-isolation-for-found-snapshots-repository.md
+                    title: Access isolation for the found-snapshots repository
                     children:
                     - page: docs-content://deploy-manage/tools/snapshot-and-restore/repository-isolation-on-azure.md
                       title: "Azure"
                     - page: docs-content://deploy-manage/tools/snapshot-and-restore/repository-isolation-on-aws-gcp.md
                       title: "AWS and GCP"
                 - page: docs-content://deploy-manage/tools/snapshot-and-restore/cloud-enterprise.md
-                  title: "{{ece}}"
+                  title: "Elastic Cloud Enterprise"
                   children:
                   - page: docs-content://deploy-manage/tools/snapshot-and-restore/ece-aws-custom-repository.md
                     title: "AWS S3"
                   - page: docs-content://deploy-manage/tools/snapshot-and-restore/google-cloud-storage-gcs-repository.md
                     title: "Google Cloud Storage"
                   - page: docs-content://deploy-manage/tools/snapshot-and-restore/azure-storage-repository.md
+                    title: Azure Storage repository
                   - page: docs-content://deploy-manage/tools/snapshot-and-restore/minio-on-premise-repository.md
+                    title: MinIO self-managed repository
                 - page: docs-content://deploy-manage/tools/snapshot-and-restore/cloud-on-k8s.md
-                  title: "{{eck}}"
+                  title: "Elastic Cloud on Kubernetes"
               - page: docs-content://deploy-manage/tools/snapshot-and-restore/create-snapshots.md
+                title: Create, monitor and delete snapshots
               - page: docs-content://deploy-manage/tools/snapshot-and-restore/restore-snapshot.md
+                title: Restore a snapshot
                 children:
                 - page: docs-content://deploy-manage/tools/snapshot-and-restore/ece-restore-across-clusters.md
+                  title: Restore a snapshot across clusters
                   children:
                   - page: docs-content://deploy-manage/tools/snapshot-and-restore/ece-restore-snapshots-into-new-deployment.md
+                    title: Restore snapshot into a new deployment
                   - page: docs-content://deploy-manage/tools/snapshot-and-restore/ece-restore-snapshots-into-existing-deployment.md
+                    title: Restore snapshot into an existing deployment
                   - page: docs-content://deploy-manage/tools/snapshot-and-restore/ece-restore-snapshots-containing-searchable-snapshots-indices-across-clusters.md
+                    title: Restore snapshots containing searchable snapshots indices across clusters
               - page: docs-content://deploy-manage/tools/snapshot-and-restore/searchable-snapshots.md
+                title: Searchable snapshots
             - page: docs-content://deploy-manage/tools/cross-cluster-replication.md
+              title: Cross-cluster replication
               children:
               - page: docs-content://deploy-manage/tools/cross-cluster-replication/set-up-cross-cluster-replication.md
                 title: "Set up cross-cluster replication"
@@ -1208,26 +1339,42 @@ nav:
                 - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-getting-started-prerequisites.md
                   title: "Prerequisites"
                 - page: docs-content://deploy-manage/tools/cross-cluster-replication/_connect_to_a_remote_cluster.md
+                  title: Connect to a remote cluster
                 - page: docs-content://deploy-manage/tools/cross-cluster-replication/_configure_privileges_for_cross_cluster_replication_2.md
+                  title: Configure privileges for cross-cluster replication
                 - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-getting-started-follower-index.md
+                  title: Create a follower index to replicate a specific index
                 - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-getting-started-auto-follow.md
+                  title: Create an auto-follow pattern to replicate time series indices
               - page: docs-content://deploy-manage/tools/cross-cluster-replication/manage-cross-cluster-replication.md
+                title: Manage cross-cluster replication
                 children:
                 - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-inspect-progress.md
+                  title: Inspect replication statistics
                 - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-pause-replication.md
+                  title: Pause and resume replication
                 - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-recreate-follower-index.md
+                  title: Recreate a follower index
                 - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-terminate-replication.md
+                  title: Terminate replication
               - page: docs-content://deploy-manage/tools/cross-cluster-replication/manage-auto-follow-patterns.md
+                title: Manage auto-follow patterns
                 children:
                 - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-auto-follow-create.md
+                  title: Create auto-follow patterns
                 - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-auto-follow-retrieve.md
+                  title: Retrieve auto-follow patterns
                 - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-auto-follow-pause.md
+                  title: Pause and resume auto-follow patterns
                 - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-auto-follow-delete.md
+                  title: Delete auto-follow patterns
               - page: docs-content://deploy-manage/tools/cross-cluster-replication/upgrading-clusters.md
                 title: "Upgrading clusters"
                 children:
                 - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-uni-directional-upgrade.md
+                  title: Uni-directional index following
                 - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-bi-directional-upgrade.md
+                  title: Bi-directional index following
               - page: docs-content://deploy-manage/tools/cross-cluster-replication/uni-directional-disaster-recovery.md
                 title: "Uni-directional disaster recovery"
                 children:
@@ -1241,11 +1388,13 @@ nav:
                 title: "Bi-directional disaster recovery"
                 children:
                 - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-tutorial-initial-setup.md
+                  title: Initial setup
                 - page: docs-content://deploy-manage/tools/cross-cluster-replication/_failover_when_clustera_is_down_2.md
                   title: "Failover when clusterA is down"
                 - page: docs-content://deploy-manage/tools/cross-cluster-replication/_failback_when_clustera_comes_back_2.md
                   title: "Failback when clusterA comes back"
                 - page: docs-content://deploy-manage/tools/cross-cluster-replication/_perform_update_or_delete_by_query.md
+                  title: Perform update or delete by query
           - group: Autoscaling
             page: docs-content://deploy-manage/autoscaling.md
             children:
@@ -1254,7 +1403,9 @@ nav:
             - page: docs-content://deploy-manage/autoscaling/autoscaling-in-eck.md
               title: "In ECK"
             - page: docs-content://deploy-manage/autoscaling/autoscaling-deciders.md
+              title: Autoscaling deciders
             - page: docs-content://deploy-manage/autoscaling/trained-model-autoscaling.md
+              title: Trained model autoscaling
           - page: docs-content://deploy-manage/stack-settings.md
             title: Stack settings
           - page: docs-content://deploy-manage/manage-connectors.md
@@ -1270,15 +1421,15 @@ nav:
               title: "On Elastic Cloud Hosted"
               children:
               - page: docs-content://deploy-manage/remote-clusters/ec-remote-cluster-same-ess.md
-                title: "To the same {{ecloud}} organization"
+                title: "To the same Elastic Cloud organization"
               - page: docs-content://deploy-manage/remote-clusters/ec-remote-cluster-other-ess.md
-                title: "To a different {{ecloud}} organization"
+                title: "To a different Elastic Cloud organization"
               - page: docs-content://deploy-manage/remote-clusters/ec-remote-cluster-ece.md
-                title: "To {{ece}}"
+                title: "To Elastic Cloud Enterprise"
               - page: docs-content://deploy-manage/remote-clusters/ec-remote-cluster-self-managed.md
                 title: "To a self-managed cluster"
               - page: docs-content://deploy-manage/remote-clusters/ec-enable-ccs-for-eck.md
-                title: "To {{eck}}"
+                title: "To Elastic Cloud on Kubernetes"
               - page: docs-content://deploy-manage/remote-clusters/ec-remote-cluster-strong-identity.md
                 title: "Strong identity verification"
               - page: docs-content://deploy-manage/remote-clusters/ec-edit-remove-trusted-environment.md
@@ -1293,22 +1444,24 @@ nav:
               - page: docs-content://deploy-manage/remote-clusters/ece-remote-cluster-other-ece.md
                 title: "To a different ECE environment"
               - page: docs-content://deploy-manage/remote-clusters/ece-remote-cluster-ece-ess.md
-                title: "To {{ecloud}}"
+                title: "To Elastic Cloud"
               - page: docs-content://deploy-manage/remote-clusters/ece-remote-cluster-self-managed.md
                 title: "To a self-managed cluster"
               - page: docs-content://deploy-manage/remote-clusters/ece-enable-ccs-for-eck.md
-                title: "To {{eck}}"
+                title: "To Elastic Cloud on Kubernetes"
               - page: docs-content://deploy-manage/remote-clusters/ece-edit-remove-trusted-environment.md
                 title: "Manage trusted environments"
               - page: docs-content://deploy-manage/remote-clusters/ece-migrate-ccs.md
                 title: "Migrate from the CCS deployment template"
             - page: docs-content://deploy-manage/remote-clusters/remote-clusters-self-managed.md
-              title: "On self-managed {{stack}}"
+              title: "On self-managed Elastic Stack"
               children:
               - page: docs-content://deploy-manage/remote-clusters/remote-clusters-api-key.md
+                title: Add remote clusters using API key authentication
               - page: docs-content://deploy-manage/remote-clusters/remote-clusters-cert.md
+                title: Add remote clusters using TLS certificate authentication
               - page: docs-content://deploy-manage/remote-clusters/self-remote-cluster-eck.md
-                title: "To {{eck}}"
+                title: "To Elastic Cloud on Kubernetes"
               - page: docs-content://deploy-manage/remote-clusters/remote-clusters-migrate.md
                 title: "Migrate from certificate to API key authentication"
             - page: docs-content://deploy-manage/remote-clusters/eck-remote-clusters-landing.md
@@ -1334,52 +1487,76 @@ nav:
             page: docs-content://deploy-manage/maintenance.md
             children:
             - page: docs-content://deploy-manage/maintenance/ece.md
+              title: ECE maintenance
               children:
               - page: docs-content://deploy-manage/maintenance/ece/deployments-maintenance.md
+                title: Deployments maintenance
                 children:
                 - page: docs-content://deploy-manage/maintenance/ece/pause-instance.md
+                  title: Pause instance
               - page: docs-content://deploy-manage/maintenance/ece/maintenance-activities.md
+                title: Maintenance activities
                 children:
                 - page: docs-content://deploy-manage/maintenance/ece/enable-maintenance-mode.md
+                  title: Enable maintenance mode
                 - page: docs-content://deploy-manage/maintenance/ece/scale-out-installation.md
+                  title: Scale out your installation
                 - page: docs-content://deploy-manage/maintenance/ece/move-nodes-instances-from-allocators.md
+                  title: Move nodes or instances from allocators
                 - page: docs-content://deploy-manage/maintenance/ece/perform-ece-hosts-maintenance.md
+                  title: Perform ECE hosts maintenance
                 - page: docs-content://deploy-manage/maintenance/ece/delete-ece-hosts.md
+                  title: Delete ECE hosts
             - page: docs-content://deploy-manage/maintenance/start-stop-services.md
+              title: Start and stop services
               children:
               - page: docs-content://deploy-manage/maintenance/start-stop-services/start-stop-elasticsearch.md
+                title: Start and stop Elasticsearch
               - page: docs-content://deploy-manage/maintenance/start-stop-services/start-stop-kibana.md
+                title: Start and stop Kibana
               - page: docs-content://deploy-manage/maintenance/start-stop-services/restart-cloud-hosted-deployment.md
+                title: Restart an Elastic Cloud Hosted deployment
               - page: docs-content://deploy-manage/maintenance/start-stop-services/restart-an-ece-deployment.md
+                title: Restart an ECE deployment
               - page: docs-content://deploy-manage/maintenance/start-stop-services/full-cluster-restart-rolling-restart-procedures.md
+                title: Full Cluster restart and rolling restart procedures
             - page: docs-content://deploy-manage/maintenance/start-stop-routing-requests.md
+              title: Start and stop routing requests
             - page: docs-content://deploy-manage/maintenance/add-and-remove-elasticsearch-nodes.md
+              title: Add and Remove Elasticsearch nodes
           - group: Upgrade
             page: docs-content://deploy-manage/upgrade.md
             children:
             - page: docs-content://deploy-manage/upgrade/plan-upgrade.md
+              title: Plan your upgrade
             - page: docs-content://deploy-manage/upgrade/prepare-to-upgrade.md
               title: "Preparation steps"
               children:
               - page: docs-content://deploy-manage/upgrade/prepare-to-upgrade/upgrade-assistant.md
+                title: Upgrade Assistant
             - page: docs-content://deploy-manage/upgrade/deployment-or-cluster.md
+              title: Upgrade your deployment or cluster
               children:
               - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/upgrade-717.md
+                title: Upgrade from 7.17 to latest
               - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/upgrade-on-ech.md
-                title: "Upgrade on {{ech}}"
+                title: "Upgrade on Elastic Cloud Hosted"
               - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/upgrade-on-ece.md
-                title: "Upgrade on {{ece}}"
+                title: "Upgrade on Elastic Cloud Enterprise"
               - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/upgrade-on-eck.md
-                title: "Upgrade on {{eck}}"
+                title: "Upgrade on Elastic Cloud on Kubernetes"
               - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/self-managed.md
                 title: "Upgrade Elastic on a self-managed cluster"
                 children:
                 - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/elasticsearch.md
+                  title: Upgrade Elasticsearch
                 - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/upgrade-elasticsearch-docker.md
                   title: "Upgrade Elasticsearch running on Docker"
                 - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/kibana.md
+                  title: Upgrade Kibana
                   children:
                   - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/saved-object-migrations.md
+                    title: Saved object migrations
                   - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/kibana-roll-back.md
                     title: "Roll back to a previous version"
               - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/archived-settings.md
@@ -1387,34 +1564,42 @@ nav:
               - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/reading-indices-from-older-elasticsearch-versions.md
                 title: "Reading indices from older versions"
               - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/enterprise-search.md
+                title: Upgrade Enterprise Search
             - page: docs-content://deploy-manage/upgrade/ingest-components.md
+              title: Upgrade your ingest components
             - page: docs-content://deploy-manage/upgrade/orchestrator.md
               title: "Upgrade your ECE or ECK orchestrator"
               children:
               - page: docs-content://deploy-manage/upgrade/orchestrator/upgrade-cloud-enterprise.md
+                title: Upgrade Elastic Cloud Enterprise
                 children:
                 - page: docs-content://deploy-manage/upgrade/orchestrator/re-running-the-ece-upgrade.md
+                  title: Re-running the ECE upgrade
               - page: docs-content://deploy-manage/upgrade/orchestrator/upgrade-cloud-on-k8s.md
+                title: Upgrade Elastic Cloud on Kubernetes
           - group: Uninstall
             page: docs-content://deploy-manage/uninstall.md
             children:
             - page: docs-content://deploy-manage/uninstall/uninstall-elastic-cloud-enterprise.md
+              title: Uninstall Elastic Cloud Enterprise
             - page: docs-content://deploy-manage/uninstall/uninstall-elastic-cloud-on-kubernetes.md
+              title: Uninstall Elastic Cloud on Kubernetes
             - page: docs-content://deploy-manage/uninstall/delete-a-cloud-deployment.md
               title: "Delete an orchestrated deployment"
           - group: Licenses and subscriptions
             page: docs-content://deploy-manage/license.md
             children:
             - page: docs-content://deploy-manage/license/manage-your-license-in-ece.md
-              title: "{{ece}}"
+              title: "Elastic Cloud Enterprise"
             - page: docs-content://deploy-manage/license/manage-your-license-in-eck.md
-              title: "{{eck}}"
+              title: "Elastic Cloud on Kubernetes"
             - page: docs-content://deploy-manage/license/manage-your-license-in-self-managed-cluster.md
               title: "Self-managed cluster"
           - group: Manage your Cloud organization
             page: docs-content://deploy-manage/cloud-organization.md
             children:
             - page: docs-content://deploy-manage/cloud-organization/billing.md
+              title: Billing
               children:
               - page: docs-content://deploy-manage/cloud-organization/billing/cloud-hosted-deployment-billing-dimensions.md
                 title: "Hosted billing dimensions"
@@ -1428,17 +1613,27 @@ nav:
                 - page: docs-content://deploy-manage/cloud-organization/billing/security-billing-dimensions.md
                   title: "Security projects"
               - page: docs-content://deploy-manage/cloud-organization/billing/billing-models.md
+                title: Billing models
               - page: docs-content://deploy-manage/cloud-organization/billing/add-billing-details.md
+                title: Add your billing details
               - page: docs-content://deploy-manage/cloud-organization/billing/view-billing-history.md
+                title: View your billing history
               - page: docs-content://deploy-manage/cloud-organization/billing/manage-billing-notifications.md
                 title: "Manage notifications"
               - page: docs-content://deploy-manage/cloud-organization/billing/manage-subscription.md
+                title: Manage your subscription
               - page: docs-content://deploy-manage/cloud-organization/billing/monitor-analyze-usage.md
+                title: Monitor and analyze usage
               - page: docs-content://deploy-manage/cloud-organization/billing/ecu.md
+                title: Elastic Consumption Units
               - page: docs-content://deploy-manage/cloud-organization/billing/billing-faq.md
+                title: Billing FAQ
             - page: docs-content://deploy-manage/cloud-organization/operational-emails.md
+              title: Operational emails
             - page: docs-content://deploy-manage/cloud-organization/billing/update-billing-operational-contacts.md
+              title: Update billing and operational contacts
             - page: docs-content://deploy-manage/cloud-organization/service-status.md
+              title: Service status
             - page: docs-content://deploy-manage/cloud-organization/tools-and-apis.md
               title: "Tools and APIs"
         - group: Deployment and administration tools
@@ -3115,7 +3310,7 @@ nav:
                   - page: docs-content://solutions/observability/apm/apm-server/configure-elasticsearch-output.md
                     title: Elasticsearch
                   - page: docs-content://solutions/observability/apm/apm-server/configure-logstash-output.md
-                    title: "{{ls}}"
+                    title: "Logstash"
                   - page: docs-content://solutions/observability/apm/apm-server/configure-kafka-output.md
                     title: Kafka
                   - page: docs-content://solutions/observability/apm/apm-server/configure-redis-output.md
@@ -3163,7 +3358,7 @@ nav:
                   - page: docs-content://solutions/observability/apm/apm-server/use-internal-collection-to-send-monitoring-data.md
                     title: Use internal collection
                   - page: docs-content://solutions/observability/apm/apm-server/use-metricbeat-to-send-monitoring-data.md
-                    title: "Use {{metricbeat}} collection"
+                    title: "Use Metricbeat collection"
                   - page: docs-content://solutions/observability/apm/apm-server/use-select-metrics-emitted-directly-to-monitoring-cluster.md
                     title: Use local collection
             - group: APM APIs
@@ -3199,16 +3394,16 @@ nav:
                 - page: docs-content://solutions/observability/apm/upgrade-self-installation-of-apm-integration-to-9.md
                   title: Self-installation APM integration
                 - page: docs-content://solutions/observability/apm/upgrade-elastic-cloud-apm-server-standalone-to-9.md
-                  title: "{{ecloud}} standalone"
+                  title: "Elastic Cloud standalone"
                 - page: docs-content://solutions/observability/apm/upgrade-elastic-cloud-with-apm-integration-to-9.md
-                  title: "{{ecloud}} APM integration"
+                  title: "Elastic Cloud APM integration"
               - group: Switch to the Elastic APM integration
                 page: docs-content://solutions/observability/apm/switch-to-elastic-apm-integration.md
                 children:
                 - page: docs-content://solutions/observability/apm/switch-self-installation-to-apm-integration.md
                   title: Switch a self-installation
                 - page: docs-content://solutions/observability/apm/switch-an-elastic-cloud-cluster-to-apm-integration.md
-                  title: "Switch an {{ecloud}} cluster"
+                  title: "Switch an Elastic Cloud cluster"
           - group: Synthetic monitoring
             page: docs-content://solutions/observability/synthetics/index.md
             children:
@@ -3314,7 +3509,7 @@ nav:
               - page: docs-content://solutions/observability/cloud/monitor-amazon-simple-queue-service-sqs.md
                 title: SQS
             - page: docs-content://solutions/observability/cloud/monitor-amazon-web-services-aws-with-beats.md
-              title: "Monitor {{aws}} with {{beats}}"
+              title: "Monitor AWS with Beats"
             - group: "Monitor {{aws}} with Amazon Data Firehose"
               page: docs-content://solutions/observability/cloud/monitor-amazon-web-services-aws-with-amazon-data-firehose.md
               children:
@@ -3329,7 +3524,7 @@ nav:
               - page: docs-content://solutions/observability/cloud/monitor-cloudwatch-logs.md
                 title: CloudWatch logs
             - page: docs-content://solutions/observability/cloud/monitor-amazon-web-services-aws-with-elastic-serverless-forwarder.md
-              title: "Monitor {{aws}} with Elastic Serverless Forwarder"
+              title: "Monitor AWS with Elastic Serverless Forwarder"
           - group: Azure
             page: docs-content://solutions/observability/cloud/azure-monitoring.md
             children:
@@ -3641,9 +3836,9 @@ nav:
             page: docs-content://solutions/security/get-started/spaces-elastic-security.md
             children:
             - page: docs-content://solutions/security/get-started/spaces-defend-faq.md
-              title: "Spaces and {{elastic-defend}} FAQ"
+              title: "Spaces and Elastic Defend FAQ"
           - page: docs-content://solutions/security/get-started/data-views-elastic-security.md
-            title: "{{data-sources-cap}} and Elastic Security"
+            title: "Data views and Elastic Security"
           - page: docs-content://solutions/security/get-started/create-runtime-fields-in-elastic-security.md
             title: Create runtime fields in Elastic Security
           - page: docs-content://solutions/security/get-started/configure-advanced-settings.md
@@ -3743,7 +3938,7 @@ nav:
               - page: docs-content://solutions/security/detect-and-alert/threshold.md
                 title: Threshold rules
               - page: docs-content://solutions/security/detect-and-alert/machine-learning.md
-                title: "{{ml-cap}} rules"
+                title: "Machine learning rules"
               - page: docs-content://solutions/security/detect-and-alert/new-terms.md
                 title: New terms rules
             - page: docs-content://solutions/security/detect-and-alert/using-the-rule-ui.md
@@ -3794,7 +3989,7 @@ nav:
           page: docs-content://solutions/security/configure-elastic-defend.md
           children:
           - page: docs-content://solutions/security/configure-elastic-defend/elastic-defend-requirements.md
-            title: "{{elastic-defend}} requirements"
+            title: "Elastic Defend requirements"
           - group: "Install {{elastic-defend}}"
             page: docs-content://solutions/security/configure-elastic-defend/install-elastic-defend.md
             children:
@@ -3805,14 +4000,14 @@ nav:
             - page: docs-content://solutions/security/configure-elastic-defend/prevent-elastic-agent-uninstallation.md
               title: Prevent Elastic Agent uninstallation
           - page: docs-content://solutions/security/configure-elastic-defend/elastic-defend-feature-privileges.md
-            title: "{{elastic-defend}} feature privileges"
+            title: "Elastic Defend feature privileges"
           - group: "Configure an integration policy for {{elastic-defend}}"
             page: docs-content://solutions/security/configure-elastic-defend/configure-an-integration-policy-for-elastic-defend.md
             children:
             - page: docs-content://solutions/security/configure-elastic-defend/configure-updates-for-protection-artifacts.md
               title: Configure updates for protection artifacts
             - page: docs-content://solutions/security/configure-elastic-defend/turn-off-diagnostic-data-for-elastic-defend.md
-              title: "Turn off diagnostic data for {{elastic-defend}}"
+              title: "Turn off diagnostic data for Elastic Defend"
             - page: docs-content://solutions/security/configure-elastic-defend/configure-self-healing-rollback-for-windows-endpoints.md
               title: Configure self-healing rollback for Windows endpoints
             - page: docs-content://solutions/security/configure-elastic-defend/configure-linux-file-system-monitoring.md
@@ -3843,17 +4038,17 @@ nav:
           - page: docs-content://solutions/security/manage-elastic-defend/blocklist.md
             title: Blocklist
           - page: docs-content://solutions/security/manage-elastic-defend/optimize-elastic-defend.md
-            title: "Optimize {{elastic-defend}}"
+            title: "Optimize Elastic Defend"
           - page: docs-content://solutions/security/manage-elastic-defend/event-capture-elastic-defend.md
-            title: "Event capture and {{elastic-defend}}"
+            title: "Event capture and Elastic Defend"
           - page: docs-content://solutions/security/manage-elastic-defend/endpoint-protection-rules.md
             title: Endpoint protection rules
           - page: docs-content://solutions/security/manage-elastic-defend/automatic-troubleshooting.md
             title: Automatic troubleshooting
           - page: docs-content://solutions/security/manage-elastic-defend/allowlist-elastic-endpoint-in-third-party-antivirus-apps.md
-            title: "Allowlist {{elastic-endpoint}} in third-party antivirus apps"
+            title: "Allowlist Elastic Endpoint in third-party antivirus apps"
           - page: docs-content://solutions/security/manage-elastic-defend/elastic-endpoint-self-protection-features.md
-            title: "{{elastic-endpoint}} self-protection features"
+            title: "Elastic Endpoint self-protection features"
         - group: Endpoint response actions
           page: docs-content://solutions/security/endpoint-response-actions.md
           children:
@@ -3873,7 +4068,7 @@ nav:
           - page: docs-content://solutions/security/cloud/security-posture-management-overview.md
             title: Security posture management overview
           - page: docs-content://solutions/security/cloud/enable-cloud-security-features.md
-            title: "Enable cloud security features in {{serverless-short}}"
+            title: "Enable cloud security features in Serverless"
           - group: Cloud security posture management
             page: docs-content://solutions/security/cloud/cloud-security-posture-management.md
             children:

--- a/config/navigation-v2.yml
+++ b/config/navigation-v2.yml
@@ -4275,9 +4275,11 @@ nav:
       - toc: elasticsearch://extend
       - toc: integrations://extend
 
-  - section: Contribute
-    url: /contribute-docs/
-    isolated: true
-    children:
-    - toc: docs-content://contribute-docs
+  # Disabled pending a decision on whether to keep the contribute-docs
+  # content in the public site. Re-enable to resurface ~35 pages.
+  # - section: Contribute
+  #   url: /contribute-docs/
+  #   isolated: true
+  #   children:
+  #   - toc: docs-content://contribute-docs
 

--- a/config/navigation-v2.yml
+++ b/config/navigation-v2.yml
@@ -3275,7 +3275,7 @@ nav:
                 title: Reduce storage
               - page: docs-content://solutions/observability/apm/explore-data-in-elasticsearch.md
                 title: Explore data in Elasticsearch
-            - group: "Work with {{apm-server}}"
+            - group: "Work with APM Server"
               page: docs-content://solutions/observability/apm/apm-server/index.md
               children:
               - group: Set up
@@ -3366,7 +3366,7 @@ nav:
               children:
               - page: docs-content://solutions/observability/apm/apm-ui-api.md
                 title: APM UI API
-              - group: "{{apm-server}} API"
+              - group: "APM Server API"
                 page: docs-content://solutions/observability/apm/apm-server/api.md
                 children:
                 - page: docs-content://solutions/observability/apm/apm-server/information-api.md
@@ -3497,7 +3497,7 @@ nav:
             children:
             - page: docs-content://solutions/observability/cloud/ingestion-options.md
               title: Ingestion options
-            - group: "Monitor {{aws}} with Elastic Agent"
+            - group: "Monitor AWS with Elastic Agent"
               page: docs-content://solutions/observability/cloud/monitor-amazon-web-services-aws-with-elastic-agent.md
               children:
               - page: docs-content://solutions/observability/cloud/monitor-amazon-cloud-compute-ec2.md
@@ -3510,7 +3510,7 @@ nav:
                 title: SQS
             - page: docs-content://solutions/observability/cloud/monitor-amazon-web-services-aws-with-beats.md
               title: "Monitor AWS with Beats"
-            - group: "Monitor {{aws}} with Amazon Data Firehose"
+            - group: "Monitor AWS with Amazon Data Firehose"
               page: docs-content://solutions/observability/cloud/monitor-amazon-web-services-aws-with-amazon-data-firehose.md
               children:
               - page: docs-content://solutions/observability/cloud/monitor-virtual-private-cloud-vpc-flow-logs.md
@@ -3985,12 +3985,12 @@ nav:
               title: View detection alert details
             - page: docs-content://solutions/security/detect-and-alert/query-alert-indices.md
               title: Query alert indices
-        - group: "Configure endpoint protection with {{elastic-defend}}"
+        - group: "Configure endpoint protection with Elastic Defend"
           page: docs-content://solutions/security/configure-elastic-defend.md
           children:
           - page: docs-content://solutions/security/configure-elastic-defend/elastic-defend-requirements.md
             title: "Elastic Defend requirements"
-          - group: "Install {{elastic-defend}}"
+          - group: "Install Elastic Defend"
             page: docs-content://solutions/security/configure-elastic-defend/install-elastic-defend.md
             children:
             - page: docs-content://solutions/security/configure-elastic-defend/enable-access-for-macos.md
@@ -4001,7 +4001,7 @@ nav:
               title: Prevent Elastic Agent uninstallation
           - page: docs-content://solutions/security/configure-elastic-defend/elastic-defend-feature-privileges.md
             title: "Elastic Defend feature privileges"
-          - group: "Configure an integration policy for {{elastic-defend}}"
+          - group: "Configure an integration policy for Elastic Defend"
             page: docs-content://solutions/security/configure-elastic-defend/configure-an-integration-policy-for-elastic-defend.md
             children:
             - page: docs-content://solutions/security/configure-elastic-defend/configure-updates-for-protection-artifacts.md
@@ -4020,7 +4020,7 @@ nav:
             title: Configure offline endpoints and air-gapped environments
           - page: docs-content://solutions/security/configure-elastic-defend/uninstall-elastic-agent.md
             title: Uninstall Elastic Agent
-        - group: "Manage {{elastic-defend}}"
+        - group: "Manage Elastic Defend"
           page: docs-content://solutions/security/manage-elastic-defend.md
           children:
           - page: docs-content://solutions/security/manage-elastic-defend/endpoints.md

--- a/config/navigation-v2.yml
+++ b/config/navigation-v2.yml
@@ -2770,6 +2770,8 @@ nav:
                 title: Upgrade
               - page: docs-content://solutions/observability/get-started/opentelemetry/use-cases/kubernetes/customization.md
                 title: Customization
+            - page: docs-content://solutions/observability/get-started/opentelemetry/use-cases/llms/index.md
+              title: LLM observability
           - group: Other Observability tutorials
             page: docs-content://solutions/observability/get-started/other-tutorials/index.md
             children:
@@ -2871,6 +2873,8 @@ nav:
                   title: Infrastructure
                 - page: docs-content://solutions/observability/apm/logs.md
                   title: Logs
+              - page: docs-content://solutions/observability/apm/discover-traces.md
+                title: Discover traces
               - group: Filter and search data
                 page: docs-content://solutions/observability/apm/filter-search-data.md
                 children:
@@ -3386,8 +3390,24 @@ nav:
             title: Rename processor
           - page: docs-content://solutions/observability/streams/management/extract/append.md
             title: Append processor
+          - page: docs-content://solutions/observability/streams/management/extract/concat.md
+            title: Concat processor
+          - page: docs-content://solutions/observability/streams/management/extract/join.md
+            title: Join processor
+          - page: docs-content://solutions/observability/streams/management/extract/lowercase.md
+            title: Lowercase processor
+          - page: docs-content://solutions/observability/streams/management/extract/uppercase.md
+            title: Uppercase processor
+          - page: docs-content://solutions/observability/streams/management/extract/trim.md
+            title: Trim processor
+          - page: docs-content://solutions/observability/streams/management/extract/redact.md
+            title: Redact processor
+          - page: docs-content://solutions/observability/streams/management/extract/network-direction.md
+            title: Network direction processor
           - page: docs-content://solutions/observability/streams/management/extract/manual-pipeline-configuration.md
             title: Manual pipeline configuration
+        - page: docs-content://solutions/observability/streams/management/streamlang.md
+          title: Streamlang
         - page: docs-content://solutions/observability/streams/management/partitioning.md
           title: Partition data into child streams
         - page: docs-content://solutions/observability/streams/management/schema.md

--- a/config/navigation-v2.yml
+++ b/config/navigation-v2.yml
@@ -32,16 +32,40 @@ nav:
         - group: Distributed architecture
           page: docs-content://deploy-manage/distributed-architecture.md
           children:
-          - page: docs-content://deploy-manage/distributed-architecture/clusters-nodes-shards.md
-            title: Clusters, nodes, and shards
+          - group: Clusters, nodes, and shards
+            page: docs-content://deploy-manage/distributed-architecture/clusters-nodes-shards.md
+            children:
+            - page: docs-content://deploy-manage/distributed-architecture/clusters-nodes-shards/node-roles.md
+              title: Node roles
           - page: docs-content://deploy-manage/distributed-architecture/reading-and-writing-documents.md
             title: Reading and writing documents
-          - page: docs-content://deploy-manage/distributed-architecture/shard-allocation-relocation-recovery.md
-            title: Shard allocation, relocation, and recovery
+          - group: Shard allocation, relocation, and recovery
+            page: docs-content://deploy-manage/distributed-architecture/shard-allocation-relocation-recovery.md
+            children:
+            - page: docs-content://deploy-manage/distributed-architecture/shard-allocation-relocation-recovery/shard-allocation-awareness.md
+              title: Shard allocation awareness
+            - group: Index-level shard allocation filtering
+              page: docs-content://deploy-manage/distributed-architecture/shard-allocation-relocation-recovery/index-level-shard-allocation.md
+              children:
+              - page: docs-content://deploy-manage/distributed-architecture/shard-allocation-relocation-recovery/delaying-allocation-when-node-leaves.md
+                title: Delaying allocation when a node leaves
           - page: docs-content://deploy-manage/distributed-architecture/shard-request-cache.md
             title: The shard request cache
-          - page: docs-content://deploy-manage/distributed-architecture/discovery-cluster-formation.md
-            title: Discovery and cluster formation
+          - group: Discovery and cluster formation
+            page: docs-content://deploy-manage/distributed-architecture/discovery-cluster-formation.md
+            children:
+            - page: docs-content://deploy-manage/distributed-architecture/discovery-cluster-formation/discovery-hosts-providers.md
+              title: Discovery hosts providers
+            - page: docs-content://deploy-manage/distributed-architecture/discovery-cluster-formation/modules-discovery-quorums.md
+              title: Quorum-based decision making
+            - page: docs-content://deploy-manage/distributed-architecture/discovery-cluster-formation/modules-discovery-voting.md
+              title: Voting configurations
+            - page: docs-content://deploy-manage/distributed-architecture/discovery-cluster-formation/modules-discovery-bootstrap-cluster.md
+              title: Bootstrapping a cluster
+            - page: docs-content://deploy-manage/distributed-architecture/discovery-cluster-formation/cluster-state-overview.md
+              title: Cluster state
+            - page: docs-content://deploy-manage/distributed-architecture/discovery-cluster-formation/cluster-fault-detection.md
+              title: Cluster fault detection
           - page: docs-content://deploy-manage/distributed-architecture/kibana-tasks-management.md
             title: Kibana task management
         - group: Plan your install
@@ -181,6 +205,8 @@ nav:
             children:
             - page: docs-content://deploy-manage/deploy/cloud-enterprise/ece-architecture.md
               title: Service-oriented architecture
+            - page: docs-content://deploy-manage/deploy/cloud-enterprise/deploy-an-orchestrator.md
+              title: Deploy an orchestrator
             - group: Prepare your environment
               page: docs-content://deploy-manage/deploy/cloud-enterprise/prepare-environment.md
               children:
@@ -262,8 +288,10 @@ nav:
             page: docs-content://deploy-manage/deploy/cloud-on-k8s.md
             children:
             - group: Deploy an orchestrator
-              page: docs-content://deploy-manage/deploy/cloud-on-k8s/install.md
+              page: docs-content://deploy-manage/deploy/cloud-on-k8s/deploy-an-orchestrator.md
               children:
+              - page: docs-content://deploy-manage/deploy/cloud-on-k8s/install.md
+                title: Install ECK
               - page: docs-content://deploy-manage/deploy/cloud-on-k8s/install-using-yaml-manifest-quickstart.md
                 title: YAML manifests
               - page: docs-content://deploy-manage/deploy/cloud-on-k8s/install-using-helm-chart.md
@@ -1426,9 +1454,47 @@ nav:
           children:
           - page: docs-content://manage-data/ingest.md
             title: Choose/Plan your ingest method
-          - page: docs-content://manage-data/ingest/ingest-reference-architectures.md
-            title: Ingest architectures
+          - group: Ingest architectures
+            page: docs-content://manage-data/ingest/ingest-reference-architectures.md
+            children:
+            - group: Agent to Elasticsearch
+              page: docs-content://manage-data/ingest/ingest-reference-architectures/agent-to-es.md
+              children:
+              - page: docs-content://manage-data/ingest/ingest-reference-architectures/agent-installed.md
+                title: Elastic Agent (installed)
+              - page: docs-content://manage-data/ingest/ingest-reference-architectures/agent-apis.md
+                title: Elastic Agent via APIs
+            - group: Agent with Logstash
+              page: docs-content://manage-data/ingest/ingest-reference-architectures/agent-ls.md
+              children:
+              - page: docs-content://manage-data/ingest/ingest-reference-architectures/ls-enrich.md
+                title: Logstash for enrichment
+              - page: docs-content://manage-data/ingest/ingest-reference-architectures/lspq.md
+                title: Logstash persistent queue
+              - page: docs-content://manage-data/ingest/ingest-reference-architectures/ls-networkbridge.md
+                title: Logstash as a network bridge
+              - page: docs-content://manage-data/ingest/ingest-reference-architectures/ls-multi.md
+                title: Logstash for multiple destinations
+            - page: docs-content://manage-data/ingest/ingest-reference-architectures/agent-proxy.md
+              title: Agent through a proxy
+            - group: Agent with Kafka
+              page: docs-content://manage-data/ingest/ingest-reference-architectures/agent-kafka-es.md
+              children:
+              - page: docs-content://manage-data/ingest/ingest-reference-architectures/agent-kafka-ls.md
+                title: Agent to Kafka via Logstash
+              - page: docs-content://manage-data/ingest/ingest-reference-architectures/agent-kafka-essink.md
+                title: Agent to Kafka with Elasticsearch sink
+            - page: docs-content://manage-data/ingest/ingest-reference-architectures/ls-for-input.md
+              title: Logstash as input
+            - group: Air-gapped environments
+              page: docs-content://manage-data/ingest/ingest-reference-architectures/airgapped-env.md
+              children:
+              - page: docs-content://manage-data/ingest/ingest-reference-architectures/agent-es-airgapped.md
+                title: Agent to Elasticsearch (air-gapped)
+              - page: docs-content://manage-data/ingest/ingest-reference-architectures/agent-ls-airgapped.md
+                title: Agent with Logstash (air-gapped)
           - group: Ingest by solution
+            page: docs-content://manage-data/ingest/ingesting-data-for-elastic-solutions.md
             children:
             - page: docs-content://solutions/search/ingest-for-search.md
               title: Ingesting data for search use cases
@@ -1507,6 +1573,8 @@ nav:
             - page: docs-content://manage-data/ingest/ingesting-data-from-applications/ingest-logs-from-nodejs-web-application-using-filebeat.md
               title: Ingest logs from a Node.js web application using Filebeat
           - title: Ingest data using the API
+          - page: docs-content://manage-data/ingest/tools.md
+            title: Ingest tools overview
           - page: docs-content://manage-data/ingest/upload-data-files.md
             title: Upload data files
           - page: docs-content://manage-data/ingest/sample-data.md
@@ -4206,4 +4274,10 @@ nav:
       - toc: beats://extend
       - toc: elasticsearch://extend
       - toc: integrations://extend
+
+  - section: Contribute
+    url: /contribute-docs/
+    isolated: true
+    children:
+    - toc: docs-content://contribute-docs
 


### PR DESCRIPTION
`demo/findability` currently surfaces a much smaller portion of the docs in nav v2 than nav v1 surfaces today. A diff of `config/navigation.yml` + the `.artifacts/checkouts/current/**/toc.yml` graph against `config/navigation-v2.yml` showed **2,733 pages reachable in v1 nav but not in v2** — most of them in Reference, Release notes, and the Deploy and manage children that v2 had stubbed out as landing pages.

This PR closes ~96% of that gap (2,733 → 103) without changing v2's curated titles, ordering, or section structure. The remaining 103 pages are mostly two intentionally-skipped sections (explore-analyze and the disabled Contribute) plus a handful of stragglers — see "What's still missing" at the bottom.

Demo: https://docs-v3-preview.elastic.dev/elastic/docs-builder/docs/3268

## What

### Bulk rewiring (commit 1)

- **Re-enabled the commented Reference block** at the live `- section: Reference` (uncomment + slot in). Recovers ~1,222 pages: `elasticsearch://reference/elasticsearch`, `kibana://reference`, `cloud://reference`, `cloud-on-k8s://reference`, `ecs://reference`, `search-ui://reference`, `ecctl://reference`, plus `aggregations`, `query-languages`, `scripting-languages`, `enrich-processor`, `text-analysis`.
- **Ported the Release notes tree** from `config/navigation.yml:33-209` into v2's stub Release notes section (dropped `path_prefix:` lines — v2 doesn't use them). Recovers ~126 pages: cloud hosted/enterprise, cloud-on-k8s, all APM agents, all EDOT SDKs, beats, logstash, elastic-agent, fleet-server, ECS, ECCTL, plus `elastic-security`, `elastic-observability`, `elastic-cloud-serverless`.
- **Added per-product reference tocs** missing from the commented block, grouped by family for readability. Recovers ~777 pages:
  - **Elasticsearch clients**: java, js, dsl-js, .net, php, py, ruby, rs, eland, go-elasticsearch, curator
  - **APM**: apm-k8s-attacher, apm-aws-lambda, dotnet, go, java, nodejs, php, python, ruby, rum-js
  - **OpenTelemetry**: opentelemetry root + motlp + edot-cloud-forwarder (aws/azure/gcp), elastic-agent edot-collector, edot-android, edot-dotnet, edot-ios, edot-java, edot-node, edot-php, edot-python, edot-browser
  - **ECS Logging**: ecs-logging root + .net, go-logrus, go-zap, go-zerolog, java, nodejs, php, python, ruby
  - Plus beats, logstash, integration-docs, elasticsearch-hadoop, elastic-serverless-forwarder, `elasticsearch-plugins`, `community-contributed`.
- **Wired children of 12 deploy-manage landings**: security, users-roles, monitor, tools, remote-clusters, upgrade, cloud-organization, maintenance, api-keys, autoscaling, license, uninstall. Hand-listed under each existing `- group:` to preserve v2's curated titles. The cleanest alternative (creating per-subtree `toc.yml` files in `docs-content` and switching v2 to `toc:`) was rejected because it would override v2's hand-curated group titles. ~369 pages.
- **Removed the dead Troubleshoot comment block** (~120 lines deleted). Verified all 53 pages it referenced are already reachable via the live `- toc: docs-content://troubleshoot` (which surfaces 190 pages).
- **Applied Liam's Search and query rewrite from #3094** — replaces the placeholder `- group: Search and query` with the full narrative arc (get-started → approaches → ingest → querying with `elasticsearch://reference/query-languages` toc inline → cross-cluster/cross-project → integrate). Liam credited as co-author. ~58 pages.

### Observability (commit 2)

- APM > View and analyze data: `discover-traces.md` (between Drill down into data and Filter and search data, mirroring v1).
- OpenTelemetry use cases: `llms/index.md` ("LLM observability") as a sibling of Kubernetes observability.
- Streams > Process documents: 7 missing string/security/network processors (concat, join, lowercase, uppercase, trim, redact, network-direction) appended after existing string-op processors, before `manual-pipeline-configuration`.
- Streams: `streamlang.md` as a sibling of Process documents.

10 pages recovered.

### Production guidance (commit 3)

Per Shaina's note that the remaining D&M misses sit under the production-guidance subtree, converted the two flat entries into groups and listed their canonical children from v1's deploy-manage toc:

- **Run Elasticsearch in production**
  - Design for resilience (3 children: small clusters, larger clusters, ECH and ECE)
  - Scaling considerations
  - Performance optimizations (6 children: general recommendations, indexing speed, search speed, approximate kNN, disk usage, size shards)
- **Run Kibana in production**
  - 6 children: HA and load balancing, configure memory, manage background tasks, traffic scaling, alerting, reporting

18 pages recovered.

### Distributed architecture, deploy orchestrators, ingest architectures (commit 4)

- **Distributed architecture**: converts three flat entries into groups with canonical children — `clusters-nodes-shards` (node-roles), `shard-allocation-relocation-recovery` (shard-allocation-awareness + index-level-shard-allocation with delaying-allocation-when-node-leaves), and `discovery-cluster-formation` (6 children: hosts-providers, quorums, voting, bootstrap-cluster, cluster-state, cluster-fault-detection).
- **Deploy orchestrators**: adds `deploy-an-orchestrator.md` as a peer page under Elastic Cloud Enterprise, and as the landing of the existing "Deploy an orchestrator" group under Elastic Cloud on Kubernetes (with `install.md` demoted to first child to match v1 hierarchy).
- **Ingest architectures**: converts the leaf entry into a group with the canonical 16 children grouped by architecture (Agent to Elasticsearch, Agent with Logstash, Agent with Kafka, Air-gapped, Logstash as input, Agent through a proxy). Sets `ingesting-data-for-elastic-solutions.md` as the "Ingest by solution" group landing. Surfaces `tools.md` alongside the existing API/upload entries.

30 pages recovered.

### Contribute section (added, then disabled — commits 4 and 5)

Initially added an isolated `- section: Contribute` pulling `docs-content://contribute-docs` via `toc:`, mirroring the Extension points pattern (~35 pages). Whether to surface contribute-docs in the public site is still open, so the section is now **commented out** as a ready-to-uncomment block rather than shipped.

## Validation

- YAML parses cleanly.
- All 175 navigation tests pass (`dotnet test tests/Navigation.Tests`).
- Diff: ~+1,100 / −180 lines across 5 commits in `config/navigation-v2.yml`.

## What's still missing (~103 pages)

### Sections skipped entirely (~50 pages — intentional)

These three explore-analyze subtrees were left out because they need design judgement on which children to surface and where in v2's curated tree:

| pages | section landing + children |
| ---: | --- |
| 32 | `docs-content://explore-analyze/scripting` (landing + 31 children — Painless tutorials, debugging, security, etc.) |
| 12 | `docs-content://explore-analyze/transforms` (landing + 11 children — checkpoints, examples, alerts, scaling, setup, etc.) |
| 5 | `docs-content://explore-analyze/query-filter` (landing + 4 children — filtering, esql-kibana, grok-debugger, playground) |
| **49** | **subtotal** |

### Sections disabled pending decision (~35 pages)

| pages | section |
| ---: | --- |
| 35 | `- section: Contribute` (commented out in this PR — toc fans into `contribute-docs/index`, `api-docs/*`, `content-types/*`, `how-to/*`, `style-guide/*`, plus `asciidoc-guide`, `locally`, `on-the-web`, `syntax-quick-reference`, `tools`, `vale-linter`, `vscode-extension`) |

### Single-page misses (18 pages)

Truly scattered — same mechanical pattern as the deploy-manage batch can be applied later if someone wants to mop them up:

**`cloud-account/`** (8)
- `docs-content://cloud-account/index.md`
- `docs-content://cloud-account/add-a-login-method.md`
- `docs-content://cloud-account/change-your-password.md`
- `docs-content://cloud-account/dark-mode.md`
- `docs-content://cloud-account/high-contrast.md`
- `docs-content://cloud-account/join-or-leave-an-organization.md`
- `docs-content://cloud-account/multifactor-authentication.md`
- `docs-content://cloud-account/update-your-email-address.md`

**`get-started/`** (4)
- `docs-content://get-started/introduction.md`
- `docs-content://get-started/deployment-options.md`
- `docs-content://get-started/the-stack.md`
- `docs-content://get-started/howto-use-the-docs.md`

**Other one-offs** (3)
- `docs-content://manage-data/index.md`
- `docs-content://deploy-manage/manage-spaces-fleet.md`
- `docs-content://solutions/search/vector.md`

**Phantom-only** (3, reachable in v1 only via `phantoms:` registration, not in either nav)
- `docs-content://release-notes/index.md`
- `cloud://release-notes/index.md`
- `elasticsearch://reference/index.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)