### PR TITLE
Prerelease: Notify docs-internal-workflows after publish

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -44,13 +44,14 @@ jobs:
           
       - name: Deploy artifact
         id: deployment
-        uses: actions/deploy-pages@v5.0.0 
-        
+        uses: actions/deploy-pages@v5.0.0
+
   build:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+      id-token: write
     outputs:
       full-version: ${{ steps.bootstrap.outputs.full-version }}
       major-version: ${{ steps.bootstrap.outputs.major-version }}
@@ -74,3 +75,18 @@ jobs:
 
       - name: Publish Containers
         run: ./build.sh publishcontainers
+
+      - name: Fetch ephemeral GitHub token
+        id: fetch-ephemeral-token
+        uses: elastic/ci-gh-actions/fetch-github-token@v1
+        with:
+          vault-instance: "ci-prod"
+
+      - name: Notify docs-internal-workflows
+        env:
+          GH_TOKEN: ${{ steps.fetch-ephemeral-token.outputs.token }}
+          SHA: ${{ github.sha }}
+        run: |
+          gh api repos/elastic/docs-internal-workflows/dispatches \
+            -f event_type=docs-builder-prereleased \
+            -F client_payload[sha]="$SHA"


### PR DESCRIPTION
## Why

PR #3626 added a repository_dispatch to elastic/docs-internal-workflows when a release finishes, so downstream automation there can react without polling. The prerelease flow (docs deploy + container publish on every push to main) had no equivalent signal.

## What

The `build` job in `prerelease.yml` now fires a `docs-builder-prereleased` repository_dispatch to `elastic/docs-internal-workflows` right after publishing containers, using the same ephemeral-token pattern as `release.yml`. Since prerelease builds aren't tagged, the payload carries the commit SHA instead of a tag_name. Added `id-token: write` to the `build` job's permissions, required for the token fetch.

## Test plan

- [ ] `actionlint .github/workflows/prerelease.yml` passes (no new findings vs. base)
- [ ] Merge to main and confirm the `build` job's log shows a successful ephemeral token fetch and `gh api ... dispatches` call
- [ ] Confirm a `docs-builder-prereleased` event lands in `elastic/docs-internal-workflows`