### PR TITLE
[Changelog] Remove unnecessary square brackets

### DIFF
--- a/src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogInlineRenderer.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogInlineRenderer.cs
@@ -613,7 +613,7 @@ public static class ChangelogInlineRenderer
 			}
 		}
 
-		return linksParts.Count > 0 ? $"[{string.Join(", ", linksParts)}]" : string.Empty;
+		return linksParts.Count > 0 ? string.Join(" ", linksParts) : string.Empty;
 	}
 
 	private static void RenderDetailedEntry(StringBuilder sb, ChangelogEntry entry, string repo, string owner, bool hideLinks, bool hideEntryDescriptions)

--- a/tests/Elastic.Markdown.Tests/Directives/ChangelogFlattenedLinksTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/ChangelogFlattenedLinksTests.cs
@@ -1,0 +1,62 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions.TestingHelpers;
+using AwesomeAssertions;
+using Elastic.Markdown.Myst.Directives.Changelog;
+
+namespace Elastic.Markdown.Tests.Directives;
+
+/// <summary>
+/// Regression tests for PR/issue link formatting in flattened separated-type changelog output
+/// (breaking changes, deprecations, known issues, highlights without <c>:dropdowns:</c>).
+/// </summary>
+public class ChangelogFlattenedLinksTests : DirectiveTest<ChangelogBlock>
+{
+	public ChangelogFlattenedLinksTests(ITestOutputHelper output) : base(output,
+		// language=markdown
+		"""
+		:::{changelog}
+		:type: deprecation
+		:::
+		""") => FileSystem.AddFile("docs/changelog/bundles/9.3.0.yaml", new MockFileData(
+		// language=yaml
+		"""
+		products:
+		- product: elasticsearch
+		  target: 9.3.0
+		entries:
+		- title: Update GET /api/status endpoint details
+		  type: deprecation
+		  products:
+		  - product: elasticsearch
+		    target: 9.3.0
+		  prs:
+		  - "268942"
+		  - "202446"
+		  issues:
+		  - "199001"
+		"""));
+
+	[Fact]
+	public void FlattenedDeprecationRendersMultipleLinksWithoutOuterBrackets()
+	{
+		var markdown = ChangelogInlineRenderer.RenderChangelogMarkdown(Block!);
+
+		markdown.Should().Contain("[#268942](https://github.com/elastic/elasticsearch/pull/268942)");
+		markdown.Should().Contain("[#202446](https://github.com/elastic/elasticsearch/pull/202446)");
+		markdown.Should().Contain("[#199001](https://github.com/elastic/elasticsearch/issues/199001)");
+		markdown.Should().NotContain("[ [#268942]");
+		markdown.Should().NotContain("[#268942, #202446]");
+	}
+
+	[Fact]
+	public void FlattenedDeprecationRendersClickableLinkHtml()
+	{
+		Html.Should().Contain("href=\"https://github.com/elastic/elasticsearch/pull/268942\"");
+		Html.Should().Contain("href=\"https://github.com/elastic/elasticsearch/pull/202446\"");
+		Html.Should().Contain("href=\"https://github.com/elastic/elasticsearch/issues/199001\"");
+		Html.Should().NotContain("[#268942, #202446]");
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/elastic/docs-builder/issues/3638

## Screenshots

**Before**

<img width="1617" height="383" alt="image" src="https://github.com/user-attachments/assets/184549d8-5509-4a87-9d68-c77595854d84" />

**After**

<img width="1391" height="324" alt="image" src="https://github.com/user-attachments/assets/2562b819-046a-421b-a4b6-e51fa0dbfe42" />

## Summary

In flattened separated-type output (deprecations, breaking changes, etc. without `:dropdowns:`), `GetLinksText` wrapped already-formatted markdown links in an extra `[...]`:

```616:616:src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogInlineRenderer.cs
return linksParts.Count > 0 ? string.Join(" ", linksParts) : string.Empty;
```

`FormatPrLink` / `FormatIssueLink` already return `[#N](url)`, so the outer wrapper produced invalid markdown like `[ [#268942](url), [#202446](url) ]`, which rendered as literal `[#268942, #202446]`.

### Fix

`GetLinksText` now space-joins links, matching `RenderEntryLinks` and `IndexMarkdownRenderer`.

### Test added

[`tests/Elastic.Markdown.Tests/Directives/ChangelogFlattenedLinksTests.cs`](tests/Elastic.Markdown.Tests/Directives/ChangelogFlattenedLinksTests.cs) — a deprecation entry with two PRs and one issue, asserting:
- Markdown contains proper `[#N](url)` links
- No `[ [#N]` wrapper or `[#N, #M]` literal text
- HTML contains clickable `href` attributes

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: composer-2.5-fast