### PR TITLE
frontend: isolate page init steps so one failure doesn't abort the rest

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/main.ts
+++ b/src/Elastic.Documentation.Site/Assets/main.ts
@@ -56,10 +56,12 @@ const { getOS } = new UAParser()
 type HtmxEvent = any
 
 // Run each init step in isolation so a failure in one does not abort the rest.
-function runInitSteps(steps: Array<[string, () => void]>) {
+async function runInitSteps(
+    steps: Array<[string, () => void | Promise<void>]>
+) {
     for (const [name, init] of steps) {
         try {
-            init()
+            await init()
         } catch (error) {
             console.error(`Init step "${name}" failed:`, error)
             logError(`Init step failed: ${name}`, {

--- a/src/Elastic.Documentation.Site/Assets/main.ts
+++ b/src/Elastic.Documentation.Site/Assets/main.ts
@@ -11,6 +11,7 @@ import { initNav } from './pages-nav'
 import { initSmoothScroll } from './smooth-scroll'
 import { initTabs } from './tabs'
 import { initializeOtel } from './telemetry/instrumentation'
+import { logError } from './telemetry/logging'
 import { initTocNav } from './toc-nav'
 import 'htmx-ext-head-support'
 import 'htmx-ext-preload'
@@ -53,6 +54,29 @@ const { getOS } = new UAParser()
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type HtmxEvent = any
+
+// Run each init step in isolation so a failure in one does not abort the rest.
+function runInitSteps(steps: Array<[string, () => void]>) {
+    for (const [name, init] of steps) {
+        try {
+            init()
+        } catch (error) {
+            console.error(`Init step "${name}" failed:`, error)
+            logError(`Init step failed: ${name}`, {
+                'init.step': name,
+                'error.message':
+                    error instanceof Error ? error.message : String(error),
+            })
+        }
+    }
+}
+
+function applyEditParam() {
+    const urlParams = new URLSearchParams(window.location.search)
+    if (urlParams.has('edit')) {
+        $optional('.edit-this-page.hidden')?.classList.remove('hidden')
+    }
+}
 
 /**
  * Initialize KaTeX math rendering for elements with class 'math'
@@ -104,31 +128,29 @@ function initMath() {
 
 // Initialize on initial page load
 document.addEventListener('DOMContentLoaded', function () {
-    initMath()
-    initMermaid()
+    runInitSteps([
+        ['initMath', initMath],
+        ['initMermaid', initMermaid],
+    ])
 })
 
 document.addEventListener('htmx:load', function () {
-    initTocNav()
-    initHighlight()
-    initCopyButton()
-    initAgentSkillCopy()
-    initTabs()
-    initAppliesSwitch()
-    initMath()
-    initMermaid()
-    initNav()
-
-    initSmoothScroll()
-    openDetailsWithAnchor()
-    initImageCarousel()
-    initApiDocs()
-
-    const urlParams = new URLSearchParams(window.location.search)
-    const editParam = urlParams.has('edit')
-    if (editParam) {
-        $optional('.edit-this-page.hidden')?.classList.remove('hidden')
-    }
+    runInitSteps([
+        ['initTocNav', initTocNav],
+        ['initHighlight', initHighlight],
+        ['initCopyButton', initCopyButton],
+        ['initAgentSkillCopy', initAgentSkillCopy],
+        ['initTabs', initTabs],
+        ['initAppliesSwitch', initAppliesSwitch],
+        ['initMath', initMath],
+        ['initMermaid', initMermaid],
+        ['initNav', initNav],
+        ['initSmoothScroll', initSmoothScroll],
+        ['openDetailsWithAnchor', openDetailsWithAnchor],
+        ['initImageCarousel', initImageCarousel],
+        ['initApiDocs', initApiDocs],
+        ['applyEditParam', applyEditParam],
+    ])
 })
 
 // Don't remove style tags because they are used by the elastic global nav.


### PR DESCRIPTION
## Why

The init chain in `main.ts` runs a sequence of functions on every `htmx:load` event with no error isolation. A single thrown exception propagates out of the event listener and silently skips every subsequent init call — meaning a bug in `initTocNav` would also break copy buttons, tabs, math rendering, and everything else on the page.

## What

Adds a `runInitSteps` helper that iterates a named list of init functions and wraps each call in a try/catch. Failures are logged to `console.error` (always visible in DevTools) and to the existing `logError` from `telemetry/logging.ts` (structured, sent to the backend when telemetry is enabled). Both `DOMContentLoaded` and `htmx:load` blocks are converted to use it.

The `?edit` query-param inline block is extracted into `applyEditParam` so it fits the same guarded list.

## How

Step names are passed as explicit strings rather than derived from `fn.name` so they survive Parcel minification and remain stable in production error logs.