### PR TITLE
Hide Supported on line for settings whose stack is fully planned

### DIFF
--- a/src/Elastic.Markdown/Myst/Directives/Settings/SettingsView.cshtml
+++ b/src/Elastic.Markdown/Myst/Directives/Settings/SettingsView.cshtml
@@ -87,7 +87,10 @@
 
 		var stackBadges = Model.RenderStackRowBadges(appliesTo);
 		var supportedOnBadges = Model.RenderSupportedOnBadges(appliesTo);
-		var showSupportedOn = appliesTo is not null && appliesTo != ApplicableTo.All && !string.IsNullOrWhiteSpace(supportedOnBadges);
+		var showSupportedOn = appliesTo is not null
+			&& appliesTo != ApplicableTo.All
+			&& !string.IsNullOrWhiteSpace(supportedOnBadges)
+			&& !Model.IsStackFullyPlanned(appliesTo);
 
 		<dt id="@SettingsViewModel.SettingFragmentId(setting, displayName)">@displayName @(new HtmlString(stackBadges))</dt>
 		<dd>

--- a/src/Elastic.Markdown/Myst/Directives/Settings/SettingsViewModel.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Settings/SettingsViewModel.cs
@@ -4,6 +4,7 @@
 
 using Elastic.Documentation.AppliesTo;
 using Elastic.Documentation.Configuration.Versions;
+using Elastic.Documentation.Versions;
 using Elastic.Markdown.Helpers;
 using Elastic.Markdown.Myst.Components;
 using Elastic.Markdown.Myst.Roles.AppliesTo;
@@ -44,6 +45,35 @@ public class SettingsViewModel
 
 	public string RenderSupportedOnBadges(ApplicableTo? appliesTo) =>
 		RenderAppliesToPlacement(appliesTo, ApplicabilityBadgePlacement.SupportedOnRow);
+
+	/// <summary>
+	/// Returns <c>true</c> when every entry in <c>applies_to.stack</c> targets a version greater
+	/// than the currently released stack version — i.e. the stack badge would render as
+	/// "Planned" because the setting does not exist in any released stack version yet.
+	/// In that case the "Supported on" line is suppressed: any deployment badge (ECH,
+	/// Self-managed, ECE, ECK) that claims general availability today is misleading,
+	/// since those surfaces run the stack and the setting has not shipped.
+	/// </summary>
+	public bool IsStackFullyPlanned(ApplicableTo? appliesTo)
+	{
+		if (appliesTo?.Stack is not { Count: > 0 } stack)
+			return false;
+
+		var stackVersion = VersionsConfig.GetVersioningSystem(VersioningSystemId.Stack);
+		if (!stackVersion.IsVersioned())
+			return false;
+
+		foreach (var applicability in stack)
+		{
+			var versionSpec = applicability.Version;
+			if (versionSpec is null || versionSpec == AllVersionsSpec.Instance)
+				return false;
+			if (versionSpec.Min <= stackVersion.Current)
+				return false;
+		}
+
+		return true;
+	}
 
 	private string RenderAppliesToPlacement(ApplicableTo? appliesTo, ApplicabilityBadgePlacement placement)
 	{

--- a/tests/Elastic.Markdown.Tests/SettingsInclusion/IncludeTests.cs
+++ b/tests/Elastic.Markdown.Tests/SettingsInclusion/IncludeTests.cs
@@ -86,7 +86,7 @@ groups:
         datatype: object
         default: "[]"
         applies_to:
-          stack: ga 9.2
+          stack: ga 7.0
         options:
           - option: strict
             description: Strict mode.
@@ -386,5 +386,127 @@ groups:
 		Html.Should().Contain("applies-to-popover");
 		Html.Should().NotContain("Applies to (stack: ga 9.2)");
 		Html.Should().NotContain("Applies to (stack: ga 9.1)");
+	}
+}
+
+/// <summary>
+/// Reproduces the "Internationalization settings in Kibana" confusion: a setting whose
+/// stack badge renders as "Planned" (because every stack entry targets a future version)
+/// should not advertise itself as already supported on ECH or Self-managed.
+/// The test stack current is 8.0.0 (see <see cref="TestHelpers.CreateConfigurationContext"/>),
+/// so <c>stack: ga 9.5</c> is unreleased.
+/// </summary>
+public class HidesSupportedOnLineWhenStackIsFullyPlanned(ITestOutputHelper output) : DirectiveTest<SettingsBlock>(output,
+"""
+:::{settings} _settings/stack-fully-planned.yml
+::::
+"""
+)
+{
+	protected override void AddToFileSystem(MockFileSystem fileSystem)
+	{
+		// language=yaml
+		fileSystem.AddFile("docs/_settings/stack-fully-planned.yml", """
+groups:
+  - group: Example
+    settings:
+      - setting: i18n.defaultLocale
+        description: Locale setting planned for a future stack version.
+        applies_to:
+          stack: ga 9.5
+          ech: ga
+          self: ga
+""");
+	}
+
+	[Fact]
+	public void RendersPlannedStackBadge() =>
+		Html.Should().Contain("badge-key=\"Stack\"").And.Contain("Planned");
+
+	[Fact]
+	public void DoesNotRenderSupportedOnLine()
+	{
+		Html.Should().NotContain("settings-supported-on");
+		Html.Should().NotContain("Supported on:");
+	}
+
+	[Fact]
+	public void DoesNotRenderEchOrSelfManagedBadges()
+	{
+		Html.Should().NotContain("badge-key=\"ECH\"");
+		Html.Should().NotContain("badge-key=\"Self-managed\"");
+	}
+}
+
+/// <summary>
+/// A setting whose stack is released today (<c>stack: ga 7.0</c> with test current 8.0.0)
+/// must continue to render the "Supported on" line with ECH and Self-managed badges.
+/// </summary>
+public class KeepsSupportedOnLineWhenStackIsReleased(ITestOutputHelper output) : DirectiveTest<SettingsBlock>(output,
+"""
+:::{settings} _settings/stack-released.yml
+::::
+"""
+)
+{
+	protected override void AddToFileSystem(MockFileSystem fileSystem)
+	{
+		// language=yaml
+		fileSystem.AddFile("docs/_settings/stack-released.yml", """
+groups:
+  - group: Example
+    settings:
+      - setting: xpack.sample.released
+        description: A setting that has been GA since 7.0.
+        applies_to:
+          stack: ga 7.0
+          ech: ga
+          self: ga
+""");
+	}
+
+	[Fact]
+	public void RendersSupportedOnLineWithBothBadges()
+	{
+		Html.Should().Contain("settings-supported-on");
+		Html.Should().Contain("badge-key=\"ECH\"");
+		Html.Should().Contain("badge-key=\"Self-managed\"");
+	}
+}
+
+/// <summary>
+/// A setting whose stack collection mixes past and future versions
+/// (e.g. <c>stack: ga 7.0, deprecated 9.0</c>) is still usable today,
+/// so the "Supported on" line must remain visible.
+/// </summary>
+public class KeepsSupportedOnLineWhenStackHasMixedReleaseAndFutureVersions(ITestOutputHelper output) : DirectiveTest<SettingsBlock>(output,
+"""
+:::{settings} _settings/stack-mixed-versions.yml
+::::
+"""
+)
+{
+	protected override void AddToFileSystem(MockFileSystem fileSystem)
+	{
+		// language=yaml
+		fileSystem.AddFile("docs/_settings/stack-mixed-versions.yml", """
+groups:
+  - group: Example
+    settings:
+      - setting: xpack.sample.mixed
+        description: GA since 7.0, scheduled for deprecation in 9.0.
+        applies_to:
+          stack: ga 7.0, deprecated 9.0
+          ech: ga
+          self: ga
+""");
+	}
+
+	[Fact]
+	public void RendersSupportedOnLine()
+	{
+		Html.Should().Contain("settings-supported-on");
+		Html.Should().Contain("badge-key=\"ECH\"");
+		Html.Should().Contain("badge-key=\"Self-managed\"");
 	}
 }

