### PR TITLE
Add experimental lifecycle to API Explorer

### DIFF
--- a/src/Elastic.ApiExplorer/Elastic.ApiExplorer.csproj
+++ b/src/Elastic.ApiExplorer/Elastic.ApiExplorer.csproj
@@ -24,6 +24,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Elastic.ApiExplorer.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <Folder Include="Elasticsearch\" />
   </ItemGroup>
 

--- a/src/Elastic.ApiExplorer/Elasticsearch/OpenApiDocumentExporter.cs
+++ b/src/Elastic.ApiExplorer/Elasticsearch/OpenApiDocumentExporter.cs
@@ -297,6 +297,8 @@ public partial class OpenApiDocumentExporter(
 			return ProductLifecycle.GenerallyAvailable;
 		if (lower.Contains("beta"))
 			return ProductLifecycle.Beta;
+		if (lower.Contains("experimental"))
+			return ProductLifecycle.Experimental;
 		if (lower.Contains("tech") && lower.Contains("preview"))
 			return ProductLifecycle.TechnicalPreview;
 		if (lower.Contains("deprecated"))

--- a/src/Elastic.ApiExplorer/Operations/AvailabilityBadgeHelper.cs
+++ b/src/Elastic.ApiExplorer/Operations/AvailabilityBadgeHelper.cs
@@ -91,6 +91,7 @@ public static partial class AvailabilityBadgeHelper
 			_ when lower.Contains("removed") => "removed",
 			_ when lower.Contains("deprecated") => "deprecated",
 			_ when lower.Contains("beta") => "beta",
+			_ when lower.Contains("experimental") => "experimental",
 			_ when lower.Contains("preview") => "preview",
 			_ when lower.Contains("generally available") => "ga",
 			_ => null

--- a/tests/Elastic.ApiExplorer.Tests/AvailabilityBadgeHelperTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/AvailabilityBadgeHelperTests.cs
@@ -1,0 +1,63 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text.Json.Nodes;
+using AwesomeAssertions;
+using Elastic.ApiExplorer.Operations;
+using Elastic.Documentation;
+using Elastic.Documentation.Configuration.Versions;
+using Elastic.Documentation.Versions;
+using Microsoft.OpenApi;
+
+namespace Elastic.ApiExplorer.Tests;
+
+public class AvailabilityBadgeHelperTests
+{
+	[Theory]
+	[InlineData("Experimental; added in 9.5.0", "experimental 9.5.0")]
+	[InlineData("Experimental", "experimental")]
+	[InlineData("Technical Preview; added in 9.4.0", "preview 9.4.0")]
+	[InlineData("Generally available; added in 9.1.0", "ga 9.1.0")]
+	[InlineData("Added in 7.7.0", "ga 7.7.0")]
+	public void ProjectToLifecycleFormat_MapsXStateToLifecycleString(string xState, string expected)
+	{
+		AvailabilityBadgeHelper.ProjectToLifecycleFormat(xState).Should().Be(expected);
+	}
+
+	[Fact]
+	public void FromOperation_ExperimentalXState_ProducesExperimentalBadge()
+	{
+		var operation = new OpenApiOperation
+		{
+			Extensions = new Dictionary<string, IOpenApiExtension>
+			{
+				["x-state"] = new JsonNodeExtension(JsonValue.Create("Experimental; added in 9.0.0"))
+			}
+		};
+
+		var versionsConfiguration = new VersionsConfiguration
+		{
+			VersioningSystems = new Dictionary<VersioningSystemId, VersioningSystem>
+			{
+				{
+					VersioningSystemId.Stack,
+					new VersioningSystem
+					{
+						Id = VersioningSystemId.Stack,
+						Base = new SemVersion(8, 0, 0),
+						Current = new SemVersion(9, 2, 0)
+					}
+				}
+			}
+		};
+
+		var badgeData = AvailabilityBadgeHelper.FromOperation(operation, versionsConfiguration);
+
+		badgeData.Should().NotBeNull();
+		badgeData.LifecycleName.Should().Be("Experimental");
+		badgeData.LifecycleClass.Should().Be("experimental");
+		badgeData.ShowLifecycleName.Should().BeTrue();
+		badgeData.BadgeVersion.Should().Be("9.0+");
+	}
+}


### PR DESCRIPTION
Relates to https://github.com/elastic/docs-builder/issues/3310

This PR updates the API Explorer feature so that it supports `x-state: experimental`

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: composer-2

## AI summary

| File | Change |
|------|--------|
| [`AvailabilityBadgeHelper.cs`](src/Elastic.ApiExplorer/Operations/AvailabilityBadgeHelper.cs) | Map `experimental` in `ProjectToLifecycleFormat` (before `preview`) |
| [`OpenApiDocumentExporter.cs`](src/Elastic.ApiExplorer/Elasticsearch/OpenApiDocumentExporter.cs) | Return `ProductLifecycle.Experimental` from `ParseLifecycle` (before tech-preview) |
| [`Elastic.ApiExplorer.csproj`](src/Elastic.ApiExplorer/Elastic.ApiExplorer.csproj) | `InternalsVisibleTo` for `Elastic.ApiExplorer.Tests` |
| [`AvailabilityBadgeHelperTests.cs`](tests/Elastic.ApiExplorer.Tests/AvailabilityBadgeHelperTests.cs) *(new)* | 5 `ProjectToLifecycleFormat` cases + `FromOperation` integration test |
