### PR TITLE
feat(cli-reference): improve intent pills, add shortcut/alias support

### DIFF
--- a/src/Elastic.Documentation.Configuration/Toc/CliReference/CliSchema.cs
+++ b/src/Elastic.Documentation.Configuration/Toc/CliReference/CliSchema.cs
@@ -22,7 +22,8 @@ public record CliSchema(
 	string[]? Tags = null,
 	bool? RequiresAuth = null,
 	string[]? AuthCommands = null,
-	CliEnvironmentSchema? Environment = null
+	CliEnvironmentSchema? Environment = null,
+	List<CliShortcutSchema>? Shortcuts = null
 )
 {
 	public static CliSchema Load(IFileInfo schemaFile)
@@ -32,6 +33,8 @@ public record CliSchema(
 			?? throw new InvalidOperationException($"Failed to deserialize CLI schema from {schemaFile.FullName}");
 	}
 }
+
+public record CliShortcutSchema(string From, string[] To);
 
 public record CliCommandSchema(
 	string[] Path,
@@ -55,10 +58,10 @@ public record CliNamespaceSchema(
 	string Segment,
 	string? Summary,
 	string? Notes,
-	List<CliParamSchema> Options,
+	List<CliParamSchema>? Options,
 	CliDefaultSchema? DefaultCommand,
-	List<CliCommandSchema> Commands,
-	List<CliNamespaceSchema> Namespaces
+	List<CliCommandSchema>? Commands,
+	List<CliNamespaceSchema>? Namespaces
 );
 
 public record CliParamSchema(

--- a/src/Elastic.Documentation.Navigation/Isolated/Node/DocumentationSetNavigation.cs
+++ b/src/Elastic.Documentation.Navigation/Isolated/Node/DocumentationSetNavigation.cs
@@ -484,7 +484,14 @@ public class DocumentationSetNavigation<TModel>
 				children.Add(childNav);
 		}
 
-		// All root commands + namespaces from the schema always follow
+		// Shortcut alias pages first, then commands and namespaces
+		foreach (var shortcut in schema.Shortcuts ?? [])
+		{
+			var aliasNav = MakeFileLeaf(docSourceDir, virtualRoot, [shortcut.From], isNamespace: true, childIndex++, folderNavigation, homeAccessor, context);
+			if (aliasNav is not null)
+				children.Add(aliasNav);
+		}
+
 		foreach (var cmd in schema.Commands)
 		{
 			var cmdNav = MakeFileLeaf(docSourceDir, virtualRoot, [cmd.Name], isNamespace: false, childIndex++, folderNavigation, homeAccessor, context);
@@ -532,7 +539,7 @@ public class DocumentationSetNavigation<TModel>
 			children.Add(nsIndexNav);
 
 		// Namespace commands
-		foreach (var cmd in ns.Commands)
+		foreach (var cmd in ns.Commands ?? [])
 		{
 			var cmdSegments = segments.Append(cmd.Name).ToArray();
 			var cmdNav = MakeFileLeaf(docSourceDir, virtualRoot, cmdSegments, isNamespace: false, childIndex++, nsFolderNav, homeAccessor, context);
@@ -541,7 +548,7 @@ public class DocumentationSetNavigation<TModel>
 		}
 
 		// Sub-namespaces
-		foreach (var subNs in ns.Namespaces)
+		foreach (var subNs in ns.Namespaces ?? [])
 		{
 			var subSegments = segments.Append(subNs.Segment).ToArray();
 			var subNav = BuildNamespaceNavigation(docSourceDir, virtualRoot, subNs, subSegments, childIndex++, nsFolderNav, homeAccessor, context);

--- a/src/Elastic.Documentation.Site/Assets/markdown/cli-modifiers.css
+++ b/src/Elastic.Documentation.Site/Assets/markdown/cli-modifiers.css
@@ -1,12 +1,22 @@
 @layer components {
 	.cli-modifiers {
-		@apply flex flex-wrap gap-2 pb-4;
+		@apply mt-4 mb-4 flex flex-wrap gap-2;
 
 		.cli-modifier {
-			@apply inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium;
+			@apply relative inline-flex cursor-help items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium;
 
 			svg {
 				@apply size-3.5 shrink-0;
+			}
+
+			/* CSS tooltip via data-tooltip attribute */
+			&[data-tooltip]::after {
+				content: attr(data-tooltip);
+				@apply pointer-events-none absolute bottom-full left-1/2 z-50 mb-2 w-max max-w-64 -translate-x-1/2 rounded px-2 py-1 text-xs text-white opacity-0 transition-opacity;
+				background: #1e293b;
+			}
+			&[data-tooltip]:hover::after {
+				@apply opacity-100;
 			}
 		}
 

--- a/src/Elastic.Documentation.Site/Assets/markdown/cli-modifiers.css
+++ b/src/Elastic.Documentation.Site/Assets/markdown/cli-modifiers.css
@@ -15,7 +15,8 @@
 				@apply pointer-events-none absolute bottom-full left-1/2 z-50 mb-2 w-max max-w-64 -translate-x-1/2 rounded px-2 py-1 text-xs text-white opacity-0 transition-opacity;
 				background: #1e293b;
 			}
-			&[data-tooltip]:hover::after {
+			&[data-tooltip]:hover::after,
+			&[data-tooltip]:focus-visible::after {
 				@apply opacity-100;
 			}
 		}

--- a/src/Elastic.Documentation.Site/Navigation/_TocTreeNav.cshtml
+++ b/src/Elastic.Documentation.Site/Navigation/_TocTreeNav.cshtml
@@ -11,14 +11,16 @@
 	{
 		if (raw.StartsWith("[ns]", StringComparison.Ordinal)) return ("ns", raw[4..]);
 		if (raw.StartsWith("[cmd]", StringComparison.Ordinal)) return ("cmd", raw[5..]);
+		if (raw.StartsWith("[alias]", StringComparison.Ordinal)) return ("alias", raw[7..]);
 		return (null, raw);
 	}
 
 	// Inline styles to avoid Tailwind purge — very muted tints, subtle border for definition
-	const string NsStyle  = "background:#f5f3ff;color:#7c3aed;border:1px solid #ddd6fe;";
-	const string CmdStyle = "background:#fffbeb;color:#b45309;border:1px solid #fde68a;";
+	const string NsStyle    = "background:#f5f3ff;color:#7c3aed;border:1px solid #ddd6fe;";
+	const string CmdStyle   = "background:#fffbeb;color:#b45309;border:1px solid #fde68a;";
+	const string AliasStyle = "background:#f0f9ff;color:#0369a1;border:1px solid #bae6fd;";
 
-	static string BadgeStyle(string? badge) => badge == "ns" ? NsStyle : badge == "cmd" ? CmdStyle : "";
+	static string BadgeStyle(string? badge) => badge switch { "ns" => NsStyle, "cmd" => CmdStyle, "alias" => AliasStyle, _ => "" };
 }
 @if (isTopLevel && !Model.IsGlobalAssemblyBuild && !Model.IsPrimaryNavEnabled && !Model.SubTree.Index.Hidden)
 {
@@ -56,6 +58,7 @@
 				<span>@groupLabel</span>
 				@if (groupBadge == "ns") { <span class="ml-auto inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold shrink-0" style="@NsStyle">ns</span> }
 				else if (groupBadge == "cmd") { <span class="ml-auto inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold shrink-0" style="@CmdStyle">cmd</span> }
+				else if (groupBadge == "alias") { <span class="ml-auto inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold shrink-0" style="@AliasStyle">alias</span> }
 			</a>
 		</li>
 	}
@@ -73,6 +76,7 @@
 					<span>@folderLabel</span>
 					@if (folderBadge == "ns") { <span class="ml-auto inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold shrink-0" style="@NsStyle">ns</span> }
 					else if (folderBadge == "cmd") { <span class="ml-auto inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold shrink-0" style="@CmdStyle">cmd</span> }
+					else if (folderBadge == "alias") { <span class="ml-auto inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold shrink-0" style="@AliasStyle">alias</span> }
 				</a>
 				@if (!allHidden)
 				{
@@ -125,6 +129,7 @@
 				<span>@leafLabel</span>
 				@if (leafBadge == "ns") { <span class="ml-auto inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold shrink-0" style="@NsStyle">ns</span> }
 				else if (leafBadge == "cmd") { <span class="ml-auto inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold shrink-0" style="@CmdStyle">cmd</span> }
+				else if (leafBadge == "alias") { <span class="ml-auto inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold shrink-0" style="@AliasStyle">alias</span> }
 			</a>
 		</li>
 	}

--- a/src/Elastic.Markdown/Extensions/CliReference/CliAliasFile.cs
+++ b/src/Elastic.Markdown/Extensions/CliReference/CliAliasFile.cs
@@ -1,0 +1,54 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions;
+using Elastic.Documentation.Configuration;
+using Elastic.Documentation.Configuration.Toc.CliReference;
+using Elastic.Markdown.Myst;
+using Markdig.Syntax;
+
+namespace Elastic.Markdown.Extensions.CliReference;
+
+public record CliAliasFile : IO.MarkdownFile
+{
+	private readonly CliShortcutSchema _shortcut;
+	private readonly string _binaryName;
+	private readonly string _canonicalRelativePath;
+
+	public CliAliasFile(
+		IFileInfo sourceFile,
+		IDirectoryInfo rootPath,
+		MarkdownParser parser,
+		BuildContext build,
+		CliShortcutSchema shortcut,
+		string binaryName,
+		string canonicalRelativePath
+	) : base(sourceFile, rootPath, parser, build)
+	{
+		_shortcut = shortcut;
+		_binaryName = binaryName;
+		_canonicalRelativePath = canonicalRelativePath;
+		Title = shortcut.From;
+	}
+
+	public override string NavigationTitle => $"[alias]{_shortcut.From}";
+
+	public override string? RedirectUrl => _canonicalRelativePath;
+
+	protected override Task<MarkdownDocument> GetMinimalParseDocumentAsync(Cancel ctx)
+	{
+		Title = _shortcut.From;
+		var markdown = BuildMarkdown();
+		return Task.FromResult(MarkdownParser.MinimalParseStringAsync(markdown, SourceFile, null));
+	}
+
+	protected override Task<MarkdownDocument> GetParseDocumentAsync(Cancel ctx)
+	{
+		var markdown = BuildMarkdown();
+		return Task.FromResult(MarkdownParser.ParseStringAsync(markdown, SourceFile, null));
+	}
+
+	private string BuildMarkdown() =>
+		CliMarkdownGenerator.AliasPage(_shortcut, _binaryName, _canonicalRelativePath);
+}

--- a/src/Elastic.Markdown/Extensions/CliReference/CliCommandFile.cs
+++ b/src/Elastic.Markdown/Extensions/CliReference/CliCommandFile.cs
@@ -17,6 +17,9 @@ public record CliCommandFile : IO.MarkdownFile
 	private readonly string? _binaryName;
 	private readonly string[] _fullPath;
 	private readonly string[]? _reservedMetaCommands;
+	private readonly IReadOnlyList<(string Segment, List<CliParamSchema>? Options)>? _ancestorNamespaceOptions;
+	private readonly List<CliParamSchema>? _globalOptions;
+	private readonly List<CliShortcutSchema>? _shortcuts;
 
 	public CliCommandFile(
 		IFileInfo sourceFile,
@@ -27,7 +30,10 @@ public record CliCommandFile : IO.MarkdownFile
 		IFileInfo? supplementalDoc,
 		string[]? fullPath = null,
 		string? binaryName = null,
-		string[]? reservedMetaCommands = null
+		string[]? reservedMetaCommands = null,
+		IReadOnlyList<(string Segment, List<CliParamSchema>? Options)>? ancestorNamespaceOptions = null,
+		List<CliParamSchema>? globalOptions = null,
+		List<CliShortcutSchema>? shortcuts = null
 	) : base(sourceFile, rootPath, parser, build)
 	{
 		_command = command;
@@ -35,6 +41,9 @@ public record CliCommandFile : IO.MarkdownFile
 		_fullPath = fullPath ?? [command.Name];
 		_binaryName = binaryName;
 		_reservedMetaCommands = reservedMetaCommands;
+		_ancestorNamespaceOptions = ancestorNamespaceOptions;
+		_globalOptions = globalOptions;
+		_shortcuts = shortcuts;
 		Title = command.Name;
 	}
 
@@ -60,6 +69,7 @@ public record CliCommandFile : IO.MarkdownFile
 			: null;
 		var supplemental = CliSupplementalDoc.Parse(rawSupplemental);
 		return CliMarkdownGenerator.CommandPage(_command, supplemental, _fullPath, _binaryName, _reservedMetaCommands,
-			error => Collector.EmitError(_supplementalDoc ?? SourceFile, error));
+			error => Collector.EmitError(_supplementalDoc ?? SourceFile, error),
+			_ancestorNamespaceOptions, _globalOptions, _shortcuts);
 	}
 }

