### PR TITLE
changelog: surface missing product label as no-label failure

### DIFF
--- a/src/services/Elastic.Changelog/Evaluation/ChangelogPrEvaluationService.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogPrEvaluationService.cs
@@ -114,16 +114,31 @@ public class ChangelogPrEvaluationService(
 		// Resolve products from labels
 		string? resolvedProducts = null;
 		string? productLabelTable = null;
-		if (config.LabelToProducts is { Count: > 0 })
+		if (config.LabelToProducts is { Count: > 0 } labelToProducts)
 		{
-			var products = PrInfoProcessor.MapLabelsToProducts(input.PrLabels, config.LabelToProducts);
+			var products = PrInfoProcessor.MapLabelsToProducts(input.PrLabels, labelToProducts);
 			if (products.Count > 0)
 			{
 				resolvedProducts = ProductArgument.FormatProductSpecs(products);
 				_logger.LogInformation("Mapped PR labels to products: {Products}", resolvedProducts);
 			}
 			else
-				productLabelTable = BuildProductLabelTable(config.LabelToProducts);
+			{
+				// When only one distinct product is configured, assigning it implicitly is
+				// unambiguous — no point requiring contributors to add a redundant label.
+				var distinctSpecs = labelToProducts.Values
+					.Distinct(StringComparer.OrdinalIgnoreCase)
+					.ToList();
+				if (distinctSpecs.Count == 1)
+				{
+					resolvedProducts = ProductArgument.FormatProductSpecs(
+						ProductArgument.ParseProductSpecs(distinctSpecs[0])
+					);
+					_logger.LogInformation("Single product configured; assigning implicitly: {Products}", resolvedProducts);
+				}
+				else
+					productLabelTable = BuildProductLabelTable(labelToProducts);
+			}
 		}
 
 		if (resolvedType == null)
@@ -133,6 +148,22 @@ public class ChangelogPrEvaluationService(
 				PrEvaluationResult.NoLabel, title,
 				resolvedDescription: description,
 				labelTable: BuildLabelTable(config.LabelToType),
+				productLabelTable: productLabelTable,
+				skipLabels: skipLabels
+			);
+		}
+
+		// Multiple products are configured via labels but none matched, and no defaults are
+		// available to fill in via inference at 'changelog add' time. Surface this as a
+		// missing-label failure so the contributor sees an actionable hint instead of a hard
+		// error later in the workflow.
+		if (productLabelTable != null
+			&& (config.ProductsConfiguration?.Default is null or { Count: 0 }))
+		{
+			_logger.LogInformation("Multiple products configured but no matching product label on PR; no default products configured");
+			return await SetOutputs(
+				PrEvaluationResult.NoLabel, title,
+				resolvedDescription: description,
 				productLabelTable: productLabelTable,
 				skipLabels: skipLabels
 			);

--- a/src/services/Elastic.Changelog/Evaluation/PrEvaluationResult.cs
+++ b/src/services/Elastic.Changelog/Evaluation/PrEvaluationResult.cs
@@ -15,7 +15,7 @@ public enum PrEvaluationResult
 	[Display(Name = "success")]
 	Success,
 
-	/// <summary>No label matching a changelog type was found on the PR.</summary>
+	/// <summary>A required label (type or product) is missing from the PR.</summary>
 	[Display(Name = "no-label")]
 	NoLabel,
 

--- a/tests/Elastic.Changelog.Tests/Evaluation/ChangelogPrEvaluationServiceTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/ChangelogPrEvaluationServiceTests.cs
@@ -520,7 +520,7 @@ public class ChangelogPrEvaluationServiceTests : ChangelogTestBase
 	}
 
 	[Fact]
