### PR TITLE
Mcp.Remote: fix internal server reporting docs-mcp as OTEL service name

### DIFF
--- a/src/api/Elastic.Documentation.Mcp.Remote/McpServerProfile.cs
+++ b/src/api/Elastic.Documentation.Mcp.Remote/McpServerProfile.cs
@@ -13,6 +13,7 @@ namespace Elastic.Documentation.Mcp.Remote;
 /// with the profile's DocsDescription at composition time.
 /// </summary>
 /// <param name="Name">Profile identifier (e.g. "public", "internal").</param>
+/// <param name="ServiceName">OTEL service.name reported by this profile's deployment (e.g. "docs-mcp", "codex-mcp").</param>
 /// <param name="ResourceNoun">Resource noun for tool names (e.g. "docs", "internal_docs"). Replaces {resource} in tool name templates.</param>
 /// <param name="ScopePrefix">Scope prefix for tool names (e.g. "" for public, "internal_" for internal). Replaces {scope} in tool name templates.</param>
 /// <param name="DocsDescription">Short noun phrase describing this profile's docs (e.g. "Elastic product documentation"). Used to replace {docs} in trigger templates.</param>
@@ -21,6 +22,7 @@ namespace Elastic.Documentation.Mcp.Remote;
 /// <param name="Modules">Enabled feature modules.</param>
 public sealed record McpServerProfile(
 	string Name,
+	string ServiceName,
 	string ResourceNoun,
 	string ScopePrefix,
 	string DocsDescription,
@@ -30,6 +32,7 @@ public sealed record McpServerProfile(
 {
 	public static McpServerProfile Public { get; } = new(
 		"public",
+		"docs-mcp",
 		"docs",
 		"",
 		"Elastic documentation",
@@ -40,6 +43,7 @@ public sealed record McpServerProfile(
 
 	public static McpServerProfile Internal { get; } = new(
 		"internal",
+		"codex-mcp",
 		"internal_docs",
 		"internal_",
 		"Elastic internal documentation",

--- a/src/api/Elastic.Documentation.Mcp.Remote/Program.cs
+++ b/src/api/Elastic.Documentation.Mcp.Remote/Program.cs
@@ -16,10 +16,13 @@ using OpenTelemetry.Trace;
 
 try
 {
+	var env = SystemEnvironmentVariables.Instance;
+	var profile = McpServerProfile.Resolve(env.McpServerProfile);
+
 	var builder = WebApplication.CreateSlimBuilder(args)
 		.AddDocumentationServiceDefaults()
 		.HealthCheckBuilderExtensions()
-		.AddDocumentationOpenTelemetry(new OtelRegistration("docs-mcp")
+		.AddDocumentationOpenTelemetry(new OtelRegistration(profile.ServiceName)
 		{
 			Tracing = (_, t) => t
 				.WithElasticDefaults()
@@ -44,9 +47,6 @@ try
 
 	var environment = Environment.GetEnvironmentVariable("ENVIRONMENT");
 	Console.WriteLine($"Docs Environment: {environment}");
-
-	var env = SystemEnvironmentVariables.Instance;
-	var profile = McpServerProfile.Resolve(env.McpServerProfile);
 
 	profile.RegisterAllServices(builder.Services);
 


### PR DESCRIPTION
## What
The internal MCP server (`MCP_SERVER_PROFILE=internal`, aka codex-mcp) reports its OTEL `service.name` as `docs-mcp` instead of `codex-mcp`.

## Why
Internal tool calls (e.g. `search_internal_docs`) were showing up under the `docs-mcp` service in OTEL traces/logs. Investigation confirmed internal tools are correctly gated by `MCP_SERVER_PROFILE=internal` and never leak into the public server — the issue is telemetry mislabeling only: `Program.cs` hardcoded `new OtelRegistration("docs-mcp")` for both profiles, and that call ran before the profile was even resolved.

## How
- Added a `ServiceName` field to `McpServerProfile`: `"docs-mcp"` for `Public`, `"codex-mcp"` for `Internal`.
- Moved profile resolution in `Program.cs` above the OTEL registration and passed `profile.ServiceName` into `OtelRegistration` instead of the hardcoded string.

## Test plan
- [x] `dotnet build` succeeds
- [x] `dotnet test tests/Mcp.Remote.Tests` — 15/15 passed
- [ ] Run with `MCP_SERVER_PROFILE=internal` and confirm exported OTEL resource has `service.name=codex-mcp`
- [ ] Run with `MCP_SERVER_PROFILE=public` (or unset) and confirm `service.name` is still `docs-mcp`
- [ ] After deploy, confirm `search_internal_docs` spans appear under `service.name=codex-mcp`, not `docs-mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)