--- a/tests/Elastic.Markdown.Tests/SettingsInclusion/IncludeTests.cs
+++ b/tests/Elastic.Markdown.Tests/SettingsInclusion/IncludeTests.cs
@@ -413,7 +413,7 @@ groups:
       - setting: i18n.defaultLocale
         description: Locale setting planned for a future stack version.
         applies_to:
-          stack: ga 9.5
+          stack: ga 99.99
           ech: ga
           self: ga
 """);

--- a/tests/Elastic.Markdown.Tests/SettingsInclusion/IncludeTests.cs
+++ b/tests/Elastic.Markdown.Tests/SettingsInclusion/IncludeTests.cs
@@ -496,7 +496,7 @@ groups:
       - setting: xpack.sample.mixed
         description: GA since 7.0, scheduled for deprecation in 9.0.
         applies_to:
-          stack: ga 7.0, deprecated 9.0
+          stack: ga 7.0, deprecated 99.0
           ech: ga
           self: ga
 """);

--- a/tests/Elastic.Markdown.Tests/SettingsInclusion/IncludeTests.cs
+++ b/tests/Elastic.Markdown.Tests/SettingsInclusion/IncludeTests.cs
@@ -494,7 +494,7 @@ groups:
   - group: Example
     settings:
       - setting: xpack.sample.mixed
-        description: GA since 7.0, scheduled for deprecation in 9.0.
+        description: GA since an existing version, scheduled for deprecation in a future version.
         applies_to:
           stack: ga 7.0, deprecated 99.0
           ech: ga


### PR DESCRIPTION
## Why

In the `{settings}` directive, when a setting's `applies_to.stack` only points at versions greater than the current released stack, the inline stack badge renders as "Planned" but the "Supported on" line could still claim ECH and Self-managed availability today. Readers see e.g. `i18n.defaultLocale` marked **Stack | Planned** while also listing **Supported on: ECH, Self-managed**, which is misleading: ECH, ECE, ECK, and Self-managed all run the Elastic Stack and cannot expose a setting that has not shipped yet.

Closes #3408.

## What

Suppresses the "Supported on" line for any individual setting whose `applies_to.stack` is non-null and where every entry has a `Version.Min` greater than the current stack version. A setting with mixed past+future stack entries (e.g. `stack: ga 9.0, deprecated 9.5`) is still usable today, so the line stays. Settings with no `stack:` at all are unaffected.

Implementation: a new `SettingsViewModel.IsStackFullyPlanned(...)` helper compares each `Stack` entry's `Version.Min` against `VersionsConfig.GetVersioningSystem(VersioningSystemId.Stack).Current`, and `SettingsView.cshtml` extends its `showSupportedOn` predicate with that check.

Three new tests cover the positive case (fully-planned), the released case, and the mixed case. One existing fixture that used `stack: ga 9.2` only to demonstrate badge rendering was switched to `stack: ga 7.0` so its positive `Should().Contain("settings-supported-on")` assertion still holds under the new rule.

### Known edge case

A setting with `stack: ga 9.5` AND `serverless: ga` will also have its "Supported on" line hidden, even though it does exist on serverless today. Per the [Slack thread](https://elastic.slack.com/archives/C0JF80CJZ/p1779885675811119), the settings corpus is published from Kibana `main` precisely because serverless usually runs ahead of stack, so this combination is not theoretical. If this comes up in practice we can narrow the rule to only hide when the would-be Supported-on badges are all deployment-stack-bound.