### PR TITLE
Add permissions for build-link-index-lambda

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,8 @@ jobs:
         run: ./build.sh publishcontainers
         
   build-link-index-lambda:
+    permissions: 
+      contents: read
     needs: 
       - release-drafter
     uses: ./.github/workflows/build-link-index-updater-lambda.yml


### PR DESCRIPTION
Fixes https://github.com/elastic/docs-builder/actions/runs/26807593314