--- a/src/Elastic.Markdown/Extensions/CliReference/CliMarkdownGenerator.cs
+++ b/src/Elastic.Markdown/Extensions/CliReference/CliMarkdownGenerator.cs
@@ -87,23 +87,52 @@ internal static partial class CliMarkdownGenerator
 		return sb.ToString();
 	}
 
+	public static string AliasPage(CliShortcutSchema shortcut, string binaryName, string canonicalUrl)
+	{
+		var sb = new StringBuilder();
+		var canonicalFull = string.Join(" ", shortcut.To);
+		_ = sb.AppendLine($"# {shortcut.From} <span class=\"cli-badge-alias\">alias</span>");
+		_ = sb.AppendLine();
+		// JS redirect — fires immediately; the link below is the no-JS fallback
+		_ = sb.AppendLine($"<script>window.location.replace('{canonicalUrl}');</script>");
+		_ = sb.AppendLine();
+		_ = sb.AppendLine($"`{binaryName} {shortcut.From}` is a shortcut for [`{binaryName} {canonicalFull}`]({canonicalUrl}).");
+		_ = sb.AppendLine();
+		return sb.ToString();
+	}
+
 	public static string NamespacePage(
 		CliNamespaceSchema ns,
 		CliSupplementalDoc? supplemental,
 		string[]? fullPath = null,
 		string? binaryName = null,
 		string[]? reservedMetaCommands = null,
-		Action<string>? emitError = null)
+		Action<string>? emitError = null,
+		List<CliShortcutSchema>? shortcuts = null)
 	{
 		var sb = new StringBuilder();
 		var heading = fullPath is { Length: > 0 } ? string.Join(" ", fullPath) : ns.Segment;
 		_ = sb.AppendLine($"# {heading} <span class=\"cli-badge-ns\">cli namespace</span>");
 		_ = sb.AppendLine();
 
+		// Usage block: canonical form first, then each alias form
+		var nsAliases = NamespaceAliases(fullPath, shortcuts);
 		_ = sb.AppendLine("```bash");
 		_ = sb.AppendLine($"{binaryName ?? heading} {heading} --help");
+		foreach (var alias in nsAliases)
+			_ = sb.AppendLine($"{binaryName ?? alias} {alias} --help");
 		_ = sb.AppendLine("```");
 		_ = sb.AppendLine();
+
+		// Alias blurb
+		if (nsAliases.Count > 0)
+		{
+			var depth = fullPath?.Length ?? 1;
+			var upPrefix = string.Concat(Enumerable.Repeat("../", depth));
+			var links = nsAliases.Select(a => $"[`{binaryName ?? a} {a}`]({upPrefix}{a}/index.md)");
+			_ = sb.AppendLine($"Also accessible as {string.Join(", ", links)}.");
+			_ = sb.AppendLine();
+		}
 
 		var description = supplemental?.Description ?? ns.Summary?.Trim();
 		if (!string.IsNullOrWhiteSpace(description))
@@ -115,7 +144,7 @@ internal static partial class CliMarkdownGenerator
 		if (ns.DefaultCommand is { Hidden: false } defaultCmd)
 			AppendDefaultCommand(sb, defaultCmd, ns, fullPath, binaryName, reservedMetaCommands);
 
-		var visibleCmds = ns.Commands.Where(c => !c.Hidden).ToList();
+		var visibleCmds = (ns.Commands ?? []).Where(c => !c.Hidden).ToList();
 		if (visibleCmds.Count > 0)
 		{
 			_ = sb.AppendLine("## Commands");
@@ -124,24 +153,26 @@ internal static partial class CliMarkdownGenerator
 				AppendPageCard(sb, cmd.Name, $"./{CommandPath(cmd.Name)}.md", cmd.Summary);
 		}
 
-		if (ns.Namespaces.Count > 0)
+		var subNamespaces = ns.Namespaces ?? [];
+		if (subNamespaces.Count > 0)
 		{
 			_ = sb.AppendLine("## Sub-namespaces");
 			_ = sb.AppendLine();
-			foreach (var sub in ns.Namespaces)
+			foreach (var sub in subNamespaces)
 				AppendPageCard(sb, sub.Segment, $"./{sub.Segment}/index.md", sub.Summary);
 		}
 
-		if (ns.Options.Count > 0)
+		var options = ns.Options ?? [];
+		if (options.Count > 0)
 		{
 			_ = sb.AppendLine("## Namespace Flags");
 			_ = sb.AppendLine();
-			AppendParameters(sb, ns.Options, supplemental?.OptionOverrides);
+			AppendParameters(sb, options, supplemental?.OptionOverrides);
 		}
 
 		if (supplemental is not null && emitError is not null)
 		{
-			var nsOptionNames = new HashSet<string>(ns.Options.Select(o => o.Name), StringComparer.OrdinalIgnoreCase);
+			var nsOptionNames = new HashSet<string>(options.Select(o => o.Name), StringComparer.OrdinalIgnoreCase);
 			foreach (var key in supplemental.OptionOverrides.Keys)
 			{
 				if (!nsOptionNames.Contains(key))
@@ -164,23 +195,39 @@ internal static partial class CliMarkdownGenerator
 		string[]? fullPath = null,
 		string? binaryName = null,
 		string[]? reservedMetaCommands = null,
-		Action<string>? emitError = null)
+		Action<string>? emitError = null,
+		IReadOnlyList<(string Segment, List<CliParamSchema>? Options)>? ancestorNamespaceOptions = null,
+		List<CliParamSchema>? globalOptions = null,
+		List<CliShortcutSchema>? shortcuts = null)
 	{
 		var sb = new StringBuilder();
 		var heading = fullPath is { Length: > 0 } ? string.Join(" ", fullPath) : cmd.Name;
 		_ = sb.AppendLine($"# {heading} <span class=\"cli-badge-cmd\">cli command</span>");
 		_ = sb.AppendLine();
 
-		var usage = !string.IsNullOrWhiteSpace(cmd.Usage)
+		AppendCommandModifiers(sb, cmd);
+
+		var canonicalUsage = !string.IsNullOrWhiteSpace(cmd.Usage)
 			? CleanUsage(cmd.Usage, reservedMetaCommands)
 			: GenerateUsage(cmd, fullPath, binaryName);
 
+		var allUsages = new[] { canonicalUsage }
+			.Concat(AliasUsages(fullPath, binaryName, canonicalUsage, shortcuts))
+			.ToList();
+		var shortestUsage = allUsages.MinBy(u => u.Length) ?? canonicalUsage;
+		var otherUsages = allUsages.Where(u => u != shortestUsage).ToList();
+
 		_ = sb.AppendLine("```bash");
-		_ = sb.AppendLine(FormatUsage(usage));
+		_ = sb.AppendLine(FormatUsage(shortestUsage));
 		_ = sb.AppendLine("```");
 		_ = sb.AppendLine();
 
-		AppendCommandModifiers(sb, cmd);
+		if (otherUsages.Count > 0)
+		{
+			var others = string.Join(", ", otherUsages.Select(u => $"`{CommandName(u)}`"));
+			_ = sb.AppendLine($"Also available as: {others}.");
+			_ = sb.AppendLine();
+		}
 
 		var description = supplemental?.Description ?? (cmd.Summary is not null ? CleanSummary(cmd.Summary).description.Trim() : null);
 		if (!string.IsNullOrWhiteSpace(description))
@@ -234,6 +281,24 @@ internal static partial class CliMarkdownGenerator
 				if (!positionalNames.Contains(key))
 					emitError($"CLI supplemental: Argument '<{key}>' not found in command '{cmd.Name}'");
 			}
+		}
+
+		foreach (var (segment, nsOptions) in ancestorNamespaceOptions ?? [])
+		{
+			var visibleNsOptions = (nsOptions ?? []).Where(p => !p.Hidden && p.Name != "_").ToList();
+			if (visibleNsOptions.Count == 0)
+				continue;
+			_ = sb.AppendLine($"## {segment} Options");
+			_ = sb.AppendLine();
+			AppendParameters(sb, visibleNsOptions, null);
+		}
+
+		var visibleGlobalOptions = (globalOptions ?? []).Where(p => !p.Hidden && p.Name != "_").ToList();
+		if (visibleGlobalOptions.Count > 0)
+		{
+			_ = sb.AppendLine("## Global Options");
+			_ = sb.AppendLine();
+			AppendParameters(sb, visibleGlobalOptions, null);
 		}
 
 		if (cmd.Examples is { Length: > 0 })
