### PR TITLE
Add OKF-conformant okf.zip exporter

### DIFF
--- a/src/Elastic.Documentation.Tooling/Exporter.cs
+++ b/src/Elastic.Documentation.Tooling/Exporter.cs
@@ -15,7 +15,8 @@ public enum Exporter
 	Configuration,
 	DocumentationState,
 	LinkMetadata,
-	Redirects
+	Redirects,
+	Okf
 }
 
 public static class ExportOptions

--- a/src/Elastic.Markdown/Exporters/ExporterExtensions.cs
+++ b/src/Elastic.Markdown/Exporters/ExporterExtensions.cs
@@ -25,6 +25,8 @@ public static class ExporterExtensions
 			markdownExporters.Add(new ConfigurationExporter(logFactory, context.ConfigurationFileProvider, context));
 		if (exportOptions.Contains(Exporter.Elasticsearch))
 			markdownExporters.Add(new ElasticsearchMarkdownExporter(logFactory, context.Collector, context.Endpoints, context));
+		if (exportOptions.Contains(Exporter.Okf))
+			markdownExporters.Add(new OkfMarkdownExporter());
 		return markdownExporters;
 	}
 }

--- a/src/Elastic.Markdown/Exporters/OkfMarkdownExporter.cs
+++ b/src/Elastic.Markdown/Exporters/OkfMarkdownExporter.cs
@@ -228,7 +228,8 @@ public class OkfMarkdownExporter : IMarkdownExporter
 			_ = frontMatter.AppendLine();
 			_ = frontMatter.AppendLine($"# {sourceFile.Title}");
 			_ = frontMatter.Append(body);
-			return frontMatter.ToString();
+			// AppendLine uses Environment.NewLine — normalize so bundle content is identical regardless of the OS the build runs on.
+			return frontMatter.ToString().Replace("\r\n", "\n", StringComparison.Ordinal);
 		}
 		finally
 		{
@@ -377,7 +378,8 @@ public class OkfMarkdownExporter : IMarkdownExporter
 				_ = sb.AppendLine();
 			}
 
