### PR TITLE
Restore url as AI enrichment match field

### DIFF
--- a/src/services/search/Elastic.Documentation.Search.Contract/Common/SearchDocumentBase.cs
+++ b/src/services/search/Elastic.Documentation.Search.Contract/Common/SearchDocumentBase.cs
@@ -61,6 +61,15 @@ public record SearchDocumentBase : ISearchDocument
 	[JsonPropertyName("path")]
 	public required string Path { get; set; } = string.Empty;
 
+	/// <summary>
+	/// Concrete mirror of <see cref="Path"/>, kept so AI enrichment can match against <c>url</c> —
+	/// the field the existing AI-cache lookup indices and enrich policies are keyed on. Do not use
+	/// this as the canonical identifier; <see cref="Path"/> is.
+	/// </summary>
+	[Keyword]
+	[JsonPropertyName("url")]
+	public string Url => Path;
+
 	[ContentHash]
 	[Keyword]
 	[JsonPropertyName("hash")]

--- a/src/services/search/Elastic.Documentation.Search.Contract/Common/SharedMappingConfig.cs
+++ b/src/services/search/Elastic.Documentation.Search.Contract/Common/SharedMappingConfig.cs
@@ -88,7 +88,6 @@ public static class SharedMappingConfig
 	/// Remove once all indices are rebuilt under the new shape and no consumer queries the old names.
 	/// </summary>
 	private static MappingsBuilder<T> AddLegacyFieldAliases<T>(this MappingsBuilder<T> m) where T : SearchDocumentBase => m
-		.AddField("url", f => f.Alias("path"))
 		.AddField("abstract", f => f.Alias("summary"))
 		.AddField("navigation_section", f => f.Alias("section"))
 		.AddField("content_tags", f => f.Alias("tags"))

--- a/src/services/search/Elastic.Documentation.Search.Contract/Docs/DocumentationMappingConfig.cs
+++ b/src/services/search/Elastic.Documentation.Search.Contract/Docs/DocumentationMappingConfig.cs
@@ -28,7 +28,7 @@ namespace Elastic.Documentation.Search.Contract;
 )]
 [AiEnrichment<DocumentationDocument>(
 	Role = "Expert technical writer creating search metadata for Elastic documentation (Elasticsearch, Kibana, Beats, Logstash). Audience: developers, DevOps, data engineers.",
-	MatchField = "path",
+	MatchField = "url",
 	IndexVariant = "Semantic"
 )]
 public static partial class DocumentationMappingContext;

--- a/src/services/search/Elastic.Documentation.Search.Contract/Guide/GuideMappingConfig.cs
+++ b/src/services/search/Elastic.Documentation.Search.Contract/Guide/GuideMappingConfig.cs
@@ -23,7 +23,7 @@ namespace Elastic.Documentation.Search.Contract;
 )]
 [AiEnrichment<GuideDocument>(
 	Role = "Expert content analyst creating search metadata for Elastic's legacy /guide documentation pages.",
-	MatchField = "path",
+	MatchField = "url",
 	IndexVariant = "Semantic"
 )]
 public static partial class GuideMappingContext;

--- a/src/services/search/Elastic.Documentation.Search.Contract/Labs/LabsMappingConfig.cs
+++ b/src/services/search/Elastic.Documentation.Search.Contract/Labs/LabsMappingConfig.cs
@@ -23,7 +23,7 @@ namespace Elastic.Documentation.Search.Contract;
 )]
 [AiEnrichment<LabsDocument>(
 	Role = "Expert content analyst creating search metadata for Elastic's website pages (blogs, labs articles, product pages, events). Audience: developers, DevOps engineers, security analysts, and IT decision-makers.",
-	MatchField = "path",
+	MatchField = "url",
 	IndexVariant = "Semantic"
 )]
 public static partial class LabsMappingContext;

--- a/src/services/search/Elastic.Documentation.Search.Contract/Site/SiteMappingConfig.cs
+++ b/src/services/search/Elastic.Documentation.Search.Contract/Site/SiteMappingConfig.cs
@@ -23,7 +23,7 @@ namespace Elastic.Documentation.Search.Contract;
 )]
 [AiEnrichment<SiteDocument>(
 	Role = "Expert content analyst creating search metadata for Elastic's website pages (blogs, labs articles, product pages, events). Audience: developers, DevOps engineers, security analysts, and IT decision-makers.",
-	MatchField = "path",
+	MatchField = "url",
 	IndexVariant = "Semantic"
 )]
 public static partial class SiteMappingContext;


### PR DESCRIPTION
## Why

#3617 renamed the search document identifier `url` -> `path`, and along with it flipped the AI-enrichment `MatchField` to `"path"` on all four mapping configs. Live clusters already have AI-cache lookup indices and enrich policies keyed on `url`, and the enrichment orchestrator never reconciles an existing lookup index's mapping when it already exists. As a result, `essc contentstack sync` (and the docs-builder Elasticsearch exporter) fails during AI-enrichment bootstrap with:

```
Failed to create enrich policy '...-ai-cache-ai-policy-...': HTTP 500 —
Could not traverse mapping to field [path]. Could not find the [path] field under [root]
```

## What

Reintroduces `url` as a concrete field mirroring `path` on `SearchDocumentBase` (rather than an ES alias, which enrich processors can't read at ingest time — they operate on the raw ingest context before aliases materialize), removes the now-conflicting legacy `url` alias, and reverts `MatchField` back to `"url"` on the four `[AiEnrichment<T>]` configs (Site, Docs, Labs, Guide).

The versioned enrich policy name is a hash of the AI output fields only, not the match field, so this reproduces the exact policy name already present in live clusters — existing AI caches are reused untouched, with no reindex or manual policy changes required.

## Test plan

- [x] `dotnet build` succeeds across the affected project and the full solution
- [x] `dotnet test tests/Elastic.SiteSearch.Tests` — 171/171 passed
- [x] `dotnet format --verify-no-changes` clean
- [ ] End-to-end `essc contentstack sync` against a dev cluster with existing `url`-keyed AI caches, confirming the enrich policy is reused (not recreated) and enrichment completes

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>