### PR TITLE
Fix Nav V2 Administer labels and Elasticsearch platform naming

### DIFF
--- a/config/navigation-v2.yml
+++ b/config/navigation-v2.yml
@@ -407,1235 +407,1238 @@ nav:
           children:
           - title: Administration skills
           - label: Deployment-specific administration
-          - group: Elastic Cloud Hosted
             children:
-            - group: Manage deployments
-              page: docs-content://deploy-manage/deploy/elastic-cloud/manage-deployments.md
+            - group: Elastic Cloud Hosted
               children:
-              - group: Configure
-                page: docs-content://deploy-manage/deploy/elastic-cloud/configure.md
+              - group: Manage deployments
+                page: docs-content://deploy-manage/deploy/elastic-cloud/manage-deployments.md
                 children:
-                - page: docs-content://deploy-manage/deploy/elastic-cloud/ec-change-hardware-profile.md
-                  title: Manage hardware profiles
+                - group: Configure
+                  page: docs-content://deploy-manage/deploy/elastic-cloud/configure.md
                   children:
-                  - page: docs-content://deploy-manage/deploy/elastic-cloud/change-hardware.md
-                    title: Change instance configuration
-                - page: docs-content://deploy-manage/deploy/elastic-cloud/ec-customize-deployment-components.md  # BOTH PHASES
-                  title: Customize deployment components
-                - page: docs-content://deploy-manage/deploy/elastic-cloud/edit-stack-settings.md
-                  title: Edit stack settings
-                - page: docs-content://deploy-manage/deploy/elastic-cloud/add-plugins-extensions.md
-                  title: Add plugins and extensions
+                  - page: docs-content://deploy-manage/deploy/elastic-cloud/ec-change-hardware-profile.md
+                    title: Manage hardware profiles
+                    children:
+                    - page: docs-content://deploy-manage/deploy/elastic-cloud/change-hardware.md
+                      title: Change instance configuration
+                  - page: docs-content://deploy-manage/deploy/elastic-cloud/ec-customize-deployment-components.md  # BOTH PHASES
+                    title: Customize deployment components
+                  - page: docs-content://deploy-manage/deploy/elastic-cloud/edit-stack-settings.md
+                    title: Edit stack settings
+                  - page: docs-content://deploy-manage/deploy/elastic-cloud/add-plugins-extensions.md
+                    title: Add plugins and extensions
+                    children:
+                    - page: docs-content://deploy-manage/deploy/elastic-cloud/upload-custom-plugins-bundles.md
+                      title: Upload custom plugins
+                    - page: docs-content://deploy-manage/deploy/elastic-cloud/manage-plugins-extensions-through-api.md
+                      title: Manage through the API
+                  - page: docs-content://deploy-manage/deploy/elastic-cloud/custom-endpoint-aliases.md
+                    title: Custom endpoint aliases
+                - page: docs-content://deploy-manage/deploy/elastic-cloud/manage-integrations-server.md
+                  title: Manage Integrations Server
                   children:
-                  - page: docs-content://deploy-manage/deploy/elastic-cloud/upload-custom-plugins-bundles.md
-                    title: Upload custom plugins
-                  - page: docs-content://deploy-manage/deploy/elastic-cloud/manage-plugins-extensions-through-api.md
-                    title: Manage through the API
-                - page: docs-content://deploy-manage/deploy/elastic-cloud/custom-endpoint-aliases.md
-                  title: Custom endpoint aliases
-              - page: docs-content://deploy-manage/deploy/elastic-cloud/manage-integrations-server.md
-                title: Manage Integrations Server
-                children:
-                - page: docs-content://deploy-manage/deploy/elastic-cloud/switch-from-apm-to-integrations-server-payload.md
-                  title: Switch from APM to Integrations Server
-              - page: docs-content://deploy-manage/deploy/elastic-cloud/find-cloud-id.md
-                title: Find your Cloud ID
-              - page: docs-content://deploy-manage/deploy/elastic-cloud/manage-deployments-using-elastic-cloud-api.md
-                title: Manage deployments using the API
-              - page: docs-content://deploy-manage/deploy/elastic-cloud/keep-track-of-deployment-activity.md
-                title: Keep track of deployment activity
-            - page: docs-content://deploy-manage/deploy/elastic-cloud/access-kibana.md  # BOTH PHASES
-              title: Access Kibana
-            - page: docs-content://deploy-manage/deploy/elastic-cloud/ec-vcpu-boost-instance.md
-              title: vCPU boosting and credits
-            - page: docs-content://deploy-manage/deploy/elastic-cloud/available-stack-versions.md
-              title: Available stack versions
-            - page: docs-content://deploy-manage/deploy/elastic-cloud/restrictions-known-problems.md
-              title: Restrictions and known problems
-            - page: docs-content://deploy-manage/deploy/elastic-cloud/tools-apis.md
-              title: Tools and APIs
-          - group: Elastic Cloud Serverless
-            children:
-            - page: docs-content://deploy-manage/deploy/elastic-cloud/project-settings.md
-              title: Manage project settings
-            - page: docs-content://deploy-manage/deploy/elastic-cloud/manage-serverless-projects-using-api.md
-              title: Manage projects with API
-            - page: docs-content://deploy-manage/deploy/elastic-cloud/tools-apis.md
-              title: Tools and APIs
-          - group: Elastic Cloud Enterprise
-            children:
-            - group: Manage your orchestrator
-              page: docs-content://deploy-manage/deploy/cloud-enterprise/configure.md
+                  - page: docs-content://deploy-manage/deploy/elastic-cloud/switch-from-apm-to-integrations-server-payload.md
+                    title: Switch from APM to Integrations Server
+                - page: docs-content://deploy-manage/deploy/elastic-cloud/find-cloud-id.md
+                  title: Find your Cloud ID
+                - page: docs-content://deploy-manage/deploy/elastic-cloud/manage-deployments-using-elastic-cloud-api.md
+                  title: Manage deployments using the API
+                - page: docs-content://deploy-manage/deploy/elastic-cloud/keep-track-of-deployment-activity.md
+                  title: Keep track of deployment activity
+              - page: docs-content://deploy-manage/deploy/elastic-cloud/access-kibana.md  # BOTH PHASES
+                title: Access Kibana
+              - page: docs-content://deploy-manage/deploy/elastic-cloud/ec-vcpu-boost-instance.md
+                title: vCPU boosting and credits
+              - page: docs-content://deploy-manage/deploy/elastic-cloud/available-stack-versions.md
+                title: Available stack versions
+              - page: docs-content://deploy-manage/deploy/elastic-cloud/restrictions-known-problems.md
+                title: Restrictions and known problems
+              - page: docs-content://deploy-manage/deploy/elastic-cloud/tools-apis.md
+                title: Tools and APIs
+            - group: Elastic Cloud Serverless
               children:
-              - page: docs-content://deploy-manage/deploy/cloud-enterprise/log-into-cloud-ui.md  # BOTH PHASES
-                title: Log into the Cloud UI
-              - page: docs-content://deploy-manage/deploy/cloud-enterprise/assign-roles-to-hosts.md
-                title: Assign roles to hosts
-              - page: docs-content://deploy-manage/deploy/cloud-enterprise/system-deployments-configuration.md  # BOTH PHASES
-                title: System deployments configuration
+              - page: docs-content://deploy-manage/deploy/elastic-cloud/project-settings.md
+                title: Manage project settings
+              - page: docs-content://deploy-manage/deploy/elastic-cloud/manage-serverless-projects-using-api.md
+                title: Manage projects with API
+              - page: docs-content://deploy-manage/deploy/elastic-cloud/tools-apis.md
+                title: Tools and APIs
+            - group: Elastic Cloud Enterprise
+              children:
+              - group: Manage your orchestrator
+                page: docs-content://deploy-manage/deploy/cloud-enterprise/configure.md
                 children:
-                - page: docs-content://deploy-manage/deploy/cloud-enterprise/default-system-deployment-versions.md
-                  title: Default system deployment versions
-              - group: Deployment templates
-                page: docs-content://deploy-manage/deploy/cloud-enterprise/configure-deployment-templates.md  # BOTH PHASES
+                - page: docs-content://deploy-manage/deploy/cloud-enterprise/log-into-cloud-ui.md  # BOTH PHASES
+                  title: Log into the Cloud UI
+                - page: docs-content://deploy-manage/deploy/cloud-enterprise/assign-roles-to-hosts.md
+                  title: Assign roles to hosts
+                - page: docs-content://deploy-manage/deploy/cloud-enterprise/system-deployments-configuration.md  # BOTH PHASES
+                  title: System deployments configuration
+                  children:
+                  - page: docs-content://deploy-manage/deploy/cloud-enterprise/default-system-deployment-versions.md
+                    title: Default system deployment versions
+                - group: Deployment templates
+                  page: docs-content://deploy-manage/deploy/cloud-enterprise/configure-deployment-templates.md  # BOTH PHASES
+                  children:
+                  - page: docs-content://deploy-manage/deploy/cloud-enterprise/deployment-templates.md  # BOTH PHASES
+                    title: Deployment templates reference
+                  - page: docs-content://deploy-manage/deploy/cloud-enterprise/ece-configuring-ece-tag-allocators.md
+                    title: Tag allocators
+                  - page: docs-content://deploy-manage/deploy/cloud-enterprise/ece-configuring-ece-instance-configurations-edit.md
+                    title: Edit instance configurations
+                  - page: docs-content://deploy-manage/deploy/cloud-enterprise/ece-configuring-ece-instance-configurations-create.md
+                    title: Create instance configurations
+                  - page: docs-content://deploy-manage/deploy/cloud-enterprise/ece-configuring-ece-create-templates.md
+                    title: Create templates
+                  - page: docs-content://deploy-manage/deploy/cloud-enterprise/ece-configuring-ece-configure-system-templates.md
+                    title: Configure default templates
+                  - page: docs-content://deploy-manage/deploy/cloud-enterprise/ece-configure-templates-index-management.md
+                    title: Configure index management
+                  - page: docs-content://deploy-manage/deploy/cloud-enterprise/ce-add-support-for-node-roles-autoscaling.md
+                    title: Data tiers and autoscaling support
+                  - page: docs-content://deploy-manage/deploy/cloud-enterprise/ece-ce-add-support-for-integrations-server.md
+                    title: Integrations server support
+                  - page: docs-content://deploy-manage/deploy/cloud-enterprise/ece-configuring-ece-instance-configurations-default.md
+                    title: Default instance configurations
+                - page: docs-content://deploy-manage/deploy/cloud-enterprise/change-ece-api-url.md
+                  title: Change the API URL
+                - page: docs-content://deploy-manage/deploy/cloud-enterprise/change-endpoint-urls.md
+                  title: Change endpoint URLs
+                - page: docs-content://deploy-manage/deploy/cloud-enterprise/enable-custom-endpoint-aliases.md
+                  title: Enable custom endpoint aliases
+                - page: docs-content://deploy-manage/deploy/cloud-enterprise/ece-manage-capacity.md
+                  title: Manage allocator capacity
+                - page: docs-content://deploy-manage/deploy/cloud-enterprise/configure-allocator-affinity.md
+                  title: Configure allocator affinity
+                - page: docs-content://deploy-manage/deploy/cloud-enterprise/change-allocator-disconnect-timeout.md
+                  title: Change allocator disconnect timeout
+                - page: docs-content://deploy-manage/deploy/cloud-enterprise/install-ece-on-additional-hosts.md
+                  title: Add hosts
+                  children:
+                  - page: docs-content://deploy-manage/deploy/cloud-enterprise/generate-roles-tokens.md
+                    title: Manage roles tokens
+                - page: docs-content://deploy-manage/deploy/cloud-enterprise/migrate-ece-to-podman-hosts.md
+                  title: Migrate to Podman
+                  children:
+                  - page: docs-content://deploy-manage/deploy/cloud-enterprise/migrate-to-podman-5.md
+                    title: Migrate to Podman 5
+                - page: docs-content://deploy-manage/deploy/cloud-enterprise/ece-include-additional-kibana-plugin.md
+                  title: Include additional Kibana plugins
+                - page: docs-content://deploy-manage/deploy/cloud-enterprise/manage-elastic-stack-versions.md
+                  title: Manage stack versions
+                - page: docs-content://deploy-manage/deploy/cloud-enterprise/statistics-collected-by-cloud-enterprise.md
+                  title: Statistics collected by ECE
+                - page: docs-content://deploy-manage/deploy/cloud-enterprise/tools-apis.md
+                  title: Tools and APIs
+              - group: Manage deployments
+                page: docs-content://deploy-manage/deploy/cloud-enterprise/working-with-deployments.md
                 children:
                 - page: docs-content://deploy-manage/deploy/cloud-enterprise/deployment-templates.md  # BOTH PHASES
                   title: Deployment templates reference
-                - page: docs-content://deploy-manage/deploy/cloud-enterprise/ece-configuring-ece-tag-allocators.md
-                  title: Tag allocators
-                - page: docs-content://deploy-manage/deploy/cloud-enterprise/ece-configuring-ece-instance-configurations-edit.md
-                  title: Edit instance configurations
-                - page: docs-content://deploy-manage/deploy/cloud-enterprise/ece-configuring-ece-instance-configurations-create.md
-                  title: Create instance configurations
-                - page: docs-content://deploy-manage/deploy/cloud-enterprise/ece-configuring-ece-create-templates.md
-                  title: Create templates
-                - page: docs-content://deploy-manage/deploy/cloud-enterprise/ece-configuring-ece-configure-system-templates.md
-                  title: Configure default templates
-                - page: docs-content://deploy-manage/deploy/cloud-enterprise/ece-configure-templates-index-management.md
-                  title: Configure index management
-                - page: docs-content://deploy-manage/deploy/cloud-enterprise/ce-add-support-for-node-roles-autoscaling.md
-                  title: Data tiers and autoscaling support
-                - page: docs-content://deploy-manage/deploy/cloud-enterprise/ece-ce-add-support-for-integrations-server.md
-                  title: Integrations server support
-                - page: docs-content://deploy-manage/deploy/cloud-enterprise/ece-configuring-ece-instance-configurations-default.md
-                  title: Default instance configurations
-              - page: docs-content://deploy-manage/deploy/cloud-enterprise/change-ece-api-url.md
-                title: Change the API URL
-              - page: docs-content://deploy-manage/deploy/cloud-enterprise/change-endpoint-urls.md
-                title: Change endpoint URLs
-              - page: docs-content://deploy-manage/deploy/cloud-enterprise/enable-custom-endpoint-aliases.md
-                title: Enable custom endpoint aliases
-              - page: docs-content://deploy-manage/deploy/cloud-enterprise/ece-manage-capacity.md
-                title: Manage allocator capacity
-              - page: docs-content://deploy-manage/deploy/cloud-enterprise/configure-allocator-affinity.md
-                title: Configure allocator affinity
-              - page: docs-content://deploy-manage/deploy/cloud-enterprise/change-allocator-disconnect-timeout.md
-                title: Change allocator disconnect timeout
-              - page: docs-content://deploy-manage/deploy/cloud-enterprise/install-ece-on-additional-hosts.md
-                title: Add hosts
+                - page: docs-content://deploy-manage/deploy/cloud-enterprise/create-deployment.md  # BOTH PHASES
+                  title: Create a deployment
+                - page: docs-content://deploy-manage/deploy/cloud-enterprise/access-kibana.md  # BOTH PHASES
+                  title: Access Kibana
+                - page: docs-content://deploy-manage/deploy/cloud-enterprise/connect-elasticsearch.md  # BOTH PHASES
+                  title: Connect to Elasticsearch
+                - page: docs-content://deploy-manage/deploy/cloud-enterprise/configure-deployment.md
+                  title: Configure
+                  children:
+                  - page: docs-content://deploy-manage/deploy/cloud-enterprise/customize-deployment.md
+                    title: Customize deployment components
+                  - page: docs-content://deploy-manage/deploy/cloud-enterprise/edit-stack-settings.md
+                    title: Edit stack settings
+                    children:
+                    - page: docs-content://deploy-manage/deploy/cloud-enterprise/edit-stack-settings-elasticsearch.md
+                      title: Elasticsearch user settings
+                    - page: docs-content://deploy-manage/deploy/cloud-enterprise/edit-stack-settings-kibana.md
+                      title: Kibana user settings
+                    - page: docs-content://deploy-manage/deploy/cloud-enterprise/edit-stack-settings-apm.md
+                      title: APM user settings
+                    - page: docs-content://deploy-manage/deploy/cloud-enterprise/edit-stack-settings-enterprise.md
+                      title: Enterprise search user settings
+                  - page: docs-content://deploy-manage/deploy/cloud-enterprise/resize-deployment.md
+                    title: Resize a deployment
+                  - page: docs-content://deploy-manage/deploy/cloud-enterprise/add-plugins.md
+                    title: Add plugins and extensions
+                  - page: docs-content://deploy-manage/deploy/cloud-enterprise/add-custom-bundles-plugins.md
+                    title: Add custom bundles and plugins
+                  - page: docs-content://deploy-manage/deploy/cloud-enterprise/ece-regional-deployment-aliases.md
+                    title: Custom endpoint aliases
+                  - page: docs-content://deploy-manage/deploy/cloud-enterprise/resource-overrides.md
+                    title: Resource overrides
+                  - page: docs-content://deploy-manage/deploy/cloud-enterprise/advanced-cluster-configuration.md
+                    title: Advanced cluster configuration
+                - page: docs-content://deploy-manage/deploy/cloud-enterprise/search-filter-deployments.md
+                  title: Search and filter deployments
+                - page: docs-content://deploy-manage/deploy/cloud-enterprise/keep-track-of-deployment-activity.md
+                  title: Keep track of deployment activity
+                - page: docs-content://deploy-manage/deploy/cloud-enterprise/manage-integrations-server.md
+                  title: Manage Integrations Server
+                  children:
+                  - page: docs-content://deploy-manage/deploy/cloud-enterprise/ece-integrations-server-api-example.md
+                    title: Enable through the API
+                  - page: docs-content://deploy-manage/deploy/cloud-enterprise/switch-from-apm-to-integrations-server-payload.md
+                    title: Switch from APM
+            - group: Elastic Cloud on Kubernetes
+              children:
+              - group: Manage the ECK operator
+                page: docs-content://deploy-manage/deploy/cloud-on-k8s/configure.md
                 children:
