### PR TITLE
fix remote var to remove spare $

### DIFF
--- a/src/services/Elastic.Documentation.Assembler/Navigation/AssemblerDocumentationSet.cs
+++ b/src/services/Elastic.Documentation.Assembler/Navigation/AssemblerDocumentationSet.cs
@@ -45,7 +45,7 @@ public record AssemblerDocumentationSet
 		{
 			RepositoryName = checkout.Repository.Name,
 			Ref = checkout.HeadReference,
-			Remote = $"elastic/${checkout.Repository.Name}",
+			Remote = $"elastic/{checkout.Repository.Name}",
 			Branch = checkout.Repository.GetBranch(env.ContentSource)
 		};
 


### PR DESCRIPTION
This pull request makes a small change to the `AssemblerDocumentationSet.cs` file, correcting the format of the `Remote` property assignment. The update ensures the remote path is constructed correctly for the repository.

Hardcoded `$` was being passed through, resulting in bad URLs to source files

fixes https://github.com/elastic/docs-builder/issues/3300