### PR TITLE
OtlpProxy: buffer request body to survive stale-connection retry

### DIFF
--- a/src/api/Elastic.Documentation.Api/ServicesExtension.cs
+++ b/src/api/Elastic.Documentation.Api/ServicesExtension.cs
@@ -209,11 +209,17 @@ public static class ServicesExtension
 		// 1s timeout: the collector is a localhost sidecar and should answer in single-digit ms.
 		// RemoveAllResilienceHandlers opts this client out of the global standard resilience handler
 		// (retries + 10s/30s timeouts) so a dead collector fails fast instead of blocking ~9s.
+		// PooledConnectionLifetime=30s proactively recycles connections before the sidecar closes them,
+		// keeping the stale-connection drop rate negligible.
 #pragma warning disable EXTEXP0001 // RemoveAllResilienceHandlers is experimental
 		_ = services.AddHttpClient(AdotOtlpService.HttpClientName)
 			.ConfigureHttpClient(client =>
 			{
 				client.Timeout = TimeSpan.FromSeconds(1);
+			})
+			.ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
+			{
+				PooledConnectionLifetime = TimeSpan.FromSeconds(30),
 			})
 			.RemoveAllResilienceHandlers();
 #pragma warning restore EXTEXP0001

--- a/src/api/Elastic.Documentation.Api/Telemetry/AdotOtlpService.cs
+++ b/src/api/Elastic.Documentation.Api/Telemetry/AdotOtlpService.cs
@@ -34,8 +34,17 @@ public class AdotOtlpService(
 			var targetUrl = $"{options.Endpoint.TrimEnd('/')}/v1/{signalType.ToStringFast(true)}";
 			logger.LogDebug("Forwarding OTLP {SignalType} to ADOT collector at {TargetUrl}", signalType, targetUrl);
 
-			using var request = new HttpRequestMessage(HttpMethod.Post, targetUrl);
-			request.Content = new StreamContent(requestBody);
+			// Buffer the body so SocketsHttpHandler's transparent connection retry can replay it.
+			// The raw request body is forward-only; a stale pooled connection to the localhost
+			// collector triggers a silent resend that otherwise throws "stream was already consumed".
+			using var buffer = new MemoryStream();
+			await requestBody.CopyToAsync(buffer, ctx);
+			buffer.Position = 0;
+
+			using var request = new HttpRequestMessage(HttpMethod.Post, targetUrl)
+			{
+				Content = new StreamContent(buffer) // seekable — SocketsHttpHandler can replay on retry
+			};
 			_ = request.Content.Headers.TryAddWithoutValidation("Content-Type", contentType);
 
 			using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseContentRead, ctx);

--- a/src/api/Elastic.Documentation.Api/Telemetry/AdotOtlpService.cs
+++ b/src/api/Elastic.Documentation.Api/Telemetry/AdotOtlpService.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using System.Net.Sockets;
 using Microsoft.Extensions.Logging;
 
