### PR TITLE
Fix publishcontainers build target after Api project merge

### DIFF
--- a/build/Targets.fs
+++ b/build/Targets.fs
@@ -135,7 +135,7 @@ let private publishContainers _ =
         exec { run "dotnet" (args @ registry) }
     createImage "src/tooling/docs-builder/docs-builder.csproj" "docs-builder"
     createImage "src/api/Elastic.Documentation.Mcp.Remote/Elastic.Documentation.Mcp.Remote.csproj" "docs-builder-mcp"
-    createImage "src/api/Elastic.Documentation.Api.App/Elastic.Documentation.Api.App.csproj" "docs-builder-api"
+    createImage "src/api/Elastic.Documentation.Api/Elastic.Documentation.Api.csproj" "docs-builder-api"
 
 let private runTests (testSuite: TestSuite) _ =
     let testFilter =


### PR DESCRIPTION
## Why

The `publishcontainers` build target references the old `Elastic.Documentation.Api.App` project path, which was deleted in #3333 when the three Api projects were merged into a single `Elastic.Documentation.Api`. This caused the container publish CI job to fail immediately with a missing project file error.

## What

Updated `build/Targets.fs` to point the `docs-builder-api` container image at the new `src/api/Elastic.Documentation.Api/Elastic.Documentation.Api.csproj` path.