### PR TITLE
Bump Nullean.Argh packages from 0.16.0 to 0.16.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
           dotnet run --project src/tooling/docs-builder -c release --no-build -- __schema > docs/cli-schema.json.tmp
-          diff docs/cli-schema.json docs/cli-schema.json.tmp || (echo "docs/cli-schema.json is out of date — run: dotnet run --project src/tooling/docs-builder -- __schema > docs/cli-schema.json" && exit 1)
+          diff <(jq 'del(.version)' docs/cli-schema.json) <(jq 'del(.version)' docs/cli-schema.json.tmp) || (echo "docs/cli-schema.json is out of date — run: dotnet run --project src/tooling/docs-builder -- __schema > docs/cli-schema.json" && exit 1)
           rm docs/cli-schema.json.tmp
 
       - name: Test

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -69,9 +69,9 @@
     <PackageVersion Include="FSharp.Core" Version="10.1.201" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Nullean.Argh" Version="0.16.0" />
-    <PackageVersion Include="Nullean.Argh.Hosting" Version="0.16.0" />
-    <PackageVersion Include="Nullean.Argh.Interfaces" Version="0.16.0" />
+    <PackageVersion Include="Nullean.Argh" Version="0.16.2" />
+    <PackageVersion Include="Nullean.Argh.Hosting" Version="0.16.2" />
+    <PackageVersion Include="Nullean.Argh.Interfaces" Version="0.16.2" />
     <PackageVersion Include="Crayon" Version="2.0.69" />
     <PackageVersion Include="DotNet.Glob" Version="3.1.3" />
     <PackageVersion Include="Errata" Version="0.16.0" />

--- a/docs/cli-schema.json
+++ b/docs/cli-schema.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "name": "docs-builder",
-  "version": "1.0.0.0",
+  "version": "1.0.0",
   "description": null,
   "reservedMetaCommands": [
     "__complete",


### PR DESCRIPTION
## Why

Nullean.Argh 0.16.2 was released on May 17, 2026 — keeping the dependency current picks up any bug fixes in the patch releases.

## What

Bumps `Nullean.Argh`, `Nullean.Argh.Hosting`, and `Nullean.Argh.Interfaces` from `0.16.0` to `0.16.2` in `Directory.Packages.props`.