### PR TITLE
Use singular S3 key prefixes for changelog/bundle artifacts

### DIFF
--- a/src/infra/docs-lambda-changelog-scrubber/Program.cs
+++ b/src/infra/docs-lambda-changelog-scrubber/Program.cs
@@ -181,7 +181,7 @@ async Task CopyPassThrough(IAmazonS3 s3Client, string sourceBucket, string key, 
 
 async Task<string> ScrubContent(string key, string content, ILambdaContext context)
 {
-	var isBundlePath = key.Contains("/bundles/", StringComparison.OrdinalIgnoreCase);
+	var isBundlePath = key.Contains("/bundle/", StringComparison.OrdinalIgnoreCase);
 
 	if (isBundlePath)
 		return await ScrubBundle(content, context);

--- a/src/infra/docs-lambda-changelog-scrubber/README.md
+++ b/src/infra/docs-lambda-changelog-scrubber/README.md
@@ -37,6 +37,6 @@ The `bootstrap` binary should be available under:
 
 ## Scrubbing logic
 
-- **Bundle files** (`{product}/bundles/*.yaml`): `LinkAllowlistSanitizer.TryApplyBundle` scrubs `prs`/`issues` lists
-- **Changelog entries** (`{product}/changelogs/*.yaml`): `LinkAllowlistSanitizer.TryApplyChangelogEntry` scrubs `prs`, `issues`, `description`, `impact`, `action`
+- **Bundle files** (`{product}/bundle/*.yaml`): `LinkAllowlistSanitizer.TryApplyBundle` scrubs `prs`/`issues` lists
+- **Changelog entries** (`{product}/changelog/*.yaml`): `LinkAllowlistSanitizer.TryApplyChangelogEntry` scrubs `prs`, `issues`, `description`, `impact`, `action`
 - The allowlist is built once at cold start from the embedded `assembler.yml` via `BuildAllowReposFromAssembler`

--- a/src/services/Elastic.Changelog/Uploading/ChangelogUploadService.cs
+++ b/src/services/Elastic.Changelog/Uploading/ChangelogUploadService.cs
@@ -133,7 +133,7 @@ public partial class ChangelogUploadService(
 					continue;
 				}
 
-				var s3Key = $"{product}/changelogs/{fileName}";
+				var s3Key = $"{product}/changelog/{fileName}";
 				targets.Add(new UploadTarget(filePath, s3Key));
 			}
 		}
@@ -200,7 +200,7 @@ public partial class ChangelogUploadService(
 					continue;
 				}
 
-				var s3Key = $"{product}/bundles/{fileName}";
+				var s3Key = $"{product}/bundle/{fileName}";
 				targets.Add(new UploadTarget(filePath, s3Key));
 			}
 		}

--- a/tests/Elastic.Changelog.Tests/Changelogs/LinkAllowlistSanitizerTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/LinkAllowlistSanitizerTests.cs
@@ -534,7 +534,7 @@ public class LinkAllowlistSanitizerTests(ITestOutputHelper output) : ChangelogTe
 	public void TryApplyChangelogEntry_BarePrNumberWithoutDefaultRepo_KeptWithWarning()
 	{
 		// The scrubber Lambda calls TryApplyChangelogEntry with defaultRepo=null because per-entry
-		// YAMLs uploaded under {product}/changelogs/*.yaml carry no embedded repo context. A bare
+		// YAMLs uploaded under {product}/changelog/*.yaml carry no embedded repo context. A bare
 		// numeric PR ref ("155500") must be tolerated rather than failing the whole entry — the
 		// reference carries no repo identity so it cannot leak a private link, and downstream
 		// rendering supplies the owner/repo from runtime context.

--- a/tests/Elastic.Changelog.Tests/Uploading/ChangelogUploadServiceTests.cs
+++ b/tests/Elastic.Changelog.Tests/Uploading/ChangelogUploadServiceTests.cs
@@ -65,7 +65,7 @@ public class ChangelogUploadServiceTests
 
 		targets.Should().HaveCount(1);
 		targets[0].LocalPath.Should().Be(path);
-		targets[0].S3Key.Should().Be("elasticsearch/changelogs/entry.yaml");
+		targets[0].S3Key.Should().Be("elasticsearch/changelog/entry.yaml");
 		_collector.Errors.Should().Be(0);
 	}
 
@@ -88,8 +88,8 @@ public class ChangelogUploadServiceTests
 		var targets = _service.DiscoverUploadTargets(_collector, _changelogDir);
 
 		targets.Should().HaveCount(2);
-		targets.Should().Contain(t => t.S3Key == "elasticsearch/changelogs/fix.yaml");
-		targets.Should().Contain(t => t.S3Key == "kibana/changelogs/fix.yaml");
+		targets.Should().Contain(t => t.S3Key == "elasticsearch/changelog/fix.yaml");
+		targets.Should().Contain(t => t.S3Key == "kibana/changelog/fix.yaml");
 	}
 
 	[Fact]
@@ -154,8 +154,8 @@ public class ChangelogUploadServiceTests
 		var targets = _service.DiscoverUploadTargets(_collector, _changelogDir);
 
 		targets.Should().HaveCount(2);
