### PR TITLE
Site: add configurable right-gutter CTA templates

### DIFF
--- a/docs/_docset.yml
+++ b/docs/_docset.yml
@@ -117,6 +117,7 @@ toc:
           - file: navigation.md
           - file: extensions.md
           - file: api-explorer.md
+          - file: cta.md
       - file: page.md
       - file: content-sources.md
   - folder: syntax

--- a/docs/_docset.yml
+++ b/docs/_docset.yml
@@ -44,7 +44,17 @@ features:
 
 storybook:
   registry: https://ci-artifacts.kibana.dev/storybooks/pr-272388/storybook-docs/docs_registry.json
-  
+
+cta:
+  docs-builder:
+    button:
+      label: Star docs-builder on GitHub
+      url: https://github.com/elastic/docs-builder
+    benefits:
+      - "Open source"
+      - "Built with .NET"
+      - "Contributions welcome"
+
 suppress:
   - AutolinkElasticCoDocs
   - DeepLinkingVirtualFile

--- a/docs/configure/content-set/cta.md
+++ b/docs/configure/content-set/cta.md
@@ -1,5 +1,6 @@
 ---
 navigation_title: CTA
+cta: docs-builder
 ---
 
 # CTA

--- a/docs/configure/content-set/cta.md
+++ b/docs/configure/content-set/cta.md
@@ -13,13 +13,14 @@ Add a `cta` map to your `docset.yml` file. Each key is a template name; the valu
 
 ```yaml
 cta:
-  mp:
+  beta:
     button:
-      label: Get started on Elastic Cloud
-      url: https://cloud.elastic.co/registration?page=docs&placement=docs-siderail
+      label: Join the private beta
+      url: https://example.com/beta-signup
     benefits:
-      - "14-day free trial"
-      - "All features included"
+      - "Early access to new features"
+      - "Direct line to the team"
+      - "Free for beta participants"
 ```
 
 - `button.label` and `button.url` are required.
@@ -33,7 +34,7 @@ Use the `cta` frontmatter field to select a template by name:
 
 ```yaml
 ---
-cta: mp
+cta: beta
 ---
 ```
 

--- a/docs/configure/content-set/cta.md
+++ b/docs/configure/content-set/cta.md
@@ -1,6 +1,7 @@
 ---
 navigation_title: CTA
-cta: docs-builder
+cta:
+  id: docs-builder
 ---
 
 # CTA
@@ -30,15 +31,16 @@ You can also override the built-in default by defining your own `trial` entry â€
 
 ## Select a CTA on a page
 
-Use the `cta` frontmatter field to select a template by name:
+Use the `cta` frontmatter field to select a template by `id`:
 
 ```yaml
 ---
-cta: beta
+cta:
+  id: beta
 ---
 ```
 
-If a page omits `cta`, or names a template that doesn't exist in `docset.yml`, it falls back to the built-in `trial` CTA. An unknown name also emits a build warning.
+If a page omits `cta`, or its `id` doesn't match a template defined in `docset.yml`, it falls back to the built-in `trial` CTA. An unknown `id` also emits a build warning.
 
 ## Click and impression tracking
 

--- a/docs/configure/content-set/cta.md
+++ b/docs/configure/content-set/cta.md
@@ -1,0 +1,43 @@
+---
+navigation_title: CTA
+---
+
+# CTA
+
+The CTA (call-to-action) feature renders a card in the right-hand sidebar of a page, with a button and a short list of benefits. By default, every page shows the built-in `trial` card. Docsets can define their own named CTA templates and have individual pages opt into them.
+
+## Define CTA templates
+
+Add a `cta` map to your `docset.yml` file. Each key is a template name; the value defines the button and benefits.
+
+```yaml
+cta:
+  mp:
+    button:
+      label: Get started on Elastic Cloud
+      url: https://cloud.elastic.co/registration?page=docs&placement=docs-siderail
+    benefits:
+      - "14-day free trial"
+      - "All features included"
+```
+
+- `button.label` and `button.url` are required.
+- `benefits` is optional and limited to 3 entries.
+
+You can also override the built-in default by defining your own `trial` entry — it replaces the default card sitewide for this docset.
+
+## Select a CTA on a page
+
+Use the `cta` frontmatter field to select a template by name:
+
+```yaml
+---
+cta: mp
+---
+```
+
+If a page omits `cta`, or names a template that doesn't exist in `docset.yml`, it falls back to the built-in `trial` CTA. An unknown name also emits a build warning.
+
+## Click and impression tracking
+
+CTA buttons are tracked via OpenTelemetry: a `cta_viewed` event fires the first time a card becomes visible, and a `cta_clicked` event fires on click. Both events carry the CTA's name, URL, label, and placement, so click-through rate can be compared across templates.

--- a/docs/configure/content-set/index.md
+++ b/docs/configure/content-set/index.md
@@ -20,3 +20,4 @@ A content set in `docs-builder` is equivalent to an AsciiDoc book. At this level
 * [Attributes](./attributes.md).
 * [Extensions](./extensions.md).
 * [API Explorer](./api-explorer.md).
+* [CTA](./cta.md).

