### PR TITLE
Tables: add fullscreen view and matrix cross-hair highlight

### DIFF
--- a/docs/syntax/tables.md
+++ b/docs/syntax/tables.md
@@ -105,7 +105,7 @@ Every table is responsive by default. The table will automatically scroll horizo
 
 ## Matrix highlight
 
-The `{table}` directive's `:matrix:` option highlights the whole row *and* column of the hovered cell. It only makes sense for lookup-style tables: a header row across the top and a row-heading first column — like the sprint velocity table below — where readers cross-reference a row label against a column label to find a value. In the fullscreen view this is enabled for every table.
+The `{table}` directive's `:matrix:` option highlights the whole row *and* column of the hovered cell. It only makes sense for lookup-style tables: a header row across the top and a row-heading first column — like the sprint velocity table below — where readers cross-reference a row label against a column label to find a value. This also applies in the fullscreen view for tables that use `:matrix:`.
 
 :::::{tab-set}
 

--- a/docs/syntax/tables.md
+++ b/docs/syntax/tables.md
@@ -70,29 +70,82 @@ A table is an arrangement of data with rows and columns. Each row consists of ce
 
 ## Responsive Table
 
-Every table is responsive by default. The table will automatically scroll horizontally when the content is wider than the viewport.
+Every table is responsive by default. The table will automatically scroll horizontally when the content is wider than the viewport. Tables that are wider than the content column also get a fullscreen button that opens the table in a fullscreen view with a sticky header row — useful for reference matrices with many scored columns.
 
 ::::{tab-set}
 
 :::{tab-item} Output
-| Product Name | Price ($) | Stock  | Category  | Rating  | Color    | Weight (kg) | Warranty (months) |
-|--------------|-----------|--------|-----------|---------|----------|-------------|-------------------|
-| Laptop Pro   | 1299.99   | 45     | Computer  | 4.5     | Silver   | 1.8         | 24                |
-| Smart Watch  | 299.99    | 120    | Wearable  | 4.2     | Black    | 0.045       | 12                |
-| Desk Chair   | 199.50    | 78     | Furniture | 4.8     | Gray     | 12.5        | 36                |
+| Region | Revenue ($M) | YoY Growth (%) | New Customers | Churn Rate (%) | NPS Score | Retention (%) | Upsell Revenue ($M) | Overall Score |
+|--------|---------------|------------------|-----------------|------------------|-----------|-----------------|-----------------------|----------------|
+| North America   | 42.5 | 12.3 | 1450 | 4.2 | 58 | 91.2 | 6.8 | 8.4 |
+| EMEA            | 31.2 | 9.8  | 1120 | 5.1 | 52 | 88.7 | 5.2 | 7.6 |
+| APAC            | 27.8 | 15.6 | 1680 | 6.3 | 47 | 85.4 | 4.1 | 7.1 |
+| LATAM           | 14.6 | 18.2 | 980  | 7.8 | 41 | 81.9 | 2.9 | 6.3 |
+| ANZ             | 9.3  | 7.4  | 340  | 3.9 | 61 | 92.5 | 1.8 | 7.9 |
+| Nordics         | 8.1  | 6.2  | 290  | 3.1 | 64 | 93.8 | 1.5 | 8.1 |
+| Southern Europe | 11.4 | 8.9  | 510  | 5.6 | 49 | 86.1 | 2.2 | 6.9 |
+| Middle East     | 6.7  | 22.1 | 410  | 8.4 | 38 | 78.3 | 1.1 | 5.8 |
 :::
 
 :::{tab-item} Markdown
 ```markdown
-| Product Name | Price ($) | Stock  | Category  | Rating  | Color    | Weight (kg) | Warranty (months) |
-|--------------|-----------|--------|-----------|---------|----------|-------------|-------------------|
-| Laptop Pro   | 1299.99   | 45     | Computer  | 4.5     | Silver   | 1.8         | 24                |
-| Smart Watch  | 299.99    | 120    | Wearable  | 4.2     | Black    | 0.045       | 12                |
-| Desk Chair   | 199.50    | 78     | Furniture | 4.8     | Gray     | 12.5        | 36                |
-:::
+| Region | Revenue ($M) | YoY Growth (%) | New Customers | Churn Rate (%) | NPS Score | Retention (%) | Upsell Revenue ($M) | Overall Score |
+|--------|---------------|------------------|-----------------|------------------|-----------|-----------------|-----------------------|----------------|
+| North America   | 42.5 | 12.3 | 1450 | 4.2 | 58 | 91.2 | 6.8 | 8.4 |
+| EMEA            | 31.2 | 9.8  | 1120 | 5.1 | 52 | 88.7 | 5.2 | 7.6 |
+| APAC            | 27.8 | 15.6 | 1680 | 6.3 | 47 | 85.4 | 4.1 | 7.1 |
+| LATAM           | 14.6 | 18.2 | 980  | 7.8 | 41 | 81.9 | 2.9 | 6.3 |
+| ANZ             | 9.3  | 7.4  | 340  | 3.9 | 61 | 92.5 | 1.8 | 7.9 |
+| Nordics         | 8.1  | 6.2  | 290  | 3.1 | 64 | 93.8 | 1.5 | 8.1 |
+| Southern Europe | 11.4 | 8.9  | 510  | 5.6 | 49 | 86.1 | 2.2 | 6.9 |
+| Middle East     | 6.7  | 22.1 | 410  | 8.4 | 38 | 78.3 | 1.1 | 5.8 |
 ```
 
 ::::
