### PR TITLE
fix(stepper): skip headings inside steps when calculating next step heading level

### DIFF
--- a/docs/syntax/stepper.md
+++ b/docs/syntax/stepper.md
@@ -224,3 +224,54 @@ Content here...
 ## Dynamic heading levels
 
 Stepper step titles automatically adjust their heading level based on the preceding heading in the document, ensuring proper document hierarchy and semantic structure.
+
+For example, a stepper that follows an `##` heading renders each step title as `###`.
+
+### Headings inside steps
+
+You can add sub-headings inside a step to organise longer content. Each heading must be **at least one level deeper** than the step's rendered level. If you write a heading at the same level as the step (or higher), the build automatically adjusts it to the correct level and emits a hint diagnostic pointing to the offending line.
+
+The following example intentionally uses the wrong heading level to demonstrate the auto-correction. This stepper follows a `###` heading, so its steps render as `####`. The `####` sub-heading inside the step is at the same level as the step itself — it is auto-adjusted to `#####` and a hint is emitted:
+
+```
+HINT: Heading level h4 inside a step renders at the same or higher level as the step itself (h4).
+      It has been adjusted to h5 — write it as '#####' to avoid this hint.
+```
+
+:::::::{tab-set}
+::::::{tab-item} Output
+:::::{stepper}
+
+::::{step} Configure
+#### Advanced options
+
+These options override the defaults.
+::::
+
+:::::
+::::::
+
+::::::{tab-item} Markdown
+````markdown
+:::::{stepper}
+
+::::{step} Configure
+#### Advanced options
+
+These options override the defaults.
+::::
+
+:::::
+````
+::::::
+:::::::
+
+To suppress the hint, write the heading at the correct level from the start:
+
+```markdown
+::::{step} Configure
+##### Advanced options
+
+These options override the defaults.
+::::
+```

--- a/src/Elastic.Markdown/Myst/Directives/Stepper/StepperBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Stepper/StepperBlock.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using Elastic.Documentation.Diagnostics;
 using Elastic.Markdown.Helpers;
 using Markdig.Syntax;
 
@@ -13,6 +14,89 @@ public class StepperBlock(DirectiveBlockParser parser, ParserContext context) : 
 
 	public override void FinalizeAndValidate(ParserContext context)
 	{
+		// Calculate the heading level once for the whole stepper and push it to every child
+		// step. All steps share the same preceding-heading context, so there is no need for
+		// each StepBlock to walk the document independently.
+		var stepLevel = CalculatePrecedingHeadingLevel();
+		foreach (var step in this.OfType<StepBlock>())
+		{
+			step.HeadingLevel = stepLevel;
+			AdjustInternalHeadings(step, stepLevel);
+		}
+	}
+
+	// Headings inside a step must be subordinate to the step's own rendered level.
+	// If the author wrote a heading at the same level or higher, adjust it and emit a hint
+	// so they know what level to use in the source.
+	private void AdjustInternalHeadings(StepBlock step, int stepLevel)
+	{
+		var adjusted = System.Math.Min(stepLevel + 1, 6);
+		foreach (var heading in step.Descendants<HeadingBlock>())
+		{
+			// Headings inside a nested StepBlock are handled by that stepper's own
+			// FinalizeAndValidate — skip them here to avoid double-adjustment.
+			if (IsInsideNestedStep(heading, step))
+				continue;
+
+			if (heading.Level > stepLevel)
+				continue;
+
+			if (SkipValidation)
+			{
+				heading.Level = adjusted;
+				continue;
+			}
+
+			var hashes = new string('#', adjusted);
+			Build.Collector.Write(new Diagnostic
+			{
+				Severity = Severity.Hint,
+				File = CurrentFile.FullName,
+				Line = heading.Line + 1,
+				Column = heading.Column,
+				Length = heading.Level,
+				Message = $"Heading level h{heading.Level} inside a step renders at the same or higher level as the step itself (h{stepLevel}). " +
+						  $"It has been adjusted to h{adjusted} — write it as '{hashes}' to avoid this hint."
+			});
+			heading.Level = adjusted;
+		}
+	}
+
+	private static bool IsInsideNestedStep(Block block, StepBlock outerStep)
+	{
+		var parent = block.Parent;
+		while (parent != null && parent != outerStep)
+		{
+			if (parent is StepBlock)
+				return true;
+			parent = parent.Parent;
+		}
+		return false;
+	}
+
+	private int CalculatePrecedingHeadingLevel()
+	{
+		// Walk up to the document root so we can search the full flat block list.
+		var root = (ContainerBlock)this;
+		while (root.Parent != null)
+			root = root.Parent;
+
+		// Descendants() is pre-order: every block appears before its own children, so the
+		// stepper's index is always before any headings that live inside it. Looking backward
+		// from that index finds only document-level predecessors — no filtering needed.
+		var allBlocks = root.Descendants().ToList();
+		var stepperIndex = allBlocks.IndexOf(this);
+
+		if (stepperIndex == -1)
+			return 2;
+
+		for (var i = stepperIndex - 1; i >= 0; i--)
+		{
+			if (allBlocks[i] is HeadingBlock heading)
+				return System.Math.Min(heading.Level + 1, 6); // Cap at h6
+		}
+
+		return 2; // No preceding heading — default to h2
 	}
 }
 
