### PR TITLE
Move Managed inputs to a top-level Ingestion tools section

### DIFF
--- a/config/navigation.yml
+++ b/config/navigation.yml
@@ -466,8 +466,6 @@ toc:
           - toc: opentelemetry://reference
             path_prefix: reference/opentelemetry
             children:
-              - toc: opentelemetry://reference/motlp
-                path_prefix: reference/opentelemetry/motlp
               - toc: opentelemetry://reference/edot-cloud-forwarder
                 path_prefix: reference/opentelemetry/edot-cloud-forwarder
                 children:
@@ -497,6 +495,11 @@ toc:
               # https://github.com/elastic/elastic-otel-rum-js/blob/main/docs/reference/edot-browser/toc.yml
               - toc: elastic-otel-rum-js://reference/edot-browser
                 path_prefix: reference/opentelemetry/edot-sdks/browser
+
+          # Managed inputs
+          # https://github.com/elastic/opentelemetry/blob/main/docs/reference/motlp/toc.yml
+          - toc: opentelemetry://reference/motlp
+            path_prefix: reference/opentelemetry/motlp
 
           # Elastic Integrations
           # https://github.com/elastic/integration-docs/blob/main/docs/reference/toc.yml


### PR DESCRIPTION
## Summary

Promotes **Managed inputs** to sit alongside EDOT under **Ingestion tools** in the global navigation, instead of being nested inside the EDOT section. This matches the in-repo restructure in `elastic/opentelemetry` (https://github.com/elastic/opentelemetry/pull/630), where the Managed OTLP Endpoint and Prometheus Remote Write docs were grouped under a Managed inputs landing page.

## Changes

- Move `opentelemetry://reference/motlp` from EDOT's `children` to a direct child of `docs-content://reference/ingestion-tools`.

`path_prefix` is unchanged, so URLs don't move and no redirects are required. A follow-up will align the URL path and rename `motlp` → `managed-inputs`.

Contributes to https://github.com/elastic/docs-content/issues/7155