### PR TITLE
fix(frontend): switch select-dom to non-throwing optional variants

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/applies-switch.ts
+++ b/src/Elastic.Documentation.Site/Assets/applies-switch.ts
@@ -1,5 +1,5 @@
 // TODO: refactor to typescript. this was copied from the tabs implementation
-import { $$ } from 'select-dom'
+import { $$optional } from 'select-dom'
 
 // Extra JS capability for selected applies switches to be synced
 // The selection is stored in local storage so that it persists across page loads.
@@ -23,7 +23,7 @@ function ready() {
 
     const groups: string[] = []
 
-    $$('.applies-switch-label').forEach((label) => {
+    $$optional('.applies-switch-label').forEach((label) => {
         if (label instanceof HTMLElement) {
             const data = create_key(label)
             if (data) {

--- a/src/Elastic.Documentation.Site/Assets/copybutton.ts
+++ b/src/Elastic.Documentation.Site/Assets/copybutton.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 // This is copied from legacy. It works, but we should rework this if we ever need to change it
-import { $$ } from 'select-dom'
+import { $$optional } from 'select-dom'
 
 const messages = {
     en: {
@@ -110,7 +110,7 @@ const addCopyButtonToCodeCells = (
     prefix: string
 ) => {
     // Add copybuttons to all of our code cells
-    const codeCells = $$(selector, baseElement)
+    const codeCells = $$optional(selector, baseElement)
     codeCells.forEach((codeCell, index) => {
         if (codeCell.id) {
             return

--- a/src/Elastic.Documentation.Site/Assets/hljs.ts
+++ b/src/Elastic.Documentation.Site/Assets/hljs.ts
@@ -36,7 +36,7 @@ import swift from 'highlight.js/lib/languages/swift'
 import typescript from 'highlight.js/lib/languages/typescript'
 import xml from 'highlight.js/lib/languages/xml'
 import yaml from 'highlight.js/lib/languages/yaml'
-import { $$ } from 'select-dom'
+import { $$optional } from 'select-dom'
 
 const languages: Array<{
     name: string
@@ -218,7 +218,7 @@ hljs.addPlugin(mergeHTMLPlugin)
 hljs.configure({ ignoreUnescapedHTML: true })
 
 export function initHighlight() {
-    $$('#markdown-content pre code:not([data-highlighted])').forEach(
+    $$optional('#markdown-content pre code:not([data-highlighted])').forEach(
         hljs.highlightElement
     )
 }

--- a/src/Elastic.Documentation.Site/Assets/image-carousel.ts
+++ b/src/Elastic.Documentation.Site/Assets/image-carousel.ts
@@ -1,4 +1,4 @@
-import { $$ } from 'select-dom'
+import { $$optional } from 'select-dom'
 
 class ImageCarousel {
     private container: HTMLElement
@@ -242,7 +242,7 @@ export function initImageCarousel(): void {
         if (!section) return
 
         // First, collect all images we want in the carousel
-        const allImageLinks = $$('a[href*="epr.elastic.co"]', section)
+        const allImageLinks = $$optional('a[href*="epr.elastic.co"]', section)
 
         // Track URLs to prevent duplicates
         const processedUrls = new Set()

--- a/src/Elastic.Documentation.Site/Assets/main.ts
+++ b/src/Elastic.Documentation.Site/Assets/main.ts
@@ -15,7 +15,7 @@ import { initTocNav } from './toc-nav'
 import 'htmx-ext-head-support'
 import 'htmx-ext-preload'
 import * as katex from 'katex'
-import { $, $$ } from 'select-dom'
+import { $optional, $$optional } from 'select-dom'
 import { UAParser } from 'ua-parser-js'
 
 // Injected at build time from MinVer
@@ -58,7 +58,7 @@ type HtmxEvent = any
  * Initialize KaTeX math rendering for elements with class 'math'
  */
 function initMath() {
-    const mathElements = $$('.math:not([data-katex-processed])')
+    const mathElements = $$optional('.math:not([data-katex-processed])')
     mathElements.forEach((element) => {
         try {
             const content = element.textContent?.trim()
@@ -127,7 +127,7 @@ document.addEventListener('htmx:load', function () {
     const urlParams = new URLSearchParams(window.location.search)
     const editParam = urlParams.has('edit')
     if (editParam) {
-        $('.edit-this-page.hidden')?.classList.remove('hidden')
+        $optional('.edit-this-page.hidden')?.classList.remove('hidden')
     }
 })
 
@@ -202,7 +202,7 @@ document.body.addEventListener(
 )
 
 // We add a query string to the get request to make sure the requested page is up to date
-const docsBuilderVersion = $('body')?.dataset.docsBuilderVersion
+const docsBuilderVersion = $optional('body')?.dataset.docsBuilderVersion
 document.body.addEventListener(
     'htmx:configRequest',
     function (event: HtmxEvent) {

--- a/src/Elastic.Documentation.Site/Assets/main.ts
+++ b/src/Elastic.Documentation.Site/Assets/main.ts
@@ -15,7 +15,7 @@ import { initTocNav } from './toc-nav'
 import 'htmx-ext-head-support'
 import 'htmx-ext-preload'
 import * as katex from 'katex'
-import { $optional, $$optional } from 'select-dom'
+import { $, $optional, $$optional } from 'select-dom'
 import { UAParser } from 'ua-parser-js'
 
 // Injected at build time from MinVer
@@ -202,7 +202,7 @@ document.body.addEventListener(
 )
 
 // We add a query string to the get request to make sure the requested page is up to date
-const docsBuilderVersion = $optional('body')?.dataset.docsBuilderVersion
+const docsBuilderVersion = $('body').dataset.docsBuilderVersion
 document.body.addEventListener(
     'htmx:configRequest',
     function (event: HtmxEvent) {

--- a/src/Elastic.Documentation.Site/Assets/pages-nav.ts
+++ b/src/Elastic.Documentation.Site/Assets/pages-nav.ts
@@ -1,5 +1,5 @@
 import { throttle } from 'lodash'
-import { $, $$ } from 'select-dom'
+import { $optional, $$optional } from 'select-dom'
 
 const NAV_STATE_KEY = 'nav-expanded'
 
@@ -8,7 +8,7 @@ function isDevMode() {
 }
 
 function saveNavState(nav: HTMLElement) {
-    const expanded = $$('input[type="checkbox"]:checked', nav)
+    const expanded = $$optional('input[type="checkbox"]:checked', nav)
         .map((el) => el.id)
         .filter(Boolean)
     sessionStorage.setItem(NAV_STATE_KEY, JSON.stringify(expanded))
@@ -20,7 +20,7 @@ function restoreNavState(nav: HTMLElement) {
     try {
         const ids: string[] = JSON.parse(raw)
         for (const id of ids) {
-            const input = $(`#${CSS.escape(id)}`, nav)
+            const input = $optional(`#${CSS.escape(id)}`, nav)
             if (input instanceof HTMLInputElement) {
                 input.checked = true
             }
@@ -42,7 +42,7 @@ function expandAllParents(navItem: HTMLElement) {
 }
 
 function scrollCurrentNaviItemIntoViewImpl(nav: HTMLElement) {
-    const currentNavItem = $('.current', nav)
+    const currentNavItem = $optional('.current', nav)
 
     if (!currentNavItem) {
         return
@@ -55,7 +55,7 @@ function scrollCurrentNaviItemIntoViewImpl(nav: HTMLElement) {
 
     // Get the sticky element's height to account for content hidden under it
     // The sticky element contains the search and dropdown, staying fixed at top when scrolling
-    const stickyElement = $('.sticky', nav)
+    const stickyElement = $optional('.sticky', nav)
     const stickyHeight = stickyElement?.getBoundingClientRect().height ?? 0
 
     // The effective visible top of the nav is below the sticky element
@@ -112,12 +112,14 @@ function preventFocusLossOnLinkClick(anchor: HTMLAnchorElement) {
 }
 
 export function initNav() {
-    const pagesNav = $('#pages-nav')
+    const pagesNav = $optional('#pages-nav')
     if (!pagesNav) {
         return
     }
 
-    const dropdownActiveAnchor = $('#pages-dropdown a.pages-dropdown_active')
+    const dropdownActiveAnchor = $optional(
+        '#pages-dropdown a.pages-dropdown_active'
+    )
     if (dropdownActiveAnchor) {
         preventFocusLossOnLinkClick(dropdownActiveAnchor)
     }
@@ -127,7 +129,7 @@ export function initNav() {
     }
 
     // Remove current class from all nav items before marking new ones
-    const currentNavItems = $$('.current', pagesNav)
+    const currentNavItems = $$optional('.current', pagesNav)
     currentNavItems.forEach((el) => {
         el.classList.remove('current')
     })
@@ -142,7 +144,7 @@ export function initNav() {
     )
     const activePathname = navActiveMeta?.content ?? pathname
 
-    const navItems = $$(
+    const navItems = $$optional(
         'a[href="' + activePathname + '"], a[href="' + activePathname + '/"]',
         pagesNav
     )
@@ -153,7 +155,7 @@ export function initNav() {
 
     if (isDevMode()) {
         saveNavState(pagesNav)
-        for (const cb of $$('input[type="checkbox"]', pagesNav)) {
+        for (const cb of $$optional('input[type="checkbox"]', pagesNav)) {
             cb.addEventListener('change', () => saveNavState(pagesNav))
         }
     }

--- a/src/Elastic.Documentation.Site/Assets/smooth-scroll.ts
+++ b/src/Elastic.Documentation.Site/Assets/smooth-scroll.ts
@@ -1,7 +1,7 @@
-import { $$ } from 'select-dom'
+import { $$optional } from 'select-dom'
 
 export function initSmoothScroll() {
-    $$('#markdown-content a[href^="#"]').forEach((el) => {
+    $$optional('#markdown-content a[href^="#"]').forEach((el) => {
         el.addEventListener('click', (e) => {
             // Using ! because href is guaranteed to be present due to the selector
             const id = el.getAttribute('href')!.slice(1) // remove the '#' character

--- a/src/Elastic.Documentation.Site/Assets/toc-nav.ts
+++ b/src/Elastic.Documentation.Site/Assets/toc-nav.ts
@@ -1,4 +1,4 @@
-import { $$, $ } from 'select-dom'
+import { $$optional, $optional } from 'select-dom'
 
 interface TocElements {
     headings: Element[]
@@ -13,12 +13,14 @@ const HEADING_OFFSET = 34 * 4
 
 function initializeTocElements(): TocElements {
     // Support both regular docs (#markdown-content) and API docs (#elastic-api-v3)
-    const headings = $$(
+    const headings = $$optional(
         '#markdown-content h2, #markdown-content h3, #elastic-api-v3 h3[data-section]'
     )
-    const tocLinks = $$('#toc-nav li>a') as HTMLAnchorElement[]
-    const tocContainer = $('#toc-nav .toc-progress-container') as HTMLDivElement
-    const progressIndicator = $(
+    const tocLinks = $$optional('#toc-nav li>a') as HTMLAnchorElement[]
+    const tocContainer = $optional(
+        '#toc-nav .toc-progress-container'
+    ) as HTMLDivElement
+    const progressIndicator = $optional(
         '.toc-progress-indicator',
         tocContainer
     ) as HTMLDivElement


### PR DESCRIPTION
## Why

`select-dom` v10 changed `$()` and `$$()` to throw `ElementNotFoundError` when no elements match — a breaking change from v9, where they returned `undefined`/`[]`. After the bump in #3499, any page without un-highlighted code blocks threw an uncaught `ElementNotFoundError: Expected elements not found: #markdown-content pre code:not([data-highlighted])` on every `htmx:load` event. The same latent crash existed at all 20 other `$`/`$$` call sites across the frontend.

## What

Switches all 8 `select-dom` import sites and 21 call sites across the frontend `Assets/` from the now-throwing `$`/`$$` to the non-throwing `$optional`/`$$optional` exports introduced in v10. Restores the original absent-is-fine semantics without aliasing, making the intent explicit at each call.