### PR TITLE
Codex: fix group layout broken by DOM reorder in #3344

### DIFF
--- a/src/Elastic.Codex/_GroupLayout.cshtml
+++ b/src/Elastic.Codex/_GroupLayout.cshtml
@@ -13,12 +13,12 @@
 				md:px-4
 	">
 		<div class="min-h-screen grid grid-cols-1 md:grid-cols-[var(--max-sidebar-width)_1fr] gap-4">
-			@await RenderPartialAsync(_PagesNav.Create(Model))
-			<main id="content-container" class="min-w-0 lg:grid lg:grid-cols-[minmax(0,var(--max-text-width))_minmax(0,var(--max-sidebar-width))] justify-center mx-4 gap-4">
+			<main id="content-container" class="min-w-0 lg:grid lg:grid-cols-[minmax(0,var(--max-text-width))_minmax(0,var(--max-sidebar-width))] justify-center mx-4 gap-4 md:order-2">
 				<div class="min-w-0">
 					@await RenderBodyAsync()
 				</div>
 			</main>
+			@await RenderPartialAsync(_PagesNav.Create(Model))
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
## Why

PR #3344 moved `<main>` before `_PagesNav` in DOM source order across all sidebar-grid layouts, and added `md:order-1` to the shared `_PagesNav` aside to keep the visual column position. `_GroupLayout.cshtml` (used by Codex group landing pages) was the one layout that was missed — leaving it with an `md:order-1` nav and no compensating `md:order-2` on `<main>`, which broke the visual layout of those pages.

## What

Apply the same fix to `src/Elastic.Codex/_GroupLayout.cshtml`: emit `<main>` first in DOM source order, add `md:order-2` so it stays visually in the right column at `md+`.