--- a/docs/configure/content-set/navigation.md
+++ b/docs/configure/content-set/navigation.md
@@ -355,6 +355,12 @@ See https://www.elastic.co/docs/solutions/search for more details.
 See [docs](docs-content://index.md) for more details.
 ```
 
+### `cta`
+
+Defines named right-gutter call-to-action templates that pages can opt into via frontmatter.
+
+See [CTA](cta.md) for full configuration details and examples.
+
 ## Navigation configuration patterns
 
 ### Single file reference

--- a/docs/syntax/frontmatter.md
+++ b/docs/syntax/frontmatter.md
@@ -17,7 +17,8 @@ products: <4>
   - id: edot-sdk
 sub: <5>
   key: value 
-cta: beta <6>
+cta: <6>
+  id: beta
 ---
 ```
 

--- a/docs/syntax/frontmatter.md
+++ b/docs/syntax/frontmatter.md
@@ -17,7 +17,7 @@ products: <4>
   - id: edot-sdk
 sub: <5>
   key: value 
-cta: mp <6>
+cta: beta <6>
 ---
 ```
 

--- a/docs/syntax/frontmatter.md
+++ b/docs/syntax/frontmatter.md
@@ -17,6 +17,7 @@ products: <4>
   - id: edot-sdk
 sub: <5>
   key: value 
+cta: mp <6>
 ---
 ```
 
@@ -25,6 +26,7 @@ sub: <5>
 3. [`applies_to`](#applies-to)
 4. [`products`](#products)
 5. [`sub`](#subs)
+6. [`cta`](#cta)
 
 ## Navigation Title
 
@@ -91,3 +93,7 @@ Only products with the `public-reference` feature enabled in [`products.yml`](ht
 ## Subs
 
 Use the `sub` field to define local substitutions. Refer to [Substitutions](substitutions.md) for more information.
+
+## CTA
+
+See [CTA](../configure/content-set/cta.md).

--- a/src/Elastic.Codex/Page/Index.cshtml
+++ b/src/Elastic.Codex/Page/Index.cshtml
@@ -79,6 +79,7 @@
 		GitRepository = Model.GitRepository,
 		GitHubDocsUrl = Model.GitHubDocsUrl,
 		GitHubRef = Model.GitHubRef,
+		Cta = Model.Cta,
 	};
 	protected override Task ExecuteSectionAsync(string name)
 	{

--- a/src/Elastic.Documentation.Configuration/Builder/ConfigurationFile.cs
+++ b/src/Elastic.Documentation.Configuration/Builder/ConfigurationFile.cs
@@ -382,6 +382,13 @@ public record ConfigurationFile
 			context.EmitError(context.ConfigurationPath, $"'cta.{name}' must define both 'button.label' and 'button.url'.");
 			return null;
 		}
+		var url = definition.Button.Url.Trim();
+		if (Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out var uri) && uri.IsAbsoluteUri &&
+			uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)
+		{
+			context.EmitError(context.ConfigurationPath, $"'cta.{name}.button.url' must use http/https or a relative URL.");
+			return null;
+		}
 		if (definition.Benefits.Count > Cta.MaxBenefits)
 		{
 			context.EmitError(context.ConfigurationPath, $"'cta.{name}.benefits' has {definition.Benefits.Count} entries; a maximum of {Cta.MaxBenefits} is allowed.");
@@ -391,7 +398,7 @@ public record ConfigurationFile
 		{
 			Name = name,
 			Label = definition.Button.Label,
-			Url = definition.Button.Url,
+			Url = url,
 			Benefits = definition.Benefits
 		};
 	}

--- a/src/Elastic.Documentation.Configuration/Builder/ConfigurationFile.cs
+++ b/src/Elastic.Documentation.Configuration/Builder/ConfigurationFile.cs
@@ -90,6 +90,14 @@ public record ConfigurationFile
 	/// </summary>
 	public BrandingConfiguration? Branding { get; private set; }
 
+	private readonly Dictionary<string, Cta> _ctas = new(StringComparer.OrdinalIgnoreCase) { [Cta.DefaultName] = Cta.Default };
+
+	/// <summary>
+	/// Named right-gutter CTA templates declared under <c>docset.yml</c>'s <c>cta</c> map, keyed by name.
+	/// Always contains at least the built-in <see cref="Cta.DefaultName"/> entry.
+	/// </summary>
+	public IReadOnlyDictionary<string, Cta> Ctas => _ctas;
+
 	/// This is a documentation set not linked to by assembler.
 	/// Setting this to true relaxes a few restrictions such as mixing toc references with file and folder reference
 	public bool DevelopmentDocs { get; }
@@ -290,6 +298,28 @@ public record ConfigurationFile
 			// Process branding with validation
 			if (docSetFile.Branding is not null)
 				Branding = ValidateBranding(docSetFile.Branding, context);
+
+			// Process CTA templates - overlays onto (and may override) the built-in 'trial' default
+			foreach (var (name, definition) in docSetFile.Cta)
+			{
+				if (string.IsNullOrWhiteSpace(definition.Button?.Label) || string.IsNullOrWhiteSpace(definition.Button?.Url))
+				{
+					context.EmitError(context.ConfigurationPath, $"'cta.{name}' must define both 'button.label' and 'button.url'.");
+					continue;
+				}
+				if (definition.Benefits.Count > Cta.MaxBenefits)
+				{
+					context.EmitError(context.ConfigurationPath, $"'cta.{name}.benefits' has {definition.Benefits.Count} entries; a maximum of {Cta.MaxBenefits} is allowed.");
+					continue;
+				}
+				_ctas[name] = new Cta
+				{
+					Name = name,
+					Label = definition.Button.Label,
+					Url = definition.Button.Url,
+					Benefits = definition.Benefits
+				};
+			}
 
 			// Process features
 			_features = [with(StringComparer.OrdinalIgnoreCase)];

--- a/src/Elastic.Documentation.Configuration/Builder/ConfigurationFile.cs
+++ b/src/Elastic.Documentation.Configuration/Builder/ConfigurationFile.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO.Abstractions;
 using DotNet.Globbing;
 using Elastic.Documentation.Configuration.Products;
+using Elastic.Documentation.Configuration.Suggestions;
 using Elastic.Documentation.Configuration.Toc;
 using Elastic.Documentation.Configuration.Versions;
 using Elastic.Documentation.Diagnostics;
@@ -302,23 +303,8 @@ public record ConfigurationFile
 			// Process CTA templates - overlays onto (and may override) the built-in 'trial' default
 			foreach (var (name, definition) in docSetFile.Cta)
 			{
-				if (string.IsNullOrWhiteSpace(definition.Button?.Label) || string.IsNullOrWhiteSpace(definition.Button?.Url))
-				{
-					context.EmitError(context.ConfigurationPath, $"'cta.{name}' must define both 'button.label' and 'button.url'.");
-					continue;
-				}
-				if (definition.Benefits.Count > Cta.MaxBenefits)
-				{
-					context.EmitError(context.ConfigurationPath, $"'cta.{name}.benefits' has {definition.Benefits.Count} entries; a maximum of {Cta.MaxBenefits} is allowed.");
-					continue;
-				}
-				_ctas[name] = new Cta
-				{
-					Name = name,
-					Label = definition.Button.Label,
-					Url = definition.Button.Url,
-					Benefits = definition.Benefits
-				};
+				if (ValidateCta(name, definition, context) is { } cta)
+					_ctas[name] = cta;
 			}
 
 			// Process features
@@ -358,6 +344,56 @@ public record ConfigurationFile
 			context.EmitError(context.ConfigurationPath, $"Could not load docset.yml: {e.Message}");
 			throw;
 		}
+	}
+
+	/// <summary>
+	/// Resolves a page's <c>cta</c> frontmatter id to a template, falling back to <see cref="Cta.DefaultName"/>
+	/// when <paramref name="id"/> is omitted or doesn't match a configured template.
+	/// </summary>
+	/// <param name="warning">Set when <paramref name="id"/> is unknown, so the caller can report it.</param>
+	public Cta ResolveCta(string? id, out string? warning)
+	{
+		warning = null;
+		if (id is not null && Ctas.TryGetValue(id, out var cta))
+			return cta;
+		if (id is not null)
+			warning = UnknownCtaWarning(id, Ctas.Keys);
+		return Ctas[Cta.DefaultName];
+	}
+
+	private static string UnknownCtaWarning(string ctaName, IEnumerable<string> knownCtaNames)
+	{
+		var known = knownCtaNames.ToHashSet();
+		var hint = new Suggestion(known, ctaName).GetSuggestionQuestion();
+		if (string.IsNullOrEmpty(hint))
+		{
+			hint = known.Count > 1
+				? $"Available: {string.Join(", ", known.Order())}."
+				: "No 'cta' templates are defined in this docset.yml yet. Add one under a top-level 'cta:' map, e.g.:\n" +
+					"cta:\n  mp:\n    button:\n      label: Get started on MP\n      url: https://example.com\n    benefits:\n      - \"Some benefit\"";
+		}
+		return $"'cta: {ctaName}' does not match any 'cta' template in docset.yml. Falling back to '{Cta.DefaultName}'. {hint}";
+	}
+
+	private static Cta? ValidateCta(string name, CtaDefinition definition, IDocumentationSetContext context)
+	{
+		if (string.IsNullOrWhiteSpace(definition.Button?.Label) || string.IsNullOrWhiteSpace(definition.Button?.Url))
+		{
+			context.EmitError(context.ConfigurationPath, $"'cta.{name}' must define both 'button.label' and 'button.url'.");
+			return null;
+		}
+		if (definition.Benefits.Count > Cta.MaxBenefits)
+		{
+			context.EmitError(context.ConfigurationPath, $"'cta.{name}.benefits' has {definition.Benefits.Count} entries; a maximum of {Cta.MaxBenefits} is allowed.");
+			return null;
+		}
+		return new Cta
+		{
+			Name = name,
+			Label = definition.Button.Label,
+			Url = definition.Button.Url,
+			Benefits = definition.Benefits
+		};
 	}
 
 	private static readonly HashSet<string> AllowedImageExtensions =

--- a/src/Elastic.Documentation.Configuration/Toc/DocumentationSetFile.cs
+++ b/src/Elastic.Documentation.Configuration/Toc/DocumentationSetFile.cs
@@ -84,6 +84,13 @@ public class DocumentationSetFile : TableOfContentsFile
 	[YamlMember(Alias = "storybook")]
 	public DocumentationSetStorybook? Storybook { get; set; }
 
+	/// <summary>
+	/// Named, reusable right-gutter CTA templates. Selected per-page via frontmatter <c>cta: &lt;name&gt;</c>;
+	/// pages that omit it fall back to the built-in <c>trial</c> default.
+	/// </summary>
+	[YamlMember(Alias = "cta")]
+	public Dictionary<string, CtaDefinition> Cta { get; set; } = [];
+
 	public static FileRef[] GetFileRefs(ITableOfContentsItem item)
 	{
 		if (item is FileRef fileRef)
@@ -810,4 +817,57 @@ public class BrandingConfiguration
 	/// </summary>
 	[YamlMember(Alias = "apple-touch-icon", ApplyNamingConventions = false)]
 	public string? AppleTouchIcon { get; set; }
+}
+
+/// <summary>
+/// A single named right-gutter CTA template, as declared under <c>docset.yml</c>'s <c>cta</c> map.
+/// </summary>
+[YamlSerializable]
+public class CtaDefinition
+{
+	[YamlMember(Alias = "button")]
+	public CtaButton? Button { get; set; }
+
+	[YamlMember(Alias = "benefits")]
+	public List<string> Benefits { get; set; } = [];
+}
+
+/// <summary>
+/// The clickable button portion of a <see cref="CtaDefinition"/>.
+/// </summary>
+[YamlSerializable]
+public class CtaButton
+{
+	[YamlMember(Alias = "label")]
+	public string? Label { get; set; }
+
+	[YamlMember(Alias = "url")]
+	public string? Url { get; set; }
+}
+
+/// <summary>
+/// A resolved, validated right-gutter CTA, ready to render. See <see cref="CtaDefinition"/> for the raw
+/// <c>docset.yml</c> shape this is parsed from.
+/// </summary>
+public record Cta
+{
+	/// <summary>Name of the template this was resolved from; <see cref="DefaultName"/> for the built-in default.</summary>
+	public required string Name { get; init; }
+	public required string Label { get; init; }
+	public required string Url { get; init; }
+	public IReadOnlyList<string> Benefits { get; init; } = [];
+
+	/// <summary>The built-in default, reproducing the CTA that renders when no <c>cta:</c> config exists.</summary>
+	public const string DefaultName = "trial";
+
+	/// <summary>Right-gutter card space is limited; benefit bullet lists are capped at this many entries.</summary>
+	public const int MaxBenefits = 3;
+
+	public static Cta Default { get; } = new()
+	{
+		Name = DefaultName,
+		Label = "Get started free",
+		Url = "https://cloud.elastic.co/registration?page=docs&placement=docs-siderail",
+		Benefits = ["14-day free trial", "All features included", "No setup required"]
+	};
 }

--- a/src/Elastic.Documentation.Site/Assets/main.ts
+++ b/src/Elastic.Documentation.Site/Assets/main.ts
@@ -11,7 +11,14 @@ import { initNav } from './pages-nav'
 import { initSmoothScroll } from './smooth-scroll'
 import { initTabs } from './tabs'
 import { initializeOtel } from './telemetry/instrumentation'
-import { logError } from './telemetry/logging'
+import { logError, logInfo } from './telemetry/logging'
+import {
+    ATTR_CTA_NAME,
+    ATTR_CTA_URL,
+    ATTR_CTA_LABEL,
+    ATTR_CTA_LOCATION,
+    ATTR_URL_PATH,
+} from './telemetry/semconv'
 import { initTocNav } from './toc-nav'
 import 'htmx-ext-head-support'
 import 'htmx-ext-preload'
@@ -128,11 +135,48 @@ function initMath() {
     })
 }
 