@@ -339,7 +404,7 @@ internal static partial class CliMarkdownGenerator
 
 		// If Kind matches a named command, emit an alias note instead of duplicating parameters
 		if (!string.IsNullOrWhiteSpace(defaultCmd.Kind) &&
-			ns.Commands.Any(c => c.Name.Equals(defaultCmd.Kind, StringComparison.OrdinalIgnoreCase)))
+			(ns.Commands ?? []).Any(c => c.Name.Equals(defaultCmd.Kind, StringComparison.OrdinalIgnoreCase)))
 		{
 			_ = sb.AppendLine($"> Running without a subcommand is an alias for [{defaultCmd.Kind}](./{CommandPath(defaultCmd.Kind)}.md).");
 			_ = sb.AppendLine();
@@ -432,7 +497,7 @@ internal static partial class CliMarkdownGenerator
 		IEnumerable<CliParamSchema> parameters,
 		Dictionary<string, string>? overrides)
 	{
-		foreach (var p in parameters.Where(p => p.Name != "_" && !p.Hidden))
+		foreach (var p in parameters.Where(p => p.Name != "_" && !p.Hidden).OrderByDescending(p => p.Required))
 		{
 			var isBool = IsBoolFlag(p.Type);
 			var flagName = FormatFlagName(p);
@@ -609,10 +674,10 @@ internal static partial class CliMarkdownGenerator
 		{
 			var defIdx = normalized.IndexOf(defaultSep, StringComparison.OrdinalIgnoreCase);
 			if (defIdx < 0)
-				return (normalized, string.Empty, string.Empty);
+				return (EscapeSubstitutions(normalized), string.Empty, string.Empty);
 
 			return (
-				normalized[..defIdx].Trim(),
+				EscapeSubstitutions(normalized[..defIdx].Trim()),
 				string.Empty,
 				normalized[(defIdx + defaultSep.Length)..].Trim().TrimEnd('.')
 			);
@@ -623,11 +688,21 @@ internal static partial class CliMarkdownGenerator
 
 		var defInRemainder = remainder.IndexOf(defaultSep, StringComparison.OrdinalIgnoreCase);
 		if (defInRemainder < 0)
-			return (description, remainder.Trim().TrimEnd('.'), string.Empty);
+			return (EscapeSubstitutions(description), remainder.Trim().TrimEnd('.'), string.Empty);
 
 		var values = remainder[..defInRemainder].Trim().TrimEnd('.');
 		var defaultValue = remainder[(defInRemainder + defaultSep.Length)..].Trim().TrimEnd('.');
-		return (description, values, defaultValue);
+		return (EscapeSubstitutions(description), values, defaultValue);
+	}
+
+	// Escapes {{key}} patterns so they are not interpreted as docs-builder substitution keys.
+	// \{ is a CommonMark escape that renders as {, so \{{key}} renders as {{key}} in output
+	// but the substitution parser (which requires two opening braces) won't fire.
+	private static string EscapeSubstitutions(string? text)
+	{
+		if (string.IsNullOrEmpty(text) || !text.Contains("{{"))
+			return text ?? string.Empty;
+		return text.Replace("{{", "\\{{", StringComparison.Ordinal);
 	}
 
 	private static bool IsBoolFlag(string type) =>
@@ -725,6 +800,72 @@ internal static partial class CliMarkdownGenerator
 			_ = result.Append(groups[g]);
 		}
 		return result.ToString();
+	}
+
+	// Returns the `from` values of shortcuts whose `to` path exactly matches the namespace's full path.
+	private static List<string> NamespaceAliases(string[]? fullPath, List<CliShortcutSchema>? shortcuts)
+	{
+		if (shortcuts is not { Count: > 0 } || fullPath is not { Length: > 0 })
+			return [];
+
+		var heading = string.Join(" ", fullPath);
+		return shortcuts
+			.Where(s => string.Join(" ", s.To).Equals(heading, StringComparison.OrdinalIgnoreCase))
+			.Select(s => s.From)
+			.ToList();
+	}
+
+	// Returns one alternate usage string per shortcut whose `to` path is a prefix of the command's full path.
+	// E.g. shortcut {from:"es", to:["stack","es"]} + command path ["stack","es","bulk"] → "elastic es bulk [options]"
+	private static string CommandName(string usage)
+	{
+		var flagIdx = usage.IndexOf(" --", StringComparison.Ordinal);
+		var argIdx = usage.IndexOf(" <", StringComparison.Ordinal);
+		var optIdx = usage.IndexOf(" [", StringComparison.Ordinal);
+		var end = new[] { flagIdx, argIdx, optIdx }.Where(i => i >= 0).DefaultIfEmpty(usage.Length).Min();
+		return usage[..end];
+	}
+
+	private static IEnumerable<string> AliasUsages(
+		string[]? fullPath,
+		string? binaryName,
+		string canonicalUsage,
+		List<CliShortcutSchema>? shortcuts)
+	{
+		if (shortcuts is not { Count: > 0 } || fullPath is not { Length: > 1 })
+			yield break;
+
+		foreach (var shortcut in shortcuts)
+		{
+			var to = shortcut.To;
+			if (to.Length == 0 || to.Length >= fullPath.Length)
+				continue;
+			// Check that to[] matches the first to.Length segments of fullPath
+			var matches = true;
+			for (var i = 0; i < to.Length; i++)
+			{
+				if (!string.Equals(fullPath[i], to[i], StringComparison.OrdinalIgnoreCase))
+				{
+					matches = false;
+					break;
+				}
+			}
+			if (!matches)
+				continue;
+
+			// Build alias usage: binary shortcut.From remaining_path_segments suffix
+			// The suffix is everything after the canonical prefix in the original usage line
+			var canonicalPrefix = string.Join(" ", binaryName is not null
+				? [binaryName, .. to]
+				: to);
+			var suffix = canonicalUsage.StartsWith(canonicalPrefix, StringComparison.OrdinalIgnoreCase)
+				? canonicalUsage[canonicalPrefix.Length..]
+				: " " + string.Join(" ", fullPath[to.Length..]);
+			var aliasBase = binaryName is not null
+				? $"{binaryName} {shortcut.From}"
+				: shortcut.From;
+			yield return aliasBase + suffix;
+		}
 	}
 
 	[GeneratedRegex(@"\s{2,}")]