-	public async Task EvaluatePr_WithoutProductLabels_OutputsProductLabelTable()
+	public async Task EvaluatePr_WithoutProductLabels_ReturnsNoLabelAndOutputsProductLabelTable()
 	{
 		await WriteMinimalConfig(Path.Join(Paths.WorkingDirectoryRoot.FullName, "config", "changelog.yml"), ConfigWithProducts);
 		var service = CreateService();
@@ -532,10 +532,113 @@ public class ChangelogPrEvaluationServiceTests : ChangelogTestBase
 		var result = await service.EvaluatePr(Collector, args, CancellationToken.None);
 
 		result.Should().BeTrue();
-		VerifyOutputSet("status", "proceed");
+		VerifyOutputSet("status", "no-label");
+		VerifyOutputSet("should-generate", "false");
 		A.CallTo(() => _mockCore.SetOutputAsync("products", A<string>._)).MustNotHaveHappened();
 		A.CallTo(() => _mockCore.SetOutputAsync("product-label-table", A<string>.That.Contains("@Product:ECH"))).MustHaveHappened();
 		A.CallTo(() => _mockCore.SetOutputAsync("product-label-table", A<string>.That.Contains("cloud-hosted"))).MustHaveHappened();
+		A.CallTo(() => _mockCore.SetOutputAsync("label-table", A<string>._)).MustNotHaveHappened();
+	}
+
+	[Fact]
+	public async Task EvaluatePr_SingleProductConfigured_WithoutLabel_AutoAssignsProduct()
+	{
+		var singleProductConfig = """
+			pivot:
+			  types:
+			    feature: "type:feature"
+			    bug-fix: "type:bug"
+			    breaking-change: "type:breaking"
+			    enhancement:
+			    deprecation:
+			    docs:
+			    known-issue:
+			    other:
+			    regression:
+			    security:
+			  products:
+			    kibana: "@Product:Kibana"
+			""";
+		await WriteMinimalConfig(content: singleProductConfig);
+		var service = CreateService();
+		var args = DefaultArgs(prLabels: ["type:feature"]);
+
+		var result = await service.EvaluatePr(Collector, args, CancellationToken.None);
+
+		result.Should().BeTrue();
+		VerifyOutputSet("status", "proceed");
+		VerifyOutputSet("products", "kibana");
+		A.CallTo(() => _mockCore.SetOutputAsync("product-label-table", A<string>._)).MustNotHaveHappened();
+	}
+
+	[Fact]
+	public async Task EvaluatePr_SingleProductConfigured_WithMultipleLabelAliases_AutoAssignsProduct()
+	{
+		// Multi-label aliasing for the same product is still a single-product config — should
+		// not require any explicit label on the PR.
+		var configWithAliases = """
+			pivot:
+			  types:
+			    feature: "type:feature"
+			    bug-fix: "type:bug"
+			    breaking-change: "type:breaking"
+			    enhancement:
+			    deprecation:
+			    docs:
+			    known-issue:
+			    other:
+			    regression:
+			    security:
+			  products:
+			    kibana:
+			      - "@Product:Kibana"
+			      - "@kibana"
+			""";
+		await WriteMinimalConfig(content: configWithAliases);
+		var service = CreateService();
+		var args = DefaultArgs(prLabels: ["type:feature"]);
+
+		var result = await service.EvaluatePr(Collector, args, CancellationToken.None);
+
+		result.Should().BeTrue();
+		VerifyOutputSet("status", "proceed");
+		VerifyOutputSet("products", "kibana");
+		A.CallTo(() => _mockCore.SetOutputAsync("product-label-table", A<string>._)).MustNotHaveHappened();
+	}
+
+	[Fact]
+	public async Task EvaluatePr_WithoutProductLabels_WithDefaultProducts_ReturnsProceed()
+	{
+		var configWithDefaults = """
+			pivot:
+			  types:
+			    feature: "type:feature"
+			    bug-fix: "type:bug"
+			    breaking-change: "type:breaking"
+			    enhancement:
+			    deprecation:
+			    docs:
+			    known-issue:
+			    other:
+			    regression:
+			    security:
+			  products:
+			    cloud-hosted: "@Product:ECH"
+			    cloud-serverless: "@Product:ESS"
+			products:
+			  default:
+			    - product: cloud-hosted
+			      lifecycle: ga
+			""";
+		await WriteMinimalConfig(content: configWithDefaults);
+		var service = CreateService();
+		var args = DefaultArgs(prLabels: ["type:feature"]);
+
+		var result = await service.EvaluatePr(Collector, args, CancellationToken.None);
+
+		result.Should().BeTrue();
+		VerifyOutputSet("status", "proceed");
+		VerifyOutputSet("should-generate", "true");
 	}
 
 	[Fact]


### PR DESCRIPTION
## Summary

- When `pivot.products` is configured with multiple products but a PR carries no matching product label (and no `products.default` is set), `changelog evaluate-pr` previously reported `proceed`. The downstream `changelog add` step then failed with `At least one product is required`, which is a workflow-level hard error and skips the helpful PR comment that lists the missing labels.
- This change treats that case the same as a missing type label: returns `NoLabel` and emits `product-label-table` so the existing comment-failure path in docs-actions posts an actionable hint to the contributor.
- When `pivot.products` defines only one distinct product, the product is now assigned implicitly — no point requiring a redundant label when there's only one possible answer (this also covers single-product configs with multiple label aliases).

## Context

Triggered by a failing run in elastic/cloud: https://github.com/elastic/cloud/actions/runs/25721262918/job/75522989644

elastic/cloud has `pivot.products` with multiple entries (`cloud-hosted`, `cloud-enterprise`, …) and no `products.default`. A test PR without any `@Product:*` label failed at \`changelog add\` instead of getting the helpful "you're missing a product label" comment that contributors get for missing type labels.

A companion PR in elastic/docs-actions adjusts the failure-comment wording so the headline matches whichever label is actually missing (type, product, or both).

## Test plan

- [x] Existing changelog evaluation tests still pass (82/82).
- [x] New unit test: multi-product config + only type label → `status=no-label`, `product-label-table` emitted, `should-generate=false`.
- [x] New unit test: single-product config (one entry, no PR label) → `status=proceed`, `products` auto-assigned, no `product-label-table`.
- [x] New unit test: single-product config with multiple label aliases → still auto-assigns, no label required.
- [x] New unit test: multi-product config + `products.default` configured + no product label → `status=proceed` (defaults will be inferred at `changelog add` time).
- [x] `./build.sh` passes (AOT).
- [x] `dotnet format` clean.

Made with [Cursor](https://cursor.com)