### PR TITLE
Image: allow images.contentstack.io as a trusted external host

### DIFF
--- a/src/Elastic.Markdown/Myst/Directives/Image/ImageBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Image/ImageBlock.cs
@@ -68,7 +68,13 @@ public class ImageBlock(DirectiveBlockParser parser, ParserContext context)
 
 	public string? Label { get; private set; }
 
-	private static readonly HashSet<string> AllowedUriHosts = ["epr.elastic.co"];
+	/// <summary>
+	/// External hosts that are trusted to serve images referenced from the <c>image</c> directive.
+	/// External URIs are discouraged in general, but these are Elastic-managed asset hosts:
+	/// <c>epr.elastic.co</c> is the Elastic Package Registry and <c>images.contentstack.io</c> is the
+	/// Elastic Contentstack CDN used for shared screenshots and animated GIFs.
+	/// </summary>
+	private static readonly HashSet<string> AllowedUriHosts = ["epr.elastic.co", "images.contentstack.io"];
 
 	public override void FinalizeAndValidate(ParserContext context)
 	{

--- a/tests/Elastic.Markdown.Tests/Directives/ImageTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/ImageTests.cs
@@ -42,6 +42,25 @@ public class ImageBlockTests(ITestOutputHelper output) : DirectiveTest<ImageBloc
 	}
 }
 
+public class AllowedExternalHostTests(ITestOutputHelper output) : DirectiveTest<ImageBlock>(output,
+"""
+:::{image} https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt/example.gif
+:alt: An animated screenshot hosted on the Elastic Contentstack CDN
+:::
+"""
+)
+{
+	[Fact]
+	public void ParsesBlock() => Block.Should().NotBeNull();
+
+	[Fact]
+	public void AllowedHostDoesNotWarn()
+	{
+		Block!.Found.Should().BeTrue();
+		Collector.Diagnostics.Count.Should().Be(0);
+	}
+}
+
 public class FigureTests(ITestOutputHelper output) : DirectiveTest<ImageBlock>(output,
 """
 :::{figure} https://github.com/rowanc1/pics/blob/main/sunset.png?raw=true


### PR DESCRIPTION
## Summary

The `image` directive emits a warning when it references an external URI, to discourage hotlinking. It carries an allowlist of Elastic-managed hosts that are exempt, which until now contained only `epr.elastic.co`.

Elastic stores shared screenshots and animated GIFs on the Contentstack CDN (`images.contentstack.io`, the `bltefdd0b53724fa2ce` asset account). Referencing those assets from an `:::{image}` directive currently trips the external-URI warning even though the host is Elastic-controlled — the same category as `epr.elastic.co`. In `docs-content`, several pages already hotlink these GIFs via inline `![...]` markdown (which isn't validated); moving them to the richer `:::{image}` directive is currently blocked by this warning.

This adds `images.contentstack.io` to `AllowedUriHosts` and documents the intent of the allowlist.

## Changes

- `ImageBlock.cs`: add `images.contentstack.io` to `AllowedUriHosts`, with a doc comment explaining that the set is for trusted Elastic-managed asset hosts.
- `ImageTests.cs`: add a test asserting a Contentstack image directive parses without diagnostics.

## Notes

- Only the exact host `images.contentstack.io` is allowlisted (not a broad `*.contentstack.io`), keeping the allowlist to Elastic-controlled delivery hosts.
- Inline markdown images (`![...]`) are unaffected; they already bypass the external-URI check.

Made with [Cursor](https://cursor.com)