+
+## Matrix highlight
+
+The `{table}` directive's `:matrix:` option highlights the whole row *and* column of the hovered cell. It only makes sense for lookup-style tables: a header row across the top and a row-heading first column — like the sprint velocity table below — where readers cross-reference a row label against a column label to find a value. In the fullscreen view this is enabled for every table.
+
+:::::{tab-set}
+
+::::{tab-item} Output
+:::{table}
+:matrix:
+
+| Team | Sprint 1 | Sprint 2 | Sprint 3 | Sprint 4 | Sprint 5 | Sprint 6 | Sprint 7 | Sprint 8 |
+|------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|
+| Team Falcon | 34 | 38 | 41 | 36 | 44 | 47 | 42 | 50 |
+| Team Nimbus | 28 | 31 | 27 | 33 | 30 | 35 | 38 | 40 |
+| Team Orbit  | 45 | 42 | 48 | 51 | 47 | 53 | 55 | 58 |
+| Team Vertex | 22 | 25 | 24 | 28 | 26 | 30 | 29 | 33 |
+| Team Atlas  | 38 | 40 | 37 | 42 | 45 | 43 | 48 | 46 |
+| Team Comet  | 31 | 29 | 34 | 32 | 36 | 38 | 35 | 39 |
+| Team Pulse  | 50 | 52 | 49 | 55 | 58 | 54 | 60 | 57 |
+| Team Nova   | 19 | 22 | 21 | 25 | 23 | 27 | 26 | 29 |
+:::
+::::
+
+::::{tab-item} Markdown
+```markdown
+:::{table}
+:matrix:
+
+| Team | Sprint 1 | Sprint 2 | Sprint 3 | Sprint 4 | Sprint 5 | Sprint 6 | Sprint 7 | Sprint 8 |
+|------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|
+| Team Falcon | 34 | 38 | 41 | 36 | 44 | 47 | 42 | 50 |
+| Team Nimbus | 28 | 31 | 27 | 33 | 30 | 35 | 38 | 40 |
+| Team Orbit  | 45 | 42 | 48 | 51 | 47 | 53 | 55 | 58 |
+| Team Vertex | 22 | 25 | 24 | 28 | 26 | 30 | 29 | 33 |
+| Team Atlas  | 38 | 40 | 37 | 42 | 45 | 43 | 48 | 46 |
+| Team Comet  | 31 | 29 | 34 | 32 | 36 | 38 | 35 | 39 |
+| Team Pulse  | 50 | 52 | 49 | 55 | 58 | 54 | 60 | 57 |
+| Team Nova   | 19 | 22 | 21 | 25 | 23 | 27 | 26 | 29 |
+:::
+```
+::::
+
+:::::
 
 ## Table directive with column widths
 

--- a/src/Elastic.Documentation.Site/Assets/icons.ts
+++ b/src/Elastic.Documentation.Site/Assets/icons.ts
@@ -1,0 +1,5 @@
+// SVG icons shared across fullscreen-view features (mermaid diagrams, tables).
+// Extracted from EUI icon assets to match the Elastic design system.
+
+// EUI fullScreen icon
+export const fullscreenIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M13 3v4h-1V4H9V3h4ZM3 3h4v1H4v3H3V3Zm10 10H9v-1h3V9h1v4ZM3 13V9h1v3h3v1H3ZM0 1.994C0 .893.895 0 1.994 0h12.012C15.107 0 16 .895 16 1.994v12.012A1.995 1.995 0 0 1 14.006 16H1.994A1.995 1.995 0 0 1 0 14.006V1.994Zm1 0v12.012c0 .548.446.994.994.994h12.012a.995.995 0 0 0 .994-.994V1.994A.995.995 0 0 0 14.006 1H1.994A.995.995 0 0 0 1 1.994Z"/></svg>`

--- a/src/Elastic.Documentation.Site/Assets/main.ts
+++ b/src/Elastic.Documentation.Site/Assets/main.ts
@@ -9,6 +9,7 @@ import { initMermaid } from './mermaid'
 import { openDetailsWithAnchor } from './open-details-with-anchor'
 import { initNav } from './pages-nav'
 import { initSmoothScroll } from './smooth-scroll'
+import { initTable } from './table'
 import { initTabs } from './tabs'
 import { initializeOtel } from './telemetry/instrumentation'
 import { logError, logInfo } from './telemetry/logging'