-                - page: docs-content://deploy-manage/deploy/cloud-enterprise/generate-roles-tokens.md
-                  title: Manage roles tokens
-              - page: docs-content://deploy-manage/deploy/cloud-enterprise/migrate-ece-to-podman-hosts.md
-                title: Migrate to Podman
+                - page: docs-content://deploy-manage/deploy/cloud-on-k8s/configure-eck.md
+                  title: Apply configuration settings
+                - page: docs-content://deploy-manage/deploy/cloud-on-k8s/configure-validating-webhook.md
+                  title: Validating webhook
+                - page: docs-content://deploy-manage/deploy/cloud-on-k8s/restrict-cross-namespace-resource-associations.md
+                  title: Cross-namespace restrictions
+                - group: Service meshes
+                  page: docs-content://deploy-manage/deploy/cloud-on-k8s/service-meshes.md
+                  children:
+                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/k8s-service-mesh-istio.md
+                    title: Istio
+                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/k8s-service-mesh-linkerd.md
+                    title: Linkerd
+                - page: docs-content://deploy-manage/deploy/cloud-on-k8s/webhook-namespace-selectors.md
+                  title: Webhook namespace selectors
+              - group: Manage deployments and workloads
+                page: docs-content://deploy-manage/deploy/cloud-on-k8s/manage-deployments.md
                 children:
-                - page: docs-content://deploy-manage/deploy/cloud-enterprise/migrate-to-podman-5.md
-                  title: Migrate to Podman 5
-              - page: docs-content://deploy-manage/deploy/cloud-enterprise/ece-include-additional-kibana-plugin.md
-                title: Include additional Kibana plugins
-              - page: docs-content://deploy-manage/deploy/cloud-enterprise/manage-elastic-stack-versions.md
-                title: Manage stack versions
-              - page: docs-content://deploy-manage/deploy/cloud-enterprise/statistics-collected-by-cloud-enterprise.md
-                title: Statistics collected by ECE
-              - page: docs-content://deploy-manage/deploy/cloud-enterprise/tools-apis.md
+                - page: docs-content://deploy-manage/deploy/cloud-on-k8s/managing-deployments-using-helm-chart.md
+                  title: Elastic Stack Helm chart
+                - page: docs-content://deploy-manage/deploy/cloud-on-k8s/update-deployments.md
+                  title: Applying updates
+                - page: docs-content://deploy-manage/deploy/cloud-on-k8s/accessing-services.md  # BOTH PHASES
+                  title: Accessing services
+                - group: Configure deployments
+                  page: docs-content://deploy-manage/deploy/cloud-on-k8s/configure-deployments.md
+                  children:
+                  - group: Elasticsearch configuration
+                    page: docs-content://deploy-manage/deploy/cloud-on-k8s/elasticsearch-configuration.md
+                    children:
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/nodes-orchestration.md
+                      title: Nodes orchestration
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/storage-recommendations.md
+                      title: Storage recommendations
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/node-configuration.md
+                      title: Node configuration
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/volume-claim-templates.md
+                      title: Volume claim templates
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/virtual-memory.md
+                      title: Virtual memory
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/settings-managed-by-eck.md
+                      title: Settings managed by ECK
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/custom-configuration-files-plugins.md
+                      title: Custom configuration files and plugins
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/init-containers-for-plugin-downloads.md
+                      title: Init containers for plugins
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/update-strategy.md
+                      title: Update strategy
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/pod-disruption-budget.md
+                      title: Pod disruption budget
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/advanced-elasticsearch-node-scheduling.md
+                      title: Advanced node scheduling
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/readiness-probe.md
+                      title: Readiness probe
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/pod-prestop-hook.md
+                      title: Pod PreStop hook
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/security-context.md
+                      title: Security context
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/requests-routing-to-elasticsearch-nodes.md
+                      title: Traffic splitting
+                  - group: Kibana configuration
+                    page: docs-content://deploy-manage/deploy/cloud-on-k8s/kibana-configuration.md
+                    children:
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/k8s-kibana-es.md
+                      title: Connect Kibana to Elasticsearch
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/k8s-kibana-advanced-configuration.md
+                      title: Advanced configuration
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/k8s-kibana-plugins.md
+                      title: Kibana plugins
+                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/customize-pods.md
+                    title: Customize pods
+                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/propagate-labels-annotations.md
+                    title: Labels and annotations
+                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/manage-compute-resources.md
+                    title: Compute resources
+                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/recipes.md
+                    title: Recipes
+                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/connect-to-external-elastic-resources.md
+                    title: Connect to external resources
+                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/elastic-stack-configuration-policies.md
+                    title: Stack configuration policies
+                - group: Other Elastic applications
+                  page: docs-content://deploy-manage/deploy/cloud-on-k8s/orchestrate-other-elastic-applications.md
+                  children:
+                  - group: APM Server
+                    page: docs-content://deploy-manage/deploy/cloud-on-k8s/apm-server.md
+                    children:
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/use-an-elasticsearch-cluster-managed-by-eck.md
+                      title: Use an ECK-managed cluster
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/advanced-configuration.md
+                      title: Advanced configuration
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/connect-to-apm-server.md
+                      title: Connect to APM Server
+                  - group: Standalone Elastic Agent
+                    page: docs-content://deploy-manage/deploy/cloud-on-k8s/standalone-elastic-agent.md
+                    children:
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/quickstart-standalone.md
+                      title: Quickstart
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/configuration-standalone.md
+                      title: Configuration
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/configuration-examples-standalone.md
+                      title: Configuration examples
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/k8s-openshift-agent.md
+                      title: Agent on OpenShift
+                  - group: Fleet-managed Elastic Agent
+                    page: docs-content://deploy-manage/deploy/cloud-on-k8s/fleet-managed-elastic-agent.md
+                    children:
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/quickstart-fleet.md
+                      title: Quickstart
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/configuration-fleet.md
+                      title: Configuration
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/configuration-examples-fleet.md
+                      title: Configuration examples
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/known-limitations.md
+                      title: Known limitations
+                  - group: Elastic Maps Server
+                    page: docs-content://deploy-manage/deploy/cloud-on-k8s/elastic-maps-server.md
+                    children:
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/deploy-elastic-maps-server.md
+                      title: Deploy Maps Server
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/map-data.md
+                      title: Map data
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/advanced-configuration-maps-server.md
+                      title: Advanced configuration
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/http-configuration.md
+                      title: HTTP configuration
+                  - group: Beats
+                    page: docs-content://deploy-manage/deploy/cloud-on-k8s/beats.md
+                    children:
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/quickstart-beats.md
+                      title: Quickstart
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/configuration-beats.md
+                      title: Configuration
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/configuration-examples-beats.md
+                      title: Configuration examples
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/troubleshooting-beats.md
+                      title: Troubleshooting
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/k8s-openshift-beats.md
+                      title: Beats on OpenShift
+                  - group: Logstash
+                    page: docs-content://deploy-manage/deploy/cloud-on-k8s/logstash.md
+                    children:
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/quickstart-logstash.md
+                      title: Quickstart
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/configuration-logstash.md
+                      title: Configuration
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/securing-logstash-api.md
+                      title: Securing the API
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/logstash-plugins.md
+                      title: Plugins
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/configuration-examples-logstash.md
+                      title: Configuration examples
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/update-strategy-logstash.md
+                      title: Update strategy
+                    - page: docs-content://deploy-manage/deploy/cloud-on-k8s/advanced-configuration-logstash.md
+                      title: Advanced configuration
+                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/package-registry.md
+                    title: Elastic Package Registry
+              - page: docs-content://deploy-manage/deploy/cloud-on-k8s/create-custom-images.md
+                title: Custom images
+              - page: docs-content://deploy-manage/deploy/cloud-on-k8s/tools-apis.md
                 title: Tools and APIs
-            - group: Manage deployments
-              page: docs-content://deploy-manage/deploy/cloud-enterprise/working-with-deployments.md
+            - group: Self-managed clusters
               children:
-              - page: docs-content://deploy-manage/deploy/cloud-enterprise/deployment-templates.md  # BOTH PHASES
-                title: Deployment templates reference
-              - page: docs-content://deploy-manage/deploy/cloud-enterprise/create-deployment.md  # BOTH PHASES
-                title: Create a deployment
-              - page: docs-content://deploy-manage/deploy/cloud-enterprise/access-kibana.md  # BOTH PHASES
+              - page: docs-content://deploy-manage/deploy/self-managed/configure-elasticsearch.md  # BOTH PHASES
+                title: Configure Elasticsearch
+              - page: docs-content://deploy-manage/deploy/self-managed/configure-kibana.md
+                title: Configure Kibana
+              - page: docs-content://deploy-manage/deploy/self-managed/plugins.md
+                title: Manage plugins
+              - page: docs-content://deploy-manage/deploy/self-managed/access-kibana.md
                 title: Access Kibana
-              - page: docs-content://deploy-manage/deploy/cloud-enterprise/connect-elasticsearch.md  # BOTH PHASES
-                title: Connect to Elasticsearch
-              - page: docs-content://deploy-manage/deploy/cloud-enterprise/configure-deployment.md
-                title: Configure
-                children:
-                - page: docs-content://deploy-manage/deploy/cloud-enterprise/customize-deployment.md
-                  title: Customize deployment components
-                - page: docs-content://deploy-manage/deploy/cloud-enterprise/edit-stack-settings.md
-                  title: Edit stack settings
-                  children:
-                  - page: docs-content://deploy-manage/deploy/cloud-enterprise/edit-stack-settings-elasticsearch.md
-                    title: Elasticsearch user settings
-                  - page: docs-content://deploy-manage/deploy/cloud-enterprise/edit-stack-settings-kibana.md
-                    title: Kibana user settings
-                  - page: docs-content://deploy-manage/deploy/cloud-enterprise/edit-stack-settings-apm.md
-                    title: APM user settings
-                  - page: docs-content://deploy-manage/deploy/cloud-enterprise/edit-stack-settings-enterprise.md
-                    title: Enterprise search user settings
-                - page: docs-content://deploy-manage/deploy/cloud-enterprise/resize-deployment.md
-                  title: Resize a deployment
-                - page: docs-content://deploy-manage/deploy/cloud-enterprise/add-plugins.md
-                  title: Add plugins and extensions
-                - page: docs-content://deploy-manage/deploy/cloud-enterprise/add-custom-bundles-plugins.md
-                  title: Add custom bundles and plugins
-                - page: docs-content://deploy-manage/deploy/cloud-enterprise/ece-regional-deployment-aliases.md
-                  title: Custom endpoint aliases
-                - page: docs-content://deploy-manage/deploy/cloud-enterprise/resource-overrides.md
-                  title: Resource overrides
-                - page: docs-content://deploy-manage/deploy/cloud-enterprise/advanced-cluster-configuration.md
-                  title: Advanced cluster configuration
-              - page: docs-content://deploy-manage/deploy/cloud-enterprise/search-filter-deployments.md
-                title: Search and filter deployments
-              - page: docs-content://deploy-manage/deploy/cloud-enterprise/keep-track-of-deployment-activity.md
-                title: Keep track of deployment activity
-              - page: docs-content://deploy-manage/deploy/cloud-enterprise/manage-integrations-server.md
-                title: Manage Integrations Server
-                children:
-                - page: docs-content://deploy-manage/deploy/cloud-enterprise/ece-integrations-server-api-example.md
-                  title: Enable through the API
-                - page: docs-content://deploy-manage/deploy/cloud-enterprise/switch-from-apm-to-integrations-server-payload.md
-                  title: Switch from APM
-          - group: Elastic Cloud on Kubernetes
+              - page: docs-content://deploy-manage/deploy/self-managed/tools-apis.md
+                title: Tools and APIs
+          - label: General administrative tasks
             children:
-            - group: Manage the ECK operator
-              page: docs-content://deploy-manage/deploy/cloud-on-k8s/configure.md
+            - group: Security and encryption
+              page: docs-content://deploy-manage/security.md
               children:
-              - page: docs-content://deploy-manage/deploy/cloud-on-k8s/configure-eck.md
-                title: Apply configuration settings
-              - page: docs-content://deploy-manage/deploy/cloud-on-k8s/configure-validating-webhook.md
-                title: Validating webhook
-              - page: docs-content://deploy-manage/deploy/cloud-on-k8s/restrict-cross-namespace-resource-associations.md
-                title: Cross-namespace restrictions
-              - group: Service meshes
-                page: docs-content://deploy-manage/deploy/cloud-on-k8s/service-meshes.md
+              - page: docs-content://deploy-manage/security/secure-hosting-environment.md
+                title: "Secure your orchestrator"
                 children:
