### PR TITLE
Changelog scrubber: keep links to public repos marked skip in assembler.yml

### DIFF
--- a/docs/changelog/scrubber-allow-public-skip-repos.yaml
+++ b/docs/changelog/scrubber-allow-public-skip-repos.yaml
@@ -1,0 +1,16 @@
+type: bug-fix
+title: Keep links to public skip-repos when scrubbing bundles for the public CDN
+products:
+  - product: docs-builder
+    target: 1.25.0
+areas:
+  - Changelog
+prs:
+  - https://github.com/elastic/docs-builder/pull/3653
+description: |
+  The changelog scrubber Lambda excluded every `assembler.yml` reference repository
+  marked `skip: true` from its link allowlist, conflating "publishes no docs" with
+  "is private". Links to public link-only repos such as `elastic/roadmap` were
+  stripped from bundles during the private-to-public bucket transition even when
+  listed in the bundle's `link_allow_repos`. Only `private: true` now excludes a
+  repository from the allowlist.

--- a/src/infra/docs-lambda-changelog-scrubber/README.md
+++ b/src/infra/docs-lambda-changelog-scrubber/README.md
@@ -37,6 +37,6 @@ The `bootstrap` binary should be available under:
 
 ## Scrubbing logic
 
-- **Bundle files** (`bundle/{product}/*.yaml`, detected by the `bundle/` key prefix): `LinkAllowlistSanitizer.TryApplyBundle` scrubs `prs`/`issues` lists
+- **Bundle files** (`bundle/{product}/*.yaml`, detected by the `bundle/` key prefix): `LinkAllowlistSanitizer.ScrubBundleForPublic` scrubs `prs`/`issues` lists and text fields, dropping disallowed references (no sentinels in public output)
 - **Changelog entries** (`changelog/{org}/{repo}/{branch}/*.yaml`): `LinkAllowlistSanitizer.TryApplyChangelogEntry` scrubs `prs`, `issues`, `description`, `impact`, `action`
-- The allowlist is built once at cold start from the embedded `assembler.yml` via `BuildAllowReposFromAssembler`
+- The allowlist is built once at cold start from the embedded `assembler.yml` via `BuildAllowReposFromAssembler`: every reference repository **not** marked `private: true` is allowed. `skip: true` is ignored here — it only means the repo publishes no docs, so public link-only repos (e.g. `elastic/roadmap`) stay linkable

--- a/src/services/Elastic.Changelog/Bundling/LinkAllowlistSanitizer.cs
+++ b/src/services/Elastic.Changelog/Bundling/LinkAllowlistSanitizer.cs
@@ -115,7 +115,9 @@ public static partial class LinkAllowlistSanitizer
 
 	/// <summary>
 	/// Builds a list of allowed <c>owner/repo</c> strings from an <see cref="AssemblyConfiguration"/>
-	/// by collecting every reference repository that is not marked <c>private: true</c> or <c>skip: true</c>.
+	/// by collecting every reference repository that is not marked <c>private: true</c>.
+	/// <c>skip: true</c> only means the repository does not publish docs — it says nothing about
+	/// visibility, so public skip-repos (e.g. <c>elastic/roadmap</c>) remain linkable.
 	/// Bare keys (without a slash) are assumed to be under the <c>elastic</c> organization.
 	/// </summary>
 	public static IReadOnlyList<string> BuildAllowReposFromAssembler(AssemblyConfiguration assembly)
@@ -123,7 +125,7 @@ public static partial class LinkAllowlistSanitizer
 		var result = new List<string>();
 		foreach (var kvp in assembly.ReferenceRepositories)
 		{
-			if (kvp.Value.Private || kvp.Value.Skip)
+			if (kvp.Value.Private)
 				continue;
 
 			var key = kvp.Key;

--- a/tests/Elastic.Changelog.Tests/Changelogs/LinkAllowlistSanitizerTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/LinkAllowlistSanitizerTests.cs
@@ -372,7 +372,7 @@ public class LinkAllowlistSanitizerTests(ITestOutputHelper output) : ChangelogTe
 	// --- BuildAllowReposFromAssembler ---
 
 	[Fact]
-	public void BuildAllowReposFromAssembler_SkipsPrivateAndSkipped()
+	public void BuildAllowReposFromAssembler_ExcludesOnlyPrivateRepos()
 	{
 		var yaml =
 			"""
@@ -392,7 +392,29 @@ public class LinkAllowlistSanitizerTests(ITestOutputHelper output) : ChangelogTe
 		allow.Should().Contain("elastic/elasticsearch");
 		allow.Should().Contain("elastic/kibana");
 		allow.Should().NotContain("elastic/secret-team");
-		allow.Should().NotContain("elastic/old-repo");
+		allow.Should().Contain("elastic/old-repo");
+	}
+
+	[Fact]
+	public void BuildAllowReposFromAssembler_PublicSkipRepo_IsAllowed()
+	{
+		// Mirrors elastic/roadmap in assembler.yml: a public repo that publishes no docs
+		// (skip: true) but is a valid link target for changelog entries.
+		var yaml =
+			"""
+			references:
+			  roadmap:
+			    private: false
+			    skip: true
+			  kibana-team:
+			    private: true
+			    skip: true
+			""";
+		var asm = AssemblyConfiguration.Deserialize(yaml, skipPrivateRepositories: false);
+		var allow = LinkAllowlistSanitizer.BuildAllowReposFromAssembler(asm);
+
+		allow.Should().Contain("elastic/roadmap");
+		allow.Should().NotContain("elastic/kibana-team");
 	}
 
 	[Fact]


### PR DESCRIPTION
## Why

Bundles from private repos lose links to public repos when the changelog scrubber Lambda copies them from the private to the public S3 bucket, even when those repos are explicitly listed in the bundle's `link_allow_repos`. Concretely, `elastic/cloud`'s `cloud-2026-07-07.yaml` bundle keeps `https://github.com/elastic/roadmap/issues/39` at bundle time, but the public CDN copy has no `issues` at all.

Fixes elastic/docs-eng-team#661.

## What

The Lambda builds its allowlist from the embedded `config/assembler.yml` via `LinkAllowlistSanitizer.BuildAllowReposFromAssembler`, which excluded every reference repository marked `skip: true` in addition to `private: true`. But `skip` only means "don't clone/build docs from this repo" — it says nothing about visibility. `elastic/roadmap` was added to `assembler.yml` with `private: false, skip: true` (#3053) precisely so changelog links to it would be recognized, and the `skip` flag defeated that.

The allowlist now excludes only `private: true` repositories. Public skip-repos (`elastic/roadmap`, `elastic/docs-builder`) become linkable; all `private: true` repos (which include every private team repo currently marked skip) remain scrubbed.

Note for rollout: the Lambda redeploys via the release workflow (`changelog-scrubber-prod` environment), and since scrubbing is S3-event-driven, already-published bundles stay scrubbed until their private-bucket objects are re-uploaded.