--- a/src/Elastic.Markdown/Extensions/CliReference/CliMarkdownGenerator.cs
+++ b/src/Elastic.Markdown/Extensions/CliReference/CliMarkdownGenerator.cs
@@ -93,9 +93,6 @@ internal static partial class CliMarkdownGenerator
 		var canonicalFull = string.Join(" ", shortcut.To);
 		_ = sb.AppendLine($"# {shortcut.From} <span class=\"cli-badge-alias\">alias</span>");
 		_ = sb.AppendLine();
-		// JS redirect — fires immediately; the link below is the no-JS fallback
-		_ = sb.AppendLine($"<script>window.location.replace('{canonicalUrl}');</script>");
-		_ = sb.AppendLine();
 		_ = sb.AppendLine($"`{binaryName} {shortcut.From}` is a shortcut for [`{binaryName} {canonicalFull}`]({canonicalUrl}).");
 		_ = sb.AppendLine();
 		return sb.ToString();
@@ -497,7 +494,10 @@ internal static partial class CliMarkdownGenerator
 		IEnumerable<CliParamSchema> parameters,
 		Dictionary<string, string>? overrides)
 	{
-		foreach (var p in parameters.Where(p => p.Name != "_" && !p.Hidden).OrderByDescending(p => p.Required))
+		var filtered = parameters.Where(p => p.Name != "_" && !p.Hidden).ToList();
+		var positionals = filtered.Where(p => p.Role == "positional");
+		var options = filtered.Where(p => p.Role != "positional").OrderByDescending(p => p.Required);
+		foreach (var p in positionals.Concat(options))
 		{
 			var isBool = IsBoolFlag(p.Type);
 			var flagName = FormatFlagName(p);
@@ -853,14 +853,13 @@ internal static partial class CliMarkdownGenerator
 			if (!matches)
 				continue;
 
-			// Build alias usage: binary shortcut.From remaining_path_segments suffix
-			// The suffix is everything after the canonical prefix in the original usage line
+			// Build alias usage by replacing the canonical prefix in the original usage line
 			var canonicalPrefix = string.Join(" ", binaryName is not null
 				? [binaryName, .. to]
 				: to);
-			var suffix = canonicalUsage.StartsWith(canonicalPrefix, StringComparison.OrdinalIgnoreCase)
-				? canonicalUsage[canonicalPrefix.Length..]
-				: " " + string.Join(" ", fullPath[to.Length..]);
+			if (!canonicalUsage.StartsWith(canonicalPrefix, StringComparison.OrdinalIgnoreCase))
+				continue; // can't safely rewrite; skip this alias variant
+			var suffix = canonicalUsage[canonicalPrefix.Length..];
 			var aliasBase = binaryName is not null
 				? $"{binaryName} {shortcut.From}"
 				: shortcut.From;

--- a/src/Elastic.Markdown/Extensions/CliReference/CliNamespaceFile.cs
+++ b/src/Elastic.Markdown/Extensions/CliReference/CliNamespaceFile.cs
@@ -17,6 +17,7 @@ public record CliNamespaceFile : IO.MarkdownFile
 	private readonly string? _binaryName;
 	private readonly string[] _fullPath;
 	private readonly string[]? _reservedMetaCommands;
+	private readonly List<CliShortcutSchema>? _shortcuts;
 
 	public CliNamespaceFile(
 		IFileInfo sourceFile,
@@ -27,7 +28,8 @@ public record CliNamespaceFile : IO.MarkdownFile
 		IFileInfo? supplementalDoc,
 		string[]? fullPath = null,
 		string? binaryName = null,
-		string[]? reservedMetaCommands = null
+		string[]? reservedMetaCommands = null,
+		List<CliShortcutSchema>? shortcuts = null
 	) : base(sourceFile, rootPath, parser, build)
 	{
 		_namespace = @namespace;
@@ -35,6 +37,7 @@ public record CliNamespaceFile : IO.MarkdownFile
 		_fullPath = fullPath ?? [@namespace.Segment];
 		_binaryName = binaryName;
 		_reservedMetaCommands = reservedMetaCommands;
+		_shortcuts = shortcuts;
 		Title = @namespace.Segment;
 	}
 
@@ -60,6 +63,6 @@ public record CliNamespaceFile : IO.MarkdownFile
 			: null;
 		var supplemental = CliSupplementalDoc.Parse(rawSupplemental);
 		return CliMarkdownGenerator.NamespacePage(_namespace, supplemental, _fullPath, _binaryName, _reservedMetaCommands,
-			error => Collector.EmitError(_supplementalDoc ?? SourceFile, error));
+			error => Collector.EmitError(_supplementalDoc ?? SourceFile, error), _shortcuts);
 	}
 }

