### PR TITLE
Codex: Make index resilient to repos that failed to clone

### DIFF
--- a/src/Elastic.Codex/Sourcing/CodexCloneService.cs
+++ b/src/Elastic.Codex/Sourcing/CodexCloneService.cs
@@ -183,7 +183,17 @@ public class CodexCloneService(ILoggerFactory logFactory, ILinkIndexReader linkI
 			var git = new CodexGitRepository(logFactory, context.Collector, repoDir);
 
 			if (assumeCloned && git.IsInitialized())
+			{
+				if (!git.HasHead())
+				{
+					// A failed prior clone leaves an initialized-but-empty .git dir. Treat this
+					// identically to a clone failure: warn and skip rather than error.
+					context.Collector.EmitWarning(context.ConfigurationPath,
+						$"Could not clone repository '{repoName}' (HEAD unresolvable); skipping");
+					return null;
+				}
 				_logger.LogInformation("Assuming {Name} is already cloned", repoName);
+			}
 			else if (git.IsInitialized() && !fetchLatest)
 				_logger.LogInformation("{Name} already cloned, skipping (use --fetch-latest to update)", repoName);
 			else

--- a/src/Elastic.Codex/Sourcing/CodexGitRepository.cs
+++ b/src/Elastic.Codex/Sourcing/CodexGitRepository.cs
@@ -26,6 +26,8 @@ public class CodexGitRepository(ILoggerFactory logFactory, IDiagnosticsCollector
 
 	public string GetCurrentCommit() => Capture("git", "rev-parse", "HEAD");
 
+	public bool HasHead() => !string.IsNullOrEmpty(CaptureQuiet("git", "rev-parse", "--verify", "HEAD"));
+
 	public void Init() => ExecIn(EnvironmentVars, "git", "init");
 
 	public bool IsInitialized() => Directory.Exists(Path.Join(WorkingDirectory.FullName, ".git"));


### PR DESCRIPTION
## Why

`codex index` was failing with `exit code 1` when the link index referenced a private/inaccessible repository (e.g. one the CI token doesn't have permission to clone yet). The `codex clone` step handled this correctly — warning and skipping — but `index` escalated to a build-breaking error.

## What

When `codex index` runs with `assumeCloned: true`, it trusts that a `.git` directory means the repo was successfully cloned. But a failed fetch leaves behind an initialized-but-empty `.git` dir. Calling `git rev-parse HEAD` on it exhausted 10 retries and then emitted an error directly to the diagnostics collector — bypassing the broad `catch` that was supposed to downgrade it to a warning.

The fix adds a `HasHead()` check to `CodexGitRepository` (using `CaptureQuiet`, so no error is emitted) and short-circuits in the `assumeCloned` branch before `GetCurrentCommit()` is ever called. An empty `.git` from a failed clone is now treated identically to the clone failure itself: warn and skip.