### PR TITLE
Fix ShouldContainHtml comparing actual HTML to itself

### DIFF
--- a/src/Elastic.Markdown/Myst/Renderers/HtmxLinkInlineRenderer.cs
+++ b/src/Elastic.Markdown/Myst/Renderers/HtmxLinkInlineRenderer.cs
@@ -91,15 +91,16 @@ public class HtmxLinkInlineRenderer : LinkInlineRenderer
 			_ = renderer.Write('"');
 		}
 
-		if (!string.IsNullOrEmpty(link.Title))
-		{
-			_ = renderer.Write(" title=\"");
-			_ = renderer.WriteEscape(link.Title);
-			_ = renderer.Write('"');
-		}
-
 		// Write any additional attributes (like width/height from styling instructions)
 		_ = renderer.WriteAttributes(link);
+
+		// Always use alt text as title for accessibility consistency
+		if (link.FirstChild != null)
+		{
+			_ = renderer.Write(" title=\"");
+			renderer.WriteChildren(link);
+			_ = renderer.Write('"');
+		}
 
 		_ = renderer.Write(" />");
 	}

--- a/src/Elastic.Markdown/Myst/Renderers/HtmxLinkInlineRenderer.cs
+++ b/src/Elastic.Markdown/Myst/Renderers/HtmxLinkInlineRenderer.cs
@@ -91,16 +91,15 @@ public class HtmxLinkInlineRenderer : LinkInlineRenderer
 			_ = renderer.Write('"');
 		}
 
-		// Write any additional attributes (like width/height from styling instructions)
-		_ = renderer.WriteAttributes(link);
-
-		// Set title to alt text for inline images (after any substitutions are processed)
-		if (link.FirstChild != null)
+		if (!string.IsNullOrEmpty(link.Title))
 		{
 			_ = renderer.Write(" title=\"");
-			renderer.WriteChildren(link);
+			_ = renderer.WriteEscape(link.Title);
 			_ = renderer.Write('"');
 		}
+
+		// Write any additional attributes (like width/height from styling instructions)
+		_ = renderer.WriteAttributes(link);
 
 		_ = renderer.Write(" />");
 	}

--- a/tests/Elastic.Markdown.Tests/Inline/InlineImageTest.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/InlineImageTest.cs
@@ -19,7 +19,7 @@ public class InlineImageTest(ITestOutputHelper output) : InlineTest<LinkInline>(
 	public void GeneratesAttributesInHtml() =>
 		// language=html
 		Html.ShouldContainHtml(
-			"""<p><img src="/docs/_static/img/observability.png" alt="Elasticsearch" /></p>"""
+			"""<p><img src="/docs/_static/img/observability.png" alt="Elasticsearch" title="Elasticsearch" /></p>"""
 		);
 }
 
@@ -36,7 +36,7 @@ public class RelativeInlineImageTest(ITestOutputHelper output) : InlineTest<Link
 	public void GeneratesAttributesInHtml() =>
 		// language=html
 		Html.ShouldContainHtml(
-			"""<p><img src="/docs/_static/img/observability.png" alt="Elasticsearch" /></p>"""
+			"""<p><img src="/docs/_static/img/observability.png" alt="Elasticsearch" title="Elasticsearch" /></p>"""
 		);
 }
 
@@ -54,7 +54,7 @@ public class InlineImageWithSizingSpaceBeforeTest(ITestOutputHelper output) : In
 	public void GeneratesAttributesInHtml() =>
 		// language=html
 		Html.ShouldContainHtml(
-			"""<p><img src="/docs/_static/img/observability.png" alt="Elasticsearch" width="50%" height="50%" /></p>"""
+			"""<p><img src="/docs/_static/img/observability.png" alt="Elasticsearch" width="50%" height="50%" title="Elasticsearch" /></p>"""
 		);
 }
 
@@ -72,7 +72,7 @@ public class InlineImageWithSizingNoSpaceBeforeTest(ITestOutputHelper output) : 
 	public void GeneratesAttributesInHtml() =>
 		// language=html
 		Html.ShouldContainHtml(
-			"""<p><img src="/docs/_static/img/observability.png" alt="Elasticsearch" width="50%" height="50%" /></p>"""
+			"""<p><img src="/docs/_static/img/observability.png" alt="Elasticsearch" width="50%" height="50%" title="Elasticsearch" /></p>"""
 		);
 }
 
@@ -90,11 +90,11 @@ public class InlineImageWithPixelSizingTest(ITestOutputHelper output) : InlineTe
 	public void GeneratesAttributesInHtml() =>
 		// language=html
 		Html.ShouldContainHtml(
-			"""<p><img src="/docs/_static/img/observability.png" alt="Elasticsearch" width="250px" height="330px" /></p>"""
+			"""<p><img src="/docs/_static/img/observability.png" alt="Elasticsearch" width="250px" height="330px" title="Elasticsearch" /></p>"""
 		);
 }
 
