### PR TITLE
Speed up dotnet format lint hook from ~85s to ~13s

### DIFF
--- a/build/Targets.fs
+++ b/build/Targets.fs
@@ -44,11 +44,15 @@ let private watch _ = exec { run "dotnet" "watch" "--project" "src/tooling/docs-
 
 let private lint (lintArgs: ParseResults<LintArgs>) =
     let includeFiles = lintArgs.TryGetResult LintArgs.Include |> Option.defaultValue []
-    let includeArgs = 
-        if includeFiles.IsEmpty then []
-        else ["--include"] @ includeFiles
+    // When files are provided (pre-push hook): whitespace only — style/analyzers require full Roslyn
+    // semantic analysis (~60s extra) and are not accidentally introduced during normal coding.
+    // When no files (CI): full check, but skip restore since packages are already available.
+    let formatArgs =
+        match includeFiles with
+        | [] -> ["format"; "--verify-no-changes"; "--no-restore"]
+        | files -> ["format"; "whitespace"; "--verify-no-changes"; "--no-restore"; "--include"] @ files
     match exec {
-        exit_code_of "dotnet" (["format"; "--verify-no-changes"] @ includeArgs)
+        exit_code_of "dotnet" formatArgs
     } with
     | 0 -> printfn "There are no dotnet formatting violations, continuing the build."
     | _ -> failwithf "There are dotnet formatting violations. Call `dotnet format` to fix or specify -c to ./build.sh to skip this check"


### PR DESCRIPTION
## Why

The pre-push git hook calls \`./build.sh lint <changed-files>\`, which runs \`dotnet format --verify-no-changes\` on the full solution. This takes ~85s because Roslyn loads all 40+ projects and runs three formatters sequentially — \`style\` and \`analyzers\` together add ~60s of semantic analysis overhead that isn't needed locally.

## What

The \`lint\` build target now differentiates based on whether files are provided:

- **With files (pre-push hook)**: runs \`dotnet format whitespace --verify-no-changes --no-restore --include <files>\` (~13s). Enforces all \`.editorconfig\` spacing/indentation rules; style and analyzer violations aren't accidentally introduced during normal coding.
- **No files (CI)**: runs \`dotnet format --verify-no-changes --no-restore\` (~52s). Full check — whitespace + style + analyzers — but skips restore since packages are already available, saving ~30s vs before.

CI's lint step continues to call \`dotnet run --project build -c release -- lint\` (no files), so it still runs the thorough check.