+// Attributes shared by cta_viewed and cta_clicked so the two are directly comparable (CTR).
+function ctaAttributes(cta: HTMLAnchorElement) {
+    return {
+        [ATTR_CTA_NAME]: cta.dataset.cta ?? '',
+        [ATTR_CTA_URL]: cta.dataset.ctaUrl ?? '',
+        [ATTR_CTA_LABEL]: cta.dataset.ctaLabel ?? '',
+        [ATTR_CTA_LOCATION]: cta.dataset.ctaLocation ?? '',
+        [ATTR_URL_PATH]: window.location.pathname,
+    }
+}
+
+let ctaImpressionObserver: IntersectionObserver | null = null
+
+// Fires 'cta_viewed' the first time a CTA becomes at least half visible, then stops
+// observing it (one impression per page view). Recreated on every load/swap so
+// htmx-replaced CTAs get (re-)observed against their current page path.
+function initCtaImpressions() {
+    ctaImpressionObserver?.disconnect()
+    ctaImpressionObserver = new IntersectionObserver(
+        (entries, observer) => {
+            for (const entry of entries) {
+                if (!entry.isIntersecting) continue
+                logInfo(
+                    'cta_viewed',
+                    ctaAttributes(entry.target as HTMLAnchorElement)
+                )
+                observer.unobserve(entry.target)
+            }
+        },
+        { threshold: 0.5 }
+    )
+    $$optional('a[data-cta]').forEach((cta) =>
+        ctaImpressionObserver?.observe(cta)
+    )
+}
+
 // Initialize on initial page load
 document.addEventListener('DOMContentLoaded', function () {
     runInitSteps([
         ['initMath', initMath],
         ['initMermaid', initMermaid],
+        ['initCtaImpressions', initCtaImpressions],
     ])
 })
 
