### PR TITLE
fix(applies-to): avoid weird "Removed Planned" multi-lifecycle badge

### DIFF
--- a/src/Elastic.Markdown/Myst/Components/ApplicabilityRenderer.cs
+++ b/src/Elastic.Markdown/Myst/Components/ApplicabilityRenderer.cs
@@ -78,14 +78,37 @@ public static class ApplicabilityRenderer
 			}
 		}
 
-		// If we've exhausted all options (none had displayable data), use the first one.
-		// Only show "Planned" when the first applicability is actually future/unreleased (has a version spec that is not yet released).
-		// When the first applicability has no version (null/AllVersionsSpec), it means GA for all versions - keep badge text empty.
+		// If we've exhausted all options (none had displayable data), pick a fallback.
+		// When the highest-version applicability is future/unreleased, prefer the "previous lifecycle"
+		// (a lower-version applicability that is current or has no version) over a synthesized "Planned" badge.
+		// This avoids weird renderings like "Removed Planned" for `deprecated, removed X` where X is unreleased.
 		if (badgeData is null && firstBadgeData is not null && firstApplicability is not null && versioningSystem.IsVersioned())
 		{
 			var versionSpec = firstApplicability.Version;
 			var isFutureVersion = versionSpec is not null && versionSpec != AllVersionsSpec.Instance && versionSpec.Min > versioningSystem.Current;
-			badgeData = isFutureVersion ? firstBadgeData with { BadgeLifecycleText = "Planned" } : firstBadgeData;
+
+			if (isFutureVersion)
+			{
+				var previousLifecycle = sortedApplicabilities.FirstOrDefault(a =>
+					a != firstApplicability &&
+					(a.Version is null || a.Version == AllVersionsSpec.Instance ||
+					 a.Version.Min <= versioningSystem.Current));
+
+				if (previousLifecycle is not null)
+					badgeData = GetBadgeData(previousLifecycle, versioningSystem, allApplications);
+				else
+				{
+					var fallbackText = firstApplicability.Lifecycle switch
+					{
+						ProductLifecycle.Deprecated => "Deprecation planned",
+						ProductLifecycle.Removed => "Removal planned",
+						_ => "Planned"
+					};
+					badgeData = firstBadgeData with { BadgeLifecycleText = fallbackText, ShowLifecycleName = false };
+				}
+			}
+			else
+				badgeData = firstBadgeData;
 		}
 
 		badgeData ??= GetBadgeData(sortedApplicabilities.First(), versioningSystem, allApplications);

--- a/src/Elastic.Markdown/Myst/Components/ApplicabilityRenderer.cs
+++ b/src/Elastic.Markdown/Myst/Components/ApplicabilityRenderer.cs
@@ -81,8 +81,6 @@ public static class ApplicabilityRenderer
 		// If we've exhausted all options (none had displayable data), pick a fallback.
 		// When the highest-version applicability is future/unreleased, prefer the "previous lifecycle"
 		// (a lower-version applicability that is current or has no version) over a synthesized "Planned" badge.
-		// This keeps combinations like `deprecated, removed 10.0` from rendering as "Removed Planned"
-		// when the removal version is still unreleased.
 		if (badgeData is null && firstBadgeData is not null && firstApplicability is not null && versioningSystem.IsVersioned())
 		{
 			var versionSpec = firstApplicability.Version;

--- a/src/Elastic.Markdown/Myst/Components/ApplicabilityRenderer.cs
+++ b/src/Elastic.Markdown/Myst/Components/ApplicabilityRenderer.cs
@@ -81,6 +81,8 @@ public static class ApplicabilityRenderer
 		// If we've exhausted all options (none had displayable data), pick a fallback.
 		// When the highest-version applicability is future/unreleased, prefer the "previous lifecycle"
 		// (a lower-version applicability that is current or has no version) over a synthesized "Planned" badge.
+		// This keeps combinations like `deprecated, removed 10.0` from rendering as "Removed Planned"
+		// when the removal version is still unreleased.
 		if (badgeData is null && firstBadgeData is not null && firstApplicability is not null && versioningSystem.IsVersioned())
 		{
 			var versionSpec = firstApplicability.Version;

--- a/src/Elastic.Markdown/Myst/Components/ApplicabilityRenderer.cs
+++ b/src/Elastic.Markdown/Myst/Components/ApplicabilityRenderer.cs
@@ -81,7 +81,6 @@ public static class ApplicabilityRenderer
 		// If we've exhausted all options (none had displayable data), pick a fallback.
 		// When the highest-version applicability is future/unreleased, prefer the "previous lifecycle"
 		// (a lower-version applicability that is current or has no version) over a synthesized "Planned" badge.
-		// This avoids weird renderings like "Removed Planned" for `deprecated, removed X` where X is unreleased.
 		if (badgeData is null && firstBadgeData is not null && firstApplicability is not null && versioningSystem.IsVersioned())
 		{
 			var versionSpec = firstApplicability.Version;


### PR DESCRIPTION
## Why

When an `applies_to` directive declares multiple lifecycles where the highest-version one is unreleased — most commonly `stack: deprecated, removed <future>` — the badge currently renders as a confusing concatenation like `Stack | Removed Planned`. The feature/option isn't actually removed yet (it's currently deprecated), and the doubled label looks like a bug to readers.

Closes #3537.

## What

In `ApplicabilityRenderer`, the catch-all fallback used to force `BadgeLifecycleText = "Planned"` on the highest-version candidate while leaving `ShowLifecycleName = true`, so the lifecycle name and the synthesised text rendered side by side.

The fallback now honours the documented "use previous lifecycle" rule: when the highest candidate is future/unreleased and there is a lower-version applicability that is current or version-less, we render that one's badge instead. So `stack: deprecated, removed 10.0` (with stack current `9.4.2`) now renders as `Stack | Deprecated`, with the planned removal still surfaced in the popover.

Only when *every* applicability is unreleased do we fall back to a synthesised label, and that path now uses the lifecycle-appropriate phrase (`Removal planned` / `Deprecation planned` / `Planned`) with `ShowLifecycleName = false` so the doubled rendering can't recur.

Made with [Cursor](https://cursor.com)