### PR TITLE
feat(search): move DocumentationDocument and friends into Elastic.Documentation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -52,7 +52,7 @@
     <PackageVersion Include="FakeItEasy" Version="9.0.1" />
     <PackageVersion Include="Elastic.Ingest.Elasticsearch" Version="0.45.0" />
     <PackageVersion Include="Elastic.Mapping" Version="0.48.0" />
-    <PackageVersion Include="Elastic.Internal.Search.Contract" Version="0.9.2" />
+    <PackageVersion Include="Elastic.Internal.Search.Contract" Version="0.11.0" />
     <PackageVersion Include="InMemoryLogger" Version="1.0.66" />
     <PackageVersion Include="MartinCostello.Logging.XUnit.v3" Version="0.7.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -51,7 +51,7 @@
     <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="9.4.2" />
     <PackageVersion Include="FakeItEasy" Version="9.0.1" />
     <PackageVersion Include="Elastic.Ingest.Elasticsearch" Version="0.45.0" />
-    <PackageVersion Include="Elastic.Mapping" Version="0.46.0" />
+    <PackageVersion Include="Elastic.Mapping" Version="0.48.0" />
     <PackageVersion Include="Elastic.Internal.Search.Contract" Version="0.9.2" />
     <PackageVersion Include="InMemoryLogger" Version="1.0.66" />
     <PackageVersion Include="MartinCostello.Logging.XUnit.v3" Version="0.7.1" />

--- a/src/Elastic.Documentation/AppliesTo/ApplicableTo.cs
+++ b/src/Elastic.Documentation/AppliesTo/ApplicableTo.cs
@@ -9,7 +9,6 @@ using System.Text.Json.Serialization;
 using Elastic.Documentation.Diagnostics;
 using Elastic.Documentation.Search;
 using Elastic.Documentation.Versions;
-using Elastic.Internal.Search;
 
 namespace Elastic.Documentation.AppliesTo;
 

--- a/src/Elastic.Documentation/Elastic.Documentation.csproj
+++ b/src/Elastic.Documentation/Elastic.Documentation.csproj
@@ -11,7 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Elastic.Internal.Search.Contract" />
+    <!-- TODO: switch back to PackageReference once the new contract version is published -->
+    <ProjectReference Include="../../../../.supacode/repos/website-search-data/feature/contract-work-move-docs-out/src/Elastic.Internal.Search.Contract/Elastic.Internal.Search.Contract.csproj" />
+    <PackageReference Include="Elastic.Mapping" />
     <PackageReference Include="Microsoft.Extensions.Logging"/>
     <PackageReference Include="NetEscapades.EnumGenerators"/>
     <PackageReference Include="Nullean.ScopedFileSystem" />

--- a/src/Elastic.Documentation/Elastic.Documentation.csproj
+++ b/src/Elastic.Documentation/Elastic.Documentation.csproj
@@ -11,8 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- TODO: switch back to PackageReference once the new contract version is published -->
-    <ProjectReference Include="../../../../.supacode/repos/website-search-data/feature/contract-work-move-docs-out/src/Elastic.Internal.Search.Contract/Elastic.Internal.Search.Contract.csproj" />
+    <PackageReference Include="Elastic.Internal.Search.Contract" />
     <PackageReference Include="Elastic.Mapping" />
     <PackageReference Include="Microsoft.Extensions.Logging"/>
     <PackageReference Include="NetEscapades.EnumGenerators"/>

