### PR TITLE
Telemetry: add event.name and url.full to CTA events

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/main.ts
+++ b/src/Elastic.Documentation.Site/Assets/main.ts
@@ -17,7 +17,9 @@ import {
     ATTR_CTA_URL,
     ATTR_CTA_LABEL,
     ATTR_CTA_LOCATION,
+    ATTR_EVENT_NAME,
     ATTR_URL_PATH,
+    ATTR_URL_FULL,
 } from './telemetry/semconv'
 import { initTocNav } from './toc-nav'
 import 'htmx-ext-head-support'
@@ -143,7 +145,17 @@ function ctaAttributes(cta: HTMLAnchorElement) {
         [ATTR_CTA_LABEL]: cta.dataset.ctaLabel ?? '',
         [ATTR_CTA_LOCATION]: cta.dataset.ctaLocation ?? '',
         [ATTR_URL_PATH]: window.location.pathname,
+        [ATTR_URL_FULL]: window.location.href,
     }
+}
+
+// Emit a CTA event: event.name mirrors the body so records can be filtered by
+// exact keyword (attributes.event.name) instead of a text match on body.
+function logCtaEvent(eventName: string, cta: HTMLAnchorElement) {
+    logInfo(eventName, {
+        [ATTR_EVENT_NAME]: eventName,
+        ...ctaAttributes(cta),
+    })
 }
 
 let ctaImpressionObserver: IntersectionObserver | null = null
@@ -157,10 +169,7 @@ function initCtaImpressions() {
         (entries, observer) => {
             for (const entry of entries) {
                 if (!entry.isIntersecting) continue
-                logInfo(
-                    'cta_viewed',
-                    ctaAttributes(entry.target as HTMLAnchorElement)
-                )
+                logCtaEvent('cta_viewed', entry.target as HTMLAnchorElement)
                 observer.unobserve(entry.target)
             }
         },
@@ -210,7 +219,7 @@ document.addEventListener('click', function (event: MouseEvent) {
         'a[data-cta]'
     )
     if (!cta) return
-    logInfo('cta_clicked', ctaAttributes(cta))
+    logCtaEvent('cta_clicked', cta)
 })
 
 // Don't remove style tags because they are used by the elastic global nav.

--- a/src/Elastic.Documentation.Site/Assets/telemetry/semconv.ts
+++ b/src/Elastic.Documentation.Site/Assets/telemetry/semconv.ts
@@ -17,6 +17,7 @@ export {
     ATTR_ERROR_TYPE,
     ATTR_EXCEPTION_MESSAGE,
     ATTR_URL_PATH,
+    ATTR_URL_FULL,
 } from '@opentelemetry/semantic-conventions'
 
 // ============================================================================


### PR DESCRIPTION
## Why

`cta_viewed`/`cta_clicked` currently carry their event identity only in the OTel log `body`, a text field. Filtering these events in Elasticsearch means a fuzzy text match instead of an exact keyword lookup, which makes dashboards and ES|QL queries awkward.

## What

Adds `event.name` as a proper log record attribute (mirroring the body) on both CTA events, following the OTel semantic convention, so they can be filtered with:

```esql
FROM logs-generic.otel-*
| WHERE attributes.event.name IN ("cta_viewed", "cta_clicked")
```

Also adds `url.full` (the full page URL) alongside the existing `url.path`, so the page the user was on can be distinguished from the CTA's destination (`cta.url`).

## Test plan

- [x] `tsc --noEmit` passes
- [x] `eslint` passes
- [x] Full jest suite passes (104/104)
- [ ] Manually verify in DevTools Network that emitted OTLP log records for `cta_viewed`/`cta_clicked` include `attributes.event.name` and `attributes.url.full`