@@ -203,6 +204,7 @@ document.addEventListener('htmx:load', function () {
         ['initSmoothScroll', initSmoothScroll],
         ['openDetailsWithAnchor', openDetailsWithAnchor],
         ['initImageCarousel', initImageCarousel],
+        ['initTable', initTable],
         ['initApiDocs', initApiDocs],
         ['applyEditParam', applyEditParam],
         ['initCtaImpressions', initCtaImpressions],

--- a/src/Elastic.Documentation.Site/Assets/markdown/table.css
+++ b/src/Elastic.Documentation.Site/Assets/markdown/table.css
@@ -149,7 +149,9 @@
 	   (no bottom border, no gap, no shadow, square bottom corners) rather
 	   than floating above it as a separate chip - and is always visible
 	   (not hover-revealed) so it's discoverable at a glance and reachable
-	   on touch devices, which have no hover state. */
+	   on touch devices, which have no hover state. Hidden below md: mobile
+	   tables already scroll full-width with native touch panning, so a
+	   fullscreen dialog on an already-small screen adds little. */
 	.table-container {
 		@apply flex flex-col items-end;
 
@@ -157,18 +159,19 @@
 			display: none;
 		}
 
-		/* Only when the button is actually showing does it provide top
-		   spacing before the table - drop .table-wrapper's own top margin
-		   just then, otherwise the two stack into an oversized gap. A
-		   non-overflowing table has no button and needs its normal margin,
-		   same as any other paragraph-to-table gap on the page. */
+		/* Only when the button is actually showing (md and up) does it
+		   provide top spacing before the table - drop .table-wrapper's own
+		   top margin just then, otherwise the two stack into an oversized
+		   gap. A non-overflowing table, or an overflowing one on mobile
+		   where the button is hidden, needs its normal margin, same as any
+		   other paragraph-to-table gap on the page. */
 		&[data-overflowing] {
 			.table-expand-btn {
-				@apply border-grey-20 text-ink flex h-8 w-8 cursor-pointer items-center justify-center rounded-t-sm border-1 border-b-0 bg-white;
+				@apply border-grey-20 text-ink hidden h-8 w-8 cursor-pointer items-center justify-center rounded-t-sm border-1 border-b-0 bg-white md:flex;
 			}
 
 			.table-wrapper {
-				@apply mt-0;
+				@apply md:mt-0;
 			}
 		}
 

--- a/src/Elastic.Documentation.Site/Assets/markdown/table.css
+++ b/src/Elastic.Documentation.Site/Assets/markdown/table.css
@@ -76,12 +76,13 @@
 
 	/* Cross-hair hover (row + column highlight): opt-in via {table} :matrix:
 	   for lookup-style tables with a row-heading first column and a header
-	   row, always on in the fullscreen dialog. Row and column share the same
-	   highlight color so they read as one crosshair rather than a faint row
-	   plus a visible column. The column is lit by an oversized pseudo-element
-	   clipped by overflow:hidden on the table. */
-	.table-matrix,
-	.table-modal {
+	   row. The class survives cloning into the fullscreen dialog, so this
+	   still applies there for matrix tables without forcing it on plain
+	   ones. Row and column share the same highlight color so they read as
+	   one crosshair rather than a faint row plus a visible column. The
+	   column is lit by an oversized pseudo-element clipped by
+	   overflow:hidden on the table. */
+	.table-matrix {
 		--crosshair-tint: color-mix(
 			in srgb,
 			var(--color-grey-30) 25%,

--- a/src/Elastic.Documentation.Site/Assets/markdown/table.css
+++ b/src/Elastic.Documentation.Site/Assets/markdown/table.css
@@ -1,6 +1,11 @@
 @layer components {
 	.table-wrapper {
 		@apply my-4 w-full overflow-x-auto;
+		--table-edge-fade: 24px;
+		/* Scopes mix-blend-mode:multiply (used by the crosshair highlight
+		   below) to blend only with this wrapper's own scroll-shadow, not
+		   with unrelated content elsewhere on the page. */
+		isolation: isolate;
 
 		/* Scroll shadows on both edges when the table is horizontally
 		   scrollable, signalling there's more content without needing a
@@ -25,8 +30,8 @@
 			);
 		background-repeat: no-repeat;
 		background-size:
-			24px 100%,
-			24px 100%,
+			var(--table-edge-fade) 100%,
+			var(--table-edge-fade) 100%,
 			10px 100%,
 			10px 100%;
 		background-position:
@@ -103,8 +108,19 @@
 			@apply relative;
 		}
 
+		/* mix-blend-mode:multiply instead of a flat background: a plain
+		   background is a descendant paint layer that always covers the
+		   wrapper's scroll-shadow beneath it, edge to edge, whether or not
+		   a shadow is actually there at that scroll position - fading the
+		   tint near the edges (tried first) fixed the overlap but then
+		   faded for no reason whenever no shadow was present. Multiply
+		   composes with whatever's beneath instead of covering it: over
+		   plain white it reads as the normal tint, and over the shadow it
+		   darkens further, so the two effects layer correctly wherever
+		   they happen to overlap without knowing scroll position at all. */
 		tbody tr:hover {
 			background: var(--crosshair-tint);
+			mix-blend-mode: multiply;
 		}
 
 		/* Skip the row-heading column and its header corner cell: they're
@@ -121,6 +137,7 @@
 			bottom: -5000px;
 			width: 100%;
 			background: var(--crosshair-tint);
+			mix-blend-mode: multiply;
 			pointer-events: none;
 		}
 
@@ -134,13 +151,17 @@
 	/* First column styled like the header row so it reads as a row heading.
 	   The tint is semi-transparent (not solid bg-grey-10) so it layers over
 	   tbody tr:hover instead of masking it - otherwise this column looks
-	   the same whether or not its row is hovered. Only for :matrix: tables,
-	   not every table in the fullscreen dialog: the class survives cloning
-	   into the modal, so this still applies there for matrix tables without
-	   forcing the look on plain ones. */
+	   the same whether or not its row is hovered. multiply blends it with
+	   the wrapper's scroll-shadow beneath instead of covering it, same
+	   reasoning as the crosshair hover above - this column sits exactly
+	   where the left shadow lives. Only for :matrix: tables, not every
+	   table in the fullscreen dialog: the class survives cloning into the
+	   modal, so this still applies there for matrix tables without forcing
+	   the look on plain ones. */
 	.table-matrix tbody td:first-child {
 		@apply font-semibold;
 		background: var(--row-heading-tint);
+		mix-blend-mode: multiply;
 	}
 
 	/* Fullscreen view for tables that overflow the content column. The

--- a/src/Elastic.Documentation.Site/Assets/markdown/table.css
+++ b/src/Elastic.Documentation.Site/Assets/markdown/table.css
@@ -38,4 +38,137 @@
 			}
 		}
 	}
+
+	/* Cross-hair hover (row + column highlight): opt-in via {table} :matrix:
+	   for lookup-style tables with a row-heading first column and a header
+	   row, always on in the fullscreen dialog. Row and column share the same
+	   highlight color so they read as one crosshair rather than a faint row
+	   plus a visible column. The column is lit by an oversized pseudo-element
+	   clipped by overflow:hidden on the table. */
+	.table-matrix,
+	.table-modal {
+		--crosshair-tint: color-mix(
+			in srgb,
+			var(--color-grey-30) 25%,
+			transparent
+		);
+		--row-heading-tint: color-mix(
+			in srgb,
+			var(--color-grey-30) 12%,
+			transparent
+		);
+
+		table {
+			overflow: hidden;
+		}
+
+		th,
+		td {
+			@apply relative;
+		}
+
+		tbody tr:hover {
+			background: var(--crosshair-tint);
+		}
+
+		/* Skip the row-heading column and its header corner cell: they're
+		   labels, not values, so crosshairing their whole column doesn't
+		   help look anything up. Hovering a row heading still highlights
+		   its own row via tbody tr:hover; hovering a column heading (th)
+		   highlights its own column here, mirroring that. */
+		tbody td:not(:first-child):hover::after,
+		thead th:not(:first-child):hover::after {
+			content: '';
+			position: absolute;
+			left: 0;
+			top: -5000px;
+			bottom: -5000px;
+			width: 100%;
+			background: var(--crosshair-tint);
+			pointer-events: none;
+		}
+
+		/* The hovered cell itself is the answer to the lookup, so it reads
+		   stronger than the dimmed row/column highlight around it. */
+		td:hover {
+			@apply text-ink-dark font-semibold;
+		}
+	}
+
+	/* First column styled like the header row so it reads as a row heading.
+	   The tint is semi-transparent (not solid bg-grey-10) so it layers over
+	   tbody tr:hover instead of masking it - otherwise this column looks
+	   the same whether or not its row is hovered. Only for :matrix: tables,
+	   not every table in the fullscreen dialog: the class survives cloning
+	   into the modal, so this still applies there for matrix tables without
+	   forcing the look on plain ones. */
+	.table-matrix tbody td:first-child {
+		@apply font-semibold;
+		background: var(--row-heading-tint);
+	}
+
+	/* Fullscreen view for tables that overflow the content column. The
+	   button is injected by table.ts; data-overflowing is kept in sync by
+	   a ResizeObserver. It docks onto the table's top-right corner like a
+	   tab built into the frame - flush against the table's own top border
+	   (no bottom border, no gap, no shadow, square bottom corners) rather
+	   than floating above it as a separate chip - and is always visible
+	   (not hover-revealed) so it's discoverable at a glance and reachable
+	   on touch devices, which have no hover state. */
+	.table-container {
+		@apply flex flex-col items-end;
+
+		.table-expand-btn {
+			display: none;
+		}
+
+		/* Only when the button is actually showing does it provide top
+		   spacing before the table - drop .table-wrapper's own top margin
+		   just then, otherwise the two stack into an oversized gap. A
+		   non-overflowing table has no button and needs its normal margin,
+		   same as any other paragraph-to-table gap on the page. */
+		&[data-overflowing] {
+			.table-expand-btn {
+				@apply border-grey-20 text-ink flex h-8 w-8 cursor-pointer items-center justify-center rounded-t-sm border-1 border-b-0 bg-white;
+			}
+
+			.table-wrapper {
+				@apply mt-0;
+			}
+		}
+
+		.table-expand-btn:hover {
+			@apply bg-grey-10;
+		}
+	}
+
+	dialog.table-modal {
+		@apply m-auto max-h-[90vh] max-w-[95vw] rounded-lg bg-white p-0;
+
+		&::backdrop {
+			background: rgba(0, 0, 0, 0.5);
+		}
+
+		.table-modal-content {
+			@apply flex flex-col items-end p-4;
+		}
+
+		.table-modal-close {
+			@apply text-grey-100 hover:text-ink mb-1 flex h-7 w-7 cursor-pointer items-center justify-center rounded-sm bg-white;
+		}
+
+		.table-wrapper {
+			@apply my-0 max-h-[calc(90vh-4rem)] overflow-auto;
+		}
+
+		thead th {
+			@apply bg-grey-10 sticky top-0 z-1;
+		}
+	}
+}
+
+@media print {
+	.table-expand-btn {
+		display: none !important;
+	}
 }

--- a/src/Elastic.Documentation.Site/Assets/markdown/table.css
+++ b/src/Elastic.Documentation.Site/Assets/markdown/table.css
@@ -2,6 +2,41 @@
 	.table-wrapper {
 		@apply my-4 w-full overflow-x-auto;
 
+		/* Scroll shadows on both edges when the table is horizontally
+		   scrollable, signalling there's more content without needing a
+		   visible scrollbar (which touch devices don't show anyway). Pure
+		   CSS: two "cover" gradients scroll with the content (local) and
+		   mask the shadows beneath, which stay fixed to the viewport edges
+		   (scroll) - so a shadow only shows on the edge you can still
+		   scroll toward. Self-adjusting: tables that don't overflow never
+		   show a shadow, since the covers already mask them at rest. */
+		background-image:
+			linear-gradient(to right, var(--color-white) 30%, transparent),
+			linear-gradient(to left, var(--color-white) 30%, transparent),
+			radial-gradient(
+				farthest-side at 0 50%,
+				rgba(0, 0, 0, 0.15),
+				transparent
+			),
+			radial-gradient(
+				farthest-side at 100% 50%,
+				rgba(0, 0, 0, 0.15),
+				transparent
+			);
+		background-repeat: no-repeat;
+		background-size:
+			24px 100%,
+			24px 100%,
+			10px 100%,
+			10px 100%;
+		background-position:
+			0 0,
+			100% 0,
+			0 0,
+			100% 0;
+		background-attachment: local, local, scroll, scroll;
+		background-color: var(--color-white);
+
 		&::-webkit-scrollbar {
 			@apply bg-grey-10 border-grey-20 h-2 border-b-1;
 		}

--- a/src/Elastic.Documentation.Site/Assets/markdown/table.css
+++ b/src/Elastic.Documentation.Site/Assets/markdown/table.css
@@ -74,7 +74,17 @@
 		tbody {
 			@apply align-top;
 			tr {
-				@apply border-grey-20 hover:bg-grey-10 not-last:border-b-1;
+				@apply border-grey-20 not-last:border-b-1;
+
+				/* Same reasoning as the crosshair highlight below: a flat
+				   hover background covers the scroll-shadow instead of
+				   composing with it. grey-10 is opaque, so multiply alone
+				   (no translucent tint needed) reproduces today's look on
+				   white and darkens further over the shadow. */
+				&:hover {
+					background: var(--color-grey-10);
+					mix-blend-mode: multiply;
+				}
 			}
 		}
 	}

--- a/src/Elastic.Documentation.Site/Assets/markdown/table.css
+++ b/src/Elastic.Documentation.Site/Assets/markdown/table.css
@@ -167,7 +167,7 @@
 		   other paragraph-to-table gap on the page. */
 		&[data-overflowing] {
 			.table-expand-btn {
-				@apply border-grey-20 text-ink hidden h-8 w-8 cursor-pointer items-center justify-center rounded-t-sm border-1 border-b-0 bg-white md:flex;
+				@apply border-grey-20 text-ink h-8 w-8 cursor-pointer items-center justify-center rounded-t-sm border-1 border-b-0 bg-white md:flex;
 			}
 
 			.table-wrapper {

--- a/src/Elastic.Documentation.Site/Assets/mermaid.ts
+++ b/src/Elastic.Documentation.Site/Assets/mermaid.ts
@@ -1,3 +1,5 @@
+import { fullscreenIcon } from './icons'
+
 // Beautiful Mermaid is loaded from local _static/ to avoid client-side CDN calls
 // The file is copied from node_modules during build (see package.json copy:mermaid)
 
@@ -66,8 +68,6 @@ const icons = {
     zoomOut: `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M9 7H4V6h5v1Z"/><path d="M6.5 1a5.5 5.5 0 0 1 4.729 8.308l3.421 2.933a1 1 0 0 1 .057 1.466l-1 1a1 1 0 0 1-1.466-.057l-2.933-3.42A5.5 5.5 0 1 1 6.5 1Zm4.139 9.12a5.516 5.516 0 0 1-.52.519L13 14l1-1-3.361-2.88ZM6.5 2a4.5 4.5 0 1 0 .314 8.987c.024-.001.047-.004.07-.006.207-.017.41-.048.607-.092l.066-.016a4.41 4.41 0 0 0 .588-.185c.012-.006.026-.01.039-.015.194-.079.382-.171.562-.275l.03-.017a4.52 4.52 0 0 0 1.605-1.605c.006-.01.01-.02.017-.03.104-.18.196-.368.275-.562l.018-.048c.074-.188.134-.38.182-.58l.016-.065a4.49 4.49 0 0 0 .093-.61l.005-.067a4.544 4.544 0 0 0 .007-.545A4.5 4.5 0 0 0 6.5 2Z"/></svg>`,
     // EUI refresh icon
     reset: `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M2 8a5.98 5.98 0 0 0 1.757 4.243A5.98 5.98 0 0 0 8 14v1a6.98 6.98 0 0 1-4.95-2.05A6.98 6.98 0 0 1 1 8c0-1.79.683-3.58 2.048-4.947l.004-.004.019-.02L3.1 3H1V2h4v4H4V3.525a6.51 6.51 0 0 0-.22.21l-.013.013-.003.002-.007.007A5.98 5.98 0 0 0 2 8Zm10.243-4.243A5.98 5.98 0 0 0 8 2V1a6.98 6.98 0 0 1 4.95 2.05A6.98 6.98 0 0 1 15 8a6.98 6.98 0 0 1-2.047 4.947l-.005.004-.018.02-.03.029H15v1h-4v-4h1v2.475a6.744 6.744 0 0 0 .22-.21l.013-.013.003-.002.007-.007A5.98 5.98 0 0 0 14 8a5.98 5.98 0 0 0-1.757-4.243Z"/></svg>`,
-    // EUI fullScreen icon
-    fullscreen: `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M13 3v4h-1V4H9V3h4ZM3 3h4v1H4v3H3V3Zm10 10H9v-1h3V9h1v4ZM3 13V9h1v3h3v1H3ZM0 1.994C0 .893.895 0 1.994 0h12.012C15.107 0 16 .895 16 1.994v12.012A1.995 1.995 0 0 1 14.006 16H1.994A1.995 1.995 0 0 1 0 14.006V1.994Zm1 0v12.012c0 .548.446.994.994.994h12.012a.995.995 0 0 0 .994-.994V1.994A.995.995 0 0 0 14.006 1H1.994A.995.995 0 0 0 1 1.994Z"/></svg>`,
     // EUI cross icon
     close: `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M7.293 8 2.646 3.354l.708-.708L8 7.293l4.646-4.647.708.708L8.707 8l4.647 4.646-.707.708L8 8.707l-4.646 4.647-.708-.707L7.293 8Z"/></svg>`,
 }
@@ -214,7 +214,7 @@ function setupControls(
         'mermaid-reset'
     )
     const fullscreenBtn = createControlButton(
-        icons.fullscreen,
+        fullscreenIcon,
         'View fullscreen',
         'mermaid-fullscreen'
     )

--- a/src/Elastic.Documentation.Site/Assets/table.ts
+++ b/src/Elastic.Documentation.Site/Assets/table.ts
@@ -1,0 +1,70 @@
+import { fullscreenIcon } from './icons'
+
+const closeIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 6.586 13.293 1.293l1.414 1.414L9.414 8l5.293 5.293-1.414 1.414L8 9.414l-5.293 5.293-1.414-1.414L6.586 8 1.293 2.707l1.414-1.414L8 6.586Z"/></svg>`
+
+// Keeps data-overflowing on each .table-container in sync with whether its
+// table actually overflows, so the expand button only shows when useful.
+const overflowObserver = new ResizeObserver((entries) => {
+    for (const entry of entries) {
+        const wrapper = entry.target as HTMLElement
+        wrapper.parentElement?.toggleAttribute(
+            'data-overflowing',
+            wrapper.scrollWidth > wrapper.clientWidth
+        )
+    }
+})
+
+function openTableModal(wrapper: HTMLElement): void {
+    const dialog = document.createElement('dialog')
+    dialog.className = 'table-modal'
+
+    const content = document.createElement('div')
+    content.className = 'table-modal-content'
+
+    const closeBtn = document.createElement('button')
+    closeBtn.type = 'button'
+    closeBtn.className = 'table-modal-close'
+    closeBtn.setAttribute('aria-label', 'Close')
+    closeBtn.title = 'Close'
+    closeBtn.innerHTML = closeIcon
+    closeBtn.addEventListener('click', () => dialog.close())
+
+    content.append(closeBtn, wrapper.cloneNode(true))
+    dialog.appendChild(content)
+
+    // Native <dialog> handles Escape and focus trapping; backdrop click is ours.
+    dialog.addEventListener('click', (e) => {
+        if (e.target === dialog) dialog.close()
+    })
+    dialog.addEventListener('close', () => dialog.remove())
+
+    document.body.appendChild(dialog)
+    dialog.showModal()
+}
+
+/**
+ * Adds a fullscreen button to markdown tables that overflow the content column.
+ */
+export function initTable(): void {
+    const wrappers = document.querySelectorAll<HTMLElement>(
+        '.markdown-content .table-wrapper:not([data-table-expand])'
+    )
+    wrappers.forEach((wrapper) => {
+        wrapper.setAttribute('data-table-expand', '')
+
+        const container = document.createElement('div')
+        container.className = 'table-container'
+        wrapper.replaceWith(container)
+
+        const expandBtn = document.createElement('button')
+        expandBtn.type = 'button'
+        expandBtn.className = 'table-expand-btn'
+        expandBtn.setAttribute('aria-label', 'View table fullscreen')
+        expandBtn.title = 'View table fullscreen'
+        expandBtn.innerHTML = fullscreenIcon
+        expandBtn.addEventListener('click', () => openTableModal(wrapper))
+
+        container.append(expandBtn, wrapper)
+        overflowObserver.observe(wrapper)
+    })
+}

--- a/src/Elastic.Documentation.Site/Assets/table.ts
+++ b/src/Elastic.Documentation.Site/Assets/table.ts
@@ -46,10 +46,10 @@ function openTableModal(wrapper: HTMLElement): void {
  * Adds a fullscreen button to markdown tables that overflow the content column.
  */
 export function initTable(): void {
-    const wrappers = document.querySelectorAll<HTMLElement>(
+    const newWrappers = document.querySelectorAll<HTMLElement>(
         '.markdown-content .table-wrapper:not([data-table-expand])'
     )
-    wrappers.forEach((wrapper) => {
+    newWrappers.forEach((wrapper) => {
         wrapper.setAttribute('data-table-expand', '')
 
         const container = document.createElement('div')
@@ -65,6 +65,14 @@ export function initTable(): void {
         expandBtn.addEventListener('click', () => openTableModal(wrapper))
 
         container.append(expandBtn, wrapper)
-        overflowObserver.observe(wrapper)
     })
+
+    // Re-sync to exactly the wrappers on the page now. htmx swaps detach old
+    // table-wrappers from the DOM without ever removing them from this
+    // observer, so without this it would keep a strong reference to every
+    // table wrapper ever seen this session, across every past page.
+    overflowObserver.disconnect()
+    document
+        .querySelectorAll<HTMLElement>('.markdown-content .table-wrapper')
+        .forEach((wrapper) => overflowObserver.observe(wrapper))
 }

--- a/src/Elastic.Documentation.Site/Assets/table.ts
+++ b/src/Elastic.Documentation.Site/Assets/table.ts
@@ -14,6 +14,13 @@ const overflowObserver = new ResizeObserver((entries) => {
     }
 })
 
+// Wrappers currently being watched. htmx swaps detach old table-wrappers
+// from the DOM without ever removing them from the observer, so this lets
+// initTable() drop exactly the ones that left instead of disconnecting and
+// re-observing everything - which would re-trigger ResizeObserver's initial
+// callback for every table still on the page, not just the ones that changed.
+const observedWrappers = new Set<HTMLElement>()
+
 function openTableModal(wrapper: HTMLElement): void {
     const dialog = document.createElement('dialog')
     dialog.className = 'table-modal'
@@ -46,6 +53,12 @@ function openTableModal(wrapper: HTMLElement): void {
  * Adds a fullscreen button to markdown tables that overflow the content column.
  */
 export function initTable(): void {
+    for (const wrapper of observedWrappers) {
+        if (wrapper.isConnected) continue
+        overflowObserver.unobserve(wrapper)
+        observedWrappers.delete(wrapper)
+    }
+
     const newWrappers = document.querySelectorAll<HTMLElement>(
         '.markdown-content .table-wrapper:not([data-table-expand])'
     )
@@ -65,14 +78,7 @@ export function initTable(): void {
         expandBtn.addEventListener('click', () => openTableModal(wrapper))
 
         container.append(expandBtn, wrapper)
+        overflowObserver.observe(wrapper)
+        observedWrappers.add(wrapper)
     })
-
-    // Re-sync to exactly the wrappers on the page now. htmx swaps detach old
-    // table-wrappers from the DOM without ever removing them from this
-    // observer, so without this it would keep a strong reference to every
-    // table wrapper ever seen this session, across every past page.
-    overflowObserver.disconnect()
-    document
-        .querySelectorAll<HTMLElement>('.markdown-content .table-wrapper')
-        .forEach((wrapper) => overflowObserver.observe(wrapper))
 }

--- a/src/Elastic.Markdown/Myst/Directives/DirectiveHtmlRenderer.cs
+++ b/src/Elastic.Markdown/Myst/Directives/DirectiveHtmlRenderer.cs
@@ -256,7 +256,8 @@ public class DirectiveHtmlRenderer : HtmlObjectRenderer<DirectiveBlock>
 		var slice = TableDirectiveView.Create(new TableDirectiveViewModel
 		{
 			DirectiveBlock = block,
-			ColumnWidths = block.ColumnWidths
+			ColumnWidths = block.ColumnWidths,
+			Matrix = block.Matrix
 		});
 		RenderRazorSlice(slice, renderer);
 	}

--- a/src/Elastic.Markdown/Myst/Directives/Table/TableDirectiveBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Table/TableDirectiveBlock.cs
@@ -22,8 +22,16 @@ public class TableDirectiveBlock(DirectiveBlockParser parser, ParserContext cont
 	/// </summary>
 	public IReadOnlyList<double> ColumnWidths { get; private set; } = [];
 
+	/// <summary>
+	/// When set, hovering a cell highlights its whole row and column (cross-hair highlight).
+	/// Intended for lookup-style tables with a row-heading first column and a header row.
+	/// </summary>
+	public bool Matrix { get; private set; }
+
 	public override void FinalizeAndValidate(ParserContext context)
 	{
+		Matrix = PropBool("matrix");
+
 		var widthsValue = Prop("widths")?.Trim();
 
 		if (string.IsNullOrEmpty(widthsValue) || widthsValue.Equals("auto", StringComparison.OrdinalIgnoreCase))

--- a/src/Elastic.Markdown/Myst/Directives/Table/TableDirectiveViewModel.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Table/TableDirectiveViewModel.cs
@@ -16,12 +16,17 @@ public partial class TableDirectiveViewModel : DirectiveViewModel
 {
 	public required IReadOnlyList<double> ColumnWidths { get; init; }
 
+	public required bool Matrix { get; init; }
+
 	/// <summary>
 	/// Renders the table content. When <see cref="ColumnWidths"/> is specified, injects a colgroup and table-layout:fixed.
+	/// When <see cref="Matrix"/> is set, adds the table-matrix class to the wrapper.
 	/// </summary>
 	public HtmlString RenderTableWithColumns()
 	{
 		var html = RenderBlock().Value ?? string.Empty;
+		if (Matrix)
+			html = InjectMatrixClass(html);
 		if (ColumnWidths.Count == 0)
 			return new HtmlString(html.EnsureTrimmed());
 
@@ -45,6 +50,19 @@ public partial class TableDirectiveViewModel : DirectiveViewModel
 		var result = html[..tableIndex] + newOpening + colgroup + html[(bracketEnd + 1)..];
 
 		return new HtmlString(result.EnsureTrimmed());
+	}
+
+	/// <summary>
+	/// Adds the table-matrix class to the wrapper div's opening tag emitted by WrappedTableRenderer,
+	/// locating that specific tag rather than replacing the class attribute wherever it appears.
+	/// </summary>
+	private static string InjectMatrixClass(string html)
+	{
+		const string wrapperOpenTag = "<div class=\"table-wrapper\">";
+		var wrapperIndex = html.IndexOf(wrapperOpenTag, StringComparison.Ordinal);
+		return wrapperIndex < 0
+			? html
+			: html[..wrapperIndex] + "<div class=\"table-wrapper table-matrix\">" + html[(wrapperIndex + wrapperOpenTag.Length)..];
 	}
 
 	[GeneratedRegex(@"\sstyle\s*=\s*""([^""]*)""", RegexOptions.IgnoreCase)]

--- a/tests/Elastic.Markdown.Tests/Directives/TableDirectiveTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/TableDirectiveTests.cs
@@ -103,6 +103,37 @@ public class TableDirectiveAutoPresetTests(ITestOutputHelper output) : Directive
 	public void DoesNotInjectColgroup() => Html.Should().NotContain("colgroup");
 }
 
+public class TableDirectiveMatrixTests(ITestOutputHelper output) : DirectiveTest<TableDirectiveBlock>(output,
+"""
+:::{table}
+:matrix:
+
+| head a | head b |
+| --- | --- |
+| a | b |
+:::
+""")
+{
+	[Fact]
+	public void ParsesMatrixOption() => Block!.Matrix.Should().BeTrue();
+
+	[Fact]
+	public void RendersMatrixClass() => Html.Should().Contain("table-wrapper table-matrix");
+}
+
+public class TableDirectiveWithoutMatrixTests(ITestOutputHelper output) : DirectiveTest<TableDirectiveBlock>(output,
+"""
+:::{table}
+| head a | head b |
+| --- | --- |
+| a | b |
+:::
+""")
+{
+	[Fact]
+	public void DoesNotRenderMatrixClass() => Html.Should().NotContain("table-matrix");
+}
+
 public class TableDirectiveWidthCountMismatchTests(ITestOutputHelper output) : DirectiveTest<TableDirectiveBlock>(output,
 """
 :::{table}


### PR DESCRIPTION
## Why

Large tables get squeezed by the docs site's three-column layout, forcing horizontal scroll with no way to see the whole table at once. There was also no good way to make a lookup-style table (e.g. a matrix of scores) easy to scan by row and column.

## What

Tables wider than the content column now get a small expand button docked onto the table's top-right corner. Clicking it opens the table in a fullscreen `<dialog>` with a sticky header row, so wide reference tables are readable without cramped scrolling.

The existing `{table}` directive gains a `:matrix:` option for lookup-style tables (a header row across the top, a row-heading first column): hovering a cell highlights its whole row and column together, and the first column is styled like the header row so it reads as a row heading. This cross-hair highlight is always on inside the fullscreen view, where cross-referencing matters most, regardless of whether `:matrix:` was set.

Docs for both features are added to `docs/syntax/tables.md` with runnable examples.

## Test plan

- `dotnet test tests/Elastic.Markdown.Tests` — new `TableDirectiveMatrixTests` / `TableDirectiveWithoutMatrixTests` cases pass alongside existing table directive tests.
- Manually verified in a local build: expand button only appears on tables that actually overflow; fullscreen dialog opens/closes via button, backdrop click, and Escape; `:matrix:` cross-hair highlights the hovered row and column without over-highlighting the row-heading column or its header corner; behavior confirmed both inline and inside the fullscreen dialog.