### PR TITLE
Rename enrich-processor to ingest-processor

### DIFF
--- a/config/navigation.yml
+++ b/config/navigation.yml
@@ -236,9 +236,9 @@ toc:
             path_prefix: reference/aggregations
 
           # Processor reference
-          # https://github.com/elastic/elasticsearch/blob/main/docs/reference/enrich-processor/toc.yml
-          - toc: elasticsearch://reference/enrich-processor
-            path_prefix: reference/enrich-processor
+          # https://github.com/elastic/elasticsearch/blob/main/docs/reference/ingest-processor/toc.yml
+          - toc: elasticsearch://reference/ingest-processor
+            path_prefix: reference/ingest-processor
 
           # Curator
           # https://github.com/elastic/curator/blob/master/docs/reference/toc.yml


### PR DESCRIPTION
Part of https://github.com/elastic/docs-content/issues/1171 - renaming [/enrich-processor](https://www.elastic.co/docs/reference/enrich-processor) path to /ingest-processor which is more accurate

1. Rebase after #3306 
2. Edit this PR remove phantom introduced ^^
3. Merge https://github.com/elastic/elasticsearch/pull/148774
4. Rerun CI and merge this
5. Final Cleanup in https://github.com/elastic/elasticsearch/pull/148922
