### PR TITLE
Fix inline callout regex and li rendering for markdown links

### DIFF
--- a/src/Elastic.Markdown/Myst/CodeBlocks/CallOutParser.cs
+++ b/src/Elastic.Markdown/Myst/CodeBlocks/CallOutParser.cs
@@ -11,6 +11,6 @@ public static partial class CallOutParser
 	[GeneratedRegex(@"^.+\S+.*?\s<\d+>$", RegexOptions.IgnoreCase, 2000)]
 	public static partial Regex CallOutNumber();
 
-	[GeneratedRegex(@"^.+\S+.*?\s(?:\/\/|#)\s[^""\/#]+$", RegexOptions.IgnoreCase, 2000)]
+	[GeneratedRegex(@"^.+\S+.*?\s(?:\/\/|#)\s[^""#]+$", RegexOptions.IgnoreCase, 2000)]
 	public static partial Regex MathInlineAnnotation();
 }

--- a/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockHtmlRenderer.cs
+++ b/src/Elastic.Markdown/Myst/CodeBlocks/EnhancedCodeBlockHtmlRenderer.cs
@@ -239,8 +239,8 @@ public class EnhancedCodeBlockHtmlRenderer : HtmlObjectRenderer<EnhancedCodeBloc
 			_ = renderer.WriteLine("<ol class=\"code-callouts\">");
 			foreach (var c in block.UniqueCallOuts)
 			{
-				_ = renderer.WriteLine("<li>");
-				_ = renderer.WriteLine(RenderCalloutMarkdown(block, c).Value ?? string.Empty);
+				_ = renderer.Write("<li>");
+				_ = renderer.Write(RenderCalloutMarkdown(block, c).Value ?? string.Empty);
 				_ = renderer.WriteLine("</li>");
 			}
 


### PR DESCRIPTION
## Why

PR #3324 added support for inline Markdown in automatic callouts, but CI started failing on main after merge. The `MathInlineAnnotation` regex excluded `/` from callout comment text, so any comment containing a link (e.g. `[link](path/to/file.md)`) was silently skipped and no callout list was generated. The test for this had been passing spuriously because `ShouldContainHtml` had a separate bug comparing actual HTML to itself (fixed in #3346) — once that was fixed, the real failure became visible.

## What

- Remove `/` from the `[^""#]` exclusion in `MathInlineAnnotation` so callout text can contain forward slashes (needed for Markdown link syntax like `[text](path/file.md)`)
- Fix `EnhancedCodeBlockHtmlRenderer` to emit `<li>` and its inline content without an intermediate newline (`Write` instead of `WriteLine`), matching the HTML structure the test asserts