--- a/src/Elastic.Markdown/Extensions/CliReference/CliReferenceDocsBuilderExtension.cs
+++ b/src/Elastic.Markdown/Extensions/CliReference/CliReferenceDocsBuilderExtension.cs
@@ -212,11 +212,16 @@ public class CliReferenceDocsBuilderExtension(BuildContext build) : IDocsBuilder
 			foreach (var shortcut in schema.Shortcuts ?? [])
 			{
 				var aliasPath = SyntheticPath(Build.DocumentationSourceDirectory.FullName, virtualRoot, [shortcut.From], isNamespace: true);
+				if (_syntheticFiles!.ContainsKey(aliasPath))
+				{
+					Build.Collector.EmitError(schemaFileInfo,
+						$"CLI shortcut '{shortcut.From}' conflicts with an existing path; skipping alias.");
+					continue;
+				}
 				var aliasFileInfo = Build.ReadFileSystem.FileInfo.New(aliasPath);
-				// Absolute URL path for the canonical target — used for JS redirect and links
 				var canonicalUrl = "/" + virtualRoot + "/" + string.Join("/", shortcut.To) + "/";
 				var aliasInfo = new CliEntityInfo(schema, shortcut, null, aliasFileInfo, AliasCanonicalRelativePath: canonicalUrl);
-				_syntheticFiles![aliasPath] = aliasInfo;
+				_syntheticFiles[aliasPath] = aliasInfo;
 				fileInfos.Add(aliasFileInfo);
 			}
 

--- a/src/Elastic.Markdown/Extensions/CliReference/CliReferenceDocsBuilderExtension.cs
+++ b/src/Elastic.Markdown/Extensions/CliReference/CliReferenceDocsBuilderExtension.cs
@@ -15,12 +15,16 @@ namespace Elastic.Markdown.Extensions.CliReference;
 
 internal sealed record CliEntityInfo(
 	CliSchema Schema,
-	object Entity, // CliSchema | CliNamespaceSchema | CliCommandSchema
+	object Entity, // CliSchema | CliNamespaceSchema | CliCommandSchema | CliShortcutSchema
 	IFileInfo? SupplementalDoc,
 	/// <summary>The clean synthetic file (no cmd- prefix) — used as the MarkdownFile source for correct URL generation.</summary>
 	IFileInfo? CleanSyntheticFile = null,
 	/// <summary>Full path segments used to build the page heading (e.g. ["assembler", "bloom-filter"]).</summary>
-	string[]? FullPath = null
+	string[]? FullPath = null,
+	/// <summary>Ancestor namespace options ordered from closest to furthest (direct parent first).</summary>
+	IReadOnlyList<(string Segment, List<CliParamSchema>? Options)>? AncestorNamespaceOptions = null,
+	/// <summary>Relative path from this file to the alias target — set for CliShortcutSchema entities only.</summary>
+	string? AliasCanonicalRelativePath = null
 );
 
 public class CliReferenceDocsBuilderExtension(BuildContext build) : IDocsBuilderExtension
@@ -110,8 +114,9 @@ public class CliReferenceDocsBuilderExtension(BuildContext build) : IDocsBuilder
 		info.Entity switch
 		{
 			CliSchema schema => new CliRootFile(sourceFile, Build.DocumentationSourceDirectory, markdownParser, Build, schema, info.SupplementalDoc),
-			CliNamespaceSchema ns => new CliNamespaceFile(sourceFile, Build.DocumentationSourceDirectory, markdownParser, Build, ns, info.SupplementalDoc, info.FullPath ?? [ns.Segment], info.Schema.Name, info.Schema.ReservedMetaCommands),
-			CliCommandSchema cmd => new CliCommandFile(sourceFile, Build.DocumentationSourceDirectory, markdownParser, Build, cmd, info.SupplementalDoc, info.FullPath ?? [cmd.Name], info.Schema.Name, info.Schema.ReservedMetaCommands),
+			CliNamespaceSchema ns => new CliNamespaceFile(sourceFile, Build.DocumentationSourceDirectory, markdownParser, Build, ns, info.SupplementalDoc, info.FullPath ?? [ns.Segment], info.Schema.Name, info.Schema.ReservedMetaCommands, info.Schema.Shortcuts),
+			CliCommandSchema cmd => new CliCommandFile(sourceFile, Build.DocumentationSourceDirectory, markdownParser, Build, cmd, info.SupplementalDoc, info.FullPath ?? [cmd.Name], info.Schema.Name, info.Schema.ReservedMetaCommands, info.AncestorNamespaceOptions, info.Schema.GlobalOptions, info.Schema.Shortcuts),
+			CliShortcutSchema shortcut => new CliAliasFile(sourceFile, Build.DocumentationSourceDirectory, markdownParser, Build, shortcut, info.Schema.Name, info.AliasCanonicalRelativePath ?? "../"),
 			_ => null
 		};
 
@@ -203,6 +208,18 @@ public class CliReferenceDocsBuilderExtension(BuildContext build) : IDocsBuilder
 			// Namespaces (recursive)
 			CollectNamespaceFiles(Build.DocumentationSourceDirectory.FullName, virtualRoot, supplementalDirPath, schema.Namespaces, [], matched, fileInfos, schema);
 
+			// Shortcut alias pages
+			foreach (var shortcut in schema.Shortcuts ?? [])
+			{
+				var aliasPath = SyntheticPath(Build.DocumentationSourceDirectory.FullName, virtualRoot, [shortcut.From], isNamespace: true);
+				var aliasFileInfo = Build.ReadFileSystem.FileInfo.New(aliasPath);
+				// Absolute URL path for the canonical target — used for JS redirect and links
+				var canonicalUrl = "/" + virtualRoot + "/" + string.Join("/", shortcut.To) + "/";
+				var aliasInfo = new CliEntityInfo(schema, shortcut, null, aliasFileInfo, AliasCanonicalRelativePath: canonicalUrl);
+				_syntheticFiles![aliasPath] = aliasInfo;
+				fileInfos.Add(aliasFileInfo);
+			}
+
 			// Validate supplemental files
 			if (supplementalDirPath is not null && Build.ReadFileSystem.Directory.Exists(supplementalDirPath))
 				ValidateSupplementalFiles(supplementalDirPath, matched, cliRef.Context);
