### PR TITLE
Release: Notify docs-internal-workflows on release finish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,8 +229,9 @@ jobs:
       - deploy-link-index-updater-lambda-prod
       - deploy-changelog-scrubber-lambda-prod
     runs-on: ubuntu-latest
-    permissions: 
+    permissions:
       contents: write
+      id-token: write
     steps:
       - name: Publish release
         env:
@@ -239,3 +240,18 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           gh release edit "$TAG_NAME" --draft=false --latest --repo "$REPO"
+
+      - name: Fetch ephemeral GitHub token
+        id: fetch-ephemeral-token
+        uses: elastic/ci-gh-actions/fetch-github-token@v1
+        with:
+          vault-instance: "ci-prod"
+
+      - name: Notify docs-internal-workflows
+        env:
+          GH_TOKEN: ${{ steps.fetch-ephemeral-token.outputs.token }}
+          TAG_NAME: ${{ needs.release-drafter.outputs.tag_name }}
+        run: |
+          gh api repos/elastic/docs-internal-workflows/dispatches \
+            -f event_type=docs-builder-released \
+            -F client_payload[tag_name]="$TAG_NAME"


### PR DESCRIPTION
## Why

`docs-internal-workflows` has no way to know when a docs-builder release finishes, so any downstream automation there has to poll or run on a fixed schedule instead of reacting immediately.

## What

The final `publish-release` job in `release.yml` now fires a `repository_dispatch` (`docs-builder-released`, with the release tag in `client_payload`) to `elastic/docs-internal-workflows` right after the GitHub release is marked non-draft. The job fetches a short-lived cross-repo token via `elastic/ci-gh-actions/fetch-github-token` (Vault `ci-prod`) since the default `github.token` can't dispatch to another repository.

## Test plan

- [ ] `actionlint .github/workflows/release.yml` passes (already verified locally)
- [ ] Confirm the Vault role behind `fetch-github-token` has contents-write access to `elastic/docs-internal-workflows`
- [ ] Add a `repository_dispatch: types: [docs-builder-released]` trigger in `docs-internal-workflows` (separate PR)
- [ ] Run a real release and confirm the "Notify docs-internal-workflows" step succeeds and triggers a run in `docs-internal-workflows`