### PR TITLE
Add essc indices copy command for cross-cluster index copies

### DIFF
--- a/docs/development/essc.md
+++ b/docs/development/essc.md
@@ -47,12 +47,14 @@ dotnet run --project src/tooling/essc -- --help
 
 ### Environment variables
 
-| Environment variable          | Description                           |
-| ----------------------------- | ------------------------------------- |
-| `ELASTICSEARCH_URL`           | Full Elasticsearch URL including port |
-| `ELASTICSEARCH_API_KEY`       | Elasticsearch API key                 |
-| `CONTENTSTACK_API_KEY`        | Contentstack Content Delivery API key |
-| `CONTENTSTACK_DELIVERY_TOKEN` | Contentstack delivery token           |
+| Environment variable          | Description                                                          |
+| ------------------------------ | --------------------------------------------------------------------- |
+| `ELASTICSEARCH_URL`           | Full Elasticsearch URL including port                                |
+| `ELASTICSEARCH_API_KEY`       | Elasticsearch API key                                                |
+| `DESTINATION_ELASTIC_URL`     | Destination cluster URL for cross-cluster commands (`indices copy`, `indices sync-remote`, `indices unify-incremental-sync`). Only needed when the destination differs from the source — it otherwise seeds from `Parameters:ElasticsearchUrl` / `ELASTICSEARCH_URL` |
+| `DESTINATION_ELASTIC_APIKEY`  | Destination cluster API key — same seeding rule as above             |
+| `CONTENTSTACK_API_KEY`        | Contentstack Content Delivery API key                                |
+| `CONTENTSTACK_DELIVERY_TOKEN` | Contentstack delivery token                                          |
 
 The dotnet configuration section keys (`Parameters:ElasticsearchUrl`, `ContentStack:ApiKey`,
 etc.) are also accepted. For CI, use the flat environment variable names above.