@@ -219,7 +236,8 @@ public class CliReferenceDocsBuilderExtension(BuildContext build) : IDocsBuilder
 		string[] nsPath,
 		HashSet<string> matched,
 		List<IFileInfo> fileInfos,
-		CliSchema schema)
+		CliSchema schema,
+		IReadOnlyList<(string Segment, List<CliParamSchema>? Options)>? ancestorOptions = null)
 	{
 		foreach (var ns in namespaces)
 		{
@@ -234,20 +252,25 @@ public class CliReferenceDocsBuilderExtension(BuildContext build) : IDocsBuilder
 				_supplementalFiles![nsSupplemental.FullName] = nsInfo;
 			fileInfos.Add(nsFileInfo);
 
-			foreach (var cmd in ns.Commands)
+			// Build ordered ancestor list for commands: direct parent first, then grandparents
+			var cmdAncestors = new List<(string, List<CliParamSchema>?)> { (ns.Segment, ns.Options) };
+			if (ancestorOptions is { Count: > 0 })
+				cmdAncestors.AddRange(ancestorOptions);
+
+			foreach (var cmd in ns.Commands ?? [])
 			{
 				var cmdSegments = fullNsPath.Append(cmd.Name).ToArray();
 				var cmdPath = SyntheticPath(docSourceDir, virtualRoot, cmdSegments, isNamespace: false);
 				var cmdFileInfo = Build.ReadFileSystem.FileInfo.New(cmdPath);
 				var cmdSupplemental = FindSupplemental(supplementalDirPath, cmdSegments, isNamespace: false, matched);
-				var cmdInfo = new CliEntityInfo(schema, cmd, cmdSupplemental, cmdFileInfo, FullPath: cmdSegments);
+				var cmdInfo = new CliEntityInfo(schema, cmd, cmdSupplemental, cmdFileInfo, FullPath: cmdSegments, AncestorNamespaceOptions: cmdAncestors);
 				_syntheticFiles[cmdPath] = cmdInfo;
 				if (cmdSupplemental != null)
 					_supplementalFiles![cmdSupplemental.FullName] = cmdInfo;
 				fileInfos.Add(cmdFileInfo);
 			}
 
-			CollectNamespaceFiles(docSourceDir, virtualRoot, supplementalDirPath, ns.Namespaces, fullNsPath, matched, fileInfos, schema);
+			CollectNamespaceFiles(docSourceDir, virtualRoot, supplementalDirPath, ns.Namespaces ?? [], fullNsPath, matched, fileInfos, schema, cmdAncestors);
 		}
 	}
 

--- a/src/Elastic.Markdown/HtmlWriter.cs
+++ b/src/Elastic.Markdown/HtmlWriter.cs
@@ -192,7 +192,8 @@ public class HtmlWriter(
 			GitRepository = gitHubRepo,
 			GitHubDocsUrl = gitHubDocsUrl,
 			GitHubRef = DocumentationSet.Context.Git.GitHubRef,
-			Branding = DocumentationSet.Configuration.Branding
+			Branding = DocumentationSet.Configuration.Branding,
+			RedirectUrl = markdown.RedirectUrl
 		});
 
 		return new RenderResult

--- a/src/Elastic.Markdown/IO/MarkdownFile.cs
+++ b/src/Elastic.Markdown/IO/MarkdownFile.cs
@@ -82,6 +82,8 @@ public record MarkdownFile : DocumentationFile, ITableOfContentsScope, IDocument
 		private set => field = value.StripMarkdown();
 	}
 
+	public virtual string? RedirectUrl => null;
+
 
 	//indexed by slug
 	private readonly Dictionary<string, PageTocItem> _pageTableOfContent = [with(StringComparer.OrdinalIgnoreCase)];

--- a/src/Elastic.Markdown/MarkdownLayoutViewModel.cs
+++ b/src/Elastic.Markdown/MarkdownLayoutViewModel.cs
@@ -30,6 +30,8 @@ public record MarkdownLayoutViewModel : GlobalLayoutViewModel
 	public required string? CurrentVersion { get; init; }
 
 	public required string? AllVersionsUrl { get; init; }
+
+	public string? RedirectUrl { get; init; }
 }
 
 public record PageTocItem

--- a/src/Elastic.Markdown/Myst/Directives/CliModifiers/CliModifiersBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/CliModifiers/CliModifiersBlock.cs
@@ -10,21 +10,35 @@ public class CliModifiersBlock(DirectiveBlockParser parser, ParserContext contex
 	public override string Directive => "cli-modifiers";
 
 	public bool Destructive { get; private set; }
+	public string? DestructiveDescription { get; private set; }
 	public bool RequiresConfirmation { get; private set; }
+	public string? RequiresConfirmationDescription { get; private set; }
 	public bool RequiresAuth { get; private set; }
+	public string? RequiresAuthDescription { get; private set; }
 	public bool Idempotent { get; private set; }
+	public string? IdempotentDescription { get; private set; }
 	public string? Scope { get; private set; }
+	public string? ScopeDescription { get; private set; }
 	public bool Streaming { get; private set; }
+	public string? StreamingDescription { get; private set; }
 	public bool LongRunning { get; private set; }
+	public string? LongRunningDescription { get; private set; }
 
 	public override void FinalizeAndValidate(ParserContext context)
 	{
 		Destructive = PropBool("destructive");
+		DestructiveDescription = Prop("destructive-description");
 		RequiresConfirmation = PropBool("requires-confirmation");
+		RequiresConfirmationDescription = Prop("requires-confirmation-description");
 		RequiresAuth = PropBool("requires-auth");
+		RequiresAuthDescription = Prop("requires-auth-description");
 		Idempotent = PropBool("idempotent");
+		IdempotentDescription = Prop("idempotent-description");
 		Scope = Prop("scope");
+		ScopeDescription = Prop("scope-description");
 		Streaming = PropBool("streaming");
+		StreamingDescription = Prop("streaming-description");
 		LongRunning = PropBool("long-running");
+		LongRunningDescription = Prop("long-running-description");
 	}
 }

--- a/src/Elastic.Markdown/Myst/Directives/CliModifiers/CliModifiersView.cshtml
+++ b/src/Elastic.Markdown/Myst/Directives/CliModifiers/CliModifiersView.cshtml
@@ -1,8 +1,13 @@
 @inherits RazorSlice<Elastic.Markdown.Myst.Directives.CliModifiers.CliModifiersViewModel>
