### PR TITLE
Skip AWS auth in docs preview when docs build fails

### DIFF
--- a/.github/workflows/docs-preview-local.yml
+++ b/.github/workflows/docs-preview-local.yml
@@ -328,8 +328,11 @@ jobs:
 
       - uses: elastic/docs-builder/.github/actions/aws-auth@main
         if: >
-          !cancelled()
+          env.MATCH == 'true'
+          && !cancelled()
           && needs.check.outputs.any_modified != 'false'
+          && steps.internal-docs-build.outputs.skip != 'true'
+          && steps.internal-docs-build.outcome == 'success'
           && steps.internal-validate-path-prefixes.outcome == 'success'
 
       - name: Upload to S3


### PR DESCRIPTION
## Why

The docs preview workflow could still run the `aws-auth` step when the local documentation build had not succeeded, which requests OIDC and configures AWS credentials unnecessarily and can be confusing when debugging failed builds.

## What

The `aws-auth` step conditions are aligned with the Upload to S3 step: AWS authentication only runs when the build completed successfully (not skipped), `MATCH` applies, and path-prefix validation succeeded, so credential setup matches the cases where we actually sync to S3.

Made with [Cursor](https://cursor.com)