### PR TITLE
Fix ShouldContainHtml expected comparison

### DIFF
--- a/tests/Elastic.Markdown.Tests/PrettyHtmlExtensions.cs
+++ b/tests/Elastic.Markdown.Tests/PrettyHtmlExtensions.cs
@@ -81,7 +81,7 @@ public static class PrettyHtmlExtensions
 		actual = actual.Trim('\n').PrettyHtml(sanitize);
 
 		var actualCompare = actual.Replace("\t", string.Empty);
-		var expectedCompare = actual.Replace("\t", string.Empty);
+		var expectedCompare = expected.Replace("\t", string.Empty);
 
 		// we compare over unindented HTML, but if that fails, we rely on the pretty HTML Contain().
 		// to throw for improved error messages

--- a/tests/Elastic.Markdown.Tests/PrettyHtmlExtensionsTests.cs
+++ b/tests/Elastic.Markdown.Tests/PrettyHtmlExtensionsTests.cs
@@ -1,0 +1,27 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using AwesomeAssertions;
+using Xunit.Sdk;
+
+namespace Elastic.Markdown.Tests;
+
+public class PrettyHtmlExtensionsTests
+{
+	[Fact]
+	public void ShouldContainHtml_WhenExpectedHtmlIsMissing_Throws()
+	{
+		var actual = """
+		             <p>Rendered output</p>
+		             """;
+
+		var expected = """
+		               <strong>Missing output</strong>
+		               """;
+
+		var act = () => actual.ShouldContainHtml(expected);
+
+		act.Should().Throw<XunitException>();
+	}
+}


### PR DESCRIPTION
## Summary

Fixes `ShouldContainHtml` so the comparison uses the pretty-printed expected HTML instead of comparing the actual HTML to itself.

Adds a regression test that verifies the helper throws when the expected HTML fragment is missing from the actual output.

Closes #3337.

## Verification

- `git diff --check`
- `dotnet test ./tests/Elastic.Markdown.Tests/Elastic.Markdown.Tests.csproj --filter FullyQualifiedName~PrettyHtmlExtensionsTests --no-restore` could not run locally because this checkout pins .NET SDK `10.0.100` and no .NET SDK is installed on this machine.

This was implemented with Codex assistance, with the patch kept focused and manually reviewed.