### PR TITLE
Keep nav-v2 focused on the active section

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/pages-nav-v2.test.ts
+++ b/src/Elastic.Documentation.Site/Assets/pages-nav-v2.test.ts
@@ -10,72 +10,74 @@ jest.mock('tippy.js', () => ({
 
 function renderNav() {
     document.body.innerHTML = `
-        <nav class="docs-sidebar-nav-v2" data-nav-v2>
-            <ul class="docs-sidebar-nav-v2__tree" id="nav-tree">
-                <li class="relative">
-                    <span class="docs-sidebar-nav-v2__label docs-sidebar-nav-v2__label--top">Guides</span>
-                    <ul class="docs-sidebar-nav-v2__label-children w-full">
-                        <li class="flex flex-wrap group-navigation relative">
-                            <div class="peer nav-folder-peer grid w-full grid-cols-1">
-                                <input id="group-a" type="checkbox" checked />
-                                <a href="/guide/a" class="sidebar-link nav-v2-link">Group A</a>
-                            </div>
-                            <div class="docs-sidebar-nav-v2__folder-clip w-full">
-                                <div class="docs-sidebar-nav-v2__folder-clip-inner">
-                                    <ul class="docs-sidebar-nav-v2__folder-children w-full relative">
-                                        <li class="flex flex-wrap group-navigation relative">
-                                            <div class="peer nav-folder-peer grid w-full grid-cols-1">
-                                                <input id="group-a-1" type="checkbox" checked />
-                                                <a href="/guide/a/topic-1" class="sidebar-link nav-v2-link">Topic 1</a>
-                                            </div>
-                                            <div class="docs-sidebar-nav-v2__folder-clip w-full">
-                                                <div class="docs-sidebar-nav-v2__folder-clip-inner">
-                                                    <ul class="docs-sidebar-nav-v2__folder-children w-full relative">
-                                                        <li class="flex group/li">
-                                                            <a href="/guide/a/topic-1/current-page" class="sidebar-link nav-v2-link">Current page</a>
-                                                        </li>
-                                                    </ul>
-                                                </div>
-                                            </div>
-                                        </li>
-                                        <li class="flex flex-wrap group-navigation relative">
-                                            <div class="peer nav-folder-peer grid w-full grid-cols-1">
-                                                <input id="group-a-2" type="checkbox" checked />
-                                                <a href="/guide/a/topic-2" class="sidebar-link nav-v2-link">Topic 2</a>
-                                            </div>
-                                            <div class="docs-sidebar-nav-v2__folder-clip w-full">
-                                                <div class="docs-sidebar-nav-v2__folder-clip-inner">
-                                                    <ul class="docs-sidebar-nav-v2__folder-children w-full relative">
-                                                        <li class="flex group/li">
-                                                            <a href="/guide/a/topic-2/other-page" class="sidebar-link nav-v2-link">Other page</a>
-                                                        </li>
-                                                    </ul>
-                                                </div>
-                                            </div>
-                                        </li>
-                                    </ul>
+        <div class="pages-nav-menu">
+            <nav class="docs-sidebar-nav-v2" data-nav-v2>
+                <ul class="docs-sidebar-nav-v2__tree" id="nav-tree">
+                    <li class="relative">
+                        <span class="docs-sidebar-nav-v2__label docs-sidebar-nav-v2__label--top">Guides</span>
+                        <ul class="docs-sidebar-nav-v2__label-children w-full">
+                            <li class="flex flex-wrap group-navigation relative">
+                                <div class="peer nav-folder-peer grid w-full grid-cols-1">
+                                    <input id="group-a" type="checkbox" checked />
+                                    <a href="/guide/a" class="sidebar-link nav-v2-link">Group A</a>
                                 </div>
-                            </div>
-                        </li>
-                        <li class="flex flex-wrap group-navigation relative">
-                            <div class="peer nav-folder-peer grid w-full grid-cols-1">
-                                <input id="group-b" type="checkbox" checked />
-                                <a href="/guide/b" class="sidebar-link nav-v2-link">Group B</a>
-                            </div>
-                            <div class="docs-sidebar-nav-v2__folder-clip w-full">
-                                <div class="docs-sidebar-nav-v2__folder-clip-inner">
-                                    <ul class="docs-sidebar-nav-v2__folder-children w-full relative">
-                                        <li class="flex group/li">
-                                            <a href="/guide/b/page" class="sidebar-link nav-v2-link">Group B page</a>
-                                        </li>
-                                    </ul>
+                                <div class="docs-sidebar-nav-v2__folder-clip w-full">
+                                    <div class="docs-sidebar-nav-v2__folder-clip-inner">
+                                        <ul class="docs-sidebar-nav-v2__folder-children w-full relative">
+                                            <li class="flex flex-wrap group-navigation relative">
+                                                <div class="peer nav-folder-peer grid w-full grid-cols-1">
+                                                    <input id="group-a-1" type="checkbox" checked />
+                                                    <a href="/guide/a/topic-1" class="sidebar-link nav-v2-link">Topic 1</a>
+                                                </div>
+                                                <div class="docs-sidebar-nav-v2__folder-clip w-full">
+                                                    <div class="docs-sidebar-nav-v2__folder-clip-inner">
+                                                        <ul class="docs-sidebar-nav-v2__folder-children w-full relative">
+                                                            <li class="flex group/li">
+                                                                <a href="/guide/a/topic-1/current-page" class="sidebar-link nav-v2-link">Current page</a>
+                                                            </li>
+                                                        </ul>
+                                                    </div>
+                                                </div>
+                                            </li>
+                                            <li class="flex flex-wrap group-navigation relative">
+                                                <div class="peer nav-folder-peer grid w-full grid-cols-1">
+                                                    <input id="group-a-2" type="checkbox" checked />
+                                                    <a href="/guide/a/topic-2" class="sidebar-link nav-v2-link">Topic 2</a>
+                                                </div>
+                                                <div class="docs-sidebar-nav-v2__folder-clip w-full">
+                                                    <div class="docs-sidebar-nav-v2__folder-clip-inner">
+                                                        <ul class="docs-sidebar-nav-v2__folder-children w-full relative">
+                                                            <li class="flex group/li">
+                                                                <a href="/guide/a/topic-2/other-page" class="sidebar-link nav-v2-link">Other page</a>
+                                                            </li>
+                                                        </ul>
+                                                    </div>
+                                                </div>
+                                            </li>
+                                        </ul>
+                                    </div>
                                 </div>
-                            </div>
-                        </li>
-                    </ul>
-                </li>
-            </ul>
-        </nav>
+                            </li>
+                            <li class="flex flex-wrap group-navigation relative">
+                                <div class="peer nav-folder-peer grid w-full grid-cols-1">
+                                    <input id="group-b" type="checkbox" checked />
+                                    <a href="/guide/b" class="sidebar-link nav-v2-link">Group B</a>
+                                </div>
+                                <div class="docs-sidebar-nav-v2__folder-clip w-full">
+                                    <div class="docs-sidebar-nav-v2__folder-clip-inner">
+                                        <ul class="docs-sidebar-nav-v2__folder-children w-full relative">
+                                            <li class="flex group/li">
+                                                <a href="/guide/b/page" class="sidebar-link nav-v2-link">Group B page</a>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </li>
+                        </ul>
+                    </li>
+                </ul>
+            </nav>
+        </div>
     `
 
     return document.querySelector<HTMLElement>('[data-nav-v2]')!
@@ -83,6 +85,10 @@ function renderNav() {
 
 function checkbox(id: string): HTMLInputElement {
     return document.getElementById(id) as HTMLInputElement
+}
+
+function groupRow(id: string): HTMLElement {
+    return checkbox(id).closest('li.group-navigation') as HTMLElement
 }
 
 describe('initNavV2', () => {
@@ -131,5 +137,51 @@ describe('initNavV2', () => {
 
         expect(groupB.checked).toBe(true)
         expect(groupA.checked).toBe(false)
+    })
+
+    it('scrolls the active branch into view when it opens below the viewport', () => {
+        window.history.pushState({}, '', '/guide/b/page')
+
+        const nav = renderNav()
+        const container = document.querySelector(
+            '.pages-nav-menu'
+        ) as HTMLElement
+        const groupB = groupRow('group-b')
+
+        Object.defineProperty(container, 'scrollTop', {
+            value: 0,
+            writable: true,
+            configurable: true,
+        })
+        Object.defineProperty(container, 'clientHeight', {
+            value: 120,
+            configurable: true,
+        })
+        container.getBoundingClientRect = jest.fn(() => ({
+            x: 0,
+            y: 0,
+            top: 0,
+            right: 280,
+            bottom: 120,
+            left: 0,
+            width: 280,
+            height: 120,
+            toJSON: () => ({}),
+        }))
+        groupB.getBoundingClientRect = jest.fn(() => ({
+            x: 0,
+            y: 150,
+            top: 150,
+            right: 280,
+            bottom: 250,
+            left: 0,
+            width: 280,
+            height: 100,
+            toJSON: () => ({}),
+        }))
+
+        initNavV2(nav)
+
+        expect(container.scrollTop).toBe(142)
     })
 })

--- a/src/Elastic.Documentation.Site/Assets/pages-nav-v2.test.ts
+++ b/src/Elastic.Documentation.Site/Assets/pages-nav-v2.test.ts
@@ -1,0 +1,135 @@
+import { initNavV2 } from './pages-nav-v2'
+
+jest.mock('tippy.js', () => ({
+    __esModule: true,
+    default: jest.fn(() => ({
+        destroy: jest.fn(),
+        setContent: jest.fn(),
+    })),
+}))
+
+function renderNav() {
+    document.body.innerHTML = `
+        <nav class="docs-sidebar-nav-v2" data-nav-v2>
+            <ul class="docs-sidebar-nav-v2__tree" id="nav-tree">
+                <li class="relative">
+                    <span class="docs-sidebar-nav-v2__label docs-sidebar-nav-v2__label--top">Guides</span>
+                    <ul class="docs-sidebar-nav-v2__label-children w-full">
+                        <li class="flex flex-wrap group-navigation relative">
+                            <div class="peer nav-folder-peer grid w-full grid-cols-1">
+                                <input id="group-a" type="checkbox" checked />
+                                <a href="/guide/a" class="sidebar-link nav-v2-link">Group A</a>
+                            </div>
+                            <div class="docs-sidebar-nav-v2__folder-clip w-full">
+                                <div class="docs-sidebar-nav-v2__folder-clip-inner">
+                                    <ul class="docs-sidebar-nav-v2__folder-children w-full relative">
+                                        <li class="flex flex-wrap group-navigation relative">
+                                            <div class="peer nav-folder-peer grid w-full grid-cols-1">
+                                                <input id="group-a-1" type="checkbox" checked />
+                                                <a href="/guide/a/topic-1" class="sidebar-link nav-v2-link">Topic 1</a>
+                                            </div>
+                                            <div class="docs-sidebar-nav-v2__folder-clip w-full">
+                                                <div class="docs-sidebar-nav-v2__folder-clip-inner">
+                                                    <ul class="docs-sidebar-nav-v2__folder-children w-full relative">
+                                                        <li class="flex group/li">
+                                                            <a href="/guide/a/topic-1/current-page" class="sidebar-link nav-v2-link">Current page</a>
+                                                        </li>
+                                                    </ul>
+                                                </div>
+                                            </div>
+                                        </li>
+                                        <li class="flex flex-wrap group-navigation relative">
+                                            <div class="peer nav-folder-peer grid w-full grid-cols-1">
+                                                <input id="group-a-2" type="checkbox" checked />
+                                                <a href="/guide/a/topic-2" class="sidebar-link nav-v2-link">Topic 2</a>
+                                            </div>
+                                            <div class="docs-sidebar-nav-v2__folder-clip w-full">
+                                                <div class="docs-sidebar-nav-v2__folder-clip-inner">
+                                                    <ul class="docs-sidebar-nav-v2__folder-children w-full relative">
+                                                        <li class="flex group/li">
+                                                            <a href="/guide/a/topic-2/other-page" class="sidebar-link nav-v2-link">Other page</a>
+                                                        </li>
+                                                    </ul>
+                                                </div>
+                                            </div>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </li>
+                        <li class="flex flex-wrap group-navigation relative">
+                            <div class="peer nav-folder-peer grid w-full grid-cols-1">
+                                <input id="group-b" type="checkbox" checked />
+                                <a href="/guide/b" class="sidebar-link nav-v2-link">Group B</a>
+                            </div>
+                            <div class="docs-sidebar-nav-v2__folder-clip w-full">
+                                <div class="docs-sidebar-nav-v2__folder-clip-inner">
+                                    <ul class="docs-sidebar-nav-v2__folder-children w-full relative">
+                                        <li class="flex group/li">
+                                            <a href="/guide/b/page" class="sidebar-link nav-v2-link">Group B page</a>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </li>
+                    </ul>
+                </li>
+            </ul>
+        </nav>
+    `
+
+    return document.querySelector<HTMLElement>('[data-nav-v2]')!
+}
+
+function checkbox(id: string): HTMLInputElement {
+    return document.getElementById(id) as HTMLInputElement
+}
+
+describe('initNavV2', () => {
+    const originalRequestAnimationFrame = window.requestAnimationFrame
+
+    beforeEach(() => {
+        sessionStorage.clear()
+        window.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+            cb(0)
+            return 0
+        }) as typeof window.requestAnimationFrame
+    })
+
+    afterEach(() => {
+        document.body.innerHTML = ''
+    })
+
+    afterAll(() => {
+        window.requestAnimationFrame = originalRequestAnimationFrame
+    })
+
+    it('keeps only the active page branch expanded', () => {
+        window.history.pushState({}, '', '/guide/a/topic-1/current-page')
+
+        const nav = renderNav()
+
+        initNavV2(nav)
+
+        expect(checkbox('group-a').checked).toBe(true)
+        expect(checkbox('group-a-1').checked).toBe(true)
+        expect(checkbox('group-a-2').checked).toBe(false)
+        expect(checkbox('group-b').checked).toBe(false)
+    })
+
+    it('collapses sibling folders when a new folder is opened manually', () => {
+        window.history.pushState({}, '', '/guide/a/topic-1/current-page')
+
+        const nav = renderNav()
+
+        initNavV2(nav)
+
+        const groupA = checkbox('group-a')
+        const groupB = checkbox('group-b')
+        groupB.checked = true
+        groupB.dispatchEvent(new Event('change', { bubbles: true }))
+
+        expect(groupB.checked).toBe(true)
+        expect(groupA.checked).toBe(false)
+    })
+})

--- a/src/Elastic.Documentation.Site/Assets/pages-nav-v2.ts
+++ b/src/Elastic.Documentation.Site/Assets/pages-nav-v2.ts
@@ -233,37 +233,35 @@ function ensureNavV2OptimisticCurrentOnNavigate() {
 }
 
 /**
- * Returns all sibling top-level accordion checkboxes for a given checkbox.
- * Siblings are other checkboxes inside [data-v2-accordion] elements at the
- * same nesting level as the given checkbox's ancestor accordion.
+ * Returns all sibling folder checkboxes at the same nesting level.
  */
 function getSiblingAccordionCheckboxes(
     checkbox: HTMLInputElement
 ): HTMLInputElement[] {
-    const accordion = checkbox.closest('[data-v2-accordion]')
-    if (!accordion) {
+    const group = checkbox.closest('li.group-navigation')
+    if (!group) {
         return []
     }
 
-    const parent = accordion.parentElement
+    const parent = group.parentElement
     if (!parent) {
         return []
     }
 
     return Array.from(
         parent.querySelectorAll<HTMLInputElement>(
-            '[data-v2-accordion] > .peer input[type=checkbox]'
+            ':scope > li.group-navigation > .nav-folder-peer input[type=checkbox]'
         )
     ).filter((c) => c !== checkbox)
 }
 
 /**
- * Accordion behaviour: when a top-level section is opened,
- * collapse all its siblings so only one section is expanded at a time.
+ * Accordion behaviour: when a folder is opened, collapse its siblings so
+ * only one branch stays expanded at that nesting level.
  */
 function initAccordion(nav: HTMLElement) {
     nav.querySelectorAll<HTMLInputElement>(
-        '[data-v2-accordion] > .peer input[type=checkbox]'
+        'li.group-navigation > .nav-folder-peer input[type=checkbox]'
     ).forEach((cb) => {
         if (cb.dataset.navV2AccordionBound === 'true') {
             return
@@ -278,6 +276,25 @@ function initAccordion(nav: HTMLElement) {
                 })
             }
         })
+    })
+}
+
+function getAllFolderCheckboxes(nav: HTMLElement): HTMLInputElement[] {
+    return Array.from(
+        nav.querySelectorAll<HTMLInputElement>(
+            'li.group-navigation > .nav-folder-peer input[type=checkbox]'
+        )
+    )
+}
+
+function collapseInactiveFolders(
+    nav: HTMLElement,
+    activeCheckboxes: Set<HTMLInputElement>
+) {
+    getAllFolderCheckboxes(nav).forEach((cb) => {
+        if (!activeCheckboxes.has(cb)) {
+            cb.checked = false
+        }
     })
 }
 
@@ -568,60 +585,59 @@ function pickDeepestAnchorMatchingPath(
 function expandToCurrentPageForPath(nav: HTMLElement, pathnameRaw: string) {
     const link = pickDeepestAnchorMatchingPath(nav, pathnameRaw)
     if (!link) {
+        collapseInactiveFolders(nav, new Set())
         return
     }
 
     const collapsedIds = readCollapsedFolderIds()
+    const activeCheckboxes = new Set<HTMLInputElement>()
+    let wroteCollapsedIds = false
 
     let el: Element | null = link.parentElement
     while (el && el !== nav) {
         if (el.matches('li')) {
             const cb = el.querySelector<HTMLInputElement>(
-                ':scope > .peer input[type=checkbox]'
+                ':scope > .nav-folder-peer input[type=checkbox]'
             )
             if (cb && cb.id) {
-                const rowLink = el.querySelector<HTMLElement>(
-                    ':scope > .nav-folder-peer > a.sidebar-link'
-                )
-                const currentIsThisFolderRow =
-                    rowLink !== null && rowLink === link
-
+                activeCheckboxes.add(cb)
                 if (collapsedIds.has(cb.id)) {
-                    if (currentIsThisFolderRow) {
-                        // User collapsed this folder while its index is current; HTML swap often
-                        // re-checks the input — force closed so a second click can stay collapsed.
-                        cb.checked = false
-                    } else {
-                        collapsedIds.delete(cb.id)
-                        writeCollapsedFolderIds(collapsedIds)
-                        cb.checked = true
-                    }
-                } else {
-                    cb.checked = true
+                    collapsedIds.delete(cb.id)
+                    wroteCollapsedIds = true
                 }
+                cb.checked = true
             } else if (cb) {
+                activeCheckboxes.add(cb)
                 cb.checked = true
             }
         }
 
         el = el.parentElement
     }
+
+    if (wroteCollapsedIds) {
+        writeCollapsedFolderIds(collapsedIds)
+    }
+
+    collapseInactiveFolders(nav, activeCheckboxes)
 }
 
 /**
  * Expand all ancestor collapsible sections that contain the current page link,
- * so that navigating directly to a URL reveals its location in the sidebar.
- * Does not re-open a folder row that the user collapsed while that folder index
- * is the current page (see session storage + folder row link match).
+ * so that navigating directly to a URL reveals its location in the sidebar,
+ * while collapsing folders that are outside the active branch.
  */
 function expandToCurrentPage(nav: HTMLElement) {
     if (isOnSectionRootPage(nav)) {
+        const activeCheckboxes = new Set<HTMLInputElement>()
         const topLevelFolders = nav.querySelectorAll<HTMLInputElement>(
-            '#nav-tree > li > .peer > input[type="checkbox"]'
+            '#nav-tree > li.group-navigation > .nav-folder-peer > input[type="checkbox"]'
         )
         if (topLevelFolders.length === 1) {
             topLevelFolders[0].checked = true
+            activeCheckboxes.add(topLevelFolders[0])
         }
+        collapseInactiveFolders(nav, activeCheckboxes)
         return
     }
     expandToCurrentPageForPath(nav, window.location.pathname)

--- a/src/Elastic.Documentation.Site/Assets/pages-nav-v2.ts
+++ b/src/Elastic.Documentation.Site/Assets/pages-nav-v2.ts
@@ -8,6 +8,7 @@ let navV2FolderLinkToggleBound = false
 let navV2OptimisticNavigateBound = false
 
 let navV2TruncationTippyInstances: Instance[] = []
+const navV2ActiveBranchScrollTimeouts = new WeakMap<HTMLElement, number[]>()
 
 function readCollapsedFolderIds(): Set<string> {
     try {
@@ -227,6 +228,7 @@ function ensureNavV2OptimisticCurrentOnNavigate() {
             markCurrentPageForPath(nav, path)
             expandToCurrentPageForPath(nav, path)
             applyActiveSubtreeHighlight(nav)
+            scheduleActiveBranchScroll(nav)
         },
         true
     )
@@ -296,6 +298,90 @@ function collapseInactiveFolders(
             cb.checked = false
         }
     })
+}
+
+function findNavV2ScrollContainer(nav: HTMLElement): HTMLElement | null {
+    return nav.closest<HTMLElement>('.pages-nav-menu')
+}
+
+function pickActiveBranchScrollTarget(
+    nav: HTMLElement,
+    current: HTMLAnchorElement
+): HTMLElement | null {
+    let target = current.closest<HTMLElement>('li')
+    let walk = target
+    while (walk && walk !== nav) {
+        if (walk.matches('li.group-navigation')) {
+            target = walk
+        }
+
+        walk = walk.parentElement?.closest<HTMLElement>('li') ?? null
+    }
+
+    return target
+}
+
+function scrollActiveBranchIntoView(nav: HTMLElement) {
+    const container = findNavV2ScrollContainer(nav)
+    if (!container) {
+        return
+    }
+
+    const current = deepestCurrentSidebarLink(nav)
+    if (!current) {
+        return
+    }
+
+    const target = pickActiveBranchScrollTarget(nav, current)
+    if (!target) {
+        return
+    }
+
+    const containerRect = container.getBoundingClientRect()
+    const targetRect = target.getBoundingClientRect()
+    const topPadding = 8
+    const bottomPadding = 16
+    const visibleTop = containerRect.top + topPadding
+    const visibleBottom = containerRect.bottom - bottomPadding
+
+    if (targetRect.top >= visibleTop && targetRect.bottom <= visibleBottom) {
+        return
+    }
+
+    const targetTop =
+        targetRect.top - containerRect.top + container.scrollTop - topPadding
+    container.scrollTop = Math.max(0, targetTop)
+}
+
+function scheduleActiveBranchScroll(nav: HTMLElement) {
+    const existingTimeouts = navV2ActiveBranchScrollTimeouts.get(nav)
+    if (existingTimeouts !== undefined) {
+        existingTimeouts.forEach((timeoutId) => window.clearTimeout(timeoutId))
+    }
+
+    const run = () => {
+        if (!nav.isConnected) {
+            return
+        }
+
+        scrollActiveBranchIntoView(nav)
+    }
+
+    requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+            run()
+        })
+    })
+
+    const timeoutIds = [260, 520].map((delay, index) =>
+        window.setTimeout(() => {
+            run()
+            if (index === 1) {
+                navV2ActiveBranchScrollTimeouts.delete(nav)
+            }
+        }, delay)
+    )
+    navV2ActiveBranchScrollTimeouts.set(nav, timeoutIds)
 }
 
 function warmFolderSubtreeLayoutFromPeer(peer: HTMLElement) {
@@ -720,6 +806,7 @@ export function initNavV2(nav: HTMLElement) {
     markCurrentPage(nav)
     expandToCurrentPage(nav)
     applyActiveSubtreeHighlight(nav)
+    scheduleActiveBranchScroll(nav)
     initNavV2FolderLayoutWarmup(nav)
     requestAnimationFrame(() => {
         requestAnimationFrame(() => initNavV2TruncationTooltips(nav))

--- a/src/Elastic.Documentation.Site/Assets/pages-nav-v2.ts
+++ b/src/Elastic.Documentation.Site/Assets/pages-nav-v2.ts
@@ -9,7 +9,10 @@ let navV2OptimisticNavigateBound = false
 
 let navV2TruncationTippyInstances: Instance[] = []
 const navV2ActiveBranchScrollTimeouts = new WeakMap<HTMLElement, number[]>()
-const navV2ActiveBranchScrollObservers = new WeakMap<HTMLElement, ResizeObserver>()
+const navV2ActiveBranchScrollObservers = new WeakMap<
+    HTMLElement,
+    ResizeObserver
+>()
 
 function readCollapsedFolderIds(): Set<string> {
     try {

--- a/src/Elastic.Documentation.Site/Assets/pages-nav-v2.ts
+++ b/src/Elastic.Documentation.Site/Assets/pages-nav-v2.ts
@@ -9,6 +9,7 @@ let navV2OptimisticNavigateBound = false
 
 let navV2TruncationTippyInstances: Instance[] = []
 const navV2ActiveBranchScrollTimeouts = new WeakMap<HTMLElement, number[]>()
+const navV2ActiveBranchScrollObservers = new WeakMap<HTMLElement, ResizeObserver>()
 
 function readCollapsedFolderIds(): Set<string> {
     try {
@@ -382,6 +383,39 @@ function scheduleActiveBranchScroll(nav: HTMLElement) {
         }, delay)
     )
     navV2ActiveBranchScrollTimeouts.set(nav, timeoutIds)
+}
+
+function initActiveBranchScrollObserver(nav: HTMLElement) {
+    if (
+        typeof ResizeObserver === 'undefined' ||
+        navV2ActiveBranchScrollObservers.has(nav)
+    ) {
+        return
+    }
+
+    const observer = new ResizeObserver(() => {
+        if (!nav.isConnected) {
+            observer.disconnect()
+            navV2ActiveBranchScrollObservers.delete(nav)
+            return
+        }
+
+        scheduleActiveBranchScroll(nav)
+    })
+    navV2ActiveBranchScrollObservers.set(nav, observer)
+
+    const container = findNavV2ScrollContainer(nav)
+    const stickyChrome =
+        container?.previousElementSibling instanceof HTMLElement
+            ? container.previousElementSibling
+            : null
+
+    if (container) {
+        observer.observe(container)
+    }
+    if (stickyChrome) {
+        observer.observe(stickyChrome)
+    }
 }
 
 function warmFolderSubtreeLayoutFromPeer(peer: HTMLElement) {
@@ -806,6 +840,7 @@ export function initNavV2(nav: HTMLElement) {
     markCurrentPage(nav)
     expandToCurrentPage(nav)
     applyActiveSubtreeHighlight(nav)
+    initActiveBranchScrollObserver(nav)
     scheduleActiveBranchScroll(nav)
     initNavV2FolderLayoutWarmup(nav)
     requestAnimationFrame(() => {


### PR DESCRIPTION
Keep nav-v2 focused on the active section by collapsing folders that are outside the current page's branch. Without this, same-section HTMX navigation can leave stale folders expanded and make the sidebar look like multiple sections are active at once.

Demo: https://docs-v3-preview.elastic.dev/elastic/docs-builder/docs/3354/deploy-manage/distributed-architecture/clusters-nodes-shards/node-roles

## Why

The nav-v2 prototype is meant to keep the current section focused, but once you open another branch it can stay expanded after navigating within the same section. That leaves the sidebar with multiple open branches and makes it harder to tell where the current page belongs.

## What

This change recomputes folder expansion from the active page path and closes every folder that is not on that branch. It also uses the rendered folder hierarchy for manual accordion behavior, so opening one folder closes its siblings at the same level, and adds a focused frontend regression test for both behaviors.