### PR TITLE
Search: bump contract to 0.12.0 and populate content_tier

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -51,8 +51,8 @@
     <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="9.4.2" />
     <PackageVersion Include="FakeItEasy" Version="9.0.1" />
     <PackageVersion Include="Elastic.Ingest.Elasticsearch" Version="0.45.0" />
-    <PackageVersion Include="Elastic.Mapping" Version="0.48.0" />
-    <PackageVersion Include="Elastic.Internal.Search.Contract" Version="0.11.0" />
+    <PackageVersion Include="Elastic.Mapping" Version="0.49.0" />
+    <PackageVersion Include="Elastic.Internal.Search.Contract" Version="0.12.0" />
     <PackageVersion Include="InMemoryLogger" Version="1.0.66" />
     <PackageVersion Include="MartinCostello.Logging.XUnit.v3" Version="0.7.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />

--- a/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchMarkdownExporter.Export.cs
+++ b/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchMarkdownExporter.Export.cs
@@ -34,6 +34,7 @@ public partial class ElasticsearchMarkdownExporter
 			doc.SearchTitle ?? string.Empty,
 			doc.NavigationSection ?? string.Empty, doc.NavigationDepth.ToString("N0"),
 			doc.NavigationTableOfContents.ToString("N0"),
+			doc.ContentTier,
 			_fixedSynonymsHash,
 			string.Join(",", doc.Parents?.Select(p => $"{p.Url}:{p.Title}") ?? [])
 		);
@@ -43,6 +44,40 @@ public partial class ElasticsearchMarkdownExporter
 	/// <summary>Computes and assigns the whitespace-normalized content hash for change detection.</summary>
 	private static void AssignContentHash(DocumentationDocument doc) =>
 		doc.ContentBodyHash = ContentHash.CreateNormalized(doc.StrippedBody ?? string.Empty);
