### PR TITLE
Fix crash when toc references a missing file

### DIFF
--- a/src/Elastic.Documentation.Navigation/Isolated/Node/DocumentationSetNavigation.cs
+++ b/src/Elastic.Documentation.Navigation/Isolated/Node/DocumentationSetNavigation.cs
@@ -196,14 +196,18 @@ public class DocumentationSetNavigation<TModel>
 	private TModel? CreateDocumentationFile(
 		IFileInfo fileInfo,
 		IFileSystem fileSystem,
-		IDocumentationSetContext context,
-		string fullPath
+		IDocumentationSetContext context
 	)
 	{
 		var relativePath = Path.GetRelativePath(context.DocumentationSourceDirectory.FullName, fileInfo.FullName);
 		var documentationFile = _factory.TryCreateDocumentationFile(fileInfo, fileSystem);
 		if (documentationFile == null)
-			context.EmitError(context.ConfigurationPath, $"File navigation '{relativePath}' could not be created. {fullPath}");
+		{
+			var reason = fileInfo.Exists
+				? "the file exists but is not a valid Markdown document"
+				: "the file does not exist on disk";
+			context.EmitError(context.ConfigurationPath, $"Table of contents references '{relativePath}' but {reason}.");
+		}
 
 		return documentationFile;
 	}
@@ -248,7 +252,7 @@ public class DocumentationSetNavigation<TModel>
 			DetectionRuleRef ruleRef => ruleRef.FileInfo,
 			_ => ResolveFileInfo(context, fullPath)
 		};
-		var documentationFile = CreateDocumentationFile(fileInfo, context.ReadFileSystem, context, fullPath);
+		var documentationFile = CreateDocumentationFile(fileInfo, context.ReadFileSystem, context);
 		if (documentationFile == null)
 			return null;
 

--- a/src/Elastic.Documentation.Navigation/NavigationItemExtensions.cs
+++ b/src/Elastic.Documentation.Navigation/NavigationItemExtensions.cs
@@ -120,9 +120,14 @@ public static class NavigationItemExtensions
 				_ = navigationByOrder.TryAdd(leaf.NavigationIndex, leaf);
 				break;
 			case INodeNavigationItem<IDocumentationFile, INavigationItem> documentationFileNode:
-				_ = navigationDocumentationFileLookup.TryAdd(documentationFileNode.Index.Model, documentationFileNode);
 				_ = navigationByOrder.TryAdd(documentationFileNode.NavigationIndex, documentationFileNode);
-				_ = navigationByOrder.TryAdd(documentationFileNode.Index.NavigationIndex, documentationFileNode.Index);
+				// Index is a null sentinel when this node's table of contents produced no items; the
+				// validation error is emitted upstream, so skip registering a missing index here.
+				if (documentationFileNode.Index is { } documentationFileIndex)
+				{
+					_ = navigationDocumentationFileLookup.TryAdd(documentationFileIndex.Model, documentationFileNode);
+					_ = navigationByOrder.TryAdd(documentationFileIndex.NavigationIndex, documentationFileIndex);
+				}
 				foreach (var child in documentationFileNode.NavigationItems)
 					BuildNavigationLookupsRecursive(child, navigationDocumentationFileLookup, navigationByOrder);
 				break;

--- a/src/Elastic.Markdown/IO/DocumentationSet.cs
+++ b/src/Elastic.Markdown/IO/DocumentationSet.cs
@@ -129,8 +129,13 @@ public class DocumentationSet : INavigationTraversable
 					extension.VisitNavigation(item, markdownLeaf.Model);
 				break;
 			case INodeNavigationItem<IDocumentationFile, INavigationItem> node:
-				foreach (var extension in EnabledExtensions)
-					extension.VisitNavigation(node, node.Index.Model);
+				// Index is a null sentinel when this node's table of contents produced no items
+				// (a validation error is emitted upstream); skip visiting a missing index.
+				if (node.Index is { } nodeIndex)
+				{
+					foreach (var extension in EnabledExtensions)
+						extension.VisitNavigation(node, nodeIndex.Model);
+				}
 				foreach (var child in node.NavigationItems)
 					VisitNavigation(child);
 				break;

--- a/tests/Elastic.Markdown.Tests/MissingTocFileTests.cs
+++ b/tests/Elastic.Markdown.Tests/MissingTocFileTests.cs
@@ -1,0 +1,51 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions.TestingHelpers;
+using AwesomeAssertions;
+using Elastic.Documentation.Configuration;
+using Elastic.Documentation.Diagnostics;
+using Elastic.Markdown.IO;
+using Nullean.ScopedFileSystem;
+
+namespace Elastic.Markdown.Tests;
+
+public class MissingTocFileTests(ITestOutputHelper output)
+{
+	[Fact]
+	public void TocReferencesMissingFile_DoesNotThrow_AndEmitsClearError()
+	{
+		var logger = new TestLoggerFactory(output);
+		var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+		{
+			{ "docs/docset.yml", new MockFileData("""
+				project: test
+				toc:
+				- file: missing.md
+				""") },
+			// A markdown file that exists on disk but is not referenced by the TOC.
+			// It keeps the documentation set non-empty so construction reaches the
+			// navigation traversal (VisitNavigation + BuildNavigationLookups) that
+			// previously dereferenced the null Index sentinel and crashed.
+			{ "docs/present.md", new MockFileData("# Present") }
+		}, new MockFileSystemOptions
+		{
+			CurrentDirectory = Paths.WorkingDirectoryRoot.FullName
+		});
+		var collector = new TestDiagnosticsCollector(output);
+		_ = collector.StartAsync(TestContext.Current.CancellationToken);
+		var configurationContext = TestHelpers.CreateConfigurationContext(fileSystem);
+		var context = new BuildContext(collector, FileSystemFactory.ScopeCurrentWorkingDirectory(fileSystem), configurationContext);
+
+		var act = () => _ = new DocumentationSet(context, logger, new TestCrossLinkResolver());
+
+		act.Should().NotThrow("a missing toc file must surface a validation error, not crash the build");
+
+		collector.Errors.Should().BeGreaterThan(0);
+		collector.Diagnostics.Should().Contain(d =>
+			d.Severity == Severity.Error &&
+			d.Message.Contains("missing.md") &&
+			d.Message.Contains("does not exist"));
+	}
+}