@@ -21,7 +105,7 @@ public class StepBlock(DirectiveBlockParser parser, ParserContext context) : Dir
 	public override string Directive => "step";
 	public string Title { get; private set; } = string.Empty;
 	public string Anchor { get; private set; } = string.Empty;
-	public int HeadingLevel { get; private set; } = 3; // Default to h3
+	public int HeadingLevel { get; internal set; } = 2; // Set by parent StepperBlock.FinalizeAndValidate
 
 	public override void FinalizeAndValidate(ParserContext context)
 	{
@@ -29,41 +113,8 @@ public class StepBlock(DirectiveBlockParser parser, ParserContext context) : Dir
 
 		Anchor = Prop("anchor") ?? Title.Slugify();
 
-		// Calculate heading level based on preceding heading
-		HeadingLevel = CalculateHeadingLevel();
-
 		// Set CrossReferenceName so this step can be found by ToC generation
 		if (!string.IsNullOrEmpty(Title))
-		{
 			CrossReferenceName = Anchor;
-		}
-	}
-
-	private int CalculateHeadingLevel()
-	{
-		// Find the document root
-		var current = (ContainerBlock)this;
-		while (current.Parent != null)
-			current = current.Parent;
-
-		// Find all headings that come before this step in document order
-		var allBlocks = current.Descendants().ToList();
-		var thisIndex = allBlocks.IndexOf(this);
-
-		if (thisIndex == -1)
-			return 3; // Default fallback
-
-		// Look backwards for the most recent heading
-		for (var i = thisIndex - 1; i >= 0; i--)
-		{
-			if (allBlocks[i] is HeadingBlock heading)
-			{
-				// Step should be one level deeper than the preceding heading
-				return System.Math.Min(heading.Level + 1, 6); // Cap at h6
-			}
-		}
-
-		// No preceding heading found, default to h2 (level 2)
-		return 2;
 	}
 }

--- a/tests/Elastic.Markdown.Tests/FileInclusion/HeadingOrderTests.cs
+++ b/tests/Elastic.Markdown.Tests/FileInclusion/HeadingOrderTests.cs
@@ -849,6 +849,110 @@ Step after h2 heading.
 }
 
 /// <summary>