+@{
+	string Tip(string? schemaDescription, string fallback) =>
+		!string.IsNullOrWhiteSpace(schemaDescription) ? schemaDescription : fallback;
+}
 <div class="cli-modifiers">
 	@if (Model.Destructive)
 	{
-		<span class="cli-modifier cli-modifier--destructive">
+		<span class="cli-modifier cli-modifier--destructive"
+		      data-tooltip="@Tip(Model.DestructiveDescription, "Modifies or removes data on the target. The change cannot be undone.")">
 			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
 				<path fill-rule="evenodd" d="M6.701 2.25c.577-1 2.02-1 2.598 0l5.196 9a1.5 1.5 0 0 1-1.299 2.25H2.804a1.5 1.5 0 0 1-1.3-2.25l5.197-9ZM8 4a.75.75 0 0 1 .75.75v3a.75.75 0 1 1-1.5 0v-3A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clip-rule="evenodd"/>
 			</svg>
@@ -11,7 +16,8 @@
 	}
 	@if (Model.RequiresConfirmation)
 	{
-		<span class="cli-modifier cli-modifier--confirmation">
+		<span class="cli-modifier cli-modifier--confirmation"
+		      data-tooltip="@Tip(Model.RequiresConfirmationDescription, "Prompts before running. Pass a non-interactive override (e.g. --yes) to skip the prompt in scripts.")">
 			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
 				<path fill-rule="evenodd" d="M15 8A7 7 0 1 1 1 8a7 7 0 0 1 14 0Zm-7-3.25a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 9.75 11H10a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 8.25 5H8ZM9 4a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z" clip-rule="evenodd"/>
 			</svg>
@@ -20,7 +26,8 @@
 	}
 	@if (Model.RequiresAuth)
 	{
-		<span class="cli-modifier cli-modifier--auth">
+		<span class="cli-modifier cli-modifier--auth"
+		      data-tooltip="@Tip(Model.RequiresAuthDescription, "Valid credentials for the target must be configured before this command can run.")">
 			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
 				<path fill-rule="evenodd" d="M8 1a3.5 3.5 0 0 1 3.5 3.5V7A1.5 1.5 0 0 1 13 8.5v5A1.5 1.5 0 0 1 11.5 15h-7A1.5 1.5 0 0 1 3 13.5v-5A1.5 1.5 0 0 1 4.5 7V4.5A3.5 3.5 0 0 1 8 1Zm0 1.5A2 2 0 0 0 6 4.5V7h4V4.5A2 2 0 0 0 8 2.5ZM8 10a1 1 0 1 0 0 2 1 1 0 0 0 0-2Z" clip-rule="evenodd"/>
 			</svg>
@@ -29,7 +36,8 @@
 	}
 	@if (Model.Idempotent)
 	{
-		<span class="cli-modifier cli-modifier--idempotent">
+		<span class="cli-modifier cli-modifier--idempotent"
+		      data-tooltip="@Tip(Model.IdempotentDescription, "Running this command repeatedly produces the same result. Safe to retry on transient failures.")">
 			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
 				<path fill-rule="evenodd" d="M12.416 3.376a.75.75 0 0 1 .208 1.04l-5 7.5a.75.75 0 0 1-1.154.114l-3-3a.75.75 0 0 1 1.06-1.06l2.353 2.353 4.493-6.74a.75.75 0 0 1 1.04-.207Z" clip-rule="evenodd"/>
 			</svg>
@@ -38,7 +46,8 @@
 	}
 	@if (!string.IsNullOrWhiteSpace(Model.Scope))
 	{
-		<span class="cli-modifier cli-modifier--scope">
+		<span class="cli-modifier cli-modifier--scope"
+		      data-tooltip="@Tip(Model.ScopeDescription, $"This command operates against the {Model.Scope} scope.")">
 			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
 				<path d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"/>
 				<path fill-rule="evenodd" d="M1.38 8a6.5 6.5 0 1 1 13.24 0A6.5 6.5 0 0 1 1.38 8ZM8 3a5 5 0 1 0 0 10A5 5 0 0 0 8 3Z" clip-rule="evenodd"/>
@@ -48,7 +57,8 @@
 	}
 	@if (Model.Streaming)
 	{
-		<span class="cli-modifier cli-modifier--streaming">
+		<span class="cli-modifier cli-modifier--streaming"
+		      data-tooltip="@Tip(Model.StreamingDescription, "Emits output incrementally as it becomes available. Designed to be piped into other tools.")">
 			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
 				<path d="M3.75 7.25a.75.75 0 0 0 0 1.5h8.5a.75.75 0 0 0 0-1.5h-8.5Z"/>
 			</svg>
@@ -57,7 +67,8 @@
 	}
 	@if (Model.LongRunning)
 	{
-		<span class="cli-modifier cli-modifier--long-running">
+		<span class="cli-modifier cli-modifier--long-running"
+		      data-tooltip="@Tip(Model.LongRunningDescription, "May take significant time to complete. Consider running unattended or with a timeout.")">
 			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
 				<path fill-rule="evenodd" d="M1 8a7 7 0 1 1 14 0A7 7 0 0 1 1 8Zm7.75-4.25a.75.75 0 0 0-1.5 0V8c0 .414.336.75.75.75h3.25a.75.75 0 0 0 0-1.5h-2.5v-3.5Z" clip-rule="evenodd"/>
 			</svg>

--- a/src/Elastic.Markdown/Myst/Directives/CliModifiers/CliModifiersView.cshtml
+++ b/src/Elastic.Markdown/Myst/Directives/CliModifiers/CliModifiersView.cshtml
@@ -6,7 +6,7 @@
 <div class="cli-modifiers">
 	@if (Model.Destructive)
 	{
-		<span class="cli-modifier cli-modifier--destructive"
+		<span class="cli-modifier cli-modifier--destructive" tabindex="0"
 		      data-tooltip="@Tip(Model.DestructiveDescription, "Modifies or removes data on the target. The change cannot be undone.")">
 			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
 				<path fill-rule="evenodd" d="M6.701 2.25c.577-1 2.02-1 2.598 0l5.196 9a1.5 1.5 0 0 1-1.299 2.25H2.804a1.5 1.5 0 0 1-1.3-2.25l5.197-9ZM8 4a.75.75 0 0 1 .75.75v3a.75.75 0 1 1-1.5 0v-3A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clip-rule="evenodd"/>
@@ -16,7 +16,7 @@
 	}
 	@if (Model.RequiresConfirmation)
 	{
-		<span class="cli-modifier cli-modifier--confirmation"
+		<span class="cli-modifier cli-modifier--confirmation" tabindex="0"
 		      data-tooltip="@Tip(Model.RequiresConfirmationDescription, "Prompts before running. Pass a non-interactive override (e.g. --yes) to skip the prompt in scripts.")">
 			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
 				<path fill-rule="evenodd" d="M15 8A7 7 0 1 1 1 8a7 7 0 0 1 14 0Zm-7-3.25a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 9.75 11H10a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 8.25 5H8ZM9 4a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z" clip-rule="evenodd"/>
@@ -26,7 +26,7 @@
 	}
 	@if (Model.RequiresAuth)
 	{
-		<span class="cli-modifier cli-modifier--auth"
+		<span class="cli-modifier cli-modifier--auth" tabindex="0"
 		      data-tooltip="@Tip(Model.RequiresAuthDescription, "Valid credentials for the target must be configured before this command can run.")">
 			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
 				<path fill-rule="evenodd" d="M8 1a3.5 3.5 0 0 1 3.5 3.5V7A1.5 1.5 0 0 1 13 8.5v5A1.5 1.5 0 0 1 11.5 15h-7A1.5 1.5 0 0 1 3 13.5v-5A1.5 1.5 0 0 1 4.5 7V4.5A3.5 3.5 0 0 1 8 1Zm0 1.5A2 2 0 0 0 6 4.5V7h4V4.5A2 2 0 0 0 8 2.5ZM8 10a1 1 0 1 0 0 2 1 1 0 0 0 0-2Z" clip-rule="evenodd"/>
@@ -36,7 +36,7 @@
 	}
 	@if (Model.Idempotent)
 	{
-		<span class="cli-modifier cli-modifier--idempotent"
+		<span class="cli-modifier cli-modifier--idempotent" tabindex="0"
 		      data-tooltip="@Tip(Model.IdempotentDescription, "Running this command repeatedly produces the same result. Safe to retry on transient failures.")">
 			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
 				<path fill-rule="evenodd" d="M12.416 3.376a.75.75 0 0 1 .208 1.04l-5 7.5a.75.75 0 0 1-1.154.114l-3-3a.75.75 0 0 1 1.06-1.06l2.353 2.353 4.493-6.74a.75.75 0 0 1 1.04-.207Z" clip-rule="evenodd"/>
@@ -46,7 +46,7 @@
 	}
 	@if (!string.IsNullOrWhiteSpace(Model.Scope))
 	{
-		<span class="cli-modifier cli-modifier--scope"
+		<span class="cli-modifier cli-modifier--scope" tabindex="0"
 		      data-tooltip="@Tip(Model.ScopeDescription, $"This command operates against the {Model.Scope} scope.")">
 			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
 				<path d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"/>
@@ -57,7 +57,7 @@
 	}
 	@if (Model.Streaming)
 	{
-		<span class="cli-modifier cli-modifier--streaming"
+		<span class="cli-modifier cli-modifier--streaming" tabindex="0"
 		      data-tooltip="@Tip(Model.StreamingDescription, "Emits output incrementally as it becomes available. Designed to be piped into other tools.")">
 			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
 				<path d="M3.75 7.25a.75.75 0 0 0 0 1.5h8.5a.75.75 0 0 0 0-1.5h-8.5Z"/>
@@ -67,7 +67,7 @@
 	}
 	@if (Model.LongRunning)
 	{
-		<span class="cli-modifier cli-modifier--long-running"
+		<span class="cli-modifier cli-modifier--long-running" tabindex="0"
 		      data-tooltip="@Tip(Model.LongRunningDescription, "May take significant time to complete. Consider running unattended or with a timeout.")">
 			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
 				<path fill-rule="evenodd" d="M1 8a7 7 0 1 1 14 0A7 7 0 0 1 1 8Zm7.75-4.25a.75.75 0 0 0-1.5 0V8c0 .414.336.75.75.75h3.25a.75.75 0 0 0 0-1.5h-2.5v-3.5Z" clip-rule="evenodd"/>

--- a/src/Elastic.Markdown/Myst/Directives/CliModifiers/CliModifiersViewModel.cs
+++ b/src/Elastic.Markdown/Myst/Directives/CliModifiers/CliModifiersViewModel.cs
@@ -7,10 +7,17 @@ namespace Elastic.Markdown.Myst.Directives.CliModifiers;
 public class CliModifiersViewModel : DirectiveViewModel
 {
 	public bool Destructive { get; init; }
+	public string? DestructiveDescription { get; init; }
 	public bool RequiresConfirmation { get; init; }
+	public string? RequiresConfirmationDescription { get; init; }
 	public bool RequiresAuth { get; init; }
+	public string? RequiresAuthDescription { get; init; }
 	public bool Idempotent { get; init; }
+	public string? IdempotentDescription { get; init; }
 	public string? Scope { get; init; }
+	public string? ScopeDescription { get; init; }
 	public bool Streaming { get; init; }
+	public string? StreamingDescription { get; init; }
 	public bool LongRunning { get; init; }
+	public string? LongRunningDescription { get; init; }
 }

--- a/src/Elastic.Markdown/Myst/Directives/DirectiveHtmlRenderer.cs
+++ b/src/Elastic.Markdown/Myst/Directives/DirectiveHtmlRenderer.cs
@@ -268,12 +268,19 @@ public class DirectiveHtmlRenderer : HtmlObjectRenderer<DirectiveBlock>
 		{
 			DirectiveBlock = block,
 			Destructive = block.Destructive,
+			DestructiveDescription = block.DestructiveDescription,
 			RequiresConfirmation = block.RequiresConfirmation,
+			RequiresConfirmationDescription = block.RequiresConfirmationDescription,
 			RequiresAuth = block.RequiresAuth,
+			RequiresAuthDescription = block.RequiresAuthDescription,
 			Idempotent = block.Idempotent,
+			IdempotentDescription = block.IdempotentDescription,
 			Scope = block.Scope,
+			ScopeDescription = block.ScopeDescription,
 			Streaming = block.Streaming,
+			StreamingDescription = block.StreamingDescription,
 			LongRunning = block.LongRunning,
+			LongRunningDescription = block.LongRunningDescription,
 		});
 		RenderRazorSlice(slice, renderer);
 	}

