### PR TITLE
[DOCS] Add details about regenerating CLI schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,14 @@ dotnet format                                   # auto-fix C# formatting
 dotnet test tests/Elastic.Markdown.Tests/       # single test project
 ```
 
+**CLI changes:** after editing `src/tooling/docs-builder/Commands/`, regenerate `docs/cli-schema.json`:
+
+```bash
+dotnet run --project src/tooling/docs-builder -- __schema > docs/cli-schema.json
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md#cli-reference-maintenance) for supplemental CLI docs under `docs/cli/`.
+
 ### TypeScript frontend
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,18 @@ Markdown files are refreshed automatically through livereload
 
 Code or layout changes will relaunch the server automatically
 
+## CLI reference maintenance
+
+When you add or change CLI options in `src/tooling/docs-builder/Commands/`, regenerate the checked-in schema so CI and the published CLI reference stay in sync:
+
+```bash
+dotnet run --project src/tooling/docs-builder -- __schema > docs/cli-schema.json
+```
+
+Commit the updated `docs/cli-schema.json` with your code changes. CI compares the schema (ignoring the `version` field) and fails if it has drifted.
+
+The schema drives auto-generated parameter tables and usage synopses on CLI reference pages. For behavior, workflows, and examples that the schema cannot express, also update supplemental files under `docs/cli/` (see [Writing supplemental content](docs/cli/cli-supplemental-docs.md)).
+
 # Release Process
 
 This section outlines the process for releasing a new version of this project.

--- a/docs/cli/cli-reference-how-to.md
+++ b/docs/cli/cli-reference-how-to.md
@@ -28,6 +28,16 @@ my-tool export-schema > docs/cli-schema.json
 
 Commit that file. It is the source of truth for the generated reference section.
 
+:::{note}
+**Maintaining docs-builder itself:** after changing CLI options in `src/tooling/docs-builder/Commands/`, regenerate this repository's schema with:
+
+```bash
+dotnet run --project src/tooling/docs-builder -- __schema > docs/cli-schema.json
+```
+
+Commit the updated file with your code changes. See [CONTRIBUTING.md](https://github.com/elastic/docs-builder/blob/main/CONTRIBUTING.md#cli-reference-maintenance) for the full workflow, including when to update supplemental files under `docs/cli/`.
+:::
+
 :::{tip}
 Add a CI step that regenerates the schema and fails if the checked-in copy has drifted:
 


### PR DESCRIPTION
While working on https://github.com/elastic/docs-builder/pull/3513 I noticed that the new command options were not automatically added to the CLI schema and there weren't obvious instructions for doing so.

This PR makes the steps more explicit.

## AI summary

1. [`CONTRIBUTING.md`](CONTRIBUTING.md)
Added **CLI reference maintenance** after the watch section:
    - Regen command: `dotnet run --project src/tooling/docs-builder -- __schema > docs/cli-schema.json`
    - CI drift check note (`version` field ignored)
    - Pointer to supplemental docs in `docs/cli/`

2. [`docs/cli/cli-reference-how-to.md`](docs/cli/cli-reference-how-to.md)
Added a **Maintaining docs-builder itself** note in step 1 with the same regen command and a link to CONTRIBUTING.

3. [`AGENTS.md`](AGENTS.md) and [`CLAUDE.md`](CLAUDE.md)
Added a **CLI changes** bullet under Essential Commands with the regen command and CONTRIBUTING link. `CLAUDE.md` already matched (likely kept in sync with `AGENTS.md`).


## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: composer-2.5-fast