### PR TITLE
Fix AOT compile error in ContentDateEnrichment.SwapAliasAsync

### DIFF
--- a/src/Elastic.Markdown/Exporters/Elasticsearch/ContentDateEnrichment.cs
+++ b/src/Elastic.Markdown/Exporters/Elasticsearch/ContentDateEnrichment.cs
@@ -192,7 +192,7 @@ public class ContentDateEnrichment(
 				new JsonObject { ["remove"] = new JsonObject { ["index"] = oldIndex, ["alias"] = _lookupAlias } },
 				addAction
 			)
-			: [addAction];
+			: [(JsonNode)addAction];
 
 		var body = new JsonObject { ["actions"] = actions };
 


### PR DESCRIPTION
## Why

The `main` branch's `Publish Containers` job is failing in CI ([run 25809931130](https://github.com/elastic/docs-builder/actions/runs/25809931130/job/75823094210)) because the AOT compiler rejects code introduced in #3308:

```
ILC : Trim analysis error IL2026: ...JsonArray.Add<JsonObject>(JsonObject)... RequiresUnreferencedCodeAttribute
ILC : AOT analysis error  IL3050: ...JsonArray.Add<JsonObject>(JsonObject)... RequiresDynamicCodeAttribute
```

This blocks container publishing for every push to `main`.

## What

In `ContentDateEnrichment.SwapAliasAsync`, the collection expression `[addAction]` (where `addAction` is a `JsonObject`) resolves to the generic `JsonArray.Add<T>(T?)` overload, which is annotated `RequiresUnreferencedCode` + `RequiresDynamicCode` and trips the AOT analyzer.

Casting to `JsonNode` — `[(JsonNode)addAction]` — makes overload resolution pick the AOT-safe non-generic `Add(JsonNode?)` (from `IList<JsonNode?>`), so we keep the collection-expression syntax that #3308 was introduced to satisfy without breaking AOT.

Verified locally with `dotnet publish -c Release` on `docs-builder.csproj` (which sets `<PublishAot>true</PublishAot>`): native code generation completes with no `ILC` errors.

Made with [Cursor](https://cursor.com)