-                - page: docs-content://deploy-manage/deploy/cloud-on-k8s/k8s-service-mesh-istio.md
-                  title: Istio
-                - page: docs-content://deploy-manage/deploy/cloud-on-k8s/k8s-service-mesh-linkerd.md
-                  title: Linkerd
-              - page: docs-content://deploy-manage/deploy/cloud-on-k8s/webhook-namespace-selectors.md
-                title: Webhook namespace selectors
-            - group: Manage deployments and workloads
-              page: docs-content://deploy-manage/deploy/cloud-on-k8s/manage-deployments.md
-              children:
-              - page: docs-content://deploy-manage/deploy/cloud-on-k8s/managing-deployments-using-helm-chart.md
-                title: Elastic Stack Helm chart
-              - page: docs-content://deploy-manage/deploy/cloud-on-k8s/update-deployments.md
-                title: Applying updates
-              - page: docs-content://deploy-manage/deploy/cloud-on-k8s/accessing-services.md  # BOTH PHASES
-                title: Accessing services
-              - group: Configure deployments
-                page: docs-content://deploy-manage/deploy/cloud-on-k8s/configure-deployments.md
-                children:
-                - group: Elasticsearch configuration
-                  page: docs-content://deploy-manage/deploy/cloud-on-k8s/elasticsearch-configuration.md
-                  children:
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/nodes-orchestration.md
-                    title: Nodes orchestration
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/storage-recommendations.md
-                    title: Storage recommendations
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/node-configuration.md
-                    title: Node configuration
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/volume-claim-templates.md
-                    title: Volume claim templates
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/virtual-memory.md
-                    title: Virtual memory
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/settings-managed-by-eck.md
-                    title: Settings managed by ECK
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/custom-configuration-files-plugins.md
-                    title: Custom configuration files and plugins
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/init-containers-for-plugin-downloads.md
-                    title: Init containers for plugins
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/update-strategy.md
-                    title: Update strategy
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/pod-disruption-budget.md
-                    title: Pod disruption budget
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/advanced-elasticsearch-node-scheduling.md
-                    title: Advanced node scheduling
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/readiness-probe.md
-                    title: Readiness probe
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/pod-prestop-hook.md
-                    title: Pod PreStop hook
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/security-context.md
-                    title: Security context
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/requests-routing-to-elasticsearch-nodes.md
-                    title: Traffic splitting
-                - group: Kibana configuration
-                  page: docs-content://deploy-manage/deploy/cloud-on-k8s/kibana-configuration.md
-                  children:
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/k8s-kibana-es.md
-                    title: Connect Kibana to Elasticsearch
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/k8s-kibana-advanced-configuration.md
-                    title: Advanced configuration
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/k8s-kibana-plugins.md
-                    title: Kibana plugins
-                - page: docs-content://deploy-manage/deploy/cloud-on-k8s/customize-pods.md
-                  title: Customize pods
-                - page: docs-content://deploy-manage/deploy/cloud-on-k8s/propagate-labels-annotations.md
-                  title: Labels and annotations
-                - page: docs-content://deploy-manage/deploy/cloud-on-k8s/manage-compute-resources.md
-                  title: Compute resources
-                - page: docs-content://deploy-manage/deploy/cloud-on-k8s/recipes.md
-                  title: Recipes
-                - page: docs-content://deploy-manage/deploy/cloud-on-k8s/connect-to-external-elastic-resources.md
-                  title: Connect to external resources
-                - page: docs-content://deploy-manage/deploy/cloud-on-k8s/elastic-stack-configuration-policies.md
-                  title: Stack configuration policies
-              - group: Other Elastic applications
-                page: docs-content://deploy-manage/deploy/cloud-on-k8s/orchestrate-other-elastic-applications.md
-                children:
-                - group: APM Server
-                  page: docs-content://deploy-manage/deploy/cloud-on-k8s/apm-server.md
-                  children:
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/use-an-elasticsearch-cluster-managed-by-eck.md
-                    title: Use an ECK-managed cluster
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/advanced-configuration.md
-                    title: Advanced configuration
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/connect-to-apm-server.md
-                    title: Connect to APM Server
-                - group: Standalone Elastic Agent
-                  page: docs-content://deploy-manage/deploy/cloud-on-k8s/standalone-elastic-agent.md
-                  children:
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/quickstart-standalone.md
-                    title: Quickstart
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/configuration-standalone.md
-                    title: Configuration
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/configuration-examples-standalone.md
-                    title: Configuration examples
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/k8s-openshift-agent.md
-                    title: Agent on OpenShift
-                - group: Fleet-managed Elastic Agent
-                  page: docs-content://deploy-manage/deploy/cloud-on-k8s/fleet-managed-elastic-agent.md
-                  children:
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/quickstart-fleet.md
-                    title: Quickstart
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/configuration-fleet.md
-                    title: Configuration
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/configuration-examples-fleet.md
-                    title: Configuration examples
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/known-limitations.md
-                    title: Known limitations
-                - group: Elastic Maps Server
-                  page: docs-content://deploy-manage/deploy/cloud-on-k8s/elastic-maps-server.md
-                  children:
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/deploy-elastic-maps-server.md
-                    title: Deploy Maps Server
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/map-data.md
-                    title: Map data
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/advanced-configuration-maps-server.md
-                    title: Advanced configuration
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/http-configuration.md
-                    title: HTTP configuration
-                - group: Beats
-                  page: docs-content://deploy-manage/deploy/cloud-on-k8s/beats.md
-                  children:
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/quickstart-beats.md
-                    title: Quickstart
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/configuration-beats.md
-                    title: Configuration
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/configuration-examples-beats.md
-                    title: Configuration examples
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/troubleshooting-beats.md
-                    title: Troubleshooting
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/k8s-openshift-beats.md
-                    title: Beats on OpenShift
-                - group: Logstash
-                  page: docs-content://deploy-manage/deploy/cloud-on-k8s/logstash.md
-                  children:
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/quickstart-logstash.md
-                    title: Quickstart
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/configuration-logstash.md
-                    title: Configuration
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/securing-logstash-api.md
-                    title: Securing the API
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/logstash-plugins.md
-                    title: Plugins
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/configuration-examples-logstash.md
-                    title: Configuration examples
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/update-strategy-logstash.md
-                    title: Update strategy
-                  - page: docs-content://deploy-manage/deploy/cloud-on-k8s/advanced-configuration-logstash.md
-                    title: Advanced configuration
-                - page: docs-content://deploy-manage/deploy/cloud-on-k8s/package-registry.md
-                  title: Elastic Package Registry
-            - page: docs-content://deploy-manage/deploy/cloud-on-k8s/create-custom-images.md
-              title: Custom images
-            - page: docs-content://deploy-manage/deploy/cloud-on-k8s/tools-apis.md
-              title: Tools and APIs
-          - group: Self-managed clusters
-            children:
-            - page: docs-content://deploy-manage/deploy/self-managed/configure-elasticsearch.md  # BOTH PHASES
-              title: Configure Elasticsearch
-            - page: docs-content://deploy-manage/deploy/self-managed/configure-kibana.md
-              title: Configure Kibana
-            - page: docs-content://deploy-manage/deploy/self-managed/plugins.md
-              title: Manage plugins
-            - page: docs-content://deploy-manage/deploy/self-managed/access-kibana.md
-              title: Access Kibana
-            - page: docs-content://deploy-manage/deploy/self-managed/tools-apis.md
-              title: Tools and APIs
-          - label: ───
-          - group: Security and encryption
-            page: docs-content://deploy-manage/security.md
-            children:
-            - page: docs-content://deploy-manage/security/secure-hosting-environment.md
-              title: "Secure your orchestrator"
-              children:
-              - page: docs-content://deploy-manage/security/secure-your-elastic-cloud-enterprise-installation.md
-                title: "Elastic Cloud Enterprise"
-                children:
-                - page: docs-content://deploy-manage/security/secure-your-elastic-cloud-enterprise-installation/manage-security-certificates.md
-                  title: "Manage security certificates"
-                - page: docs-content://deploy-manage/security/secure-your-elastic-cloud-enterprise-installation/allow-x509-certificates-signed-with-sha-1.md
-                  title: "Allow X.509 certificates signed with SHA-1"
-                - page: docs-content://deploy-manage/security/secure-your-elastic-cloud-enterprise-installation/configure-tls-version.md
-                  title: "Configure the TLS version"
-                - page: docs-content://deploy-manage/security/secure-your-elastic-cloud-enterprise-installation/migrate-ece-on-podman-hosts-to-selinux-enforce.md
-                  title: "Migrate ECE on Podman hosts to SELinux enforce"
-              - page: docs-content://deploy-manage/security/secure-your-eck-installation.md
-                title: "Elastic Cloud on Kubernetes"
-            - page: docs-content://deploy-manage/security/secure-your-cluster-deployment.md
-              title: "Secure your cluster, deployment, or project"
-              children:
-              - page: docs-content://deploy-manage/security/self-setup.md
-                title: "Self-managed security setup"
-                children:
-                - page: docs-content://deploy-manage/security/self-auto-setup.md
-                  title: "Automatic security setup"
-                - page: docs-content://deploy-manage/security/set-up-minimal-security.md
-                  title: "Minimal security setup"
-                - page: docs-content://deploy-manage/security/set-up-basic-security.md
-                  title: "Set up transport TLS"
-                - page: docs-content://deploy-manage/security/set-up-basic-security-plus-https.md
-                  title: "Set up HTTPS"
-                - page: docs-content://deploy-manage/security/using-kibana-with-security.md
-                  title: "Configure security in Kibana"
-              - page: docs-content://deploy-manage/security/secure-cluster-communications.md
-                title: "Manage TLS encryption"
-                children:
-                - page: docs-content://deploy-manage/security/self-tls.md
-                  title: "Self-managed"
-                  children:
-                  - page: docs-content://deploy-manage/security/updating-certificates.md
-                    title: "Update TLS certificates"
-                    children:
-                    - page: docs-content://deploy-manage/security/same-ca.md
-                      title: "With the same CA"
-                    - page: docs-content://deploy-manage/security/different-ca.md
-                      title: "With a different CA"
-                  - page: docs-content://deploy-manage/security/kibana-es-mutual-tls.md
-                    title: "Mutual authentication"
-                  - page: docs-content://deploy-manage/security/supported-ssltls-versions-by-jdk-version.md
-                    title: "Supported SSL/TLS versions by JDK version"
-                  - page: docs-content://deploy-manage/security/enabling-cipher-suites-for-stronger-encryption.md
-                    title: "Enabling cipher suites for stronger encryption"
-                - page: docs-content://deploy-manage/security/eck-tls.md
-                  title: "ECK"
-                  children:
-                  - page: docs-content://deploy-manage/security/k8s-https-settings.md
-                    title: "Manage HTTP certificates on ECK"
-                  - page: docs-content://deploy-manage/security/k8s-transport-settings.md
-                    title: Manage transport certificates on ECK
-                  - page: docs-content://deploy-manage/security/k8s-es-client-certificate-auth.md
-                    title: "Client certificate authentication"
-                - page: docs-content://deploy-manage/security/external-ca-transport.md
-                  title: "External CA for TLS"
-              - page: docs-content://deploy-manage/security/network-security.md
-                title: "Network security"
-                children:
-                - page: docs-content://deploy-manage/security/network-security-policies.md
-                  title: "How network security policies work in Cloud"
-                - page: docs-content://deploy-manage/security/ece-filter-rules.md
-                  title: "How IP filtering rules work in ECE"
-                - page: docs-content://deploy-manage/security/ip-filtering.md
-                  title: "Add IP filters"
-                  children:
-                  - page: docs-content://deploy-manage/security/ip-filtering-cloud.md
-                    title: "In ECH or Serverless"
-                  - page: docs-content://deploy-manage/security/ip-filtering-ece.md
-                    title: "In ECE"
-                  - page: docs-content://deploy-manage/security/ip-filtering-basic.md
-                    title: "In ECK and Self Managed"
-                - page: docs-content://deploy-manage/security/remote-cluster-filtering.md
-                  title: "Remote cluster filters"
-                - page: docs-content://deploy-manage/security/private-connectivity.md
-                  title: "Private connectivity"
-                  children:
-                  - page: docs-content://deploy-manage/security/private-connectivity-aws.md
-                    title: "AWS PrivateLink"
-                  - page: docs-content://deploy-manage/security/private-connectivity-azure.md
-                    title: "Azure Private Link"
-                  - page: docs-content://deploy-manage/security/private-connectivity-gcp.md
-                    title: "GCP Private Service Connect"
-                  - page: docs-content://deploy-manage/security/claim-private-connection-api.md
-                    title: "Claim private connection ownership"
-                - page: docs-content://deploy-manage/security/network-security-api.md
-                  title: "Through the API"
-                - page: docs-content://deploy-manage/security/k8s-network-policies.md
-                  title: "Kubernetes network policies"
-              - page: docs-content://deploy-manage/security/elastic-cloud-static-ips.md
-                title: "Elastic Cloud static IPs"
-              - page: docs-content://deploy-manage/security/kibana-session-management.md
-                title: "Kibana session management"
-              - page: docs-content://deploy-manage/security/data-security.md
-                title: "Encrypt your deployment data"
-                children:
-                - page: docs-content://deploy-manage/security/encrypt-deployment-with-customer-managed-encryption-key.md
-                  title: "Use a customer-managed encryption key"
-              - page: docs-content://deploy-manage/security/secure-settings.md
-                title: "Secure your settings"
-                children:
-                - page: docs-content://deploy-manage/security/k8s-secure-settings.md
-                  title: "Secure settings on ECK"
-              - page: docs-content://deploy-manage/security/secure-saved-objects.md
-                title: "Secure Kibana saved objects"
-              - page: docs-content://deploy-manage/security/logging-configuration/security-event-audit-logging.md
-                title: "Security event audit logging"
-                children:
-                - page: docs-content://deploy-manage/security/logging-configuration/enabling-audit-logs.md
-                  title: "Enable audit logging"
-                - page: docs-content://deploy-manage/security/logging-configuration/configuring-audit-logs.md
-                  title: Configure audit logging
-                  children:
-                  - page: docs-content://deploy-manage/security/logging-configuration/logfile-audit-events-ignore-policies.md
-                    title: "Elasticsearch audit events ignore policies"
-                  - page: docs-content://deploy-manage/security/logging-configuration/logfile-audit-output.md
-                    title: "Elasticsearch logfile output"
-                - page: docs-content://deploy-manage/security/logging-configuration/auditing-search-queries.md
-                  title: Audit Elasticsearch search queries
-                - page: docs-content://deploy-manage/security/logging-configuration/correlating-kibana-elasticsearch-audit-logs.md
-                  title: "Correlate audit events"
-            - page: docs-content://deploy-manage/security/secure-clients-integrations.md
-              title: Secure other Elastic Stack components
-            - page: docs-content://deploy-manage/security/httprest-clients-security.md
-              title: Securing HTTP client applications
-            - page: docs-content://deploy-manage/security/limitations.md
-              title: "Limitations"
-            - page: docs-content://deploy-manage/security/fips.md
-              title: FIPS compliance
-              children:
-              - page: docs-content://deploy-manage/security/fips-es.md
-                title: FIPS compliance for Elasticsearch
-              - page: docs-content://deploy-manage/security/fips-kib.md
-                title: FIPS compliance for Kibana
-              - page: docs-content://deploy-manage/security/fips-ingest.md
-                title: FIPS mode for Ingest tools
-          - group: Authentication and authorization
-            page: docs-content://deploy-manage/users-roles.md
-            children:
-            - page: docs-content://deploy-manage/users-roles/cloud-organization.md
-              title: "Cloud organization"
-              children:
-              - page: docs-content://deploy-manage/users-roles/cloud-organization/manage-users.md
-                title: Manage users
-              - page: docs-content://deploy-manage/users-roles/cloud-organization/user-roles.md
-                title: User roles and privileges
-              - page: docs-content://deploy-manage/users-roles/cloud-organization/configure-saml-authentication.md
-                title: "Configure SAML SSO"
-                children:
-                - page: docs-content://deploy-manage/users-roles/cloud-organization/register-elastic-cloud-saml-in-okta.md
-                  title: "Okta"
-                - page: docs-content://deploy-manage/users-roles/cloud-organization/register-elastic-cloud-saml-in-microsoft-entra-id.md
-                  title: "Microsoft Entra ID"
-            - page: docs-content://deploy-manage/users-roles/cloud-enterprise-orchestrator.md
-              title: "ECE orchestrator"
-              children:
-              - page: docs-content://deploy-manage/users-roles/cloud-enterprise-orchestrator/manage-system-passwords.md
-                title: Manage system passwords
-              - page: docs-content://deploy-manage/users-roles/cloud-enterprise-orchestrator/manage-users-roles.md
-                title: Manage users and roles
-                children:
-                - page: docs-content://deploy-manage/users-roles/cloud-enterprise-orchestrator/native-user-authentication.md
-                  title: Native users
-                - page: docs-content://deploy-manage/users-roles/cloud-enterprise-orchestrator/active-directory.md
-                  title: Active Directory
-                - page: docs-content://deploy-manage/users-roles/cloud-enterprise-orchestrator/ldap.md
-                  title: LDAP
-                - page: docs-content://deploy-manage/users-roles/cloud-enterprise-orchestrator/saml.md
-                  title: SAML
-              - page: docs-content://deploy-manage/users-roles/cloud-enterprise-orchestrator/configure-sso-for-deployments.md
-                title: Configure SSO for deployments
-            - page: docs-content://deploy-manage/users-roles/serverless-custom-roles.md
-              title: Serverless project custom roles
-            - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth.md
-              title: "Cluster or deployment"
-              children:
-              - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/quickstart.md
-                title: "Quickstart"
-              - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/user-authentication.md
-                title: User authentication
-                children:
-                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/authentication-realms.md
-                  title: Authentication realms
-                  children:
-                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/realm-chains.md
-                    title: Realm chains
-                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/security-domains.md
-                    title: Security domains
-                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/internal-authentication.md
-                  title: Internal authentication
-                  children:
-                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/native.md
-                    title: "Native"
-                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/file-based.md
-                    title: "File-based"
-                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/external-authentication.md
-                  title: External authentication
-                  children:
-                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/active-directory.md
-                    title: "Active Directory"
-                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/jwt.md
-                    title: "JWT"
-                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/kerberos.md
-                    title: "Kerberos"
-                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/ldap.md
-                    title: "LDAP"
-                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/openid-connect.md
-                    title: "OpenID Connect"
-                    children:
-                    - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/oidc-examples.md
-                      title: "With Azure, Google, or Okta"
-                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/saml.md
-                    title: "SAML"
-                    children:
-                    - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/saml-entra.md
-                      title: "With Microsoft Entra ID"
-                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/pki.md
-                    title: PKI
-                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/custom.md
-                    title: Custom realms
-                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/built-in-users.md
-                  title: "Built-in users"
-                  children:
-                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/built-in-sm.md
-                    title: "Change passwords"
-                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/orchestrator-managed-users-overview.md
-                  title: "Orchestrator-managed users"
-                  children:
-                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/manage-elastic-user-cloud.md
-                    title: "ECH and ECE"
-                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/managed-credentials-eck.md
-                    title: "ECK managed credentials"
-                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/kibana-authentication.md
-                  title: "Kibana authentication"
-                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/access-agreement.md
-                  title: Kibana access agreement
-                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/anonymous-access.md
-                  title: Anonymous access
-                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/token-based-authentication-services.md
-                  title: Token-based authentication services
-                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/service-accounts.md
-                  title: Service accounts
-                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/internal-users.md
-                  title: Internal users
-                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/operator-privileges.md
-                  title: Operator privileges
-                  children:
-                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/configure-operator-privileges.md
-                    title: Configure operator privileges
-                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/operator-only-functionality.md
-                    title: Operator-only functionality
-                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/operator-privileges-for-snapshot-restore.md
-                    title: Operator privileges for snapshot and restore
-                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/user-profiles.md
-                  title: User profiles
-                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/looking-up-users-without-authentication.md
-                  title: Looking up users without authentication
-                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/controlling-user-cache.md
-                  title: Controlling the user cache
-                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/manage-authentication-for-multiple-clusters.md
-                  title: Manage authentication for multiple clusters
-              - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/user-roles.md
-                title: User roles
-                children:
-                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/defining-roles.md
-                  title: Defining roles
-                  children:
-                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/role-structure.md
-                    title: Role structure
-                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/granting-privileges-for-data-streams-aliases.md
-                    title: "For data streams and aliases"
-                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/kibana-role-management.md
-                    title: "Using Kibana"
-                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/role-restriction.md
-                    title: Role restriction
-                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/kibana-privileges.md
-                  title: Kibana privileges
-                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/mapping-users-groups-to-roles.md
-                  title: "Map users and groups to roles"
-                  children:
-                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/role-mapping-resources.md
-                    title: "Role mapping properties"
-                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/authorization-delegation.md
-                  title: Authorization delegation
-                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/authorization-plugins.md
-                  title: Authorization plugins
-                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/controlling-access-at-document-field-level.md
-                  title: "Control access at the document and field level"
-                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/submitting-requests-on-behalf-of-other-users.md
-                  title: "Submit requests on behalf of other users"
-          - group: API keys
-            page: docs-content://deploy-manage/api-keys.md
-            children:
-            - page: docs-content://deploy-manage/api-keys/elasticsearch-api-keys.md
-              title: Elasticsearch API keys
-            - page: docs-content://deploy-manage/api-keys/serverless-project-api-keys.md
-              title: Serverless project API keys
-            - page: docs-content://deploy-manage/api-keys/elastic-cloud-api-keys.md
-              title: Elastic Cloud API keys
-            - page: docs-content://deploy-manage/api-keys/elastic-cloud-enterprise-api-keys.md
-              title: Elastic Cloud Enterprise API keys
-          - group: Spaces
-            page: docs-content://deploy-manage/manage-spaces.md
-          - group: Monitoring
-            page: docs-content://deploy-manage/monitor.md
-            children:
-            - page: docs-content://deploy-manage/monitor/autoops.md
-              title: AutoOps
-              children:
-              - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-how-to-access.md
-                title: "For Elastic Cloud Hosted"
-              - page: docs-content://deploy-manage/monitor/autoops/autoops-for-serverless.md
-                title: "For Elastic Cloud Serverless"
-                children:
-                - page: docs-content://deploy-manage/monitor/autoops/access-autoops-for-serverless.md
-                  title: "Access AutoOps in your project"
-                - page: docs-content://deploy-manage/monitor/autoops/search-tier-view-autoops-serverless.md
-                  title: "Search Tier view"
-                - page: docs-content://deploy-manage/monitor/autoops/indexing-tier-view-autoops-serverless.md
-                  title: "Indexing Tier view"
-                - page: docs-content://deploy-manage/monitor/autoops/search-ai-lake-view-autoops-serverless.md
-                  title: "Search AI Lake view"
-              - page: docs-content://deploy-manage/monitor/autoops/cc-autoops-as-cloud-connected.md
-                title: "For ECE, ECK, and self-managed clusters"
-                children:
-                - page: docs-content://deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md
-                  title: "Connect your cluster"
-                - page: docs-content://deploy-manage/monitor/autoops/cc-connect-local-dev-to-autoops.md
-                  title: "Connect your local development cluster"
-                - page: docs-content://deploy-manage/monitor/autoops/autoops-sm-custom-certification.md
-                  title: "Configure Elastic agent with custom certificate"
-                - page: docs-content://deploy-manage/monitor/autoops/autoops-disable-metrics-collection.md
-                  title: "Disable certain types of data collection"
-                - page: docs-content://deploy-manage/monitor/autoops/cc-manage-users.md
-                  title: "Manage connected cluster users"
-                - page: docs-content://deploy-manage/monitor/autoops/cc-cloud-connect-autoops-troubleshooting.md
-                  title: "Troubleshooting"
-                  children:
-                  - page: docs-content://deploy-manage/monitor/autoops/autoops-connectivity-check.md
-                    title: "Run the Connectivity Check"
-                  - page: docs-content://deploy-manage/monitor/autoops/autoops-sm-troubleshoot-firewalls.md
-                    title: "Firewalls blocking Elastic Agent"
-                  - page: docs-content://deploy-manage/monitor/autoops/autoops-sm-troubleshoot-eck-no-clusters.md
-                    title: "Connected clusters not appearing with ECK"
-              - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-regions.md
-                title: "Regions"
-              - page: docs-content://deploy-manage/monitor/autoops/views.md
-                title: "Views"
-                children:
-                - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-overview-view.md
-                  title: "Overview"
-                - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-deployment-view.md
-                  title: "Deployment or Cluster"
-                - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-nodes-view.md
-                  title: "Nodes"
-                - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-index-view.md
-                  title: "Indices"
-                - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-shards-view.md
-                  title: "Shards"
-                - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-template-optimizer.md
-                  title: "Template Optimizer"
-              - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-events.md
-                title: "Events"
-                children:
-                - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-event-settings.md
-                  title: Event Settings
-                - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-notifications-settings.md
-                  title: Notifications Settings
-              - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-faq.md
-                title: "FAQ"
-            - page: docs-content://deploy-manage/monitor/stack-monitoring.md
-              title: Stack monitoring
-              children:
-              - page: docs-content://deploy-manage/monitor/stack-monitoring/ece-ech-stack-monitoring.md
-                title: "Enable on ECH and ECE"
-              - page: docs-content://deploy-manage/monitor/stack-monitoring/eck-stack-monitoring.md
-                title: "Enable on ECK"
-              - page: docs-content://deploy-manage/monitor/stack-monitoring/elasticsearch-monitoring-self-managed.md
-                title: "Self-managed: Elasticsearch"
-                children:
-                - page: docs-content://deploy-manage/monitor/stack-monitoring/collecting-monitoring-data-with-elastic-agent.md
-                  title: "Collecting monitoring data with Elastic Agent"
-                - page: docs-content://deploy-manage/monitor/stack-monitoring/collecting-monitoring-data-with-metricbeat.md
-                  title: "Collecting monitoring data with Metricbeat"
-                - page: docs-content://deploy-manage/monitor/stack-monitoring/collecting-log-data-with-filebeat.md
-                  title: "Collecting log data with Filebeat"
-                - page: docs-content://deploy-manage/monitor/stack-monitoring/es-self-monitoring-prod.md
-                  title: Monitoring in a production environment
-                - page: docs-content://deploy-manage/monitor/stack-monitoring/es-legacy-collection-methods.md
-                  title: "Legacy collection methods"
-                  children:
-                  - page: docs-content://deploy-manage/monitor/stack-monitoring/es-monitoring-collectors.md
-                    title: Collectors
-                  - page: docs-content://deploy-manage/monitor/stack-monitoring/es-monitoring-exporters.md
-                    title: Exporters
-                  - page: docs-content://deploy-manage/monitor/stack-monitoring/es-local-exporter.md
-                    title: Local exporters
-                  - page: docs-content://deploy-manage/monitor/stack-monitoring/es-http-exporter.md
-                    title: HTTP exporters
-                  - page: docs-content://deploy-manage/monitor/stack-monitoring/es-pause-export.md
-                    title: Pausing data collection
-              - page: docs-content://deploy-manage/monitor/stack-monitoring/kibana-monitoring-self-managed.md
-                title: "Self-managed: Kibana"
-                children:
-                - page: docs-content://deploy-manage/monitor/stack-monitoring/kibana-monitoring-elastic-agent.md
-                  title: "Collect monitoring data with Elastic Agent"
-                - page: docs-content://deploy-manage/monitor/stack-monitoring/kibana-monitoring-metricbeat.md
-                  title: "Collect monitoring data with Metricbeat"
-                - page: docs-content://deploy-manage/monitor/stack-monitoring/kibana-monitoring-legacy.md
-                  title: "Legacy collection methods"
-              - page: docs-content://deploy-manage/monitor/stack-monitoring/kibana-monitoring-data.md
-                title: Access monitoring data in Kibana
-              - page: docs-content://deploy-manage/monitor/monitoring-data/visualizing-monitoring-data.md
-                title: Visualizing monitoring data
-                children:
-                - page: docs-content://deploy-manage/monitor/monitoring-data/beats-page.md
-                  title: Beats metrics
-                - page: docs-content://deploy-manage/monitor/monitoring-data/elasticsearch-metrics.md
-                  title: Elasticsearch metrics
-                - page: docs-content://deploy-manage/monitor/monitoring-data/kibana-page.md
-                  title: Kibana metrics
-                - page: docs-content://deploy-manage/monitor/monitoring-data/integrations-server-page.md
-                  title: Integrations Server metrics
-                - page: docs-content://deploy-manage/monitor/monitoring-data/logstash-page.md
-                  title: Logstash metrics
-                - page: docs-content://deploy-manage/monitor/monitoring-data/monitor-troubleshooting.md
-                  title: "Troubleshooting"
-              - page: docs-content://deploy-manage/monitor/monitoring-data/configure-stack-monitoring-alerts.md
-                title: Stack monitoring alerts
-              - page: docs-content://deploy-manage/monitor/monitoring-data/configuring-data-streamsindices-for-monitoring.md
-                title: Configuring monitoring data streams and indices
-                children:
-                - page: docs-content://deploy-manage/monitor/monitoring-data/config-monitoring-data-streams-elastic-agent.md
-                  title: Configuring data streams created by Elastic Agent
-                - page: docs-content://deploy-manage/monitor/monitoring-data/config-monitoring-data-streams-metricbeat-8.md
-                  title: Configuring data streams created by Metricbeat 8
-                - page: docs-content://deploy-manage/monitor/monitoring-data/config-monitoring-indices-metricbeat-7-internal-collection.md
-                  title: Configuring indices created by Metricbeat 7 or internal collection
-            - page: docs-content://deploy-manage/monitor/autoops-vs-stack-monitoring.md
-              title: "AutoOps vs. Stack Monitoring"
-            - page: docs-content://deploy-manage/monitor/cloud-health-perf.md
-              title: "Cloud deployment health"
-              children:
-              - page: docs-content://deploy-manage/monitor/access-performance-metrics-on-elastic-cloud.md
-                title: Performance metrics on Elastic Cloud
-              - page: docs-content://deploy-manage/monitor/ec-memory-pressure.md
-                title: JVM memory pressure indicator
-            - page: docs-content://deploy-manage/monitor/kibana-task-manager-health-monitoring.md
-              title: "Kibana task manager monitoring"
-            - page: docs-content://deploy-manage/monitor/orchestrators.md
-              title: Monitoring orchestrators
-              children:
-              - page: docs-content://deploy-manage/monitor/orchestrators/eck-metrics-configuration.md
-                title: ECK operator metrics
-                children:
-                - page: docs-content://deploy-manage/monitor/orchestrators/k8s-enabling-metrics-endpoint.md
-                  title: Enabling the metrics endpoint
-                - page: docs-content://deploy-manage/monitor/orchestrators/k8s-securing-metrics-endpoint.md
-                  title: Securing the metrics endpoint
-                - page: docs-content://deploy-manage/monitor/orchestrators/k8s-prometheus-requirements.md
-                  title: Prometheus requirements
-              - page: docs-content://deploy-manage/monitor/orchestrators/ece-platform-monitoring.md
-                title: ECE platform monitoring
-                children:
-                - page: docs-content://deploy-manage/monitor/orchestrators/ece-monitoring-ece-access.md
-                  title: Platform monitoring deployment logs and metrics
-                - page: docs-content://deploy-manage/monitor/orchestrators/ece-proxy-log-fields.md
-                  title: Proxy log fields
-                - page: docs-content://deploy-manage/monitor/orchestrators/ece-monitoring-ece-set-retention.md
-                  title: Set the retention period for logging and metrics indices
-            - page: docs-content://deploy-manage/monitor/logging-configuration.md
-              title: Logging
-              children:
-              - page: docs-content://deploy-manage/monitor/logging-configuration/elasticsearch-log4j-configuration-self-managed.md
-                title: Elasticsearch log4j configuration
-              - page: docs-content://deploy-manage/monitor/logging-configuration/update-elasticsearch-logging-levels.md
-                title: Update Elasticsearch logging levels
-              - page: docs-content://deploy-manage/monitor/logging-configuration/elasticsearch-deprecation-logs.md
-                title: Elasticsearch deprecation logs
-              - page: docs-content://deploy-manage/monitor/logging-configuration/slow-logs.md
-                title: Slow query and index logging
-              - page: docs-content://deploy-manage/monitor/logging-configuration/kibana-logging.md
-                title: Kibana logging
-                children:
-                - page: docs-content://deploy-manage/monitor/logging-configuration/kibana-log-levels.md
-                  title: Set global log levels for Kibana
-                - page: docs-content://deploy-manage/monitor/logging-configuration/kib-advanced-logging.md
-                  title: Advanced Kibana logging settings
-                  children:
-                  - page: docs-content://deploy-manage/monitor/logging-configuration/kibana-log-settings-examples.md
-                    title: "Examples"
-          - page: docs-content://deploy-manage/kibana-reporting-configuration.md
-            title: Configure Kibana reporting
-          - group: Backup, high availability, and resilience tools
-            page: docs-content://deploy-manage/tools.md
-            children:
-            - page: docs-content://deploy-manage/tools/snapshot-and-restore.md
-              title: Snapshot and restore
-              children:
-              - page: docs-content://deploy-manage/tools/snapshot-and-restore/manage-snapshot-repositories.md
-                title: Manage snapshot repositories
-                children:
-                - page: docs-content://deploy-manage/tools/snapshot-and-restore/self-managed.md
-                  title: "Self-managed"
-                  children:
-                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/azure-repository.md
-                    title: Azure repository
-                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/google-cloud-storage-repository.md
-                    title: Google Cloud Storage repository
-                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/s3-repository.md
-                    title: S3 repository
-                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/shared-file-system-repository.md
-                    title: Shared file system repository
-                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/read-only-url-repository.md
-                    title: Read-only URL repository
-                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/source-only-repository.md
-                    title: Source-only repository
-                - page: docs-content://deploy-manage/tools/snapshot-and-restore/elastic-cloud-hosted.md
-                  title: "Elastic Cloud Hosted"
-                  children:
-                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/ec-aws-custom-repository.md
-                    title: "AWS S3"
-                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/ec-gcs-snapshotting.md
-                    title: "Google Cloud Storage"
-                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/ec-azure-snapshotting.md
-                    title: "Azure Blob Storage"
-                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/access-isolation-for-found-snapshots-repository.md
-                    title: Access isolation for the found-snapshots repository
-                    children:
-                    - page: docs-content://deploy-manage/tools/snapshot-and-restore/repository-isolation-on-azure.md
-                      title: "Azure"
-                    - page: docs-content://deploy-manage/tools/snapshot-and-restore/repository-isolation-on-aws-gcp.md
-                      title: "AWS and GCP"
-                - page: docs-content://deploy-manage/tools/snapshot-and-restore/cloud-enterprise.md
+                - page: docs-content://deploy-manage/security/secure-your-elastic-cloud-enterprise-installation.md
                   title: "Elastic Cloud Enterprise"
                   children:
-                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/ece-aws-custom-repository.md
-                    title: "AWS S3"
-                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/google-cloud-storage-gcs-repository.md
-                    title: "Google Cloud Storage"
-                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/azure-storage-repository.md
-                    title: Azure Storage repository
-                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/minio-on-premise-repository.md
-                    title: MinIO self-managed repository
-                - page: docs-content://deploy-manage/tools/snapshot-and-restore/cloud-on-k8s.md
+                  - page: docs-content://deploy-manage/security/secure-your-elastic-cloud-enterprise-installation/manage-security-certificates.md
+                    title: "Manage security certificates"
+                  - page: docs-content://deploy-manage/security/secure-your-elastic-cloud-enterprise-installation/allow-x509-certificates-signed-with-sha-1.md
+                    title: "Allow X.509 certificates signed with SHA-1"
+                  - page: docs-content://deploy-manage/security/secure-your-elastic-cloud-enterprise-installation/configure-tls-version.md
+                    title: "Configure the TLS version"
+                  - page: docs-content://deploy-manage/security/secure-your-elastic-cloud-enterprise-installation/migrate-ece-on-podman-hosts-to-selinux-enforce.md
+                    title: "Migrate ECE on Podman hosts to SELinux enforce"
+                - page: docs-content://deploy-manage/security/secure-your-eck-installation.md
                   title: "Elastic Cloud on Kubernetes"