--- a/src/Elastic.Markdown/Page/Index.cshtml
+++ b/src/Elastic.Markdown/Page/Index.cshtml
@@ -63,6 +63,7 @@
 		GitHubDocsUrl = Model.GitHubDocsUrl,
 		GitHubRef = Model.GitHubRef,
 		Branding = Model.Branding,
+		RedirectUrl = Model.RedirectUrl,
 	};
 	protected override Task ExecuteSectionAsync(string name)
 	{

--- a/src/Elastic.Markdown/Page/IndexViewModel.cs
+++ b/src/Elastic.Markdown/Page/IndexViewModel.cs
@@ -82,6 +82,9 @@ public class IndexViewModel
 
 	/// <summary>Pre-computed site root path for HTMX. When set (codex builds), used as data-root-path.</summary>
 	public string? SiteRootPath { get; set; }
+
+	/// <summary>When set, the page performs a client-side redirect to this URL (used for alias pages).</summary>
+	public string? RedirectUrl { get; init; }
 }
 
 public class VersionDropDownItemViewModel

--- a/src/Elastic.Markdown/_Layout.cshtml
+++ b/src/Elastic.Markdown/_Layout.cshtml
@@ -13,9 +13,10 @@
 
 		if (name == GlobalSections.Head)
 		{
-			if (Model.RedirectUrl is { } redirectUrl)
+			if (Model.RedirectUrl is { } redirectUrl && Model.Layout is not MarkdownPageLayout.Archive)
 			{
-				<script>window.location.replace('@redirectUrl');</script>
+				var encodedUrl = System.Text.Encodings.Web.JavaScriptEncoder.Default.Encode(redirectUrl);
+				<script>window.location.replace('@(new HtmlString(encodedUrl))');</script>
 			}
 			//this ensures we forward head sections declared in this project into to GlobalLayout view's section
 			await RenderSectionAsync(GlobalSections.Head);

--- a/src/Elastic.Markdown/_Layout.cshtml
+++ b/src/Elastic.Markdown/_Layout.cshtml
@@ -13,6 +13,10 @@
 
 		if (name == GlobalSections.Head)
 		{
+			if (Model.RedirectUrl is { } redirectUrl)
+			{
+				<script>window.location.replace('@redirectUrl');</script>
+			}
 			//this ensures we forward head sections declared in this project into to GlobalLayout view's section
 			await RenderSectionAsync(GlobalSections.Head);
 		}


### PR DESCRIPTION
## Summary

### Intent modifier pills

The row of colored pills that indicate a command's operational characteristics (destructive, auth required, idempotent, etc.) has been improved in two ways:

- **Moved above the usage block.** Previously the pills appeared directly below the bash usage example, which made them easy to miss. They now sit above the usage block so readers see the warnings before the command.
- **Tooltips on hover.** Each pill now shows a plain-English explanation when hovered — e.g. "Modifies or removes data on the target. The change cannot be undone." for the destructive badge. When the CLI schema supplies its own description for a flag, that takes precedence; otherwise a sensible hardcoded fallback is shown.

### CLI shortcut / alias support

The upstream CLI schema now ships a `shortcuts` list (e.g. `es` → `stack es`, `elasticsearch` → `stack es`). The docs now reflect this:

- **Alias pages in the navigation.** Each shortcut gets its own entry in the nav sidebar with a distinct sky-blue "alias" badge, listed before commands and namespaces so they're easy to spot.
- **Alias pages redirect.** Navigating to an alias URL (e.g. `/cli/es`) immediately redirects the browser to the canonical page (`/cli/stack/es/`) so there's no dead-end stub.
- **Canonical namespace pages list their aliases.** The namespace page shows all known shorthand usages and includes a note linking to each alias.
- **Command pages show the shortest usage first.** When a command is reachable via multiple aliases, the shortest form is shown in the bash block, followed by a compact "Also available as: …" note listing just the command names without the full argument list.
- **Required options listed first.** Within any command's option list, required options are now sorted to the top so the most important flags are immediately visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)