### PR TITLE
Fix markdown formatting in dropdown titles

### DIFF
--- a/docs/syntax/changelog.md
+++ b/docs/syntax/changelog.md
@@ -150,6 +150,8 @@ Controls how the "separated" entry types (`breaking-change`, `deprecation`, `kno
 
 Use dropdowns when breaking-change and deprecation entries have long `description`, `impact`, or `action` prose that benefits from being collapsed by default. Use the flattened default for compact release-notes pages where the list itself is the primary content.
 
+Entry titles may contain inline markdown markers from changelog YAML (for example, `` `setting.name` ``). Dropdown titles are plain text; see [Plain-text titles](/syntax/dropdowns.md#plain-text-titles).
+
 #### `:release-dates:` [release-dates]
 
 Controls whether the bundle `release-date` field is rendered as italicized _Released: …_ text immediately after each version heading. Defaults to `false`.

--- a/docs/syntax/dropdowns.md
+++ b/docs/syntax/dropdowns.md
@@ -2,6 +2,10 @@
 
 Dropdowns allow you to hide and reveal content on user interaction. By default, dropdowns are collapsed. This hides content until a user clicks the title of the collapsible block.
 
+## Plain-text titles
+
+Dropdown titles are plain text. They do not render inline markdown such as `` `code` ``, `**bold**`, or `_italic_`. If you include those markers in the title line, docs-builder converts them to plain text automatically (for example, `` Deprecate `elastic.apm` settings `` renders as "Deprecate elastic.apm settings"). Use the dropdown body for formatted code, emphasis, and links.
+
 ## Basic dropdown
 
 

--- a/src/Elastic.Markdown/Myst/Directives/Admonition/AdmonitionBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Admonition/AdmonitionBlock.cs
@@ -53,6 +53,9 @@ public class AdmonitionBlock : DirectiveBlock, IBlockTitle, IBlockAppliesTo
 		else if (!string.IsNullOrEmpty(Arguments))
 			Title += $" {Arguments}";
 		Title = Title.ReplaceSubstitutions(context);
+
+		if (Admonition is "dropdown")
+			Title = Title.StripMarkdown();
 	}
 
 	private ApplicableTo? ParseApplicableTo(string yaml)

--- a/tests/Elastic.Markdown.Tests/Directives/AdmonitionTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/AdmonitionTests.cs
@@ -100,6 +100,63 @@ A regular paragraph.
 	public void SetsDropdownOpen() => Block!.DropdownOpen.Should().BeTrue();
 }
 
+public class DropdownPlainTextTitleTests(ITestOutputHelper output) : DirectiveTest<AdmonitionBlock>(output,
+"""
+:::{dropdown} Deprecate `elastic.apm` settings
+Dropdown body content.
+:::
+"""
+)
+{
+	[Fact]
+	public void StripsBackticksFromTitle() => Block!.Title.Should().Be("Deprecate elastic.apm settings");
+
+	[Fact]
+	public void RendersPlainTextTitleInHtml()
+	{
+		Html.Should().Contain("Deprecate elastic.apm settings");
+		Html.Should().NotContain("`elastic.apm`");
+	}
+}
+
+public class DropdownPlainTextBoldTitleTests(ITestOutputHelper output) : DirectiveTest<AdmonitionBlock>(output,
+"""
+:::{dropdown} Disable **Save** button
+Dropdown body content.
+:::
+"""
+)
+{
+	[Fact]
+	public void StripsBoldMarkersFromTitle() => Block!.Title.Should().Be("Disable Save button");
+
+	[Fact]
+	public void RendersBoldTitleAsPlainTextInHtml()
+	{
+		Html.Should().Contain("Disable Save button");
+		Html.Should().NotContain("**Save**");
+	}
+}
+
+public class DropdownPlainTextItalicTitleTests(ITestOutputHelper output) : DirectiveTest<AdmonitionBlock>(output,
+"""
+:::{dropdown} Use _italic_ emphasis
+Dropdown body content.
+:::
+"""
+)
+{
+	[Fact]
+	public void StripsItalicMarkersFromTitle() => Block!.Title.Should().Be("Use italic emphasis");
+
+	[Fact]
+	public void RendersItalicTitleAsPlainTextInHtml()
+	{
+		Html.Should().Contain("Use italic emphasis");
+		Html.Should().NotContain("_italic_");
+	}
+}
+
 public class DropdownAppliesToTests(ITestOutputHelper output) : DirectiveTest<AdmonitionBlock>(output,
 """
 :::{dropdown} This is my custom dropdown

--- a/tests/Elastic.Markdown.Tests/Directives/ChangelogDropdownsTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/ChangelogDropdownsTests.cs
@@ -388,3 +388,43 @@ public class ChangelogDropdownsExplicitWithDifferentTypesTests : DirectiveTest<C
 		Html.Should().NotContain("<li><p>Known issue with search.");
 	}
 }
+
+/// <summary>
+/// Changelog-generated dropdown titles pass through the dropdown parser, which strips inline markdown markers.
+/// </summary>
+public class ChangelogDropdownsPlainTextTitleTests : DirectiveTest<ChangelogBlock>
+{
+	public ChangelogDropdownsPlainTextTitleTests(ITestOutputHelper output) : base(output,
+		// language=markdown
+		"""
+		:::{changelog}
+		:type: known-issue
+		:dropdowns:
+		:description-visibility: keep-descriptions
+		:::
+		""") => FileSystem.AddFile("docs/changelog/bundles/9.3.0.yaml", new MockFileData(
+		// language=yaml
+		"""
+		products:
+		- product: elasticsearch
+		  target: 9.3.0
+		entries:
+		- title: "The `ElasticAgentVersion` parameter is malformed"
+		  type: known-issue
+		  products:
+		  - product: elasticsearch
+		    target: 9.3.0
+		  description: The default value has a space instead of a plus sign.
+		  impact: Deployments fail.
+		  action: Update the template.
+		  prs:
+		  - "242365"
+		"""));
+
+	[Fact]
+	public void ChangelogDropdownTitleStripsBackticksInHtml()
+	{
+		Html.Should().Contain("The ElasticAgentVersion parameter is malformed.");
+		Html.Should().NotContain("`ElasticAgentVersion`");
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/elastic/docs-builder/issues/3637

## Screenshots

**Before**

<img width="1458" height="318" alt="image" src="https://github.com/user-attachments/assets/941af67f-eb24-476c-b1af-96d6e5565732" />

**After**

<img width="1384" height="277" alt="image" src="https://github.com/user-attachments/assets/caac674c-725f-4bd6-bce7-50585cff6c05" />

## Summary

[`AdmonitionBlock.cs`](src/Elastic.Markdown/Myst/Directives/Admonition/AdmonitionBlock.cs) — after substitutions, dropdown titles are converted to plain text:

```csharp
if (Admonition is "dropdown")
    Title = Title.StripMarkdown();
```

This uses the existing `StripMarkdown()` helper (Markdig `ToPlainText`). It applies to:
- Hand-authored `{dropdown}` directives
- Changelog-generated dropdowns (re-parsed through the normal directive pipeline)
- CLI `changelog render` output on the next docs build

No changelog renderer changes.

### Tests added

| File | Coverage |
|------|----------|
| [`AdmonitionTests.cs`](tests/Elastic.Markdown.Tests/Directives/AdmonitionTests.cs) | Backticks, `**bold**`, `_italic_` stripped from title and HTML |
| [`ChangelogDropdownsTests.cs`](tests/Elastic.Markdown.Tests/Directives/ChangelogDropdownsTests.cs) | `ChangelogDropdownsPlainTextTitleTests` — known-issue entry with `` `ElasticAgentVersion` `` |

### Docs updated

- [`docs/syntax/dropdowns.md`](docs/syntax/dropdowns.md) — new **Plain-text titles** section
- [`docs/syntax/changelog.md`](docs/syntax/changelog.md) — cross-reference under `:dropdowns:`

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: composer-2.5-fast