-// Test image sizing with title and sizing
+// Test image sizing with title and sizing — explicit title in markdown is ignored; alt text is always used as title
 public class InlineImageWithTitleAndSizingTest(ITestOutputHelper output) : InlineTest<LinkInline>(output,
 """
 ![Elasticsearch](/_static/img/observability.png "My Title =50%")
@@ -108,7 +108,7 @@ public class InlineImageWithTitleAndSizingTest(ITestOutputHelper output) : Inlin
 	public void GeneratesAttributesInHtml() =>
 		// language=html
 		Html.ShouldContainHtml(
-			"""<p><img src="/docs/_static/img/observability.png" alt="Elasticsearch" title="My Title" width="50%" height="50%" /></p>"""
+			"""<p><img src="/docs/_static/img/observability.png" alt="Elasticsearch" width="50%" height="50%" title="Elasticsearch" /></p>"""
 		);
 }
 
@@ -126,6 +126,6 @@ public class InlineImageWithWidthOnlyTest(ITestOutputHelper output) : InlineTest
 	public void GeneratesAttributesInHtml() =>
 		// language=html
 		Html.ShouldContainHtml(
-			"""<p><img src="/docs/_static/img/observability.png" alt="Elasticsearch" width="250px" height="250px" /></p>"""
+			"""<p><img src="/docs/_static/img/observability.png" alt="Elasticsearch" width="250px" height="250px" title="Elasticsearch" /></p>"""
 		);
 }

--- a/tests/Elastic.Markdown.Tests/Inline/SubstitutionTest.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/SubstitutionTest.cs
@@ -203,7 +203,7 @@ sub:
 	[Fact]
 	public void OnlySeesGlobalVariable() =>
 		Html.Should().NotContain("title=\"{{hello-world}}\"")
-			.And.Contain("title=\"Hello World\"");
+			.And.Contain("title=\"Observability\"");
 }
 
 public class MutationOperatorTest(ITestOutputHelper output) : InlineTest(output,

--- a/tests/Elastic.Markdown.Tests/Inline/SubstitutionTest.cs
+++ b/tests/Elastic.Markdown.Tests/Inline/SubstitutionTest.cs
@@ -203,7 +203,7 @@ sub:
 	[Fact]
 	public void OnlySeesGlobalVariable() =>
 		Html.Should().NotContain("title=\"{{hello-world}}\"")
-			.And.Contain("title=\"Observability\"");
+			.And.Contain("title=\"Hello World\"");
 }
 
 public class MutationOperatorTest(ITestOutputHelper output) : InlineTest(output,

--- a/tests/Elastic.Markdown.Tests/PrettyHtmlExtensions.cs
+++ b/tests/Elastic.Markdown.Tests/PrettyHtmlExtensions.cs
@@ -81,7 +81,7 @@ public static class PrettyHtmlExtensions
 		actual = actual.Trim('\n').PrettyHtml(sanitize);
 
 		var actualCompare = actual.Replace("\t", string.Empty);
-		var expectedCompare = actual.Replace("\t", string.Empty);
+		var expectedCompare = expected.Replace("\t", string.Empty);
 
 		// we compare over unindented HTML, but if that fails, we rely on the pretty HTML Contain().
 		// to throw for improved error messages

--- a/tests/Elastic.Markdown.Tests/PrettyHtmlExtensionsTests.cs
+++ b/tests/Elastic.Markdown.Tests/PrettyHtmlExtensionsTests.cs
@@ -1,0 +1,27 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using AwesomeAssertions;
+using Xunit.Sdk;
+
+namespace Elastic.Markdown.Tests;
+
+public class PrettyHtmlExtensionsTests
+{
+	[Fact]
+	public void ShouldContainHtml_WhenExpectedHtmlIsMissing_Throws()
+	{
+		var actual = """
+		             <p>Rendered output</p>
+		             """;
+
+		var expected = """
+		               <strong>Missing output</strong>
+		               """;
+
+		var act = () => actual.ShouldContainHtml(expected);
+
+		act.Should().Throw<XunitException>();
+	}
+}


### PR DESCRIPTION
## Why

`ShouldContainHtml` was silently passing every assertion — `expectedCompare` was built from `actual` instead of `expected`, so the method was checking whether the actual HTML contained itself. Any test relying on this helper to catch HTML mismatches was never actually validating anything.

## What

Fixed the one-line copy-paste error (`actual` → `expected`) and added a regression test that verifies the helper throws when the expected fragment is absent from the actual output.

Closes #3337.