### PR TITLE
Fix comparer collection initializers

### DIFF
--- a/src/Elastic.ApiExplorer/Schema/SchemaHelpers.cs
+++ b/src/Elastic.ApiExplorer/Schema/SchemaHelpers.cs
@@ -19,8 +19,8 @@ public static class SchemaHelpers
 	/// <summary>
 	/// Types that are known to be value types (resolve to primitives like string).
 	/// </summary>
-	public static readonly HashSet<string> KnownValueTypes = new(StringComparer.OrdinalIgnoreCase)
-	{
+	public static readonly HashSet<string> KnownValueTypes = new(
+	[
 		"Field", "Fields", "Id", "Ids", "IndexName", "Indices", "Name", "Names",
 		"Routing", "VersionNumber", "SequenceNumber", "PropertyName", "RelationName",
 		"TaskId", "ScrollId", "SuggestionName", "Duration", "DateMath", "Fuzziness",
@@ -28,26 +28,26 @@ public static class SchemaHelpers
 		"ByteSize", "Percentage", "Stringifiedboolean", "ExpandWildcards", "float", "Stringifiedinteger",
 		// Numeric value types
 		"uint", "ulong", "long", "int", "short", "ushort", "byte", "sbyte", "double", "decimal"
-	};
+	], StringComparer.OrdinalIgnoreCase);
 
 	/// <summary>
 	/// Types that have dedicated pages we can link to.
 	/// Only container types get their own pages - individual queries/aggregations are rendered inline.
 	/// </summary>
-	public static readonly HashSet<string> LinkedTypes = new(StringComparer.OrdinalIgnoreCase)
-	{
+	public static readonly HashSet<string> LinkedTypes = new(
+	[
 		"QueryContainer", "AggregationContainer", "Aggregate"
-	};
+	], StringComparer.OrdinalIgnoreCase);
 
 	/// <summary>
 	/// Primitive/generic type names that are not named schema types.
 	/// These should not be considered for recursive type detection since they
 	/// represent generic types rather than specific schema references.
 	/// </summary>
-	public static readonly HashSet<string> PrimitiveTypeNames = new(StringComparer.OrdinalIgnoreCase)
-	{
+	public static readonly HashSet<string> PrimitiveTypeNames = new(
+	[
 		"boolean", "number", "string", "integer", "object", "null", "array"
-	};
+	], StringComparer.OrdinalIgnoreCase);
 
 	/// <summary>
 	/// Gets the URL for a container type's dedicated page.

--- a/src/Elastic.ApiExplorer/Schema/SchemaHelpers.cs
+++ b/src/Elastic.ApiExplorer/Schema/SchemaHelpers.cs
@@ -19,9 +19,8 @@ public static class SchemaHelpers
 	/// <summary>
 	/// Types that are known to be value types (resolve to primitives like string).
 	/// </summary>
-	public static readonly HashSet<string> KnownValueTypes =
-	[
-		with(StringComparer.OrdinalIgnoreCase),
+	public static readonly HashSet<string> KnownValueTypes = new(StringComparer.OrdinalIgnoreCase)
+	{
 		"Field", "Fields", "Id", "Ids", "IndexName", "Indices", "Name", "Names",
 		"Routing", "VersionNumber", "SequenceNumber", "PropertyName", "RelationName",
 		"TaskId", "ScrollId", "SuggestionName", "Duration", "DateMath", "Fuzziness",
@@ -29,28 +28,26 @@ public static class SchemaHelpers
 		"ByteSize", "Percentage", "Stringifiedboolean", "ExpandWildcards", "float", "Stringifiedinteger",
 		// Numeric value types
 		"uint", "ulong", "long", "int", "short", "ushort", "byte", "sbyte", "double", "decimal"
-	];
+	};
 
 	/// <summary>
 	/// Types that have dedicated pages we can link to.
 	/// Only container types get their own pages - individual queries/aggregations are rendered inline.
 	/// </summary>
-	public static readonly HashSet<string> LinkedTypes =
-	[
-		with(StringComparer.OrdinalIgnoreCase),
+	public static readonly HashSet<string> LinkedTypes = new(StringComparer.OrdinalIgnoreCase)
+	{
 		"QueryContainer", "AggregationContainer", "Aggregate"
-	];
+	};
 
 	/// <summary>
 	/// Primitive/generic type names that are not named schema types.
 	/// These should not be considered for recursive type detection since they
 	/// represent generic types rather than specific schema references.
 	/// </summary>
