### PR TITLE
Changelog: Explicit init parameters and logging for the scrubber lambda 

### DIFF
--- a/docs-builder.slnx
+++ b/docs-builder.slnx
@@ -65,7 +65,8 @@
     <Project Path="src/authoring/Elastic.Documentation.Refactor/Elastic.Documentation.Refactor.csproj" />
   </Folder>
   <Folder Name="/src/infra/">
-    <Project Path="src/infra/docs-lambda-index-publisher/docs-lambda-index-publisher.csproj" />
+	  <Project Path="src/infra/docs-lambda-index-publisher/docs-lambda-index-publisher.csproj" />
+	  <Project Path="src/infra/docs-lambda-changelog-scrubber/docs-lambda-changelog-scrubber.csproj" />
   </Folder>
   <Folder Name="/src/services/">
     <Project Path="src/services/Elastic.Changelog/Elastic.Changelog.csproj" />

--- a/src/infra/docs-lambda-changelog-scrubber/Program.cs
+++ b/src/infra/docs-lambda-changelog-scrubber/Program.cs
@@ -101,6 +101,7 @@ async Task<SQSBatchResponse> Handler(SQSEvent ev, ILambdaContext context)
 
 async Task DeleteFromPublicBucket(IAmazonS3 s3Client, string key, ILambdaContext context)
 {
+	context.Logger.LogDebug($"Removing {key} from the public bucket", key);
 	try
 	{
 		_ = await s3Client.DeleteObjectAsync(new DeleteObjectRequest
@@ -118,6 +119,8 @@ async Task DeleteFromPublicBucket(IAmazonS3 s3Client, string key, ILambdaContext
 
 async Task ScrubAndCopyToPublicBucket(IAmazonS3 s3Client, string sourceBucket, string key, ILambdaContext context)
 {
+	context.Logger.LogDebug("Scrubbing {Key} to public bucket", key);
+
 	var fileName = Path.GetFileName(key);
 	if (string.Equals(fileName, "registry-index.json", StringComparison.OrdinalIgnoreCase))
 	{
@@ -138,6 +141,7 @@ async Task ScrubAndCopyToPublicBucket(IAmazonS3 s3Client, string sourceBucket, s
 		return;
 	}
 
+	context.Logger.LogInformation("Getting {Key} from private bucket", key);
 	var getResponse = await s3Client.GetObjectAsync(new GetObjectRequest
 	{
 		BucketName = sourceBucket,
@@ -148,8 +152,10 @@ async Task ScrubAndCopyToPublicBucket(IAmazonS3 s3Client, string sourceBucket, s
 	using (var reader = new StreamReader(getResponse.ResponseStream))
 		content = await reader.ReadToEndAsync();
 
+	context.Logger.LogInformation("Performing scrub pass for {Key}", key);
 	var scrubbed = await ScrubContent(key, content, context);
 
+	context.Logger.LogInformation("Putting scrubbed {Key} on public bucket", key);
 	_ = await s3Client.PutObjectAsync(new PutObjectRequest
 	{
 		BucketName = publicBucketName,

--- a/src/infra/docs-lambda-changelog-scrubber/Program.cs
+++ b/src/infra/docs-lambda-changelog-scrubber/Program.cs
@@ -43,7 +43,17 @@ IReadOnlyList<string> BuildAllowlist()
 
 async Task<SQSBatchResponse> Handler(SQSEvent ev, ILambdaContext context)
 {
-	using var s3Client = new AmazonS3Client();
+	var region = Amazon.RegionEndpoint.GetBySystemName(
+		Environment.GetEnvironmentVariable("AWS_REGION") ?? "us-east-1");
+	var credentials = new Amazon.Runtime.EnvironmentVariablesAWSCredentials();
+
+	using var s3Client = new AmazonS3Client(credentials, new AmazonS3Config
+	{
+		RegionEndpoint = region,
+		Timeout = TimeSpan.FromSeconds(10),
+		MaxErrorRetry = 2
+	});
+
 	var batchItemFailures = new List<SQSBatchResponse.BatchItemFailure>();
 
 	foreach (var message in ev.Records)


### PR DESCRIPTION
This pull request introduces the new `docs-lambda-changelog-scrubber` project to the solution and enhances its logging and AWS client initialization. The most important changes are grouped below:

**Project and Solution Structure**

* Added the `docs-lambda-changelog-scrubber` project to the solution file `docs-builder.slnx`, making it part of the build and deployment pipeline.

**AWS Client Initialization**

* Updated the S3 client initialization in `Program.cs` to explicitly use environment variable credentials and region, with custom timeout and retry settings for improved reliability and configuration clarity.

**Logging Improvements**

* Added debug and information-level logging throughout the Lambda handler in `Program.cs` to trace key operations, including removing objects from the public bucket, scrubbing and copying files, fetching objects from the private bucket, performing the scrub pass, and uploading to the public bucket. [[1]](diffhunk://#diff-2c6d67749892f3caf9530fbb116a2a29bcff04cea1c0c2b5271b1e9b7d19d048R104) [[2]](diffhunk://#diff-2c6d67749892f3caf9530fbb116a2a29bcff04cea1c0c2b5271b1e9b7d19d048R122-R123) [[3]](diffhunk://#diff-2c6d67749892f3caf9530fbb116a2a29bcff04cea1c0c2b5271b1e9b7d19d048R144) [[4]](diffhunk://#diff-2c6d67749892f3caf9530fbb116a2a29bcff04cea1c0c2b5271b1e9b7d19d048R155-R158)