### PR TITLE
Add docs as product

### DIFF
--- a/config/products.yml
+++ b/config/products.yml
@@ -138,6 +138,10 @@ products:
   elastic-agent:
     display: 'Elastic Agent'
     versioning: 'stack'
+  elastic-docs:
+    display: 'Elastic Documentation'
+    features:
+      public-reference: false
   elastic-serverless-forwarder:
     display: 'Elastic Serverless Forwarder'
     versioning: 'esf'


### PR DESCRIPTION
This PR updates products.yml so we can start down the path of creating a release notes page specifically for docs.
It uses the `product-reference:false` clause as described in https://elastic.github.io/docs-builder/configure/site/products/#structure