@@ -18,6 +19,10 @@ public class AdotOtlpService(
 {
 	public const string HttpClientName = "OtlpProxy";
 	private static readonly ActivitySource ActivitySource = new(TelemetryConstants.OtlpProxySourceName);
+	private static readonly Meter Meter = new(TelemetryConstants.OtlpProxySourceName);
+	internal static readonly Counter<int> StaleConnectionDrops =
+		Meter.CreateCounter<int>("otlp.proxy.stale_connection.dropped",
+			description: "OTLP batches silently dropped due to a stale pooled connection to the ADOT collector");
 	private readonly HttpClient _httpClient = httpClientFactory.CreateClient(HttpClientName);
 
 	/// <inheritdoc />
@@ -34,17 +39,8 @@ public class AdotOtlpService(
 			var targetUrl = $"{options.Endpoint.TrimEnd('/')}/v1/{signalType.ToStringFast(true)}";
 			logger.LogDebug("Forwarding OTLP {SignalType} to ADOT collector at {TargetUrl}", signalType, targetUrl);
 
-			// Buffer the body so SocketsHttpHandler's transparent connection retry can replay it.
-			// The raw request body is forward-only; a stale pooled connection to the localhost
-			// collector triggers a silent resend that otherwise throws "stream was already consumed".
-			using var buffer = new MemoryStream();
-			await requestBody.CopyToAsync(buffer, ctx);
-			buffer.Position = 0;
-
-			using var request = new HttpRequestMessage(HttpMethod.Post, targetUrl)
-			{
-				Content = new StreamContent(buffer) // seekable — SocketsHttpHandler can replay on retry
-			};
+			using var request = new HttpRequestMessage(HttpMethod.Post, targetUrl);
+			request.Content = new StreamContent(requestBody);
 			_ = request.Content.Headers.TryAddWithoutValidation("Content-Type", contentType);
 
 			using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseContentRead, ctx);
@@ -71,12 +67,14 @@ public class AdotOtlpService(
 		catch (Exception ex)
 		{
 			var (statusCode, message) = MapExceptionToStatusCode(ex);
-			logger.LogError(ex, "Error forwarding OTLP {SignalType}: {ErrorMessage}", signalType, message);
-			return new OtlpForwardResult
+			if (statusCode == 204)
 			{
-				StatusCode = statusCode,
-				Content = message
-			};
+				StaleConnectionDrops.Add(1);
+				logger.LogDebug("Dropped OTLP {SignalType} batch on stale connection; collector will reconnect", signalType);
+			}
+			else
+				logger.LogError(ex, "Error forwarding OTLP {SignalType}: {ErrorMessage}", signalType, message);
+			return new OtlpForwardResult { StatusCode = statusCode, Content = message };
 		}
 	}
 
@@ -93,6 +91,12 @@ public class AdotOtlpService(
 
 			TaskCanceledException or OperationCanceledException
 				=> (504, "Request to telemetry collector timed out"),
+
+			// Stale pooled connection — SocketsHttpHandler sets AllowRetry=false for non-seekable
+			// StreamContent, so it throws rather than retrying. OTLP is best-effort; return 204
+			// so the browser exporter doesn't treat this as a retryable 502.
+			HttpRequestException { InnerException: IOException }
+				=> (204, string.Empty),
 
 			// Other HTTP/network errors - bad gateway
 			HttpRequestException

--- a/tests/Elastic.Documentation.Api.Tests/OtlpProxyTests.cs
+++ b/tests/Elastic.Documentation.Api.Tests/OtlpProxyTests.cs
@@ -306,29 +306,21 @@ public class OtlpProxyTests
 	}
 
 	[Fact]
-	public async Task OtlpProxy_StaleConnectionRetry_DoesNotThrow()
+	public async Task OtlpProxy_SendAsyncThrows_MapsToGatewayError()
 	{
-		// Arrange: first call fails with a stale-connection-style error; second succeeds.
-		// This simulates SocketsHttpHandler's transparent retry when a pooled keep-alive
-		// connection has been closed by the server. With a non-seekable StreamContent the
-		// retry would throw "stream was already consumed"; with a buffered MemoryStream it
-		// must succeed.
+		// SocketsHttpHandler's transparent stale-connection retry happens below the
+		// HttpMessageHandler mock layer and cannot be exercised here. This test verifies
+		// the adjacent property: when SendAsync throws HttpRequestException the service
+		// handles it gracefully (no InvalidOperationException escapes, exactly one attempt
+		// is made, and the error is mapped to 502).
 		var callCount = 0;
 		var mockHandler = A.Fake<HttpMessageHandler>();
 
 		A.CallTo(mockHandler)
 			.Where(call => call.Method.Name == "SendAsync")
 			.WithReturnType<Task<HttpResponseMessage>>()
-			.ReturnsLazily((HttpRequestMessage _, CancellationToken _) =>
-			{
-				callCount++;
-				if (callCount == 1)
-					throw new HttpRequestException("Connection reset (stale pooled connection)");
-				return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-				{
-					Content = new StringContent("{}")
-				});
-			});
+			.Invokes((HttpRequestMessage _, CancellationToken _) => callCount++)
+			.Throws(new HttpRequestException("Connection reset (stale pooled connection)"));
 
 		using var factory = ApiWebApplicationFactory.WithMockedServices(services =>
 		{
@@ -339,14 +331,10 @@ public class OtlpProxyTests
 		var client = factory.CreateClient();
 		using var content = new StringContent(/*lang=json,strict*/ """{"resourceSpans":[]}""", Encoding.UTF8, "application/json");
 
-		// Act — should not throw; the buffered body is replayable
 		using var response = await client.PostAsync("/docs/_api/v1/o/t", content, TestContext.Current.CancellationToken);
 
-		// First attempt threw HttpRequestException → mapped to 502 by the service.
-		// The retry here is at the application level (service catches the exception);
-		// the point is no InvalidOperationException escapes.
-		response.StatusCode.Should().BeOneOf(HttpStatusCode.NoContent, HttpStatusCode.BadGateway);
-		callCount.Should().BeGreaterThan(0);
+		callCount.Should().Be(1);
+		response.StatusCode.Should().Be(HttpStatusCode.BadGateway);
 	}
 
 	[Fact]

--- a/tests/Elastic.Documentation.Api.Tests/OtlpProxyTests.cs
+++ b/tests/Elastic.Documentation.Api.Tests/OtlpProxyTests.cs
@@ -290,7 +290,7 @@ public class OtlpProxyTests
 		}, otlpEndpoint: OtlpEndpoint);
 
 		var client = factory.CreateClient();
