### PR TITLE
Remove empty sections from changelog directive

### DIFF
--- a/docs/syntax/changelog.md
+++ b/docs/syntax/changelog.md
@@ -105,6 +105,11 @@ To show all entries on a single page (previous default behavior):
 :::
 ```
 
+**General release notes** (default or `:type: all`):
+
+- Section headings are shown when that type has entries.
+- Releases with no matching entries are omitted unless the bundle has a `description`; in that case only the version heading and description are shown (no placeholder messages). A `release-date` alone does not preserve an otherwise empty release.
+
 #### `:link-visibility:`
 
 Controls how pull request and issue links are shown when the directive applies source-repo-based privacy.
@@ -303,7 +308,7 @@ Bundle descriptions are rendered when present in the bundle YAML file. The descr
 - The "Highlights" section is only created when at least one entry has `highlight: true`
 - When using `:type: highlight`, only highlighted entries are shown (no section headers or other content)
 
-Sections with no entries of that type are omitted from the output.
+Sections with no entries of that type are omitted from the output. Releases with no entries after the `:type:` filter are omitted entirely, except on general release-notes pages (`:type: all` or default) when the bundle has a `description`.
 
 ## Error behavior for missing files [changelog-missing-files]
 

--- a/src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogBlock.cs
@@ -465,51 +465,46 @@ public class ChangelogBlock(DirectiveBlockParser parser, ParserContext context) 
 
 	private IEnumerable<string> ComputeGeneratedAnchors()
 	{
+		var dedicatedPage = ChangelogInlineRenderer.IsDedicatedSeparatedTypePage(TypeFilter);
+
 		foreach (var bundle in LoadedBundles)
 		{
+			if (!BundleContributesToNavigation(bundle))
+				continue;
+
 			var titleSlug = ChangelogTextUtilities.TitleToSlug(bundle.Version);
 			var anchorSlug = titleSlug.Slugify();
 			var repo = bundle.Repo;
-
-			// Group filtered entries by type to determine which sections will exist
 			var entriesByType = GetFilteredEntryCounts(bundle);
-
-			// Apply type filter to determine which sections to include
 			var shouldInclude = CreateTypeFilterPredicate();
 
-			// Critical sections
-			if (shouldInclude(ChangelogEntryType.BreakingChange) && entriesByType.ContainsKey(ChangelogEntryType.BreakingChange))
+			if (!dedicatedPage && shouldInclude(ChangelogEntryType.BreakingChange) && entriesByType.ContainsKey(ChangelogEntryType.BreakingChange))
 				yield return $"{repo}-{anchorSlug}-breaking-changes";
 
-			if (shouldInclude(ChangelogEntryType.Security) && entriesByType.ContainsKey(ChangelogEntryType.Security))
+			if (!dedicatedPage && shouldInclude(ChangelogEntryType.Security) && entriesByType.ContainsKey(ChangelogEntryType.Security))
 				yield return $"{repo}-{anchorSlug}-security";
 
-			if (shouldInclude(ChangelogEntryType.KnownIssue) && entriesByType.ContainsKey(ChangelogEntryType.KnownIssue))
+			if (!dedicatedPage && shouldInclude(ChangelogEntryType.KnownIssue) && entriesByType.ContainsKey(ChangelogEntryType.KnownIssue))
 				yield return $"{repo}-{anchorSlug}-known-issues";
 
-			if (shouldInclude(ChangelogEntryType.Deprecation) && entriesByType.ContainsKey(ChangelogEntryType.Deprecation))
+			if (!dedicatedPage && shouldInclude(ChangelogEntryType.Deprecation) && entriesByType.ContainsKey(ChangelogEntryType.Deprecation))
 				yield return $"{repo}-{anchorSlug}-deprecations";
 
-			// Features and enhancements section
-			if (shouldInclude(ChangelogEntryType.Feature) &&
+			if (!dedicatedPage && shouldInclude(ChangelogEntryType.Feature) &&
 				(entriesByType.ContainsKey(ChangelogEntryType.Feature) ||
 				 entriesByType.ContainsKey(ChangelogEntryType.Enhancement)))
 				yield return $"{repo}-{anchorSlug}-features-enhancements";
 
-			// Fixes section (bug fixes only, security is separate)
-			if (shouldInclude(ChangelogEntryType.BugFix) && entriesByType.ContainsKey(ChangelogEntryType.BugFix))
+			if (!dedicatedPage && shouldInclude(ChangelogEntryType.BugFix) && entriesByType.ContainsKey(ChangelogEntryType.BugFix))
 				yield return $"{repo}-{anchorSlug}-fixes";
 
-			// Documentation section
-			if (shouldInclude(ChangelogEntryType.Docs) && entriesByType.ContainsKey(ChangelogEntryType.Docs))
+			if (!dedicatedPage && shouldInclude(ChangelogEntryType.Docs) && entriesByType.ContainsKey(ChangelogEntryType.Docs))
 				yield return $"{repo}-{anchorSlug}-docs";
 
-			// Regressions section
-			if (shouldInclude(ChangelogEntryType.Regression) && entriesByType.ContainsKey(ChangelogEntryType.Regression))
+			if (!dedicatedPage && shouldInclude(ChangelogEntryType.Regression) && entriesByType.ContainsKey(ChangelogEntryType.Regression))
 				yield return $"{repo}-{anchorSlug}-regressions";
 
-			// Other changes section
-			if (shouldInclude(ChangelogEntryType.Other) && entriesByType.ContainsKey(ChangelogEntryType.Other))
+			if (!dedicatedPage && shouldInclude(ChangelogEntryType.Other) && entriesByType.ContainsKey(ChangelogEntryType.Other))
 				yield return $"{repo}-{anchorSlug}-other";
 		}
 	}
@@ -528,40 +523,32 @@ public class ChangelogBlock(DirectiveBlockParser parser, ParserContext context) 
 		};
 
 	/// <summary>
-	/// Returns entry counts by type after applying publish blocker and hide-features filters.
+	/// Returns entry counts by type after applying publish blocker, hide-features, and type filters.
 	/// This ensures the TOC and generated anchors match what the renderer actually outputs.
 	/// </summary>
-	private Dictionary<ChangelogEntryType, int> GetFilteredEntryCounts(LoadedBundle bundle)
-	{
-		IEnumerable<ChangelogEntry> entries = bundle.Entries;
-
-		// Filter by publish blocker
-		if (PublishBlocker is { HasBlockingRules: true })
-			entries = entries.Where(e => !PublishBlocker.ShouldBlock(e));
-
-		// Filter by hide-features
-		if (HideFeatures.Count > 0)
-			entries = entries.Where(e => string.IsNullOrWhiteSpace(e.FeatureId) || !HideFeatures.Contains(e.FeatureId));
-
-		return entries
+	private Dictionary<ChangelogEntryType, int> GetFilteredEntryCounts(LoadedBundle bundle) =>
+		ChangelogInlineRenderer.GetFilteredEntries(bundle, PublishBlocker, HideFeatures, TypeFilter)
 			.GroupBy(e => e.Type)
 			.ToDictionary(g => g.Key, g => g.Count());
-	}
+
+	private bool BundleContributesToNavigation(LoadedBundle bundle) =>
+		ChangelogInlineRenderer.BundleHasRenderableEntries(bundle, PublishBlocker, HideFeatures, TypeFilter)
+		|| ChangelogInlineRenderer.ShouldRenderEmptyBundleMetadata(TypeFilter, bundle.Data?.Description);
 
 	private IEnumerable<PageTocItem> ComputeTableOfContent()
 	{
+		var dedicatedPage = ChangelogInlineRenderer.IsDedicatedSeparatedTypePage(TypeFilter);
+
 		foreach (var bundle in LoadedBundles)
 		{
+			if (!BundleContributesToNavigation(bundle))
+				continue;
+
 			var titleSlug = ChangelogTextUtilities.TitleToSlug(bundle.Version);
-			// Slugify the title slug to match what SectionedHeadingRenderer produces from explicit anchors.
-			// e.g. "9.3.0" -> "9-3-0", "2025-11" -> "2025-11"
 			var anchorSlug = titleSlug.Slugify();
 			var repo = bundle.Repo;
 			var displayVersion = VersionOrDate.FormatDisplayVersion(bundle.Version);
 
-			// Version header: slug must match what SectionedHeadingRenderer auto-derives from
-			// the display text (since there is no explicit anchor on the version heading).
-			// e.g. "November 2025" -> "november-2025", "9.3.0" -> "9-3-0"
 			yield return new PageTocItem
 			{
 				Heading = displayVersion,
@@ -569,13 +556,12 @@ public class ChangelogBlock(DirectiveBlockParser parser, ParserContext context) 
 				Level = 2
 			};
 
-			// Group filtered entries by type to determine which sections will exist
-			var entriesByType = GetFilteredEntryCounts(bundle);
+			if (dedicatedPage || TypeFilter == ChangelogTypeFilter.Highlight)
+				continue;
 
-			// Apply type filter to determine which sections to include
+			var entriesByType = GetFilteredEntryCounts(bundle);
 			var shouldInclude = CreateTypeFilterPredicate();
 
-			// Critical sections first (new ordering) - all at h3 level (children of version)
 			if (shouldInclude(ChangelogEntryType.BreakingChange) && entriesByType.ContainsKey(ChangelogEntryType.BreakingChange))
 				yield return new PageTocItem
 				{
@@ -584,8 +570,8 @@ public class ChangelogBlock(DirectiveBlockParser parser, ParserContext context) 
 					Level = 3
 				};
 
-			// Check for highlights (any entry with highlight == true) - only show in :type: all
-			var hasHighlights = bundle.Entries.Any(e => e.Highlight == true);
+			var hasHighlights = ChangelogInlineRenderer.GetFilteredEntries(bundle, PublishBlocker, HideFeatures, TypeFilter)
+				.Any(e => e.Highlight == true);
 			if (hasHighlights && TypeFilter == ChangelogTypeFilter.All)
 				yield return new PageTocItem
 				{
@@ -593,10 +579,6 @@ public class ChangelogBlock(DirectiveBlockParser parser, ParserContext context) 
 					Slug = $"{repo}-{anchorSlug}-highlights",
 					Level = 3
 				};
-
-			// When filtering by highlight, skip all other type-based sections
-			if (TypeFilter == ChangelogTypeFilter.Highlight)
-				continue;
 
 			if (shouldInclude(ChangelogEntryType.Security) && entriesByType.ContainsKey(ChangelogEntryType.Security))
 				yield return new PageTocItem
@@ -622,7 +604,6 @@ public class ChangelogBlock(DirectiveBlockParser parser, ParserContext context) 
 					Level = 3
 				};
 
-			// Features and enhancements section
 			if (shouldInclude(ChangelogEntryType.Feature) &&
 				(entriesByType.ContainsKey(ChangelogEntryType.Feature) ||
 				 entriesByType.ContainsKey(ChangelogEntryType.Enhancement)))
@@ -633,7 +614,6 @@ public class ChangelogBlock(DirectiveBlockParser parser, ParserContext context) 
 					Level = 3
 				};
 
-			// Fixes section (bug fixes only, security is separate)
 			if (shouldInclude(ChangelogEntryType.BugFix) && entriesByType.ContainsKey(ChangelogEntryType.BugFix))
 				yield return new PageTocItem
 				{
@@ -642,7 +622,6 @@ public class ChangelogBlock(DirectiveBlockParser parser, ParserContext context) 
 					Level = 3
 				};
 
-			// Documentation section
 			if (shouldInclude(ChangelogEntryType.Docs) && entriesByType.ContainsKey(ChangelogEntryType.Docs))
 				yield return new PageTocItem
 				{
@@ -651,7 +630,6 @@ public class ChangelogBlock(DirectiveBlockParser parser, ParserContext context) 
 					Level = 3
 				};
 
-			// Regressions section
 			if (shouldInclude(ChangelogEntryType.Regression) && entriesByType.ContainsKey(ChangelogEntryType.Regression))
 				yield return new PageTocItem
 				{
@@ -660,7 +638,6 @@ public class ChangelogBlock(DirectiveBlockParser parser, ParserContext context) 
 					Level = 3
 				};
 
-			// Other changes section
 			if (shouldInclude(ChangelogEntryType.Other) && entriesByType.ContainsKey(ChangelogEntryType.Other))
 				yield return new PageTocItem
 				{

--- a/src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogInlineRenderer.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogInlineRenderer.cs
@@ -28,9 +28,6 @@ public static class ChangelogInlineRenderer
 		var isFirst = true;
 		foreach (var bundle in block.LoadedBundles)
 		{
-			if (!isFirst)
-				_ = sb.AppendLine();
-
 			var bundleMarkdown = RenderSingleBundle(
 				bundle,
 				block.Subsections,
@@ -41,13 +38,65 @@ public static class ChangelogInlineRenderer
 				block.LinkVisibility,
 				block.DescriptionVisibility,
 				block.DropdownsEnabled);
-			_ = sb.Append(bundleMarkdown);
 
+			if (string.IsNullOrWhiteSpace(bundleMarkdown))
+				continue;
+
+			if (!isFirst)
+				_ = sb.AppendLine();
+
+			_ = sb.Append(bundleMarkdown);
 			isFirst = false;
 		}
 
-		return sb.ToString();
+		return sb.Length == 0 ? null : sb.ToString();
 	}
+
+	/// <summary>
+	/// True when the directive filters to a single separated type page (deprecations, breaking changes, etc.).
+	/// </summary>
+	public static bool IsDedicatedSeparatedTypePage(ChangelogTypeFilter typeFilter) =>
+		typeFilter is ChangelogTypeFilter.BreakingChange
+			or ChangelogTypeFilter.Deprecation
+			or ChangelogTypeFilter.KnownIssue
+			or ChangelogTypeFilter.Highlight;
+
+	/// <summary>
+	/// True when <paramref name="typeFilter"/> is <see cref="ChangelogTypeFilter.All"/> or default.
+	/// </summary>
+	public static bool IsGeneralReleaseNotesPage(ChangelogTypeFilter typeFilter) =>
+		typeFilter is ChangelogTypeFilter.All or ChangelogTypeFilter.Default;
+
+	/// <summary>
+	/// Returns filtered changelog entries for a bundle using the same filters as rendering.
+	/// </summary>
+	public static IReadOnlyList<ChangelogEntry> GetFilteredEntries(
+		LoadedBundle bundle,
+		PublishBlocker? publishBlocker,
+		HashSet<string> hideFeatures,
+		ChangelogTypeFilter typeFilter)
+	{
+		var entries = FilterEntries(bundle.Entries, publishBlocker);
+		entries = FilterEntriesByHideFeatures(entries, hideFeatures);
+		return FilterEntriesByType(entries, typeFilter);
+	}
+
+	/// <summary>
+	/// True when the bundle would produce visible entry content after filtering.
+	/// </summary>
+	public static bool BundleHasRenderableEntries(
+		LoadedBundle bundle,
+		PublishBlocker? publishBlocker,
+		HashSet<string> hideFeatures,
+		ChangelogTypeFilter typeFilter) =>
+		GetFilteredEntries(bundle, publishBlocker, hideFeatures, typeFilter).Count > 0;
+
+	/// <summary>
+	/// True when an empty bundle should still render a version block for bundle-level <c>description</c> only.
+	/// <c>release-date</c> alone does not preserve an otherwise empty release.
+	/// </summary>
+	public static bool ShouldRenderEmptyBundleMetadata(ChangelogTypeFilter typeFilter, string? description) =>
+		IsGeneralReleaseNotesPage(typeFilter) && !string.IsNullOrEmpty(description);
 
 	private static string RenderSingleBundle(
 		LoadedBundle bundle,
@@ -204,6 +253,7 @@ public static class ChangelogInlineRenderer
 		DateOnly? releaseDate = null)
 	{
 		var sb = new StringBuilder();
+		var dedicatedPage = IsDedicatedSeparatedTypePage(typeFilter);
 
 		// Get entries by category
 		var features = entriesByType.GetValueOrDefault(ChangelogEntryType.Feature, []);
@@ -223,21 +273,6 @@ public static class ChangelogInlineRenderer
 			.Where(e => e.Highlight == true)
 			.ToList();
 
-		_ = sb.AppendLine(CultureInfo.InvariantCulture, $"## {title}");
-
-		if (releaseDate is { } date)
-		{
-			_ = sb.AppendLine();
-			_ = sb.AppendLine(CultureInfo.InvariantCulture, $"_Released: {date.ToString("MMMM d, yyyy", CultureInfo.InvariantCulture)}_");
-		}
-
-		// Add description if present
-		if (!string.IsNullOrEmpty(description))
-		{
-			_ = sb.AppendLine();
-			_ = sb.AppendLine(description);
-		}
-
 		// Check if we have any content at all
 		var hasAnyContent = features.Count > 0 || enhancements.Count > 0 || security.Count > 0 ||
 							bugFixes.Count > 0 || docs.Count > 0 || regressions.Count > 0 || other.Count > 0 ||
@@ -246,27 +281,33 @@ public static class ChangelogInlineRenderer
 
 		if (!hasAnyContent)
 		{
-			_ = sb.AppendLine(GetEmptyMessage(typeFilter));
-			return sb.ToString();
+			if (ShouldRenderEmptyBundleMetadata(typeFilter, description))
+			{
+				AppendVersionHeader(sb, title, description, releaseDate);
+				return sb.ToString();
+			}
+
+			return string.Empty;
 		}
+
+		AppendVersionHeader(sb, title, description, releaseDate);
 
 		// Special case: When filtering by highlight, render only highlights without type-based sections
 		if (typeFilter == ChangelogTypeFilter.Highlight)
 		{
 			if (highlights.Count > 0)
 			{
-				if (dropdownsEnabled)
-					RenderDetailedEntries(sb, highlights, repo, owner, groupBySubtype: false, hideLinks, hideEntryDescriptions, publishBlocker);
-				else
-					RenderDetailedEntriesFlattened(sb, highlights, repo, owner, groupBySubtype: false, hideLinks, hideEntryDescriptions);
+				_ = sb.AppendLine();
+				RenderSeparatedTypeEntries(
+					sb, highlights, repo, owner, subsections, dropdownsEnabled, groupBySubtype: false,
+					hideLinks, hideEntryDescriptions, publishBlocker);
 			}
 			return sb.ToString();
 		}
 
 		if (breakingChanges.Count > 0)
 		{
-			_ = sb.AppendLine();
-			_ = sb.AppendLine(CultureInfo.InvariantCulture, $"### Breaking changes [{repo}-{titleSlug}-breaking-changes]");
+			AppendSectionHeader(sb, dedicatedPage, $"### Breaking changes [{repo}-{titleSlug}-breaking-changes]");
 			if (dropdownsEnabled)
 				RenderDetailedEntries(sb, breakingChanges, repo, owner, groupBySubtype: true, hideLinks, hideEntryDescriptions, publishBlocker);
 			else
@@ -292,22 +333,18 @@ public static class ChangelogInlineRenderer
 
 		if (knownIssues.Count > 0)
 		{
-			_ = sb.AppendLine();
-			_ = sb.AppendLine(CultureInfo.InvariantCulture, $"### Known issues [{repo}-{titleSlug}-known-issues]");
-			if (dropdownsEnabled)
-				RenderDetailedEntries(sb, knownIssues, repo, owner, groupBySubtype: false, hideLinks, hideEntryDescriptions, publishBlocker);
-			else
-				RenderDetailedEntriesFlattened(sb, knownIssues, repo, owner, groupBySubtype: false, hideLinks, hideEntryDescriptions);
+			AppendSectionHeader(sb, dedicatedPage, $"### Known issues [{repo}-{titleSlug}-known-issues]");
+			RenderSeparatedTypeEntries(
+				sb, knownIssues, repo, owner, subsections, dropdownsEnabled, groupBySubtype: false,
+				hideLinks, hideEntryDescriptions, publishBlocker);
 		}
 
 		if (deprecations.Count > 0)
 		{
-			_ = sb.AppendLine();
-			_ = sb.AppendLine(CultureInfo.InvariantCulture, $"### Deprecations [{repo}-{titleSlug}-deprecations]");
-			if (dropdownsEnabled)
-				RenderDetailedEntries(sb, deprecations, repo, owner, groupBySubtype: false, hideLinks, hideEntryDescriptions, publishBlocker);
-			else
-				RenderDetailedEntriesFlattened(sb, deprecations, repo, owner, groupBySubtype: false, hideLinks, hideEntryDescriptions);
+			AppendSectionHeader(sb, dedicatedPage, $"### Deprecations [{repo}-{titleSlug}-deprecations]");
+			RenderSeparatedTypeEntries(
+				sb, deprecations, repo, owner, subsections, dropdownsEnabled, groupBySubtype: false,
+				hideLinks, hideEntryDescriptions, publishBlocker);
 		}
 
 		if (features.Count > 0 || enhancements.Count > 0)
@@ -655,16 +692,55 @@ public static class ChangelogInlineRenderer
 		_ = sb.AppendLine();
 	}
 
-	/// <summary>
-	/// Gets the appropriate empty message based on the type filter.
-	/// Matches messages used by CLI renderers for consistency.
-	/// </summary>
-	private static string GetEmptyMessage(ChangelogTypeFilter typeFilter) =>
-		typeFilter switch
+	private static void AppendVersionHeader(StringBuilder sb, string title, string? description, DateOnly? releaseDate)
+	{
+		_ = sb.AppendLine(CultureInfo.InvariantCulture, $"## {title}");
+
+		if (releaseDate is { } date)
 		{
-			ChangelogTypeFilter.BreakingChange => "_There are no breaking changes associated with this release._",
-			ChangelogTypeFilter.Deprecation => "_There are no deprecations associated with this release._",
-			ChangelogTypeFilter.KnownIssue => "_There are no known issues associated with this release._",
-			_ => "_No new features, enhancements, or fixes._"
-		};
+			_ = sb.AppendLine();
+			_ = sb.AppendLine(CultureInfo.InvariantCulture, $"_Released: {date.ToString("MMMM d, yyyy", CultureInfo.InvariantCulture)}_");
+		}
+
+		if (!string.IsNullOrEmpty(description))
+		{
+			_ = sb.AppendLine();
+			_ = sb.AppendLine(description);
+		}
+	}
+
+	private static void AppendSectionHeader(StringBuilder sb, bool dedicatedPage, string sectionHeading)
+	{
+		if (dedicatedPage)
+			_ = sb.AppendLine();
+		else
+		{
+			_ = sb.AppendLine();
+			_ = sb.AppendLine(sectionHeading);
+		}
+	}
+
+	private static void RenderSeparatedTypeEntries(
+		StringBuilder sb,
+		List<ChangelogEntry> entries,
+		string repo,
+		string owner,
+		bool subsections,
+		bool dropdownsEnabled,
+		bool groupBySubtype,
+		bool hideLinks,
+		bool hideEntryDescriptions,
+		PublishBlocker? publishBlocker)
+	{
+		if (dropdownsEnabled)
+		{
+			RenderDetailedEntries(sb, entries, repo, owner, groupBySubtype, hideLinks, hideEntryDescriptions, publishBlocker);
+			return;
+		}
+
+		if (subsections && !groupBySubtype)
+			RenderDetailedEntries(sb, entries, repo, owner, groupBySubtype: false, hideLinks, hideEntryDescriptions, publishBlocker);
+		else
+			RenderDetailedEntriesFlattened(sb, entries, repo, owner, groupBySubtype, hideLinks, hideEntryDescriptions);
+	}
 }

--- a/src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogInlineRenderer.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogInlineRenderer.cs
@@ -534,6 +534,31 @@ public static class ChangelogInlineRenderer
 		}
 	}
 
+	private static void RenderDetailedEntriesFlattenedByArea(
+		StringBuilder sb,
+		List<ChangelogEntry> entries,
+		string repo,
+		string owner,
+		bool hideLinks,
+		bool hideEntryDescriptions,
+		PublishBlocker? publishBlocker)
+	{
+		var groupedByArea = entries.GroupBy(e => publishBlocker.GetPreferredArea(e)).OrderBy(g => g.Key).ToList();
+
+		foreach (var areaGroup in groupedByArea)
+		{
+			if (!string.IsNullOrWhiteSpace(areaGroup.Key))
+			{
+				var header = ChangelogTextUtilities.FormatAreaHeader(areaGroup.Key);
+				_ = sb.AppendLine();
+				_ = sb.AppendLine(CultureInfo.InvariantCulture, $"**{header}**");
+			}
+
+			foreach (var entry in areaGroup)
+				RenderDetailedEntryFlattened(sb, entry, repo, owner, hideLinks, hideEntryDescriptions);
+		}
+	}
+
 	private static void RenderDetailedEntryFlattened(StringBuilder sb, ChangelogEntry entry, string repo, string owner, bool hideLinks, bool hideEntryDescriptions)
 	{
 		// Start with bullet point and title (no bold, matching regular entries)
@@ -739,7 +764,7 @@ public static class ChangelogInlineRenderer
 		}
 
 		if (subsections && !groupBySubtype)
-			RenderDetailedEntries(sb, entries, repo, owner, groupBySubtype: false, hideLinks, hideEntryDescriptions, publishBlocker);
+			RenderDetailedEntriesFlattenedByArea(sb, entries, repo, owner, hideLinks, hideEntryDescriptions, publishBlocker);
 		else
 			RenderDetailedEntriesFlattened(sb, entries, repo, owner, groupBySubtype, hideLinks, hideEntryDescriptions);
 	}

--- a/tests/Elastic.Markdown.Tests/Directives/ChangelogBasicTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/ChangelogBasicTests.cs
@@ -330,9 +330,10 @@ public class ChangelogEmptyBundleTests : DirectiveTest<ChangelogBlock>
 		"""));
 
 	[Fact]
-	public void HandlesEmptyBundle()
+	public void OmitsEmptyVersionBlock()
 	{
-		Html.Should().Contain("No new features, enhancements, or fixes");
+		Html.Should().NotContain("No new features, enhancements, or fixes");
+		Html.Should().NotContain("9.3.0");
 	}
 }
 

--- a/tests/Elastic.Markdown.Tests/Directives/ChangelogIndexPageTocTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/ChangelogIndexPageTocTests.cs
@@ -1,0 +1,90 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions.TestingHelpers;
+using AwesomeAssertions;
+using Elastic.Markdown.IO;
+using Elastic.Markdown.Myst.Directives.Changelog;
+using Markdig.Syntax;
+
+namespace Elastic.Markdown.Tests.Directives;
+
+/// <summary>
+/// Mirrors the elastic-cloud-serverless index page: changelog directive at the top, manual release
+/// sections below. Separated-type changelog TOC entries must survive page-level TOC merging.
+/// </summary>
+public class ChangelogIndexPageTocTests(ITestOutputHelper output) : DirectiveTest(output,
+	// language=markdown
+	"""
+	# Serverless changelog [elastic-cloud-serverless-changelog]
+
+	:::{changelog} /changelog/bundles
+	:type: all
+	:subsections:
+	:::
+
+	## April 30, 2026 [serverless-changelog-04302026]
+
+	### Features and enhancements [serverless-changelog-04302026-features-enhancements]
+
+	* Manual feature entry
+	""")
+{
+	protected override void AddToFileSystem(MockFileSystem fileSystem)
+	{
+		fileSystem.AddFile("docs/changelog/bundles/2026-05-19.yaml", new MockFileData(
+			// language=yaml
+			"""
+			products:
+			- product: cloud-serverless
+			  target: 2026-05-19
+			  repo: kibana
+			entries:
+			- title: New feature
+			  type: feature
+			  products:
+			  - product: cloud-serverless
+			    target: 2026-05-19
+			  prs:
+			  - "111111"
+			- title: Deprecated API
+			  type: deprecation
+			  products:
+			  - product: cloud-serverless
+			    target: 2026-05-19
+			  description: Deprecated.
+			  impact: Impact.
+			  action: Action.
+			  prs:
+			  - "222222"
+			"""));
+	}
+
+	[Fact]
+	public void ChangelogBlockLoadsBundles()
+	{
+		var block = Document.Descendants<ChangelogBlock>().Single();
+		block.Found.Should().BeTrue();
+		block.LoadedBundles.Should().NotBeEmpty();
+	}
+
+	[Fact]
+	public void PageTableOfContentsIncludesChangelogDeprecations()
+	{
+		var toc = File.PageTableOfContent.Values.ToList();
+
+		toc.Should().Contain(t => t.Heading == "May 19, 2026" && t.Level == 2);
+		toc.Should().Contain(t => t.Heading == "Deprecations" && t.Level == 3);
+		toc.Should().Contain(t => t.Slug == "kibana-2026-05-19-deprecations");
+	}
+
+	[Fact]
+	public void PageTableOfContentsRetainsManualSections()
+	{
+		var toc = File.PageTableOfContent.Values.ToList();
+
+		toc.Should().Contain(t => t.Heading == "April 30, 2026");
+		toc.Should().Contain(t => t.Slug == "serverless-changelog-04302026-features-enhancements");
+	}
+}

--- a/tests/Elastic.Markdown.Tests/Directives/ChangelogTocFilteringTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/ChangelogTocFilteringTests.cs
@@ -454,8 +454,8 @@ public class ChangelogPublishBlockerAreaFiltersTocTests : DirectiveTest<Changelo
 }
 
 /// <summary>
-/// Tests that when ALL entries across ALL types in a bundle are filtered out by hide-features,
-/// the version header still appears in the TOC but no section headers do.
+/// Tests that when ALL entries across ALL types in a bundle are filtered out by hide-features
+/// and the bundle has no description, the version is omitted from the TOC and rendered output.
 /// </summary>
 public class ChangelogAllEntriesFilteredTocTests : DirectiveTest<ChangelogBlock>
 {
@@ -492,11 +492,16 @@ public class ChangelogAllEntriesFilteredTocTests : DirectiveTest<ChangelogBlock>
 			"""));
 
 	[Fact]
-	public void TocContainsVersionHeaderOnly()
+	public void OmitsVersionFromTocWhenNoRenderableEntries()
 	{
 		var tocItems = Block!.GeneratedTableOfContent.ToList();
-		tocItems.Should().ContainSingle(t => t.Level == 2 && t.Heading == "9.3.0");
-		tocItems.Should().NotContain(t => t.Level == 3);
+		tocItems.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void OmitsVersionFromRenderedOutput()
+	{
+		Html.Should().NotContain("9.3.0");
 	}
 
 	[Fact]

--- a/tests/Elastic.Markdown.Tests/Directives/ChangelogTypeFilterTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/ChangelogTypeFilterTests.cs
@@ -260,7 +260,8 @@ public class ChangelogTypeFilterBreakingChangeTests : DirectiveTest<ChangelogBlo
 	[Fact]
 	public void ShowsBreakingChanges()
 	{
-		Html.Should().Contain("Breaking changes");
+		Html.Should().NotContain("### Breaking changes");
+		Html.Should().NotContain(">Breaking changes<");
 		Html.Should().Contain("Breaking API change");
 	}
 
@@ -330,7 +331,8 @@ public class ChangelogTypeFilterDeprecationTests : DirectiveTest<ChangelogBlock>
 	[Fact]
 	public void ShowsDeprecations()
 	{
-		Html.Should().Contain("Deprecations");
+		Html.Should().NotContain("### Deprecations");
+		Html.Should().NotContain(">Deprecations<");
 		Html.Should().Contain("Deprecated feature");
 		Html.Should().Contain("Another deprecation");
 	}
@@ -399,7 +401,8 @@ public class ChangelogTypeFilterKnownIssueTests : DirectiveTest<ChangelogBlock>
 	[Fact]
 	public void ShowsKnownIssues()
 	{
-		Html.Should().Contain("Known issues");
+		Html.Should().NotContain("### Known issues");
+		Html.Should().NotContain(">Known issues<");
 		Html.Should().Contain("Known issue 1");
 		Html.Should().Contain("Known issue 2");
 	}
@@ -629,10 +632,7 @@ public class ChangelogTypeFilterGeneratedAnchorsTests : DirectiveTest<ChangelogB
 	{
 		var anchors = Block!.GeneratedAnchors.ToList();
 
-		// Should have anchor for breaking changes
-		anchors.Should().Contain(a => a.Contains("breaking-changes"));
-
-		// Should NOT have anchor for features since we're filtering to breaking-change only
+		anchors.Should().NotContain(a => a.Contains("breaking-changes"));
 		anchors.Should().NotContain(a => a.Contains("features-enhancements"));
 	}
 }
@@ -679,17 +679,14 @@ public class ChangelogTypeFilterTableOfContentsTests : DirectiveTest<ChangelogBl
 	{
 		var tocItems = Block!.GeneratedTableOfContent.ToList();
 
-		// Should have TOC item for deprecations
-		tocItems.Should().Contain(t => t.Heading == "Deprecations");
-
-		// Should NOT have TOC item for features since we're filtering to deprecation only
+		tocItems.Should().NotContain(t => t.Heading == "Deprecations");
+		tocItems.Should().Contain(t => t.Heading == "9.3.0" && t.Level == 2);
 		tocItems.Should().NotContain(t => t.Heading == "Features and enhancements");
 	}
 }
 
 /// <summary>
-/// Tests that empty result shows appropriate message when type filter excludes all entries.
-/// For known-issue filter, we should show known-issue-specific message.
+/// Tests that empty bundles are omitted when type filter excludes all entries.
 /// </summary>
 public class ChangelogTypeFilterEmptyKnownIssueTests : DirectiveTest<ChangelogBlock>
 {
@@ -716,11 +713,10 @@ public class ChangelogTypeFilterEmptyKnownIssueTests : DirectiveTest<ChangelogBl
 		"""));
 
 	[Fact]
-	public void ShowsKnownIssueSpecificEmptyMessage()
+	public void OmitsEmptyVersionBlock()
 	{
-		// When filtering to known-issue but bundle only has features,
-		// should show known-issue-specific message
-		Html.Should().Contain("There are no known issues associated with this release");
+		Html.Should().NotContain("There are no known issues associated with this release");
+		Html.Should().NotContain("9.3.0");
 	}
 }
 
@@ -752,11 +748,10 @@ public class ChangelogTypeFilterEmptyBreakingChangeTests : DirectiveTest<Changel
 		"""));
 
 	[Fact]
-	public void ShowsBreakingChangeSpecificEmptyMessage()
+	public void OmitsEmptyVersionBlock()
 	{
-		// When filtering to breaking-change but bundle only has features,
-		// should show breaking-change-specific message
-		Html.Should().Contain("There are no breaking changes associated with this release");
+		Html.Should().NotContain("There are no breaking changes associated with this release");
+		Html.Should().NotContain("9.3.0");
 	}
 }
 
@@ -788,11 +783,10 @@ public class ChangelogTypeFilterEmptyDeprecationTests : DirectiveTest<ChangelogB
 		"""));
 
 	[Fact]
-	public void ShowsDeprecationSpecificEmptyMessage()
+	public void OmitsEmptyVersionBlock()
 	{
-		// When filtering to deprecation but bundle only has features,
-		// should show deprecation-specific message
-		Html.Should().Contain("There are no deprecations associated with this release");
+		Html.Should().NotContain("There are no deprecations associated with this release");
+		Html.Should().NotContain("9.3.0");
 	}
 }
 
@@ -826,11 +820,10 @@ public class ChangelogTypeFilterEmptyDefaultTests : DirectiveTest<ChangelogBlock
 		"""));
 
 	[Fact]
-	public void ShowsGenericEmptyMessageForDefaultFilter()
+	public void OmitsEmptyVersionBlock()
 	{
-		// When using default filter but bundle only has breaking changes (which are excluded by default),
-		// should show the generic "no features, enhancements, or fixes" message
-		Html.Should().Contain("No new features, enhancements, or fixes");
+		Html.Should().NotContain("No new features, enhancements, or fixes");
+		Html.Should().NotContain("9.3.0");
 	}
 }
 
@@ -855,10 +848,220 @@ public class ChangelogTypeFilterEmptyAllTests : DirectiveTest<ChangelogBlock>
 		"""));
 
 	[Fact]
-	public void ShowsGenericEmptyMessageForAllFilter()
+	public void OmitsEmptyVersionBlock()
 	{
-		// When using "all" filter with empty entries,
-		// should show the generic message (not type-specific since All includes everything)
-		Html.Should().Contain("No new features, enhancements, or fixes");
+		Html.Should().NotContain("No new features, enhancements, or fixes");
+		Html.Should().NotContain("9.3.0");
+	}
+}
+
+/// <summary>
+/// Tests that only bundles with matching entries render when multiple bundles are loaded.
+/// </summary>
+public class ChangelogTypeFilterMixedBundlesEmptyOmissionTests : DirectiveTest<ChangelogBlock>
+{
+	public ChangelogTypeFilterMixedBundlesEmptyOmissionTests(ITestOutputHelper output) : base(output,
+		// language=markdown
+		"""
+		:::{changelog}
+		:type: known-issue
+		:::
+		""")
+	{
+		FileSystem.AddFile("docs/changelog/bundles/9.3.0.yaml", new MockFileData(
+			// language=yaml
+			"""
+			products:
+			- product: elasticsearch
+			  target: 9.3.0
+			entries:
+			- title: Known issue in 9.3
+			  type: known-issue
+			  products:
+			  - product: elasticsearch
+			    target: 9.3.0
+			  description: Issue exists.
+			  impact: Some impact.
+			  action: Workaround available.
+			  prs:
+			  - "444444"
+			"""));
+		FileSystem.AddFile("docs/changelog/bundles/9.2.0.yaml", new MockFileData(
+			// language=yaml
+			"""
+			products:
+			- product: elasticsearch
+			  target: 9.2.0
+			entries:
+			- title: Feature only
+			  type: feature
+			  products:
+			  - product: elasticsearch
+			    target: 9.2.0
+			  prs:
+			  - "111111"
+			"""));
+	}
+
+	[Fact]
+	public void RendersOnlyPopulatedVersions()
+	{
+		Html.Should().Contain("Known issue in 9.3");
+		Html.Should().Contain("9.3.0");
+		Html.Should().NotContain("9.2.0");
+	}
+}
+
+/// <summary>
+/// Tests that :type: all preserves bundle description when there are no entries.
+/// </summary>
+public class ChangelogEmptyBundleWithDescriptionTests : DirectiveTest<ChangelogBlock>
+{
+	public ChangelogEmptyBundleWithDescriptionTests(ITestOutputHelper output) : base(output,
+		// language=markdown
+		"""
+		:::{changelog}
+		:type: all
+		:::
+		""") => FileSystem.AddFile("docs/changelog/bundles/9.3.0.yaml", new MockFileData(
+		// language=yaml
+		"""
+		products:
+		- product: elasticsearch
+		  target: 9.3.0
+		description: |
+		  This release was pulled due to critical issues.
+		entries: []
+		"""));
+
+	[Fact]
+	public void ShowsVersionAndDescriptionWithoutPlaceholder()
+	{
+		Html.Should().Contain("9.3.0");
+		Html.Should().Contain("This release was pulled due to critical issues");
+		Html.Should().NotContain("No new features, enhancements, or fixes");
+	}
+}
+
+/// <summary>
+/// Tests that release-date alone does not preserve an otherwise empty release on general pages.
+/// </summary>
+public class ChangelogEmptyBundleWithReleaseDateOnlyTests : DirectiveTest<ChangelogBlock>
+{
+	public ChangelogEmptyBundleWithReleaseDateOnlyTests(ITestOutputHelper output) : base(output,
+		// language=markdown
+		"""
+		:::{changelog}
+		:type: all
+		:::
+		""") => FileSystem.AddFile("docs/changelog/bundles/9.3.0.yaml", new MockFileData(
+		// language=yaml
+		"""
+		products:
+		- product: elasticsearch
+		  target: 9.3.0
+		release-date: "2026-04-09"
+		entries: []
+		"""));
+
+	[Fact]
+	public void OmitsVersionBlockWhenOnlyReleaseDate()
+	{
+		Html.Should().NotContain("9.3.0");
+		Html.Should().NotContain("Released:");
+	}
+}
+
+/// <summary>
+/// Tests that dedicated type pages omit empty bundles even when they have a description.
+/// </summary>
+public class ChangelogDedicatedPageIgnoresDescriptionTests : DirectiveTest<ChangelogBlock>
+{
+	public ChangelogDedicatedPageIgnoresDescriptionTests(ITestOutputHelper output) : base(output,
+		// language=markdown
+		"""
+		:::{changelog}
+		:type: deprecation
+		:::
+		""") => FileSystem.AddFile("docs/changelog/bundles/9.3.0.yaml", new MockFileData(
+		// language=yaml
+		"""
+		products:
+		- product: elasticsearch
+		  target: 9.3.0
+		description: |
+		  General release notes for this version.
+		entries:
+		- title: New feature
+		  type: feature
+		  products:
+		  - product: elasticsearch
+		    target: 9.3.0
+		  prs:
+		  - "111111"
+		"""));
+
+	[Fact]
+	public void OmitsVersionBlockWhenNoMatchingEntries()
+	{
+		Html.Should().NotContain("9.3.0");
+		Html.Should().NotContain("General release notes for this version");
+	}
+}
+
+/// <summary>
+/// Tests that :subsections: area grouping works on dedicated deprecation pages without a section H3.
+/// </summary>
+public class ChangelogDedicatedPageWithSubsectionsTests : DirectiveTest<ChangelogBlock>
+{
+	public ChangelogDedicatedPageWithSubsectionsTests(ITestOutputHelper output) : base(output,
+		// language=markdown
+		"""
+		:::{changelog}
+		:type: deprecation
+		:subsections:
+		:::
+		""") => FileSystem.AddFile("docs/changelog/bundles/9.3.0.yaml", new MockFileData(
+		// language=yaml
+		"""
+		products:
+		- product: elasticsearch
+		  target: 9.3.0
+		entries:
+		- title: Search deprecation
+		  type: deprecation
+		  products:
+		  - product: elasticsearch
+		    target: 9.3.0
+		  areas:
+		  - Search
+		  description: Deprecated search API.
+		  impact: Will be removed.
+		  action: Migrate to new API.
+		  prs:
+		  - "555555"
+		- title: Indexing deprecation
+		  type: deprecation
+		  products:
+		  - product: elasticsearch
+		    target: 9.3.0
+		  areas:
+		  - Indexing
+		  description: Deprecated indexing config.
+		  impact: Will be removed.
+		  action: Update config.
+		  prs:
+		  - "666666"
+		"""));
+
+	[Fact]
+	public void GroupsEntriesByAreaWithoutSectionHeading()
+	{
+		Html.Should().NotContain("### Deprecations");
+		Html.Should().NotContain(">Deprecations<");
+		Html.Should().Contain("Search");
+		Html.Should().Contain("Search deprecation");
+		Html.Should().Contain("Indexing");
+		Html.Should().Contain("Indexing deprecation");
 	}
 }

--- a/tests/Elastic.Markdown.Tests/Directives/ChangelogTypeFilterTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/ChangelogTypeFilterTests.cs
@@ -202,6 +202,27 @@ public class ChangelogTypeFilterAllTests : DirectiveTest<ChangelogBlock>
 		Html.Should().Contain("Deprecations");
 		Html.Should().Contain("Deprecated feature");
 	}
+
+	[Fact]
+	public void TableOfContentsIncludesSeparatedTypeSections()
+	{
+		var tocItems = Block!.GeneratedTableOfContent.ToList();
+
+		tocItems.Should().Contain(t => t.Heading == "Breaking changes" && t.Level == 3);
+		tocItems.Should().Contain(t => t.Heading == "Known issues" && t.Level == 3);
+		tocItems.Should().Contain(t => t.Heading == "Deprecations" && t.Level == 3);
+	}
+
+	[Fact]
+	public void SeparatedTypeTocSlugsMatchHtmlIds()
+	{
+		var tocItems = Block!.GeneratedTableOfContent.ToList();
+		foreach (var item in tocItems.Where(t => t.Level == 3))
+		{
+			Html.Should().Contain($"id=\"{item.Slug}\"",
+				$"TOC item '{item.Heading}' (slug '{item.Slug}') must have a matching heading-wrapper id");
+		}
+	}
 }
 
 /// <summary>

--- a/tests/Elastic.Markdown.Tests/Directives/ChangelogTypeFilterTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/ChangelogTypeFilterTests.cs
@@ -1059,6 +1059,7 @@ public class ChangelogDedicatedPageWithSubsectionsTests : DirectiveTest<Changelo
 	{
 		Html.Should().NotContain("### Deprecations");
 		Html.Should().NotContain(">Deprecations<");
+		Html.Should().NotContain("{dropdown}");
 		Html.Should().Contain("Search");
 		Html.Should().Contain("Search deprecation");
 		Html.Should().Contain("Indexing");


### PR DESCRIPTION
Fixes https://github.com/elastic/docs-builder/issues/3368

## AI Summary

Improves `{changelog}` rendering for dedicated release-notes pages and removes low-value empty output on general release-notes pages. Release note pages such as known issues, deprecations, and breaking changes no longer show redundant section headings, empty dated releases, or “there are no … associated with this release” placeholders.

### Problem

On pages that already have an H1 and use `:type:` to narrow entries (for example `:type: known-issue` on a known-issues page), the directive was still emitting:

- Redundant `### Deprecations` / `### Breaking changes` / `### Known issues` under each `## {version}`
- `## {version}` blocks with no matching entries, often with italic placeholder text
- Matching TOC entries and anchors for those empty releases

