### PR TITLE
Fix import ordering in ContentDateEnrichmentTests

### DIFF
--- a/tests-integration/Elastic.ContentDateEnrichment.IntegrationTests/ContentDateEnrichmentTests.cs
+++ b/tests-integration/Elastic.ContentDateEnrichment.IntegrationTests/ContentDateEnrichmentTests.cs
@@ -3,13 +3,13 @@
 // See the LICENSE file in the project root for more information
 
 using System.Globalization;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using AwesomeAssertions;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
 using Elastic.Documentation.Search;
 using Elastic.Documentation.Serialization;
-using System.Text.Json;
 using Elastic.Ingest.Elasticsearch;
 using Elastic.Internal.Search.Mapping;
 using Elastic.Markdown.Exporters.Elasticsearch;


### PR DESCRIPTION
## Why

The `lint` CI check (`dotnet format --verify-no-changes`) is currently failing on `main`: `ContentDateEnrichmentTests.cs` orders `using System.Text.Json;` after the `Elastic.*` usings, tripping the import-ordering analyzer. This blocks every open PR once it rebases onto `main`.

## What

Move `using System.Text.Json;` into the `System.*` import group so `dotnet format` passes. No functional change.

Made with [Cursor](https://cursor.com)