### PR TITLE
codex: limit ungrouped spaces to two columns on landing page

### DIFF
--- a/src/Elastic.Codex/Landing/LandingView.cshtml
+++ b/src/Elastic.Codex/Landing/LandingView.cshtml
@@ -131,14 +131,14 @@
 			.OrderBy(x => x.sortKey, StringComparer.OrdinalIgnoreCase)
 			.ToList();
 	}
-	<div id="codex-grid" class="pt-8 pb-8 max-w-7xl p-4 mx-auto grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4" style="position: relative; z-index: 1;">
+	<div id="codex-grid" class="pt-8 pb-8 max-w-7xl p-4 mx-auto grid grid-cols-1 md:grid-cols-2 gap-4" style="position: relative; z-index: 1;">
 		@foreach (var item in sortedSections)
 		{
 			@if (item.group is { } group)
 			{
 				var repoCount = group.DocumentationSetInfos.Count;
-				var colSpan = repoCount >= 5 || repoCount == 3 ? "col-span-full" : repoCount >= 2 ? "col-span-1 md:col-span-2" : "col-span-1";
-				var innerCols = repoCount >= 5 || repoCount == 3 ? "grid-cols-1 md:grid-cols-2 lg:grid-cols-3" : repoCount >= 2 ? "grid-cols-1 md:grid-cols-2" : "grid-cols-1";
+				var colSpan = repoCount >= 2 ? "col-span-full" : "col-span-1";
+				var innerCols = repoCount >= 3 ? "grid-cols-1 md:grid-cols-2 lg:grid-cols-3" : repoCount >= 2 ? "grid-cols-1 md:grid-cols-2" : "grid-cols-1";
 				<div class="@colSpan border border-dashed border-grey-40 rounded-xl p-3">
 					<a href="@group.Url"
 					   hx-select-oob="#main-container"


### PR DESCRIPTION
## Why

The Codex landing grid uses 3 columns for all items. When the number of ungrouped spaces doesn't divide evenly into 3, a lone card at the end of a row leaves two empty slots — a visually jarring gap.

## What

The outer grid is reduced from `lg:grid-cols-3` to `md:grid-cols-2`. Ungrouped cards now flow in a 2-column layout, so an odd orphan leaves at most one empty slot. Groups with 2+ docsets are promoted to `col-span-full` (they fill both outer columns), while their internal card grid still renders up to 3 columns inside the group box — so group density is unchanged.