### PR TITLE
Search: Fix schema key content_type → type to match API response

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/web-components/ModalSearch/useModalSearchQuery.ts
+++ b/src/Elastic.Documentation.Site/Assets/web-components/ModalSearch/useModalSearchQuery.ts
@@ -36,7 +36,7 @@ const SearchResultItemParent = z.object({
 })
 
 const SearchResultItem = z.object({
-    content_type: z.enum(['docs']),
+    type: z.enum(['docs']),
     url: z.string(),
     title: z.string(),
     description: z.string(),

--- a/src/Elastic.Documentation.Site/Assets/web-components/NavigationSearch/NavigationSearchTelemetry.test.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/NavigationSearch/NavigationSearchTelemetry.test.tsx
@@ -32,7 +32,7 @@ const mockSearchResults = {
             title: 'Elasticsearch Guide',
             description: 'Learn about Elasticsearch',
             score: 0.95,
-            content_type: 'docs' as const,
+            type: 'docs' as const,
             parents: [{ title: 'Docs' }, { title: 'Elasticsearch' }],
         },
         {
@@ -40,7 +40,7 @@ const mockSearchResults = {
             title: 'Kibana Dashboard',
             description: 'Create dashboards',
             score: 0.85,
-            content_type: 'docs' as const,
+            type: 'docs' as const,
             parents: [{ title: 'Docs' }, { title: 'Kibana' }],
         },
     ],

--- a/src/Elastic.Documentation.Site/Assets/web-components/NavigationSearch/useNavigationSearchQuery.ts
+++ b/src/Elastic.Documentation.Site/Assets/web-components/NavigationSearch/useNavigationSearchQuery.ts
@@ -40,7 +40,7 @@ const SearchResultItemParent = z.object({
 })
 
 const SearchResultItem = z.object({
-    content_type: z.enum(['docs']),
+    type: z.enum(['docs']),
     url: z.string(),
     title: z.string(),
     description: z.string(),


### PR DESCRIPTION
## Why

The navigation-search API serializes `NavigationSearchResultItem.Type` with a CamelCase policy — the JSON key is `type`. A follow-up commit to the previous fix incorrectly renamed the Zod schema key from `type` to `content_type`, so `SearchResponse.parse()` failed on every result item in production.

## What

Reverts the Zod schema key back to `type` in both `useModalSearchQuery` and `useNavigationSearchQuery`, and updates the test fixture to match.