### Behavior changes

**Dedicated type pages** (`:type: breaking-change`, `deprecation`, `known-issue`, `highlight`):

| Aspect | Before | After |
|--------|--------|-------|
| Section H3 (`### Deprecations`, etc.) | Shown under each version | Omitted; entries render under `## {version}` |
| `:subsections:` | N/A for separated types in practice | Area grouping preserved (no redundant type-level H3) |
| Empty release (no matching entries) | Version + placeholder message | Entire version block omitted (including bundle `description`) |
| TOC / anchors | Version + type subsection | Version only when entries exist; no type subsection |

**General release notes** (default or `:type: all`):

| Aspect | Before | After |
|--------|--------|-------|
| Section H3s | Shown when type has entries | Unchanged |
| Empty release | Version + `_There are no …_` / `_No new features…_` | Omitted entirely |
| Empty release with bundle `description` | N/A (still showed placeholder) | `## {version}` + description only (e.g. pulled release) |
| Empty release with `release-date` only | Would show version + `_Released: …_` | Omitted (`release-date` does not preserve an empty release) |
| All entries hidden via `hide-features` | Version still in TOC/output | Omitted from TOC, output, and anchors |

**Breaking change:** Empty placeholder messages are removed with no opt-out flag.

**Out of scope:** `changelog render` CLI (static file output) is unchanged.

