### PR TITLE
Add experimental lifecycle to applies-to

### DIFF
--- a/docs/_snippets/applies_to-lifecycle.md
+++ b/docs/_snippets/applies_to-lifecycle.md
@@ -1,5 +1,6 @@
 `applies_to` accepts the following lifecycle states:
 
+* `experimental`
 * `preview`
 * `beta`
 * `ga`

--- a/docs/syntax/applies-switch.md
+++ b/docs/syntax/applies-switch.md
@@ -13,6 +13,10 @@ The applies-switch directive creates tabbed content where each tab displays an a
 Content for Stack
 :::
 
+:::{applies-item} stack: experimental 9.1+
+Content for experimental Stack features
+:::
+
 :::{applies-item} serverless: ga
 Content for Serverless
 :::
@@ -27,6 +31,10 @@ Content for Serverless
 
 :::{applies-item} stack: ga 9.0+
 Content for Stack
+:::
+
+:::{applies-item} stack: experimental 9.1+
+Content for experimental Stack features
 :::
 
 :::{applies-item} serverless: ga

--- a/docs/syntax/applies.md
+++ b/docs/syntax/applies.md
@@ -144,7 +144,7 @@ The following table shows how different version syntaxes render:
 
 The build process enforces the following validation rules:
 
-- **One version per lifecycle**: Each lifecycle (GA, Preview, Beta, etc.) can only have one version declaration.
+- **One version per lifecycle**: Each lifecycle (GA, Preview, Beta, Experimental, etc.) can only have one version declaration.
   - ✅ `stack: ga 9.2+, beta 9.0-9.1`
   - ❌ `stack: ga 9.2, ga 9.3`
 - **One "greater than" per key**: Only one lifecycle per product key can use the `+` (greater than or equal to) syntax.
@@ -275,6 +275,8 @@ applies_to:
 | `` {applies_to}`stack: preview 8.18` `` | {applies_to}`stack: preview 8.18` |
 | `` {applies_to}`stack: preview 9.0` `` | {applies_to}`stack: preview 9.0` |
 | `` {applies_to}`stack: preview 9.1` `` | {applies_to}`stack: preview 9.1` |
+| `` {applies_to}`stack: experimental` `` | {applies_to}`stack: experimental` |
+| `` {applies_to}`stack: experimental 9.0` `` | {applies_to}`stack: experimental 9.0` |
 | `` {applies_to}`stack: ga` `` | {applies_to}`stack: ga` |
 | `` {applies_to}`stack: ga 8.18` `` | {applies_to}`stack: ga 8.18` |
 | `` {applies_to}`stack: ga 9.0` `` | {applies_to}`stack: ga 9.0` |
@@ -294,6 +296,7 @@ applies_to:
 |--------------|--------|
 | `` {applies_to}`serverless: ` `` | {applies_to}`serverless: ` |
 | `` {applies_to}`serverless: preview` `` | {applies_to}`serverless: preview` |
+| `` {applies_to}`serverless: experimental` `` | {applies_to}`serverless: experimental` |
 | `` {applies_to}`serverless: ga` `` | {applies_to}`serverless: ga` |
 | `` {applies_to}`serverless: beta` `` | {applies_to}`serverless: beta` |
 | `` {applies_to}`serverless: deprecated` `` | {applies_to}`serverless: deprecated` |
@@ -401,6 +404,7 @@ Inline applies annotations are rendered in the order they appear in the source f
 |:----------|:---------------|-----------------|:----------------|
 | GA | – | – | `{product}` |
 | Preview | – | – | `{product}\|Preview` |
+| Experimental | – | – | `{product}\|Experimental` |
 | Beta | – | – | `{product}\|Beta` |
 | Deprecated | – | – | `{product}\|Deprecated` |
 | Removed | – | – | `{product}\|Removed` |
@@ -417,6 +421,7 @@ When no version is declared, the badge does not show a version. The lifecycle na
 | GA | – | 1 | `{product}` |
 | GA | – | \>= 2 | `{product}\|GA` |
 | Preview | – | – | `{product}\|Preview` |
