### PR TITLE
Codex: resolve `internal` environment for index and search

### DIFF
--- a/src/Elastic.Codex/Building/CodexBuildService.cs
+++ b/src/Elastic.Codex/Building/CodexBuildService.cs
@@ -97,6 +97,7 @@ public class CodexBuildService(
 		{
 			var firstContext = buildContexts[0].BuildContext;
 			firstContext.Endpoints.BuildType = "codex";
+			firstContext.Endpoints.Environment = environment; // from codex.yml; ensures the correct index (e.g. internal)
 			sharedExporters = exporters.CreateMarkdownExporters(logFactory, firstContext).ToArray();
 			var startTasks = sharedExporters.Select(async e => await e.StartAsync(ctx));
 			await Task.WhenAll(startTasks);

--- a/src/Elastic.Documentation.Configuration/Codex/CodexConfiguration.cs
+++ b/src/Elastic.Documentation.Configuration/Codex/CodexConfiguration.cs
@@ -94,6 +94,12 @@ public record CodexConfiguration
 			sitePrefix = sitePrefix.TrimEnd('/');
 		}
 
-		return config with { SitePrefix = sitePrefix };
+		// Normalize environment: trim and lowercase so it maps cleanly to the
+		// lowercase Elasticsearch index namespace (e.g. "INTERNAL" / " internal " -> "internal").
+		var environment = config.Environment?.Trim().ToLowerInvariant();
+		if (string.IsNullOrEmpty(environment))
+			environment = null;
+
+		return config with { SitePrefix = sitePrefix, Environment = environment };
 	}
 }

--- a/src/Elastic.Documentation.ServiceDefaults/CodexEnvironmentValidator.cs
+++ b/src/Elastic.Documentation.ServiceDefaults/CodexEnvironmentValidator.cs
@@ -1,0 +1,22 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic.Documentation.ServiceDefaults;
+
+/// <summary>
+/// Validates the deployment environment for codex builds.
+/// Extend <see cref="Allowed"/> as new codex environments are introduced (e.g. <c>security</c>).
+/// Falls back to <c>dev</c> for unrecognized values.
+/// </summary>
+internal sealed class CodexEnvironmentValidator : IEnvironmentValidator
+{
+	// Extend as new codex environments are added.
+	private static readonly string[] Allowed = ["internal"];
+
+	public string Resolve(string? rawEnvironment)
+	{
+		var env = rawEnvironment?.Trim().ToLowerInvariant();
+		return env is not null && Allowed.Contains(env) ? env : "dev";
+	}
+}

--- a/src/Elastic.Documentation.ServiceDefaults/ElasticsearchEndpointFactory.cs
+++ b/src/Elastic.Documentation.ServiceDefaults/ElasticsearchEndpointFactory.cs
@@ -56,8 +56,11 @@ public static class ElasticsearchEndpointFactory
 			Username = username
 		};
 
-		environment ??= ResolveEnvironment(config, appConfiguration);
 		buildType ??= appConfiguration?["DOCS_BUILD_TYPE"] ?? config["DOCS_BUILD_TYPE"] ?? "isolated";
+		IEnvironmentValidator environmentValidator = buildType == "codex"
+			? new CodexEnvironmentValidator()
+			: new SiteEnvironmentValidator();
+		environment ??= environmentValidator.Resolve(appConfiguration?["ENVIRONMENT"] ?? config["ENVIRONMENT"]);
 
 		var searchIndexOverride =
 			config["DOCUMENTATION_ELASTIC_INDEX_OVERRIDE"]
@@ -70,27 +73,5 @@ public static class ElasticsearchEndpointFactory
 			BuildType = buildType,
 			SearchIndexOverride = !string.IsNullOrEmpty(searchIndexOverride) ? searchIndexOverride : null
 		};
-	}
-
-	/// <summary>
-	/// Resolves the domain environment name using this priority:
-	/// 1. <c>ENVIRONMENT</c> env var (our deployment env: dev, edge, staging, prod)
-	/// 2. Fallback: <c>"dev"</c>
-	/// </summary>
-	/// <remarks>
-	/// Deliberately reads only <c>ENVIRONMENT</c>, not <c>DOTNET_ENVIRONMENT</c>.
-	/// <c>DOTNET_ENVIRONMENT</c> is set by <c>AddDocumentationServiceDefaults</c> to the
-	/// mapped .NET hosting name (Development/Staging/Production) and must not be used as the
-	/// domain environment for index naming or telemetry.
-	/// </remarks>
-	private static string ResolveEnvironment(IConfiguration config, IConfiguration? appConfiguration)
-	{
-		var envVar = appConfiguration?["ENVIRONMENT"] ?? config["ENVIRONMENT"];
-
-		string[] allowedEnvironments = ["dev", "edge", "staging", "prod"];
-		if (!allowedEnvironments.Contains(envVar?.ToLowerInvariant()))
-			envVar = "dev";
-
-		return envVar!.ToLowerInvariant();
 	}
 }

--- a/src/Elastic.Documentation.ServiceDefaults/IEnvironmentValidator.cs
+++ b/src/Elastic.Documentation.ServiceDefaults/IEnvironmentValidator.cs
@@ -1,0 +1,19 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic.Documentation.ServiceDefaults;
+
+/// <summary>
+/// Validates and normalizes an <c>ENVIRONMENT</c> value for a specific build type.
+/// Returns the normalized value when valid, or a safe fallback when not.
+/// </summary>
+public interface IEnvironmentValidator
+{
+	/// <summary>
+	/// Validates <paramref name="rawEnvironment"/> and returns the normalized environment name.
+	/// Returns the fallback environment when <paramref name="rawEnvironment"/> is null, empty,
+	/// or not in the allowed set for this build type.
+	/// </summary>
+	string Resolve(string? rawEnvironment);
+}

--- a/src/Elastic.Documentation.ServiceDefaults/SiteEnvironmentValidator.cs
+++ b/src/Elastic.Documentation.ServiceDefaults/SiteEnvironmentValidator.cs
@@ -1,0 +1,20 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic.Documentation.ServiceDefaults;
+
+/// <summary>
+/// Validates the deployment environment for the main documentation site.
+/// Accepts <c>dev</c>, <c>edge</c>, <c>staging</c>, and <c>prod</c>; falls back to <c>dev</c>.
+/// </summary>
+internal sealed class SiteEnvironmentValidator : IEnvironmentValidator
+{
+	private static readonly string[] Allowed = ["dev", "edge", "staging", "prod"];
+
+	public string Resolve(string? rawEnvironment)
+	{
+		var env = rawEnvironment?.Trim().ToLowerInvariant();
+		return env is not null && Allowed.Contains(env) ? env : "dev";
+	}
+}


### PR DESCRIPTION
## Why

The codex API (search) and `codex index` (ingest) were targeting the wrong Elasticsearch index — `docs-codex.semantic-dev-latest` instead of `docs-codex.semantic-internal-latest`. The `ENVIRONMENT` allow-list only accepted `dev`/`edge`/`staging`/`prod` and silently fell back to `dev` for anything else, so the `internal` value injected by the codex deployment was discarded.

## What

Environment validation is now chosen per build type via a small strategy (`IEnvironmentValidator`): codex builds accept `internal` while the main documentation site keeps its strict deployment-environment list. In addition, the codex environment declared in `codex.yml` is now propagated onto the endpoints during the build, so ingest writes to the correct index regardless of the `ENVIRONMENT`/`DOCS_BUILD_TYPE` env vars — making the existing `codex index` validation actually meaningful.