### PR TITLE
Disable Storybook directive pending working registry

### DIFF
--- a/docs/_docset.yml
+++ b/docs/_docset.yml
@@ -42,8 +42,10 @@ subs:
 features:
   primary-nav: false
 
-storybook:
-  registry: https://ci-artifacts.kibana.dev/storybooks/pr-272388/storybook-docs/docs_registry.json
+# Temporarily disabled: the pr-272388 preview registry artifact is gone and there is no
+# working `main` registry to fall back to yet. Re-enable once a registry URL resolves.
+# storybook:
+#   registry: https://ci-artifacts.kibana.dev/storybooks/pr-272388/storybook-docs/docs_registry.json
 
 cta:
   docs-builder:

--- a/docs/syntax/storybook.md
+++ b/docs/syntax/storybook.md
@@ -48,11 +48,16 @@ Use a registry ID directly:
 :::
 ```
 
+<!--
+Temporarily disabled: the pr-272388 preview registry artifact is gone and there is no
+working `main` registry to fall back to yet. Re-enable once a registry URL resolves.
+
 :::{storybook}
 :id: kibana:shared_ux:ai-components-aibutton--default
 :height: 300
 :title: AI button default story
 :::
+-->
 
 Or use structured properties:
 
@@ -65,12 +70,17 @@ Or use structured properties:
 :::
 ```
 
+<!--
+Temporarily disabled: the pr-272388 preview registry artifact is gone and there is no
+working `main` registry to fall back to yet. Re-enable once a registry URL resolves.
+
 :::{storybook}
 :project: kibana
 :storybook: shared_ux
 :component: ai-components-aibutton
 :story: default
 :::
+-->
 
 If a bare `:id:` is used, it must match exactly one story in the configured registry:
 


### PR DESCRIPTION
## Summary
- The `main` build is failing because the `{storybook}` directive's registry (`docset.yml`) still pointed at a per-PR preview artifact (`pr-272388`) that no longer exists, and there is no working `main`-branch registry to fall back to yet.
- Comments out the `storybook:` registry registration in `docs/_docset.yml` and the two live `{storybook}` directive invocations in `docs/syntax/storybook.md` (the code-fenced examples are untouched, only the two rendered blocks that actually hit the registry).
- The page stays in the toc; only the live examples are disabled.

## Test plan
- [x] `dotnet run --project src/tooling/docs-builder -- build --path docs` completes with 0 Errors (previously failed with a 404 fetching the registry)
- [ ] CI `build` job passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)