-	public static readonly HashSet<string> PrimitiveTypeNames =
-	[
-		with(StringComparer.OrdinalIgnoreCase),
+	public static readonly HashSet<string> PrimitiveTypeNames = new(StringComparer.OrdinalIgnoreCase)
+	{
 		"boolean", "number", "string", "integer", "object", "null", "array"
-	];
+	};
 
 	/// <summary>
 	/// Gets the URL for a container type's dedicated page.

--- a/src/Elastic.Documentation.Configuration/Builder/ConfigurationFile.cs
+++ b/src/Elastic.Documentation.Configuration/Builder/ConfigurationFile.cs
@@ -47,10 +47,10 @@ public record ConfigurationFile
 
 	public HashSet<Product> Products { get; private set; } = [];
 
-	private readonly Dictionary<string, string> _substitutions = [with(StringComparer.OrdinalIgnoreCase)];
+	private readonly Dictionary<string, string> _substitutions = new(StringComparer.OrdinalIgnoreCase);
 	public IReadOnlyDictionary<string, string> Substitutions => _substitutions;
 
-	private readonly Dictionary<string, bool> _features = [with(StringComparer.OrdinalIgnoreCase)];
+	private readonly Dictionary<string, bool> _features = new(StringComparer.OrdinalIgnoreCase);
 
 	[field: AllowNull, MaybeNull]
 	public FeatureFlags Features => field ??= new FeatureFlags(_features);
@@ -259,7 +259,7 @@ public record ConfigurationFile
 				Branding = ValidateBranding(docSetFile.Branding, context);
 
 			// Process features
-			_features = [with(StringComparer.OrdinalIgnoreCase)];
+			_features = new(StringComparer.OrdinalIgnoreCase);
 			if (docSetFile.Features.PrimaryNav.HasValue)
 				_features["primary-nav"] = docSetFile.Features.PrimaryNav.Value;
 			if (docSetFile.Features.DisableGithubEditLink.HasValue)

--- a/src/Elastic.Documentation.Configuration/Builder/ConfigurationFile.cs
+++ b/src/Elastic.Documentation.Configuration/Builder/ConfigurationFile.cs
@@ -47,10 +47,10 @@ public record ConfigurationFile
 
 	public HashSet<Product> Products { get; private set; } = [];
 
-	private readonly Dictionary<string, string> _substitutions = new(StringComparer.OrdinalIgnoreCase);
+	private readonly Dictionary<string, string> _substitutions = new(0, StringComparer.OrdinalIgnoreCase);
 	public IReadOnlyDictionary<string, string> Substitutions => _substitutions;
 
-	private readonly Dictionary<string, bool> _features = new(StringComparer.OrdinalIgnoreCase);
+	private readonly Dictionary<string, bool> _features = new(0, StringComparer.OrdinalIgnoreCase);
 
 	[field: AllowNull, MaybeNull]
 	public FeatureFlags Features => field ??= new FeatureFlags(_features);
@@ -259,7 +259,7 @@ public record ConfigurationFile
 				Branding = ValidateBranding(docSetFile.Branding, context);
 
 			// Process features
-			_features = new(StringComparer.OrdinalIgnoreCase);
+			_features = new(0, StringComparer.OrdinalIgnoreCase);
 			if (docSetFile.Features.PrimaryNav.HasValue)
 				_features["primary-nav"] = docSetFile.Features.PrimaryNav.Value;
 			if (docSetFile.Features.DisableGithubEditLink.HasValue)

