### PR TITLE
Site: raise mobile pages nav z-index

### DIFF
--- a/src/Elastic.Documentation.Site/Layout/_PagesNav.cshtml
+++ b/src/Elastic.Documentation.Site/Layout/_PagesNav.cshtml
@@ -1,5 +1,5 @@
 @inherits RazorSlice<Elastic.Documentation.Site.GlobalLayoutViewModel>
-<aside class="sidebar font-sans bg-white fixed md:sticky shadow-2xl md:shadow-none left-full group-has-[#pages-nav-hamburger:checked]/body:left-0 bottom-0 md:left-auto top-[calc(var(--offset-top)+1px)] w-[80%] md:w-auto shrink-0 border-r border-r-grey-20 z-40 md:z-auto transition-[top,max-height] duration-300 md:order-1">
+<aside class="sidebar font-sans bg-white fixed md:sticky shadow-2xl md:shadow-none left-full group-has-[#pages-nav-hamburger:checked]/body:left-0 bottom-0 md:left-auto top-[calc(var(--offset-top)+1px)] w-[80%] md:w-auto shrink-0 border-r border-r-grey-20 z-[10000] md:z-auto transition-[top,max-height] duration-300 md:order-1">
 	<nav
 		id="pages-nav"
 		class="sidebar-nav h-full simple-scrollbar">
@@ -13,6 +13,6 @@
 	</label>
 </aside>
 @* ReSharper disable once Html.IdNotResolved *@
-<label for="pages-nav-hamburger" aria-hidden="true" class="hidden group-has-[#pages-nav-hamburger:checked]/body:block md:hidden! fixed top-0 left-0 right-0 bottom-0 bg-black/50 z-30 ">
+<label for="pages-nav-hamburger" aria-hidden="true" class="hidden group-has-[#pages-nav-hamburger:checked]/body:block md:hidden! fixed top-0 left-0 right-0 bottom-0 bg-black/50 z-[9999] ">
 	
 </label>


### PR DESCRIPTION
## What

- Raise the mobile pages navigation drawer z-index to 10000
- Raise the mobile navigation backdrop z-index to 9999

## Why

- On mobile, the open pages navigation drawer was appearing behind Elastic's global nav (z-index 9999)
- Users could not interact with the drawer correctly when the global nav overlapped it

## Notes

- Desktop layout is unchanged (`md:z-auto` on the sidebar, backdrop hidden on desktop)
- The drawer sits above the backdrop so navigation stays clickable when open


Made with [Cursor](https://cursor.com)