-              - page: docs-content://deploy-manage/tools/snapshot-and-restore/create-snapshots.md
-                title: Create, monitor and delete snapshots
-              - page: docs-content://deploy-manage/tools/snapshot-and-restore/restore-snapshot.md
-                title: Restore a snapshot
+              - page: docs-content://deploy-manage/security/secure-your-cluster-deployment.md
+                title: "Secure your cluster, deployment, or project"
                 children:
-                - page: docs-content://deploy-manage/tools/snapshot-and-restore/ece-restore-across-clusters.md
-                  title: Restore a snapshot across clusters
+                - page: docs-content://deploy-manage/security/self-setup.md
+                  title: "Self-managed security setup"
                   children:
-                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/ece-restore-snapshots-into-new-deployment.md
-                    title: Restore snapshot into a new deployment
-                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/ece-restore-snapshots-into-existing-deployment.md
-                    title: Restore snapshot into an existing deployment
-                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/ece-restore-snapshots-containing-searchable-snapshots-indices-across-clusters.md
-                    title: Restore snapshots containing searchable snapshots indices across clusters
-              - page: docs-content://deploy-manage/tools/snapshot-and-restore/searchable-snapshots.md
-                title: Searchable snapshots
-            - page: docs-content://deploy-manage/tools/cross-cluster-replication.md
-              title: Cross-cluster replication
-              children:
-              - page: docs-content://deploy-manage/tools/cross-cluster-replication/set-up-cross-cluster-replication.md
-                title: "Set up cross-cluster replication"
-                children:
-                - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-getting-started-prerequisites.md
-                  title: "Prerequisites"
-                - page: docs-content://deploy-manage/tools/cross-cluster-replication/_connect_to_a_remote_cluster.md
-                  title: Connect to a remote cluster
-                - page: docs-content://deploy-manage/tools/cross-cluster-replication/_configure_privileges_for_cross_cluster_replication_2.md
-                  title: Configure privileges for cross-cluster replication
-                - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-getting-started-follower-index.md
-                  title: Create a follower index to replicate a specific index
-                - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-getting-started-auto-follow.md
-                  title: Create an auto-follow pattern to replicate time series indices
-              - page: docs-content://deploy-manage/tools/cross-cluster-replication/manage-cross-cluster-replication.md
-                title: Manage cross-cluster replication
-                children:
-                - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-inspect-progress.md
-                  title: Inspect replication statistics
-                - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-pause-replication.md
-                  title: Pause and resume replication
-                - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-recreate-follower-index.md
-                  title: Recreate a follower index
-                - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-terminate-replication.md
-                  title: Terminate replication
-              - page: docs-content://deploy-manage/tools/cross-cluster-replication/manage-auto-follow-patterns.md
-                title: Manage auto-follow patterns
-                children:
-                - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-auto-follow-create.md
-                  title: Create auto-follow patterns
-                - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-auto-follow-retrieve.md
-                  title: Retrieve auto-follow patterns
-                - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-auto-follow-pause.md
-                  title: Pause and resume auto-follow patterns
-                - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-auto-follow-delete.md
-                  title: Delete auto-follow patterns
-              - page: docs-content://deploy-manage/tools/cross-cluster-replication/upgrading-clusters.md
-                title: "Upgrading clusters"
-                children:
-                - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-uni-directional-upgrade.md
-                  title: Uni-directional index following
-                - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-bi-directional-upgrade.md
-                  title: Bi-directional index following
-              - page: docs-content://deploy-manage/tools/cross-cluster-replication/uni-directional-disaster-recovery.md
-                title: "Uni-directional disaster recovery"
-                children:
-                - page: docs-content://deploy-manage/tools/cross-cluster-replication/_prerequisites_14.md
-                  title: "Prerequisites"
-                - page: docs-content://deploy-manage/tools/cross-cluster-replication/_failover_when_clustera_is_down.md
-                  title: "Failover when clusterA is down"
-                - page: docs-content://deploy-manage/tools/cross-cluster-replication/_failback_when_clustera_comes_back.md
-                  title: "Failback when clusterA comes back"
-              - page: docs-content://deploy-manage/tools/cross-cluster-replication/bi-directional-disaster-recovery.md
-                title: "Bi-directional disaster recovery"
-                children:
-                - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-tutorial-initial-setup.md
-                  title: Initial setup
-                - page: docs-content://deploy-manage/tools/cross-cluster-replication/_failover_when_clustera_is_down_2.md
-                  title: "Failover when clusterA is down"
-                - page: docs-content://deploy-manage/tools/cross-cluster-replication/_failback_when_clustera_comes_back_2.md
-                  title: "Failback when clusterA comes back"
-                - page: docs-content://deploy-manage/tools/cross-cluster-replication/_perform_update_or_delete_by_query.md
-                  title: Perform update or delete by query
-          - group: Autoscaling
-            page: docs-content://deploy-manage/autoscaling.md
-            children:
-            - page: docs-content://deploy-manage/autoscaling/autoscaling-in-ece-and-ech.md
-              title: "In ECE and ECH"
-            - page: docs-content://deploy-manage/autoscaling/autoscaling-in-eck.md
-              title: "In ECK"
-            - page: docs-content://deploy-manage/autoscaling/autoscaling-deciders.md
-              title: Autoscaling deciders
-            - page: docs-content://deploy-manage/autoscaling/trained-model-autoscaling.md
-              title: Trained model autoscaling
-          - page: docs-content://deploy-manage/stack-settings.md
-            title: Stack settings
-          - page: docs-content://deploy-manage/manage-connectors.md
-            title: Connectors
-          - group: Remote clusters
-            page: docs-content://deploy-manage/remote-clusters.md
-            children:
-            - page: docs-content://deploy-manage/remote-clusters/security-models.md
-              title: "Security models"
-            - page: docs-content://deploy-manage/remote-clusters/connection-modes.md
-              title: "Connection modes"
-            - page: docs-content://deploy-manage/remote-clusters/ec-enable-ccs.md
-              title: "On Elastic Cloud Hosted"
-              children:
-              - page: docs-content://deploy-manage/remote-clusters/ec-remote-cluster-same-ess.md
-                title: "To the same Elastic Cloud organization"
-              - page: docs-content://deploy-manage/remote-clusters/ec-remote-cluster-other-ess.md
-                title: "To a different Elastic Cloud organization"
-              - page: docs-content://deploy-manage/remote-clusters/ec-remote-cluster-ece.md
-                title: "To Elastic Cloud Enterprise"
-              - page: docs-content://deploy-manage/remote-clusters/ec-remote-cluster-self-managed.md
-                title: "To a self-managed cluster"
-              - page: docs-content://deploy-manage/remote-clusters/ec-enable-ccs-for-eck.md
-                title: "To Elastic Cloud on Kubernetes"
-              - page: docs-content://deploy-manage/remote-clusters/ec-remote-cluster-strong-identity.md
-                title: "Strong identity verification"
-              - page: docs-content://deploy-manage/remote-clusters/ec-edit-remove-trusted-environment.md
-                title: "Manage trusted environments"
-              - page: docs-content://deploy-manage/remote-clusters/ec-migrate-ccs.md
-                title: "Migrate from the CCS deployment template"
-            - page: docs-content://deploy-manage/remote-clusters/ece-enable-ccs.md
-              title: "On Elastic Cloud Enterprise"
-              children:
-              - page: docs-content://deploy-manage/remote-clusters/ece-remote-cluster-same-ece.md
-                title: "To the same ECE environment"
-              - page: docs-content://deploy-manage/remote-clusters/ece-remote-cluster-other-ece.md
-                title: "To a different ECE environment"
-              - page: docs-content://deploy-manage/remote-clusters/ece-remote-cluster-ece-ess.md
-                title: "To Elastic Cloud"
-              - page: docs-content://deploy-manage/remote-clusters/ece-remote-cluster-self-managed.md
-                title: "To a self-managed cluster"
-              - page: docs-content://deploy-manage/remote-clusters/ece-enable-ccs-for-eck.md
-                title: "To Elastic Cloud on Kubernetes"
-              - page: docs-content://deploy-manage/remote-clusters/ece-edit-remove-trusted-environment.md
-                title: "Manage trusted environments"
-              - page: docs-content://deploy-manage/remote-clusters/ece-migrate-ccs.md
-                title: "Migrate from the CCS deployment template"
-            - page: docs-content://deploy-manage/remote-clusters/remote-clusters-self-managed.md
-              title: "On self-managed Elastic Stack"
-              children:
-              - page: docs-content://deploy-manage/remote-clusters/remote-clusters-api-key.md
-                title: Add remote clusters using API key authentication
-              - page: docs-content://deploy-manage/remote-clusters/remote-clusters-cert.md
-                title: Add remote clusters using TLS certificate authentication
-              - page: docs-content://deploy-manage/remote-clusters/self-remote-cluster-eck.md
-                title: "To Elastic Cloud on Kubernetes"
-              - page: docs-content://deploy-manage/remote-clusters/remote-clusters-migrate.md
-                title: "Migrate from certificate to API key authentication"
-            - page: docs-content://deploy-manage/remote-clusters/eck-remote-clusters-landing.md
-              title: "On Elastic Cloud on Kubernetes"
-              children:
-              - page: docs-content://deploy-manage/remote-clusters/eck-remote-clusters.md
-                title: "To the same ECK environment"
-              - page: docs-content://deploy-manage/remote-clusters/eck-remote-clusters-to-other-eck.md
-                title: "To a different ECK environment"
-              - page: docs-content://deploy-manage/remote-clusters/eck-remote-clusters-to-external.md
-                title: "To an external cluster or deployment"
-          - group: Cross-project search
-            page: docs-content://deploy-manage/cross-project-search-config.md
-            children:
-            - page: docs-content://deploy-manage/cross-project-search-config/cps-config-link-and-manage.md
-              title: Link and manage projects
-            - page: docs-content://deploy-manage/cross-project-search-config/cps-config-access-and-scope.md
-              title: Access and scope
-          - page: docs-content://deploy-manage/cloud-connect.md
-            title: Cloud Connect
-          - label: ───
-          - group: Maintenance
-            page: docs-content://deploy-manage/maintenance.md
-            children:
-            - page: docs-content://deploy-manage/maintenance/ece.md
-              title: ECE maintenance
-              children:
-              - page: docs-content://deploy-manage/maintenance/ece/deployments-maintenance.md
-                title: Deployments maintenance
-                children:
-                - page: docs-content://deploy-manage/maintenance/ece/pause-instance.md
-                  title: Pause instance
-              - page: docs-content://deploy-manage/maintenance/ece/maintenance-activities.md
-                title: Maintenance activities
-                children:
-                - page: docs-content://deploy-manage/maintenance/ece/enable-maintenance-mode.md
-                  title: Enable maintenance mode
-                - page: docs-content://deploy-manage/maintenance/ece/scale-out-installation.md
-                  title: Scale out your installation
-                - page: docs-content://deploy-manage/maintenance/ece/move-nodes-instances-from-allocators.md
-                  title: Move nodes or instances from allocators
-                - page: docs-content://deploy-manage/maintenance/ece/perform-ece-hosts-maintenance.md
-                  title: Perform ECE hosts maintenance
-                - page: docs-content://deploy-manage/maintenance/ece/delete-ece-hosts.md
-                  title: Delete ECE hosts
-            - page: docs-content://deploy-manage/maintenance/start-stop-services.md
-              title: Start and stop services
-              children:
-              - page: docs-content://deploy-manage/maintenance/start-stop-services/start-stop-elasticsearch.md
-                title: Start and stop Elasticsearch
-              - page: docs-content://deploy-manage/maintenance/start-stop-services/start-stop-kibana.md
-                title: Start and stop Kibana
-              - page: docs-content://deploy-manage/maintenance/start-stop-services/restart-cloud-hosted-deployment.md
-                title: Restart an Elastic Cloud Hosted deployment
-              - page: docs-content://deploy-manage/maintenance/start-stop-services/restart-an-ece-deployment.md
-                title: Restart an ECE deployment
-              - page: docs-content://deploy-manage/maintenance/start-stop-services/full-cluster-restart-rolling-restart-procedures.md
-                title: Full Cluster restart and rolling restart procedures
-            - page: docs-content://deploy-manage/maintenance/start-stop-routing-requests.md
-              title: Start and stop routing requests
-            - page: docs-content://deploy-manage/maintenance/add-and-remove-elasticsearch-nodes.md
-              title: Add and Remove Elasticsearch nodes
-          - group: Upgrade
-            page: docs-content://deploy-manage/upgrade.md
-            children:
-            - page: docs-content://deploy-manage/upgrade/plan-upgrade.md
-              title: Plan your upgrade
-            - page: docs-content://deploy-manage/upgrade/prepare-to-upgrade.md
-              title: "Preparation steps"
-              children:
-              - page: docs-content://deploy-manage/upgrade/prepare-to-upgrade/upgrade-assistant.md
-                title: Upgrade Assistant
-            - page: docs-content://deploy-manage/upgrade/deployment-or-cluster.md
-              title: Upgrade your deployment or cluster
-              children:
-              - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/upgrade-717.md
-                title: Upgrade from 7.17 to latest
-              - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/upgrade-on-ech.md
-                title: "Upgrade on Elastic Cloud Hosted"
-              - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/upgrade-on-ece.md
-                title: "Upgrade on Elastic Cloud Enterprise"
-              - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/upgrade-on-eck.md
-                title: "Upgrade on Elastic Cloud on Kubernetes"
-              - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/self-managed.md
-                title: "Upgrade Elastic on a self-managed cluster"
-                children:
-                - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/elasticsearch.md
-                  title: Upgrade Elasticsearch
-                - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/upgrade-elasticsearch-docker.md
-                  title: "Upgrade Elasticsearch running on Docker"
-                - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/kibana.md
-                  title: Upgrade Kibana
+                  - page: docs-content://deploy-manage/security/self-auto-setup.md
+                    title: "Automatic security setup"
+                  - page: docs-content://deploy-manage/security/set-up-minimal-security.md
+                    title: "Minimal security setup"
+                  - page: docs-content://deploy-manage/security/set-up-basic-security.md
+                    title: "Set up transport TLS"
+                  - page: docs-content://deploy-manage/security/set-up-basic-security-plus-https.md
+                    title: "Set up HTTPS"
+                  - page: docs-content://deploy-manage/security/using-kibana-with-security.md
+                    title: "Configure security in Kibana"
+                - page: docs-content://deploy-manage/security/secure-cluster-communications.md
+                  title: "Manage TLS encryption"
                   children:
-                  - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/saved-object-migrations.md
-                    title: Saved object migrations
-                  - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/kibana-roll-back.md
-                    title: "Roll back to a previous version"
-              - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/archived-settings.md
-                title: "Archived settings"
-              - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/reading-indices-from-older-elasticsearch-versions.md
-                title: "Reading indices from older versions"
-              - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/enterprise-search.md
-                title: Upgrade Enterprise Search
-            - page: docs-content://deploy-manage/upgrade/ingest-components.md
-              title: Upgrade your ingest components
-            - page: docs-content://deploy-manage/upgrade/orchestrator.md
-              title: "Upgrade your ECE or ECK orchestrator"
-              children:
-              - page: docs-content://deploy-manage/upgrade/orchestrator/upgrade-cloud-enterprise.md
-                title: Upgrade Elastic Cloud Enterprise
+                  - page: docs-content://deploy-manage/security/self-tls.md
+                    title: "Self-managed"
+                    children:
+                    - page: docs-content://deploy-manage/security/updating-certificates.md
+                      title: "Update TLS certificates"
+                      children:
+                      - page: docs-content://deploy-manage/security/same-ca.md
+                        title: "With the same CA"
+                      - page: docs-content://deploy-manage/security/different-ca.md
+                        title: "With a different CA"
+                    - page: docs-content://deploy-manage/security/kibana-es-mutual-tls.md
+                      title: "Mutual authentication"
+                    - page: docs-content://deploy-manage/security/supported-ssltls-versions-by-jdk-version.md
+                      title: "Supported SSL/TLS versions by JDK version"
+                    - page: docs-content://deploy-manage/security/enabling-cipher-suites-for-stronger-encryption.md
+                      title: "Enabling cipher suites for stronger encryption"
+                  - page: docs-content://deploy-manage/security/eck-tls.md
+                    title: "ECK"
+                    children:
+                    - page: docs-content://deploy-manage/security/k8s-https-settings.md
+                      title: "Manage HTTP certificates on ECK"
+                    - page: docs-content://deploy-manage/security/k8s-transport-settings.md
+                      title: Manage transport certificates on ECK
+                    - page: docs-content://deploy-manage/security/k8s-es-client-certificate-auth.md
+                      title: "Client certificate authentication"
+                  - page: docs-content://deploy-manage/security/external-ca-transport.md
+                    title: "External CA for TLS"
+                - page: docs-content://deploy-manage/security/network-security.md
+                  title: "Network security"
+                  children:
+                  - page: docs-content://deploy-manage/security/network-security-policies.md
+                    title: "How network security policies work in Cloud"
+                  - page: docs-content://deploy-manage/security/ece-filter-rules.md
+                    title: "How IP filtering rules work in ECE"
+                  - page: docs-content://deploy-manage/security/ip-filtering.md
+                    title: "Add IP filters"
+                    children:
+                    - page: docs-content://deploy-manage/security/ip-filtering-cloud.md
+                      title: "In ECH or Serverless"
+                    - page: docs-content://deploy-manage/security/ip-filtering-ece.md
+                      title: "In ECE"
+                    - page: docs-content://deploy-manage/security/ip-filtering-basic.md
+                      title: "In ECK and Self Managed"
+                  - page: docs-content://deploy-manage/security/remote-cluster-filtering.md
+                    title: "Remote cluster filters"
+                  - page: docs-content://deploy-manage/security/private-connectivity.md
+                    title: "Private connectivity"
+                    children:
+                    - page: docs-content://deploy-manage/security/private-connectivity-aws.md
+                      title: "AWS PrivateLink"
+                    - page: docs-content://deploy-manage/security/private-connectivity-azure.md
+                      title: "Azure Private Link"
+                    - page: docs-content://deploy-manage/security/private-connectivity-gcp.md
+                      title: "GCP Private Service Connect"
+                    - page: docs-content://deploy-manage/security/claim-private-connection-api.md
+                      title: "Claim private connection ownership"
+                  - page: docs-content://deploy-manage/security/network-security-api.md
+                    title: "Through the API"
+                  - page: docs-content://deploy-manage/security/k8s-network-policies.md
+                    title: "Kubernetes network policies"
+                - page: docs-content://deploy-manage/security/elastic-cloud-static-ips.md
+                  title: "Elastic Cloud static IPs"
+                - page: docs-content://deploy-manage/security/kibana-session-management.md
+                  title: "Kibana session management"
+                - page: docs-content://deploy-manage/security/data-security.md
+                  title: "Encrypt your deployment data"
+                  children:
+                  - page: docs-content://deploy-manage/security/encrypt-deployment-with-customer-managed-encryption-key.md
+                    title: "Use a customer-managed encryption key"
+                - page: docs-content://deploy-manage/security/secure-settings.md
+                  title: "Secure your settings"
+                  children:
+                  - page: docs-content://deploy-manage/security/k8s-secure-settings.md
+                    title: "Secure settings on ECK"
+                - page: docs-content://deploy-manage/security/secure-saved-objects.md
+                  title: "Secure Kibana saved objects"
+                - page: docs-content://deploy-manage/security/logging-configuration/security-event-audit-logging.md
+                  title: "Security event audit logging"
+                  children:
+                  - page: docs-content://deploy-manage/security/logging-configuration/enabling-audit-logs.md
+                    title: "Enable audit logging"
+                  - page: docs-content://deploy-manage/security/logging-configuration/configuring-audit-logs.md
+                    title: Configure audit logging
+                    children:
+                    - page: docs-content://deploy-manage/security/logging-configuration/logfile-audit-events-ignore-policies.md
+                      title: "Elasticsearch audit events ignore policies"
+                    - page: docs-content://deploy-manage/security/logging-configuration/logfile-audit-output.md
+                      title: "Elasticsearch logfile output"
+                  - page: docs-content://deploy-manage/security/logging-configuration/auditing-search-queries.md
+                    title: Audit Elasticsearch search queries
+                  - page: docs-content://deploy-manage/security/logging-configuration/correlating-kibana-elasticsearch-audit-logs.md
+                    title: "Correlate audit events"
+              - page: docs-content://deploy-manage/security/secure-clients-integrations.md
+                title: Secure other Elastic Stack components
+              - page: docs-content://deploy-manage/security/httprest-clients-security.md
+                title: Securing HTTP client applications
+              - page: docs-content://deploy-manage/security/limitations.md
+                title: "Limitations"
+              - page: docs-content://deploy-manage/security/fips.md
+                title: FIPS compliance
                 children:
-                - page: docs-content://deploy-manage/upgrade/orchestrator/re-running-the-ece-upgrade.md
-                  title: Re-running the ECE upgrade
-              - page: docs-content://deploy-manage/upgrade/orchestrator/upgrade-cloud-on-k8s.md
-                title: Upgrade Elastic Cloud on Kubernetes
-          - group: Uninstall
-            page: docs-content://deploy-manage/uninstall.md
-            children:
-            - page: docs-content://deploy-manage/uninstall/uninstall-elastic-cloud-enterprise.md
-              title: Uninstall Elastic Cloud Enterprise
-            - page: docs-content://deploy-manage/uninstall/uninstall-elastic-cloud-on-kubernetes.md
-              title: Uninstall Elastic Cloud on Kubernetes
-            - page: docs-content://deploy-manage/uninstall/delete-a-cloud-deployment.md
-              title: "Delete an orchestrated deployment"
-          - group: Licenses and subscriptions
-            page: docs-content://deploy-manage/license.md
-            children:
-            - page: docs-content://deploy-manage/license/manage-your-license-in-ece.md
-              title: "Elastic Cloud Enterprise"
-            - page: docs-content://deploy-manage/license/manage-your-license-in-eck.md
-              title: "Elastic Cloud on Kubernetes"
-            - page: docs-content://deploy-manage/license/manage-your-license-in-self-managed-cluster.md
-              title: "Self-managed cluster"
-          - group: Manage your Cloud organization
-            page: docs-content://deploy-manage/cloud-organization.md
-            children:
-            - page: docs-content://deploy-manage/cloud-organization/billing.md
-              title: Billing
+                - page: docs-content://deploy-manage/security/fips-es.md
+                  title: FIPS compliance for Elasticsearch
+                - page: docs-content://deploy-manage/security/fips-kib.md
+                  title: FIPS compliance for Kibana
+                - page: docs-content://deploy-manage/security/fips-ingest.md
+                  title: FIPS mode for Ingest tools
+            - group: Authentication and authorization
+              page: docs-content://deploy-manage/users-roles.md
               children:
-              - page: docs-content://deploy-manage/cloud-organization/billing/cloud-hosted-deployment-billing-dimensions.md
-                title: "Hosted billing dimensions"
-              - page: docs-content://deploy-manage/cloud-organization/billing/serverless-project-billing-dimensions.md
-                title: "Serverless billing dimensions"
+              - page: docs-content://deploy-manage/users-roles/cloud-organization.md
+                title: "Cloud organization"
                 children:
-                - page: docs-content://deploy-manage/cloud-organization/billing/elasticsearch-billing-dimensions.md
-                  title: "Elasticsearch projects"
-                - page: docs-content://deploy-manage/cloud-organization/billing/elastic-observability-billing-dimensions.md
-                  title: "Observability projects"
-                - page: docs-content://deploy-manage/cloud-organization/billing/security-billing-dimensions.md
-                  title: "Security projects"
-              - page: docs-content://deploy-manage/cloud-organization/billing/billing-models.md
-                title: Billing models
-              - page: docs-content://deploy-manage/cloud-organization/billing/add-billing-details.md
-                title: Add your billing details
-              - page: docs-content://deploy-manage/cloud-organization/billing/view-billing-history.md
-                title: View your billing history
-              - page: docs-content://deploy-manage/cloud-organization/billing/manage-billing-notifications.md
-                title: "Manage notifications"
-              - page: docs-content://deploy-manage/cloud-organization/billing/manage-subscription.md
-                title: Manage your subscription
-              - page: docs-content://deploy-manage/cloud-organization/billing/monitor-analyze-usage.md
-                title: Monitor and analyze usage
-              - page: docs-content://deploy-manage/cloud-organization/billing/ecu.md
-                title: Elastic Consumption Units
-              - page: docs-content://deploy-manage/cloud-organization/billing/billing-faq.md
-                title: Billing FAQ
-            - page: docs-content://deploy-manage/cloud-organization/operational-emails.md
-              title: Operational emails
-            - page: docs-content://deploy-manage/cloud-organization/billing/update-billing-operational-contacts.md
-              title: Update billing and operational contacts
-            - page: docs-content://deploy-manage/cloud-organization/service-status.md
-              title: Service status
-            - page: docs-content://deploy-manage/cloud-organization/tools-and-apis.md
-              title: "Tools and APIs"
+                - page: docs-content://deploy-manage/users-roles/cloud-organization/manage-users.md
+                  title: Manage users
+                - page: docs-content://deploy-manage/users-roles/cloud-organization/user-roles.md
+                  title: User roles and privileges
+                - page: docs-content://deploy-manage/users-roles/cloud-organization/configure-saml-authentication.md
+                  title: "Configure SAML SSO"
+                  children:
+                  - page: docs-content://deploy-manage/users-roles/cloud-organization/register-elastic-cloud-saml-in-okta.md
+                    title: "Okta"
+                  - page: docs-content://deploy-manage/users-roles/cloud-organization/register-elastic-cloud-saml-in-microsoft-entra-id.md
+                    title: "Microsoft Entra ID"
+              - page: docs-content://deploy-manage/users-roles/cloud-enterprise-orchestrator.md
+                title: "ECE orchestrator"
+                children:
+                - page: docs-content://deploy-manage/users-roles/cloud-enterprise-orchestrator/manage-system-passwords.md
+                  title: Manage system passwords
+                - page: docs-content://deploy-manage/users-roles/cloud-enterprise-orchestrator/manage-users-roles.md
+                  title: Manage users and roles
+                  children:
+                  - page: docs-content://deploy-manage/users-roles/cloud-enterprise-orchestrator/native-user-authentication.md
+                    title: Native users
+                  - page: docs-content://deploy-manage/users-roles/cloud-enterprise-orchestrator/active-directory.md
+                    title: Active Directory
+                  - page: docs-content://deploy-manage/users-roles/cloud-enterprise-orchestrator/ldap.md
+                    title: LDAP
+                  - page: docs-content://deploy-manage/users-roles/cloud-enterprise-orchestrator/saml.md
+                    title: SAML
+                - page: docs-content://deploy-manage/users-roles/cloud-enterprise-orchestrator/configure-sso-for-deployments.md
+                  title: Configure SSO for deployments
+              - page: docs-content://deploy-manage/users-roles/serverless-custom-roles.md
+                title: Serverless project custom roles
+              - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth.md
+                title: "Cluster or deployment"
+                children:
+                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/quickstart.md
+                  title: "Quickstart"
+                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/user-authentication.md
+                  title: User authentication
+                  children:
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/authentication-realms.md
+                    title: Authentication realms
+                    children:
+                    - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/realm-chains.md
+                      title: Realm chains
+                    - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/security-domains.md
+                      title: Security domains
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/internal-authentication.md
+                    title: Internal authentication
+                    children:
+                    - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/native.md
+                      title: "Native"
+                    - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/file-based.md
+                      title: "File-based"
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/external-authentication.md
+                    title: External authentication
+                    children:
+                    - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/active-directory.md
+                      title: "Active Directory"
+                    - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/jwt.md
+                      title: "JWT"
+                    - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/kerberos.md
+                      title: "Kerberos"
+                    - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/ldap.md
+                      title: "LDAP"
+                    - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/openid-connect.md
+                      title: "OpenID Connect"
+                      children:
+                      - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/oidc-examples.md
+                        title: "With Azure, Google, or Okta"
+                    - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/saml.md
+                      title: "SAML"
+                      children:
+                      - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/saml-entra.md
+                        title: "With Microsoft Entra ID"
+                    - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/pki.md
+                      title: PKI
+                    - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/custom.md
+                      title: Custom realms
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/built-in-users.md
+                    title: "Built-in users"
+                    children:
+                    - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/built-in-sm.md
+                      title: "Change passwords"
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/orchestrator-managed-users-overview.md
+                    title: "Orchestrator-managed users"
+                    children:
+                    - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/manage-elastic-user-cloud.md
+                      title: "ECH and ECE"
+                    - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/managed-credentials-eck.md
+                      title: "ECK managed credentials"
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/kibana-authentication.md
+                    title: "Kibana authentication"
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/access-agreement.md
+                    title: Kibana access agreement
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/anonymous-access.md
+                    title: Anonymous access
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/token-based-authentication-services.md
+                    title: Token-based authentication services
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/service-accounts.md
+                    title: Service accounts
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/internal-users.md
+                    title: Internal users
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/operator-privileges.md
+                    title: Operator privileges
+                    children:
+                    - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/configure-operator-privileges.md
+                      title: Configure operator privileges
+                    - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/operator-only-functionality.md
+                      title: Operator-only functionality
+                    - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/operator-privileges-for-snapshot-restore.md
+                      title: Operator privileges for snapshot and restore
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/user-profiles.md
+                    title: User profiles
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/looking-up-users-without-authentication.md
+                    title: Looking up users without authentication
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/controlling-user-cache.md
+                    title: Controlling the user cache
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/manage-authentication-for-multiple-clusters.md
+                    title: Manage authentication for multiple clusters
+                - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/user-roles.md
+                  title: User roles
+                  children:
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/defining-roles.md
+                    title: Defining roles
+                    children:
+                    - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/role-structure.md
+                      title: Role structure
+                    - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/granting-privileges-for-data-streams-aliases.md
+                      title: "For data streams and aliases"
+                    - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/kibana-role-management.md
+                      title: "Using Kibana"
+                    - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/role-restriction.md
+                      title: Role restriction
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/kibana-privileges.md
+                    title: Kibana privileges
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/mapping-users-groups-to-roles.md
+                    title: "Map users and groups to roles"
+                    children:
+                    - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/role-mapping-resources.md
+                      title: "Role mapping properties"
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/authorization-delegation.md
+                    title: Authorization delegation
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/authorization-plugins.md
+                    title: Authorization plugins
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/controlling-access-at-document-field-level.md
+                    title: "Control access at the document and field level"
+                  - page: docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/submitting-requests-on-behalf-of-other-users.md
+                    title: "Submit requests on behalf of other users"
+            - group: API keys
+              page: docs-content://deploy-manage/api-keys.md
+              children:
+              - page: docs-content://deploy-manage/api-keys/elasticsearch-api-keys.md
+                title: Elasticsearch API keys
+              - page: docs-content://deploy-manage/api-keys/serverless-project-api-keys.md
+                title: Serverless project API keys
+              - page: docs-content://deploy-manage/api-keys/elastic-cloud-api-keys.md
+                title: Elastic Cloud API keys
+              - page: docs-content://deploy-manage/api-keys/elastic-cloud-enterprise-api-keys.md
+                title: Elastic Cloud Enterprise API keys
+            - group: Spaces
+              page: docs-content://deploy-manage/manage-spaces.md
+            - group: Monitoring
+              page: docs-content://deploy-manage/monitor.md
+              children:
+              - page: docs-content://deploy-manage/monitor/autoops.md
+                title: AutoOps
+                children:
+                - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-how-to-access.md
+                  title: "For Elastic Cloud Hosted"
+                - page: docs-content://deploy-manage/monitor/autoops/autoops-for-serverless.md
+                  title: "For Elastic Cloud Serverless"
+                  children:
+                  - page: docs-content://deploy-manage/monitor/autoops/access-autoops-for-serverless.md
+                    title: "Access AutoOps in your project"
+                  - page: docs-content://deploy-manage/monitor/autoops/search-tier-view-autoops-serverless.md
+                    title: "Search Tier view"
+                  - page: docs-content://deploy-manage/monitor/autoops/indexing-tier-view-autoops-serverless.md
+                    title: "Indexing Tier view"
+                  - page: docs-content://deploy-manage/monitor/autoops/search-ai-lake-view-autoops-serverless.md
+                    title: "Search AI Lake view"
+                - page: docs-content://deploy-manage/monitor/autoops/cc-autoops-as-cloud-connected.md
+                  title: "For ECE, ECK, and self-managed clusters"
+                  children:
+                  - page: docs-content://deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md
+                    title: "Connect your cluster"
+                  - page: docs-content://deploy-manage/monitor/autoops/cc-connect-local-dev-to-autoops.md
+                    title: "Connect your local development cluster"
+                  - page: docs-content://deploy-manage/monitor/autoops/autoops-sm-custom-certification.md
+                    title: "Configure Elastic agent with custom certificate"
+                  - page: docs-content://deploy-manage/monitor/autoops/autoops-disable-metrics-collection.md
+                    title: "Disable certain types of data collection"
+                  - page: docs-content://deploy-manage/monitor/autoops/cc-manage-users.md
+                    title: "Manage connected cluster users"
+                  - page: docs-content://deploy-manage/monitor/autoops/cc-cloud-connect-autoops-troubleshooting.md
+                    title: "Troubleshooting"
+                    children:
+                    - page: docs-content://deploy-manage/monitor/autoops/autoops-connectivity-check.md
+                      title: "Run the Connectivity Check"
+                    - page: docs-content://deploy-manage/monitor/autoops/autoops-sm-troubleshoot-firewalls.md
+                      title: "Firewalls blocking Elastic Agent"
+                    - page: docs-content://deploy-manage/monitor/autoops/autoops-sm-troubleshoot-eck-no-clusters.md
+                      title: "Connected clusters not appearing with ECK"
+                - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-regions.md
+                  title: "Regions"
+                - page: docs-content://deploy-manage/monitor/autoops/views.md
+                  title: "Views"
+                  children:
+                  - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-overview-view.md
+                    title: "Overview"
+                  - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-deployment-view.md
+                    title: "Deployment or Cluster"
+                  - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-nodes-view.md
+                    title: "Nodes"
+                  - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-index-view.md
+                    title: "Indices"
+                  - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-shards-view.md
+                    title: "Shards"
+                  - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-template-optimizer.md
+                    title: "Template Optimizer"
+                - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-events.md
+                  title: "Events"
+                  children:
+                  - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-event-settings.md
+                    title: Event Settings
+                  - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-notifications-settings.md
+                    title: Notifications Settings
+                - page: docs-content://deploy-manage/monitor/autoops/ec-autoops-faq.md
+                  title: "FAQ"
+              - page: docs-content://deploy-manage/monitor/stack-monitoring.md
+                title: Stack monitoring
+                children:
+                - page: docs-content://deploy-manage/monitor/stack-monitoring/ece-ech-stack-monitoring.md
+                  title: "Enable on ECH and ECE"
+                - page: docs-content://deploy-manage/monitor/stack-monitoring/eck-stack-monitoring.md
+                  title: "Enable on ECK"
+                - page: docs-content://deploy-manage/monitor/stack-monitoring/elasticsearch-monitoring-self-managed.md
+                  title: "Self-managed: Elasticsearch"
+                  children:
+                  - page: docs-content://deploy-manage/monitor/stack-monitoring/collecting-monitoring-data-with-elastic-agent.md
+                    title: "Collecting monitoring data with Elastic Agent"
+                  - page: docs-content://deploy-manage/monitor/stack-monitoring/collecting-monitoring-data-with-metricbeat.md
+                    title: "Collecting monitoring data with Metricbeat"
+                  - page: docs-content://deploy-manage/monitor/stack-monitoring/collecting-log-data-with-filebeat.md
+                    title: "Collecting log data with Filebeat"
+                  - page: docs-content://deploy-manage/monitor/stack-monitoring/es-self-monitoring-prod.md
+                    title: Monitoring in a production environment
+                  - page: docs-content://deploy-manage/monitor/stack-monitoring/es-legacy-collection-methods.md
+                    title: "Legacy collection methods"
+                    children:
+                    - page: docs-content://deploy-manage/monitor/stack-monitoring/es-monitoring-collectors.md
+                      title: Collectors
+                    - page: docs-content://deploy-manage/monitor/stack-monitoring/es-monitoring-exporters.md
+                      title: Exporters
+                    - page: docs-content://deploy-manage/monitor/stack-monitoring/es-local-exporter.md
+                      title: Local exporters
+                    - page: docs-content://deploy-manage/monitor/stack-monitoring/es-http-exporter.md
+                      title: HTTP exporters
+                    - page: docs-content://deploy-manage/monitor/stack-monitoring/es-pause-export.md
+                      title: Pausing data collection
+                - page: docs-content://deploy-manage/monitor/stack-monitoring/kibana-monitoring-self-managed.md
+                  title: "Self-managed: Kibana"
+                  children:
+                  - page: docs-content://deploy-manage/monitor/stack-monitoring/kibana-monitoring-elastic-agent.md
+                    title: "Collect monitoring data with Elastic Agent"
+                  - page: docs-content://deploy-manage/monitor/stack-monitoring/kibana-monitoring-metricbeat.md
+                    title: "Collect monitoring data with Metricbeat"
+                  - page: docs-content://deploy-manage/monitor/stack-monitoring/kibana-monitoring-legacy.md
+                    title: "Legacy collection methods"
+                - page: docs-content://deploy-manage/monitor/stack-monitoring/kibana-monitoring-data.md
+                  title: Access monitoring data in Kibana
+                - page: docs-content://deploy-manage/monitor/monitoring-data/visualizing-monitoring-data.md
+                  title: Visualizing monitoring data
+                  children:
+                  - page: docs-content://deploy-manage/monitor/monitoring-data/beats-page.md
+                    title: Beats metrics
+                  - page: docs-content://deploy-manage/monitor/monitoring-data/elasticsearch-metrics.md
+                    title: Elasticsearch metrics
+                  - page: docs-content://deploy-manage/monitor/monitoring-data/kibana-page.md
+                    title: Kibana metrics
+                  - page: docs-content://deploy-manage/monitor/monitoring-data/integrations-server-page.md
+                    title: Integrations Server metrics
+                  - page: docs-content://deploy-manage/monitor/monitoring-data/logstash-page.md
+                    title: Logstash metrics
+                  - page: docs-content://deploy-manage/monitor/monitoring-data/monitor-troubleshooting.md
+                    title: "Troubleshooting"
+                - page: docs-content://deploy-manage/monitor/monitoring-data/configure-stack-monitoring-alerts.md
+                  title: Stack monitoring alerts
+                - page: docs-content://deploy-manage/monitor/monitoring-data/configuring-data-streamsindices-for-monitoring.md
+                  title: Configuring monitoring data streams and indices
+                  children:
+                  - page: docs-content://deploy-manage/monitor/monitoring-data/config-monitoring-data-streams-elastic-agent.md
+                    title: Configuring data streams created by Elastic Agent
+                  - page: docs-content://deploy-manage/monitor/monitoring-data/config-monitoring-data-streams-metricbeat-8.md
+                    title: Configuring data streams created by Metricbeat 8
+                  - page: docs-content://deploy-manage/monitor/monitoring-data/config-monitoring-indices-metricbeat-7-internal-collection.md
+                    title: Configuring indices created by Metricbeat 7 or internal collection
+              - page: docs-content://deploy-manage/monitor/autoops-vs-stack-monitoring.md
+                title: "AutoOps vs. Stack Monitoring"
+              - page: docs-content://deploy-manage/monitor/cloud-health-perf.md
+                title: "Cloud deployment health"
+                children:
+                - page: docs-content://deploy-manage/monitor/access-performance-metrics-on-elastic-cloud.md
+                  title: Performance metrics on Elastic Cloud
+                - page: docs-content://deploy-manage/monitor/ec-memory-pressure.md
+                  title: JVM memory pressure indicator
+              - page: docs-content://deploy-manage/monitor/kibana-task-manager-health-monitoring.md
+                title: "Kibana task manager monitoring"
+              - page: docs-content://deploy-manage/monitor/orchestrators.md
+                title: Monitoring orchestrators
+                children:
+                - page: docs-content://deploy-manage/monitor/orchestrators/eck-metrics-configuration.md
+                  title: ECK operator metrics
+                  children:
+                  - page: docs-content://deploy-manage/monitor/orchestrators/k8s-enabling-metrics-endpoint.md
+                    title: Enabling the metrics endpoint
+                  - page: docs-content://deploy-manage/monitor/orchestrators/k8s-securing-metrics-endpoint.md
+                    title: Securing the metrics endpoint
+                  - page: docs-content://deploy-manage/monitor/orchestrators/k8s-prometheus-requirements.md
+                    title: Prometheus requirements
+                - page: docs-content://deploy-manage/monitor/orchestrators/ece-platform-monitoring.md
+                  title: ECE platform monitoring
+                  children:
+                  - page: docs-content://deploy-manage/monitor/orchestrators/ece-monitoring-ece-access.md
+                    title: Platform monitoring deployment logs and metrics
+                  - page: docs-content://deploy-manage/monitor/orchestrators/ece-proxy-log-fields.md
+                    title: Proxy log fields
+                  - page: docs-content://deploy-manage/monitor/orchestrators/ece-monitoring-ece-set-retention.md
+                    title: Set the retention period for logging and metrics indices
+              - page: docs-content://deploy-manage/monitor/logging-configuration.md
+                title: Logging
+                children:
+                - page: docs-content://deploy-manage/monitor/logging-configuration/elasticsearch-log4j-configuration-self-managed.md
+                  title: Elasticsearch log4j configuration
+                - page: docs-content://deploy-manage/monitor/logging-configuration/update-elasticsearch-logging-levels.md
+                  title: Update Elasticsearch logging levels
+                - page: docs-content://deploy-manage/monitor/logging-configuration/elasticsearch-deprecation-logs.md
+                  title: Elasticsearch deprecation logs
+                - page: docs-content://deploy-manage/monitor/logging-configuration/slow-logs.md
+                  title: Slow query and index logging
+                - page: docs-content://deploy-manage/monitor/logging-configuration/kibana-logging.md
+                  title: Kibana logging
+                  children:
+                  - page: docs-content://deploy-manage/monitor/logging-configuration/kibana-log-levels.md
+                    title: Set global log levels for Kibana
+                  - page: docs-content://deploy-manage/monitor/logging-configuration/kib-advanced-logging.md
+                    title: Advanced Kibana logging settings
+                    children:
+                    - page: docs-content://deploy-manage/monitor/logging-configuration/kibana-log-settings-examples.md
+                      title: "Examples"
+            - page: docs-content://deploy-manage/kibana-reporting-configuration.md
+              title: Configure Kibana reporting
+            - group: Backup, high availability, and resilience tools
+              page: docs-content://deploy-manage/tools.md
+              children:
+              - page: docs-content://deploy-manage/tools/snapshot-and-restore.md
+                title: Snapshot and restore
+                children:
+                - page: docs-content://deploy-manage/tools/snapshot-and-restore/manage-snapshot-repositories.md
+                  title: Manage snapshot repositories
+                  children:
+                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/self-managed.md
+                    title: "Self-managed"
+                    children:
+                    - page: docs-content://deploy-manage/tools/snapshot-and-restore/azure-repository.md
+                      title: Azure repository
+                    - page: docs-content://deploy-manage/tools/snapshot-and-restore/google-cloud-storage-repository.md
+                      title: Google Cloud Storage repository
+                    - page: docs-content://deploy-manage/tools/snapshot-and-restore/s3-repository.md
+                      title: S3 repository
+                    - page: docs-content://deploy-manage/tools/snapshot-and-restore/shared-file-system-repository.md
+                      title: Shared file system repository
+                    - page: docs-content://deploy-manage/tools/snapshot-and-restore/read-only-url-repository.md
+                      title: Read-only URL repository
+                    - page: docs-content://deploy-manage/tools/snapshot-and-restore/source-only-repository.md
+                      title: Source-only repository
+                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/elastic-cloud-hosted.md
+                    title: "Elastic Cloud Hosted"
+                    children:
+                    - page: docs-content://deploy-manage/tools/snapshot-and-restore/ec-aws-custom-repository.md
+                      title: "AWS S3"
+                    - page: docs-content://deploy-manage/tools/snapshot-and-restore/ec-gcs-snapshotting.md
+                      title: "Google Cloud Storage"
+                    - page: docs-content://deploy-manage/tools/snapshot-and-restore/ec-azure-snapshotting.md
+                      title: "Azure Blob Storage"
+                    - page: docs-content://deploy-manage/tools/snapshot-and-restore/access-isolation-for-found-snapshots-repository.md
+                      title: Access isolation for the found-snapshots repository
+                      children:
+                      - page: docs-content://deploy-manage/tools/snapshot-and-restore/repository-isolation-on-azure.md
+                        title: "Azure"
+                      - page: docs-content://deploy-manage/tools/snapshot-and-restore/repository-isolation-on-aws-gcp.md
+                        title: "AWS and GCP"
+                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/cloud-enterprise.md
+                    title: "Elastic Cloud Enterprise"
+                    children:
+                    - page: docs-content://deploy-manage/tools/snapshot-and-restore/ece-aws-custom-repository.md
+                      title: "AWS S3"
+                    - page: docs-content://deploy-manage/tools/snapshot-and-restore/google-cloud-storage-gcs-repository.md
+                      title: "Google Cloud Storage"
+                    - page: docs-content://deploy-manage/tools/snapshot-and-restore/azure-storage-repository.md
+                      title: Azure Storage repository
+                    - page: docs-content://deploy-manage/tools/snapshot-and-restore/minio-on-premise-repository.md
+                      title: MinIO self-managed repository
+                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/cloud-on-k8s.md
+                    title: "Elastic Cloud on Kubernetes"
+                - page: docs-content://deploy-manage/tools/snapshot-and-restore/create-snapshots.md
+                  title: Create, monitor and delete snapshots
+                - page: docs-content://deploy-manage/tools/snapshot-and-restore/restore-snapshot.md
+                  title: Restore a snapshot
+                  children:
+                  - page: docs-content://deploy-manage/tools/snapshot-and-restore/ece-restore-across-clusters.md
+                    title: Restore a snapshot across clusters
+                    children:
+                    - page: docs-content://deploy-manage/tools/snapshot-and-restore/ece-restore-snapshots-into-new-deployment.md
+                      title: Restore snapshot into a new deployment
+                    - page: docs-content://deploy-manage/tools/snapshot-and-restore/ece-restore-snapshots-into-existing-deployment.md
+                      title: Restore snapshot into an existing deployment
+                    - page: docs-content://deploy-manage/tools/snapshot-and-restore/ece-restore-snapshots-containing-searchable-snapshots-indices-across-clusters.md
+                      title: Restore snapshots containing searchable snapshots indices across clusters
+                - page: docs-content://deploy-manage/tools/snapshot-and-restore/searchable-snapshots.md
+                  title: Searchable snapshots
+              - page: docs-content://deploy-manage/tools/cross-cluster-replication.md
+                title: Cross-cluster replication
+                children:
+                - page: docs-content://deploy-manage/tools/cross-cluster-replication/set-up-cross-cluster-replication.md
+                  title: "Set up cross-cluster replication"
+                  children:
+                  - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-getting-started-prerequisites.md
+                    title: "Prerequisites"
+                  - page: docs-content://deploy-manage/tools/cross-cluster-replication/_connect_to_a_remote_cluster.md
+                    title: Connect to a remote cluster
+                  - page: docs-content://deploy-manage/tools/cross-cluster-replication/_configure_privileges_for_cross_cluster_replication_2.md
+                    title: Configure privileges for cross-cluster replication
+                  - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-getting-started-follower-index.md
+                    title: Create a follower index to replicate a specific index
+                  - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-getting-started-auto-follow.md
+                    title: Create an auto-follow pattern to replicate time series indices
+                - page: docs-content://deploy-manage/tools/cross-cluster-replication/manage-cross-cluster-replication.md
+                  title: Manage cross-cluster replication
+                  children:
+                  - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-inspect-progress.md
+                    title: Inspect replication statistics
+                  - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-pause-replication.md
+                    title: Pause and resume replication
+                  - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-recreate-follower-index.md
+                    title: Recreate a follower index
+                  - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-terminate-replication.md
+                    title: Terminate replication
+                - page: docs-content://deploy-manage/tools/cross-cluster-replication/manage-auto-follow-patterns.md
+                  title: Manage auto-follow patterns
+                  children:
+                  - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-auto-follow-create.md
+                    title: Create auto-follow patterns
+                  - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-auto-follow-retrieve.md
+                    title: Retrieve auto-follow patterns
+                  - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-auto-follow-pause.md
+                    title: Pause and resume auto-follow patterns
+                  - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-auto-follow-delete.md
+                    title: Delete auto-follow patterns
+                - page: docs-content://deploy-manage/tools/cross-cluster-replication/upgrading-clusters.md
+                  title: "Upgrading clusters"
+                  children:
+                  - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-uni-directional-upgrade.md
+                    title: Uni-directional index following
+                  - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-bi-directional-upgrade.md
+                    title: Bi-directional index following
+                - page: docs-content://deploy-manage/tools/cross-cluster-replication/uni-directional-disaster-recovery.md
+                  title: "Uni-directional disaster recovery"
+                  children:
+                  - page: docs-content://deploy-manage/tools/cross-cluster-replication/_prerequisites_14.md
+                    title: "Prerequisites"
+                  - page: docs-content://deploy-manage/tools/cross-cluster-replication/_failover_when_clustera_is_down.md
+                    title: "Failover when clusterA is down"
+                  - page: docs-content://deploy-manage/tools/cross-cluster-replication/_failback_when_clustera_comes_back.md
+                    title: "Failback when clusterA comes back"
+                - page: docs-content://deploy-manage/tools/cross-cluster-replication/bi-directional-disaster-recovery.md
+                  title: "Bi-directional disaster recovery"
+                  children:
+                  - page: docs-content://deploy-manage/tools/cross-cluster-replication/ccr-tutorial-initial-setup.md
+                    title: Initial setup
+                  - page: docs-content://deploy-manage/tools/cross-cluster-replication/_failover_when_clustera_is_down_2.md
+                    title: "Failover when clusterA is down"
+                  - page: docs-content://deploy-manage/tools/cross-cluster-replication/_failback_when_clustera_comes_back_2.md
+                    title: "Failback when clusterA comes back"
+                  - page: docs-content://deploy-manage/tools/cross-cluster-replication/_perform_update_or_delete_by_query.md
+                    title: Perform update or delete by query
+            - group: Autoscaling
+              page: docs-content://deploy-manage/autoscaling.md
+              children:
+              - page: docs-content://deploy-manage/autoscaling/autoscaling-in-ece-and-ech.md
+                title: "In ECE and ECH"
+              - page: docs-content://deploy-manage/autoscaling/autoscaling-in-eck.md
+                title: "In ECK"
+              - page: docs-content://deploy-manage/autoscaling/autoscaling-deciders.md
+                title: Autoscaling deciders
+              - page: docs-content://deploy-manage/autoscaling/trained-model-autoscaling.md
+                title: Trained model autoscaling
+            - page: docs-content://deploy-manage/stack-settings.md
+              title: Stack settings
+            - page: docs-content://deploy-manage/manage-connectors.md
+              title: Connectors
+            - group: Remote clusters
+              page: docs-content://deploy-manage/remote-clusters.md
+              children:
+              - page: docs-content://deploy-manage/remote-clusters/security-models.md
+                title: "Security models"
+              - page: docs-content://deploy-manage/remote-clusters/connection-modes.md
+                title: "Connection modes"
+              - page: docs-content://deploy-manage/remote-clusters/ec-enable-ccs.md
+                title: "On Elastic Cloud Hosted"
+                children:
+                - page: docs-content://deploy-manage/remote-clusters/ec-remote-cluster-same-ess.md
+                  title: "To the same Elastic Cloud organization"
+                - page: docs-content://deploy-manage/remote-clusters/ec-remote-cluster-other-ess.md
+                  title: "To a different Elastic Cloud organization"
+                - page: docs-content://deploy-manage/remote-clusters/ec-remote-cluster-ece.md
+                  title: "To Elastic Cloud Enterprise"
+                - page: docs-content://deploy-manage/remote-clusters/ec-remote-cluster-self-managed.md
+                  title: "To a self-managed cluster"
+                - page: docs-content://deploy-manage/remote-clusters/ec-enable-ccs-for-eck.md
+                  title: "To Elastic Cloud on Kubernetes"
+                - page: docs-content://deploy-manage/remote-clusters/ec-remote-cluster-strong-identity.md
+                  title: "Strong identity verification"
+                - page: docs-content://deploy-manage/remote-clusters/ec-edit-remove-trusted-environment.md
+                  title: "Manage trusted environments"
+                - page: docs-content://deploy-manage/remote-clusters/ec-migrate-ccs.md
+                  title: "Migrate from the CCS deployment template"
+              - page: docs-content://deploy-manage/remote-clusters/ece-enable-ccs.md
+                title: "On Elastic Cloud Enterprise"
+                children:
+                - page: docs-content://deploy-manage/remote-clusters/ece-remote-cluster-same-ece.md
+                  title: "To the same ECE environment"
+                - page: docs-content://deploy-manage/remote-clusters/ece-remote-cluster-other-ece.md
+                  title: "To a different ECE environment"
+                - page: docs-content://deploy-manage/remote-clusters/ece-remote-cluster-ece-ess.md
+                  title: "To Elastic Cloud"
+                - page: docs-content://deploy-manage/remote-clusters/ece-remote-cluster-self-managed.md
+                  title: "To a self-managed cluster"
+                - page: docs-content://deploy-manage/remote-clusters/ece-enable-ccs-for-eck.md
+                  title: "To Elastic Cloud on Kubernetes"
+                - page: docs-content://deploy-manage/remote-clusters/ece-edit-remove-trusted-environment.md
+                  title: "Manage trusted environments"
+                - page: docs-content://deploy-manage/remote-clusters/ece-migrate-ccs.md
+                  title: "Migrate from the CCS deployment template"
+              - page: docs-content://deploy-manage/remote-clusters/remote-clusters-self-managed.md
+                title: "On self-managed Elastic Stack"
+                children:
+                - page: docs-content://deploy-manage/remote-clusters/remote-clusters-api-key.md
+                  title: Add remote clusters using API key authentication
+                - page: docs-content://deploy-manage/remote-clusters/remote-clusters-cert.md
+                  title: Add remote clusters using TLS certificate authentication
+                - page: docs-content://deploy-manage/remote-clusters/self-remote-cluster-eck.md
+                  title: "To Elastic Cloud on Kubernetes"
+                - page: docs-content://deploy-manage/remote-clusters/remote-clusters-migrate.md
+                  title: "Migrate from certificate to API key authentication"
+              - page: docs-content://deploy-manage/remote-clusters/eck-remote-clusters-landing.md
+                title: "On Elastic Cloud on Kubernetes"
+                children:
+                - page: docs-content://deploy-manage/remote-clusters/eck-remote-clusters.md
+                  title: "To the same ECK environment"
+                - page: docs-content://deploy-manage/remote-clusters/eck-remote-clusters-to-other-eck.md
+                  title: "To a different ECK environment"
+                - page: docs-content://deploy-manage/remote-clusters/eck-remote-clusters-to-external.md
+                  title: "To an external cluster or deployment"
+            - group: Cross-project search
+              page: docs-content://deploy-manage/cross-project-search-config.md
+              children:
+              - page: docs-content://deploy-manage/cross-project-search-config/cps-config-link-and-manage.md
+                title: Link and manage projects
+              - page: docs-content://deploy-manage/cross-project-search-config/cps-config-access-and-scope.md
+                title: Access and scope
+            - page: docs-content://deploy-manage/cloud-connect.md
+              title: Cloud Connect
+          - label: Lifecycle tasks
+            children:
+            - group: Maintenance
+              page: docs-content://deploy-manage/maintenance.md
+              children:
+              - page: docs-content://deploy-manage/maintenance/ece.md
+                title: ECE maintenance
+                children:
+                - page: docs-content://deploy-manage/maintenance/ece/deployments-maintenance.md
+                  title: Deployments maintenance
+                  children:
+                  - page: docs-content://deploy-manage/maintenance/ece/pause-instance.md
+                    title: Pause instance
+                - page: docs-content://deploy-manage/maintenance/ece/maintenance-activities.md
+                  title: Maintenance activities
+                  children:
+                  - page: docs-content://deploy-manage/maintenance/ece/enable-maintenance-mode.md
+                    title: Enable maintenance mode
+                  - page: docs-content://deploy-manage/maintenance/ece/scale-out-installation.md
+                    title: Scale out your installation
+                  - page: docs-content://deploy-manage/maintenance/ece/move-nodes-instances-from-allocators.md
+                    title: Move nodes or instances from allocators
+                  - page: docs-content://deploy-manage/maintenance/ece/perform-ece-hosts-maintenance.md
+                    title: Perform ECE hosts maintenance
+                  - page: docs-content://deploy-manage/maintenance/ece/delete-ece-hosts.md
+                    title: Delete ECE hosts
+              - page: docs-content://deploy-manage/maintenance/start-stop-services.md
+                title: Start and stop services
+                children:
+                - page: docs-content://deploy-manage/maintenance/start-stop-services/start-stop-elasticsearch.md
+                  title: Start and stop Elasticsearch
+                - page: docs-content://deploy-manage/maintenance/start-stop-services/start-stop-kibana.md
+                  title: Start and stop Kibana
+                - page: docs-content://deploy-manage/maintenance/start-stop-services/restart-cloud-hosted-deployment.md
+                  title: Restart an Elastic Cloud Hosted deployment
+                - page: docs-content://deploy-manage/maintenance/start-stop-services/restart-an-ece-deployment.md
+                  title: Restart an ECE deployment
+                - page: docs-content://deploy-manage/maintenance/start-stop-services/full-cluster-restart-rolling-restart-procedures.md
+                  title: Full Cluster restart and rolling restart procedures
+              - page: docs-content://deploy-manage/maintenance/start-stop-routing-requests.md
+                title: Start and stop routing requests
+              - page: docs-content://deploy-manage/maintenance/add-and-remove-elasticsearch-nodes.md
+                title: Add and Remove Elasticsearch nodes
+            - group: Upgrade
+              page: docs-content://deploy-manage/upgrade.md
+              children:
+              - page: docs-content://deploy-manage/upgrade/plan-upgrade.md
+                title: Plan your upgrade
+              - page: docs-content://deploy-manage/upgrade/prepare-to-upgrade.md
+                title: "Preparation steps"
+                children:
+                - page: docs-content://deploy-manage/upgrade/prepare-to-upgrade/upgrade-assistant.md
+                  title: Upgrade Assistant
+              - page: docs-content://deploy-manage/upgrade/deployment-or-cluster.md
+                title: Upgrade your deployment or cluster
+                children:
+                - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/upgrade-717.md
+                  title: Upgrade from 7.17 to latest
+                - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/upgrade-on-ech.md
+                  title: "Upgrade on Elastic Cloud Hosted"
+                - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/upgrade-on-ece.md
+                  title: "Upgrade on Elastic Cloud Enterprise"
+                - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/upgrade-on-eck.md
+                  title: "Upgrade on Elastic Cloud on Kubernetes"
+                - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/self-managed.md
+                  title: "Upgrade Elastic on a self-managed cluster"
+                  children:
+                  - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/elasticsearch.md
+                    title: Upgrade Elasticsearch
+                  - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/upgrade-elasticsearch-docker.md
+                    title: "Upgrade Elasticsearch running on Docker"
+                  - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/kibana.md
+                    title: Upgrade Kibana
+                    children:
+                    - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/saved-object-migrations.md
+                      title: Saved object migrations
+                    - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/kibana-roll-back.md
+                      title: "Roll back to a previous version"
+                - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/archived-settings.md
+                  title: "Archived settings"
+                - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/reading-indices-from-older-elasticsearch-versions.md
+                  title: "Reading indices from older versions"
+                - page: docs-content://deploy-manage/upgrade/deployment-or-cluster/enterprise-search.md
+                  title: Upgrade Enterprise Search
+              - page: docs-content://deploy-manage/upgrade/ingest-components.md
+                title: Upgrade your ingest components
+              - page: docs-content://deploy-manage/upgrade/orchestrator.md
+                title: "Upgrade your ECE or ECK orchestrator"
+                children:
+                - page: docs-content://deploy-manage/upgrade/orchestrator/upgrade-cloud-enterprise.md
+                  title: Upgrade Elastic Cloud Enterprise
+                  children:
+                  - page: docs-content://deploy-manage/upgrade/orchestrator/re-running-the-ece-upgrade.md
+                    title: Re-running the ECE upgrade
+                - page: docs-content://deploy-manage/upgrade/orchestrator/upgrade-cloud-on-k8s.md
+                  title: Upgrade Elastic Cloud on Kubernetes
+            - group: Uninstall
+              page: docs-content://deploy-manage/uninstall.md
+              children:
+              - page: docs-content://deploy-manage/uninstall/uninstall-elastic-cloud-enterprise.md
+                title: Uninstall Elastic Cloud Enterprise
+              - page: docs-content://deploy-manage/uninstall/uninstall-elastic-cloud-on-kubernetes.md
+                title: Uninstall Elastic Cloud on Kubernetes
+              - page: docs-content://deploy-manage/uninstall/delete-a-cloud-deployment.md
+                title: "Delete an orchestrated deployment"
+            - group: Licenses and subscriptions
+              page: docs-content://deploy-manage/license.md
+              children:
+              - page: docs-content://deploy-manage/license/manage-your-license-in-ece.md
+                title: "Elastic Cloud Enterprise"
+              - page: docs-content://deploy-manage/license/manage-your-license-in-eck.md
+                title: "Elastic Cloud on Kubernetes"
+              - page: docs-content://deploy-manage/license/manage-your-license-in-self-managed-cluster.md
+                title: "Self-managed cluster"
+            - group: Manage your Cloud organization
+              page: docs-content://deploy-manage/cloud-organization.md
+              children:
+              - page: docs-content://deploy-manage/cloud-organization/billing.md
+                title: Billing
+                children:
+                - page: docs-content://deploy-manage/cloud-organization/billing/cloud-hosted-deployment-billing-dimensions.md
+                  title: "Hosted billing dimensions"
+                - page: docs-content://deploy-manage/cloud-organization/billing/serverless-project-billing-dimensions.md
+                  title: "Serverless billing dimensions"
+                  children:
+                  - page: docs-content://deploy-manage/cloud-organization/billing/elasticsearch-billing-dimensions.md
+                    title: "Elasticsearch projects"
+                  - page: docs-content://deploy-manage/cloud-organization/billing/elastic-observability-billing-dimensions.md
+                    title: "Observability projects"
+                  - page: docs-content://deploy-manage/cloud-organization/billing/security-billing-dimensions.md
+                    title: "Security projects"
+                - page: docs-content://deploy-manage/cloud-organization/billing/billing-models.md
+                  title: Billing models
+                - page: docs-content://deploy-manage/cloud-organization/billing/add-billing-details.md
+                  title: Add your billing details
+                - page: docs-content://deploy-manage/cloud-organization/billing/view-billing-history.md
+                  title: View your billing history
+                - page: docs-content://deploy-manage/cloud-organization/billing/manage-billing-notifications.md
+                  title: "Manage notifications"
+                - page: docs-content://deploy-manage/cloud-organization/billing/manage-subscription.md
+                  title: Manage your subscription
+                - page: docs-content://deploy-manage/cloud-organization/billing/monitor-analyze-usage.md
+                  title: Monitor and analyze usage
+                - page: docs-content://deploy-manage/cloud-organization/billing/ecu.md
+                  title: Elastic Consumption Units
+                - page: docs-content://deploy-manage/cloud-organization/billing/billing-faq.md
+                  title: Billing FAQ
+              - page: docs-content://deploy-manage/cloud-organization/operational-emails.md
+                title: Operational emails
+              - page: docs-content://deploy-manage/cloud-organization/billing/update-billing-operational-contacts.md
+                title: Update billing and operational contacts
+              - page: docs-content://deploy-manage/cloud-organization/service-status.md
+                title: Service status
+              - page: docs-content://deploy-manage/cloud-organization/tools-and-apis.md
+                title: "Tools and APIs"
         - group: Deployment and administration tools
           children:
           - toc: ecctl://reference
@@ -1643,7 +1646,7 @@ nav:
             title: Command-line tools
           - island: Account and preferences
             toc: docs-content://cloud-account
-    - label: The Elasticsearch platform
+    - label: Elasticsearch platform
       children:
       - label: Ingest and manage data
         children:


### PR DESCRIPTION
## Summary
- Replace `───` placeholder labels in the Administer nav section with proper subsection headers (`Deployment-specific administration`, `General administrative tasks`, `Lifecycle tasks`) and nest the related groups under each label's `children:` block.
- Rename "The Elasticsearch platform" to "Elasticsearch platform" in Nav V2.
Targets the findability PoC branch from #3256 (`demo/findability`), not `main`.
## Test plan
- [ ] Preview deploy-manage sidebar on the #3256 preview and confirm `----` dividers are gone
- [ ] Confirm deployment, general admin, and lifecycle groups nest under their subsection labels
- [ ] Confirm sidebar shows "Elasticsearch platform" (without "The")