--- a/src/Elastic.Documentation.Configuration/Builder/FeatureFlags.cs
+++ b/src/Elastic.Documentation.Configuration/Builder/FeatureFlags.cs
@@ -6,7 +6,7 @@ namespace Elastic.Documentation.Configuration.Builder;
 
 public class FeatureFlags(Dictionary<string, bool> initFeatureFlags)
 {
-	private readonly Dictionary<string, bool> _featureFlags = [with(initFeatureFlags)];
+	private readonly Dictionary<string, bool> _featureFlags = new(initFeatureFlags, initFeatureFlags.Comparer);
 
 	public void Set(string key, bool value)
 	{

--- a/src/Elastic.Markdown/IO/MarkdownFile.cs
+++ b/src/Elastic.Markdown/IO/MarkdownFile.cs
@@ -84,10 +84,10 @@ public record MarkdownFile : DocumentationFile, ITableOfContentsScope, IDocument
 
 
 	//indexed by slug
-	private readonly Dictionary<string, PageTocItem> _pageTableOfContent = [with(StringComparer.OrdinalIgnoreCase)];
+	private readonly Dictionary<string, PageTocItem> _pageTableOfContent = new(StringComparer.OrdinalIgnoreCase);
 	public IReadOnlyDictionary<string, PageTocItem> PageTableOfContent => _pageTableOfContent;
 
-	private readonly HashSet<string> _anchors = [with(StringComparer.OrdinalIgnoreCase)];
+	private readonly HashSet<string> _anchors = new(StringComparer.OrdinalIgnoreCase);
 	public IReadOnlySet<string> Anchors => _anchors;
 
 	public string FilePath { get; }

--- a/src/Elastic.Markdown/IO/MarkdownFile.cs
+++ b/src/Elastic.Markdown/IO/MarkdownFile.cs
@@ -84,10 +84,10 @@ public record MarkdownFile : DocumentationFile, ITableOfContentsScope, IDocument
 
 
 	//indexed by slug
-	private readonly Dictionary<string, PageTocItem> _pageTableOfContent = new(StringComparer.OrdinalIgnoreCase);
+	private readonly Dictionary<string, PageTocItem> _pageTableOfContent = new(0, StringComparer.OrdinalIgnoreCase);
 	public IReadOnlyDictionary<string, PageTocItem> PageTableOfContent => _pageTableOfContent;
 
-	private readonly HashSet<string> _anchors = new(StringComparer.OrdinalIgnoreCase);
+	private readonly HashSet<string> _anchors = new(0, StringComparer.OrdinalIgnoreCase);
 	public IReadOnlySet<string> Anchors => _anchors;
 
 	public string FilePath { get; }

--- a/src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogBlock.cs
@@ -146,14 +146,14 @@ public class ChangelogBlock(DirectiveBlockParser parser, ParserContext context) 
 	/// Links to these repositories will be hidden (commented out) in the rendered output.
 	/// Auto-detected from assembler configuration when available.
 	/// </summary>
-	public HashSet<string> PrivateRepositories { get; private set; } = [with(StringComparer.OrdinalIgnoreCase)];
+	public HashSet<string> PrivateRepositories { get; private set; } = new(StringComparer.OrdinalIgnoreCase);
 
 	/// <summary>
 	/// Feature IDs that should be hidden when rendering changelog entries.
 	/// Combined from all loaded bundles' hide-features fields.
 	/// Entries with matching feature-id values will be excluded from the output.
 	/// </summary>
-	public HashSet<string> HideFeatures { get; private set; } = [with(StringComparer.OrdinalIgnoreCase)];
+	public HashSet<string> HideFeatures { get; private set; } = new(StringComparer.OrdinalIgnoreCase);
 
 	/// <summary>
 	/// How to handle PR/issue links relative to private bundle repos (see :link-visibility: option).

--- a/src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogBlock.cs
@@ -146,14 +146,14 @@ public class ChangelogBlock(DirectiveBlockParser parser, ParserContext context) 
 	/// Links to these repositories will be hidden (commented out) in the rendered output.
 	/// Auto-detected from assembler configuration when available.
 	/// </summary>
-	public HashSet<string> PrivateRepositories { get; private set; } = new(StringComparer.OrdinalIgnoreCase);
+	public HashSet<string> PrivateRepositories { get; private set; } = new(0, StringComparer.OrdinalIgnoreCase);
 
 	/// <summary>
 	/// Feature IDs that should be hidden when rendering changelog entries.
 	/// Combined from all loaded bundles' hide-features fields.
 	/// Entries with matching feature-id values will be excluded from the output.
 	/// </summary>
-	public HashSet<string> HideFeatures { get; private set; } = new(StringComparer.OrdinalIgnoreCase);
+	public HashSet<string> HideFeatures { get; private set; } = new(0, StringComparer.OrdinalIgnoreCase);
 
 	/// <summary>
 	/// How to handle PR/issue links relative to private bundle repos (see :link-visibility: option).

--- a/src/services/Elastic.Changelog/Configuration/ChangelogConfigurationLoader.cs
+++ b/src/services/Elastic.Changelog/Configuration/ChangelogConfigurationLoader.cs
@@ -749,7 +749,7 @@ public class ChangelogConfigurationLoader(ILoggerFactory logFactory, IConfigurat
 		Dictionary<string, BundlePerProductRule>? byProduct = null;
 		if (yaml.Products is { Count: > 0 })
 		{
-			byProduct = [with(StringComparer.OrdinalIgnoreCase)];
+			byProduct = new(StringComparer.OrdinalIgnoreCase);
 			foreach (var (productKey, productYaml) in yaml.Products)
 			{
 				var productIds = productKey.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
@@ -947,7 +947,7 @@ public class ChangelogConfigurationLoader(ILoggerFactory logFactory, IConfigurat
 		Dictionary<string, CreateRules>? byProduct = null;
 		if (yaml.Products is { Count: > 0 })
 		{
-			byProduct = [with(StringComparer.OrdinalIgnoreCase)];
+			byProduct = new(StringComparer.OrdinalIgnoreCase);
 			foreach (var (productKey, productYaml) in yaml.Products)
 			{
 				var productIds = productKey.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
@@ -1012,7 +1012,7 @@ public class ChangelogConfigurationLoader(ILoggerFactory logFactory, IConfigurat
 		Dictionary<string, PublishBlocker>? byProduct = null;
 		if (yaml.Products is { Count: > 0 })
 		{
-			byProduct = [with(StringComparer.OrdinalIgnoreCase)];
+			byProduct = new(StringComparer.OrdinalIgnoreCase);
 			foreach (var (productKey, productYaml) in yaml.Products)
 			{
 				var productIds = productKey.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);

--- a/src/services/Elastic.Changelog/Configuration/ChangelogConfigurationLoader.cs
+++ b/src/services/Elastic.Changelog/Configuration/ChangelogConfigurationLoader.cs
@@ -749,7 +749,7 @@ public class ChangelogConfigurationLoader(ILoggerFactory logFactory, IConfigurat
 		Dictionary<string, BundlePerProductRule>? byProduct = null;
 		if (yaml.Products is { Count: > 0 })
 		{
-			byProduct = new(StringComparer.OrdinalIgnoreCase);
+			byProduct = new(0, StringComparer.OrdinalIgnoreCase);
 			foreach (var (productKey, productYaml) in yaml.Products)
 			{
 				var productIds = productKey.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
@@ -947,7 +947,7 @@ public class ChangelogConfigurationLoader(ILoggerFactory logFactory, IConfigurat
 		Dictionary<string, CreateRules>? byProduct = null;
 		if (yaml.Products is { Count: > 0 })
 		{
-			byProduct = new(StringComparer.OrdinalIgnoreCase);
+			byProduct = new(0, StringComparer.OrdinalIgnoreCase);
 			foreach (var (productKey, productYaml) in yaml.Products)
 			{
 				var productIds = productKey.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
@@ -1012,7 +1012,7 @@ public class ChangelogConfigurationLoader(ILoggerFactory logFactory, IConfigurat
 		Dictionary<string, PublishBlocker>? byProduct = null;
 		if (yaml.Products is { Count: > 0 })
 		{
-			byProduct = new(StringComparer.OrdinalIgnoreCase);
+			byProduct = new(0, StringComparer.OrdinalIgnoreCase);
 			foreach (var (productKey, productYaml) in yaml.Products)
 			{
 				var productIds = productKey.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);

--- a/tests/Elastic.Documentation.Build.Tests/MockEnvironmentVariables.cs
+++ b/tests/Elastic.Documentation.Build.Tests/MockEnvironmentVariables.cs
@@ -13,7 +13,7 @@ namespace Elastic.Documentation.Build.Tests;
 /// </summary>
 public class MockEnvironmentVariables : IEnvironmentVariables
 {
-	private readonly Dictionary<string, string> _variables = [with(StringComparer.OrdinalIgnoreCase)];
+	private readonly Dictionary<string, string> _variables = new(StringComparer.OrdinalIgnoreCase);
 
 	/// <summary>
 	/// Sets an environment variable value for testing.

--- a/tests/Elastic.Documentation.Build.Tests/MockEnvironmentVariables.cs
+++ b/tests/Elastic.Documentation.Build.Tests/MockEnvironmentVariables.cs
@@ -13,7 +13,7 @@ namespace Elastic.Documentation.Build.Tests;
 /// </summary>
 public class MockEnvironmentVariables : IEnvironmentVariables
 {
-	private readonly Dictionary<string, string> _variables = new(StringComparer.OrdinalIgnoreCase);
+	private readonly Dictionary<string, string> _variables = new(0, StringComparer.OrdinalIgnoreCase);
 
 	/// <summary>
 	/// Sets an environment variable value for testing.


### PR DESCRIPTION
## Why

Current `main` fails to compile because the compiler treats the comparer `with(...)` collection expressions as calls to a missing method.

## What

Replace those expressions with explicit `Dictionary` and `HashSet` constructors while preserving the intended case-insensitive comparers. Verified with `dotnet build src/tooling/docs-builder/docs-builder.csproj -c Release --verbosity minimal`.

Made with [Cursor](https://cursor.com)