### PR TITLE
changelog: publish docs-builder release notes to the CDN

### DIFF
--- a/.github/workflows/changelog-publish.yml
+++ b/.github/workflows/changelog-publish.yml
@@ -1,0 +1,40 @@
+name: Publish changelog bundle
+
+# Turns a published GitHub release (drafted by release-drafter in release.yml) into a
+# CDN-hosted changelog bundle via `changelog gh-release`. Entries are derived from the
+# release's PRs and their labels — there are no hand-authored changelog files.
+#
+# workflow_dispatch is provided to backfill past releases by tag.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release tag to bundle (e.g. 1.19.0). Defaults to the latest release.'
+        type: string
+        required: false
+
+permissions: {}
+
+concurrency:
+  group: changelog-publish-${{ github.event.release.tag_name || inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    permissions:
+      contents: read
+      packages: read
+      id-token: write
+    uses: elastic/docs-actions/.github/workflows/changelog-bundle.yml@v1
+    with:
+      mode: gh-release
+      repo: docs-builder
+      owner: elastic
+      version: ${{ github.event.release.tag_name || inputs.version || 'latest' }}
+      config: docs/changelog.yml
+      # docs-builder image that includes the changelog bundle/registry support.
+      # Pin to a released version once one ships with it.
+      docs-builder-version: edge

--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -1,0 +1,41 @@
+# Changelog configuration for docs-builder's own release notes.
+#
+# docs-builder publishes its release notes with the `changelog gh-release` flow:
+# the `Release` workflow (release-drafter) publishes a GitHub release, and
+# `.github/workflows/changelog-publish.yml` turns that release into a CDN-hosted
+# bundle. There are no hand-authored entry files — entries are derived from the
+# release's PRs and their labels.
+#
+# Generated with `docs-builder changelog init`, then edited for this repo.
+
+# Map docs-builder's PR labels to changelog types.
+# The label set is the same one enforced by `.github/workflows/required-labels.yml`,
+# which derives it from `.github/release-drafter.yml` (every PR carries exactly one).
+# Keep this in sync with release-drafter.yml if labels ever change.
+pivot:
+  types:
+    breaking-change: "breaking"
+    feature: "feature"
+    enhancement: "enhancement"
+    bug-fix: "bug, fix"
+    docs: "documentation"
+    # Maintenance/automation labels (chore, dependencies, automation, ci, redesign)
+    # are intentionally not mapped — they're excluded from release notes below.
+
+# Controls which PRs become changelog entries.
+rules:
+  # `changelog:skip` is already dropped from the release body by release-drafter
+  # (exclude-labels); the rest keep maintenance/automation churn out of the notes.
+  create:
+    exclude: "changelog:skip, chore, dependencies, automation, ci, redesign"
+
+# Bundle defaults (owner/repo/link_allow_repos seeded by `changelog init`).
+bundle:
+  output_directory: docs/releases
+  resolve: true
+  owner: elastic
+  repo: docs-builder
+  # Keep only docs-builder's own PR/issue links in resolved bundles; anything else
+  # is scrubbed to a private sentinel.
+  link_allow_repos:
+    - elastic/docs-builder


### PR DESCRIPTION
> Stacked on #3536 (parser fix). Base will retarget to `main` once #3536 merges.

## Why

Dogfood the changelog CDN flow on docs-builder itself: turn each published GitHub release into a CDN-hosted bundle so docs-builder's own release notes can later be rendered via the `:cdn:` `{changelog}` directive.

docs-builder cuts releases via release-drafter (`release.yml`) and has no per-PR changelog files, so the natural fit is `gh-release` mode — entries are derived from the release's PRs and labels in one step.

## What

- **`docs/changelog.yml`** — generated with `docs-builder changelog init` (which seeded `owner`/`repo`/`link_allow_repos`), then edited to the `gh-release` shape. `pivot.types` maps the repository's established release-drafter labels (kept in sync with `.github/release-drafter.yml`, which `required-labels.yml` derives its set from). `rules.create.exclude` keeps `changelog:skip` + maintenance/automation churn out of the notes.
- **`.github/workflows/changelog-publish.yml`** — calls `elastic/docs-actions/.github/workflows/changelog-bundle.yml@v1` in `gh-release` mode on `release: published`, plus a `workflow_dispatch` to backfill past release tags by version.

Mirrors the `mode: gh-release` template in docs-actions's `changelog/README.md` (with an added backfill trigger and explicit `docs-builder-version: edge` pin marker).

## Ordering / dependencies

1. Merge #3536 (parser fix) and ship it to the `edge` image — without it the producer parses 0 PRs.
2. Merge this PR.
3. Run/backfill via `workflow_dispatch` to publish `docs-builder/registry.json` to the CDN.
4. Follow-up consumer PR: declare `release_notes` in `docs/_docset.yml` and switch directives to `:cdn:`.

## Test plan

- [x] `changelog init` produces a valid config from a clean checkout
- [x] `docs/changelog.yml` loads; `changelog gh-release docs-builder <tag>` resolves product + parses the release (with #3536)
- [ ] After merge + edge image: `workflow_dispatch` publishes a bundle + `registry.json` to the CDN

Made with [Cursor](https://cursor.com)