--- a/tests/Navigation.Tests/Isolation/ValidationTests.cs
+++ b/tests/Navigation.Tests/Isolation/ValidationTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System.IO.Abstractions.TestingHelpers;
+using System.Runtime.CompilerServices;
 using AwesomeAssertions;
 using Elastic.Documentation.Configuration.Toc;
 using Elastic.Documentation.Diagnostics;
@@ -257,6 +258,38 @@ public class ValidationTests(ITestOutputHelper output) : DocumentationSetNavigat
 
 		context.Collector.Hints.Should().Be(0, "simple virtual files without deep-linking should not trigger hints");
 		context.Diagnostics.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task BuildNavigationLookupsDoesNotThrowWhenTocReferencesMissingFile()
+	{
+		// language=yaml
+		var yaml = """
+		           project: 'test-project'
+		           toc:
+		             - file: missing.md
+		           """;
+
+		var fileSystem = new MockFileSystem();
+		fileSystem.AddDirectory("/docs");
+		// Note: /docs/missing.md is intentionally not created on disk
+		var context = CreateContext(fileSystem);
+		var docSet = DocumentationSetFile.LoadAndResolve(context.Collector, yaml, fileSystem.NewDirInfo("docs"));
+		_ = context.Collector.StartAsync(TestContext.Current.CancellationToken);
+
+		var navigation = new DocumentationSetNavigation<IDocumentationFile>(docSet, context, MissingFileDocumentationFileFactory.Instance);
+
+		var lookup = new ConditionalWeakTable<IDocumentationFile, INavigationItem>();
+		var buildLookups = () => navigation.BuildNavigationLookups(lookup);
+		buildLookups.Should().NotThrow("a missing toc file must surface a validation error, not crash the build");
+
+		await context.Collector.StopAsync(TestContext.Current.CancellationToken);
+
+		context.Collector.Errors.Should().BeGreaterThan(0);
+		var diagnostics = context.Diagnostics;
+		diagnostics.Should().Contain(d =>
+			d.Message.Contains("missing.md") &&
+			d.Message.Contains("does not exist"));
 	}
 
 	[Fact]

--- a/tests/Navigation.Tests/TestDocumentationSetContext.cs
+++ b/tests/Navigation.Tests/TestDocumentationSetContext.cs
@@ -171,6 +171,26 @@ public class CodexTestDocumentationFileFactory : IDocumentationFileFactory<TestD
 	}
 }
 
+// Factory that mirrors production behaviour: returns null when the referenced file is not present on disk.
+// Used to reproduce the missing-toc-file scenario where navigation produces a null Index sentinel.
+public class MissingFileDocumentationFileFactory : IDocumentationFileFactory<IDocumentationFile>
+{
+	public static MissingFileDocumentationFileFactory Instance { get; } = new();
+
+	/// <inheritdoc />
+	public IDocumentationFile? TryCreateDocumentationFile(IFileInfo path, IFileSystem readFileSystem)
+	{
+		if (!path.Exists)
+			return null;
+
+		var fileName = path.Name;
+		var title = fileName.EndsWith(".md", StringComparison.OrdinalIgnoreCase)
+			? fileName[..^3]
+			: fileName;
+		return new TestDocumentationFile(title);
+	}
+}
+
 // Factory that creates base IDocumentationFile instances for tests that don't need concrete types
 public class GenericDocumentationFileFactory : IDocumentationFileFactory<IDocumentationFile>
 {


### PR DESCRIPTION
## Why

Running `docs-builder build`/`serve` on a docset whose `toc` references a Markdown file that doesn't exist on disk crashed with an unhandled `NullReferenceException` while building navigation lookups, instead of reporting a clear validation error. The validation error was actually already computed — the process just died on an unguarded null dereference before it could be shown.

Closes #3245.

## What

When a TOC entry resolves to a file the factory can't create, that nav item is dropped. If a node ends up with zero items, its `Index` is set to a `null!` sentinel. Because `INodeNavigationItem<out TIndex, …>` is covariant, the root node matches the `INodeNavigationItem<IDocumentationFile, …>` branch in both `BuildNavigationLookups` and `DocumentationSet.VisitNavigation`, where `Index.Model` was dereferenced unconditionally → the reported NRE.

This change:
- Guards the null `Index` sentinel at both dereference sites, so the build no longer crashes and the already-emitted validation error surfaces, exiting cleanly.
- Clarifies the diagnostic to say whether the referenced file is missing on disk or exists but isn't a valid Markdown document, anchored to the `docset.yml` location.
- Adds a `Navigation.Tests` case that drives `BuildNavigationLookups` with a missing-file TOC and asserts it does not throw and emits a clear error (the existing validation tests never exercised this path).

Verified end-to-end: a docset with a missing `file:` entry now prints `Table of contents references '…' but the file does not exist on disk.` and exits with an error rather than crashing.

Made with [Cursor](https://cursor.com)