### PR TITLE
fix: make phantoms cover descendant paths and remove skip cap

### DIFF
--- a/src/services/Elastic.Documentation.Assembler/Navigation/NavigationPrefixChecker.cs
+++ b/src/services/Elastic.Documentation.Assembler/Navigation/NavigationPrefixChecker.cs
@@ -99,7 +99,6 @@ public class NavigationPrefixChecker
 		if (!string.IsNullOrEmpty(updateRepository) && updateReference is not null)
 			crossLinks = crossLinkResolver.UpdateLinkReference(updateRepository, updateReference);
 
-		var skippedPhantoms = 0;
 		foreach (var (repository, linkReference) in crossLinks.LinkReferences)
 		{
 			if (!_repositories.Contains(repository))
@@ -117,14 +116,9 @@ public class NavigationPrefixChecker
 					var path = relativeLink.Split('/').SkipLast(1);
 					var pathUri = new Uri($"{repository}://{string.Join('/', path)}");
 
-					var baseOfAPhantom = _phantoms.Any(p => p == pathUri);
+					var baseOfAPhantom = _phantoms.Any(p => IsPhantomOrDescendant(p, pathUri));
 					if (baseOfAPhantom)
-					{
-						skippedPhantoms++;
-						if (skippedPhantoms > _phantoms.Count * 3)
-							collector.EmitError(repository, $"Too many items are being marked as part of a phantom this looks like a bug. ({skippedPhantoms})");
 						continue;
-					}
 					collector.EmitError(repository, $"'Can not validate '{crossLink}' it's not declared in any link reference nor is it a phantom");
 					continue;
 				}
@@ -156,6 +150,12 @@ public class NavigationPrefixChecker
 			}
 		}
 	}
+
+	private static bool IsPhantomOrDescendant(Uri phantom, Uri candidate) =>
+		candidate.Scheme == phantom.Scheme &&
+		candidate.Host == phantom.Host &&
+		(candidate.AbsolutePath == phantom.AbsolutePath ||
+		 candidate.AbsolutePath.StartsWith(phantom.AbsolutePath.TrimEnd('/') + '/'));
 
 	private async Task<RepositoryLinks> ReadLocalLinksJsonAsync(string localLinksJson, Cancel ctx)
 	{

--- a/src/services/Elastic.Documentation.Assembler/Navigation/NavigationPrefixChecker.cs
+++ b/src/services/Elastic.Documentation.Assembler/Navigation/NavigationPrefixChecker.cs
@@ -155,7 +155,7 @@ public class NavigationPrefixChecker
 		candidate.Scheme == phantom.Scheme &&
 		candidate.Host == phantom.Host &&
 		(candidate.AbsolutePath == phantom.AbsolutePath ||
-		 candidate.AbsolutePath.StartsWith(phantom.AbsolutePath.TrimEnd('/') + '/'));
+		 candidate.AbsolutePath.StartsWith(phantom.AbsolutePath.TrimEnd('/') + '/', StringComparison.Ordinal));
 
 	private async Task<RepositoryLinks> ReadLocalLinksJsonAsync(string localLinksJson, Cancel ctx)
 	{


### PR DESCRIPTION
## Why

Declaring a phantom for a TOC path (e.g. `elasticsearch://reference/ingest-processor`) is the intended way to unblock a content-repo PR that adds a new TOC before it's wired into `navigation.yml`. But two bugs made this fail in practice:

1. **Exact-match instead of prefix match.** The checker computed the direct parent directory of each file and compared it to the phantom set with `==`. A file at `ingest-processor/subdir/file.md` produced `pathUri = elasticsearch://reference/ingest-processor/subdir`, which does not equal the declared phantom `elasticsearch://reference/ingest-processor`. Only files exactly one level deep in the phantom namespace were ever skipped; anything nested deeper generated errors.

2. **Hard cap of `_phantoms.Count * 3` triggered errors on real TOC trees.** With the current six phantoms the limit was 21. Shaina's [ingest-processor PR](https://github.com/elastic/elasticsearch/pull/148774) has 22 files directly in the phantom directory, which is why the phantom was added in [#3306](https://github.com/elastic/docs-builder/pull/3306), caused CI to emit `Too many items are being marked as part of a phantom this looks like a bug. (22)`, and had to be reverted twice.

## What

- Replaced the `p == pathUri` exact comparison with `IsPhantomOrDescendant`, which checks that the candidate URI shares the same scheme and host as the phantom and that its path starts with the phantom's path. This means a single phantom entry covers all files nested under that path.
- Removed the `skippedPhantoms` counter and the `> _phantoms.Count * 3` error guard entirely. The guard was a rough heuristic that fired on legitimate large TOC trees; with proper prefix matching there is no meaningful upper bound to enforce.

## Order of operations for Shaina's work (after this merges)

Shaina is trying to move the processor reference docs from `enrich-processor` to `ingest-processor` ([docs-content#1171](https://github.com/elastic/docs-content/issues/1171)). Her current approach (the "copy first" strategy in [#3367](https://github.com/elastic/docs-builder/pull/3367)) is:

1. **Merge this PR.**
2. **Re-add the phantom** — add `elasticsearch://reference/ingest-processor` back to the `phantoms:` section of `navigation.yml` in a small docs-builder PR and merge it.
3. **Merge [elasticsearch#149537](https://github.com/elastic/elasticsearch/pull/149537)** — CI will now pass because the 22+ files under `ingest-processor/` are covered by the phantom.
4. **Merge [#3367](https://github.com/elastic/docs-builder/pull/3367)** — moves the entry from `phantoms:` to `toc:` with a `path_prefix`, wiring up the new docs in the nav.
5. Continue with the remaining steps (copy changes, add redirects, delist old `enrich-processor`, clean up stub).