@@ -65,6 +67,13 @@ dotnet user-secrets set --id docs-builder Parameters:ElasticsearchApiKey <key>
 dotnet user-secrets set --id docs-builder ContentStack:ApiKey <key>
 dotnet user-secrets set --id docs-builder ContentStack:DeliveryToken <token>
 ```
+
+For cross-cluster commands (`indices copy`, `indices sync-remote`, `indices unify-incremental-sync`),
+the destination cluster seeds from the same `Parameters:ElasticsearchUrl` / `Parameters:ElasticsearchApiKey`
+secret as the source — so configuring just one cluster in the secrets store is enough; pass
+`--to-url`/`--to-api-key` (or `--from-url`/`--from-api-key`) on the command to point only one side
+at a different cluster, or set `DESTINATION_ELASTIC_URL`/`DESTINATION_ELASTIC_APIKEY` to override
+the destination for every run.
 
 If you previously used essc from the website-search-data repository, copy the
 `Parameters:Elasticsearch*` and `ContentStack:*` values from your old
@@ -150,6 +159,35 @@ Runs generative AI enrichment on existing **`labs-*`** semantic indices without 
 ```bash
 essc labs ai
 ```
+
+## Indices commands
+
+### `indices copy`
+
+Copies one or more indices verbatim between clusters using the Elasticsearch server-side remote
+reindex API. Unlike `indices sync-remote` / `indices unify-incremental-sync`, this command is not
+docs-search specific — it copies no synonym/query-rule resources and runs no lexical/semantic
+inference phases. Useful for pulling standalone indices (e.g. AI-enrichment `-ai-cache` lookup
+indices) from production down to a local cluster.
+
+```bash
+essc indices copy docs-assembler.semantic-prod-ai-cache labs-public.semantic-prod-ai-cache \
+  --from-url https://<prod-es> --from-api-key <key> \
+  --to-url http://localhost:9200
+```
+
+- Takes one or more source index/alias names as positional arguments.
+- `--rename-from` / `--rename-to` — regex rename applied to each source name to derive its
+  destination name (back-references supported), e.g. `--rename-from 'semantic-prod-' --rename-to
+  'semantic-local-'`.
+- `--force` — delete and recreate an existing destination index from the source's mapping and
+  settings before reindexing. Without it, an existing destination index is reindexed into as-is.
+- `--strip-semantic-fields` — strip `_inference_fields` metadata when the source has
+  `semantic_text` mappings (see `indices sync-remote`).
+- Shares `--from-url` / `--from-api-key` / `--to-url` / `--to-api-key` / `--slices` / `--rps` /
+  `--aliases` with `indices sync-remote` and `indices unify-incremental-sync`. `--slices` has no
+  effect on `indices copy` — every reindex it does is a remote reindex, and Elasticsearch rejects
+  `slices > 1` for reindex from a remote source.
 
 ## CI behaviour
 

--- a/src/tooling/essc/Commands/IndicesCommands.cs
+++ b/src/tooling/essc/Commands/IndicesCommands.cs
@@ -45,14 +45,18 @@ internal sealed class IndicesRemoteSyncOptions
 
 	/// <summary>
 	/// Destination cluster base URL, including scheme and port.
-	/// Defaults to <c>DESTINATION_ELASTIC_URL</c>.
+	/// Defaults to <c>DESTINATION_ELASTIC_URL</c> if set, otherwise seeds from the same configured
+	/// Elasticsearch URL as <c>--from-url</c> (<c>Parameters:ElasticsearchUrl</c> user secret /
+	/// <c>DOCUMENTATION_ELASTIC_URL</c> / <c>ELASTICSEARCH_URL</c>) — so only one cluster needs to be
+	/// configured and you pass <c>--to-url</c> (or <c>--from-url</c>) for the other.
 	/// </summary>
 	[Url]
 	public Uri? ToUrl { get; set; }
 
 	/// <summary>
 	/// Destination cluster encoded API key.
-	/// Defaults to <c>DESTINATION_ELASTIC_APIKEY</c>.
+	/// Defaults to <c>DESTINATION_ELASTIC_APIKEY</c> if set, otherwise seeds from the same configured
+	/// API key as <c>--from-api-key</c> (see <c>ToUrl</c>).
 	/// </summary>
 	public string? ToApiKey { get; set; }
 
@@ -644,6 +648,70 @@ internal sealed class IndicesCommands(SourcingConfiguration config, ILoggerFacto
 			AnsiConsole.MarkupLine($"[green]✓[/] Created [white]{Markup.Escape(destIndex)}[/] with source mapping");
 	}
 
+	// Internal/read-only top-level settings keys stripped when copying an index's settings to a
+	// fresh destination index — these are cluster/identity-specific and must not be replayed.
+	private static readonly string[] ReadOnlySettingsKeys =
+	[
+		"creation_date", "creation_date_string", "uuid", "version", "provided_name", "resize", "routing", "history",
+	];
+
+	/// <summary>
+	/// Creates <paramref name="destIndex"/> on the destination cluster with the mapping and
+	/// settings copied from <paramref name="sourceIndex"/> on the source cluster. Used by
+	/// <see cref="Copy"/> to faithfully recreate a destination index before reindexing into it.
+	/// </summary>
+	private static async Task CopyIndexDefinitionAsync(
+		DistributedTransport fromTransport, DistributedTransport toTransport,
+		string sourceIndex, string destIndex, ILogger logger, CancellationToken ct)
+	{
+		AnsiConsole.MarkupLine($"[dim]  Creating [white]{Markup.Escape(destIndex)}[/] from source mapping+settings of [white]{Markup.Escape(sourceIndex)}[/]...[/]");
+
+		var mappingResp = await fromTransport.RequestAsync<StringResponse>(
+			Transport.HttpMethod.GET, $"{Uri.EscapeDataString(sourceIndex)}/_mapping", cancellationToken: ct);
+		if (!mappingResp.ApiCallDetails.HasSuccessfulStatusCode || mappingResp.Body is null)
+		{
+			logger.LogError("Failed to fetch source mapping from {Index}: {Info}", sourceIndex, mappingResp.ApiCallDetails.DebugInformation);
+			return;
+		}
+
+		var settingsResp = await fromTransport.RequestAsync<StringResponse>(
+			Transport.HttpMethod.GET, $"{Uri.EscapeDataString(sourceIndex)}/_settings", cancellationToken: ct);
+
+		// Response shapes:
+		//   _mapping:  { "<backing>": { "mappings": { ... } } }
+		//   _settings: { "<backing>": { "settings": { "index": { ... } } } }
+		var mappingRoot = JsonNode.Parse(mappingResp.Body);
+		var mappings = mappingRoot?.AsObject().FirstOrDefault().Value?["mappings"];
+		if (mappings is null)
+		{
+			logger.LogError("No mappings found in source {Index} — skipping create", sourceIndex);
+			return;
+		}
+
+		JsonNode? settings = null;
+		if (settingsResp.ApiCallDetails.HasSuccessfulStatusCode && settingsResp.Body is not null)
+		{
+			var settingsRoot = JsonNode.Parse(settingsResp.Body);
+			settings = settingsRoot?.AsObject().FirstOrDefault().Value?["settings"]?["index"];
+			if (settings is JsonObject settingsObj)
+			{
+				foreach (var key in ReadOnlySettingsKeys)
+					_ = settingsObj.Remove(key);
+			}
+		}
+
+		var body = settings is not null
+			? $"{{\"settings\":{{\"index\":{settings.ToJsonString()}}},\"mappings\":{mappings.ToJsonString()}}}"
+			: $"{{\"mappings\":{mappings.ToJsonString()}}}";
+
+		var createResp = await toTransport.RequestAsync<StringResponse>(
+			Transport.HttpMethod.PUT, Uri.EscapeDataString(destIndex), PostData.String(body), cancellationToken: ct);
+		if (!createResp.ApiCallDetails.HasSuccessfulStatusCode)
+			logger.LogError("Failed to create {Index} with source mapping+settings: {Info}", destIndex, createResp.ApiCallDetails.DebugInformation);
+		else
+			AnsiConsole.MarkupLine($"[green]✓[/] Created [white]{Markup.Escape(destIndex)}[/] with source mapping+settings");
+	}
+
 	/// <summary>
 	/// Applies a regex rename to <paramref name="indexName"/>.
 	/// <paramref name="from"/> is a regular expression; <paramref name="to"/> is the replacement
@@ -834,6 +902,147 @@ internal sealed class IndicesCommands(SourcingConfiguration config, ILoggerFacto
 		}
 
 		await ApplyAliasesAsync(transport, options.Aliases, destIndex, logger, ct);
+		AnsiConsole.MarkupLine("[green]✓[/] Done");
+	}
+
+	/// <summary>
+	/// Copies one or more indices verbatim from a source cluster to a destination cluster using
+	/// the Elasticsearch server-side remote reindex API. Unlike <see cref="SyncRemote"/> and
+	/// <see cref="UnifyIncrementalSync"/> this command is not docs-search specific — no search
+	/// resources (synonyms/query rulesets) are copied and no lexical/semantic inference phases run.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// The destination cluster must whitelist the source host:port in
+	/// <c>reindex.remote.whitelist</c> (Elastic Cloud: advanced user settings).
+	/// </para>
+	/// <para>
+	/// When the destination index already exists, documents are reindexed into it as-is (its
+	/// existing mapping/settings are left untouched) unless <c>--force</c> is passed, in which case
+	/// the destination index is deleted and recreated from the source index's mapping and settings
+	/// before reindexing — guaranteeing a faithful fresh copy.
+	/// </para>
+	/// <para>
+	/// <c>--slices</c> (from the shared connection options) has no effect here — Elasticsearch
+	/// rejects <c>slices &gt; 1</c> for reindex from a remote source, so it is never sent.
+	/// </para>
+	/// </remarks>
+	/// <param name="indices">
+	/// One or more source index (or alias) names to copy. Each is used verbatim as the source name
+	/// on the source cluster.
+	/// </param>
+	/// <param name="renameFrom">
+	/// Regular expression applied to each source index name to derive its destination name
+	/// (e.g. <c>-prod-</c>). Must be paired with <c>--rename-to</c>. When omitted, destination
+	/// names equal source names.
+	/// </param>
+	/// <param name="renameTo">
+	/// Replacement string for <c>--rename-from</c> — supports regex back-references
+	/// (e.g. <c>-local-</c>). Must be paired with <c>--rename-from</c>.
+	/// </param>
+	/// <param name="force">
+	/// Delete and recreate the destination index (from the source's mapping and settings) before
+	/// reindexing, even if it already exists. Without this flag an existing destination index is
+	/// reindexed into as-is.
+	/// </param>
+	/// <param name="stripSemanticFields">
+	/// Strip <c>_inference_fields</c> metadata before writing to the destination. See
+	/// <see cref="SyncRemote"/> for details on why this matters for <c>semantic_text</c> indices.
+	/// </param>
+	/// <param name="options">Connection and throttle options.</param>
+	/// <param name="ct">Cancellation token.</param>
+	public async Task Copy(
+		[Argument] string[] indices,
+		string? renameFrom = null,
+		string? renameTo = null,
+		bool force = false,
+		bool stripSemanticFields = false,
+		[AsParameters] IndicesRemoteSyncOptions options = default!,
+		Cancel ct = default)
+	{
+		if (indices.Length == 0)
+		{
+			AnsiConsole.MarkupLine("[red]✗ At least one index must be given.[/]");
+			Environment.Exit(1);
+			return;
+		}
+
+		var (fromEndpoint, transport, toUri) = ResolveSyncTransport(options);
+		var fromTransport = ElasticsearchTransportFactory.Create(fromEndpoint);
+		var remoteSource = BuildRemoteSource(fromEndpoint);
+		var logger = loggerFactory.CreateLogger<IndicesCommands>();
+
+		AnsiConsole.MarkupLine("[aqua bold]Indices copy[/]");
+		AnsiConsole.MarkupLine($"[dim]From (source):[/] {Markup.Escape(fromEndpoint.Uri.ToString())}");
+		AnsiConsole.MarkupLine($"[dim]To (dest):[/]      {Markup.Escape(toUri)}");
+		AnsiConsole.MarkupLine($"[dim]rps:[/]             [white]{(options.Rps.HasValue ? options.Rps.Value.ToString("F0") : "unlimited")}[/]");
+		AnsiConsole.MarkupLine($"[dim]Force:[/]          [white]{force}[/]  [dim]Strip sem. fields:[/] [white]{stripSemanticFields}[/]");
+		AnsiConsole.WriteLine();
+
+		if (!string.IsNullOrWhiteSpace(options.Aliases) && indices.Length > 1)
+			AnsiConsole.MarkupLine("[yellow]⚠ --aliases is ignored when copying more than one index.[/]");
+
+		var failed = 0;
+		foreach (var source in indices)
+		{
+			var destIndex = ApplyRename(source, renameFrom, renameTo);
+			var renamed = destIndex != source;
+			AnsiConsole.MarkupLine(renamed
+				? $"[aqua]{Markup.Escape(source)}[/] [dim](renamed →)[/] [aqua]{Markup.Escape(destIndex)}[/]"
+				: $"[aqua]{Markup.Escape(source)}[/]");
+
+			var sourceHead = await fromTransport.HeadAsync(source, ct);
+			if (sourceHead.ApiCallDetails.HttpStatusCode != 200)
+			{
+				AnsiConsole.MarkupLine($"[red]✗ Source index [white]{Markup.Escape(source)}[/] not found on {Markup.Escape(fromEndpoint.Uri.ToString())}[/]");
+				failed++;
+				continue;
+			}
+
+			var destHead = await transport.HeadAsync(destIndex, ct);
+			var destExists = destHead.ApiCallDetails.HttpStatusCode == 200;
+
+			if (destExists && force)
+			{
+				_ = await transport.DeleteAsync<StringResponse>(destIndex, cancellationToken: ct);
+				AnsiConsole.MarkupLine($"[dim]  Deleted existing [white]{Markup.Escape(destIndex)}[/] (--force)[/]");
+				destExists = false;
+			}
+
+			if (!destExists)
+				await CopyIndexDefinitionAsync(fromTransport, transport, source, destIndex, logger, ct);
+
+			// Slices is intentionally omitted — Elasticsearch rejects slices > 1 for reindex
+			// from a remote source ("reindex from remote sources doesn't support slices > 1").
+			if (!await RunServerReindexAsync(transport,
+				new ServerReindexOptions
+				{
+					Remote = remoteSource,
+					Source = source,
+					Destination = destIndex,
+					RequestsPerSecond = options.Rps,
+					ExcludeInferenceFields = stripSemanticFields,
+				},
+				$"copy ({Markup.Escape(source)})", ct))
+			{
+				AnsiConsole.MarkupLine($"[red]✗ Copy failed for {Markup.Escape(source)}.[/]");
+				failed++;
+				continue;
+			}
+
+			if (indices.Length == 1)
+				await ApplyAliasesAsync(transport, options.Aliases, destIndex, logger, ct);
+
+			AnsiConsole.MarkupLine($"[green]✓[/] {Markup.Escape(source)} → {Markup.Escape(destIndex)}");
+		}
+
+		if (failed > 0)
+		{
+			AnsiConsole.MarkupLine($"[red]✗ {failed} of {indices.Length} index copy(ies) failed.[/]");
+			Environment.Exit(1);
+			return;
+		}
+
 		AnsiConsole.MarkupLine("[green]✓[/] Done");
 	}
 
@@ -1253,7 +1462,10 @@ internal sealed class IndicesCommands(SourcingConfiguration config, ILoggerFacto
 	{
 		var from = ResolveEndpoint(o.FromUrl, o.FromApiKey);
 
-		var to = config.Destination ?? new ElasticsearchEndpoint { Uri = new Uri("http://localhost:9200") };
+		// Destination seeds from the same configured Elasticsearch endpoint as the source
+		// (see SourcingConfiguration.Destination) — override with --to-url/--to-api-key to
+		// point only the destination elsewhere.
+		var to = config.Destination;
 		if (o.ToUrl is not null)
 			to.Uri = o.ToUrl;
 		if (o.ToApiKey is not null)
@@ -1261,15 +1473,6 @@ internal sealed class IndicesCommands(SourcingConfiguration config, ILoggerFacto
 			to.ApiKey = o.ToApiKey;
 			to.Username = null;
 			to.Password = null;
-		}
-
-		if (to.Uri.Host == "localhost" && o.ToUrl is null && config.Destination is null)
-		{
-			AnsiConsole.MarkupLine("[red]✗ Destination cluster URL is not configured.[/]");
-			AnsiConsole.MarkupLine("[dim]Set [white]DESTINATION_ELASTIC_URL[/] or pass [white]--to-url[/].[/]");
-			Environment.Exit(1);
-			// Environment.Exit throws; return is unreachable but required for the compiler.
-			return (from, null, string.Empty);
 		}
 
 		return (from, ElasticsearchTransportFactory.Create(to), to.Uri.ToString().TrimEnd('/'));

--- a/src/tooling/essc/Elasticsearch/SourcingConfiguration.cs
+++ b/src/tooling/essc/Elasticsearch/SourcingConfiguration.cs
@@ -33,11 +33,13 @@ internal sealed class SourcingConfiguration
 	public required ElasticsearchEndpoint Elasticsearch { get; init; }
 
 	/// <summary>
-	/// Optional destination cluster for cross-cluster operations (e.g. <c>indices sync</c>).
-	/// Resolved from <c>DESTINATION_ELASTIC_URL</c> / <c>DESTINATION_ELASTIC_APIKEY</c>.
-	/// Null when not configured.
+	/// Destination cluster for cross-cluster operations (e.g. <c>indices copy</c>, <c>indices sync-remote</c>).
+	/// Seeds from the same <c>Parameters:ElasticsearchUrl</c> / <c>Parameters:ElasticsearchApiKey</c> values as
+	/// <see cref="Elasticsearch"/> — one configured secret covers both ends of a copy. Set
+	/// <c>DESTINATION_ELASTIC_URL</c> / <c>DESTINATION_ELASTIC_APIKEY</c> (or pass <c>--to-url</c> / <c>--to-api-key</c>
+	/// on the command) to point only the destination elsewhere while the source still comes from the seed.
 	/// </summary>
-	public ElasticsearchEndpoint? Destination { get; init; }
+	public required ElasticsearchEndpoint Destination { get; init; }
 
 	public string ElasticsearchEnvironment { get; init; } = "dev";
 	public string BuildType { get; init; } = "public";
@@ -79,20 +81,21 @@ internal sealed class SourcingConfiguration
 			Password = string.IsNullOrEmpty(apiKey) ? password : null,
 		};
 
-		// Optional destination cluster for cross-cluster commands (e.g. indices sync).
-		var destUrl = config["DESTINATION_ELASTIC_URL"];
-		var destApiKey = config["DESTINATION_ELASTIC_APIKEY"];
-		var destUsername = config["DESTINATION_ELASTIC_USERNAME"] ?? "elastic";
-		var destPassword = config["DESTINATION_ELASTIC_PASSWORD"];
-		var destEndpoint = destUrl is not null
-			? new ElasticsearchEndpoint
-			{
-				Uri = new Uri(destUrl),
-				ApiKey = destApiKey,
-				Username = string.IsNullOrEmpty(destApiKey) ? destUsername : null,
-				Password = string.IsNullOrEmpty(destApiKey) ? destPassword : null,
-			}
-			: null;
+		// Destination cluster for cross-cluster commands (e.g. indices copy). Seeds from the same
+		// Parameters:ElasticsearchUrl / Parameters:ElasticsearchApiKey values as the source so a single
+		// configured secret covers both ends — DESTINATION_ELASTIC_* only needs to be set to point the
+		// destination somewhere else.
+		var destUrl = config["DESTINATION_ELASTIC_URL"] ?? elasticUrl;
+		var destApiKey = config["DESTINATION_ELASTIC_APIKEY"] ?? apiKey;
+		var destUsername = config["DESTINATION_ELASTIC_USERNAME"] ?? username;
+		var destPassword = config["DESTINATION_ELASTIC_PASSWORD"] ?? password;
+		var destEndpoint = new ElasticsearchEndpoint
+		{
+			Uri = new Uri(destUrl),
+			ApiKey = destApiKey,
+			Username = string.IsNullOrEmpty(destApiKey) ? destUsername : null,
+			Password = string.IsNullOrEmpty(destApiKey) ? destPassword : null,
+		};
 
 		return new SourcingConfiguration
 		{


### PR DESCRIPTION
## Why

Some production indices (e.g. AI-enrichment `-ai-cache` lookup indices like
`docs-assembler.semantic-prod-ai-cache`) live only on the production cluster, with no simple way
to pull them down locally. The existing `indices sync-remote` / `indices unify-incremental-sync`
commands are docs-search specific — they copy synonym/query-rule resources and run a two-phase
lexical→semantic inference pipeline, which doesn't apply to arbitrary standalone indices.

## What

Adds `indices copy` to `essc`: copies one or more indices verbatim from a source cluster to a
destination cluster via Elasticsearch's server-side remote reindex API, with no docs-search
resource copying and no inference orchestration.

```bash
essc indices copy docs-assembler.semantic-prod-ai-cache labs-public.semantic-prod-ai-cache \
  --from-url https://<prod-cluster> --from-api-key <redacted> \
  --to-url http://localhost:9200 \
  --rename-from '-prod-' --rename-to '-dev-'
```

- Takes one or more source index/alias names positionally.
- `--rename-from`/`--rename-to` — same regex rename mechanism as the sibling commands, applied
  per index.
- `--force` — delete and recreate an existing destination index from the source's mapping and
  settings before reindexing; without it, an existing destination is reindexed into as-is.
- Shares `--from-url`/`--from-api-key`/`--to-url`/`--to-api-key`/`--rps`/`--aliases` with
  `indices sync-remote` and `indices unify-incremental-sync`. `--slices` is accepted for parity
  but has no effect — every reindex here is a remote reindex, and Elasticsearch rejects
  `slices > 1` for reindex from a remote source.

Also fixes the destination cluster's configuration resolution: it now seeds from the same
`Parameters:ElasticsearchUrl`/`Parameters:ElasticsearchApiKey` secret as the source cluster, so
only one cluster needs to be configured in `dotnet user-secrets` — pass `--to-url`/`--from-url`
(or set `DESTINATION_ELASTIC_URL`/`DESTINATION_ELASTIC_APIKEY`) to point just one side elsewhere.