### PR TITLE
Codex: sort landing sections alphabetically and redesign cards

### DIFF
--- a/src/Elastic.Codex/Group/GroupLandingView.cshtml
+++ b/src/Elastic.Codex/Group/GroupLandingView.cshtml
@@ -25,7 +25,8 @@
 				Title = docSet.Title ?? docSet.Name,
 				Description = docSet.Description,
 				Icon = docSet.Icon,
-				PageCount = docSet.PageCount
+				PageCount = docSet.PageCount,
+				RepoPath = $"/r/{docSet.Name}"
 			})))
 		}
 	</div>

--- a/src/Elastic.Codex/Group/GroupLandingView.cshtml
+++ b/src/Elastic.Codex/Group/GroupLandingView.cshtml
@@ -19,15 +19,7 @@
 	<div id="codex-grid" class="pt-8 max-w-7xl mx-auto grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
 		@foreach (var docSet in Model.DocumentationSets.OrderBy(ds => ds.Title))
 		{
-			@(await RenderPartialAsync(_CodexCard.Create(new CodexCardModel
-			{
-				Url = docSet.Url,
-				Title = docSet.Title ?? docSet.Name,
-				Description = docSet.Description,
-				Icon = docSet.Icon,
-				PageCount = docSet.PageCount,
-				RepoPath = $"/r/{docSet.Name}"
-			})))
+			@(await RenderPartialAsync(_CodexCard.Create(CodexCardModel.FromDocumentationSet(docSet))))
 		}
 	</div>
 </section>

--- a/src/Elastic.Codex/Landing/CodexCardModel.cs
+++ b/src/Elastic.Codex/Landing/CodexCardModel.cs
@@ -14,4 +14,10 @@ public record CodexCardModel
 	public string? Description { get; init; }
 	public string? Icon { get; init; }
 	public int PageCount { get; init; }
+
+	/// <summary>
+	/// The repo path (e.g. "/r/beacon") shown on docset cards so it is findable via browser ctrl+F. Null for group cards.
+	/// </summary>
+	public string? RepoPath { get; init; }
+
 }

--- a/src/Elastic.Codex/Landing/CodexCardModel.cs
+++ b/src/Elastic.Codex/Landing/CodexCardModel.cs
@@ -2,6 +2,8 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using Elastic.Codex.Navigation;
+
 namespace Elastic.Codex.Landing;
 
 /// <summary>
@@ -20,4 +22,16 @@ public record CodexCardModel
 	/// </summary>
 	public string? RepoPath { get; init; }
 
+	/// <summary>
+	/// Builds the card model for a documentation set, so every docset card renders the same fields.
+	/// </summary>
+	public static CodexCardModel FromDocumentationSet(CodexDocumentationSetInfo docSet) => new()
+	{
+		Url = docSet.Url,
+		Title = docSet.Title ?? docSet.Name,
+		Description = docSet.Description,
+		Icon = docSet.Icon,
+		PageCount = docSet.PageCount,
+		RepoPath = docSet.RepoPath,
+	};
 }

--- a/src/Elastic.Codex/Landing/LandingView.cshtml
+++ b/src/Elastic.Codex/Landing/LandingView.cshtml
@@ -123,28 +123,67 @@
 		</div>
 	</div>
 
+	@{
+		var sortedSections = Model.Groups
+			.Select(g => (sortKey: g.DisplayTitle, group: (GroupNavigation?)g, docSet: (CodexDocumentationSetInfo?)null))
+			.Concat(Model.UngroupedDocumentationSets
+				.Select(ds => (sortKey: ds.Title ?? ds.Name, group: (GroupNavigation?)null, docSet: (CodexDocumentationSetInfo?)ds)))
+			.OrderBy(x => x.sortKey, StringComparer.OrdinalIgnoreCase)
+			.ToList();
+	}
 	<div id="codex-grid" class="pt-8 pb-8 max-w-7xl p-4 mx-auto grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4" style="position: relative; z-index: 1;">