+| Experimental | – | – | `{product}\|Experimental` |
 | Beta | – | – | `{product}\|Beta` |
 | Deprecated | – | – | `{product}\|Deprecated` |
 | Removed | – | – | `{product}\|Removed` |
@@ -432,6 +437,9 @@ When no version is declared, the badge does not show a version. The lifecycle na
 | | Unreleased | 1 | `{product}\|Planned` |
 | | | \>= 2 | Use previous lifecycle |
 | Preview | Released | \>= 1 | `{product}\|Preview x.x+` |
+| | Unreleased | 1 | `{product}\|Planned` |
+| | | \>= 2 | Use previous lifecycle |
+| Experimental | Released | \>= 1 | `{product}\|Experimental x.x+` |
 | | Unreleased | 1 | `{product}\|Planned` |
 | | | \>= 2 | Use previous lifecycle |
 | Beta | Released | \>= 1 | `{product}\|Beta x.x+` |
@@ -456,6 +464,10 @@ When no version is declared, the badge does not show a version. The lifecycle na
 | | | \>= 2 | Use previous lifecycle |
 | Preview | `y.y.y` is released | \>= 1 | `{product}\|Preview x.x-y.y` |
 | | `y.y.y` is **not** released, `x.x.x` is released | \>= 1 | `{product}\|Preview x.x+` |
+| | `y.y.y` is **not** released, `x.x.x` is **not** released | 1 | `{product}\|Planned` |
+| | | \>= 2 | Use previous lifecycle |
+| Experimental | `y.y.y` is released | \>= 1 | `{product}\|Experimental x.x-y.y` |
+| | `y.y.y` is **not** released, `x.x.x` is released | \>= 1 | `{product}\|Experimental x.x+` |
 | | `y.y.y` is **not** released, `x.x.x` is **not** released | 1 | `{product}\|Planned` |
 | | | \>= 2 | Use previous lifecycle |
 | Beta | `y.y.y` is released | \>= 1 | `{product}\|Beta x.x-y.y` |
@@ -484,6 +496,9 @@ When no version is declared, the badge does not show a version. The lifecycle na
 | Preview | Released | \>= 1 | `{product}\|Preview X.X` |
 | | Unreleased | 1 | `{product}\|Planned` |
 | | | \>= 2 | Use previous lifecycle |
+| Experimental | Released | \>= 1 | `{product}\|Experimental X.X` |
+| | Unreleased | 1 | `{product}\|Planned` |
+| | | \>= 2 | Use previous lifecycle |
 | Beta | Released | \>= 1 | `{product}\|Beta X.X` |
 | | Unreleased | 1 | `{product}\|Planned` |
 | | | \>= 2 | Use previous lifecycle |
@@ -504,6 +519,7 @@ When no version is declared, the badge does not show a version. The lifecycle na
 |:----------|:---------------|-----------------|:----------------|
 | GA | – | 1 | `Generally available` |
 | Preview | – | 1 | `Preview` |
+| Experimental | – | 1 | `Experimental` |
 | Beta | – | 1 | `Beta` |
 | Deprecated | – | 1 | `Deprecated` |
 | Removed | – | 1 | `Removed` |