--- a/src/Elastic.Documentation/Search/AppliesToEntry.cs
+++ b/src/Elastic.Documentation/Search/AppliesToEntry.cs
@@ -1,0 +1,27 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text.Json.Serialization;
+
+namespace Elastic.Documentation.Search;
+
+/// <summary>
+/// Flat wire-format entry for the <c>applies_to</c> nested array on <see cref="DocumentationDocument"/>.
+/// One entry per (type, sub_type, lifecycle, version) tuple.
+/// </summary>
+public record AppliesToEntry
+{
+	[JsonPropertyName("type")]
+	public required string Type { get; set; }
+
+	[JsonPropertyName("sub_type")]
+	public required string SubType { get; set; }
+
+	[JsonPropertyName("lifecycle")]
+	public required string Lifecycle { get; set; }
+
+	[JsonPropertyName("version")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public string? Version { get; set; }
+}

--- a/src/Elastic.Documentation/Search/DocumentationDocument.cs
+++ b/src/Elastic.Documentation/Search/DocumentationDocument.cs
@@ -1,0 +1,58 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text.Json.Serialization;
+using Elastic.Internal.Search;
+using Elastic.Mapping;
+
+namespace Elastic.Documentation.Search;
+
+/// <summary>
+/// Concrete document type for <c>/docs</c> pages indexed by docs-builder. Carries the docs-specific
+/// fields (applicability matrix, primary/related products, change tracking, outbound links) on top
+/// of <see cref="SearchDocumentBase"/>.
+/// </summary>
+public record DocumentationDocument : SearchDocumentBase
+{
+	[JsonIgnore]
+	public override string Type { get; } = "docs";
+
+	/// <summary>Canonical product for this page (the product the page is primarily about).</summary>
+	[Object]
+	[JsonPropertyName("product")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public IndexedProduct? Product { get; set; }
+
+	/// <summary>All related products discovered through inference (primary + cross-references).</summary>
+	[JsonPropertyName("related_products")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public IndexedProduct[]? RelatedProducts { get; set; }
+
+	/// <summary>Applicability matrix entries (deployment type / sub-type / lifecycle / version).</summary>
+	[Nested]
+	[JsonPropertyName("applies_to")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public IReadOnlyCollection<AppliesToEntry>? Applies { get; set; }
+
+	/// <summary>Outbound link URLs harvested from the page body.</summary>
+	[JsonPropertyName("links")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public string[]? Links { get; set; }
+
+	/// <summary>
+	/// Whitespace-normalized hash of the page body. Drives the docs change feed —
+	/// only advances when the meaningful content changes.
+	/// </summary>
+	[Keyword]
+	[JsonPropertyName("content_hash")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+	public string ContentBodyHash { get; set; } = string.Empty;
+
+	/// <summary>
+	/// Timestamp of the last meaningful content change. Drives the docs change feed
+	/// (cursor-paginated diff API).
+	/// </summary>
+	[JsonPropertyName("content_last_updated")]
+	public DateTimeOffset ContentLastUpdated { get; set; }
+}

--- a/src/Elastic.Documentation/Search/DocumentationMappingConfig.cs
+++ b/src/Elastic.Documentation/Search/DocumentationMappingConfig.cs
@@ -1,0 +1,55 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Internal.Search;
+using Elastic.Internal.Search.Mapping;
+using Elastic.Mapping;
+using Elastic.Mapping.Analysis;
+using Elastic.Mapping.Mappings;
+
+namespace Elastic.Documentation.Search;
+
+/// <summary>
+/// docs-builder index topology: <c>docs-{type}.{lexical|semantic}-{env}</c>.
+/// Defines the Elasticsearch index configuration for the documentation search indices,
+/// including analysis settings, mapping extensions, and AI enrichment configuration.
+/// </summary>
+[ElasticsearchMappingContext]
+[Index<DocumentationDocument>(
+	NameTemplate = "docs-{type}.lexical-{env}",
+	DatePattern = "yyyy.MM.dd.HHmmss",
+	Configuration = typeof(DocumentationLexicalConfig)
+)]
+[Index<DocumentationDocument>(
+	NameTemplate = "docs-{type}.semantic-{env}",
+	Variant = "Semantic",
+	DatePattern = "yyyy.MM.dd.HHmmss",
+	Configuration = typeof(DocumentationSemanticConfig)
+)]
+[AiEnrichment<DocumentationDocument>(
+	Role = "Expert technical writer creating search metadata for Elastic documentation (Elasticsearch, Kibana, Beats, Logstash). Audience: developers, DevOps, data engineers.",
+	MatchField = "url",
+	IndexVariant = "Semantic"
+)]
+public static partial class DocumentationMappingContext;
+
+public class DocumentationLexicalConfig : IConfigureElasticsearch<DocumentationDocument>
+{
+	public AnalysisBuilder ConfigureAnalysis(AnalysisBuilder analysis) => SharedAnalysisFactory.BuildBaseAnalysis(analysis);
+
+	public IReadOnlyDictionary<string, string>? IndexSettings => null;
+
+	public MappingsBuilder<DocumentationDocument> ConfigureMappings(MappingsBuilder<DocumentationDocument> mappings) =>
+		mappings.AddSearchDocumentMappings().AddDocumentationMappings();
+}
+
+public class DocumentationSemanticConfig : IConfigureElasticsearch<DocumentationDocument>
+{
+	public AnalysisBuilder ConfigureAnalysis(AnalysisBuilder analysis) => analysis;
+
+	public IReadOnlyDictionary<string, string>? IndexSettings => null;
+
+	public MappingsBuilder<DocumentationDocument> ConfigureMappings(MappingsBuilder<DocumentationDocument> mappings) =>
+		mappings.AddSearchDocumentMappings(semantic: true).AddDocumentationMappings();
+}

--- a/src/Elastic.Documentation/Search/DocumentationMappingExtensions.cs
+++ b/src/Elastic.Documentation/Search/DocumentationMappingExtensions.cs
@@ -1,0 +1,37 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Internal.Search.Mapping;
+using Elastic.Mapping.Mappings;
+
+namespace Elastic.Documentation.Search;
+
+/// <summary>
+/// Documentation-specific mapping extensions for <c>docs-{type}.{lexical|semantic}-{env}</c> indices.
+/// Layers the <c>applies_to</c> nested and <c>parents</c> object sub-field definitions on top of
+/// <see cref="SharedMappingConfig.AddSearchDocumentMappings{T}"/>.
+/// </summary>
+public static class DocumentationMappingExtensions
+{
+	/// <summary>
+	/// Applies documentation-specific field topology to a <see cref="DocumentationDocument"/> mappings builder:
+	/// keyword overrides for <c>applies_to</c> sub-fields and multi-field configuration for <c>parents</c>.
+	/// </summary>
+	public static MappingsBuilder<DocumentationDocument> AddDocumentationMappings(this MappingsBuilder<DocumentationDocument> m) =>
+		m
+			// applies_to is [Nested] — AddProperty places sub-fields under "properties".
+			// Note: AppliesToEntry properties have no [Keyword] attributes so the generated
+			// AppliesToEntryNestedBuilder pre-types them as Text; AddProperty lets us override to Keyword.
+			.AddProperty("applies_to.type", f => f.Keyword().Normalizer(SharedMappingConfig.KeywordNormalizer))
+			.AddProperty("applies_to.sub_type", f => f.Keyword().Normalizer(SharedMappingConfig.KeywordNormalizer))
+			.AddProperty("applies_to.lifecycle", f => f.Keyword().Normalizer(SharedMappingConfig.KeywordNormalizer))
+			.AddProperty("applies_to.version", f => f.Version())
+			// parents is an object array — AddProperty places sub-fields under "properties".
+			.AddProperty("parents.url", f => f.Keyword()
+				.MultiField("match", mf => mf.Text())
+				.MultiField("prefix", mf => mf.Text().Analyzer(SharedMappingConfig.HierarchyAnalyzer)))
+			.AddProperty("parents.title", f => f.Text()
+				.SearchAnalyzer(SharedMappingConfig.SynonymsAnalyzer)
+				.MultiField("keyword", mf => mf.Keyword()));
+}

--- a/src/Elastic.Documentation/Search/IndexedProduct.cs
+++ b/src/Elastic.Documentation/Search/IndexedProduct.cs
@@ -1,0 +1,26 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text.Json.Serialization;
+using Elastic.Mapping;
+
+namespace Elastic.Documentation.Search;
+
+/// <summary>
+/// JSON-serializable product reference embedded on <see cref="DocumentationDocument.Product"/> /
+/// <see cref="DocumentationDocument.RelatedProducts"/>. Only id + repository are stored;
+/// display names are resolved at read time by the consumer.
+/// </summary>
+public record IndexedProduct
+{
+	[Keyword(Normalizer = "keyword_normalizer")]
+	[JsonPropertyName("id")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public string? Id { get; set; }
+
+	[Keyword(Normalizer = "keyword_normalizer")]
+	[JsonPropertyName("repository")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public string? Repository { get; set; }
+}

--- a/src/Elastic.Documentation/Serialization/SourceGenerationContext.cs
+++ b/src/Elastic.Documentation/Serialization/SourceGenerationContext.cs
@@ -8,7 +8,6 @@ using Elastic.Documentation.Links;
 using Elastic.Documentation.Search;
 using Elastic.Documentation.State;
 using Elastic.Documentation.Versions;
-using Elastic.Internal.Search;
 
 namespace Elastic.Documentation.Serialization;
 
@@ -22,6 +21,8 @@ namespace Elastic.Documentation.Serialization;
 [JsonSerializable(typeof(LinkRegistryEntry))]
 [JsonSerializable(typeof(DocumentationDocument))]
 [JsonSerializable(typeof(AppliesToEntry))]
+[JsonSerializable(typeof(IndexedProduct))]
+[JsonSerializable(typeof(IndexedProduct[]))]
 [JsonSerializable(typeof(Dictionary<string, string>))]
 [JsonSerializable(typeof(ApplicableTo))]
 [JsonSerializable(typeof(AppliesCollection))]

--- a/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchMarkdownExporter.cs
+++ b/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchMarkdownExporter.cs
@@ -14,7 +14,6 @@ using Elastic.Documentation.Serialization;
 using Elastic.Ingest.Elasticsearch;
 using Elastic.Ingest.Elasticsearch.Enrichment;
 using Elastic.Ingest.Elasticsearch.Indices;
-using Elastic.Internal.Search;
 using Elastic.Internal.Search.Mapping;
 using Elastic.Mapping;
 using Elastic.Transport;
@@ -177,7 +176,7 @@ public partial class ElasticsearchMarkdownExporter : IMarkdownExporter, IDisposa
 			ExportMaxConcurrency = _endpoint.IndexNumThreads,
 			ExportMaxRetries = _endpoint.MaxRetries
 		};
-		options.SerializerContext = Documentation.Serialization.SourceGenerationContext.Default;
+		options.SerializerContext = SourceGenerationContext.Default;
 		options.ExportResponseCallback = (response, buffer) =>
 		{
 			var sent = response.Items?.Count ?? 0;

--- a/src/api/Elastic.Documentation.Mcp.Remote/Gateways/DocumentGateway.cs
+++ b/src/api/Elastic.Documentation.Mcp.Remote/Gateways/DocumentGateway.cs
@@ -5,7 +5,6 @@
 using Elastic.Clients.Elasticsearch;
 using Elastic.Documentation.Search;
 using Elastic.Documentation.Search.Common;
-using Elastic.Internal.Search;
 using Microsoft.Extensions.Logging;
 
 namespace Elastic.Documentation.Mcp.Remote.Gateways;

--- a/src/services/Elastic.Documentation.Assembler/Building/AssemblerSitemapService.cs
+++ b/src/services/Elastic.Documentation.Assembler/Building/AssemblerSitemapService.cs
@@ -9,7 +9,6 @@ using Elastic.Documentation.Configuration.Assembler;
 using Elastic.Documentation.Diagnostics;
 using Elastic.Documentation.Search;
 using Elastic.Documentation.Services;
-using Elastic.Internal.Search;
 using Elastic.Markdown.Exporters.Elasticsearch;
 using Microsoft.Extensions.Logging;
 using Nullean.ScopedFileSystem;

--- a/src/services/search/Elastic.Documentation.Search/ChangesService.cs
+++ b/src/services/search/Elastic.Documentation.Search/ChangesService.cs
@@ -9,7 +9,7 @@ using Elastic.Clients.Elasticsearch;
 using Elastic.Documentation.Search.Common;
 using Elastic.Internal.Search;
 using Microsoft.Extensions.Logging;
-using EsSearchResponse = Elastic.Clients.Elasticsearch.SearchResponse<Elastic.Internal.Search.DocumentationDocument>;
+using EsSearchResponse = Elastic.Clients.Elasticsearch.SearchResponse<Elastic.Documentation.Search.DocumentationDocument>;
 
 namespace Elastic.Documentation.Search;
 

--- a/src/services/search/Elastic.Documentation.Search/Common/ElasticsearchClientAccessor.cs
+++ b/src/services/search/Elastic.Documentation.Search/Common/ElasticsearchClientAccessor.cs
@@ -6,7 +6,7 @@ using Elastic.Clients.Elasticsearch;
 using Elastic.Clients.Elasticsearch.Serialization;
 using Elastic.Documentation.Configuration;
 using Elastic.Documentation.Configuration.Search;
-using Elastic.Internal.Search;
+using Elastic.Documentation.Search;
 using Elastic.Transport;
 
 namespace Elastic.Documentation.Search.Common;

--- a/src/services/search/Elastic.Documentation.Search/Common/ElasticsearchClientJsonResolver.cs
+++ b/src/services/search/Elastic.Documentation.Search/Common/ElasticsearchClientJsonResolver.cs
@@ -3,24 +3,42 @@
 // See the LICENSE file in the project root for more information
 
 using System.Text.Json.Serialization.Metadata;
+using Elastic.Documentation.Search;
+using Elastic.Internal.Search;
 using DocSerializationContext = Elastic.Documentation.Serialization.SourceGenerationContext;
-using InternalSearch = Elastic.Internal.Search;
 using QuerySerializationContext = Elastic.Documentation.Search.SourceGenerationContext;
 
 namespace Elastic.Documentation.Search.Common;
 
 /// <summary>
-/// Combined JSON type info resolver for the shared Elasticsearch client: external search contract types,
-/// docs-builder document metadata, and query-rule criteria.
+/// Combined JSON type info resolver for the shared Elasticsearch client.
+/// <para>
+/// Combines the contract source-gen context (ISearchDocument, SearchDocumentBase,
+/// SiteDocument, LabsDocument, GuideDocument, WebsiteSearchDocument) with the
+/// in-repo query context and the docs-builder context (DocumentationDocument,
+/// AppliesToEntry, IndexedProduct).
+/// </para>
+/// <para>
+/// Registers <c>DocumentationDocument → "docs"</c> as a runtime-derived type on both
+/// <c>ISearchDocument</c> and <c>SearchDocumentBase</c>, and configures
+/// <c>SearchDocumentBase</c> with <c>FallBackToBaseType</c> so that a missing or
+/// unrecognized <c>$type</c> deserializes to a <see cref="SearchDocumentBase"/> instance
+/// rather than throwing.
+/// </para>
 /// </summary>
 internal static class ElasticsearchClientJsonResolver
 {
 	public static IJsonTypeInfoResolver Default { get; } = Create();
 
 	private static IJsonTypeInfoResolver Create() =>
-		JsonTypeInfoResolver.Combine(
-			InternalSearch.SourceGenerationContext.Default,
-			QuerySerializationContext.Default,
-			DocSerializationContext.Default
+		SearchDocumentPolymorphism.Compose(
+			consumerContexts:
+			[
+				QuerySerializationContext.Default,
+				DocSerializationContext.Default,
+			],
+			SearchDocumentPolymorphism.AddDerivedType<ISearchDocument>(typeof(DocumentationDocument), "docs"),
+			SearchDocumentPolymorphism.AddDerivedType<SearchDocumentBase>(typeof(DocumentationDocument), "docs"),
+			SearchDocumentPolymorphism.WithFallback()
 		);
 }

--- a/src/services/search/Elastic.Documentation.Search/Elastic.Documentation.Search.csproj
+++ b/src/services/search/Elastic.Documentation.Search/Elastic.Documentation.Search.csproj
@@ -16,7 +16,8 @@
 
     <ItemGroup>
       <PackageReference Include="Elastic.Clients.Elasticsearch" />
-      <PackageReference Include="Elastic.Internal.Search.Contract" />
+      <!-- TODO: switch back to PackageReference once the new contract version is published -->
+      <ProjectReference Include="../../../../../../.supacode/repos/website-search-data/feature/contract-work-move-docs-out/src/Elastic.Internal.Search.Contract/Elastic.Internal.Search.Contract.csproj" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
       <PackageReference Include="Microsoft.Extensions.Logging" />
     </ItemGroup>

--- a/src/services/search/Elastic.Documentation.Search/Elastic.Documentation.Search.csproj
+++ b/src/services/search/Elastic.Documentation.Search/Elastic.Documentation.Search.csproj
@@ -16,8 +16,7 @@
 
     <ItemGroup>
       <PackageReference Include="Elastic.Clients.Elasticsearch" />
-      <!-- TODO: switch back to PackageReference once the new contract version is published -->
-      <ProjectReference Include="../../../../../../.supacode/repos/website-search-data/feature/contract-work-move-docs-out/src/Elastic.Internal.Search.Contract/Elastic.Internal.Search.Contract.csproj" />
+      <PackageReference Include="Elastic.Internal.Search.Contract" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
       <PackageReference Include="Microsoft.Extensions.Logging" />
     </ItemGroup>

--- a/tests-integration/Elastic.Documentation.IntegrationTests/Search/SearchBootstrapFixture.cs
+++ b/tests-integration/Elastic.Documentation.IntegrationTests/Search/SearchBootstrapFixture.cs
@@ -8,6 +8,7 @@ using Aspire.Hosting.Testing;
 using AwesomeAssertions;
 using Documentation.Builder.Diagnostics.Console;
 using Elastic.Documentation.Aspire;
+using Elastic.Documentation.Search;
 using Elastic.Documentation.ServiceDefaults;
 using Elastic.Ingest.Elasticsearch;
 using Elastic.Internal.Search;

--- a/tests-integration/Mcp.Remote.IntegrationTests/McpToolsIntegrationTestsBase.cs
+++ b/tests-integration/Mcp.Remote.IntegrationTests/McpToolsIntegrationTestsBase.cs
@@ -87,9 +87,9 @@ public abstract class McpToolsIntegrationTestsBase(ITestOutputHelper output)
 			RulesetName = clientAccessor.RulesetName,
 			SemanticEnabled = true
 		};
-		var inner = new DefaultSearchService<Elastic.Internal.Search.DocumentationDocument>(
+		var inner = new DefaultSearchService<DocumentationDocument>(
 			clientAccessor.Client, clientAccessor.SearchIndex, queryConfig,
-			NullLogger<DefaultSearchService<Elastic.Internal.Search.DocumentationDocument>>.Instance,
+			NullLogger<DefaultSearchService<DocumentationDocument>>.Instance,
 			productsConfig);
 		return new FullSearchService(inner, productsConfig, NullLogger<FullSearchService>.Instance);
 	}

--- a/tests-integration/Search.IntegrationTests/SearchRelevanceTests.cs
+++ b/tests-integration/Search.IntegrationTests/SearchRelevanceTests.cs
@@ -256,9 +256,9 @@ See test output above for detailed scoring breakdowns from Elasticsearch's _expl
 			RulesetName = clientAccessor.RulesetName,
 			SemanticEnabled = true
 		};
-		var inner = new DefaultSearchService<Elastic.Internal.Search.DocumentationDocument>(
+		var inner = new DefaultSearchService<DocumentationDocument>(
 			clientAccessor.Client, clientAccessor.SearchIndex, queryConfig,
-			NullLogger<DefaultSearchService<Elastic.Internal.Search.DocumentationDocument>>.Instance);
+			NullLogger<DefaultSearchService<DocumentationDocument>>.Instance);
 
 		var gateway = new NavigationSearchService(inner, clientAccessor, NullLogger<NavigationSearchService>.Instance);
 		return (gateway, clientAccessor);


### PR DESCRIPTION
## Summary

Moves `DocumentationDocument`, `AppliesToEntry`, `IndexedProduct`, and `DocumentationMappingConfig` (plus the extracted `DocumentationMappingExtensions`) from the `Elastic.Internal.Search.Contract` NuGet package into the `Elastic.Documentation` project under the `Elastic.Documentation.Search` namespace. These docs-builder-specific types belong to the docs producer, not the shared contract package.

- **Runtime polymorphism** via `SearchDocumentPolymorphism.Compose()` (new in the companion contract PR):
  - Registers `DocumentationDocument → "docs"` on both `ISearchDocument` and `SearchDocumentBase` at startup.
  - Enables `WithFallback()` so missing/unknown `$type` deserializes to a concrete `SearchDocumentBase` instead of throwing `NotSupportedException`.
- **`ElasticsearchClientJsonResolver`** is rewritten to use `Compose()`, composing the contract, Elasticsearch, and docs source-gen contexts.
- **`Elastic.Mapping` bumped** to `0.48.0` to match the updated contract dependency.
- **Temporary `ProjectReference`** to the local contract branch (TODO: switch back to `PackageReference` once published).

## Depends on

**[website-search-data PR #215](https://github.com/elastic/website-search-data/pull/215)** — introduces `SearchDocumentPolymorphism` and removes `DocumentationDocument` from the contract package. Switch the `ProjectReference` back to a `PackageReference` before merging this PR (after PR #215 is published).

## Test plan

- [x] `dotnet build` — 0 errors, 1 pre-existing vulnerability warning
- [x] `dotnet-lint` pre-push hook — passes (no formatting violations)
- [x] `dotnet test tests/Elastic.Documentation.Build.Tests/` — 44 tests, all green
- [x] Integration tests (`tests-integration/`) compile cleanly; runtime requires ES connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)