### PR TITLE
Add content_type to DocumentationDocument for site search parity

### DIFF
--- a/src/Elastic.Documentation/Search/DocumentationDocument.cs
+++ b/src/Elastic.Documentation/Search/DocumentationDocument.cs
@@ -35,6 +35,34 @@ public record DocumentationDocument
 	[JsonPropertyName("type")]
 	public required string Type { get; set; } = "doc";
 
+#pragma warning disable IDE0032 // Backing field: ContentType getter/setter normalizes away values equal to Type for stable JSON.
+	private string? _contentType;
+#pragma warning restore IDE0032
+
+	/// <summary>
+	/// Indexed document kind for filtering, stored as <c>content_type</c> alongside <see cref="Type"/> (<c>type</c>).
+	/// Both fields exist for future shared <c>_source</c> with website-ai-search, where CLR type may stay JSON-ignored
+	/// to avoid System.Text.Json polymorphic <c>$type</c> clashes with a serialized <c>type</c> property; the persisted
+	/// filter value then uses <c>content_type</c>. Values present in JSON win over <see cref="Type"/>; otherwise
+	/// <see cref="Type"/> applies, then <c>doc</c> when both are absent (sparse hits).
+	/// </summary>
+	[Keyword]
+	[JsonPropertyName("content_type")]
+	public string ContentType
+	{
+		get => _contentType ?? Type ?? "doc";
+		set
+		{
+			if (string.IsNullOrWhiteSpace(value))
+			{
+				_contentType = null;
+				return;
+			}
+
+			_contentType = string.Equals(value, Type, StringComparison.Ordinal) ? null : value;
+		}
+	}
+
 	/// <summary>
 	/// The canonical/primary product for this document (nested object with id and repository).
 	/// Name and version are looked up dynamically by product id.

--- a/tests/Elastic.Markdown.Tests/Search/DocumentationDocumentSerializationTests.cs
+++ b/tests/Elastic.Markdown.Tests/Search/DocumentationDocumentSerializationTests.cs
@@ -332,7 +332,7 @@ public class DocumentationDocumentSerializationTests
 		deserialized.Applies.Deployment.Ess.Should().BeEquivalentTo(original.Applies.Deployment.Ess);
 		deserialized.ContentLastUpdated.Should().Be(original.ContentLastUpdated);
 		deserialized.ContentBodyHash.Should().Be(original.ContentBodyHash);
-		deserialized!.ContentType.Should().Be(original.ContentType);
+		deserialized.ContentType.Should().Be(original.ContentType);
 	}
 
 	[Fact]
@@ -374,7 +374,7 @@ public class DocumentationDocumentSerializationTests
 		var deserialized = JsonSerializer.Deserialize<DocumentationDocument>(json, _options);
 
 		deserialized.Should().NotBeNull();
-		deserialized!.Type.Should().Be("doc");
+		deserialized.Type.Should().Be("doc");
 		deserialized.ContentType.Should().Be("archived-docs");
 	}
 

--- a/tests/Elastic.Markdown.Tests/Search/DocumentationDocumentSerializationTests.cs
+++ b/tests/Elastic.Markdown.Tests/Search/DocumentationDocumentSerializationTests.cs
@@ -332,6 +332,50 @@ public class DocumentationDocumentSerializationTests
 		deserialized.Applies.Deployment.Ess.Should().BeEquivalentTo(original.Applies.Deployment.Ess);
 		deserialized.ContentLastUpdated.Should().Be(original.ContentLastUpdated);
 		deserialized.ContentBodyHash.Should().Be(original.ContentBodyHash);
+		deserialized!.ContentType.Should().Be(original.ContentType);
+	}
+
+	[Fact]
+	public void SerializeDocumentationDocument_IncludesContentType_MatchingType()
+	{
+		foreach (var type in new[] { "doc", "api" })
+		{
+			var doc = new DocumentationDocument
+			{
+				Type = type,
+				Url = $"/test/{type}",
+				Title = "T",
+				SearchTitle = "T"
+			};
+
+			var json = JsonSerializer.Serialize(doc, _options);
+			using var parsed = JsonDocument.Parse(json);
+			var root = parsed.RootElement;
+
+			root.GetProperty("type").GetString().Should().Be(type);
+			root.GetProperty("content_type").GetString().Should().Be(type);
+		}
+	}
+
+	[Fact]
+	public void ContentType_FromJson_Overrides_Type()
+	{
+		var json = """
+		{
+			"title": "Legacy",
+			"search_title": "Legacy",
+			"url": "/x",
+			"type": "doc",
+			"hash": "h",
+			"content_type": "archived-docs"
+		}
+		""";
+
+		var deserialized = JsonSerializer.Deserialize<DocumentationDocument>(json, _options);
+
+		deserialized.Should().NotBeNull();
+		deserialized!.Type.Should().Be("doc");
+		deserialized.ContentType.Should().Be("archived-docs");
 	}
 
 	[Fact]


### PR DESCRIPTION
## Why

Site-wide search combines documentation with other surfaces that classify documents in `_source` differently than our plain `type` field alone. We need a persisted keyword that can diverge from `type` when JSON carries an explicit classification, while staying aligned with website-ai-search so a future shared `DocumentationDocument` can round-trip the same shape. The intentional duplication supports **wider site search filtering** across those indices and clients.

## What

- Add `content_type` on `DocumentationDocument` with the same JSON-first normalization pattern used on the site side (stored value omitted when it matches `type` for stable round-trips).
- Document in XML why `type` and `content_type` coexist (polymorphic `$type` / JSON-ignored CLR type on the other repo; persisted filter via `content_type`).
- Extend serialization tests for emit, override-from-JSON, and round-trip.

Made with [Cursor](https://cursor.com)