### PR TITLE
Codex: make index resilient to missing clones

### DIFF
--- a/src/tooling/docs-builder/Commands/Codex/CodexIndexCommand.cs
+++ b/src/tooling/docs-builder/Commands/Codex/CodexIndexCommand.cs
@@ -14,7 +14,6 @@ using Elastic.Documentation.Configuration;
 using Elastic.Documentation.Configuration.Codex;
 using Elastic.Documentation.Diagnostics;
 using Elastic.Documentation.Isolated;
-using Elastic.Documentation.LinkIndex;
 using Elastic.Documentation.Services;
 using Microsoft.Extensions.Logging;
 using Nullean.Argh;
@@ -65,11 +64,9 @@ internal sealed class CodexIndexCommand(
 
 		var codexContext = new CodexContext(codexConfig, configFile, collector, fs, fs, null, null);
 
-		using var linkIndexReader = new GitLinkIndexReader(codexConfig.Environment);
-		var cloneService = new CodexCloneService(logFactory, linkIndexReader);
-		var cloneResult = await cloneService.CloneAll(codexContext, fetchLatest: false, assumeCloned: true, ct);
+		var cloneResult = await CodexCloneService.DiscoverCheckouts(codexContext, logFactory, ct);
 
-		if (cloneResult.Checkouts.Count == 0)
+		if (cloneResult == null || cloneResult.Checkouts.Count == 0)
 		{
 			collector.EmitGlobalError("No documentation sets found. Run 'docs-builder codex clone' first.");
 			return 1;


### PR DESCRIPTION
## Why

`codex index` called `CloneAll` on every run, which re-walks all repositories and only writes the `link-index.snapshot.json` snapshot after the full parallel loop completes. A mid-run clone failure meant the snapshot was never written, so the next invocation re-cloned everything from scratch — the same failure mode that `codex clone` and `codex build` already handle.

## What

`codex index` now uses `CodexCloneService.DiscoverCheckouts` (the same static method `codex build` uses) instead of `CloneAll`. This reads the snapshot written by `codex clone` and discovers checkouts from disk — no network, no reclone. If the snapshot is missing or empty it emits a clear error directing the user to run `codex clone` first.