### PR TITLE
Search: sync agg/aggs synonym with website-search-data

### DIFF
--- a/config/search.yml
+++ b/config/search.yml
@@ -42,6 +42,7 @@ rules:
 
 synonyms:
   - [ ".net", "c#", "csharp", "dotnet", "net" ]
+  - [ "agg", "aggs => aggregations" ]
   - [ "apm", "application performance monitoring" ]
   - [ "aws", "amazon" ]
   - [ "ccr", "cross-cluster replication", "cross cluster replication" ]

--- a/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchMarkdownExporter.cs
+++ b/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchMarkdownExporter.cs
@@ -81,7 +81,9 @@ public partial class ElasticsearchMarkdownExporter : IMarkdownExporter, IDisposa
 		_operations = new ElasticsearchOperations(_transport, _logger, collector);
 		_contentDateEnrichment = new ContentDateEnrichment(_transport, _operations, _logger, endpoints.BuildType, endpoints.Environment);
 
-		string[] fixedSynonyms = ["esql", "data-stream", "data-streams", "machine-learning"];
+		// Keep in sync with website-search-data's IndexTimeSynonyms.Docs — these are baked into the
+		// index-time analyzer (synonyms_fixed_filter) rather than the updateable search-time set.
+		string[] fixedSynonyms = ["esql", "data-stream", "data-streams", "machine-learning", "agg"];
 		var indexTimeSynonyms = _synonyms
 			.Where(s => s.Any(t => fixedSynonyms.Contains(t)))
 			.Select(s => string.Join(", ", s))


### PR DESCRIPTION
## Summary
- Adds an `agg`/`aggs => aggregations` synonym group to `config/search.yml`, matching the entry website-search-data's `IndexTimeSynonyms.Docs` list now expects.
- Adds `"agg"` to the `fixedSynonyms` subset in `ElasticsearchMarkdownExporter`, so the group is baked into the index-time analyzer (`synonyms_fixed_filter`) the same way `esql`, `data-stream(s)`, and `machine-learning` already are, rather than only landing in the updateable search-time set.

Coordinated with the parallel relevance work in `elastic/website-search-data` (commit `e6cfa72`), whose `IndexTimeSynonyms.Docs` comment explicitly calls out staying in sync with this file.

## Test plan
- [x] `dotnet build src/Elastic.Markdown` succeeds
- [x] `dotnet format` / lint clean (pre-push hook passed)
- [ ] Confirm the derived index-time synonym list (`esql, data-stream, data-streams, machine-learning, agg`) matches `IndexTimeSynonyms.Docs` in website-search-data byte-for-byte before reindexing