### PR TITLE
fix style for checkbox, also adding an example to review it

### DIFF
--- a/docs/syntax/task-lists.md
+++ b/docs/syntax/task-lists.md
@@ -13,7 +13,7 @@ Task lists let you render checkboxes in documentation. Use `- [ ]` for unchecked
 - [x] Set up the project
 - [x] Install dependencies
 - [ ] Write tests
-  - [x] Unit tests
+  - [x] Unit tests with [An Internal Link](#basic-task-list)
   - [ ] Integration tests
 - [ ] Deploy
 

--- a/src/Elastic.Documentation.Site/Assets/markdown/list.css
+++ b/src/Elastic.Documentation.Site/Assets/markdown/list.css
@@ -56,17 +56,19 @@
 		margin-left: 0.25em;
 
 		li.task-list-item {
-			display: flex;
-			align-items: baseline;
-			gap: 0.5em;
+			position: relative;
+			padding-left: 1.5em;
 		}
 
 		input[type='checkbox'] {
+			position: absolute;
+			left: 0;
+			top: 0.15em;
 			margin: 0;
-			flex-shrink: 0;
 			width: 1em;
 			height: 1em;
 			cursor: default;
 		}
 	}
+
 }

--- a/src/Elastic.Documentation.Site/Assets/markdown/list.css
+++ b/src/Elastic.Documentation.Site/Assets/markdown/list.css
@@ -4,6 +4,7 @@
 		line-height: 1.5em;
 		letter-spacing: 0;
 		margin-left: 1.5em;
+
 		li::marker {
 			@apply text-grey-80;
 		}
@@ -16,18 +17,23 @@
 	ul {
 		list-style-type: disc;
 	}
+
 	ul > li > ul {
 		list-style-type: square;
 	}
+
 	ul > li > ul > li > ul {
 		list-style-type: circle;
 	}
+
 	ul > li > ul > li > ul > li > ul {
 		list-style-type: disc;
 	}
+
 	ul > li > ul > li > ul > li > ul > li > ul {
 		list-style-type: square;
 	}
+
 	ul > li > ul > li > ul > li > ul > li > ul > li > ul {
 		list-style-type: circle;
 	}
@@ -35,18 +41,23 @@
 	ol {
 		list-style-type: decimal;
 	}
+
 	ol > li > ol {
 		list-style-type: lower-alpha;
 	}
+
 	ol > li > ol > li > ol {
 		list-style-type: lower-roman;
 	}
+
 	ol > li > ol > li > ol > li > ol {
 		list-style-type: decimal;
 	}
+
 	ol > li > ol > li > ol > li > ol > li > ol {
 		list-style-type: lower-alpha;
 	}
+
 	ol > li > ol > li > ol > li > ol > li > ol > li > ol {
 		list-style-type: lower-roman;
 	}

--- a/src/Elastic.Documentation.Site/Assets/markdown/list.css
+++ b/src/Elastic.Documentation.Site/Assets/markdown/list.css
@@ -81,5 +81,4 @@
 			cursor: default;
 		}
 	}
-
 }


### PR DESCRIPTION
There was a problem with checkbox styling as it was treating all elements as flex container.

Previously

<img width="961" height="823" alt="image" src="https://github.com/user-attachments/assets/8797c1ae-8ce2-470b-968e-350b8cd4311d" />


Now 

<img width="960" height="840" alt="image" src="https://github.com/user-attachments/assets/4f78bdad-1ba9-420e-ad9c-ab92beaa75f4" />
