### PR TITLE
Remove links between changelog render output files

### DIFF
--- a/src/services/Elastic.Changelog/Rendering/Markdown/IndexMarkdownRenderer.cs
+++ b/src/services/Elastic.Changelog/Rendering/Markdown/IndexMarkdownRenderer.cs
@@ -32,23 +32,6 @@ public class IndexMarkdownRenderer(ScopedFileSystem fileSystem) : MarkdownRender
 		var regressions = entriesByType.GetValueOrDefault(Regression, []);
 		var other = entriesByType.GetValueOrDefault(Other, []);
 
-		var hasBreakingChanges = entriesByType.ContainsKey(BreakingChange);
-		var hasDeprecations = entriesByType.ContainsKey(Deprecation);
-		var hasKnownIssues = entriesByType.ContainsKey(KnownIssue);
-		var hasHighlights = entriesByType.Values
-			.SelectMany(e => e)
-			.Any(e => e.Highlight == true);
-
-		var otherLinks = new List<string>();
-		if (hasHighlights)
-			otherLinks.Add($"[Highlights](/release-notes/highlights.md#{context.Repo}-{context.TitleSlug}-highlights)");
-		if (hasKnownIssues)
-			otherLinks.Add($"[Known issues](/release-notes/known-issues.md#{context.Repo}-{context.TitleSlug}-known-issues)");
-		if (hasBreakingChanges)
-			otherLinks.Add($"[Breaking changes](/release-notes/breaking-changes.md#{context.Repo}-{context.TitleSlug}-breaking-changes)");
-		if (hasDeprecations)
-			otherLinks.Add($"[Deprecations](/release-notes/deprecations.md#{context.Repo}-{context.TitleSlug}-deprecations)");
-
 		var sb = new StringBuilder();
 		_ = sb.AppendLine(InvariantCulture, $"## {context.Title} [{context.Repo}-release-notes-{context.TitleSlug}]");
 
@@ -65,12 +48,6 @@ public class IndexMarkdownRenderer(ScopedFileSystem fileSystem) : MarkdownRender
 			_ = sb.AppendLine(context.BundleDescription);
 		}
 
-		if (otherLinks.Count > 0)
-		{
-			var linksText = string.Join(" and ", otherLinks);
-			_ = sb.AppendLine(InvariantCulture, $"_{linksText}._");
-			_ = sb.AppendLine();
-		}
 
 		var hasAnyEntries = features.Count > 0 || enhancements.Count > 0 || security.Count > 0 || bugFixes.Count > 0 || docs.Count > 0 || regressions.Count > 0 || other.Count > 0;
 

--- a/tests/Elastic.Changelog.Tests/Changelogs/Render/BasicRenderTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/Render/BasicRenderTests.cs
@@ -77,6 +77,124 @@ public class BasicRenderTests(ITestOutputHelper output) : RenderChangelogTestBas
 	}
 
 	[Fact]
