### PR TITLE
Align changelog authoring-owner resolution between upload and CDN

### DIFF
--- a/src/services/Elastic.Changelog/Bundling/ChangelogBundlingService.cs
+++ b/src/services/Elastic.Changelog/Bundling/ChangelogBundlingService.cs
@@ -226,8 +226,8 @@ public partial class ChangelogBundlingService(
 			// (bundle.use_local_changelogs / --directory), the repo is unresolvable, or no CDN base is
 			// configured. This stays in lockstep with PlanBundleAsync's needs_network decision.
 			var useLocalChangelogs = config?.Bundle?.UseLocalChangelogs ?? false;
-			var authoringRepo = NormalizeRepo(input.Repo);
-			var authoringOwner = ResolveAuthoringOwner(input.Owner, input.Repo);
+			var authoringRepo = ChangelogRepoOwnerResolver.NormalizeRepo(input.Repo);
+			var authoringOwner = ChangelogRepoOwnerResolver.ResolveOwner(input.Owner, input.Repo, DefaultOwner);
 			var authoringBranch = string.IsNullOrWhiteSpace(input.Branch) ? DefaultBranch : input.Branch;
 			var useCdn = ShouldSourceFromCdn(authoringRepo, useLocalChangelogs: useLocalChangelogs, explicitDirectory: explicitDirectory);
 
@@ -666,7 +666,7 @@ public partial class ChangelogBundlingService(
 		// local sourcing, and a CDN base is configured.
 		var useLocalChangelogs = config?.Bundle?.UseLocalChangelogs ?? false;
 		var explicitDirectory = !string.IsNullOrWhiteSpace(input.Directory);
-		var authoringRepo = NormalizeRepo(input.Repo ?? profileDef?.Repo ?? config?.Bundle?.Repo);
+		var authoringRepo = ChangelogRepoOwnerResolver.NormalizeRepo(input.Repo ?? profileDef?.Repo ?? config?.Bundle?.Repo);
 		if (ShouldSourceFromCdn(authoringRepo, useLocalChangelogs: useLocalChangelogs, explicitDirectory: explicitDirectory))
 			needsNetwork = true;
 
@@ -800,35 +800,6 @@ public partial class ChangelogBundlingService(
 			byName.Count, $"{resolvedOrg}/{repo}/{resolvedBranch}");
 
 		return byName.Select(kv => (kv.Key, kv.Value)).ToList();
-	}
-
-	/// <summary>Reduces a configured repo value to the single CDN-key path segment (<c>owner/repo</c> -&gt; <c>repo</c>); null/empty unchanged.</summary>
-	private static string? NormalizeRepo(string? repo)
-	{
-		if (string.IsNullOrWhiteSpace(repo))
-			return repo;
-		var slash = repo.LastIndexOf('/');
-		return slash >= 0 && slash < repo.Length - 1 ? repo[(slash + 1)..] : repo;
-	}
-
-	/// <summary>
-	/// Resolves the org segment for the CDN entry pool: the explicit <paramref name="owner"/> when set,
-	/// otherwise the <c>owner/</c> prefix of a combined <paramref name="repo"/> value (e.g. <c>acme/widget</c>
-	/// -&gt; <c>acme</c>) so it is not lost, falling back to <see cref="DefaultOwner"/>.
-	/// </summary>
-	private static string ResolveAuthoringOwner(string? owner, string? repo)
-	{
-		if (!string.IsNullOrWhiteSpace(owner))
-			return owner;
-
-		if (!string.IsNullOrWhiteSpace(repo))
-		{
-			var slash = repo.IndexOf('/', StringComparison.Ordinal);
-			if (slash > 0)
-				return repo[..slash];
-		}
-
-		return DefaultOwner;
 	}
 
 	/// <summary>Gate for repo-scoped CDN entry sourcing: true when the authoring repo resolves, local sourcing is not forced (<c>bundle.use_local_changelogs</c>/<c>--directory</c>), and a CDN base is configured.</summary>

--- a/src/services/Elastic.Changelog/Bundling/ChangelogRepoOwnerResolver.cs
+++ b/src/services/Elastic.Changelog/Bundling/ChangelogRepoOwnerResolver.cs
@@ -1,0 +1,43 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic.Changelog.Bundling;
+
+/// <summary>
+/// Resolves the owner/repo segments used to key the changelog entry pool (<c>changelog/{owner}/{repo}/{branch}/...</c>).
+/// Shared by CDN entry sourcing (<see cref="ChangelogBundlingService"/>) and upload
+/// (<c>ChangelogCommands.ResolveUploadRepoOwnerBranch</c>) so a <c>bundle.repo: "owner/repo"</c> value without
+/// an explicit <c>bundle.owner</c> resolves to the same owner on both sides.
+/// </summary>
+public static class ChangelogRepoOwnerResolver
+{
+	/// <summary>
+	/// Resolves the owner: <paramref name="owner"/> when set, otherwise the <c>owner/</c> prefix of a combined
+	/// <paramref name="repo"/> value (e.g. <c>acme/widget</c> -&gt; <c>acme</c>) so it is not lost, otherwise
+	/// <paramref name="fallback"/>.
+	/// </summary>
+	public static string? ResolveOwner(string? owner, string? repo, string? fallback)
+	{
+		if (!string.IsNullOrWhiteSpace(owner))
+			return owner;
+
+		if (!string.IsNullOrWhiteSpace(repo))
+		{
+			var slash = repo.IndexOf('/', StringComparison.Ordinal);
+			if (slash > 0)
+				return repo[..slash];
+		}
+
+		return fallback;
+	}
+
+	/// <summary>Reduces a configured repo value to the single CDN-key path segment (<c>owner/repo</c> -&gt; <c>repo</c>); null/empty unchanged.</summary>
+	public static string? NormalizeRepo(string? repo)
+	{
+		if (string.IsNullOrWhiteSpace(repo))
+			return repo;
+		var slash = repo.LastIndexOf('/');
+		return slash >= 0 && slash < repo.Length - 1 ? repo[(slash + 1)..] : repo;
+	}
+}

--- a/src/tooling/docs-builder/Commands/ChangelogCommand.cs
+++ b/src/tooling/docs-builder/Commands/ChangelogCommand.cs
@@ -1666,7 +1666,7 @@ internal sealed partial class ChangelogCommands(
 		return await serviceInvoker.InvokeAsync(ctx);
 	}
 
-	/// <summary>Resolves the authoring repo/owner/branch for uploads (CLI flags &gt; <c>bundle.{repo,owner}</c> &gt; git), reducing the repo to a single path segment.</summary>
+	/// <summary>Resolves the authoring repo/owner/branch for uploads (CLI flags &gt; <c>bundle.{repo,owner}</c> &gt; git); owner falls back to the <c>owner/</c> prefix of repo (<see cref="ChangelogRepoOwnerResolver"/>) before git, reducing the repo to a single path segment.</summary>
 	private async Task<(string? Repo, string? Owner, string? Branch)> ResolveUploadRepoOwnerBranch(string? repoCli, string? ownerCli, string? branchCli, string? configPath, string? uploadDirectory, CancellationToken ctx)
 	{
 		var bundleConfig = await new ChangelogConfigurationLoader(logFactory, configurationContext, _fileSystem)
@@ -1692,8 +1692,9 @@ internal sealed partial class ChangelogCommands(
 		if (GitRemoteConfigurationReader.TryReadOriginUrl(_fileSystem, repoRoot, out var originUrl))
 			_ = GitHubRemoteParser.TryParseGitHubComOwnerRepo(originUrl, out gitOwner, out gitRepo);
 
-		var resolvedRepo = !string.IsNullOrWhiteSpace(repoCli) ? repoCli : (bundleConfig?.Bundle?.Repo ?? gitRepo);
-		var resolvedOwner = ownerCli ?? bundleConfig?.Bundle?.Owner ?? gitOwner;
+		var explicitRepo = !string.IsNullOrWhiteSpace(repoCli) ? repoCli : bundleConfig?.Bundle?.Repo;
+		var resolvedRepo = explicitRepo ?? gitRepo;
+		var resolvedOwner = ChangelogRepoOwnerResolver.ResolveOwner(ownerCli ?? bundleConfig?.Bundle?.Owner, explicitRepo, gitOwner);
 
 		// The producer branch is the branch being published: --branch, else the current checkout's branch.
 		// bundle.branch is intentionally not consulted here — it selects which pool to read when bundling.
@@ -1704,12 +1705,7 @@ internal sealed partial class ChangelogCommands(
 			resolvedBranch = checkout.Branch;
 		}
 
-		if (!string.IsNullOrWhiteSpace(resolvedRepo))
-		{
-			var slash = resolvedRepo.LastIndexOf('/');
-			if (slash >= 0 && slash < resolvedRepo.Length - 1)
-				resolvedRepo = resolvedRepo[(slash + 1)..];
-		}
+		resolvedRepo = ChangelogRepoOwnerResolver.NormalizeRepo(resolvedRepo);
 
 		return (resolvedRepo, resolvedOwner, resolvedBranch);
 	}

--- a/tests/Elastic.Changelog.Tests/Changelogs/ChangelogRepoOwnerResolverTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/ChangelogRepoOwnerResolverTests.cs
@@ -1,0 +1,75 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using AwesomeAssertions;
+using Elastic.Changelog.Bundling;
+
+namespace Elastic.Changelog.Tests.Changelogs;
+
+/// <summary>
+/// <see cref="ChangelogRepoOwnerResolver"/> is the single source of truth for owner/repo resolution shared by
+/// CDN entry sourcing (<see cref="ChangelogBundlingService"/>) and upload (<c>ChangelogCommands</c>). These
+/// tests pin the precedence so a <c>bundle.repo: "owner/repo"</c> value without an explicit <c>bundle.owner</c>
+/// always resolves to the same owner on both the produce (upload) and consume (CDN sourcing) sides.
+/// </summary>
+public class ChangelogRepoOwnerResolverTests
+{
+	[Fact]
+	public void ResolveOwner_ExplicitOwnerSet_ReturnsExplicitOwner() =>
+		ChangelogRepoOwnerResolver.ResolveOwner("acme-corp", "widget", "elastic").Should().Be("acme-corp");
+
+	[Fact]
+	public void ResolveOwner_ExplicitOwnerSet_IgnoresCombinedRepoOwner() =>
+		ChangelogRepoOwnerResolver.ResolveOwner("acme-corp", "other-org/widget", "elastic").Should().Be("acme-corp");
+
+	[Fact]
+	public void ResolveOwner_NoExplicitOwner_CombinedRepo_SplitsOwnerFromRepoPrefix() =>
+		ChangelogRepoOwnerResolver.ResolveOwner(owner: null, repo: "acme-corp/widget", fallback: "elastic").Should().Be("acme-corp");
+
+	[Fact]
+	public void ResolveOwner_NoExplicitOwner_BareRepo_ReturnsFallback() =>
+		ChangelogRepoOwnerResolver.ResolveOwner(owner: null, repo: "widget", fallback: "elastic").Should().Be("elastic");
+
+	[Fact]
+	public void ResolveOwner_NoExplicitOwnerOrRepo_ReturnsFallback() =>
+		ChangelogRepoOwnerResolver.ResolveOwner(owner: null, repo: null, fallback: "elastic").Should().Be("elastic");
+
+	[Fact]
+	public void ResolveOwner_NoExplicitOwnerOrFallback_CombinedRepo_SplitsOwnerFromRepoPrefix() =>
+		ChangelogRepoOwnerResolver.ResolveOwner(owner: null, repo: "acme-corp/widget", fallback: null).Should().Be("acme-corp");
+
+	[Fact]
+	public void NormalizeRepo_CombinedRepo_StripsOwnerPrefix() =>
+		ChangelogRepoOwnerResolver.NormalizeRepo("acme-corp/widget").Should().Be("widget");
+
+	[Fact]
+	public void NormalizeRepo_BareRepo_ReturnsUnchanged() =>
+		ChangelogRepoOwnerResolver.NormalizeRepo("widget").Should().Be("widget");
+
+	[Fact]
+	public void NormalizeRepo_NullOrEmpty_ReturnsUnchanged()
+	{
+		ChangelogRepoOwnerResolver.NormalizeRepo(null).Should().BeNull();
+		ChangelogRepoOwnerResolver.NormalizeRepo(string.Empty).Should().Be(string.Empty);
+	}
+
+	/// <summary>
+	/// Regression for elastic/docs-eng-team#636: with <c>bundle.repo: "acme-corp/widget"</c> and no explicit
+	/// <c>bundle.owner</c>, upload and CDN sourcing must resolve to the same owner even when a different
+	/// fallback (git remote owner for upload, a fixed default for CDN sourcing) is available — the combined
+	/// repo's owner prefix takes precedence over either fallback.
+	/// </summary>
+	[Fact]
+	public void ResolveOwner_CombinedRepoWithoutExplicitOwner_AgreesAcrossDifferentFallbacks()
+	{
+		const string repo = "acme-corp/widget";
+
+		var cdnSourcingOwner = ChangelogRepoOwnerResolver.ResolveOwner(owner: null, repo, fallback: "elastic");
+		var uploadOwner = ChangelogRepoOwnerResolver.ResolveOwner(owner: null, repo, fallback: "some-other-git-remote-owner");
+
+		cdnSourcingOwner.Should().Be("acme-corp");
+		uploadOwner.Should().Be("acme-corp");
+		uploadOwner.Should().Be(cdnSourcingOwner);
+	}
+}


### PR DESCRIPTION
## Why

CDN entry sourcing (`ChangelogBundlingService`) and upload (`ChangelogCommands.ResolveUploadRepoOwnerBranch`) resolved the authoring **owner** differently when `bundle.owner` was not set explicitly. CDN sourcing split a combined `bundle.repo: "owner/repo"` to derive the owner, but upload fell straight through to the git remote owner instead. With that config shape, the produced and consumed `changelog/{owner}/{repo}/{branch}/` pools could point at different owners, so CDN bundling would silently source from an empty/nonexistent pool instead of erroring.

## What

Extracted the owner/repo resolution precedence into a shared `ChangelogRepoOwnerResolver` (explicit owner > `owner/` prefix of a combined repo value > fallback) and used it from both `ChangelogBundlingService` and `ChangelogCommands.ResolveUploadRepoOwnerBranch`, so a `bundle.repo: "owner/repo"` value without an explicit `bundle.owner` now resolves to the same owner on both sides — falling back to `elastic` for CDN sourcing and to the git remote owner for upload, as before.

Added unit tests pinning the resolver's precedence, including a regression case asserting upload and CDN sourcing agree for the `bundle.repo: owner/repo` + no `bundle.owner` case.

Fixes elastic/docs-eng-team#636