### PR TITLE
Telemetry: capture middle-click CTA opens

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/main.ts
+++ b/src/Elastic.Documentation.Site/Assets/main.ts
@@ -209,17 +209,24 @@ document.addEventListener('htmx:load', function () {
     ])
 })
 
-// Delegated listener: survives htmx swaps without needing re-init, unlike the
+// Delegated listeners: survive htmx swaps without needing re-init, unlike the
 // runInitSteps above which bind directly to elements that get replaced.
 // logInfo's export survives this same-tab navigation: the batch processor flushes on
 // 'pagehide' (registered in initializeOtel) via a keepalive fetch, which browsers keep
 // alive past unload.
-document.addEventListener('click', function (event: MouseEvent) {
+function handleCtaActivation(event: MouseEvent) {
     const cta = (event.target as HTMLElement)?.closest<HTMLAnchorElement>(
         'a[data-cta]'
     )
     if (!cta) return
     logCtaEvent('cta_clicked', cta)
+}
+document.addEventListener('click', handleCtaActivation)
+// 'auxclick' with button 1 covers middle-click (open in new tab), which does NOT
+// fire 'click' per the DOM spec - without this those opens went untracked. Button 2
+// (right-click / context menu) also fires auxclick but isn't a real engagement.
+document.addEventListener('auxclick', function (event: MouseEvent) {
+    if (event.button === 1) handleCtaActivation(event)
 })
 
 // Don't remove style tags because they are used by the elastic global nav.


### PR DESCRIPTION
## Why

CTA click telemetry (`cta_clicked`) is emitted from a `click` listener on the CTA link. Per the DOM spec, middle-click ("open in new tab") fires `auxclick`, not `click`, so those engagements were silently going untracked — undercounting CTA click-through rate for anyone opening links in a background tab.

## What

Bind the existing CTA activation handler to `auxclick` as well, gated to `event.button === 1` so right-click (context menu) doesn't also count as an engagement. Left-click, Cmd/Ctrl+click, and keyboard activation are unaffected — they already fire `click`.

## Test plan

- [x] `prettier`, `tsc --noEmit`, and `eslint` all pass (verified via husky pre-commit hooks)
- [ ] Load a page with a right-gutter CTA, open DevTools Network filtered to `/v1/o/l`, middle-click the CTA → new tab opens and a `cta_clicked` log record is sent (previously nothing was sent)
- [ ] Left-click and Cmd/Ctrl+click still emit `cta_clicked` as before