@@ -519,6 +535,7 @@ When no version is declared, the popover shows only the lifecycle state (no base
 |:----------|:---------------|-----------------|:----------------|
 | GA | – | 1 | `Generally available` |
 | Preview | – | 1 | `Preview` |
+| Experimental | – | 1 | `Experimental` |
 | Beta | – | 1 | `Beta` |
 | Deprecated | – | 1 | `Deprecated` |
 | Removed | – | 1 | `Removed` |
@@ -534,6 +551,9 @@ When no version is declared, the popover shows only the lifecycle state (no base
 | | Unreleased | 1 | `Planned` |
 | | | \>= 2 | Do not add to availability list |
 | Preview | Released | \>= 1 | `Preview since X.X` |
+| | Unreleased | 1 | `Planned` |
+| | | \>= 2 | Do not add to availability list |
+| Experimental | Released | \>= 1 | `Experimental since X.X` |
 | | Unreleased | 1 | `Planned` |
 | | | \>= 2 | Do not add to availability list |
 | Beta | Released | \>= 1 | `Beta since X.X` |
@@ -561,6 +581,10 @@ When no version is declared, the popover shows only the lifecycle state (no base
 | | `y.y.y` is **not** released, `x.x.x` is released | \>= 1 | `Preview since X.X` |
 | | `y.y.y` is **not** released, `x.x.x` is **not** released | 1 | `Planned` |
 | | | \>= 2 | Do not add to availability list |
+| Experimental | `y.y.y` is released | \>= 1 | `Experimental from X.X to Y.Y` |
+| | `y.y.y` is **not** released, `x.x.x` is released | \>= 1 | `Experimental since X.X` |
+| | `y.y.y` is **not** released, `x.x.x` is **not** released | 1 | `Planned` |
+| | | \>= 2 | Do not add to availability list |
 | Beta | `y.y.y` is released | \>= 1 | `Beta from X.X to Y.Y` |
 | | `y.y.y` is **not** released, `x.x.x` is released | \>= 1 | `Beta since X.X` |
 | | `y.y.y` is **not** released, `x.x.x` is **not** released | 1 | `Planned` |
@@ -585,6 +609,9 @@ When no version is declared, the popover shows only the lifecycle state (no base
 | | Unreleased | 1 | `Planned` |
 | | | \>= 2 | Do not add to availability list |
 | Preview | Released | \>= 1 | `Preview in X.X` |
+| | Unreleased | 1 | `Planned` |
+| | | \>= 2 | Do not add to availability list |
+| Experimental | Released | \>= 1 | `Experimental in X.X` |
 | | Unreleased | 1 | `Planned` |
 | | | \>= 2 | Do not add to availability list |
 | Beta | Released | \>= 1 | `Beta in X.X` |

--- a/src/Elastic.ApiExplorer/Elastic.ApiExplorer.csproj
+++ b/src/Elastic.ApiExplorer/Elastic.ApiExplorer.csproj
@@ -24,6 +24,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Elastic.ApiExplorer.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <Folder Include="Elasticsearch\" />
   </ItemGroup>
 

--- a/src/Elastic.ApiExplorer/Elasticsearch/OpenApiDocumentExporter.cs
+++ b/src/Elastic.ApiExplorer/Elasticsearch/OpenApiDocumentExporter.cs
@@ -297,6 +297,8 @@ public partial class OpenApiDocumentExporter(
 			return ProductLifecycle.GenerallyAvailable;
 		if (lower.Contains("beta"))
 			return ProductLifecycle.Beta;
+		if (lower.Contains("experimental"))
+			return ProductLifecycle.Experimental;
 		if (lower.Contains("tech") && lower.Contains("preview"))
 			return ProductLifecycle.TechnicalPreview;
 		if (lower.Contains("deprecated"))

--- a/src/Elastic.ApiExplorer/Operations/AvailabilityBadgeHelper.cs
+++ b/src/Elastic.ApiExplorer/Operations/AvailabilityBadgeHelper.cs
@@ -91,6 +91,7 @@ public static partial class AvailabilityBadgeHelper
 			_ when lower.Contains("removed") => "removed",
 			_ when lower.Contains("deprecated") => "deprecated",
 			_ when lower.Contains("beta") => "beta",
+			_ when lower.Contains("experimental") => "experimental",
 			_ when lower.Contains("preview") => "preview",
 			_ when lower.Contains("generally available") => "ga",
 			_ => null

--- a/src/Elastic.Documentation/AppliesTo/Applicability.cs
+++ b/src/Elastic.Documentation/AppliesTo/Applicability.cs
@@ -208,6 +208,7 @@ public record Applicability : IComparable<Applicability>, IComparable
 		var lifecycle = Lifecycle switch
 		{
 			ProductLifecycle.TechnicalPreview => "preview",
+			ProductLifecycle.Experimental => "experimental",
 			ProductLifecycle.Beta => "beta",
 			ProductLifecycle.Development => "dev",
 			ProductLifecycle.Deprecated => "deprecated",
@@ -256,6 +257,7 @@ public record Applicability : IComparable<Applicability>, IComparable
 		{
 			"preview" => ProductLifecycle.TechnicalPreview,
 			"tech-preview" => ProductLifecycle.TechnicalPreview,
+			"experimental" => ProductLifecycle.Experimental,
 			"beta" => ProductLifecycle.Beta,
 			"ga" => ProductLifecycle.GenerallyAvailable,
 			"deprecated" => ProductLifecycle.Deprecated,
@@ -272,7 +274,7 @@ public record Applicability : IComparable<Applicability>, IComparable
 		};
 		if (lifecycle is null)
 		{
-			diagnostics.Add((Severity.Error, $"Unknown product lifecycle: '{tokens[0]}'. Valid lifecycles are: ga, preview, tech-preview, beta, deprecated, removed."));
+			diagnostics.Add((Severity.Error, $"Unknown product lifecycle: '{tokens[0]}'. Valid lifecycles are: ga, preview, tech-preview, experimental, beta, deprecated, removed."));
 			availability = null;
 			return false;
 		}

--- a/src/Elastic.Documentation/AppliesTo/ApplicableTo.cs
+++ b/src/Elastic.Documentation/AppliesTo/ApplicableTo.cs
@@ -134,6 +134,7 @@ public record ApplicableTo
 	private static string LifecycleName(ProductLifecycle lc) => lc switch
 	{
 		ProductLifecycle.TechnicalPreview => "preview",
+		ProductLifecycle.Experimental => "experimental",
 		ProductLifecycle.Beta => "beta",
 		ProductLifecycle.GenerallyAvailable => "ga",
 		ProductLifecycle.Deprecated => "deprecated",

--- a/src/Elastic.Documentation/AppliesTo/ApplicableToJsonConverter.cs
+++ b/src/Elastic.Documentation/AppliesTo/ApplicableToJsonConverter.cs
@@ -223,6 +223,7 @@ public class ApplicableToJsonConverter : JsonConverter<ApplicableTo>
 	private static ProductLifecycle ParseLifecycle(string lifecycleStr) => lifecycleStr.ToLowerInvariant() switch
 	{
 		"preview" => ProductLifecycle.TechnicalPreview,
+		"experimental" => ProductLifecycle.Experimental,
 		"beta" => ProductLifecycle.Beta,
 		"ga" => ProductLifecycle.GenerallyAvailable,
 		"deprecated" => ProductLifecycle.Deprecated,
@@ -246,6 +247,7 @@ public class ApplicableToJsonConverter : JsonConverter<ApplicableTo>
 			var lifecycleName = applicability.Lifecycle switch
 			{
 				ProductLifecycle.TechnicalPreview => "preview",
+				ProductLifecycle.Experimental => "experimental",
 				ProductLifecycle.Beta => "beta",
 				ProductLifecycle.GenerallyAvailable => "ga",
 				ProductLifecycle.Deprecated => "deprecated",

--- a/src/Elastic.Documentation/AppliesTo/ProductLifecycle.cs
+++ b/src/Elastic.Documentation/AppliesTo/ProductLifecycle.cs
@@ -11,6 +11,9 @@ public enum ProductLifecycle
 	// technical preview (exists in current docs system per https://github.com/elastic/docs?tab=readme-ov-file#beta-dev-and-preview-experimental)
 	[JsonStringEnumMemberName("preview")]
 	TechnicalPreview,
+	// experimental (rapid iteration phase, less mature than technical preview)
+	[JsonStringEnumMemberName("experimental")]
+	Experimental,
 	// beta (ditto)
 	[JsonStringEnumMemberName("beta")]
 	Beta,

--- a/src/Elastic.Documentation/AppliesTo/ProductLifecycleInfo.cs
+++ b/src/Elastic.Documentation/AppliesTo/ProductLifecycleInfo.cs
@@ -51,12 +51,13 @@ public static class ProductLifecycleInfo
 		[ProductLifecycle.GenerallyAvailable] = new("GA", "Generally available", 0),
 		[ProductLifecycle.Beta] = new("Beta", "Beta", 1),
 		[ProductLifecycle.TechnicalPreview] = new("Preview", "Preview", 2),
-		[ProductLifecycle.Planned] = new("Planned", "Planned", 3),
-		[ProductLifecycle.Deprecated] = new("Deprecated", "Deprecated", 4),
-		[ProductLifecycle.Removed] = new("Removed", "Removed", 5),
-		[ProductLifecycle.Unavailable] = new("Unavailable", "Unavailable", 6),
-		[ProductLifecycle.Development] = new("Development", "Development", 7),
-		[ProductLifecycle.Discontinued] = new("Discontinued", "Discontinued", 8),
+		[ProductLifecycle.Experimental] = new("Experimental", "Experimental", 3),
+		[ProductLifecycle.Planned] = new("Planned", "Planned", 4),
+		[ProductLifecycle.Deprecated] = new("Deprecated", "Deprecated", 5),
+		[ProductLifecycle.Removed] = new("Removed", "Removed", 6),
+		[ProductLifecycle.Unavailable] = new("Unavailable", "Unavailable", 7),
+		[ProductLifecycle.Development] = new("Development", "Development", 8),
+		[ProductLifecycle.Discontinued] = new("Discontinued", "Discontinued", 9),
 	};
 }
 

--- a/src/Elastic.Markdown/Myst/Components/ApplicabilityRenderer.cs
+++ b/src/Elastic.Markdown/Myst/Components/ApplicabilityRenderer.cs
@@ -397,6 +397,7 @@ public static class ApplicabilityRenderer
 				badgeText = applicability.Lifecycle switch
 				{
 					ProductLifecycle.TechnicalPreview => "Planned",
+					ProductLifecycle.Experimental => "Planned",
 					ProductLifecycle.Beta => "Planned",
 					ProductLifecycle.GenerallyAvailable => "Planned",
 					ProductLifecycle.Deprecated => "Deprecation planned",

--- a/src/Elastic.Markdown/Myst/Components/LifecycleDescriptions.cs
+++ b/src/Elastic.Markdown/Myst/Components/LifecycleDescriptions.cs
@@ -42,6 +42,12 @@ public static class LifecycleDescriptions
 		[(ProductLifecycle.TechnicalPreview, false)] =
 			"We plan to add this functionality in a future {product} update. Subject to changes.",
 
+		// Experimental — PLACEHOLDER pending product/docs review
+		[(ProductLifecycle.Experimental, true)] =
+			"This functionality is experimental and is not ready for production usage. Experimental features may change or be removed at any time. Elastic will work to fix any issues, but experimental features are not subject to the support SLA of official GA features. Specific Support terms apply.",
+		[(ProductLifecycle.Experimental, false)] =
+			"We plan to add this functionality in a future {product} update. Subject to changes.",
+
 		// Beta
 		[(ProductLifecycle.Beta, true)] =
 			"This functionality is in beta and is not ready for production usage. For beta features, the design and code is less mature than official GA features and is being provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features. Specific Support terms apply.",

--- a/tests/Elastic.ApiExplorer.Tests/AvailabilityBadgeHelperTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/AvailabilityBadgeHelperTests.cs
@@ -1,0 +1,63 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text.Json.Nodes;
+using AwesomeAssertions;
+using Elastic.ApiExplorer.Operations;
+using Elastic.Documentation;
+using Elastic.Documentation.Configuration.Versions;
+using Elastic.Documentation.Versions;
+using Microsoft.OpenApi;
+
+namespace Elastic.ApiExplorer.Tests;
+
+public class AvailabilityBadgeHelperTests
+{
+	[Theory]
+	[InlineData("Experimental; added in 9.5.0", "experimental 9.5.0")]
+	[InlineData("Experimental", "experimental")]
+	[InlineData("Technical Preview; added in 9.4.0", "preview 9.4.0")]
+	[InlineData("Generally available; added in 9.1.0", "ga 9.1.0")]
+	[InlineData("Added in 7.7.0", "ga 7.7.0")]
+	public void ProjectToLifecycleFormat_MapsXStateToLifecycleString(string xState, string expected)
+	{
+		AvailabilityBadgeHelper.ProjectToLifecycleFormat(xState).Should().Be(expected);
+	}
+
+	[Fact]
+	public void FromOperation_ExperimentalXState_ProducesExperimentalBadge()
+	{
+		var operation = new OpenApiOperation
+		{
+			Extensions = new Dictionary<string, IOpenApiExtension>
+			{
+				["x-state"] = new JsonNodeExtension(JsonValue.Create("Experimental; added in 9.0.0"))
+			}
+		};
+
+		var versionsConfiguration = new VersionsConfiguration
+		{
+			VersioningSystems = new Dictionary<VersioningSystemId, VersioningSystem>
+			{
+				{
+					VersioningSystemId.Stack,
+					new VersioningSystem
+					{
+						Id = VersioningSystemId.Stack,
+						Base = new SemVersion(8, 0, 0),
+						Current = new SemVersion(9, 2, 0)
+					}
+				}
+			}
+		};
+
+		var badgeData = AvailabilityBadgeHelper.FromOperation(operation, versionsConfiguration);
+
+		badgeData.Should().NotBeNull();
+		badgeData.LifecycleName.Should().Be("Experimental");
+		badgeData.LifecycleClass.Should().Be("experimental");
+		badgeData.ShowLifecycleName.Should().BeTrue();
+		badgeData.BadgeVersion.Should().Be("9.0+");
+	}
+}

--- a/tests/Elastic.Markdown.Tests/AppliesTo/ApplicabilityTryParseTests.cs
+++ b/tests/Elastic.Markdown.Tests/AppliesTo/ApplicabilityTryParseTests.cs
@@ -15,6 +15,7 @@ public class ApplicabilityTryParseTests
 	[InlineData("GA", ProductLifecycle.GenerallyAvailable)]
 	[InlineData("preview", ProductLifecycle.TechnicalPreview)]
 	[InlineData("tech-preview", ProductLifecycle.TechnicalPreview)]
+	[InlineData("experimental", ProductLifecycle.Experimental)]
 	[InlineData("beta", ProductLifecycle.Beta)]
 	[InlineData("deprecated", ProductLifecycle.Deprecated)]
 	[InlineData("removed", ProductLifecycle.Removed)]
@@ -33,6 +34,7 @@ public class ApplicabilityTryParseTests
 	[Theory]
 	[InlineData("ga 8.0", ProductLifecycle.GenerallyAvailable)]
 	[InlineData("beta 9.1.0", ProductLifecycle.Beta)]
+	[InlineData("experimental 9.1.0", ProductLifecycle.Experimental)]
 	[InlineData("preview 10.0+", ProductLifecycle.TechnicalPreview)]
 	public void ValidLifecycleWithVersionReturnsTrueAndParsesCorrectly(string input, ProductLifecycle expectedLifecycle)
 	{

--- a/tests/Elastic.Markdown.Tests/AppliesTo/ApplicableToJsonConverterRoundTripTests.cs
+++ b/tests/Elastic.Markdown.Tests/AppliesTo/ApplicableToJsonConverterRoundTripTests.cs
@@ -308,6 +308,22 @@ public class ApplicableToJsonConverterRoundTripTests
 	}
 
 	[Fact]
+	public void DeserializeExperimentalLifecycle()
+	{
+		var json = """
+			[
+				{ "type": "stack", "sub_type": "stack", "lifecycle": "experimental", "version": "9.1.0" }
+			]
+			""";
+
+		var deserialized = JsonSerializer.Deserialize<ApplicableTo>(json, _options);
+
+		deserialized.Should().NotBeNull();
+		deserialized.Stack.Should().NotBeNull();
+		deserialized.Stack.First().Lifecycle.Should().Be(ProductLifecycle.Experimental);
+	}
+
+	[Fact]
 	public void RoundTripAllLifecycles()
 	{
 		var lifecycles = Enum.GetValues<ProductLifecycle>();

--- a/tests/Elastic.Markdown.Tests/AppliesTo/ApplicableToJsonConverterSerializationTests.cs
+++ b/tests/Elastic.Markdown.Tests/AppliesTo/ApplicableToJsonConverterSerializationTests.cs
@@ -279,6 +279,11 @@ public class ApplicableToJsonConverterSerializationTests
 				},
 				new Applicability
 				{
+					Lifecycle = ProductLifecycle.Experimental,
+					Version = (VersionSpec)"1.0.0"
+				},
+				new Applicability
+				{
 					Lifecycle = ProductLifecycle.Beta,
 					Version = (VersionSpec)"1.0.0"
 				},
@@ -303,6 +308,7 @@ public class ApplicableToJsonConverterSerializationTests
 		var json = JsonSerializer.Serialize(applicableTo, _options);
 
 		json.Should().Contain("\"lifecycle\": \"preview\"");
+		json.Should().Contain("\"lifecycle\": \"experimental\"");
 		json.Should().Contain("\"lifecycle\": \"beta\"");
 		json.Should().Contain("\"lifecycle\": \"ga\"");
 		json.Should().Contain("\"lifecycle\": \"deprecated\"");

--- a/tests/Elastic.Markdown.Tests/AppliesTo/ProductLifecycleInfoTests.cs
+++ b/tests/Elastic.Markdown.Tests/AppliesTo/ProductLifecycleInfoTests.cs
@@ -1,0 +1,27 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using AwesomeAssertions;
+using Elastic.Documentation.AppliesTo;
+
+namespace Elastic.Markdown.Tests.AppliesTo;
+
+public class ProductLifecycleInfoTests
+{
+	[Fact]
+	public void Experimental_HasExpectedMetadata()
+	{
+		ProductLifecycleInfo.GetShortName(ProductLifecycle.Experimental).Should().Be("Experimental");
+		ProductLifecycleInfo.GetDisplayText(ProductLifecycle.Experimental).Should().Be("Experimental");
+		ProductLifecycleInfo.GetOrder(ProductLifecycle.Experimental).Should().Be(3);
+	}
+
+	[Fact]
+	public void Experimental_IsLessMatureThanPreview()
+	{
+		ProductLifecycleInfo.GetOrder(ProductLifecycle.Experimental)
+			.Should()
+			.BeGreaterThan(ProductLifecycleInfo.GetOrder(ProductLifecycle.TechnicalPreview));
+	}
+}

--- a/tests/authoring/Applicability/ApplicableToComponent.fs
+++ b/tests/authoring/Applicability/ApplicableToComponent.fs
@@ -68,6 +68,30 @@ stack: beta 8.8.0
 </p>
 """
 
+type ``stack experimental future version`` () =
+    static let markdown = Setup.Markdown """
+```{applies_to}
+stack: experimental 9.1.0
+```
+"""
+
+    [<Fact>]
+    let ``parses to AppliesDirective`` () =
+        let directives = markdown |> converts "index.md" |> parses<AppliesToDirective>
+        test <@ directives.Length = 1 @>
+        directives |> appliesToDirective (ApplicableTo(
+            Stack=AppliesCollection.op_Explicit "experimental 9.1.0"
+        ))
+
+    [<Fact>]
+    let ``renders experimental future version as planned`` () =
+        markdown |> convertsToHtml """
+<p class="applies applies-block">
+	<applies-to-popover badge-key="Stack" badge-lifecycle-text="Planned" lifecycle-class="experimental" lifecycle-name="Experimental" show-lifecycle-name="false" show-version="false" has-multiple-lifecycles="false" popover-data="{&quot;productDescription&quot;:&quot;The \u003Cstrong\u003EElastic Stack\u003C/strong\u003E includes Elastic\u0027s core products such as Elasticsearch, Kibana, Logstash, and Beats.&quot;,&quot;availabilityItems&quot;:[{&quot;text&quot;:&quot;Planned&quot;,&quot;lifecycleDescription&quot;:&quot;We plan to add this functionality in a future Elastic Stack update. Subject to changes.&quot;}],&quot;additionalInfo&quot;:&quot;Unless stated otherwise on the page, this functionality is available when your Elastic Stack is deployed on Elastic Cloud Hosted, Elastic Cloud Enterprise, Elastic Cloud on Kubernetes, and self-managed environments.&quot;,&quot;showVersionNote&quot;:true,&quot;versionNote&quot;:&quot;This documentation corresponds to the latest patch available for each minor version. If you\u0027re not using the latest patch, check the \u003Ca href=\u0022https://www.elastic.co/docs/release-notes\u0022\u003Erelease notes\u003C/a\u003E for changes.&quot;}" show-popover="true" is-inline="false">
+</applies-to-popover>
+</p>
+"""
+
 type ``stack planned deprecation`` () =
     static let markdown = Setup.Markdown """
 ```{applies_to}


### PR DESCRIPTION
Relates to https://github.com/elastic/docs-builder/issues/3310

This PR adds the `experimental` lifecycle value for use in the "applies-to" docs feature.

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: composer-2

## AI summary

### Core parsing & serialization

- [`ProductLifecycle.cs`](src/Elastic.Documentation/AppliesTo/ProductLifecycle.cs) — `Experimental` enum member with JSON name `experimental`
- [`Applicability.cs`](src/Elastic.Documentation/AppliesTo/Applicability.cs) — parse, serialize, and error-message support
- [`ApplicableToJsonConverter.cs`](src/Elastic.Documentation/AppliesTo/ApplicableToJsonConverter.cs) — JSON read/write
- [`ApplicableTo.cs`](src/Elastic.Documentation/AppliesTo/ApplicableTo.cs) — `LifecycleName` helper

### Rendering & metadata

- [`ProductLifecycleInfo.cs`](src/Elastic.Documentation/AppliesTo/ProductLifecycleInfo.cs) — `Experimental` at order **3**; bumped Planned→Discontinued orders by 1
- [`LifecycleDescriptions.cs`](src/Elastic.Markdown/Myst/Components/LifecycleDescriptions.cs) — placeholder popover text (released + unreleased)
- [`ApplicabilityRenderer.cs`](src/Elastic.Markdown/Myst/Components/ApplicabilityRenderer.cs) — `BuildBadgeLifecycleText` → `"Planned"` for unreleased experimental

### Documentation

- [`docs/_snippets/applies_to-lifecycle.md`](docs/_snippets/applies_to-lifecycle.md) — lifecycle list 
- [`docs/syntax/applies.md`](docs/syntax/applies.md) — Experimental rows in badge/popover tables, inline examples, validation rule
- [`docs/syntax/applies-switch.md`](docs/syntax/applies-switch.md) — experimental `applies-item` in basic usage example

### Tests

- [`ApplicabilityTryParseTests.cs`](tests/Elastic.Markdown.Tests/AppliesTo/ApplicabilityTryParseTests.cs)
- [`ApplicableToJsonConverterSerializationTests.cs`](tests/Elastic.Markdown.Tests/AppliesTo/ApplicableToJsonConverterSerializationTests.cs)
- [`ApplicableToJsonConverterRoundTripTests.cs`](tests/Elastic.Markdown.Tests/AppliesTo/ApplicableToJsonConverterRoundTripTests.cs) — `DeserializeExperimentalLifecycle`
- [`ProductLifecycleInfoTests.cs`](tests/Elastic.Markdown.Tests/AppliesTo/ProductLifecycleInfoTests.cs) *(new)*
- [`ApplicableToComponent.fs`](tests/authoring/Applicability/ApplicableToComponent.fs) — parse + HTML snapshot for `stack: experimental 9.1.0`