@@ -152,7 +196,21 @@ document.addEventListener('htmx:load', function () {
         ['initImageCarousel', initImageCarousel],
         ['initApiDocs', initApiDocs],
         ['applyEditParam', applyEditParam],
+        ['initCtaImpressions', initCtaImpressions],
     ])
+})
+
+// Delegated listener: survives htmx swaps without needing re-init, unlike the
+// runInitSteps above which bind directly to elements that get replaced.
+// logInfo's export survives this same-tab navigation: the batch processor flushes on
+// 'pagehide' (registered in initializeOtel) via a keepalive fetch, which browsers keep
+// alive past unload.
+document.addEventListener('click', function (event: MouseEvent) {
+    const cta = (event.target as HTMLElement)?.closest<HTMLAnchorElement>(
+        'a[data-cta]'
+    )
+    if (!cta) return
+    logInfo('cta_clicked', ctaAttributes(cta))
 })
 
 // Don't remove style tags because they are used by the elastic global nav.

--- a/src/Elastic.Documentation.Site/Assets/main.ts
+++ b/src/Elastic.Documentation.Site/Assets/main.ts
@@ -149,11 +149,11 @@ function ctaAttributes(cta: HTMLAnchorElement) {
 let ctaImpressionObserver: IntersectionObserver | null = null
 
 // Fires 'cta_viewed' the first time a CTA becomes at least half visible, then stops
-// observing it (one impression per page view). Recreated on every load/swap so
-// htmx-replaced CTAs get (re-)observed against their current page path.
+// observing it (one impression per page view). The observer is created once and
+// reused across htmx swaps; re-observing an already-observed element is a no-op per
+// spec, so this only needs to (re-)register CTAs that are new since the last swap.
 function initCtaImpressions() {
-    ctaImpressionObserver?.disconnect()
-    ctaImpressionObserver = new IntersectionObserver(
+    ctaImpressionObserver ??= new IntersectionObserver(
         (entries, observer) => {
             for (const entry of entries) {
                 if (!entry.isIntersecting) continue

--- a/src/Elastic.Documentation.Site/Assets/telemetry/semconv.ts
+++ b/src/Elastic.Documentation.Site/Assets/telemetry/semconv.ts
@@ -16,6 +16,7 @@ export {
     ATTR_HTTP_RESPONSE_STATUS_CODE,
     ATTR_ERROR_TYPE,
     ATTR_EXCEPTION_MESSAGE,
+    ATTR_URL_PATH,
 } from '@opentelemetry/semantic-conventions'
 
 // ============================================================================
@@ -198,6 +199,37 @@ export const ATTR_NAVIGATION_SEARCH_RESULT_SCORE =
  */
 export const ATTR_NAVIGATION_SEARCH_RETRY_AFTER =
     'navigation_search.retry_after'
+
+// ============================================================================
+// CTA ATTRIBUTES (Custom)
+// ============================================================================
+
+/**
+ * Name of the right-gutter CTA template that was clicked
+ * @example "trial" | "mp"
+ */
+export const ATTR_CTA_NAME = 'cta.name'
+
+/**
+ * Destination URL of the clicked CTA button
+ * @example "https://cloud.elastic.co/registration?page=docs&placement=docs-siderail"
+ */
+export const ATTR_CTA_URL = 'cta.url'
+
+/**
+ * Button label shown on the clicked CTA — lets click counts be grouped by exact wording,
+ * so copy changes to the same cta.name can still be told apart.
+ * @example "Get started free"
+ */
+export const ATTR_CTA_LABEL = 'cta.label'
+
+/**
+ * Where on the page the CTA is placed. Lets performance be compared across placements
+ * (e.g. an always-visible sidebar card vs. a CTA embedded partway through the article body),
+ * which otherwise have very different exposure and aren't comparable by click count alone.
+ * @example "sidebar" | "inline"
+ */
+export const ATTR_CTA_LOCATION = 'cta.location'
 
 // ============================================================================
 // EVENT ATTRIBUTES (Custom)

--- a/src/Elastic.Markdown/HtmlWriter.cs
+++ b/src/Elastic.Markdown/HtmlWriter.cs
@@ -8,8 +8,6 @@ using Elastic.Documentation;
 using Elastic.Documentation.Configuration.Inference;
 using Elastic.Documentation.Configuration.LegacyUrlMappings;
 using Elastic.Documentation.Configuration.Products;
-using Elastic.Documentation.Configuration.Suggestions;
-using Elastic.Documentation.Configuration.Toc;
 using Elastic.Documentation.Configuration.Versions;
 using Elastic.Documentation.Extensions;
 using Elastic.Documentation.Navigation;
@@ -110,16 +108,12 @@ public class HtmlWriter(
 		var siteName = DocumentationSet.Navigation.NavigationTitle;
 		var legacyPages = LegacyUrlMapper.MapLegacyUrl(markdown.YamlFrontMatter?.MappedPages);
 
-		// Resolve the right-gutter CTA: an explicit, known frontmatter name is 'custom' and renders in
+		// Resolve the right-gutter CTA: an explicit, known frontmatter id is 'custom' and renders in
 		// isolated builds too (so authors can preview it); otherwise fall back to the built-in default,
 		// which stays assembler-only to preserve today's behavior.
-		var ctaName = markdown.YamlFrontMatter?.Cta?.Id;
-		if (ctaName is null || !DocumentationSet.Configuration.Ctas.TryGetValue(ctaName, out var cta))
-		{
-			if (ctaName is not null)
-				DocumentationSet.Context.Collector.EmitWarning(markdown.FilePath, UnknownCtaWarning(ctaName, DocumentationSet.Configuration.Ctas.Keys));
-			cta = DocumentationSet.Configuration.Ctas[Cta.DefaultName];
-		}
+		var cta = DocumentationSet.Configuration.ResolveCta(markdown.YamlFrontMatter?.Cta?.Id, out var ctaWarning);
+		if (ctaWarning is not null)
+			DocumentationSet.Context.Collector.EmitWarning(markdown.FilePath, ctaWarning);
 
 		// Use DocumentInferrerService to get merged products and versioning info
 		var inference = DocumentInferrerService.InferForMarkdown(
@@ -219,20 +213,6 @@ public class HtmlWriter(
 			Html = await slice.RenderAsync(cancellationToken: ctx)
 		};
 
-	}
-
-	private static string UnknownCtaWarning(string ctaName, IEnumerable<string> knownCtaNames)
-	{
-		var known = knownCtaNames.ToHashSet();
-		var hint = new Suggestion(known, ctaName).GetSuggestionQuestion();
-		if (string.IsNullOrEmpty(hint))
-		{
-			hint = known.Count > 1
-				? $"Available: {string.Join(", ", known.Order())}."
-				: "No 'cta' templates are defined in this docset.yml yet. Add one under a top-level 'cta:' map, e.g.:\n" +
-					"cta:\n  mp:\n    button:\n      label: Get started on MP\n      url: https://example.com\n    benefits:\n      - \"Some benefit\"";
-		}
-		return $"'cta: {ctaName}' does not match any 'cta' template in docset.yml. Falling back to '{Cta.DefaultName}'. {hint}";
 	}
 
 	private BreadcrumbsList CreateStructuredBreadcrumbsData(MarkdownFile markdown, INavigationItem[] crumbs)

--- a/src/Elastic.Markdown/HtmlWriter.cs
+++ b/src/Elastic.Markdown/HtmlWriter.cs
@@ -113,7 +113,7 @@ public class HtmlWriter(
 		// Resolve the right-gutter CTA: an explicit, known frontmatter name is 'custom' and renders in
 		// isolated builds too (so authors can preview it); otherwise fall back to the built-in default,
 		// which stays assembler-only to preserve today's behavior.
-		var ctaName = markdown.YamlFrontMatter?.Cta;
+		var ctaName = markdown.YamlFrontMatter?.Cta?.Id;
 		if (ctaName is null || !DocumentationSet.Configuration.Ctas.TryGetValue(ctaName, out var cta))
 		{
 			if (ctaName is not null)

--- a/src/Elastic.Markdown/HtmlWriter.cs
+++ b/src/Elastic.Markdown/HtmlWriter.cs
@@ -8,6 +8,8 @@ using Elastic.Documentation;
 using Elastic.Documentation.Configuration.Inference;
 using Elastic.Documentation.Configuration.LegacyUrlMappings;
 using Elastic.Documentation.Configuration.Products;
+using Elastic.Documentation.Configuration.Suggestions;
+using Elastic.Documentation.Configuration.Toc;
 using Elastic.Documentation.Configuration.Versions;
 using Elastic.Documentation.Extensions;
 using Elastic.Documentation.Navigation;
@@ -108,6 +110,17 @@ public class HtmlWriter(
 		var siteName = DocumentationSet.Navigation.NavigationTitle;
 		var legacyPages = LegacyUrlMapper.MapLegacyUrl(markdown.YamlFrontMatter?.MappedPages);
 
+		// Resolve the right-gutter CTA: an explicit, known frontmatter name is 'custom' and renders in
+		// isolated builds too (so authors can preview it); otherwise fall back to the built-in default,
+		// which stays assembler-only to preserve today's behavior.
+		var ctaName = markdown.YamlFrontMatter?.Cta;
+		if (ctaName is null || !DocumentationSet.Configuration.Ctas.TryGetValue(ctaName, out var cta))
+		{
+			if (ctaName is not null)
+				DocumentationSet.Context.Collector.EmitWarning(markdown.FilePath, UnknownCtaWarning(ctaName, DocumentationSet.Configuration.Ctas.Keys));
+			cta = DocumentationSet.Configuration.Ctas[Cta.DefaultName];
+		}
+
 		// Use DocumentInferrerService to get merged products and versioning info
 		var inference = DocumentInferrerService.InferForMarkdown(
 			DocumentationSet.Context.Git.RepositoryName,
@@ -197,7 +210,8 @@ public class HtmlWriter(
 			GitHubDocsUrl = gitHubDocsUrl,
 			GitHubRef = DocumentationSet.Context.Git.GitHubRef,
 			Branding = DocumentationSet.Configuration.Branding,
-			RedirectUrl = markdown.RedirectUrl
+			RedirectUrl = markdown.RedirectUrl,
+			Cta = cta
 		});
 
 		return new RenderResult
@@ -205,6 +219,20 @@ public class HtmlWriter(
 			Html = await slice.RenderAsync(cancellationToken: ctx)
 		};
 
+	}
+
+	private static string UnknownCtaWarning(string ctaName, IEnumerable<string> knownCtaNames)
+	{
+		var known = knownCtaNames.ToHashSet();
+		var hint = new Suggestion(known, ctaName).GetSuggestionQuestion();
+		if (string.IsNullOrEmpty(hint))
+		{
+			hint = known.Count > 1
+				? $"Available: {string.Join(", ", known.Order())}."
+				: "No 'cta' templates are defined in this docset.yml yet. Add one under a top-level 'cta:' map, e.g.:\n" +
+					"cta:\n  mp:\n    button:\n      label: Get started on MP\n      url: https://example.com\n    benefits:\n      - \"Some benefit\"";
+		}
+		return $"'cta: {ctaName}' does not match any 'cta' template in docset.yml. Falling back to '{Cta.DefaultName}'. {hint}";
 	}
 
 	private BreadcrumbsList CreateStructuredBreadcrumbsData(MarkdownFile markdown, INavigationItem[] crumbs)

--- a/src/Elastic.Markdown/Layout/_TableOfContents.cshtml
+++ b/src/Elastic.Markdown/Layout/_TableOfContents.cshtml
@@ -1,3 +1,4 @@
+@using Elastic.Documentation.Configuration.Toc
 @using Elastic.Documentation.Svg
 @using Microsoft.AspNetCore.Html
 @inherits RazorSlice<Elastic.Markdown.MarkdownLayoutViewModel>
@@ -71,27 +72,22 @@
 				</li>
 			}
 		</ul>
-		@if (Model.BuildType == BuildType.Assembler) 
+		@if (Model.BuildType != BuildType.Codex && (Model.BuildType == BuildType.Assembler || Model.Cta.Name != Cta.DefaultName))
 		{
 		<div class="mt-4 hidden lg:block">
 			<div class="sidebar-trial-card">
 				<div class="sidebar-trial-card__inner">
-					<a href="https://cloud.elastic.co/registration?page=docs&placement=docs-siderail" class="w-full min-h-[30px] cursor-pointer text-white text-nowrap bg-blue-elastic hover:bg-blue-elastic-110 focus:ring-4 focus:outline-none focus:ring-blue-elastic-50 font-semibold font-sans rounded-sm px-6 py-2 text-center flex items-center justify-center leading-[30px]">
-					Get started free
+					<a href="@Model.Cta.Url" data-cta="@Model.Cta.Name" data-cta-url="@Model.Cta.Url" data-cta-label="@Model.Cta.Label" data-cta-location="sidebar" class="w-full min-h-[30px] cursor-pointer text-white text-nowrap bg-blue-elastic hover:bg-blue-elastic-110 focus:ring-4 focus:outline-none focus:ring-blue-elastic-50 font-semibold font-sans rounded-sm px-6 py-2 text-center flex items-center justify-center leading-[30px]">
+					@Model.Cta.Label
 				</a>
 					<ul class="mt-4 list-none text-sm">
-						<li class="flex items-start gap-2 py-1 text-ink-light leading-[17px]">
-							<span class="sidebar-trial-card__icon">@(new HtmlString(EuiSvgIcons.GetIcon("checkInCircleFilled") ?? string.Empty))</span>
-							<span>14-day free trial</span>
-						</li>
-						<li class="flex items-start gap-2 py-1 text-ink-light leading-[17px]">
-							<span class="sidebar-trial-card__icon">@(new HtmlString(EuiSvgIcons.GetIcon("checkInCircleFilled") ?? string.Empty))</span>
-							<span>All features included</span>
-						</li>
-						<li class="flex items-start gap-2 py-1 text-ink-light leading-[17px]">
-							<span class="sidebar-trial-card__icon">@(new HtmlString(EuiSvgIcons.GetIcon("checkInCircleFilled") ?? string.Empty))</span>
-							<span>No setup required</span>
-						</li>
+						@foreach (var benefit in Model.Cta.Benefits)
+						{
+							<li class="flex items-start gap-2 py-1 text-ink-light leading-[17px]">
+								<span class="sidebar-trial-card__icon">@(new HtmlString(EuiSvgIcons.GetIcon("checkInCircleFilled") ?? string.Empty))</span>
+								<span>@benefit</span>
+							</li>
+						}
 					</ul>
 				</div>
 			</div>

--- a/src/Elastic.Markdown/Layout/_TableOfContents.cshtml
+++ b/src/Elastic.Markdown/Layout/_TableOfContents.cshtml
@@ -72,7 +72,7 @@
 				</li>
 			}
 		</ul>
-		@if (Model.BuildType == BuildType.Assembler || (Model.Cta.Name != Cta.DefaultName && Model.BuildType != BuildType.Codex))
+		@if (Model.BuildType != BuildType.Codex && (Model.Cta.Name != Cta.DefaultName || (Model.BuildType == BuildType.Assembler && Model.Branding is null)))
 		{
 		<div class="mt-4 hidden lg:block">
 			<div class="sidebar-trial-card">

--- a/src/Elastic.Markdown/Layout/_TableOfContents.cshtml
+++ b/src/Elastic.Markdown/Layout/_TableOfContents.cshtml
@@ -77,7 +77,7 @@
 		<div class="mt-4 hidden lg:block">
 			<div class="sidebar-trial-card">
 				<div class="sidebar-trial-card__inner">
-					<a href="@Model.Cta.Url" data-cta="@Model.Cta.Name" data-cta-url="@Model.Cta.Url" data-cta-label="@Model.Cta.Label" data-cta-location="sidebar" class="w-full min-h-[30px] cursor-pointer text-white text-nowrap bg-blue-elastic hover:bg-blue-elastic-110 focus:ring-4 focus:outline-none focus:ring-blue-elastic-50 font-semibold font-sans rounded-sm px-6 py-2 text-center flex items-center justify-center leading-[30px]">
+					<a href="@Model.Cta.Url" data-cta="@Model.Cta.Name" data-cta-url="@Model.Cta.Url" data-cta-label="@Model.Cta.Label" data-cta-location="sidebar" class="w-full min-h-[30px] cursor-pointer text-white bg-blue-elastic hover:bg-blue-elastic-110 focus:ring-4 focus:outline-none focus:ring-blue-elastic-50 font-semibold font-sans rounded-sm px-6 py-2 text-center flex items-center justify-center leading-normal">
 					@Model.Cta.Label
 				</a>
 					<ul class="mt-4 list-none text-sm">

--- a/src/Elastic.Markdown/Layout/_TableOfContents.cshtml
+++ b/src/Elastic.Markdown/Layout/_TableOfContents.cshtml
@@ -72,7 +72,7 @@
 				</li>
 			}
 		</ul>
-		@if (Model.BuildType != BuildType.Codex && (Model.BuildType == BuildType.Assembler || Model.Cta.Name != Cta.DefaultName))
+		@if (Model.BuildType == BuildType.Assembler || (Model.Cta.Name != Cta.DefaultName && Model.BuildType != BuildType.Codex))
 		{
 		<div class="mt-4 hidden lg:block">
 			<div class="sidebar-trial-card">

--- a/src/Elastic.Markdown/MarkdownLayoutViewModel.cs
+++ b/src/Elastic.Markdown/MarkdownLayoutViewModel.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using Elastic.Documentation.Configuration.Toc;
 using Elastic.Documentation.Configuration.Versions;
 using Elastic.Documentation.Navigation;
 using Elastic.Documentation.Site;
@@ -32,6 +33,9 @@ public record MarkdownLayoutViewModel : GlobalLayoutViewModel
 	public required string? AllVersionsUrl { get; init; }
 
 	public string? RedirectUrl { get; init; }
+
+	/// <summary>The resolved right-gutter CTA for this page (docset.yml template, or the built-in default).</summary>
+	public required Cta Cta { get; init; }
 }
 
 public record PageTocItem

--- a/src/Elastic.Markdown/Myst/FrontMatter/FrontMatterParser.cs
+++ b/src/Elastic.Markdown/Myst/FrontMatter/FrontMatterParser.cs
@@ -41,9 +41,20 @@ public class YamlFrontMatter
 	public bool? NoIndex { get; set; }
 
 	/// <summary>
-	/// Name of a right-gutter CTA template declared in the docset's <c>docset.yml</c> <c>cta</c> map.
+	/// Selects a right-gutter CTA template declared in the docset's <c>docset.yml</c> <c>cta</c> map.
 	/// Falls back to the built-in <c>trial</c> default when omitted or unknown.
 	/// </summary>
 	[YamlMember(Alias = "cta")]
-	public string? Cta { get; set; }
+	public CtaFrontMatter? Cta { get; set; }
+}
+
+/// <summary>
+/// Selects a right-gutter CTA template by <see cref="Id"/>. A dedicated type (rather than a bare string)
+/// so future per-page CTA options can be added here without another frontmatter format change.
+/// </summary>
+[YamlSerializable]
+public class CtaFrontMatter
+{
+	[YamlMember(Alias = "id")]
+	public string? Id { get; set; }
 }

--- a/src/Elastic.Markdown/Myst/FrontMatter/FrontMatterParser.cs
+++ b/src/Elastic.Markdown/Myst/FrontMatter/FrontMatterParser.cs
@@ -39,4 +39,11 @@ public class YamlFrontMatter
 
 	[YamlMember(Alias = "noindex")]
 	public bool? NoIndex { get; set; }
+
+	/// <summary>
+	/// Name of a right-gutter CTA template declared in the docset's <c>docset.yml</c> <c>cta</c> map.
+	/// Falls back to the built-in <c>trial</c> default when omitted or unknown.
+	/// </summary>
+	[YamlMember(Alias = "cta")]
+	public string? Cta { get; set; }
 }

--- a/src/Elastic.Markdown/Page/Index.cshtml
+++ b/src/Elastic.Markdown/Page/Index.cshtml
@@ -65,6 +65,7 @@
 		GitHubRef = Model.GitHubRef,
 		Branding = Model.Branding,
 		RedirectUrl = Model.RedirectUrl,
+		Cta = Model.Cta,
 	};
 	protected override Task ExecuteSectionAsync(string name)
 	{

--- a/src/Elastic.Markdown/Page/IndexViewModel.cs
+++ b/src/Elastic.Markdown/Page/IndexViewModel.cs
@@ -91,6 +91,9 @@ public class IndexViewModel
 
 	/// <summary>When set, the page performs a client-side redirect to this URL (used for alias pages).</summary>
 	public string? RedirectUrl { get; init; }
+
+	/// <summary>The resolved right-gutter CTA for this page (docset.yml template, or the built-in default).</summary>
+	public required Cta Cta { get; init; }
 }
 
 public class VersionDropDownItemViewModel


### PR DESCRIPTION
## Why

The right-gutter CTA card (the "Get started free" trial widget) was hardcoded sitewide, with no way for a docset or page to show a different offer, and no click/impression tracking to measure its effectiveness.

## What

Docsets can now define named CTA templates (button label/url, up to 3 benefit bullets) under a `cta` map in `docset.yml`, and individual pages select one via the `cta` frontmatter field. Pages that don't opt in keep the existing built-in `trial` card. An unknown `cta` name falls back to the default and emits a build warning with a "did you mean" hint. CTA clicks and impressions are now tracked via OpenTelemetry (`cta_clicked` / `cta_viewed`) so click-through rate can be compared across templates and placements.

Codex builds are explicitly excluded from rendering the CTA card, matching their existing exclusion from other assembler-only sidebar chrome.

Docs for the new `docset.yml` key and frontmatter field are added under `docs/configure/content-set/cta.md`, linked from `navigation.md` and `frontmatter.md`.

## Test plan

- [x] `dotnet build` on `Elastic.Markdown` and `Elastic.Codex` succeeds
- [x] `docs-builder build --path docs` succeeds with 0 errors/warnings on the new docs page and links
- [ ] Manually verify a docset with a custom `cta:` template renders the correct label/url/benefits in the sidebar, and that an unknown name falls back to `trial` with a warning
- [ ] Manually verify Codex-built pages never render the sidebar CTA card, even with a `cta:` frontmatter value set

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>