+	public async Task RenderChangelogs_WithMultipleTypes_DoesNotIncludeCrossFileLinksInIndex()
+	{
+		// Arrange
+		var changelogDir = FileSystem.Path.Join(Paths.WorkingDirectoryRoot.FullName, Guid.NewGuid().ToString());
+		FileSystem.Directory.CreateDirectory(changelogDir);
+
+		// Create test changelog files with different types to trigger separated files
+		// language=yaml
+		var featureChangelog =
+			"""
+			title: Test feature
+			type: feature
+			products:
+			  - product: elasticsearch
+			    target: 9.3.0
+			prs:
+			- "100"
+			""";
+
+		// language=yaml
+		var deprecationChangelog =
+			"""
+			title: Deprecated API
+			type: deprecation
+			products:
+			  - product: elasticsearch
+			    target: 9.3.0
+			prs:
+			- "200"
+			""";
+
+		// language=yaml
+		var highlightChangelog =
+			"""
+			title: Highlighted feature
+			type: feature
+			highlight: true
+			products:
+			  - product: elasticsearch
+			    target: 9.3.0
+			prs:
+			- "300"
+			""";
+
+		var featureFile = FileSystem.Path.Join(changelogDir, "feature.yaml");
+		var deprecationFile = FileSystem.Path.Join(changelogDir, "deprecation.yaml");
+		var highlightFile = FileSystem.Path.Join(changelogDir, "highlight.yaml");
+
+		await FileSystem.File.WriteAllTextAsync(featureFile, featureChangelog, TestContext.Current.CancellationToken);
+		await FileSystem.File.WriteAllTextAsync(deprecationFile, deprecationChangelog, TestContext.Current.CancellationToken);
+		await FileSystem.File.WriteAllTextAsync(highlightFile, highlightChangelog, TestContext.Current.CancellationToken);
+
+		// Create bundle file
+		var bundleFile = FileSystem.Path.Join(Paths.WorkingDirectoryRoot.FullName, Guid.NewGuid().ToString(), "bundle.yaml");
+		FileSystem.Directory.CreateDirectory(FileSystem.Path.GetDirectoryName(bundleFile)!);
+
+		// language=yaml
+		var bundleContent =
+			$"""
+			products:
+			  - product: elasticsearch
+			    target: 9.3.0
+			entries:
+			  - file:
+			      name: feature.yaml
+			      checksum: {ComputeSha1(featureChangelog)}
+			  - file:
+			      name: deprecation.yaml
+			      checksum: {ComputeSha1(deprecationChangelog)}
+			  - file:
+			      name: highlight.yaml
+			      checksum: {ComputeSha1(highlightChangelog)}
+			""";
+		await FileSystem.File.WriteAllTextAsync(bundleFile, bundleContent, TestContext.Current.CancellationToken);
+
+		var outputDir = FileSystem.Path.Join(Paths.WorkingDirectoryRoot.FullName, Guid.NewGuid().ToString());
+
+		var input = new RenderChangelogsArguments
+		{
+			Bundles = [new BundleInput { BundleFile = bundleFile, Directory = changelogDir }],
+			Output = outputDir,
+			Title = "9.3.0"
+		};
+
+		// Act
+		var result = await Service.RenderChangelogs(Collector, input, TestContext.Current.CancellationToken);
+
+		// Assert
+		result.Should().BeTrue();
+		Collector.Errors.Should().Be(0);
+
+		// Verify index.md exists but does NOT contain cross-file links
+		var indexFile = FileSystem.Path.Join(outputDir, "9.3.0", "index.md");
+		FileSystem.File.Exists(indexFile).Should().BeTrue();
+		var indexContent = await FileSystem.File.ReadAllTextAsync(indexFile, TestContext.Current.CancellationToken);
+
+		indexContent.Should().Contain("## 9.3.0");
+		indexContent.Should().Contain("Test feature");
+		indexContent.Should().Contain("Highlighted feature");
+
+		// Verify NO cross-file links are present
+		indexContent.Should().NotContain("[Highlights]");
+		indexContent.Should().NotContain("[Deprecations]");
+		indexContent.Should().NotContain("/release-notes/");
+
+		// Verify individual separated files are still generated
+		var deprecationsFile = FileSystem.Path.Join(outputDir, "9.3.0", "deprecations.md");
+		FileSystem.File.Exists(deprecationsFile).Should().BeTrue();
+		var deprecationsContent = await FileSystem.File.ReadAllTextAsync(deprecationsFile, TestContext.Current.CancellationToken);
+		deprecationsContent.Should().Contain("Deprecated API");
+
+		var highlightsFile = FileSystem.Path.Join(outputDir, "9.3.0", "highlights.md");
+		FileSystem.File.Exists(highlightsFile).Should().BeTrue();
+		var highlightsContent = await FileSystem.File.ReadAllTextAsync(highlightsFile, TestContext.Current.CancellationToken);
+		highlightsContent.Should().Contain("Highlighted feature");
+	}
+
+	[Fact]
 	public async Task RenderChangelogs_WithMultipleBundles_MergesAndRenders()
 	{
 		// Arrange

--- a/tests/Elastic.Changelog.Tests/Changelogs/Render/HighlightsRenderTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/Render/HighlightsRenderTests.cs
@@ -83,7 +83,7 @@ public class HighlightsRenderTests(ITestOutputHelper output) : RenderChangelogTe
 		FileSystem.File.Exists(indexFile).Should().BeTrue();
 		var indexContent = await FileSystem.File.ReadAllTextAsync(indexFile, TestContext.Current.CancellationToken);
 		indexContent.Should().Contain("New Cloud Connect UI");
-		indexContent.Should().Contain("[Highlights]");
+		// Note: Cross-file links like "[Highlights]" have been removed from index.md
 	}
 
 	[Fact]


### PR DESCRIPTION
Fixes https://github.com/elastic/docs-builder/issues/3322

Rather than add complexity to the `changelog render` command to make it aware of whether or not you want to use the output file in [inclusions](https://elastic.github.io/docs-builder/syntax/file_inclusion/), I've updated the command to just omit those unnecessary links.

## Before

The `index.md` file generated by the "docs-builder changelog render" command (e.g. in https://github.com/elastic/docs-content/pull/6509) included:

```md
## May 14, 2026 [elastic-release-notes-2026-05-14]
_[Deprecations](/release-notes/deprecations.md#elastic-2026-05-14-deprecations)._
```

... which was a broken link:

<img width="1329" height="502" alt="image" src="https://github.com/user-attachments/assets/c2785c79-5256-42d4-bdc7-85ebc3c64500" />

## After

The link is no longer added to the output files.