### PR TITLE
Search: preserve operation id (e.g. _bulk) in OpenAPI search_title

### DIFF
--- a/src/Elastic.ApiExplorer/Elasticsearch/OpenApiDocumentExporter.cs
+++ b/src/Elastic.ApiExplorer/Elasticsearch/OpenApiDocumentExporter.cs
@@ -106,8 +106,9 @@ public partial class OpenApiDocumentExporter(
 
 	/// <summary>
 	/// Converts an OpenAPI document to DocumentationDocument instances.
+	/// Internal (rather than private) so tests can exercise it against an in-memory spec.
 	/// </summary>
-	private IEnumerable<DocumentationDocument> ConvertToDocuments(OpenApiDocument openApiDocument, string product)
+	internal IEnumerable<DocumentationDocument> ConvertToDocuments(OpenApiDocument openApiDocument, string product)
 	{
 		foreach (var path in openApiDocument.Paths)
 		{
@@ -126,7 +127,10 @@ public partial class OpenApiDocumentExporter(
 
 				var productName = CultureInfo.InvariantCulture.TextInfo.ToTitleCase(product);
 				// inject product name into title to ensure differentiation and better scoring
-				var title = $"{operation.Value.Summary ?? operationId} - {productName} API ";
+				var title = $"{operation.Value.Summary ?? operationId} - {productName} API";
+				// append the raw operation id (e.g. "_bulk") so the REST endpoint name is searchable —
+				// keep it verbatim (no case/underscore normalization) since that's exactly what users type.
+				var searchTitle = $"{title} - {operationId}";
 				var description = TransformOperationListToMarkdown(operation.Value.Description);
 
 				// Build body content from operation details
@@ -173,7 +177,7 @@ public partial class OpenApiDocumentExporter(
 					ContentType = "api",
 					Url = url,
 					Title = title,
-					SearchTitle = title,
+					SearchTitle = searchTitle,
 					Description = description,
 					Body = body,
 					StrippedBody = body,

--- a/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchMarkdownExporter.Export.cs
+++ b/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchMarkdownExporter.Export.cs
@@ -44,10 +44,18 @@ public partial class ElasticsearchMarkdownExporter
 	private static void AssignContentHash(DocumentationDocument doc) =>
 		doc.ContentBodyHash = ContentHash.CreateNormalized(doc.StrippedBody ?? string.Empty);
 
-	/// <summary>Internal (rather than private) so tests can assert navigation_* rank features never fall back to the contract's penalty default.</summary>
+	/// <summary>
+	/// Internal (rather than private) so tests can assert navigation_* rank features never fall back
+	/// to the contract's penalty default, and that search_title construction is correct.
+	/// </summary>
 	internal static void CommonEnrichments(DocumentationDocument doc, INavigationItem? navigationItem)
 	{
-		doc.SearchTitle = CreateSearchTitle();
+		// OpenApiDocumentExporter builds its own search title, including the raw operation id
+		// (e.g. "_bulk") — CreateSearchTitle below is tuned for markdown pages and derives extra
+		// tokens from the URL by splitting on '_' among other chars, which would strip that
+		// leading underscore. Leave API docs' search_title alone.
+		if (doc.ContentType != "api")
+			doc.SearchTitle = CreateSearchTitle();
 		// if we have no navigation, initialize to 20 since rank_feature would score 0 too high
 		doc.NavigationDepth = navigationItem?.NavigationDepth ?? 20;
 		doc.NavigationTableOfContents = navigationItem switch

--- a/tests/Elastic.ApiExplorer.Tests/OpenApiOperationIdSearchTitleTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/OpenApiOperationIdSearchTitleTests.cs
@@ -1,0 +1,63 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using AwesomeAssertions;
+using Elastic.ApiExplorer.Elasticsearch;
+using Elastic.Documentation.Configuration.Versions;
+using Elastic.Documentation.Versions;
+using Microsoft.OpenApi;
+
+namespace Elastic.ApiExplorer.Tests;
+
+/// <summary>
+/// The Bulk API's operation id ("_bulk") must survive into search_title verbatim, underscore
+/// intact — it's a high-value search token users type literally. Exercises
+/// OpenApiDocumentExporter.ConvertToDocuments directly against an in-memory spec, no network.
+/// </summary>
+public class OpenApiOperationIdSearchTitleTests
+{
+	private static readonly VersionsConfiguration VersionsConfiguration = new()
+	{
+		VersioningSystems = new Dictionary<VersioningSystemId, VersioningSystem>
+		{
+			{
+				VersioningSystemId.Stack,
+				new VersioningSystem { Id = VersioningSystemId.Stack, Base = new SemVersion(8, 0, 0), Current = new SemVersion(9, 2, 0) }
+			}
+		}
+	};
+
+	private static OpenApiDocument CreateBulkSpec() => new()
+	{
+		Paths = new OpenApiPaths
+		{
+			["/_bulk"] = new OpenApiPathItem
+			{
+				Operations = new Dictionary<HttpMethod, OpenApiOperation>
+				{
+					[HttpMethod.Put] = new OpenApiOperation
+					{
+						OperationId = "_bulk",
+						Summary = "Bulk index or delete documents"
+					}
+				}
+			}
+		}
+	};
+
+	[Fact]
+	public void BulkOperation_SearchTitleContainsTheRawOperationIdWithUnderscore()
+	{
+		var exporter = new OpenApiDocumentExporter(VersionsConfiguration);
+
+		var docs = exporter.ConvertToDocuments(CreateBulkSpec(), "elasticsearch").ToArray();
+
+		docs.Should().HaveCount(1);
+		var doc = docs[0];
+
+		doc.Title.Should().Be("Bulk index or delete documents - Elasticsearch API");
+		doc.SearchTitle.Should().Be("Bulk index or delete documents - Elasticsearch API - _bulk");
+		doc.SearchTitle.Should().Contain("_bulk");
+	}
+}

--- a/tests/Elastic.Markdown.Tests/Search/OpenApiSearchTitleTests.cs
+++ b/tests/Elastic.Markdown.Tests/Search/OpenApiSearchTitleTests.cs
@@ -1,0 +1,52 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using AwesomeAssertions;
+using Elastic.Documentation.Search;
+using Elastic.Markdown.Exporters.Elasticsearch;
+
+namespace Elastic.Markdown.Tests.Search;
+
+/// <summary>
+/// OpenApiDocumentExporter builds its own search_title, including the raw operation id
+/// (e.g. "_bulk"). CommonEnrichments must not overwrite it with the markdown-tuned
+/// CreateSearchTitle, which derives extra tokens from the URL by splitting on '_' among other
+/// characters — that would strip the leading underscore from operation ids like "_bulk".
+/// </summary>
+public class OpenApiSearchTitleTests
+{
+	[Fact]
+	public void ApiDocs_PreserveTheExporterSSearchTitle()
+	{
+		var doc = new DocumentationDocument
+		{
+			ContentType = "api",
+			Url = "/docs/api/doc/elasticsearch/operation/operation-_bulk",
+			Title = "Bulk index or delete documents - Elasticsearch API",
+			SearchTitle = "Bulk index or delete documents - Elasticsearch API - _bulk"
+		};
+
+		ElasticsearchMarkdownExporter.CommonEnrichments(doc, null);
+
+		doc.SearchTitle.Should().Be("Bulk index or delete documents - Elasticsearch API - _bulk");
+		doc.SearchTitle.Should().Contain("_bulk");
+	}
+
+	[Fact]
+	public void MarkdownDocs_StillGetTheDerivedSearchTitle()
+	{
+		var doc = new DocumentationDocument
+		{
+			Url = "/docs/reference/elasticsearch/settings",
+			Title = "Settings",
+			SearchTitle = "Settings"
+		};
+
+		ElasticsearchMarkdownExporter.CommonEnrichments(doc, null);
+
+		// unaffected by this change — still rebuilt from the URL, not left as the seeded value
+		doc.SearchTitle.Should().NotBe("Settings");
+		doc.SearchTitle.Should().StartWith("Settings - ");
+	}
+}


### PR DESCRIPTION
## Summary
For OpenAPI-exported docs (e.g. the Elasticsearch Bulk API, operation id `_bulk`), `search_title` currently reads `"Bulk index or delete documents - Elasticsearch API  - doc operation"` — the operation id never appears, and its leading underscore would be lost even if it did. Users search Elasticsearch docs by REST endpoint name a lot (`_bulk`, `_search`, `_cat`, dotted ids like `ml.start_datafeed`), so this is a real, missing search token.

**Root cause**: OpenAPI docs are built in two stages, and the second silently overwrites the first's `search_title`. `OpenApiDocumentExporter` sets `Title == SearchTitle`, but `ElasticsearchMarkdownExporter.CommonEnrichments` then unconditionally rebuilds `SearchTitle` via `CreateSearchTitle()`, which derives extra tokens from the URL by splitting on `/`, ` `, `-`, `.`, and `_`. For the Bulk API (URL segment `operation-_bulk`), that split turns `_bulk` into a bare `bulk`, which then gets deduplicated against the title's existing `Bulk` token and dropped entirely.

**Fix**: let OpenAPI docs own their `SearchTitle`.
- `CommonEnrichments` now only rebuilds `SearchTitle` via `CreateSearchTitle()` for non-API content (`doc.ContentType != "api"`) — markdown docs are unaffected.
- `OpenApiDocumentExporter` builds a dedicated search title appending the raw operation id verbatim (underscore/casing intact): `"Bulk index or delete documents - Elasticsearch API - _bulk"`. Also drops a stray trailing space in `Title` that caused the reported double space.

**website-search-data check**: no mapping/analyzer change needed. `search_title` is analyzed by `synonyms_fixed_analyzer`/`synonyms_analyzer`, both using `group_tokenizer`, whose delimiter set doesn't include `_` or `.` — so `_bulk` (and dotted ids like `ml.start_datafeed`) index and search as a single token, both index- and search-time, including on the `completion` (search_as_you_type) sub-field. Flagged separately, not blocking: `title.starts_with`'s EdgeNGram tokenizer `token_chars` omits `"punctuation"` and would strip a leading underscore if operation ids are ever added to `Title` too.

## Test plan
- [x] `dotnet build` for `Elastic.Markdown` and `Elastic.ApiExplorer` succeeds
- [x] New `OpenApiSearchTitleTests` (Elastic.Markdown.Tests) — asserts `CommonEnrichments` preserves the API exporter's `search_title` and still rebuilds it for markdown docs
- [x] New `OpenApiOperationIdSearchTitleTests` (Elastic.ApiExplorer.Tests) — exercises `OpenApiDocumentExporter.ConvertToDocuments` against an in-memory Bulk API spec (no network), asserts `search_title` == `"Bulk index or delete documents - Elasticsearch API - _bulk"`
- [x] Full `Elastic.Markdown.Tests` and `Elastic.ApiExplorer.Tests` suites run; pre-existing failures are unrelated `ScopedFileSystem`/git-checkout tests failing in this worktree environment
- [x] `dotnet format` / lint clean (pre-push hook passed)
- [ ] Coordinate a reindex with the website-search-data owner once merged, alongside the companion relevance-tweaks PRs (#3606, #3607, #3608)