### PR TITLE
CI: Increase assembler preview S3 upload concurrency

### DIFF
--- a/.github/workflows/assembler-preview.yml
+++ b/.github/workflows/assembler-preview.yml
@@ -108,7 +108,13 @@ jobs:
         env:
           AWS_RETRY_MODE: standard
           AWS_MAX_ATTEMPTS: 6
+          AWS_S3_MAX_CONCURRENT_REQUESTS: 50
+          AWS_S3_MAX_QUEUE_SIZE: 20000
         run: |
+          aws configure set default.s3.preferred_transfer_client classic
+          aws configure set default.s3.max_concurrent_requests "${AWS_S3_MAX_CONCURRENT_REQUESTS}"
+          aws configure set default.s3.max_queue_size "${AWS_S3_MAX_QUEUE_SIZE}"
+
           aws s3 sync .artifacts/assembly/${ASSEMBLER_PREVIEW_PATH_PREFIX} "s3://elastic-docs-v3-website-preview/${ASSEMBLER_PREVIEW_PATH_PREFIX}" --delete --no-follow-symlinks
           aws cloudfront create-invalidation \
             --distribution-id EKT7LT5PM8RKS \


### PR DESCRIPTION
## Why

Assembler previews upload thousands of small files to S3, and the AWS CLI's default transfer settings limit concurrency, slowing down preview publishing on the larger runner.

## What

Configures the AWS CLI's S3 transfer planner to use the classic transfer client with a higher concurrent request limit (50) and queue size (20000) before running `aws s3 sync` in the assembler preview workflow.