### PR TITLE
Search: Fix modal rejecting valid responses with content type "docs"

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/web-components/ModalSearch/ModalSearchResultsList.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/ModalSearch/ModalSearchResultsList.tsx
@@ -178,9 +178,9 @@ const ModalSearchResultRow = ({
             return result.parents.map((p) => p.title)
         }
 
-        const typePrefix = result.type === 'api' ? 'API' : 'Docs'
+        const typePrefix = 'Docs'
         return [typePrefix, ...result.parents.slice(1).map((p) => p.title)]
-    }, [result.type, result.parents])
+    }, [result.parents])
 
     return (
         <a

--- a/src/Elastic.Documentation.Site/Assets/web-components/ModalSearch/useModalSearchQuery.ts
+++ b/src/Elastic.Documentation.Site/Assets/web-components/ModalSearch/useModalSearchQuery.ts
@@ -36,7 +36,7 @@ const SearchResultItemParent = z.object({
 })
 
 const SearchResultItem = z.object({
-    type: z.enum(['docs']),
+    content_type: z.enum(['docs']),
     url: z.string(),
     title: z.string(),
     description: z.string(),

--- a/src/Elastic.Documentation.Site/Assets/web-components/ModalSearch/useModalSearchQuery.ts
+++ b/src/Elastic.Documentation.Site/Assets/web-components/ModalSearch/useModalSearchQuery.ts
@@ -1,5 +1,5 @@
 import { config } from '../../config'
-import { logInfo, logWarn } from '../../telemetry/logging'
+import { logError, logInfo, logWarn } from '../../telemetry/logging'
 import {
     ATTR_NAVIGATION_SEARCH_QUERY,
     ATTR_NAVIGATION_SEARCH_QUERY_LENGTH,
@@ -36,7 +36,7 @@ const SearchResultItemParent = z.object({
 })
 
 const SearchResultItem = z.object({
-    type: z.enum(['doc', 'api']),
+    type: z.enum(['docs']),
     url: z.string(),
     title: z.string(),
     description: z.string(),
@@ -189,6 +189,14 @@ export const useModalSearchQuery = () => {
                     'error.message': query.error.message,
                 })
             }
+        } else if (query.error) {
+            const err = query.error as Error
+            logError('modal_search_parse_error', {
+                [ATTR_NAVIGATION_SEARCH_QUERY]: debouncedSearchTerm,
+                [ATTR_ERROR_TYPE]: err.name,
+                'error.message': err.message,
+            })
+            console.error('[modal-search] failed to parse search response', err)
         }
     }, [query.error, debouncedSearchTerm])
 

--- a/src/Elastic.Documentation.Site/Assets/web-components/NavigationSearch/NavigationSearchTelemetry.test.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/NavigationSearch/NavigationSearchTelemetry.test.tsx
@@ -32,7 +32,7 @@ const mockSearchResults = {
             title: 'Elasticsearch Guide',
             description: 'Learn about Elasticsearch',
             score: 0.95,
-            type: 'doc' as const,
+            type: 'docs' as const,
             parents: [{ title: 'Docs' }, { title: 'Elasticsearch' }],
         },
         {
@@ -40,7 +40,7 @@ const mockSearchResults = {
             title: 'Kibana Dashboard',
             description: 'Create dashboards',
             score: 0.85,
-            type: 'doc' as const,
+            type: 'docs' as const,
             parents: [{ title: 'Docs' }, { title: 'Kibana' }],
         },
     ],

--- a/src/Elastic.Documentation.Site/Assets/web-components/NavigationSearch/NavigationSearchTelemetry.test.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/NavigationSearch/NavigationSearchTelemetry.test.tsx
@@ -32,7 +32,7 @@ const mockSearchResults = {
             title: 'Elasticsearch Guide',
             description: 'Learn about Elasticsearch',
             score: 0.95,
-            type: 'docs' as const,
+            content_type: 'docs' as const,
             parents: [{ title: 'Docs' }, { title: 'Elasticsearch' }],
         },
         {
@@ -40,7 +40,7 @@ const mockSearchResults = {
             title: 'Kibana Dashboard',
             description: 'Create dashboards',
             score: 0.85,
-            type: 'docs' as const,
+            content_type: 'docs' as const,
             parents: [{ title: 'Docs' }, { title: 'Kibana' }],
         },
     ],

--- a/src/Elastic.Documentation.Site/Assets/web-components/NavigationSearch/SearchResultsList.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/NavigationSearch/SearchResultsList.tsx
@@ -158,9 +158,9 @@ const SearchResultRow = ({
             return result.parents.map((p) => p.title)
         }
 
-        const typePrefix = result.type === 'api' ? 'API' : 'Docs'
+        const typePrefix = 'Docs'
         return [typePrefix, ...result.parents.slice(1).map((p) => p.title)]
-    }, [result.type, result.parents])
+    }, [result.parents])
 
     return (
         <a

--- a/src/Elastic.Documentation.Site/Assets/web-components/NavigationSearch/useNavigationSearchQuery.ts
+++ b/src/Elastic.Documentation.Site/Assets/web-components/NavigationSearch/useNavigationSearchQuery.ts
@@ -40,7 +40,7 @@ const SearchResultItemParent = z.object({
 })
 
 const SearchResultItem = z.object({
-    type: z.enum(['docs']),
+    content_type: z.enum(['docs']),
     url: z.string(),
     title: z.string(),
     description: z.string(),

--- a/src/Elastic.Documentation.Site/Assets/web-components/NavigationSearch/useNavigationSearchQuery.ts
+++ b/src/Elastic.Documentation.Site/Assets/web-components/NavigationSearch/useNavigationSearchQuery.ts
@@ -1,5 +1,5 @@
 import { config } from '../../config'
-import { logInfo, logWarn } from '../../telemetry/logging'
+import { logError, logInfo, logWarn } from '../../telemetry/logging'
 import {
     ATTR_NAVIGATION_SEARCH_QUERY,
     ATTR_NAVIGATION_SEARCH_QUERY_LENGTH,
@@ -40,7 +40,7 @@ const SearchResultItemParent = z.object({
 })
 
 const SearchResultItem = z.object({
-    type: z.enum(['doc', 'api']),
+    type: z.enum(['docs']),
     url: z.string(),
     title: z.string(),
     description: z.string(),
@@ -203,6 +203,17 @@ export const useNavigationSearchQuery = () => {
                     'error.message': query.error.message,
                 })
             }
+        } else if (query.error) {
+            const err = query.error as Error
+            logError('navigation_search_parse_error', {
+                [ATTR_NAVIGATION_SEARCH_QUERY]: debouncedSearchTerm,
+                [ATTR_ERROR_TYPE]: err.name,
+                'error.message': err.message,
+            })
+            console.error(
+                '[navigation-search] failed to parse search response',
+                err
+            )
         }
     }, [query.error, debouncedSearchTerm])
 


### PR DESCRIPTION
## Why

The upstream search contract (`Elastic.Internal.Search.Contract`) changed the field name from `type` to `content_type` and updated the value from `"doc"` to `"docs"` on indexed documents. The frontend Zod schemas still declared `type: z.enum(['doc', 'api'])`, so `SearchResponse.parse()` threw a `ZodError` on every result item — rejecting the entire valid 200 response and showing "Error loading search results" in the codex search modal.

## What

- Renamed `type` → `content_type` and updated `z.enum(['doc', 'api'])` to `z.enum(['docs'])` in both `useModalSearchQuery` and `useNavigationSearchQuery`.
- Removed the now-dead `result.type === 'api'` branch from both result list components; codex is docs-only so `typePrefix` is always `'Docs'`.
- Added an `else if (query.error)` branch to the error-logging effect in both hooks, so `ZodError`/parse failures are no longer silent — they now emit `logError` to OTLP and `console.error` to devtools.
- Updated the test fixture to use `content_type: 'docs'`.