### PR TITLE
Add --bootstrap-only flag to ai-enrich commands

### DIFF
--- a/docs/cli-schema.json
+++ b/docs/cli-schema.json
@@ -1166,6 +1166,14 @@
             },
             {
               "role": "flag",
+              "name": "bootstrap-only",
+              "type": "boolean",
+              "required": false,
+              "summary": "Bootstrap the enrich policy, pipeline, and lookup index, then exit without enriching any documents.",
+              "defaultValue": "false"
+            },
+            {
+              "role": "flag",
               "name": "log-level",
               "shortName": "l",
               "type": "enum",

--- a/src/services/Elastic.Documentation.Assembler/Indexing/AssemblerAiEnrichService.cs
+++ b/src/services/Elastic.Documentation.Assembler/Indexing/AssemblerAiEnrichService.cs
@@ -28,12 +28,17 @@ public class AssemblerAiEnrichService(
 	private readonly ILogger _logger = logFactory.CreateLogger<AssemblerAiEnrichService>();
 
 	/// <summary>Enrich the existing semantic index for <paramref name="environment"/>; does not crawl, build, or index documents.</summary>
+	/// <param name="bootstrapOnly">
+	/// When <see langword="true"/>, bootstrap the enrich policy, pipeline, and lookup index and then return without
+	/// enriching any documents.
+	/// </param>
 	public async Task<bool> AiEnrich(
 		IDiagnosticsCollector collector,
 		ScopedFileSystem readFs,
 		ScopedFileSystem writeFs,
 		ElasticsearchIndexOptions es,
 		string? environment,
+		bool bootstrapOnly,
 		Cancel ctx
 	)
 	{
@@ -54,6 +59,12 @@ public class AssemblerAiEnrichService(
 
 		// Bootstraps and resolves the existing aliases only; never writes or deletes documents.
 		await exporter.StartAsync(ctx);
+
+		if (bootstrapOnly)
+		{
+			_logger.LogInformation("--bootstrap-only set — skipping AI enrichment");
+			return true;
+		}
 
 		var budget = new AiEnrichmentBudget(cfg.MaxAiDocs, cfg.MaxAiTime);
 		using var deadline = AiEnrichmentDeadline.Create(budget.MaxTime, ctx);

--- a/src/tooling/docs-builder/Commands/Assembler/AssemblerAiEnrichCommand.cs
+++ b/src/tooling/docs-builder/Commands/Assembler/AssemblerAiEnrichCommand.cs
@@ -32,11 +32,13 @@ internal sealed class AssemblerAiEnrichCommand(
 	/// </para>
 	/// </remarks>
 	/// <param name="environment">Named deployment target whose existing indices should be enriched.</param>
+	/// <param name="bootstrapOnly">Bootstrap the enrich policy, pipeline, and lookup index, then exit without enriching any documents.</param>
 	[CommandName("ai-enrich")]
 	public async Task<int> AiEnrich(
 		GlobalCliOptions _,
 		[AsParameters] ElasticsearchIndexOptions es,
 		string? environment = null,
+		bool bootstrapOnly = false,
 		CancellationToken ct = default
 	)
 	{
@@ -45,7 +47,7 @@ internal sealed class AssemblerAiEnrichCommand(
 		var writeFs = FileSystemFactory.RealWrite;
 		var service = new AssemblerAiEnrichService(logFactory, configuration, configurationContext, githubActionsService);
 		serviceInvoker.AddCommand(service,
-			async (s, col, ctx) => await s.AiEnrich(col, readFs, writeFs, es, environment, ctx)
+			async (s, col, ctx) => await s.AiEnrich(col, readFs, writeFs, es, environment, bootstrapOnly, ctx)
 		);
 		return await serviceInvoker.InvokeAsync(ct);
 	}

--- a/src/tooling/essc/Commands/ContentStackCommands.cs
+++ b/src/tooling/essc/Commands/ContentStackCommands.cs
@@ -111,6 +111,7 @@ internal sealed class ContentStackCommands(
 	/// <remarks>
 	/// <paramref name="maxAiDocs"/> is an optional cap; <c>0</c> means no document limit.
 	/// Omit <paramref name="maxAiTime"/> for no wall-clock limit, or set a duration of at least one minute (for example <c>1h</c>, <c>90m</c>).
+	/// Use <paramref name="bootstrapOnly"/> to create the enrich policy, pipeline, and lookup index without enriching any documents.
 	/// </remarks>
 	[CommandName("ai-enrich")]
 	public async Task AiEnrich(
@@ -118,6 +119,7 @@ internal sealed class ContentStackCommands(
 		[Url] Uri? endpoint = null,
 		[Range(0, int.MaxValue)] int maxAiDocs = 0,
 		TimeSpan? maxAiTime = null,
+		bool bootstrapOnly = false,
 		Cancel ct = default
 	)
 	{
@@ -176,6 +178,12 @@ internal sealed class ContentStackCommands(
 
 			AnsiConsole.MarkupLine($"[green]✓[/] Elasticsearch indices ready [dim]({exporter.Strategy})[/]");
 			AnsiConsole.WriteLine();
+
+			if (bootstrapOnly)
+			{
+				AnsiConsole.MarkupLine("[dim]--bootstrap-only set — skipping AI enrichment[/]");
+				return;
+			}
 
 			var aiResult = await AiEnrichmentConsole.RunInteractiveAsync(
 				exporter.AiEnrichmentEnabled,

--- a/src/tooling/essc/Commands/LabsCommands.cs
+++ b/src/tooling/essc/Commands/LabsCommands.cs
@@ -350,6 +350,7 @@ internal sealed class LabsCommands(
 	/// <remarks>
 	/// <paramref name="maxAiDocs"/> is an optional cap; <c>0</c> means no document limit.
 	/// Omit <paramref name="maxAiTime"/> for no wall-clock limit, or set a duration of at least one minute (for example <c>1h</c>, <c>90m</c>).
+	/// Use <paramref name="bootstrapOnly"/> to create the enrich policy, pipeline, and lookup index without enriching any documents.
 	/// </remarks>
 	[CommandName("ai-enrich")]
 	public async Task AiEnrich(
@@ -357,6 +358,7 @@ internal sealed class LabsCommands(
 		[Url] Uri? endpoint = null,
 		[Range(0, int.MaxValue)] int maxAiDocs = 0,
 		TimeSpan? maxAiTime = null,
+		bool bootstrapOnly = false,
 		Cancel ct = default
 	)
 	{
@@ -408,6 +410,12 @@ internal sealed class LabsCommands(
 			AnsiConsole.MarkupLine($"[green]✓[/] Elasticsearch indices ready [dim]({exporter.Strategy})[/]");
 			WriteBootstrapSummary(exporter);
 			AnsiConsole.WriteLine();
+
+			if (bootstrapOnly)
+			{
+				AnsiConsole.MarkupLine("[dim]--bootstrap-only set — skipping AI enrichment[/]");
+				return;
+			}
 
 			var aiResult = await AiEnrichmentConsole.RunInteractiveAsync(
 				exporter.AiEnrichmentEnabled,


### PR DESCRIPTION
## Why

`essc labs ai-enrich`, `essc contentstack ai-enrich`, and `docs-builder assembler ai-enrich` all bootstrap the enrich policy, pipeline, and lookup index as a side effect of running, but there was no way to run just that bootstrap step. `--max-ai-docs 0` looks like it would do this but doesn't — `0` means "no document cap," so it enriches every eligible document rather than skipping enrichment. This came up because a CI job was failing due to a missing enrich policy in an environment, and there was no clean way to provision it without also kicking off a full enrichment pass.

## What

Adds a `--bootstrap-only` boolean flag to all three `ai-enrich` commands. When set, the command still bootstraps the enrich policy, pipeline, and lookup index, then returns immediately afterward instead of running the document enrichment loop. Regenerated `docs/cli-schema.json` to include the new flag.