### PR TITLE
perf(mcp): cache JWT signing key and disable indented JSON responses

### DIFF
--- a/src/api/Elastic.Documentation.Mcp.Remote/Gateways/DocumentGateway.cs
+++ b/src/api/Elastic.Documentation.Mcp.Remote/Gateways/DocumentGateway.cs
@@ -25,29 +25,31 @@ public class DocumentGateway(
 		try
 		{
 			var normalizedUrl = NormalizeUrl(url);
+			// TODO: conditionally omit Body from the source filter when the caller doesn't need it —
+			// currently Body is always fetched even when includeBody=false, wasting network + deserialization.
 			var response = await clientAccessor.Client.SearchAsync<DocumentationDocument>(s => s
 				.Indices(clientAccessor.SearchIndex)
 				.Query(q => q.Term(t => t.Field(f => f.Url).Value(normalizedUrl)))
 				.Size(1)
-			.Source(sf => sf.Filter(f => f.Includes(
-				e => e.Url,
-				e => e.Title,
-				e => e.SearchTitle,
-				e => e.Type,
-				e => e.Description,
-				e => e.NavigationSection,
-				e => e.Body,
-				e => e.Parents,
-				e => e.Headings,
-				e => e.Links,
-				e => e.AiShortSummary,
-				e => e.AiRagOptimizedSummary,
-				e => e.AiQuestions,
-				e => e.AiUseCases,
-				e => e.LastUpdated,
-				e => e.Product,
-				e => e.RelatedProducts
-			))),
+				.Source(sf => sf.Filter(f => f.Includes(
+					e => e.Url,
+					e => e.Title,
+					e => e.SearchTitle,
+					e => e.Type,
+					e => e.Description,
+					e => e.NavigationSection,
+					e => e.Body,
+					e => e.Parents,
+					e => e.Headings,
+					e => e.Links,
+					e => e.AiShortSummary,
+					e => e.AiRagOptimizedSummary,
+					e => e.AiQuestions,
+					e => e.AiUseCases,
+					e => e.LastUpdated,
+					e => e.Product,
+					e => e.RelatedProducts
+				))),
 				ct);
 
 			if (!response.IsValidResponse || response.Documents.Count == 0)
@@ -108,6 +110,7 @@ public class DocumentGateway(
 				.Indices(clientAccessor.SearchIndex)
 				.Query(q => q.Term(t => t.Field(f => f.Url).Value(normalizedUrl)))
 				.Size(1)
+			// Body is fetched solely to compute BodyLength — no stored length field exists in the index.
 			.Source(sf => sf.Filter(f => f.Includes(
 				e => e.Url,
 				e => e.Title,

--- a/src/api/Elastic.Documentation.Mcp.Remote/McpBearerAuthMiddleware.cs
+++ b/src/api/Elastic.Documentation.Mcp.Remote/McpBearerAuthMiddleware.cs
@@ -23,6 +23,7 @@ public class McpBearerAuthMiddleware(RequestDelegate next, ILogger<McpBearerAuth
 	// Cache the parsed signing key — PEM and key ID are immutable for process lifetime.
 	private static RsaSecurityKey? CachedKey;
 	private static string? CachedKeyPem;
+	private static string? CachedKeyId;
 	private static readonly Lock KeyLock = new();
 
 	public async Task InvokeAsync(HttpContext context)
@@ -214,17 +215,18 @@ public class McpBearerAuthMiddleware(RequestDelegate next, ILogger<McpBearerAuth
 
 	private static RsaSecurityKey GetOrCreateSigningKey(string publicKeyPem, string? keyId)
 	{
-		if (CachedKey is not null && CachedKeyPem == publicKeyPem)
+		if (CachedKey is not null && CachedKeyPem == publicKeyPem && CachedKeyId == keyId)
 			return CachedKey;
 		lock (KeyLock)
 		{
-			if (CachedKey is not null && CachedKeyPem == publicKeyPem)
+			if (CachedKey is not null && CachedKeyPem == publicKeyPem && CachedKeyId == keyId)
 				return CachedKey;
 			using var rsa = RSA.Create();
 			rsa.ImportFromPem(publicKeyPem);
 			var key = new RsaSecurityKey(rsa.ExportParameters(includePrivateParameters: false)) { KeyId = keyId };
 			CachedKey = key;
 			CachedKeyPem = publicKeyPem;
+			CachedKeyId = keyId;
 			return key;
 		}
 	}

--- a/src/api/Elastic.Documentation.Mcp.Remote/McpBearerAuthMiddleware.cs
+++ b/src/api/Elastic.Documentation.Mcp.Remote/McpBearerAuthMiddleware.cs
@@ -20,6 +20,11 @@ public class McpBearerAuthMiddleware(RequestDelegate next, ILogger<McpBearerAuth
 	private const string ExpectedAlg = "RS256";
 	private static readonly JwtSecurityTokenHandler TokenHandler = new() { MapInboundClaims = false };
 
+	// Cache the parsed signing key — PEM and key ID are immutable for process lifetime.
+	private static RsaSecurityKey? CachedKey;
+	private static string? CachedKeyPem;
+	private static readonly Lock KeyLock = new();
+
 	public async Task InvokeAsync(HttpContext context)
 	{
 		var env = SystemEnvironmentVariables.Instance;
@@ -130,12 +135,10 @@ public class McpBearerAuthMiddleware(RequestDelegate next, ILogger<McpBearerAuth
 			return (null, 401);
 		}
 
-		RSAParameters rsaParams;
+		RsaSecurityKey signingKey;
 		try
 		{
-			using var rsa = RSA.Create();
-			rsa.ImportFromPem(env.McpJwtPublicKey);
-			rsaParams = rsa.ExportParameters(includePrivateParameters: false);
+			signingKey = GetOrCreateSigningKey(env.McpJwtPublicKey, env.McpJwtKeyId);
 		}
 		catch (CryptographicException)
 		{
@@ -152,7 +155,7 @@ public class McpBearerAuthMiddleware(RequestDelegate next, ILogger<McpBearerAuth
 
 		var validationParams = new TokenValidationParameters
 		{
-			IssuerSigningKey = new RsaSecurityKey(rsaParams) { KeyId = env.McpJwtKeyId },
+			IssuerSigningKey = signingKey,
 			ValidateIssuerSigningKey = true,
 			ValidateIssuer = env.McpOAuthIssuer is not null,
 			ValidIssuer = env.McpOAuthIssuer,
@@ -206,6 +209,23 @@ public class McpBearerAuthMiddleware(RequestDelegate next, ILogger<McpBearerAuth
 			logger.LogWarning("MCP auth validation failed: {Type} (kid={Kid}, jti={Jti}, err={Err})",
 				ex.GetType().Name, jwt.Header.Kid, jwt.Payload.Jti, ex.Message);
 			return (null, 401);
+		}
+	}
+
+	private static RsaSecurityKey GetOrCreateSigningKey(string publicKeyPem, string? keyId)
+	{
+		if (CachedKey is not null && CachedKeyPem == publicKeyPem)
+			return CachedKey;
+		lock (KeyLock)
+		{
+			if (CachedKey is not null && CachedKeyPem == publicKeyPem)
+				return CachedKey;
+			using var rsa = RSA.Create();
+			rsa.ImportFromPem(publicKeyPem);
+			var key = new RsaSecurityKey(rsa.ExportParameters(includePrivateParameters: false)) { KeyId = keyId };
+			CachedKey = key;
+			CachedKeyPem = publicKeyPem;
+			return key;
 		}
 	}
 

--- a/src/api/Elastic.Documentation.Mcp.Remote/Responses/McpResponses.cs
+++ b/src/api/Elastic.Documentation.Mcp.Remote/Responses/McpResponses.cs
@@ -151,7 +151,7 @@ public sealed record AiEnrichmentStatusDto
 	public required bool HasUseCases { get; init; }
 }
 
-[JsonSourceGenerationOptions(WriteIndented = true, PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSourceGenerationOptions(WriteIndented = false, PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 [JsonSerializable(typeof(ErrorResponse))]
 [JsonSerializable(typeof(SemanticSearchResponse))]
 [JsonSerializable(typeof(SearchResultDto))]


### PR DESCRIPTION
## Why

Two hot-path costs per MCP request:

1. **JWT key re-parsed on every authenticated request.** `RSA.ImportFromPem` + `ExportParameters` + building `TokenValidationParameters` ran on every call — the dominant per-request CPU cost. The PEM and key ID are immutable for process lifetime; there was no reason to re-import them.

2. **`WriteIndented = true` on all tool responses.** Pretty-printing every JSON response is measurably slower to serialize and produces larger payloads for no benefit in a machine-to-machine protocol.

## What

- Caches the parsed `RsaSecurityKey` on first auth request using a double-checked lock. Subsequent requests reuse the cached key; only `TokenValidationParameters` (cheap field assignments) is built per-request.
- Sets `WriteIndented = false` on `McpJsonContext`.
- Adds a TODO in `DocumentGateway.GetByUrlAsync` noting that `Body` is always fetched even when the caller passes `includeBody=false` — the gateway-level fix is deferred to a follow-up PR.