-		targets.Should().Contain(t => t.S3Key == "elasticsearch/changelogs/mixed.yaml");
-		targets.Should().Contain(t => t.S3Key == "kibana/changelogs/mixed.yaml");
+		targets.Should().Contain(t => t.S3Key == "elasticsearch/changelog/mixed.yaml");
+		targets.Should().Contain(t => t.S3Key == "kibana/changelog/mixed.yaml");
 		_collector.Warnings.Should().BeGreaterThan(0);
 	}
 
@@ -184,8 +184,8 @@ public class ChangelogUploadServiceTests
 		var targets = _service.DiscoverUploadTargets(_collector, _changelogDir);
 
 		targets.Should().HaveCount(2);
-		targets.Should().Contain(t => t.S3Key == "elasticsearch/changelogs/first.yaml");
-		targets.Should().Contain(t => t.S3Key == "kibana/changelogs/second.yaml");
+		targets.Should().Contain(t => t.S3Key == "elasticsearch/changelog/first.yaml");
+		targets.Should().Contain(t => t.S3Key == "kibana/changelog/second.yaml");
 	}
 
 	[Fact]
@@ -205,8 +205,8 @@ public class ChangelogUploadServiceTests
 		var targets = _service.DiscoverUploadTargets(_collector, _changelogDir);
 
 		targets.Should().HaveCount(2);
-		targets.Should().Contain(t => t.S3Key == "elastic-agent/changelogs/hyphen.yaml");
-		targets.Should().Contain(t => t.S3Key == "cloud_hosted/changelogs/hyphen.yaml");
+		targets.Should().Contain(t => t.S3Key == "elastic-agent/changelog/hyphen.yaml");
+		targets.Should().Contain(t => t.S3Key == "cloud_hosted/changelog/hyphen.yaml");
 		_collector.Errors.Should().Be(0);
 		_collector.Warnings.Should().Be(0);
 	}
@@ -245,7 +245,7 @@ public class ChangelogUploadServiceTests
 		_collector.Errors.Should().Be(0);
 
 		A.CallTo(() => _s3Client.PutObjectAsync(
-			A<PutObjectRequest>.That.Matches(r => r.Key == "elasticsearch/changelogs/entry.yaml" && r.BucketName == "test-bucket"),
+			A<PutObjectRequest>.That.Matches(r => r.Key == "elasticsearch/changelog/entry.yaml" && r.BucketName == "test-bucket"),
 			A<CancellationToken>._
 		)).MustHaveHappenedOnceExactly();
 	}
@@ -375,7 +375,7 @@ public class ChangelogUploadServiceTests
 		_collector.Errors.Should().Be(0);
 
 		A.CallTo(() => _s3Client.PutObjectAsync(
-			A<PutObjectRequest>.That.Matches(r => r.Key == "elasticsearch/bundles/elasticsearch-9.2.0.yaml" && r.BucketName == "test-bucket"),
+			A<PutObjectRequest>.That.Matches(r => r.Key == "elasticsearch/bundle/elasticsearch-9.2.0.yaml" && r.BucketName == "test-bucket"),
 			A<CancellationToken>._
 		)).MustHaveHappenedOnceExactly();
 	}
@@ -405,7 +405,7 @@ public class ChangelogUploadServiceTests
 		var targets = _service.DiscoverBundleUploadTargets(_collector, bundleDir);
 
 		targets.Should().HaveCount(1);
-		targets[0].S3Key.Should().Be("elasticsearch/bundles/elasticsearch-9.2.0.yaml");
+		targets[0].S3Key.Should().Be("elasticsearch/bundle/elasticsearch-9.2.0.yaml");
 		_collector.Errors.Should().Be(0);
 	}
 
@@ -436,8 +436,8 @@ public class ChangelogUploadServiceTests
 		var targets = _service.DiscoverBundleUploadTargets(_collector, bundleDir);
 
 		targets.Should().HaveCount(2);
-		targets.Should().Contain(t => t.S3Key == "elasticsearch/bundles/stack-9.2.0.yaml");
-		targets.Should().Contain(t => t.S3Key == "kibana/bundles/stack-9.2.0.yaml");
+		targets.Should().Contain(t => t.S3Key == "elasticsearch/bundle/stack-9.2.0.yaml");
+		targets.Should().Contain(t => t.S3Key == "kibana/bundle/stack-9.2.0.yaml");
 	}
 
 	[Fact]

--- a/tests/Elastic.Documentation.Integrations.Tests/S3/S3IncrementalUploaderTests.cs
+++ b/tests/Elastic.Documentation.Integrations.Tests/S3/S3IncrementalUploaderTests.cs
@@ -42,14 +42,14 @@ public class S3IncrementalUploaderTests
 
 		var uploader = CreateUploader();
 		var ct = TestContext.Current.CancellationToken;