-			return sb.ToString().TrimEnd() + Environment.NewLine;
+			// AppendLine uses Environment.NewLine — normalize so bundle content is identical regardless of the OS the build runs on.
+			return sb.ToString().Replace("\r\n", "\n", StringComparison.Ordinal).TrimEnd() + "\n";
 		}
 		finally
 		{

--- a/src/Elastic.Markdown/Exporters/OkfMarkdownExporter.cs
+++ b/src/Elastic.Markdown/Exporters/OkfMarkdownExporter.cs
@@ -1,0 +1,389 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Collections.Concurrent;
+using System.IO.Abstractions;
+using System.IO.Compression;
+using System.Text;
+using Elastic.Documentation.AppliesTo;
+using Elastic.Documentation.Configuration.Inference;
+using Elastic.Documentation.Configuration.Products;
+using Elastic.Markdown.Helpers;
+using Elastic.Markdown.IO;
+using Elastic.Markdown.Myst.Components;
+using Markdig.Syntax;
+
+namespace Elastic.Markdown.Exporters;
+
+/// <summary>
+/// Exports markdown files as an <see href="https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md">
+/// Open Knowledge Format (OKF) v0.1</see> conformant zip bundle ("okf.zip"). Unlike <see cref="LlmMarkdownExporter"/>,
+/// links are rewritten to bundle-relative paths (not public URLs), and directory-listing <c>index.md</c> files are
+/// synthesized rather than treated as content — authored landing pages are emitted as a sibling <c>{folder}.md</c>
+/// concept next to the <c>{folder}/</c> directory (see <see cref="ComputeBundlePath"/>).
+/// </summary>
+public class OkfMarkdownExporter : IMarkdownExporter
+{
+	private const string ReservedIndexFileName = "index.md";
+
+	private readonly ConcurrentBag<ConceptEntry> _entries = [];
+	private IDirectoryInfo? _stagingDirectory;
+	private readonly Lock _stagingLock = new();
+
+	public ValueTask StartAsync(Cancel ctx = default) => ValueTask.CompletedTask;
+
+	public ValueTask StopAsync(Cancel ctx = default) => ValueTask.CompletedTask;
+
+	public async ValueTask<bool> ExportAsync(MarkdownExportFileContext fileContext, Cancel ctx)
+	{
+		if (IsUtilityPage(fileContext.SourceFile.YamlFrontMatter?.Layout))
+			return true;
+
+		// Remove the first H1 since we already emit the title as frontmatter + a synthesized heading —
+		// don't rely on the HTML exporter (which isn't guaranteed to run) having already stripped it via
+		// its own mutation of the shared Document instance. Mirrors ElasticsearchMarkdownExporter.ExportAsync.
+		var h1 = fileContext.Document.Descendants<HeadingBlock>().FirstOrDefault(h => h.Level == 1);
+		if (h1 is not null)
+			_ = fileContext.Document.Remove(h1);
+
+		var fs = fileContext.BuildContext.WriteFileSystem;
+		var staging = GetOrCreateStagingDirectory(fs);
+
+		var sourceFile = fileContext.SourceFile;
+		var bundlePath = ComputeBundlePath(fileContext.NavigationItem.Url, fileContext.BuildContext.UrlPathPrefix);
+		var content = CreateConceptContent(fileContext);
+
+		var outputFile = fs.FileInfo.New(fs.Path.Combine(staging.FullName, bundlePath));
+		if (outputFile.Directory is { Exists: false })
+			outputFile.Directory.Create();
+
+		await fs.File.WriteAllTextAsync(outputFile.FullName, content, Encoding.UTF8, ctx);
+
+		_entries.Add(new ConceptEntry(bundlePath, sourceFile.Title, GetDescription(fileContext)));
+		return true;
+	}
+
+	public async ValueTask<bool> FinishExportAsync(IDirectoryInfo outputFolder, Cancel ctx)
+	{
+		var fs = outputFolder.FileSystem;
+		var staging = GetOrCreateStagingDirectory(fs);
+
+		await WriteIndexFilesAsync(fs, staging, ctx);
+
+		// Nothing else guarantees outputFolder exists — unlike LlmMarkdownExporter, ExportAsync writes
+		// into a temp staging dir rather than outputFolder, so this may be the first write to it.
+		if (!outputFolder.Exists)
+			outputFolder.Create();
+
+		var zipPath = fs.Path.Combine(outputFolder.FullName, "okf.zip");
+		await using var zipStream = fs.File.Create(zipPath);
+		using var archive = new ZipArchive(zipStream, ZipArchiveMode.Create);
+		foreach (var file in staging.EnumerateFiles("*", SearchOption.AllDirectories))
+		{
+			var relativePath = fs.Path.GetRelativePath(staging.FullName, file.FullName).Replace('\\', '/');
+			var entry = archive.CreateEntry(relativePath, CompressionLevel.Optimal);
+			await using var entryStream = entry.Open();
+			await using var sourceStream = fs.File.OpenRead(file.FullName);
+			await sourceStream.CopyToAsync(entryStream, ctx);
+		}
+
+		staging.Delete(recursive: true);
+		_stagingDirectory = null;
+		return true;
+	}
+
+	private IDirectoryInfo GetOrCreateStagingDirectory(IFileSystem fs)
+	{
+		if (_stagingDirectory is { } existing)
+			return existing;
+		lock (_stagingLock)
+		{
+			if (_stagingDirectory is { } created)
+				return created;
+			var path = fs.Path.Combine(fs.Path.GetTempPath(), $"okf-export-{Guid.NewGuid():N}");
+			var directory = fs.DirectoryInfo.New(path);
+			directory.Create();
+			_stagingDirectory = directory;
+			return directory;
+		}
+	}
+
+	/// <summary>
+	/// Utility/system pages (404, search, archive) back site chrome, not documentation content — OKF has no
+	/// use for them as concepts. Deliberately excludes <see cref="MarkdownPageLayout.LandingPage"/>: those are
+	/// real authored landing pages, handled uniformly by <see cref="ComputeBundlePath"/>'s sibling-file mapping.
+	/// </summary>
+	internal static bool IsUtilityPage(MarkdownPageLayout? layout) =>
+		layout is MarkdownPageLayout.NotFound or MarkdownPageLayout.Archive or MarkdownPageLayout.FullSearch;
+
+	/// <summary>
+	/// Maps a page's final site URL to its path within the OKF bundle — a pure function of the URL, needing
+	/// no knowledge of other pages or which repo backs it. A folder's landing page URL has no trailing
+	/// <c>/index</c> segment, so it naturally maps to a <em>sibling</em> <c>{folder}.md</c> file next to the
+	/// <c>{folder}/</c> directory (mirrors <see cref="LlmMarkdownExporter"/>'s <c>GetLlmOutputFile</c> convention)
+	/// rather than colliding with OKF's reserved, synthesized <c>index.md</c> directory listing.
+	/// </summary>
+	internal static string ComputeBundlePath(string navigationUrl, string? urlPathPrefix)
+	{
+		var prefix = urlPathPrefix ?? string.Empty;
+		var url = navigationUrl;
+		if (prefix.Length > 0 && url.StartsWith(prefix, StringComparison.Ordinal))
+			url = url[prefix.Length..];
+		var trimmed = url.Trim('/');
+		return trimmed.Length == 0 ? "overview.md" : $"{trimmed}.md";
+	}
+
+	/// <summary>
+	/// Derives the OKF <c>type</c> from the page's top-level navigation section (the first URL path
+	/// segment after any configured <see cref="Elastic.Documentation.Configuration.BuildContext.UrlPathPrefix"/>),
+	/// e.g. <c>/reference/query-languages/eql</c> -> <c>reference</c>.
+	/// </summary>
+	internal static string DeriveType(string navigationUrl, string? urlPathPrefix)
+	{
+		var prefix = urlPathPrefix ?? string.Empty;
+		var url = navigationUrl;
+		if (prefix.Length > 0 && url.StartsWith(prefix, StringComparison.Ordinal))
+			url = url[prefix.Length..];
+		var segments = url.Split('/', StringSplitOptions.RemoveEmptyEntries);
+		return segments.Length > 0 ? segments[0] : "documentation";
+	}
+
+	/// <summary>
+	/// Rewrites an already-resolved link URL to its bundle-relative form via <see cref="ComputeBundlePath"/>.
+	/// Internal links are normally host-relative paths, but some render paths (image/figure URLs, cross-links
+	/// resolved via the assembler's production <see cref="Elastic.Documentation.Configuration.BuildContext.CanonicalBaseUrl"/>)
+	/// absolutize even same-site links before this rewriter sees them — <paramref name="canonicalBaseUrl"/>
+	/// lets us recognize and unwrap those self-referencing URLs back to bundle-relative form. Only URLs whose
+	/// host genuinely differs (real external references) are left untouched — OKF tolerates those.
+	/// </summary>
+	internal static string? RewriteLinkUrl(string? url, string? urlPathPrefix, Uri? canonicalBaseUrl)
+	{
+		if (string.IsNullOrEmpty(url))
+			return url;
+
+		if (canonicalBaseUrl is not null
+			&& Uri.TryCreate(url, UriKind.Absolute, out var absolute)
+			&& string.Equals(absolute.Scheme, canonicalBaseUrl.Scheme, StringComparison.OrdinalIgnoreCase)
+			&& string.Equals(absolute.Host, canonicalBaseUrl.Host, StringComparison.OrdinalIgnoreCase))
+			url = absolute.PathAndQuery + absolute.Fragment;
+
+		if (Uri.IsWellFormedUriString(url, UriKind.Absolute))
+			return url;
+
+		var anchorIndex = url.IndexOf('#');
+		var path = anchorIndex >= 0 ? url[..anchorIndex] : url;
+		var anchor = anchorIndex >= 0 ? url[anchorIndex..] : string.Empty;
+
+		// TODO(api-explorer): /api/* pages are genuine third-party (OpenAPI-generated) reference endpoints —
+		// they have no backing markdown file in this export, so link to the live site instead of a bundle path
+		// that doesn't exist. Once ApiExplorer output is resolvable as markdown, remove this exception.
+		if (IsApiReferencePath(path, urlPathPrefix))
+			return canonicalBaseUrl is not null ? $"{new Uri(canonicalBaseUrl, path)}{anchor}" : $"{path}{anchor}";
+
+		return $"/{ComputeBundlePath(path, urlPathPrefix)}{anchor}";
+	}
+
+	/// <summary>
+	/// True when the (prefix-stripped) path falls under the <c>/api</c> section — see the TODO in
+	/// <see cref="RewriteLinkUrl"/> for why these are excepted from bundle-relative rewriting.
+	/// </summary>
+	internal static bool IsApiReferencePath(string path, string? urlPathPrefix)
+	{
+		var prefix = urlPathPrefix ?? string.Empty;
+		var stripped = prefix.Length > 0 && path.StartsWith(prefix, StringComparison.Ordinal) ? path[prefix.Length..] : path;
+		stripped = stripped.Trim('/');
+		return stripped == "api" || stripped.StartsWith("api/", StringComparison.Ordinal);
+	}
+
+	private static string CreateConceptContent(MarkdownExportFileContext context)
+	{
+		var urlPathPrefix = context.BuildContext.UrlPathPrefix;
+		var canonicalBaseUrl = context.BuildContext.CanonicalBaseUrl;
+		var body = DocumentationObjectPoolProvider.UseLlmMarkdownRenderer(context.BuildContext, url => RewriteLinkUrl(url, urlPathPrefix, canonicalBaseUrl), context.Document, static (renderer, document) =>
+		{
+			_ = renderer.Render(document);
+		});
+
+		var sourceFile = context.SourceFile;
+		var frontMatter = DocumentationObjectPoolProvider.StringBuilderPool.Get();
+		try
+		{
+			_ = frontMatter.AppendLine("---");
+			_ = frontMatter.AppendLine($"type: {DeriveType(context.NavigationItem.Url, context.BuildContext.UrlPathPrefix)}");
+			_ = frontMatter.AppendLine($"title: {sourceFile.Title}");
+			if (!string.IsNullOrEmpty(sourceFile.YamlFrontMatter?.NavigationTitle))
+				_ = frontMatter.AppendLine($"navigation_title: {sourceFile.YamlFrontMatter.NavigationTitle}");
+			_ = frontMatter.AppendLine($"description: {GetDescription(context)}");
+			_ = frontMatter.AppendLine($"resource: {GetResourceUrl(context)}");
+
+			var tags = GetTags(context);
+			if (tags.Count > 0)
+			{
+				_ = frontMatter.AppendLine("tags:");
+				foreach (var tag in tags)
+					_ = frontMatter.AppendLine($"  - {tag}");
+			}
+			_ = frontMatter.AppendLine("---");
+			_ = frontMatter.AppendLine();
+			_ = frontMatter.AppendLine($"# {sourceFile.Title}");
+			_ = frontMatter.Append(body);
+			return frontMatter.ToString();
+		}
+		finally
+		{
+			DocumentationObjectPoolProvider.StringBuilderPool.Return(frontMatter);
+		}
+	}
+
+	private static string GetDescription(MarkdownExportFileContext context) =>
+		!string.IsNullOrEmpty(context.SourceFile.YamlFrontMatter?.Description)
+			? context.SourceFile.YamlFrontMatter.Description
+			: new DescriptionGenerator().GenerateDescription(context.Document);
+
+	private static string GetResourceUrl(MarkdownExportFileContext context) =>
+		context.BuildContext.CanonicalBaseUrl is { } baseUrl
+			? new Uri(baseUrl, context.NavigationItem.Url).ToString().TrimEnd('/')
+			: context.NavigationItem.Url.TrimEnd('/');
+
+	private static List<string> GetTags(MarkdownExportFileContext context)
+	{
+		var sourceFile = context.SourceFile;
+		var inferrer = context.InferenceService ?? new NoopDocumentInferrer();
+		var inference = inferrer.InferForMarkdown(
+			context.BuildContext.Git.RepositoryName,
+			sourceFile.YamlFrontMatter?.MappedPages,
+			context.DocumentationSet.Configuration.Products,
+			sourceFile.YamlFrontMatter?.Products,
+			sourceFile.YamlFrontMatter?.AppliesTo
+		);
+
+		var tags = inference.RelatedProducts.Select(p => p.DisplayName).Order().ToList();
+
+		var appliesTo = sourceFile.YamlFrontMatter?.AppliesTo;
+		if (appliesTo is not null && appliesTo != ApplicableTo.All && appliesTo != ApplicableTo.Default)
+			tags.AddRange(GetAppliesToItems(appliesTo, context.BuildContext));
+
+		return tags;
+	}
+
+	private static List<string> GetAppliesToItems(ApplicableTo appliesTo, Elastic.Documentation.Configuration.BuildContext buildContext)
+	{
+		var viewModel = new ApplicableToViewModel
+		{
+			AppliesTo = appliesTo,
+			Inline = true,
+			ShowTooltip = true,
+			VersionsConfig = buildContext.VersionsConfiguration
+		};
+
+		var items = viewModel.GetApplicabilityItems();
+		return items.Select(item =>
+		{
+			var displayName = item.ApplicabilityDefinition.DisplayName.Replace("&nbsp;", " ");
+			var popoverData = item.RenderData.PopoverData;
+			var availabilityText = popoverData?.AvailabilityItems is { Length: > 0 }
+				? string.Join(", ", popoverData.AvailabilityItems.Select(a => a.Text))
+				: "Available";
+			return $"{displayName}: {availabilityText}";
+		}).ToList();
+	}
+
+	/// <summary>
+	/// Synthesizes a reserved <c>index.md</c> per bundle directory (including the root), grouping concepts
+	/// and subdirectories into markdown lists as described by OKF §6. Reserved index files carry no
+	/// frontmatter, except the bundle-root index which declares <c>okf_version</c>.
+	/// </summary>
+	private async Task WriteIndexFilesAsync(IFileSystem fs, IDirectoryInfo staging, Cancel ctx)
+	{
+		var byDirectory = _entries
+			.GroupBy(e => GetDirectory(e.BundlePath), StringComparer.Ordinal)
+			.ToDictionary(g => g.Key, g => g.ToList(), StringComparer.Ordinal);
+
+		var directories = new HashSet<string>(byDirectory.Keys, StringComparer.Ordinal) { "" };
+		foreach (var directory in byDirectory.Keys)
+		{
+			var parent = GetDirectory(directory);
+			while (true)
+			{
+				_ = directories.Add(parent);
+				if (parent.Length == 0)
+					break;
+				parent = GetDirectory(parent);
+			}
+		}
+
+		var subdirectoriesByParent = directories
+			.Where(d => d.Length > 0)
+			.GroupBy(GetDirectory, StringComparer.Ordinal)
+			.ToDictionary(g => g.Key, g => g.OrderBy(d => d, StringComparer.Ordinal).ToList(), StringComparer.Ordinal);
+
+		foreach (var directory in directories)
+		{
+			var concepts = byDirectory.GetValueOrDefault(directory, []);
+			var subdirectories = subdirectoriesByParent.GetValueOrDefault(directory, []);
+			var content = RenderIndexContent(directory, concepts, subdirectories);
+
+			var indexPath = directory.Length == 0
+				? fs.Path.Combine(staging.FullName, ReservedIndexFileName)
+				: fs.Path.Combine(staging.FullName, directory, ReservedIndexFileName);
+			if (fs.Path.GetDirectoryName(indexPath) is { } dir && !fs.Directory.Exists(dir))
+				_ = fs.Directory.CreateDirectory(dir);
+			await fs.File.WriteAllTextAsync(indexPath, content, Encoding.UTF8, ctx);
+		}
+	}
+
+	internal static string GetDirectory(string bundlePath)
+	{
+		var lastSlash = bundlePath.LastIndexOf('/');
+		return lastSlash < 0 ? string.Empty : bundlePath[..lastSlash];
+	}
+
+	internal static string RenderIndexContent(
+		string directory,
+		IReadOnlyCollection<ConceptEntry> concepts,
+		IReadOnlyCollection<string> subdirectories)
+	{
+		var sb = DocumentationObjectPoolProvider.StringBuilderPool.Get();
+		try
+		{
+			if (directory.Length == 0)
+				_ = sb.AppendLine("---").AppendLine("okf_version: \"0.1\"").AppendLine("---").AppendLine();
+
+			if (concepts.Count > 0)
+			{
+				_ = sb.AppendLine("# Documents").AppendLine();
+				foreach (var concept in concepts.OrderBy(c => c.BundlePath, StringComparer.Ordinal))
+				{
+					var fileName = concept.BundlePath[(concept.BundlePath.LastIndexOf('/') + 1)..];
+					_ = sb.AppendLine($"* [{concept.Title}]({fileName}) - {concept.Description}");
+				}
+				_ = sb.AppendLine();
+			}
+
+			if (subdirectories.Count > 0)
+			{
+				_ = sb.AppendLine("# Subdirectories").AppendLine();
+				foreach (var subdirectory in subdirectories)
+				{
+					var folderName = subdirectory[(subdirectory.LastIndexOf('/') + 1)..];
+					// The subdirectory's landing page (if any) is a sibling file in THIS directory, not a child.
+					var landingEntry = concepts.FirstOrDefault(e => e.BundlePath == $"{subdirectory}.md");
+					var description = landingEntry?.Description;
+					_ = string.IsNullOrEmpty(description)
+						? sb.AppendLine($"* [{folderName}]({folderName}/)")
+						: sb.AppendLine($"* [{folderName}]({folderName}/) - {description}");
+				}
+				_ = sb.AppendLine();
+			}
+
+			return sb.ToString().TrimEnd() + Environment.NewLine;
+		}
+		finally
+		{
+			DocumentationObjectPoolProvider.StringBuilderPool.Return(sb);
+		}
+	}
+
+	internal sealed record ConceptEntry(string BundlePath, string Title, string Description);
+}

--- a/src/Elastic.Markdown/Helpers/DocumentationObjectPoolProvider.cs
+++ b/src/Elastic.Markdown/Helpers/DocumentationObjectPoolProvider.cs
@@ -23,11 +23,19 @@ internal static class DocumentationObjectPoolProvider
 	private static readonly ObjectPool<LlmMarkdownRenderSubscription> LlmMarkdownRendererPool = PoolProvider.Create(new LlmMarkdownRendererPooledObjectPolicy());
 	private static readonly ObjectPool<PlainTextRenderSubscription> PlainTextRendererPool = PoolProvider.Create(new PlainTextRendererPooledObjectPolicy());
 
-	public static string UseLlmMarkdownRenderer<TContext>(IDocumentationConfigurationContext buildContext, TContext context, Action<LlmMarkdownRenderer, TContext> action)
+	public static string UseLlmMarkdownRenderer<TContext>(IDocumentationConfigurationContext buildContext, TContext context, Action<LlmMarkdownRenderer, TContext> action) =>
+		UseLlmMarkdownRenderer(buildContext, linkUrlRewriter: null, context, action);
+
+	/// <summary>
+	/// Same as <see cref="UseLlmMarkdownRenderer{TContext}(IDocumentationConfigurationContext,TContext,Action{LlmMarkdownRenderer,TContext})"/>
+	/// but allows overriding link URL resolution (e.g. for the OKF exporter's bundle-relative links).
+	/// </summary>
+	public static string UseLlmMarkdownRenderer<TContext>(IDocumentationConfigurationContext buildContext, Func<string?, string?>? linkUrlRewriter, TContext context, Action<LlmMarkdownRenderer, TContext> action)
 	{
 		var subscription = LlmMarkdownRendererPool.Get();
 		subscription.SetBuildContext(buildContext);
 		subscription.LlmMarkdownRenderer.Reset();
+		subscription.LlmMarkdownRenderer.LinkUrlRewriter = linkUrlRewriter;
 		try
 		{
 			action(subscription.LlmMarkdownRenderer, context);

--- a/src/Elastic.Markdown/Myst/Renderers/LlmMarkdown/LlmBlockRenderers.cs
+++ b/src/Elastic.Markdown/Myst/Renderers/LlmMarkdown/LlmBlockRenderers.cs
@@ -31,7 +31,7 @@ public static class LlmRenderingHelpers
 {
 	public static void RenderBlockWithIndentation(LlmMarkdownRenderer renderer, MarkdownObject block, string indentation = "  ")
 	{
-		var content = DocumentationObjectPoolProvider.UseLlmMarkdownRenderer(renderer.BuildContext, block, static (tmpRenderer, obj) =>
+		var content = DocumentationObjectPoolProvider.UseLlmMarkdownRenderer(renderer.BuildContext, renderer.LinkUrlRewriter, block, static (tmpRenderer, obj) =>
 		{
 			_ = tmpRenderer.Render(obj);
 		});
@@ -359,7 +359,7 @@ public class LlmListRenderer : MarkdownObjectRenderer<LlmMarkdownRenderer, ListB
 		}
 
 		// Render other blocks in separate context and re-indent each line
-		var blockOutput = DocumentationObjectPoolProvider.UseLlmMarkdownRenderer(renderer.BuildContext, block, static (tmpRenderer, obj) =>
+		var blockOutput = DocumentationObjectPoolProvider.UseLlmMarkdownRenderer(renderer.BuildContext, renderer.LinkUrlRewriter, block, static (tmpRenderer, obj) =>
 		{
 			_ = tmpRenderer.Render(obj);
 		});
@@ -464,6 +464,7 @@ public class LlmTableRenderer : MarkdownObjectRenderer<LlmMarkdownRenderer, Tabl
 	private static string RenderTableCellContent(LlmMarkdownRenderer renderer, TableCell cell) =>
 		DocumentationObjectPoolProvider.UseLlmMarkdownRenderer(
 			renderer.BuildContext,
+			renderer.LinkUrlRewriter,
 			cell,
 			static (tmpRenderer, c) =>
 			{
@@ -893,7 +894,7 @@ public class LlmDirectiveRenderer : MarkdownObjectRenderer<LlmMarkdownRenderer, 
 	private static void WriteChildrenWithIndentation(LlmMarkdownRenderer renderer, Block container, string indent)
 	{
 		// Capture output and manually add indentation
-		var content = DocumentationObjectPoolProvider.UseLlmMarkdownRenderer(renderer.BuildContext, container, static (tmpRenderer, obj) =>
+		var content = DocumentationObjectPoolProvider.UseLlmMarkdownRenderer(renderer.BuildContext, renderer.LinkUrlRewriter, container, static (tmpRenderer, obj) =>
 		{
 			switch (obj)
 			{
@@ -946,7 +947,7 @@ public class LlmDefinitionItemRenderer : MarkdownObjectRenderer<LlmMarkdownRende
 
 	private static string GetPlainTextFromLeafBlock(LlmMarkdownRenderer renderer, LeafBlock leafBlock)
 	{
-		var markdownText = DocumentationObjectPoolProvider.UseLlmMarkdownRenderer(renderer.BuildContext, leafBlock, static (tmpRenderer, obj) =>
+		var markdownText = DocumentationObjectPoolProvider.UseLlmMarkdownRenderer(renderer.BuildContext, renderer.LinkUrlRewriter, leafBlock, static (tmpRenderer, obj) =>
 		{
 			tmpRenderer.WriteLeafInline(obj);
 		});

--- a/src/Elastic.Markdown/Myst/Renderers/LlmMarkdown/LlmInlineRenderers.cs
+++ b/src/Elastic.Markdown/Myst/Renderers/LlmMarkdown/LlmInlineRenderers.cs
@@ -33,8 +33,10 @@ public class LlmLinkInlineRenderer : MarkdownObjectRenderer<LlmMarkdownRenderer,
 			renderer.WriteChildren(obj);
 			renderer.Writer.Write("](");
 			var url = obj.GetDynamicUrl?.Invoke() ?? obj.Url;
-			var absoluteUrl = LlmRenderingHelpers.MakeAbsoluteUrl(renderer, url);
-			renderer.Writer.Write(absoluteUrl ?? string.Empty);
+			var rewrittenUrl = renderer.LinkUrlRewriter is { } rewriter
+				? rewriter(url)
+				: LlmRenderingHelpers.MakeAbsoluteUrl(renderer, url);
+			renderer.Writer.Write(rewrittenUrl ?? string.Empty);
 		}
 		if (!string.IsNullOrEmpty(obj.Title))
 		{

--- a/src/Elastic.Markdown/Myst/Renderers/LlmMarkdown/LlmMarkdownRenderer.cs
+++ b/src/Elastic.Markdown/Myst/Renderers/LlmMarkdown/LlmMarkdownRenderer.cs
@@ -17,9 +17,20 @@ public class LlmMarkdownRenderer : TextRendererBase
 	private bool _isAtLineStart = true;
 
 	/// <summary>
+	/// Optional hook to override how link URLs are rewritten (e.g. to bundle-relative paths for the
+	/// OKF exporter). When <c>null</c>, <see cref="LlmLinkInlineRenderer"/> falls back to
+	/// <see cref="LlmRenderingHelpers.MakeAbsoluteUrl(LlmMarkdownRenderer, string?)"/>.
+	/// </summary>
+	public Func<string?, string?>? LinkUrlRewriter { get; set; }
+
+	/// <summary>
 	/// Resets internal state for pooled reuse
 	/// </summary>
-	public void Reset() => _isAtLineStart = true;
+	public void Reset()
+	{
+		_isAtLineStart = true;
+		LinkUrlRewriter = null;
+	}
 
 	/// <summary>
 	/// Ensures that the output ends with a line break (only adds one if needed)

--- a/src/services/Elastic.Documentation.Assembler/Building/ExporterParser.cs
+++ b/src/services/Elastic.Documentation.Assembler/Building/ExporterParser.cs
@@ -12,7 +12,7 @@ namespace Elastic.Documentation.Assembler.Building;
 /// </summary>
 /// <remarks>
 /// Aliases: llm/llmtext, es/elasticsearch, html, config/configuration,
-///          links/linkmetadata, state/documentationstate, redirect/redirects,
+///          links/linkmetadata, state/documentationstate, redirect/redirects, okf,
 ///          default (expands to <see cref="ExportOptions.Default"/>),
 ///          metadata (expands to <see cref="ExportOptions.MetadataOnly"/>),
 ///          none (empty set).
@@ -53,6 +53,9 @@ public class ExporterParser : IArgumentParser<IReadOnlySet<Exporter>>
 				case "redirects":
 					_ = set.Add(Exporter.Redirects);
 					break;
+				case "okf":
+					_ = set.Add(Exporter.Okf);
+					break;
 				case "none":
 					break;
 				case "default":
@@ -65,7 +68,7 @@ public class ExporterParser : IArgumentParser<IReadOnlySet<Exporter>>
 					break;
 				default:
 					throw new ArgumentException(
-						$"Unknown exporter '{token}'. Valid values: html, llm, es, config, links, state, redirects, default, metadata, none.");
+						$"Unknown exporter '{token}'. Valid values: html, llm, es, config, links, state, redirects, okf, default, metadata, none.");
 			}
 		}
 		result = set;

--- a/src/services/Elastic.Documentation.Isolated/ExporterParser.cs
+++ b/src/services/Elastic.Documentation.Isolated/ExporterParser.cs
@@ -12,7 +12,7 @@ namespace Elastic.Documentation.Isolated;
 /// </summary>
 /// <remarks>
 /// Aliases: llm/llmtext, es/elasticsearch, html, config/configuration,
-///          links/linkmetadata, state/documentationstate, redirect/redirects,
+///          links/linkmetadata, state/documentationstate, redirect/redirects, okf,
 ///          default (expands to <see cref="ExportOptions.Default"/>),
 ///          metadata (expands to <see cref="ExportOptions.MetadataOnly"/>),
 ///          none (empty set).
@@ -53,6 +53,9 @@ public class ExporterParser : IArgumentParser<IReadOnlySet<Exporter>>
 				case "redirects":
 					_ = set.Add(Exporter.Redirects);
 					break;
+				case "okf":
+					_ = set.Add(Exporter.Okf);
+					break;
 				case "none":
 					break;
 				case "default":
@@ -65,7 +68,7 @@ public class ExporterParser : IArgumentParser<IReadOnlySet<Exporter>>
 					break;
 				default:
 					throw new ArgumentException(
-						$"Unknown exporter '{token}'. Valid values: html, llm, es, config, links, state, redirects, default, metadata, none.");
+						$"Unknown exporter '{token}'. Valid values: html, llm, es, config, links, state, redirects, okf, default, metadata, none.");
 			}
 		}
 		result = set;

--- a/src/services/Elastic.Documentation.Isolated/IsolatedBuildService.cs
+++ b/src/services/Elastic.Documentation.Isolated/IsolatedBuildService.cs
@@ -175,6 +175,9 @@ public class IsolatedBuildService(
 		if (runningOnCi)
 			await githubActionsService.SetOutputAsync("landing-page-path", set.FirstInterestingUrl);
 
+		var finishTasks = markdownExporters.Select(async e => await e.FinishExportAsync(context.OutputDirectory, ctx));
+		_ = await Task.WhenAll(finishTasks);
+
 		tasks = markdownExporters.Select(async e => await e.StopAsync(ctx));
 		await Task.WhenAll(tasks);
 		_logger.LogInformation("Finished building and exporting exporters {Exporters}", exporters);
@@ -234,6 +237,9 @@ public class IsolatedBuildService(
 
 		if (manageLifecycle)
 		{
+			var finishTasks = allExporters.Select(async e => await e.FinishExportAsync(context.OutputDirectory, ctx));
+			_ = await Task.WhenAll(finishTasks);
+
 			var stopTasks = allExporters.Select(async e => await e.StopAsync(ctx));
 			await Task.WhenAll(stopTasks);
 		}

--- a/tests/Elastic.Markdown.Tests/Exporters/OkfMarkdownExporterTests.cs
+++ b/tests/Elastic.Markdown.Tests/Exporters/OkfMarkdownExporterTests.cs
@@ -1,0 +1,255 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using AwesomeAssertions;
+using Elastic.Markdown;
+using Elastic.Markdown.Exporters;
+
+namespace Elastic.Markdown.Tests.Exporters;
+
+public class OkfMarkdownExporterTests
+{
+	[Fact]
+	public void ComputeBundlePath_RootUrl_ReturnsOverviewMd()
+	{
+		var bundlePath = OkfMarkdownExporter.ComputeBundlePath("/", urlPathPrefix: "");
+
+		bundlePath.Should().Be("overview.md");
+	}
+
+	[Fact]
+	public void ComputeBundlePath_FolderLandingUrl_ReturnsSiblingFolderMd()
+	{
+		var bundlePath = OkfMarkdownExporter.ComputeBundlePath("/reference/foo", urlPathPrefix: "");
+
+		bundlePath.Should().Be("reference/foo.md");
+	}
+
+	[Fact]
+	public void ComputeBundlePath_LeafPageUrl_ReturnsPathWithMdExtension()
+	{
+		var bundlePath = OkfMarkdownExporter.ComputeBundlePath("/reference/foo/bar", urlPathPrefix: "");
+
+		bundlePath.Should().Be("reference/foo/bar.md");
+	}
+
+	[Fact]
+	public void ComputeBundlePath_UrlPathPrefixConfigured_IsStripped()
+	{
+		var bundlePath = OkfMarkdownExporter.ComputeBundlePath("/docs/reference/foo", urlPathPrefix: "/docs");
+
+		bundlePath.Should().Be("reference/foo.md");
+	}
+
+	[Fact]
+	public void DeriveType_UrlWithPrefixAndSection_ReturnsFirstSegmentAfterPrefix()
+	{
+		var type = OkfMarkdownExporter.DeriveType("/docs/reference/query-languages/eql", "/docs");
+
+		type.Should().Be("reference");
+	}
+
+	[Fact]
+	public void DeriveType_NoPrefixConfigured_ReturnsFirstSegment()
+	{
+		var type = OkfMarkdownExporter.DeriveType("/solutions/search", urlPathPrefix: "");
+
+		type.Should().Be("solutions");
+	}
+
+	[Fact]
+	public void DeriveType_RootUrl_ReturnsDocumentationFallback()
+	{
+		var type = OkfMarkdownExporter.DeriveType("/", urlPathPrefix: "");
+
+		type.Should().Be("documentation");
+	}
+
+	[Fact]
+	public void RewriteLinkUrl_InternalLinkWithAnchor_ReturnsBundleRelativePathWithAnchor()
+	{
+		var rewritten = OkfMarkdownExporter.RewriteLinkUrl("/reference/foo/bar#section", urlPathPrefix: "", canonicalBaseUrl: null);
+
+		rewritten.Should().Be("/reference/foo/bar.md#section");
+	}
+
+	[Fact]
+	public void RewriteLinkUrl_ExternalAbsoluteUrl_ReturnsUnchanged()
+	{
+		var rewritten = OkfMarkdownExporter.RewriteLinkUrl("https://example.com/page", urlPathPrefix: "", canonicalBaseUrl: new Uri("https://www.elastic.co"));
+
+		rewritten.Should().Be("https://example.com/page");
+	}
+
+	[Fact]
+	public void RewriteLinkUrl_UrlPathPrefixConfigured_IsStripped()
+	{
+		var rewritten = OkfMarkdownExporter.RewriteLinkUrl("/docs/reference/foo", urlPathPrefix: "/docs", canonicalBaseUrl: null);
+
+		rewritten.Should().Be("/reference/foo.md");
+	}
+
+	[Fact]
+	public void RewriteLinkUrl_NullOrEmpty_ReturnsInputUnchanged()
+	{
+		OkfMarkdownExporter.RewriteLinkUrl(null, urlPathPrefix: "", canonicalBaseUrl: null).Should().BeNull();
+		OkfMarkdownExporter.RewriteLinkUrl(string.Empty, urlPathPrefix: "", canonicalBaseUrl: null).Should().Be(string.Empty);
+	}
+
+	[Fact]
+	public void RewriteLinkUrl_RootLink_ReturnsOverviewMd()
+	{
+		var rewritten = OkfMarkdownExporter.RewriteLinkUrl("/", urlPathPrefix: "", canonicalBaseUrl: null);
+
+		rewritten.Should().Be("/overview.md");
+	}
+
+	[Fact]
+	public void RewriteLinkUrl_SelfReferencingAbsoluteUrlMatchingCanonicalBase_UnwrapsToBundleRelativePath()
+	{
+		// The assembler always sets CanonicalBaseUrl to the production URL, which can leak into rendered
+		// link text for otherwise-internal links (e.g. via cross-link resolution or image URL absolutization
+		// paths that bypass the rewriter). These must still resolve to bundle-relative paths, not pass through.
+		var rewritten = OkfMarkdownExporter.RewriteLinkUrl(
+			"https://www.elastic.co/docs/deploy-manage/deploy#about-orchestration",
+			urlPathPrefix: "/docs",
+			canonicalBaseUrl: new Uri("https://www.elastic.co"));
+
+		rewritten.Should().Be("/deploy-manage/deploy.md#about-orchestration");
+	}
+
+	[Fact]
+	public void RewriteLinkUrl_ApiReferencePath_ReturnsLiveSiteUrlUnchanged()
+	{
+		// /api/* pages are genuine third-party (OpenAPI-generated) endpoints with no backing markdown file
+		// in this export — see the TODO(api-explorer) in RewriteLinkUrl.
+		var rewritten = OkfMarkdownExporter.RewriteLinkUrl(
+			"https://www.elastic.co/docs/api/some-endpoint",
+			urlPathPrefix: "/docs",
+			canonicalBaseUrl: new Uri("https://www.elastic.co"));
+
+		rewritten.Should().Be("https://www.elastic.co/docs/api/some-endpoint");
+	}
+
+	[Fact]
+	public void RewriteLinkUrl_RelativeApiReferencePath_ReturnsAbsoluteLiveSiteUrl()
+	{
+		var rewritten = OkfMarkdownExporter.RewriteLinkUrl(
+			"/docs/api/some-endpoint#section",
+			urlPathPrefix: "/docs",
+			canonicalBaseUrl: new Uri("https://www.elastic.co"));
+
+		rewritten.Should().Be("https://www.elastic.co/docs/api/some-endpoint#section");
+	}
+
+	[Fact]
+	public void IsApiReferencePath_ApiSegmentAfterPrefix_ReturnsTrue()
+	{
+		OkfMarkdownExporter.IsApiReferencePath("/docs/api/some-endpoint", urlPathPrefix: "/docs").Should().BeTrue();
+		OkfMarkdownExporter.IsApiReferencePath("/docs/api", urlPathPrefix: "/docs").Should().BeTrue();
+	}
+
+	[Fact]
+	public void IsApiReferencePath_NonApiSegment_ReturnsFalse()
+	{
+		OkfMarkdownExporter.IsApiReferencePath("/docs/reference/foo", urlPathPrefix: "/docs").Should().BeFalse();
+		// "apic" shouldn't fuzzy-match "api"
+		OkfMarkdownExporter.IsApiReferencePath("/docs/apiconfig", urlPathPrefix: "/docs").Should().BeFalse();
+	}
+
+	[Fact]
+	public void RewriteLinkUrl_AbsoluteUrlWithDifferentHost_ReturnsUnchangedEvenWithCanonicalBaseSet()
+	{
+		var rewritten = OkfMarkdownExporter.RewriteLinkUrl(
+			"https://github.com/elastic/docs-builder",
+			urlPathPrefix: "/docs",
+			canonicalBaseUrl: new Uri("https://www.elastic.co"));
+
+		rewritten.Should().Be("https://github.com/elastic/docs-builder");
+	}
+
+	[Fact]
+	public void IsUtilityPage_NotFoundArchiveOrFullSearch_ReturnsTrue()
+	{
+		OkfMarkdownExporter.IsUtilityPage(MarkdownPageLayout.NotFound).Should().BeTrue();
+		OkfMarkdownExporter.IsUtilityPage(MarkdownPageLayout.Archive).Should().BeTrue();
+		OkfMarkdownExporter.IsUtilityPage(MarkdownPageLayout.FullSearch).Should().BeTrue();
+	}
+
+	[Fact]
+	public void IsUtilityPage_LandingPageOrNull_ReturnsFalse()
+	{
+		OkfMarkdownExporter.IsUtilityPage(MarkdownPageLayout.LandingPage).Should().BeFalse();
+		OkfMarkdownExporter.IsUtilityPage(null).Should().BeFalse();
+	}
+
+	[Fact]
+	public void GetDirectory_NestedPath_ReturnsParentDirectory()
+	{
+		OkfMarkdownExporter.GetDirectory("reference/foo/bar.md").Should().Be("reference/foo");
+	}
+
+	[Fact]
+	public void GetDirectory_TopLevelFile_ReturnsEmptyString()
+	{
+		OkfMarkdownExporter.GetDirectory("overview.md").Should().Be(string.Empty);
+	}
+
+	[Fact]
+	public void RenderIndexContent_RootDirectory_DeclaresOkfVersionAndNoOtherFrontmatter()
+	{
+		var content = OkfMarkdownExporter.RenderIndexContent(
+			directory: "",
+			concepts: [],
+			subdirectories: []);
+
+		content.Should().StartWith("---\nokf_version: \"0.1\"\n---");
+	}
+
+	[Fact]
+	public void RenderIndexContent_NonRootDirectory_HasNoFrontmatter()
+	{
+		var content = OkfMarkdownExporter.RenderIndexContent(
+			directory: "reference",
+			concepts: [],
+			subdirectories: []);
+
+		content.Should().NotContain("---");
+		content.Should().NotContain("okf_version");
+	}
+
+	[Fact]
+	public void RenderIndexContent_WithConceptsAndSubdirectories_GroupsThemUnderSeparateHeadings()
+	{
+		// "reference/foo.md" is the sibling landing page for the "reference/foo" subdirectory.
+		var concepts = new List<OkfMarkdownExporter.ConceptEntry>
+		{
+			new("reference/bar.md", "Bar", "Bar description"),
+			new("reference/foo.md", "Foo", "Foo description"),
+		};
+
+		var content = OkfMarkdownExporter.RenderIndexContent(
+			directory: "reference",
+			concepts: concepts,
+			subdirectories: ["reference/foo"]);
+
+		content.Should().Contain("# Documents");
+		content.Should().Contain("* [Bar](bar.md) - Bar description");
+		content.Should().Contain("* [Foo](foo.md) - Foo description");
+		content.Should().Contain("# Subdirectories");
+		content.Should().Contain("* [foo](foo/) - Foo description");
+	}
+
+	[Fact]
+	public void RenderIndexContent_SubdirectoryWithoutSiblingLandingPage_OmitsDescriptionSuffix()
+	{
+		var content = OkfMarkdownExporter.RenderIndexContent(
+			directory: "reference",
+			concepts: [],
+			subdirectories: ["reference/foo"]);
+
+		content.Should().Contain("* [foo](foo/)");
+		content.Should().NotContain("* [foo](foo/) -");
+	}
+}


### PR DESCRIPTION
## Why

We ship an `llm.zip` export today, optimized for feeding public documentation into LLM pipelines: it resolves every internal link to a public `elastic.co/docs/...` URL and treats `index.md` as ordinary content. That's the wrong shape for the [Open Knowledge Format (OKF) v0.1 spec](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md), which several downstream knowledge-catalog tools expect: OKF requires internal links to stay bundle-relative (so a bundle is browsable standalone, offline, without a live site behind it), reserves `index.md` for auto-generated directory listings only, and requires every concept doc to declare a `type` in its frontmatter.

## What

Adds a new, **opt-in** exporter (`--exporters okf`, not part of the default exporter set) that produces an `okf.zip` bundle conformant with OKF v0.1:

- **Concept docs**: every exported page gets curated OKF frontmatter (`type`, `title`, `navigation_title`, `description`, `resource`, `tags`) — internal-only fields from our own frontmatter (`layout`, `sub`, `noindex`, `cta`, `mapped_pages`) are dropped rather than passed through.
- **`type`** is derived from the page's top-level navigation section (e.g. `/reference/query-languages/eql` → `reference`).
- **Concept IDs / bundle paths** are derived purely from each page's final site URL, not its on-disk repository-relative path — this matters once multiple repos are merged into one site by the assembler, since two repos can otherwise have colliding relative paths (e.g. every repo's own `404.md`). A folder's landing page maps to a *sibling* `{folder}.md` file next to the `{folder}/` directory (mirroring `llm.zip`'s existing convention), so it never collides with OKF's reserved `index.md`.
- **`index.md`** files are synthesized per bundle directory (never treated as content) — grouped `# Documents` / `# Subdirectories` markdown lists per OKF §6, with `okf_version: "0.1"` declared only at the bundle root.
- **Utility/system pages** (404, search, archive) are excluded from the bundle — they're site chrome, not documentation concepts.
- **`/api/*` pages** are excepted from bundle-relative rewriting for now (kept as live `elastic.co` links) since they're OpenAPI-generated third-party endpoints with no backing markdown file yet — flagged with a `TODO(api-explorer)` to revisit once ApiExplorer output is exportable as markdown.

### `llm.zip` vs `okf.zip`

|  | `llm.zip` | `okf.zip` |
|---|---|---|
| Link resolution | Rewrites every internal link to a public `elastic.co/docs/...` URL | Rewrites every internal link to a bundle-relative local file (e.g. `/deploy-manage/deploy.md`) |
| Best for | Indexing public knowledge bases / feeding LLMs a self-contained public-URL-addressable corpus | Offline / local knowledge bases that need to browse and follow links without a live site behind them |
| `index.md` | Not reserved — root becomes `llms.txt`, folder landing pages become sibling `.md` files | Reserved for auto-generated directory listings per OKF §6; never contains authored content |
| Frontmatter | `title`, `description`, `url`, `products`, `applies_to` | OKF-required `type` plus `title`, `navigation_title`, `description`, `resource`, `tags` |
| Spec | Internal convention | [OKF v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) |

### How existing `index.md` content is handled

Our source repos author folder landing pages as `index.md` (e.g. `deploy-manage/index.md`). OKF reserves the `index.md` filename exclusively for auto-generated directory listings — it must never contain authored content — so this exporter never copies a source `index.md` into the bundle under that name. Instead:

- A landing page's content is written to a **sibling** `{folder}.md` file next to the `{folder}/` directory — e.g. `docs-content/deploy-manage/index.md` becomes `deploy-manage.md` sitting alongside the `deploy-manage/` directory in the bundle, not `deploy-manage/index.md`. This falls out naturally from deriving bundle paths from the page's site URL (a landing page's URL has no trailing `/index` segment) rather than its on-disk path, and mirrors the sibling-file convention `llm.zip` already uses for the same reason.
- Every bundle directory (including the bundle root) gets its **own freshly synthesized `index.md`** — a `# Documents` list of the concept files directly in that directory, and a `# Subdirectories` list of child folders. These are generated from the exported concepts themselves, not copied or derived from any source `index.md` file, and carry no frontmatter (except the bundle-root `index.md`, which declares `okf_version: "0.1"` per OKF §11).
- A subdirectory's entry in its parent's `# Subdirectories` list reuses the sibling landing page's own description (looked up as `{folder}.md` in the *current* directory's concept list) when one exists, so `[deploy-manage](deploy-manage/)` in the root index shows the same description as the `deploy-manage.md` concept itself. If a folder has no authored landing page, the subdirectory entry is listed with no description.
- Source `index.md` pages that are actually **utility/system pages** (404, search, archive — identified via their `layout` frontmatter) are dropped entirely rather than mapped to a sibling file, since they're site chrome, not documentation concepts.

Also includes two fixes that surfaced while building this against a real multi-repo assembler build:

- `IsolatedBuildService` (the plain `docs-builder build` CLI command) never called `FinishExportAsync` on any exporter, so local builds silently never produced `llm.zip`/`llms.txt` either — only the assembler/Codex pipelines did. Now wired up for both `Build` and `BuildDocumentationSet`.
- `LlmMarkdownRenderer`'s link-rewriter hook (added for `okf.zip`, used by nothing else) was silently dropped when rendering nested blocks (list items, table cells, quote blocks) because those recurse through a fresh pooled renderer instance. Fixed by propagating the rewriter through all five nested-render call sites.
