### PR TITLE
Rename Managed inputs toc reference: motlp → managed-inputs

### DIFF
--- a/config/navigation.yml
+++ b/config/navigation.yml
@@ -497,9 +497,9 @@ toc:
                 path_prefix: reference/opentelemetry/edot-sdks/browser
 
           # Managed inputs
-          # https://github.com/elastic/opentelemetry/blob/main/docs/reference/motlp/toc.yml
-          - toc: opentelemetry://reference/motlp
-            path_prefix: reference/opentelemetry/motlp
+          # https://github.com/elastic/opentelemetry/blob/main/docs/reference/managed-inputs/toc.yml
+          - toc: opentelemetry://reference/managed-inputs
+            path_prefix: reference/managed-inputs
 
           # Elastic Integrations
           # https://github.com/elastic/integration-docs/blob/main/docs/reference/toc.yml


### PR DESCRIPTION
## Summary

Points the Managed inputs nav entry at `opentelemetry://reference/managed-inputs` and sets `path_prefix: reference/managed-inputs`, matching the folder rename in elastic/opentelemetry#634.

## Changes

- `config/navigation.yml`: `opentelemetry://reference/motlp` → `opentelemetry://reference/managed-inputs`; `path_prefix: reference/opentelemetry/motlp` → `reference/managed-inputs`; update the source comment URL.

## Coordinated PR

Paired with elastic/opentelemetry#634.

**Merge order:** merge **this PR first** (it will show a temporary red `validate-link-reference` because `opentelemetry://reference/managed-inputs` isn't in the published link index until the opentelemetry PR lands), then merge elastic/opentelemetry#634 to republish the link index and turn everything green. The live site stays up via last-known-good resilience.

Related to elastic/docs-content#7155

Made with [Cursor](https://cursor.com)