### PR TITLE
fix: add missing permissions to build-changelog-scrubber-lambda job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,8 @@ jobs:
       ref: ${{ needs.release-drafter.outputs.tag_name }}
 
   build-changelog-scrubber-lambda:
+    permissions:
+      contents: read
     needs:
       - release-drafter
     uses: ./.github/workflows/build-changelog-scrubber-lambda.yml


### PR DESCRIPTION
## Why

The release workflow sets `permissions: {}` at the top level, which zeros out all token permissions. The `build-changelog-scrubber-lambda` job was missing its own `permissions` block, so the reusable workflow's nested job could only inherit `contents: none` — causing a validation error that blocked the entire release run.

## What

Added `permissions: contents: read` to `build-changelog-scrubber-lambda` in `release.yml`, mirroring the identical block already present on `build-link-index-lambda` (added in #3444).