### PR TITLE
Deploying: add --exclude flag to codex sync plan

### DIFF
--- a/docs/cli-schema.json
+++ b/docs/cli-schema.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "name": "docs-builder",
-  "version": "1",
+  "version": "0",
   "reservedMetaCommands": [
     "__complete",
     "__completion",
@@ -4925,6 +4925,15 @@
                   "required": false,
                   "summary": "Abort if the plan would delete more than this percentage of objects (0\u2013100).",
                   "defaultValue": "default"
+                },
+                {
+                  "role": "flag",
+                  "name": "exclude",
+                  "type": "array",
+                  "required": false,
+                  "summary": "Glob patterns to exclude from both upload and deletion (repeatable).\nFor example: --exclude \u0027_preview/*\u0027 --exclude \u0027403/*\u0027.\nMatched against the S3 key / relative path of each object.",
+                  "repeatable": true,
+                  "elementType": "string"
                 },
                 {
                   "role": "flag",

--- a/src/services/Elastic.Documentation.Deploying/Elastic.Documentation.Deploying.csproj
+++ b/src/services/Elastic.Documentation.Deploying/Elastic.Documentation.Deploying.csproj
@@ -8,6 +8,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AWSSDK.S3" />
+		<PackageReference Include="DotNet.Glob" />
 		<PackageReference Include="GitHub.Actions.Core" />
 		<PackageReference Include="Nullean.ScopedFileSystem" />
 		<PackageReference Include="Microsoft.Extensions.Logging" />

--- a/src/services/Elastic.Documentation.Deploying/IncrementalDeployService.cs
+++ b/src/services/Elastic.Documentation.Deploying/IncrementalDeployService.cs
@@ -24,10 +24,12 @@ public class IncrementalDeployService(
 	private readonly ILogger _logger = logFactory.CreateLogger<IncrementalDeployService>();
 	private readonly IAmazonS3 _s3 = s3Client ?? new AmazonS3Client();
 
-	public async Task<bool> Plan(IDiagnosticsCollector collector, IDocsSyncContext context, string s3BucketName, string @out, float? deleteThreshold, Cancel ctx)
+	public async Task<bool> Plan(IDiagnosticsCollector collector, IDocsSyncContext context, string s3BucketName, string @out, float? deleteThreshold, string[] excludePatterns, Cancel ctx)
 	{
+		if (excludePatterns.Length > 0)
+			_logger.LogInformation("Excluding patterns from sync: {ExcludePatterns}", string.Join(", ", excludePatterns));
 		var planner = new AwsS3SyncPlanStrategy(logFactory, _s3, s3BucketName, context, etagCalculator);
-		var plan = await planner.Plan(deleteThreshold, ctx);
+		var plan = await planner.Plan(deleteThreshold, excludePatterns, ctx);
 		LogPlanSummary(plan);
 		var validator = new DocsSyncPlanValidator(logFactory);
 		var validationResult = validator.Validate(plan);

--- a/src/services/Elastic.Documentation.Deploying/Synchronization/AwsS3SyncPlanStrategy.cs
+++ b/src/services/Elastic.Documentation.Deploying/Synchronization/AwsS3SyncPlanStrategy.cs
@@ -5,6 +5,7 @@
 using System.Collections.Concurrent;
 using Amazon.S3;
 using Amazon.S3.Model;
+using DotNet.Globbing;
 using Elastic.Documentation.Integrations.S3;
 using Microsoft.Extensions.Logging;
 
@@ -27,8 +28,22 @@ public class AwsS3SyncPlanStrategy(
 		return fileInfo.LinkTarget != null;
 	}
 
-	public async Task<SyncPlan> Plan(float? deleteThreshold, Cancel ctx = default)
+	private static bool IsExcluded(string destinationPath, Glob[] globs) =>
+		globs.Length > 0 && globs.Any(g => g.IsMatch(destinationPath));
+
+	/// <summary>
+	/// Normalize an exclude pattern so it behaves like <c>aws s3 sync --exclude</c>, where
+	/// <c>*</c> matches path separators (e.g. <c>_preview/*</c> matches
+	/// <c>_preview/pr-42/index.html</c>).  A trailing <c>/*</c> is expanded to <c>/**</c> so
+	/// DotNet.Glob treats it as a recursive wildcard.
+	/// </summary>
+	private static string NormalizePattern(string pattern) =>
+		pattern.EndsWith("/*", StringComparison.Ordinal) ? string.Concat(pattern.AsSpan(0, pattern.Length - 2), "/**") : pattern;
+
+	public async Task<SyncPlan> Plan(float? deleteThreshold, string[] excludePatterns, Cancel ctx = default)
 	{
+		var excludeGlobs = excludePatterns.Select(p => Glob.Parse(NormalizePattern(p))).ToArray();
+
 		// Start S3 listing in background while scanning local files concurrently
 		var listTask = ListObjects(ctx);
 		var localObjects = context.OutputDirectory.GetFiles("*", SearchOption.AllDirectories)
@@ -44,6 +59,9 @@ public class AwsS3SyncPlanStrategy(
 		{
 			var relativePath = Path.GetRelativePath(context.OutputDirectory.FullName, localFile.FullName);
 			var destinationPath = relativePath.Replace('\\', '/');
+
+			if (IsExcluded(destinationPath, excludeGlobs))
+				return;
 
 			if (remoteObjects.TryGetValue(destinationPath, out var remoteObject))
 			{
@@ -80,9 +98,11 @@ public class AwsS3SyncPlanStrategy(
 			}
 		});
 
-		// Find deletions (files in S3 but not locally)
+		// Find deletions (files in S3 but not locally), honouring excludes
 		foreach (var remoteObject in remoteObjects)
 		{
+			if (IsExcluded(remoteObject.Key, excludeGlobs))
+				continue;
 			var localPath = Path.Join(context.OutputDirectory.FullName, remoteObject.Key.Replace('/', Path.DirectorySeparatorChar));
 			if (context.ReadFileSystem.File.Exists(localPath))
 				continue;
@@ -97,6 +117,7 @@ public class AwsS3SyncPlanStrategy(
 		{
 			RemoteListingCompleted = readToCompletion,
 			DeleteThresholdDefault = deleteThreshold,
+			ExcludePatterns = excludePatterns,
 			TotalRemoteFiles = remoteObjects.Count,
 			TotalSourceFiles = localObjects.Length,
 			DeleteRequests = deleteRequests.ToList(),

--- a/src/services/Elastic.Documentation.Deploying/Synchronization/DocsSync.cs
+++ b/src/services/Elastic.Documentation.Deploying/Synchronization/DocsSync.cs
@@ -9,7 +9,7 @@ namespace Elastic.Documentation.Deploying.Synchronization;
 
 public interface IDocsSyncPlanStrategy
 {
-	Task<SyncPlan> Plan(float? deleteThreshold, Cancel ctx = default);
+	Task<SyncPlan> Plan(float? deleteThreshold, string[] excludePatterns, Cancel ctx = default);
 }
 
 public record PlanValidationResult(bool Valid, float DeleteRatio, float DeleteThreshold);
@@ -54,6 +54,10 @@ public record SyncPlan
 	/// The user-specified delete threshold
 	[JsonPropertyName("deletion_threshold_default")]
 	public required float? DeleteThresholdDefault { get; init; }
+
+	/// Glob patterns excluded from both local upload and remote deletion
+	[JsonPropertyName("exclude_patterns")]
+	public required string[] ExcludePatterns { get; init; }
 
 	/// The user-specified delete threshold
 	[JsonPropertyName("remote_listing_completed")]

--- a/src/tooling/docs-builder/Commands/Assembler/DeployCommands.cs
+++ b/src/tooling/docs-builder/Commands/Assembler/DeployCommands.cs
@@ -46,7 +46,7 @@ internal sealed class DeployCommands(
 		var context = new AssembleContext(assemblyConfiguration, configurationContext, environment, collector, FileSystemFactory.RealRead, FileSystemFactory.RealWrite, null, null);
 		var service = new IncrementalDeployService(logFactory, githubActionsService);
 		serviceInvoker.AddCommand(service, (context, s3BucketName, @out, deleteThreshold),
-			static async (s, collector, state, ctx) => await s.Plan(collector, state.context, state.s3BucketName, state.@out?.FullName ?? "", state.deleteThreshold, ctx)
+			static async (s, collector, state, ctx) => await s.Plan(collector, state.context, state.s3BucketName, state.@out?.FullName ?? "", state.deleteThreshold, [], ctx)
 		);
 		return await serviceInvoker.InvokeAsync(ct);
 	}

--- a/src/tooling/docs-builder/Commands/Codex/CodexSyncCommand.cs
+++ b/src/tooling/docs-builder/Commands/Codex/CodexSyncCommand.cs
@@ -33,6 +33,11 @@ internal sealed class CodexSyncCommand(
 	/// <param name="s3BucketName">S3 bucket to deploy to.</param>
 	/// <param name="out">Path to write the plan file. Defaults to <c>stdout</c>.</param>
 	/// <param name="deleteThreshold">Abort if the plan would delete more than this percentage of objects (0–100).</param>
+	/// <param name="exclude">
+	/// Glob patterns to exclude from both upload and deletion (repeatable).
+	/// For example: <c>--exclude '_preview/*' --exclude '403/*'</c>.
+	/// Matched against the S3 key / relative path of each object.
+	/// </param>
 	[RequiresAuth]
 	[MutationScope(MutationScope.Global)]
 	[NoOptionsInjection]
@@ -42,12 +47,14 @@ internal sealed class CodexSyncCommand(
 		string s3BucketName,
 		[ExpandUserProfile, RejectSymbolicLinks] FileInfo? @out = null,
 		float? deleteThreshold = null,
+		string[]? exclude = null,
 		CancellationToken ct = default)
 	{
 		await using var serviceInvoker = new ServiceInvoker(collector);
 		var (context, service) = LoadContext(config);
-		serviceInvoker.AddCommand(service, (context, s3BucketName, @out, deleteThreshold),
-			static async (s, collector, state, ctx) => await s.Plan(collector, state.context, state.s3BucketName, state.@out?.FullName ?? "", state.deleteThreshold, ctx)
+		var excludePatterns = exclude ?? [];
+		serviceInvoker.AddCommand(service, (context, s3BucketName, @out, deleteThreshold, excludePatterns),
+			static async (s, collector, state, ctx) => await s.Plan(collector, state.context, state.s3BucketName, state.@out?.FullName ?? "", state.deleteThreshold, state.excludePatterns, ctx)
 		);
 		return await serviceInvoker.InvokeAsync(ct);
 	}

--- a/tests-integration/Elastic.Documentation.IntegrationTests/DocsSyncTests.cs
+++ b/tests-integration/Elastic.Documentation.IntegrationTests/DocsSyncTests.cs
@@ -70,7 +70,7 @@ public class DocsSyncTests
 		var planStrategy = new AwsS3SyncPlanStrategy(new LoggerFactory(), mockS3Client, "fake", context);
 
 		// Act
-		var plan = await planStrategy.Plan(null, Cancel.None);
+		var plan = await planStrategy.Plan(null, [], Cancel.None);
 
 		// Assert
 
@@ -214,7 +214,7 @@ public class DocsSyncTests
 		var planStrategy = new AwsS3SyncPlanStrategy(new LoggerFactory(), mockS3Client, "fake", context, mockEtagCalculator);
 
 		// Act
-		var plan = await planStrategy.Plan(deleteThreshold, Cancel.None);
+		var plan = await planStrategy.Plan(deleteThreshold, [], Cancel.None);
 		var validator = new DocsSyncPlanValidator(new LoggerFactory());
 		return (validator, planStrategy, plan);
 	}
@@ -248,6 +248,7 @@ public class DocsSyncTests
 		{
 			RemoteListingCompleted = true,
 			DeleteThresholdDefault = null,
+			ExcludePatterns = [],
 			TotalRemoteFiles = 0,
 			TotalSourceFiles = 5,
 			TotalSyncRequests = 6,

--- a/tests-integration/Elastic.Documentation.IntegrationTests/IncrementalDeployRoundTripTests.cs
+++ b/tests-integration/Elastic.Documentation.IntegrationTests/IncrementalDeployRoundTripTests.cs
@@ -149,7 +149,7 @@ public class IncrementalDeployRoundTripTests
 		// Act — Plan
 		// deleteThreshold: 1.0 permits any delete ratio (needed because the validator
 		// enforces a 0.8 floor for small sync sets where TotalSyncRequests < 100)
-		var planOk = await svc.Plan(context.Collector, context, "fake-bucket", planPath, deleteThreshold: 1.0f, Cancel.None);
+		var planOk = await svc.Plan(context.Collector, context, "fake-bucket", planPath, deleteThreshold: 1.0f, excludePatterns: [], Cancel.None);
 		planOk.Should().BeTrue("plan should succeed with valid file mix");
 		fs.File.Exists(planPath).Should().BeTrue("plan JSON must be written to the mock filesystem");
 
@@ -174,5 +174,103 @@ public class IncrementalDeployRoundTripTests
 		// Assert — uploads called once
 		A.CallTo(() => xfer.UploadDirectoryAsync(A<TransferUtilityUploadDirectoryRequest>._, A<Cancel>._))
 			.MustHaveHappenedOnceExactly();
+	}
+}
+
+/// <summary>
+/// Verifies that <c>--exclude</c> patterns prevent matching objects from being uploaded or deleted.
+/// </summary>
+/// <remarks>
+/// Scenario: the S3 bucket contains a <c>_preview/pr-42/index.html</c> object written by a
+/// PR-preview workflow. The local build output does NOT contain that file. Without excludes the
+/// planner would queue it for deletion; with <c>_preview/*</c> excluded it must be untouched.
+/// Similarly a local file under an excluded prefix must not be added to the plan.
+/// </remarks>
+public class IncrementalDeployExcludeTests
+{
+	private const string SkipETag = "aaaa0000skip0000etag0000aaaa0000";
+	private const string AnyOtherETag = "bbbb1111other1111etag1111bbbb1111";
+
+	[Fact]
+	public async Task ExcludedRemoteObjectsAreNotDeleted()
+	{
+		var outputDir = Path.Join(Paths.WorkingDirectoryRoot.FullName, ".artifacts", "codex", "docs");
+
+		// Local build output: one regular page, nothing under _preview/
+		var fs = new MockFileSystem(new Dictionary<string, MockFileData>
+		{
+			{ Path.Join(outputDir, "docs/page.md"), new MockFileData("# Page") },
+		}, new MockFileSystemOptions { CurrentDirectory = outputDir });
+
+		var s3 = A.Fake<IAmazonS3>();
+		var xfer = A.Fake<ITransferUtility>();
+		var gh = A.Fake<ICoreService>();
+
+		var etagCalculator = A.Fake<IS3EtagCalculator>();
+		A.CallTo(() => etagCalculator.CalculateS3ETag(A<string>._, A<Cancel>._)).Returns(AnyOtherETag);
+
+		// Remote has both a regular page (stale) and a preview object that lives alongside codex output
+		A.CallTo(() => s3.ListObjectsV2Async(A<ListObjectsV2Request>._, A<Cancel>._))
+			.Returns(new ListObjectsV2Response
+			{
+				S3Objects =
+				[
+					new S3Object { Key = "docs/page.md", ETag = "\"stale-etag\"" },
+					new S3Object { Key = "_preview/pr-42/index.html" },
+					new S3Object { Key = "403/index.html" },
+					new S3Object { Key = "404/index.html" },
+				]
+			});
+
+		A.CallTo(() => s3.DeleteObjectsAsync(A<DeleteObjectsRequest>._, A<Cancel>._))
+			.Returns(new DeleteObjectsResponse { HttpStatusCode = System.Net.HttpStatusCode.OK });
+
+		var svc = new IncrementalDeployService(new LoggerFactory(), gh, s3, xfer, etagCalculator);
+		var collector = new DiagnosticsCollector([]);
+		var scopedFs = FileSystemFactory.ScopeCurrentWorkingDirectory(fs);
+		var scopedWriteFs = FileSystemFactory.ScopeCurrentWorkingDirectoryForWrite(fs);
+		var codexConfig = new CodexConfiguration { Environment = "dev" };
+		var configFile = fs.FileInfo.New(Path.Join(Paths.WorkingDirectoryRoot.FullName, "codex.yml"));
+		var context = new CodexContext(codexConfig, configFile, collector, scopedFs, scopedWriteFs, null, outputDir);
+
+		var planPath = Path.Join(outputDir, "sync-plan.json");
+		var planOk = await svc.Plan(
+			context.Collector,
+			context,
+			"fake-bucket",
+			planPath,
+			deleteThreshold: 1.0f,
+			excludePatterns: ["_preview/*", "403/*", "404/*"],
+			Cancel.None);
+		planOk.Should().BeTrue("plan should succeed");
+
+		var applyOk = await svc.Apply(context.Collector, context, "fake-bucket", planPath, Cancel.None);
+		applyOk.Should().BeTrue("apply should succeed");
+
+		// The plan must not contain deletions for any excluded key
+		var planJson = fs.File.ReadAllText(planPath);
+		var plan = SyncPlan.Deserialize(planJson);
+		plan.DeleteRequests.Should().NotContain(r => r.DestinationPath.StartsWith("_preview/", StringComparison.Ordinal),
+			"excluded _preview/* objects must not be queued for deletion");
+		plan.DeleteRequests.Should().NotContain(r => r.DestinationPath.StartsWith("403/", StringComparison.Ordinal),
+			"excluded 403/* objects must not be queued for deletion");
+		plan.DeleteRequests.Should().NotContain(r => r.DestinationPath.StartsWith("404/", StringComparison.Ordinal),
+			"excluded 404/* objects must not be queued for deletion");
+
+		// docs/page.md is not excluded so it should be an update (stale ETag)
+		plan.UpdateRequests.Should().Contain(r => r.DestinationPath == "docs/page.md");
+
+		// No S3 delete calls should include excluded prefixes
+		A.CallTo(() => s3.DeleteObjectsAsync(
+				A<DeleteObjectsRequest>.That.Matches(r => r.Objects.Any(o =>
+					o.Key.StartsWith("_preview/", StringComparison.Ordinal) ||
+					o.Key.StartsWith("403/", StringComparison.Ordinal) ||
+					o.Key.StartsWith("404/", StringComparison.Ordinal))),
+				A<Cancel>._))
+			.MustNotHaveHappened();
+
+		// Excluded patterns are recorded in the plan file
+		plan.ExcludePatterns.Should().BeEquivalentTo(["_preview/*", "403/*", "404/*"],
+			"plan must record which patterns were excluded");
 	}
 }


### PR DESCRIPTION
## What

Adds a repeatable `--exclude` flag to `codex sync plan` so that objects at co-resident S3 prefixes (PR previews, error pages) are ignored during both upload planning and deletion detection.

```
docs-builder codex sync plan codex.yml \
  --s3-bucket-name elastic-codex-website-internal \
  --exclude '_preview/*' --exclude '403/*' --exclude '404/*' \
  --delete-threshold 20 \
  --out codex-sync-plan.json
```

## Why

The `codex-environments` repo's S3 bucket holds `_preview/*` (PR previews written by a separate workflow) and `403/*` / `404/*` error pages alongside the main codex output. A naive `codex sync plan` would treat all three prefixes as deletions, either aborting the deploy (threshold violation) or wiping previews.

This unblocks adopting `codex sync plan/apply` in the daily deploy workflow as a drop-in replacement for the current `aws s3 sync --delete --exclude` step.

## How

- `IDocsSyncPlanStrategy.Plan` and `AwsS3SyncPlanStrategy.Plan` accept `string[] excludePatterns`.
- Patterns are compiled via `DotNet.Glob`. A trailing `/*` is normalized to `/**` so e.g. `_preview/*` matches `_preview/pr-42/index.html`, mirroring AWS CLI semantics.
- `SyncPlan` records `ExcludePatterns` so the plan file is self-describing.
- `CodexSyncCommand.Plan` exposes the new repeatable `--exclude` option.
- `DeployCommands.Plan` (assembler path) passes `[]` — no behaviour change.

## Test plan

- `dotnet build docs-builder.slnx` — clean build (✅ verified).
- New `IncrementalDeployExcludeTests.ExcludedRemoteObjectsAreNotDeleted` integration test: bucket contains `_preview/pr-42/index.html`, `403/index.html`, `404/index.html`; plan with `--exclude '_preview/*' '403/*' '404/*'`; asserts none appear in `DeleteRequests` and `ExcludePatterns` is persisted in the plan JSON.
- All 22 integration tests pass (✅ verified).
- `docs-builder codex sync plan --help` — `--exclude` option present.

## Notes

`apply` intentionally has no `--exclude` flag — it executes a pre-computed plan that already has exclusions baked in.

cc @reakaleek