-		var result = await uploader.Upload([new UploadTarget(path, "elasticsearch/changelogs/entry.yaml")], ct);
+		var result = await uploader.Upload([new UploadTarget(path, "elasticsearch/changelog/entry.yaml")], ct);
 
 		result.Uploaded.Should().Be(1);
 		result.Skipped.Should().Be(0);
 		result.Failed.Should().Be(0);
 
 		A.CallTo(() => _s3Client.PutObjectAsync(
-			A<PutObjectRequest>.That.Matches(r => r.Key == "elasticsearch/changelogs/entry.yaml" && r.BucketName == BucketName),
+			A<PutObjectRequest>.That.Matches(r => r.Key == "elasticsearch/changelog/entry.yaml" && r.BucketName == BucketName),
 			A<Cancel>._
 		)).MustHaveHappenedOnceExactly();
 	}
@@ -67,7 +67,7 @@ public class S3IncrementalUploaderTests
 
 		var uploader = CreateUploader();
 		var ct = TestContext.Current.CancellationToken;
-		var result = await uploader.Upload([new UploadTarget(path, "kibana/changelogs/entry.yaml")], ct);
+		var result = await uploader.Upload([new UploadTarget(path, "kibana/changelog/entry.yaml")], ct);
 
 		result.Uploaded.Should().Be(0);
 		result.Skipped.Should().Be(1);
@@ -91,7 +91,7 @@ public class S3IncrementalUploaderTests
 
 		var uploader = CreateUploader();
 		var ct = TestContext.Current.CancellationToken;
-		var result = await uploader.Upload([new UploadTarget(path, "elasticsearch/changelogs/entry.yaml")], ct);
+		var result = await uploader.Upload([new UploadTarget(path, "elasticsearch/changelog/entry.yaml")], ct);
 
 		result.Uploaded.Should().Be(1);
 		result.Skipped.Should().Be(0);
@@ -112,7 +112,7 @@ public class S3IncrementalUploaderTests
 
 		var uploader = CreateUploader();
 		var ct = TestContext.Current.CancellationToken;
-		var result = await uploader.Upload([new UploadTarget(path, "elasticsearch/changelogs/entry.yaml")], ct);
+		var result = await uploader.Upload([new UploadTarget(path, "elasticsearch/changelog/entry.yaml")], ct);
 
 		result.Uploaded.Should().Be(0);
 		result.Skipped.Should().Be(0);
@@ -129,12 +129,12 @@ public class S3IncrementalUploaderTests
 		var unchangedEtag = Convert.ToHexStringLower(MD5.HashData("unchanged"u8.ToArray()));
 
 		A.CallTo(() => _s3Client.GetObjectMetadataAsync(
-			A<GetObjectMetadataRequest>.That.Matches(r => r.Key == "es/changelogs/new.yaml"),
+			A<GetObjectMetadataRequest>.That.Matches(r => r.Key == "es/changelog/new.yaml"),
 			A<Cancel>._
 		)).Throws(new AmazonS3Exception("Not Found") { StatusCode = HttpStatusCode.NotFound });
 
 		A.CallTo(() => _s3Client.GetObjectMetadataAsync(
-			A<GetObjectMetadataRequest>.That.Matches(r => r.Key == "es/changelogs/unchanged.yaml"),
+			A<GetObjectMetadataRequest>.That.Matches(r => r.Key == "es/changelog/unchanged.yaml"),
 			A<Cancel>._
 		)).Returns(new GetObjectMetadataResponse { ETag = $"\"{unchangedEtag}\"" });
 
@@ -144,8 +144,8 @@ public class S3IncrementalUploaderTests
 		var uploader = CreateUploader();
 		var ct = TestContext.Current.CancellationToken;
 		var result = await uploader.Upload([
-			new UploadTarget(newPath, "es/changelogs/new.yaml"),
-			new UploadTarget(unchangedPath, "es/changelogs/unchanged.yaml")
+			new UploadTarget(newPath, "es/changelog/new.yaml"),
+			new UploadTarget(unchangedPath, "es/changelog/unchanged.yaml")
 		], ct);
 
 		result.Uploaded.Should().Be(1);


### PR DESCRIPTION
## Why

The changelog automation uploads artifacts to S3 under plural folder prefixes (`{product}/changelogs/` and `{product}/bundles/`), but everywhere else in the codebase these entities are singular (`ArtifactType.Changelog`, `ArtifactType.Bundle`). This inconsistency is a small mishap worth correcting now, before any consumer reads the published layout from the CDN.

## What

Artifacts now upload under `{product}/changelog/` and `{product}/bundle/`, and the scrubber Lambda detects bundles via the `/bundle/` path segment. Upload-target and incremental-uploader tests were updated to assert the new keys.

This changes where new objects are written in the `elastic-docs-v3-changelog-bundles[-private]` buckets. There is no consumer of these prefixes yet, so the only follow-up is housekeeping: optionally migrate/relabel any objects already written under the old plural prefixes (or let them age out). The S3 bucket names and the local `:::{changelog}` directive folder convention (`changelog/bundles/` in a docset) are unchanged.

Companion docs-only PRs update the matching references in `docs-infra` and `docs-actions`.

Made with [Cursor](https://cursor.com)