### Implementation notes

- Shared helpers on `ChangelogInlineRenderer`: `IsDedicatedSeparatedTypePage`, `GetFilteredEntries`, `BundleHasRenderableEntries`, `ShouldRenderEmptyBundleMetadata` (description only)
- `RenderChangelogMarkdown` skips whitespace-only bundle output; returns `null` when nothing renders
- `ChangelogBlock` TOC and anchors use the same filtering logic via `BundleContributesToNavigation`
- `RenderSeparatedTypeEntries` uses area grouping when `:subsections:` is set on dedicated pages

### Files changed

| File | Change |
|------|--------|
| `src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogInlineRenderer.cs` | Dedicated-page layout, empty-bundle omission, removed `GetEmptyMessage` |
| `src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogBlock.cs` | TOC/anchor parity with renderer |
| `tests/Elastic.Markdown.Tests/Directives/ChangelogTypeFilterTests.cs` | Updated assertions; new tests (mixed bundles, description, release-date-only, subsections, dedicated page ignores description) |
| `tests/Elastic.Markdown.Tests/Directives/ChangelogTocFilteringTests.cs` | All entries hidden → omit version from TOC/output |
| `tests/Elastic.Markdown.Tests/Directives/ChangelogBasicTests.cs` | Empty bundle test updated |
| `docs/syntax/changelog.md` | Documents empty-release and description-only preservation |

## Screenshots

### Before

Per https://github.com/elastic/docs-content/pull/6599

Unnecessary deprecation headings:

<img width="2495" height="1616" alt="image" src="https://github.com/user-attachments/assets/8d891359-366e-469d-b091-30628a652365" />

Empty breaking change sections:

<img width="2456" height="1224" alt="image" src="https://github.com/user-attachments/assets/9eea4a26-6356-43b2-bb7a-1a953988b070" />

### After

No more unnecessary deprecation headings:

<img width="2268" height="1394" alt="image" src="https://github.com/user-attachments/assets/4a99cfe0-7427-4b0a-95b9-0f67a48c7ca6" />

No more empty breaking change sections:

<img width="2258" height="1279" alt="image" src="https://github.com/user-attachments/assets/425618ca-1cd7-49fd-80e5-e65a25208d81" />

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: composer-2.5, claude-4-sonnet-thinking
