### PR TITLE
Fix --version and __schema to report the semantic release version

### DIFF
--- a/docs/cli-schema.json
+++ b/docs/cli-schema.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "name": "docs-builder",
-  "version": "1.0.0.0",
+  "version": "1.0.0",
   "description": null,
   "reservedMetaCommands": [
     "__complete",

--- a/src/tooling/docs-builder/Program.cs
+++ b/src/tooling/docs-builder/Program.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Reflection;
 using Documentation.Builder;
 using Documentation.Builder.Commands;
 using Documentation.Builder.Commands.Assembler;
@@ -15,7 +16,39 @@ using Microsoft.Extensions.Hosting;
 using Nullean.Argh;
 using Nullean.Argh.Hosting;
 
-// Pre-host fast path: run --help, --version, __schema, __completion directly and exit
+var informationalVersion =
+	Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+	?? Assembly.GetExecutingAssembly().GetName().Version?.ToString()
+	?? "unknown";
+
+// Intercept --version before Argh to print the semantic release version (set by
+// MinVer) rather than the CLR assembly file version.
+if (args is ["--version"])
+{
+	Console.WriteLine(informationalVersion);
+	return;
+}
+
+// Intercept __schema to patch the version field in Argh's JSON output with the
+// informational version. Argh calls Environment.Exit after writing; the ProcessExit
+// handler below runs before the process terminates and rewrites the captured output.
+if (args is ["__schema"])
+{
+	var originalOut = Console.Out;
+	var captured = new StringWriter();
+	Console.SetOut(captured);
+
+	AppDomain.CurrentDomain.ProcessExit += (_, _) =>
+	{
+		var json = captured.ToString();
+		var patched = SchemaVersionRewriter.VersionField().Replace(json,
+			$@"$1""{informationalVersion}""");
+		originalOut.Write(patched);
+		originalOut.Flush();
+	};
+}
+
+// Pre-host fast path: run --help, __schema, __completion directly and exit
 // before the host (and its startup logs) are ever constructed.
 await ArghApp.TryArghIntrinsicCommand(args);
 
@@ -71,3 +104,9 @@ _ = builder.Services.AddArgh(args, app =>
 
 using var host = builder.Build();
 await host.RunAsync();
+
+internal static partial class SchemaVersionRewriter
+{
+	[System.Text.RegularExpressions.GeneratedRegex(@"(""version""\s*:\s*)""[^""]*""")]
+	internal static partial System.Text.RegularExpressions.Regex VersionField();
+}


### PR DESCRIPTION
## Why

`docs-builder --version` was printing the CLR assembly file version (`1.0.0.0`) instead of the MinVer-assigned semantic version. The same value leaked into the `version` field of the `__schema` output (used to generate `docs/cli-schema.json`). On a tagged release the version should be clean — e.g. `1.9.0` — not the CLR default.

This is a follow-up to the Nullean.Argh 0.16.2 bump (#3330), which exposed the mismatch because Argh 0.16.2 switched from `AssemblyFileVersionAttribute` to `AssemblyInformationalVersionAttribute` internally. The same fix applies to Argh 0.16.0 as well.

## What

Both `--version` and `__schema` are now intercepted in `Program.cs` before Argh's intrinsic handler runs:

- `--version` prints `AssemblyInformationalVersionAttribute` directly and exits.
- `__schema` redirects `Console.Out` to a `StringWriter`, registers a `ProcessExit` handler that patches the `version` JSON field with the informational version, then lets Argh write and exit as normal.

`docs/cli-schema.json` is regenerated to reflect the change (`1.0.0.0` → `1.0.0` for local non-MinVer builds; tagged releases will show the clean semver).

> **Note:** merge after #3330, which adds `jq`-based version-field exclusion to the CI schema diff so the check stays green across canary commits.