### PR TITLE
changelog(prepare-artifact): treat empty existing-filename as unset

### DIFF
--- a/src/services/Elastic.Changelog/Evaluation/ChangelogPrepareArtifactService.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogPrepareArtifactService.cs
@@ -47,11 +47,17 @@ public class ChangelogPrepareArtifactService(
 
 			if (sourceYaml != null)
 			{
-				changelogFilename = input.ExistingChangelogFilename != null
-					? _fileSystem.Path.GetFileName(input.ExistingChangelogFilename)
+				// Treat empty as unset: CLI parsers (e.g. Argh) forward `--flag ""`
+				// as the empty string instead of null. An empty filename here would
+				// make Path.Combine(OutputDir, "") collapse to OutputDir itself and
+				// turn the artifact write into a write against the directory path,
+				// which fails with EACCES on Linux.
+				var hasExistingFilename = !string.IsNullOrEmpty(input.ExistingChangelogFilename);
+				changelogFilename = hasExistingFilename
+					? _fileSystem.Path.GetFileName(input.ExistingChangelogFilename!)
 					: _fileSystem.Path.GetFileName(sourceYaml);
 
-				if (input.ExistingChangelogFilename != null)
+				if (hasExistingFilename)
 					_logger.LogInformation("Reusing existing filename {Filename} for stable path on branch", changelogFilename);
 
 				var destYaml = _fileSystem.Path.Combine(input.OutputDir, changelogFilename);

--- a/tests/Elastic.Changelog.Tests/Evaluation/ChangelogPrepareArtifactServiceTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/ChangelogPrepareArtifactServiceTests.cs
@@ -233,6 +233,26 @@ public class ChangelogPrepareArtifactServiceTests(ITestOutputHelper output) : Ch
 	}
 
 	[Fact]
+	public async Task PrepareArtifact_EmptyExistingFilename_FallsBackToStagingFilename()
+	{
+		// Regression: CLI parsers (Argh) forward `--existing-changelog-filename ""`
+		// as the empty string instead of null. An empty filename used to make
+		// Path.Combine(OutputDir, "") collapse to OutputDir itself and write the
+		// artifact YAML at the directory path → EACCES on Linux.
+		await SetupStagingYaml("1735700000-new-title.yaml");
+		await SetupConfig();
+		var service = CreateService();
+		var args = DefaultArgs() with { ExistingChangelogFilename = string.Empty };
+
+		var result = await service.PrepareArtifact(Collector, args, CancellationToken.None);
+
+		result.Should().BeTrue();
+		FileSystem.File.Exists(Path.Join(OutputDir, "1735700000-new-title.yaml")).Should().BeTrue();
+		var metadata = ReadMetadata();
+		metadata.ChangelogFilename.Should().Be("1735700000-new-title.yaml");
+	}
+
+	[Fact]
 	public async Task PrepareArtifact_MissingStagingYaml_StatusError()
 	{
 		await SetupConfig();


### PR DESCRIPTION
## Summary

CLI parsers (Argh, since #3202) forward `--existing-changelog-filename ""` as the empty string instead of `null`, so the existing `!= null` guard let empty filenames through:

```csharp
changelogFilename = input.ExistingChangelogFilename != null
    ? _fileSystem.Path.GetFileName(input.ExistingChangelogFilename)  // GetFileName("") == ""
    : _fileSystem.Path.GetFileName(sourceYaml);

var destYaml = _fileSystem.Path.Combine(input.OutputDir, changelogFilename);
// Path.Combine(".artifacts/changelog-artifact", "") == ".artifacts/changelog-artifact"
await _fileSystem.File.WriteAllTextAsync(destYaml, ...);
```

The artifact write target collapses to the output directory path itself, and on Linux opening a directory for write returns `EACCES`:

```
Unhandled ChangelogPrepareArtifactService exception:
Access to the path '/home/runner/work/cloud/cloud/.artifacts/changelog-artifact' is denied.
System.IO.IOException: Permission denied
  at System.IO.File.OpenHandle(...)
  at System.IO.File.<WriteToFileAsync>...
```

This switches the guard to `!string.IsNullOrEmpty` and adds a regression test that exercises the empty-string path explicitly.

A complementary fix in `elastic/docs-actions` (https://github.com/elastic/docs-actions/pull/152) stops forwarding the flag when the evaluate-step output is empty, so neither side relies on the other.

## Test plan

- [x] `dotnet format` clean
- [x] `./build.sh` clean (AOT)
- [x] `dotnet test tests/Elastic.Changelog.Tests --filter ChangelogPrepareArtifactServiceTests` — 18/18 passing, including new `PrepareArtifact_EmptyExistingFilename_FallsBackToStagingFilename`
- [ ] Repro from elastic/cloud PR #154858 (run 25721575364) succeeds once both PRs are released


Made with [Cursor](https://cursor.com)