### PR TITLE
Simplify redundant SourceGenerationContext qualifier in ContentDateEnrichmentTests

### DIFF
--- a/tests-integration/Elastic.ContentDateEnrichment.IntegrationTests/ContentDateEnrichmentTests.cs
+++ b/tests-integration/Elastic.ContentDateEnrichment.IntegrationTests/ContentDateEnrichmentTests.cs
@@ -111,7 +111,7 @@ public class ContentDateEnrichmentTests(ElasticsearchFixture fixture, ITestOutpu
 
 		var options = new IngestChannelOptions<DocumentationDocument>(_transport, typeContext, indexNameOverride: indexNameOverride)
 		{
-			SerializerContext = Elastic.Documentation.Serialization.SourceGenerationContext.Default
+			SerializerContext = SourceGenerationContext.Default
 		};
 		return new IngestChannel<DocumentationDocument>(options);
 	}
@@ -325,7 +325,7 @@ public class ContentDateEnrichmentTests(ElasticsearchFixture fixture, ITestOutpu
 			Hash = "testhash123",
 			ContentBodyHash = "contenthash123"
 		};
-		var serializedDoc = JsonSerializer.Serialize(doc, Elastic.Documentation.Serialization.SourceGenerationContext.Default.DocumentationDocument);
+		var serializedDoc = JsonSerializer.Serialize(doc, SourceGenerationContext.Default.DocumentationDocument);
 
 		// Index via scripted upsert (same as HashedBulkUpdate)
 		await IndexFullDocumentViaScriptedUpsert(index, doc.Url, serializedDoc);
@@ -554,7 +554,7 @@ public class ContentDateEnrichmentTests(ElasticsearchFixture fixture, ITestOutpu
 				Hash = contentHash,
 				ContentBodyHash = contentHash
 			};
-			var serialized = JsonSerializer.Serialize(doc, Elastic.Documentation.Serialization.SourceGenerationContext.Default.DocumentationDocument);
+			var serialized = JsonSerializer.Serialize(doc, SourceGenerationContext.Default.DocumentationDocument);
 			await IndexFullDocumentViaScriptedUpsert(index, url, serialized);
 		}
 	}


### PR DESCRIPTION
## Why

`main`'s `lint` check is still failing after #3575. `dotnet format --verify-no-changes` exits non-zero for *any* pending change, including the `IDE0002` "name can be simplified" hints in `ContentDateEnrichmentTests.cs`. #3575 only fixed the import ordering — the qualifier simplification missed the squash-merge — so `main` (and every PR rebased onto it) is still red.

## What

`SourceGenerationContext` is already in scope via `using Elastic.Documentation.Serialization;`, so drop the redundant full qualifier at the three call sites. No functional change. Verified locally with `dotnet run --project build -c release -- lint` → no formatting violations.

Made with [Cursor](https://cursor.com)