### PR TITLE
Fix zizmor ref-version-mismatch on docker/login-action pin

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -65,7 +65,7 @@ jobs:
         uses: ./.github/actions/bootstrap
         
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
         uses: ./.github/actions/bootstrap
         
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
## Summary
- The zizmor CI check on `main` is failing (exit code 13) due to a `ref-version-mismatch` finding: `docker/login-action` in `release.yml` and `prerelease.yml` is pinned to the commit for `v4.2.0` but annotated `# v4`, and the `v4` tag has since moved to point at `v4.4.0`'s commit.
- Updates the pin in both workflows to `v4.4.0`'s commit (`af1e73f918a031802d376d3c8bbc3fe56130a9b0`) with a matching `# v4.4.0` comment so the hash and comment stay in sync.

## Test plan
- [x] Verified `af1e73f918a031802d376d3c8bbc3fe56130a9b0` is the commit currently tagged `v4` (and `v4.4.0`) on `docker/login-action` via `git ls-remote`
- [ ] zizmor CI check passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)