-		@foreach (var group in Model.Groups)
+		@foreach (var item in sortedSections)
 		{
-			@(await RenderPartialAsync(_CodexCard.Create(new CodexCardModel
+			@if (item.group is { } group)
 			{
-				Url = group.Url,
-				Title = group.DisplayTitle,
-				Description = group.Description,
-				Icon = group.Icon,
-				PageCount = group.DocumentationSetInfos.Sum(ds => ds.PageCount)
-			})))
-		}
-		@foreach (var docSet in Model.UngroupedDocumentationSets)
-		{
-			@(await RenderPartialAsync(_CodexCard.Create(new CodexCardModel
+				var repoCount = group.DocumentationSetInfos.Count;
+				var colSpan = repoCount >= 5 || repoCount == 3 ? "col-span-full" : repoCount >= 2 ? "col-span-1 md:col-span-2" : "col-span-1";
+				var innerCols = repoCount >= 5 || repoCount == 3 ? "grid-cols-1 md:grid-cols-2 lg:grid-cols-3" : repoCount >= 2 ? "grid-cols-1 md:grid-cols-2" : "grid-cols-1";
+				<div class="@colSpan border border-dashed border-grey-40 rounded-xl p-3">
+					<a href="@group.Url"
+					   hx-select-oob="#main-container"
+					   preload="mousedown"
+					   class="flex items-center gap-3 group bg-white docset-card rounded-lg border border-grey-20 p-4 mb-3 hover:border-blue-elastic-90 hover:bg-blue-elastic-10 transition-colors">
+						<div class="docset-icon text-blue-elastic-90 bg-blue-elastic-10 group-hover:bg-blue-elastic-20 rounded-lg p-3 shrink-0">
+							@GetIconSvg(group.Icon, "w-6 h-6 fill-current")
+						</div>
+						<div>
+							<div class="text-sm font-semibold group-hover:text-blue-elastic-90 transition-colors">@group.DisplayTitle</div>
+							<div class="text-xs text-subdued font-mono mt-0.5">/g/@group.GroupSlug</div>
+							@if (!string.IsNullOrEmpty(group.Description))
+							{
+								<p class="text-xs text-subdued mt-0.5">@group.Description</p>
+							}
+						</div>
+					</a>
+					<div class="grid @innerCols gap-3">
+						@foreach (var docSet in group.DocumentationSetInfos.OrderBy(ds => ds.Title))
+						{
+							@(await RenderPartialAsync(_CodexCard.Create(new CodexCardModel
+							{
+								Url = docSet.Url,
+								Title = docSet.Title ?? docSet.Name,
+								Description = docSet.Description,
+								Icon = docSet.Icon,
+								PageCount = docSet.PageCount,
+								RepoPath = $"/r/{docSet.Name}"
+							})))
+						}
+					</div>
+				</div>
+			}
+			else if (item.docSet is { } docSet)
 			{
-				Url = docSet.Url,
-				Title = docSet.Title ?? docSet.Name,
-				Description = docSet.Description,
-				Icon = docSet.Icon,
-				PageCount = docSet.PageCount
-			})))
+				@(await RenderPartialAsync(_CodexCard.Create(new CodexCardModel
+				{
+					Url = docSet.Url,
+					Title = docSet.Title ?? docSet.Name,
+					Description = docSet.Description,
+					Icon = docSet.Icon,
+					PageCount = docSet.PageCount,
+					RepoPath = $"/r/{docSet.Name}"
+				})))
+			}
 		}
 	</div>
 </section>

--- a/src/Elastic.Codex/Landing/LandingView.cshtml
+++ b/src/Elastic.Codex/Landing/LandingView.cshtml
@@ -159,30 +159,14 @@
 					<div class="grid @innerCols gap-3">
 						@foreach (var docSet in group.DocumentationSetInfos.OrderBy(ds => ds.Title))
 						{
-							@(await RenderPartialAsync(_CodexCard.Create(new CodexCardModel
-							{
-								Url = docSet.Url,
-								Title = docSet.Title ?? docSet.Name,
-								Description = docSet.Description,
-								Icon = docSet.Icon,
-								PageCount = docSet.PageCount,
-								RepoPath = $"/r/{docSet.Name}"
-							})))
+							@(await RenderPartialAsync(_CodexCard.Create(CodexCardModel.FromDocumentationSet(docSet))))
 						}
 					</div>
 				</div>
 			}
 			else if (item.docSet is { } docSet)
 			{
-				@(await RenderPartialAsync(_CodexCard.Create(new CodexCardModel
-				{
-					Url = docSet.Url,
-					Title = docSet.Title ?? docSet.Name,
-					Description = docSet.Description,
-					Icon = docSet.Icon,
-					PageCount = docSet.PageCount,
-					RepoPath = $"/r/{docSet.Name}"
-				})))
+				@(await RenderPartialAsync(_CodexCard.Create(CodexCardModel.FromDocumentationSet(docSet))))
 			}
 		}
 	</div>

--- a/src/Elastic.Codex/Landing/_CodexCard.cshtml
+++ b/src/Elastic.Codex/Landing/_CodexCard.cshtml
@@ -11,25 +11,25 @@
 <a href="@(Model.Url)"
    hx-select-oob="#main-container"
    preload="mousedown"
-   class="flex flex-col group bg-white docset-card rounded-lg border p-6 border-grey-20 hover:border-blue-elastic-90"
+   class="flex flex-col group bg-white docset-card rounded-lg border p-4 border-grey-20 hover:border-blue-elastic-90 hover:bg-blue-elastic-10 transition-colors"
    >