+/// Tests that a heading at the same level as a step is auto-adjusted to one level deeper
+/// and that a hint diagnostic is emitted pointing to the heading.
+/// </summary>
+public class StepperWithInternalHeadingAtSameLevelTests(ITestOutputHelper output) : DirectiveTest<StepperBlock>(output,
+"""
+## Section
+
+:::::{stepper}
+
+::::{step} First Step
+### Internal Heading
+
+Some content under the internal heading.
+::::
+
+::::{step} Second Step
+This step should still be at the same level as First Step.
+::::
+
+:::::
+"""
+)
+{
+	[Fact]
+	public void ParsesBlock() => Block.Should().NotBeNull();
+
+	[Fact]
+	public void InternalHeadingIsAdjustedToOneLevelDeeper()
+	{
+		var toc = File.PageTableOfContent.Values.ToList();
+
+		// Should have: Section (2), First Step (3), Internal Heading (4, adjusted), Second Step (3)
+		// The step renders at h3. The ### inside it was also h3 (invalid — same level).
+		// It is auto-adjusted to h4.
+		toc.Should().HaveCount(4);
+
+		toc[0].Heading.Should().Be("Section");
+		toc[0].Level.Should().Be(2);
+
+		toc[1].Heading.Should().Be("First Step");
+		toc[1].Level.Should().Be(3, "step is one level deeper than the preceding h2");
+		toc[1].IsStepperStep.Should().BeTrue();
+
+		toc[2].Heading.Should().Be("Internal Heading");
+		toc[2].Level.Should().Be(4, "### inside an h3 step is adjusted to h4");
+		toc[2].IsStepperStep.Should().BeFalse();
+
+		toc[3].Heading.Should().Be("Second Step");
+		toc[3].Level.Should().Be(3);
+		toc[3].IsStepperStep.Should().BeTrue();
+	}
+
+	[Fact]
+	public void HintIsEmittedForAdjustedHeading() =>
+		Collector.Diagnostics.Should().ContainSingle(d =>
+			d.Severity == Documentation.Diagnostics.Severity.Hint &&
+			d.Message.Contains("h3") &&
+			d.Message.Contains("h4") &&
+			d.Message.Contains("####"));
+}
+
+/// <summary>
+/// Tests that a heading already deeper than the step level is left untouched (no adjustment, no hint).
+/// </summary>
+public class StepperWithDeepInternalHeadingTests(ITestOutputHelper output) : DirectiveTest<StepperBlock>(output,
+"""
+## Section
+
+:::::{stepper}
+
+::::{step} First Step
+#### Deep Heading
+
+Already deeper than the step.
+::::
+
+:::::
+"""
+)
+{
+	[Fact]
+	public void ParsesBlock() => Block.Should().NotBeNull();
+
+	[Fact]
+	public void DeepHeadingIsUntouched()
+	{
+		var toc = File.PageTableOfContent.Values.ToList();
+
+		// Step renders at h3. #### is h4 — already deeper, no adjustment needed.
+		toc.Should().HaveCount(3);
+
+		toc[1].Heading.Should().Be("First Step");
+		toc[1].Level.Should().Be(3);
+
+		toc[2].Heading.Should().Be("Deep Heading");
+		toc[2].Level.Should().Be(4, "h4 inside an h3 step is already valid — no adjustment");
+	}
+
+	[Fact]
+	public void NoHintEmittedForValidHeading() =>
+		Collector.Diagnostics.Should().BeEmpty();
+}
+
+/// <summary>
 /// Tests stepper steps at the beginning of a document (no preceding heading).
 /// </summary>
 public class StepperAtDocumentStartTests(ITestOutputHelper output) : DirectiveTest<StepperBlock>(output,


### PR DESCRIPTION
## Why

When a heading is manually added inside a stepper step, two problems occur: the *next* step renders at an inferior heading level, and the internal heading itself can collide with the step's own rendered level, producing invalid document structure.

## What

All steps in a stepper share the same preceding-heading context, so the level calculation now happens once in \`StepperBlock.FinalizeAndValidate()\` and is pushed to every child step. Because \`Descendants()\` is pre-order, looking backward from the stepper's position in the flat block list naturally lands on document-level predecessors only — no extra filtering needed.

After setting each step's level, \`AdjustInternalHeadings\` walks the step's \`HeadingBlock\` descendants (skipping headings inside nested steps, which are handled by their own stepper). Any heading at a level ≤ the step's rendered level is automatically bumped to \`stepLevel + 1\`, and a \`Hint\` diagnostic is emitted at the heading's exact line telling the author what level to write instead.

Headings already deeper than the step are left untouched with no diagnostic.