+
+	/// <summary>
+	/// Classifies a docs page into the shared <see cref="ContentTiers"/> taxonomy. docs-builder owns
+	/// this classification for its own docs/api content — it only agrees with other producers
+	/// (e.g. essc) on the <see cref="ContentTiers"/> string constants themselves.
+	/// </summary>
+	internal static string ClassifyContentTier(INavigationItem? navigationItem, string url)
+	{
+		var section = navigationItem?.NavigationSection;
+		if (IsReleaseNotes(section, url))
+			return ContentTiers.Peripheral;
+		if (IsSupplementary(section, url))
+			return ContentTiers.Supplementary;
+		if (IsPrimary(navigationItem, section))
+			return ContentTiers.Primary;
+		return ContentTiers.Reference;
+
+		static bool IsReleaseNotes(string? section, string url) =>
+			section == "release notes" || url.Contains("/release-notes/", StringComparison.OrdinalIgnoreCase);
+
+		// Aligns with the existing `diminish_terms` in search.yml (plugin, glossary, curator, hadoop, integration, client).
+		static bool IsSupplementary(string? section, string url) =>
+			ContainsAny(section, "deprecat", "plugin", "glossary")
+			|| url.Contains("/docs/extend/", StringComparison.OrdinalIgnoreCase);
+
+		// A section's root/index page is effectively that section's overview — treat it as primary
+		// alongside pages explicitly living under a "get started"/"getting started"/"overview" section.
+		static bool IsPrimary(INavigationItem? navigationItem, string? section) =>
+			navigationItem is IRootNavigationItem<INavigationModel, INavigationItem>
+			|| ContainsAny(section, "get started", "getting started", "overview");
+
+		static bool ContainsAny(string? value, params string[] fragments) =>
+			value is not null && fragments.Any(f => value.Contains(f, StringComparison.OrdinalIgnoreCase));
+	}
 
 	private static void CommonEnrichments(DocumentationDocument doc, INavigationItem? navigationItem)
 	{
@@ -66,6 +101,11 @@ public partial class ElasticsearchMarkdownExporter
 		// e.g. `Use high-contrast mode in Kibana - ( docs cloud-account high contrast`
 		if (doc.NavigationSection == "manage your cloud account and preferences")
 			doc.NavigationDepth *= 2;
+
+		// API reference pages have no navigation item to classify from — treat them as plain reference content.
+		// (doc.Type is a fixed CLR/$type discriminator, always "docs" — ContentType is the field
+		// OpenApiDocumentExporter actually sets to "api".)
+		doc.ContentTier = doc.ContentType == "api" ? ContentTiers.Reference : ClassifyContentTier(navigationItem, doc.Url);
 
 		string CreateSearchTitle()
 		{

--- a/tests/Elastic.Markdown.Tests/Search/ContentTierClassificationTests.cs
+++ b/tests/Elastic.Markdown.Tests/Search/ContentTierClassificationTests.cs
@@ -1,0 +1,136 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using AwesomeAssertions;
+using Elastic.Documentation.Navigation;
+using Elastic.Internal.Search;
+using Elastic.Markdown.Exporters.Elasticsearch;
+
+namespace Elastic.Markdown.Tests.Search;
+
+/// <summary>
+/// content_tier is a shared keyword field (primary/reference/supplementary/peripheral) with a
+/// NEUTRAL default of "reference" — unlike navigation_depth/navigation_table_of_contents which
+/// default to a penalty. docs-builder classifies its own docs/api taxonomy; these tests pin that
+/// classification to the shared <see cref="ContentTiers"/> constants so it can't silently drift
+/// from the values website-search-data agrees on.
+/// </summary>
+public class ContentTierClassificationTests
+{
+	[Fact]
+	public void ReleaseNotesRoot_IsPeripheral()
+	{
+		var root = new FakeRootNavigationItem { NavigationTitle = "Release Notes" };
+
+		var tier = ElasticsearchMarkdownExporter.ClassifyContentTier(root, "/docs/release-notes/elasticsearch");
+
+		tier.Should().Be(ContentTiers.Peripheral);
+	}
+
+	[Fact]
+	public void ReleaseNotesUrlWithoutNavigation_IsPeripheral()
+	{
+		var tier = ElasticsearchMarkdownExporter.ClassifyContentTier(null, "/docs/release-notes/8.15.0");
+
+		tier.Should().Be(ContentTiers.Peripheral);
+	}
+
+	[Theory]
+	[InlineData("deprecated features")]
+	[InlineData("plugins")]
+	[InlineData("glossary")]
+	public void SupplementarySection_IsSupplementary(string sectionTitle)
+	{
+		var root = new FakeRootNavigationItem { NavigationTitle = "Reference" };
+		var leaf = new FakeLeafNavigationItem { NavigationTitle = sectionTitle, Parent = root };
+
+		var tier = ElasticsearchMarkdownExporter.ClassifyContentTier(leaf, "/docs/reference/some-page");
+
+		tier.Should().Be(ContentTiers.Supplementary);
+	}
+
+	[Fact]
+	public void PluginExtendUrl_IsSupplementary()
+	{
+		var tier = ElasticsearchMarkdownExporter.ClassifyContentTier(null, "/docs/extend/logstash");
+
+		tier.Should().Be(ContentTiers.Supplementary);
+	}
+
+	[Theory]
+	[InlineData("get started")]
+	[InlineData("getting started")]
+	[InlineData("overview")]
+	public void GetStartedOrOverviewSection_IsPrimary(string sectionTitle)
+	{
+		var root = new FakeRootNavigationItem { NavigationTitle = "Reference" };
+		var leaf = new FakeLeafNavigationItem { NavigationTitle = sectionTitle, Parent = root };
+
+		var tier = ElasticsearchMarkdownExporter.ClassifyContentTier(leaf, "/docs/reference/some-page");
+
+		tier.Should().Be(ContentTiers.Primary);
+	}
+
+	[Fact]
+	public void SectionRootPage_IsPrimary()
+	{
+		var root = new FakeRootNavigationItem { NavigationTitle = "Elasticsearch" };
+
+		var tier = ElasticsearchMarkdownExporter.ClassifyContentTier(root, "/docs/reference/elasticsearch");
+
+		tier.Should().Be(ContentTiers.Primary);
+	}
+
+	[Fact]
+	public void OrdinaryLeafPage_DefaultsToReference()
+	{
+		var root = new FakeRootNavigationItem { NavigationTitle = "Reference" };
+		var section = new FakeNodeNavigationItem { NavigationTitle = "Elasticsearch", Parent = root };
+		var leaf = new FakeLeafNavigationItem { NavigationTitle = "Settings", Parent = section };
+
+		var tier = ElasticsearchMarkdownExporter.ClassifyContentTier(leaf, "/docs/reference/elasticsearch/settings");
+
+		tier.Should().Be(ContentTiers.Reference);
+	}
+
+	[Fact]
+	public void NoNavigation_DefaultsToReference()
+	{
+		var tier = ElasticsearchMarkdownExporter.ClassifyContentTier(null, "/docs/reference/some-page");
+
+		tier.Should().Be(ContentTiers.Reference);
+	}
+
+	private sealed class FakeNavigationModel : INavigationModel;
+
+	private abstract class FakeNavigationItemBase : INavigationItem
+	{
+		// GetParents() dedupes by Url, so each fake needs a distinct one — not a fixed constant.
+		public required string NavigationTitle { get; init; }
+		public string Url { get; init; } = Guid.NewGuid().ToString();
+		public IRootNavigationItem<INavigationModel, INavigationItem> NavigationRoot => null!;
+		public INodeNavigationItem<INavigationModel, INavigationItem>? Parent { get; set; }
+		public bool Hidden { get; init; }
+		public int NavigationIndex { get; set; }
+	}
+
+	private sealed class FakeLeafNavigationItem : FakeNavigationItemBase, ILeafNavigationItem<INavigationModel>
+	{
+		public INavigationModel Model { get; } = new FakeNavigationModel();
+	}
+
+	private class FakeNodeNavigationItem : FakeNavigationItemBase, INodeNavigationItem<INavigationModel, INavigationItem>
+	{
+		public string Id => NavigationTitle;
+		public ILeafNavigationItem<INavigationModel> Index => null!;
+		public IReadOnlyCollection<INavigationItem> NavigationItems { get; init; } = [];
+	}
+
+	private sealed class FakeRootNavigationItem : FakeNodeNavigationItem, IRootNavigationItem<INavigationModel, INavigationItem>
+	{
+		public bool IsUsingNavigationDropdown => false;
+		public Uri Identifier => new("https://elastic.co/docs");
+		public void SetNavigationItems(IReadOnlyCollection<INavigationItem> navigationItems) { }
+	}
+}


### PR DESCRIPTION
## Summary
website-search-data's relevance work (`e6cfa72` + follow-ups) is published as `Elastic.Internal.Search.Contract` 0.12.0 (requires `Elastic.Mapping` 0.49.0). This bumps both and populates the new shared `content_tier` field for docs pages.

- **Package bump**: `Elastic.Mapping` 0.48.0 → 0.49.0, `Elastic.Internal.Search.Contract` 0.11.0 → 0.12.0. This alone activates, with no docs-builder code changes needed: the `content_tags` copy_to field, the `stemmer_override` (config/install/auth), the `c#`/`.net` → `dotnet` char_filter, the split fixed/updateable synonym filters, and a brand-qualified `ai_search_query` enrichment prompt.
- **content_tier classification**: added `ElasticsearchMarkdownExporter.ClassifyContentTier`, called from `CommonEnrichments`:
  - release notes → `Peripheral`
  - deprecated / plugin / glossary / `/docs/extend/` → `Supplementary`
  - section root/index pages, get-started/overview sections → `Primary`
  - everything else → `Reference` (the neutral default)
  - API reference pages (no navigation item) → `Reference` explicitly
  
  Uses the shared `ContentTiers` constants (not string literals) so values can't drift from website-search-data. `ContentTier` is folded into `AssignDocumentMetadata`'s hash so a tier change triggers a re-index.

## Test plan
- [x] `dotnet build` (whole solution, 43 projects) succeeds with no API drift from the bump
- [x] `dotnet test tests/Elastic.Markdown.Tests` — new `ContentTierClassificationTests` (12/12) and existing `DocumentationDocumentSerializationTests` all pass
- [x] Full `Elastic.Markdown.Tests` suite run; 14 pre-existing failures are unrelated `ScopedFileSystem`/git-checkout tests failing in this worktree environment
- [x] `dotnet format` / lint clean (pre-push hook passed)
- [ ] Coordinate a reindex with the website-search-data owner once this and the two companion PRs (#3606 synonym sync, #3607 navigation guard) land — new index-time analysis only applies to newly created indices