-	<div class="flex justify-between items-center">
-		<div class="docset-icon text-blue-elastic-90 bg-blue-elastic-10 group-hover:bg-blue-elastic-20 rounded-md p-2">
-			@GetIconSvg(Model.Icon, "w-6 h-6 fill-current")
+	<div class="flex items-start gap-3">
+		<div class="docset-icon text-blue-elastic-90 bg-blue-elastic-10 group-hover:bg-blue-elastic-20 rounded-md p-1.5 shrink-0">
+			@GetIconSvg(Model.Icon, "w-4 h-4 fill-current")
+		</div>
+		<div class="min-w-0">
+			<div class="text-sm font-medium group-hover:text-blue-elastic-90 leading-tight">@Model.Title</div>
+			@if (!string.IsNullOrEmpty(Model.RepoPath))
+			{
+				<div class="text-xs text-subdued font-mono mt-0.5">@Model.RepoPath</div>
+			}
 		</div>
 	</div>
-	<div class="pt-8 text-xl font-medium group-hover:text-blue-elastic-90">
-		@Model.Title
-	</div>
-	<div class="grow">
-		@if (!string.IsNullOrEmpty(Model.Description))
-		{
-			<div class="pt-8 text-sm text-subdued">
-				@Model.Description
-			</div>
-		}
-	</div>
-	<div class="pt-8 text-xs text-subdued flex items-center gap-1">
+	@if (!string.IsNullOrEmpty(Model.Description))
+	{
+		<div class="mt-3 text-xs text-subdued line-clamp-2">@Model.Description</div>
+	}
+	<div class="mt-auto pt-3 text-xs text-subdued flex items-center gap-1">
 		@GetIconSvg("documents", "fill-current size-3") <span>@Model.PageCount pages</span>
 	</div>
 </a>

--- a/src/Elastic.Codex/Navigation/CodexIndexPage.cs
+++ b/src/Elastic.Codex/Navigation/CodexIndexPage.cs
@@ -39,6 +39,11 @@ public record CodexDocumentationSetInfo
 	public required string Url { get; init; }
 
 	/// <summary>
+	/// The repo-scoped path segment (e.g. "/r/beacon"), derived from <see cref="Name"/>.
+	/// </summary>
+	public string RepoPath => $"/r/{Name}";
+
+	/// <summary>
 	/// The group id this documentation set belongs to, if any.
 	/// </summary>
 	public string? Group { get; init; }

--- a/src/Elastic.Codex/Navigation/CodexNavigation.cs
+++ b/src/Elastic.Codex/Navigation/CodexNavigation.cs
@@ -97,14 +97,13 @@ public class CodexNavigation : IRootNavigationItem<IDocumentationFile, INavigati
 			if (docSetNav is not IRootNavigationItem<IDocumentationFile, INavigationItem> rootNavItem)
 				return;
 
-			var pathPrefix = $"{codex.Url}/r/{repoName}";
 			var docSetInfo = CreateDocumentationSetInfo(docSetRef, rootNavItem, repoName);
 			_docSetInfos.Add(docSetInfo);
 
 			if (!string.IsNullOrEmpty(docSetRef.Group))
-				AttachToGroup(docSetRef, docSetNav, rootNavItem, pathPrefix, docSetInfo);
+				AttachToGroup(docSetRef, docSetNav, rootNavItem, docSetInfo.Url, docSetInfo);
 			else
-				AttachToCodexRoot(docSetNav, rootNavItem, pathPrefix);
+				AttachToCodexRoot(docSetNav, rootNavItem, docSetInfo.Url);
 		}
 
 		private CodexDocumentationSetInfo CreateDocumentationSetInfo(


### PR DESCRIPTION
## Why

The codex landing page listed groups first, then ungrouped doc sets — in whatever order the config defined them. Users had no way to predict where a doc set would appear. Cards were also oversized and lacked a machine-readable path, making ctrl+F searches unreliable.

## What

- Groups and ungrouped doc sets are now sorted together alphabetically by title, so the grid order is consistent and predictable.
- Group cards expand into a header + inner grid: the group title/description/icon appears at the top, and each of its doc sets is shown as a compact card below, with adaptive column spanning (1, 2, or 3 cols) based on how many repos the group contains.
- Doc set cards are more compact: smaller icon, tighter padding, description clamped to 2 lines.
- A `RepoPath` (e.g. `/r/beacon`) is now rendered in monospace below each card title, so users can find a doc set with browser ctrl+F using its URL path.

## Screenshot

<img width="1140" height="846" alt="image" src="https://github.com/user-attachments/assets/9acb8437-1013-4c73-9322-7d7c35fa0449" />
