### PR TITLE
Fix Managed inputs nav path_prefix (404 on staging)

### DIFF
--- a/config/navigation.yml
+++ b/config/navigation.yml
@@ -499,7 +499,7 @@ toc:
           # Managed inputs
           # https://github.com/elastic/opentelemetry/blob/main/docs/reference/managed-inputs/toc.yml
           - toc: opentelemetry://reference/managed-inputs
-            path_prefix: reference/managed-inputs
+            path_prefix: reference/opentelemetry/managed-inputs
 
           # Elastic Integrations
           # https://github.com/elastic/integration-docs/blob/main/docs/reference/toc.yml


### PR DESCRIPTION
## Summary

Hotfix for the 404s on the Managed inputs pages after #3601. The `managed-inputs` toc is built as part of `opentelemetry://reference` (`path_prefix: reference/opentelemetry`), so its pages are served under `reference/opentelemetry/managed-inputs/...`. The standalone nav entry pointed at `reference/managed-inputs`, which has no built content, so every Managed inputs page 404'd.

This restores the `opentelemetry` segment on the `path_prefix`, matching the previous `motlp` behavior and the actual (working) content location.

## Effect

- Nav links resolve to the built pages, e.g. `/reference/opentelemetry/managed-inputs/managed-otlp-endpoint`.
- Existing `motlp` redirects remain valid (`/reference/opentelemetry/motlp/*` → `/reference/opentelemetry/managed-inputs/*`).

Related to elastic/docs-content#7155

Made with [Cursor](https://cursor.com)