### PR TITLE
Footer: disable htmx boosting on footer links

### DIFF
--- a/src/Elastic.Codex/Layout/_CodexFooter.cshtml
+++ b/src/Elastic.Codex/Layout/_CodexFooter.cshtml
@@ -1,6 +1,6 @@
 @inherits RazorSlice<Elastic.Documentation.Site.GlobalLayoutViewModel>
 
-<footer class="py-6 px-6 w-full mx-auto bg-ink-dark">
+<footer hx-disable="true" class="py-6 px-6 w-full mx-auto bg-ink-dark">
 	<div class="max-w-6xl w-full mx-auto text-grey-20 text-[12px]">
 		<a href="https://www.elastic.co/">
 			<img class="block" loading="lazy" alt="Elastic logo" src="@Model.Static("logo-elastic-horizontal-white.svg")" width="120" height="41"/>

--- a/src/Elastic.Documentation.Site/Layout/_AssemblerFooter.cshtml
+++ b/src/Elastic.Documentation.Site/Layout/_AssemblerFooter.cshtml
@@ -1,6 +1,6 @@
 @inherits RazorSlice<Elastic.Documentation.Site.GlobalLayoutViewModel>
 
-<footer class="py-12 px-6 w-full mx-auto bg-ink-dark">
+<footer hx-disable="true" class="py-12 px-6 w-full mx-auto bg-ink-dark">
 	<div class="max-w-(--max-layout-width) w-full mx-auto">
 	<div class="text-grey-20 text-[12px]">
 		<a href="https://www.elastic.co/">

--- a/src/Elastic.Documentation.Site/Layout/_IsolatedFooter.cshtml
+++ b/src/Elastic.Documentation.Site/Layout/_IsolatedFooter.cshtml
@@ -2,7 +2,7 @@
 
 @if (Model.Branding is null)
 {
-	<footer class="py-8 px-6 w-full mx-auto bg-ink-dark">
+	<footer hx-disable="true" class="py-8 px-6 w-full mx-auto bg-ink-dark">
 		<div class="max-w-(--max-layout-width) w-full mx-auto text-grey-20 text-[12px]">
 			<a href="https://www.elastic.co/">
 				<img class="block" loading="lazy" alt="Elastic logo" src="@Model.Static("logo-elastic-horizontal-white.svg")" width="120" height="41"/>
@@ -28,7 +28,7 @@
 }
 else
 {
-	<footer>
+	<footer hx-disable="true">
 		@if (Model.Features.DiagnosticsPanelEnabled)
 		{
 			<div class="h-10"></div>


### PR DESCRIPTION
## Why

Footer links all point off-site to elastic.co, but the `<footer>` elements inherit `hx-boost="true"` from the global `<body>` — so links in the footer were falsely boosted, with htmx intercepting clicks for an AJAX/history navigation instead of a normal browser navigation.

## What

Added `hx-disable="true"` to each `<footer>` element (`_AssemblerFooter.cshtml`, `_IsolatedFooter.cshtml` — both branches, `_CodexFooter.cshtml`), which disables all htmx processing on the footer and its descendants.