### PR TITLE
Fail fast on OTLP proxy: 1s timeout, no retries

### DIFF
--- a/src/api/Elastic.Documentation.Api/ServicesExtension.cs
+++ b/src/api/Elastic.Documentation.Api/ServicesExtension.cs
@@ -205,12 +205,18 @@ public static class ServicesExtension
 			return new OtlpProxyOptions(config);
 		});
 
-		// Register named HttpClient for OTLP proxy
+		// Register named HttpClient for OTLP proxy.
+		// 1s timeout: the collector is a localhost sidecar and should answer in single-digit ms.
+		// RemoveAllResilienceHandlers opts this client out of the global standard resilience handler
+		// (retries + 10s/30s timeouts) so a dead collector fails fast instead of blocking ~9s.
+#pragma warning disable EXTEXP0001 // RemoveAllResilienceHandlers is experimental
 		_ = services.AddHttpClient(AdotOtlpService.HttpClientName)
 			.ConfigureHttpClient(client =>
 			{
-				client.Timeout = TimeSpan.FromSeconds(30);
-			});
+				client.Timeout = TimeSpan.FromSeconds(1);
+			})
+			.RemoveAllResilienceHandlers();
+#pragma warning restore EXTEXP0001
 
 		_ = services.AddScoped<IOtlpService, AdotOtlpService>();
 		logger?.LogInformation("OTLP proxy configured to forward to ADOT Lambda Layer collector");

--- a/tests/Elastic.Documentation.Api.Tests/OtlpProxyTests.cs
+++ b/tests/Elastic.Documentation.Api.Tests/OtlpProxyTests.cs
@@ -234,6 +234,37 @@ public class OtlpProxyTests
 	}
 
 	[Fact]
+	public async Task OtlpProxy_CollectorUnavailable_FailsFastWithoutRetries()
+	{
+		// Arrange
+		var callCount = 0;
+		var mockHandler = A.Fake<HttpMessageHandler>();
+
+		A.CallTo(mockHandler)
+			.Where(call => call.Method.Name == "SendAsync")
+			.WithReturnType<Task<HttpResponseMessage>>()
+			.Invokes((HttpRequestMessage _, CancellationToken _) => callCount++)
+			.Throws(new HttpRequestException("Connection refused",
+				new System.Net.Sockets.SocketException((int)System.Net.Sockets.SocketError.ConnectionRefused)));
+
+		using var factory = ApiWebApplicationFactory.WithMockedServices(services =>
+		{
+			_ = services.AddHttpClient(AdotOtlpService.HttpClientName)
+				.ConfigurePrimaryHttpMessageHandler(() => mockHandler);
+		}, otlpEndpoint: OtlpEndpoint);
+
+		var client = factory.CreateClient();
+		using var content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+		// Act
+		using var response = await client.PostAsync("/docs/_api/v1/o/t", content, TestContext.Current.CancellationToken);
+
+		// Assert — exactly one attempt, no retries
+		callCount.Should().Be(1, "telemetry forwarding must fail fast with no retries");
+		response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+	}
+
+	[Fact]
 	public async Task OtlpProxyInvalidSignalTypeReturns404()
 	{
 		// Arrange


### PR DESCRIPTION
## Why

When the OTLP collector sidecar is unreachable, the `OtlpProxy` HttpClient was inheriting the global `AddStandardResilienceHandler` — giving it 3 retries with exponential backoff and 10s/30s timeouts. A browser telemetry beacon to `/o/t` would block for ~9.2s before returning a 502. Since the collector is a `localhost` sidecar that should answer in single-digit milliseconds, retrying makes no sense and the latency cost is entirely avoidable.

## What

The `OtlpProxy` named HttpClient now opts out of the global resilience handler via `RemoveAllResilienceHandlers()` and sets a 1s timeout. A dead collector fails in <1s with a 503 instead of blocking ~9s through 4 attempts. A new test locks in the no-retry guarantee by asserting exactly one outbound attempt on connection-refused.