### PR TITLE
Create phantom for WIP ingest-processor

### DIFF
--- a/config/navigation.yml
+++ b/config/navigation.yml
@@ -12,6 +12,7 @@ phantoms:
   - toc: docs-content://release-notes/apm-agents
   - toc: docs-content://
   - toc: cloud://release-notes
+  - toc: elasticsearch://reference/ingest-processor
 
 toc:
   #############


### PR DESCRIPTION
I need to unblock https://github.com/elastic/elasticsearch/pull/148774 and I think a phantom entry will do it.

order of operations

1. this
2. merge https://github.com/elastic/elasticsearch/pull/148774 (full ingest-processor file move, enrich-processor minimized to a stub - chose this method to retain file history)
3. merge https://github.com/elastic/docs-builder/pull/3298
4. clean up /enrich-processor stub (TODO)