### PR TITLE
fix: include repo prefix in agent skill copy command

### DIFF
--- a/docs/syntax/agent-skill.md
+++ b/docs/syntax/agent-skill.md
@@ -1,6 +1,6 @@
 # Agent skill
 
-The `{agent-skill}` directive renders a standardized callout that points readers to an [Elastic AI agent skill](https://github.com/elastic/agent-skills). When the URL includes a skill name (after `@`), it shows a "Copy install command" button that copies the `npx skills add @skill-name` command to clipboard. Otherwise, it falls back to a "Get the skill" link.
+The `{agent-skill}` directive renders a standardized callout that points readers to an [Elastic AI agent skill](https://github.com/elastic/agent-skills). When the URL includes a skill name (after `@`), it shows a "Copy install command" button that copies the `npx skills add owner/repo@skill-name` command to clipboard. Otherwise, it falls back to a "Get the skill" link.
 
 ## Usage
 
@@ -64,4 +64,4 @@ This skill helps agents write and optimize ES|QL queries.
 
 The `:url:` property must be an absolute URL. Relative paths are not accepted, and the directive will emit a build error if the URL is missing or relative.
 
-The skill name is extracted from the URL as the segment after the final `@`. For example, `https://github.com/elastic/agent-skills@elasticsearch-esql` produces the install command `npx skills add @elasticsearch-esql`.
+The skill name is extracted from the URL as the segment after the final `@`, and the repository prefix is extracted from the URL path. For example, `https://github.com/elastic/agent-skills@elasticsearch-esql` produces the install command `npx skills add elastic/agent-skills@elasticsearch-esql`.

--- a/src/Elastic.Markdown/Myst/Directives/AgentSkill/AgentSkillBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/AgentSkill/AgentSkillBlock.cs
@@ -15,7 +15,11 @@ public class AgentSkillBlock(DirectiveBlockParser parser, ParserContext context)
 
 	public string? SkillName { get; private set; }
 
-	public string? InstallCommand => SkillName is not null ? $"npx skills add @{SkillName}" : null;
+	public string? RepoPrefix { get; private set; }
+
+	public string? InstallCommand => SkillName is not null && RepoPrefix is not null
+		? $"npx skills add {RepoPrefix}@{SkillName}"
+		: null;
 
 	public override void FinalizeAndValidate(ParserContext context)
 	{
@@ -25,17 +29,24 @@ public class AgentSkillBlock(DirectiveBlockParser parser, ParserContext context)
 		else if (!Uri.TryCreate(Url, UriKind.Absolute, out var uri) || uri.Scheme is not ("http" or "https"))
 			this.EmitError($"agent-skill :url: must be an absolute URL, got '{Url}'");
 		else
-			SkillName = ExtractSkillName(uri);
+			(RepoPrefix, SkillName) = ExtractSkillParts(uri);
 	}
 
-	private static string? ExtractSkillName(Uri uri)
+	private static (string? RepoPrefix, string? SkillName) ExtractSkillParts(Uri uri)
 	{
 		var path = uri.AbsolutePath.TrimEnd('/');
 		var atIndex = path.LastIndexOf('@');
 		if (atIndex < 0)
-			return null;
+			return (null, null);
 
 		var name = path[(atIndex + 1)..];
-		return string.IsNullOrWhiteSpace(name) ? null : name;
+		if (string.IsNullOrWhiteSpace(name))
+			return (null, null);
+
+		var repoPath = path[1..atIndex].TrimEnd('/');
+		if (string.IsNullOrWhiteSpace(repoPath))
+			return (null, null);
+
+		return (repoPath, name);
 	}
 }

--- a/tests/Elastic.Markdown.Tests/Directives/AgentSkillTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/AgentSkillTests.cs
@@ -26,7 +26,7 @@ A regular paragraph.
 	public void SetsSkillName() => Block!.SkillName.Should().Be("elasticsearch-esql");
 
 	[Fact]
-	public void SetsInstallCommand() => Block!.InstallCommand.Should().Be("npx skills add @elasticsearch-esql");
+	public void SetsInstallCommand() => Block!.InstallCommand.Should().Be("npx skills add elastic/agent-skills@elasticsearch-esql");
 
 	[Fact]
 	public void SetsDirective() => Block!.Directive.Should().Be("agent-skill");
@@ -59,7 +59,7 @@ A regular paragraph.
 	{
 		Html.Should().Contain("class=\"agent-skill-button\"");
 		Html.Should().Contain("Copy install command");
-		Html.Should().Contain("data-copy-text=\"npx skills add @elasticsearch-esql\"");
+		Html.Should().Contain("data-copy-text=\"npx skills add elastic/agent-skills@elasticsearch-esql\"");
 	}
 
 	[Fact]

--- a/tests/authoring/Blocks/AgentSkill.fs
+++ b/tests/authoring/Blocks/AgentSkill.fs
@@ -28,7 +28,7 @@ type ``agent skill with url`` () =
 			<p>A skill is available to help AI agents with this topic.</p>
 			<p><a href="/explore-analyze/ai-features/agent-skills#available-skills">Learn more about agent skills for Elastic</a></p>
 		</div>
-		<button type="button" class="agent-skill-button" data-copy-text="npx skills add @elasticsearch-esql">
+		<button type="button" class="agent-skill-button" data-copy-text="npx skills add elastic/agent-skills@elasticsearch-esql">
 			<svg class="agent-skill-button-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
 				<path stroke-linecap="round" stroke-linejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 0 0 2.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 0 0-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75 2.25 2.25 0 0 0-.1-.664m-5.8 0A2.251 2.251 0 0 1 13.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25ZM6.75 12h.008v.008H6.75V12Zm0 3h.008v.008H6.75V15Zm0 3h.008v.008H6.75V18Z"></path>
 			</svg>
@@ -66,7 +66,7 @@ This skill helps agents write and optimize ES|QL queries.
 			<p>This skill helps agents write and optimize ES|QL queries.</p>
 			<p><a href="/explore-analyze/ai-features/agent-skills#available-skills">Learn more about agent skills for Elastic</a></p>
 		</div>
-		<button type="button" class="agent-skill-button" data-copy-text="npx skills add @elasticsearch-esql">
+		<button type="button" class="agent-skill-button" data-copy-text="npx skills add elastic/agent-skills@elasticsearch-esql">
 			<svg class="agent-skill-button-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
 				<path stroke-linecap="round" stroke-linejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 0 0 2.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 0 0-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75 2.25 2.25 0 0 0-.1-.664m-5.8 0A2.251 2.251 0 0 1 13.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25ZM6.75 12h.008v.008H6.75V12Zm0 3h.008v.008H6.75V15Zm0 3h.008v.008H6.75V18Z"></path>
 			</svg>


### PR DESCRIPTION
## Summary
- The agent skill directive's copy command was missing the repository prefix, generating, for example, `npx skills add @elasticsearch-esql` instead of the correct `npx skills add elastic/agent-skills@elasticsearch-esql`
- Extracts the `owner/repo` path from the URL alongside the skill name so the install command works out of the box

Closes #3439

## Test plan
- [x] C# unit tests pass (25 AgentSkill tests)
- [x] F# authoring tests pass (8 agent skill tests)
- [ ] Verify on preview site that the copy button produces the correct command

🤖 Generated with [Claude Code](https://claude.com/claude-code)