-		var originalPayload = Encoding.UTF8.GetBytes("""{"resourceSpans":[]}""");
+		var originalPayload = Encoding.UTF8.GetBytes(/*lang=json,strict*/ """{"resourceSpans":[]}""");
 		using var content = new ByteArrayContent(originalPayload);
 		content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
 
@@ -337,7 +337,7 @@ public class OtlpProxyTests
 		}, otlpEndpoint: OtlpEndpoint);
 
 		var client = factory.CreateClient();
-		using var content = new StringContent("""{"resourceSpans":[]}""", Encoding.UTF8, "application/json");
+		using var content = new StringContent(/*lang=json,strict*/ """{"resourceSpans":[]}""", Encoding.UTF8, "application/json");
 
 		// Act — should not throw; the buffered body is replayable
 		using var response = await client.PostAsync("/docs/_api/v1/o/t", content, TestContext.Current.CancellationToken);

--- a/tests/Elastic.Documentation.Api.Tests/OtlpProxyTests.cs
+++ b/tests/Elastic.Documentation.Api.Tests/OtlpProxyTests.cs
@@ -306,13 +306,8 @@ public class OtlpProxyTests
 	}
 
 	[Fact]
-	public async Task OtlpProxy_SendAsyncThrows_MapsToGatewayError()
+	public async Task OtlpProxy_SendAsyncThrowsNonIo_MapsToGatewayError()
 	{
-		// SocketsHttpHandler's transparent stale-connection retry happens below the
-		// HttpMessageHandler mock layer and cannot be exercised here. This test verifies
-		// the adjacent property: when SendAsync throws HttpRequestException the service
-		// handles it gracefully (no InvalidOperationException escapes, exactly one attempt
-		// is made, and the error is mapped to 502).
 		var callCount = 0;
 		var mockHandler = A.Fake<HttpMessageHandler>();
 
@@ -320,7 +315,7 @@ public class OtlpProxyTests
 			.Where(call => call.Method.Name == "SendAsync")
 			.WithReturnType<Task<HttpResponseMessage>>()
 			.Invokes((HttpRequestMessage _, CancellationToken _) => callCount++)
-			.Throws(new HttpRequestException("Connection reset (stale pooled connection)"));
+			.Throws(new HttpRequestException("Some non-IO network error"));
 
 		using var factory = ApiWebApplicationFactory.WithMockedServices(services =>
 		{
@@ -335,6 +330,34 @@ public class OtlpProxyTests
 
 		callCount.Should().Be(1);
 		response.StatusCode.Should().Be(HttpStatusCode.BadGateway);
+	}
+
+	[Fact]
+	public async Task OtlpProxy_StaleConnection_DropsWithNoContent()
+	{
+		// SocketsHttpHandler detects a stale pooled connection and throws
+		// HttpRequestException { InnerException: IOException } (AllowRetry=false on non-seekable
+		// StreamContent). The proxy maps this to 204 so the browser OTLP exporter doesn't
+		// interpret it as a retryable 502.
+		var mockHandler = A.Fake<HttpMessageHandler>();
+
+		A.CallTo(mockHandler)
+			.Where(call => call.Method.Name == "SendAsync")
+			.WithReturnType<Task<HttpResponseMessage>>()
+			.Throws(new HttpRequestException("Stale connection", new IOException("Connection reset by peer")));
+
+		using var factory = ApiWebApplicationFactory.WithMockedServices(services =>
+		{
+			_ = services.AddHttpClient(AdotOtlpService.HttpClientName)
+				.ConfigurePrimaryHttpMessageHandler(() => mockHandler);
+		}, otlpEndpoint: OtlpEndpoint);
+
+		var client = factory.CreateClient();
+		using var content = new StringContent(/*lang=json,strict*/ """{"resourceSpans":[]}""", Encoding.UTF8, "application/json");
+
+		using var response = await client.PostAsync("/docs/_api/v1/o/t", content, TestContext.Current.CancellationToken);
+
+		response.StatusCode.Should().Be(HttpStatusCode.NoContent);
 	}
 
 	[Fact]

--- a/tests/Elastic.Documentation.Api.Tests/OtlpProxyTests.cs
+++ b/tests/Elastic.Documentation.Api.Tests/OtlpProxyTests.cs
@@ -265,6 +265,91 @@ public class OtlpProxyTests
 	}
 
 	[Fact]
+	public async Task OtlpProxy_ForwardedBodyMatchesInput()
+	{
+		// Arrange
+		var mockHandler = A.Fake<HttpMessageHandler>();
+		var capturedBody = (byte[]?)null;
+
+		var mockResponse = new HttpResponseMessage(HttpStatusCode.OK)
+		{
+			Content = new StringContent("{}")
+		};
+
+		A.CallTo(mockHandler)
+			.Where(call => call.Method.Name == "SendAsync")
+			.WithReturnType<Task<HttpResponseMessage>>()
+			.Invokes(async (HttpRequestMessage req, CancellationToken ct) =>
+				capturedBody = await req.Content!.ReadAsByteArrayAsync(ct))
+			.Returns(Task.FromResult(mockResponse));
+
+		using var factory = ApiWebApplicationFactory.WithMockedServices(services =>
+		{
+			_ = services.AddHttpClient(AdotOtlpService.HttpClientName)
+				.ConfigurePrimaryHttpMessageHandler(() => mockHandler);
+		}, otlpEndpoint: OtlpEndpoint);
+
+		var client = factory.CreateClient();
+		var originalPayload = Encoding.UTF8.GetBytes("""{"resourceSpans":[]}""");
+		using var content = new ByteArrayContent(originalPayload);
+		content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
+
+		// Act
+		using var response = await client.PostAsync("/docs/_api/v1/o/t", content, TestContext.Current.CancellationToken);
+
+		// Assert — bytes arriving at the collector must exactly match the original payload
+		response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+		capturedBody.Should().NotBeNull();
+		capturedBody.Should().BeEquivalentTo(originalPayload);
+
+		mockResponse.Dispose();
+	}
+
+	[Fact]
+	public async Task OtlpProxy_StaleConnectionRetry_DoesNotThrow()
+	{
+		// Arrange: first call fails with a stale-connection-style error; second succeeds.
+		// This simulates SocketsHttpHandler's transparent retry when a pooled keep-alive
+		// connection has been closed by the server. With a non-seekable StreamContent the
+		// retry would throw "stream was already consumed"; with a buffered MemoryStream it
+		// must succeed.
+		var callCount = 0;
+		var mockHandler = A.Fake<HttpMessageHandler>();
+
+		A.CallTo(mockHandler)
+			.Where(call => call.Method.Name == "SendAsync")
+			.WithReturnType<Task<HttpResponseMessage>>()
+			.ReturnsLazily((HttpRequestMessage _, CancellationToken _) =>
+			{
+				callCount++;
+				if (callCount == 1)
+					throw new HttpRequestException("Connection reset (stale pooled connection)");
+				return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+				{
+					Content = new StringContent("{}")
+				});
+			});
+
+		using var factory = ApiWebApplicationFactory.WithMockedServices(services =>
+		{
+			_ = services.AddHttpClient(AdotOtlpService.HttpClientName)
+				.ConfigurePrimaryHttpMessageHandler(() => mockHandler);
+		}, otlpEndpoint: OtlpEndpoint);
+
+		var client = factory.CreateClient();
+		using var content = new StringContent("""{"resourceSpans":[]}""", Encoding.UTF8, "application/json");
+
+		// Act — should not throw; the buffered body is replayable
+		using var response = await client.PostAsync("/docs/_api/v1/o/t", content, TestContext.Current.CancellationToken);
+
+		// First attempt threw HttpRequestException → mapped to 502 by the service.
+		// The retry here is at the application level (service catches the exception);
+		// the point is no InvalidOperationException escapes.
+		response.StatusCode.Should().BeOneOf(HttpStatusCode.NoContent, HttpStatusCode.BadGateway);
+		callCount.Should().BeGreaterThan(0);
+	}
+
+	[Fact]
 	public async Task OtlpProxyInvalidSignalTypeReturns404()
 	{
 		// Arrange


### PR DESCRIPTION
## Why

`AdotOtlpService` was wrapping `context.Request.Body` directly in `StreamContent`. `SocketsHttpHandler` has a built-in transparent connection retry (`SendWithVersionDetectionAndRetryAsync`) that fires when it picks a stale pooled keep-alive connection. For a non-seekable stream, `StreamContent.AllowRetry` returns `false`, so `SocketsHttpHandler` skips the transparent retry and throws `HttpRequestException` wrapping an `IOException`. The existing `catch` handles this, but it was returning 502 — which the browser OTLP exporter interprets as "please retry", defeating fire-and-forget semantics. The noisy error logs were also misleading.

## What

Three small changes:

- **`PooledConnectionLifetime = 30s`** on the `SocketsHttpHandler` — proactively recycles connections before the sidecar can close them, making stale connections extremely rare.
- **Map `HttpRequestException { InnerException: IOException }` → 204** — a silent drop. The browser exporter sees 204 (success) and moves on rather than retrying.
- **`otlp.proxy.stale_connection.dropped` counter** — emitted on every silent drop so the rate is observable.