### PR TITLE
[Release notes] Add changelog upload --skip-etag-check option

### DIFF
--- a/docs/cli-schema.json
+++ b/docs/cli-schema.json
@@ -4398,6 +4398,14 @@
             },
             {
               "role": "flag",
+              "name": "skip-etag-check",
+              "type": "boolean",
+              "required": false,
+              "summary": "Upload every discovered file even when its content hash matches the remote object. Use to re-trigger downstream scrubbers without changing file content.",
+              "defaultValue": "false"
+            },
+            {
+              "role": "flag",
               "name": "log-level",
               "shortName": "l",
               "type": "enum",

--- a/docs/cli/changelog/cmd-upload.md
+++ b/docs/cli/changelog/cmd-upload.md
@@ -115,7 +115,14 @@ The registry refresh is best-effort: upload failures block the run, but a stale 
 
 :::{note}
 Upload uses content-hash–based incremental transfer. Unchanged files are skipped. Re-running the same command is safe and idempotent.
+If it's necessary to re-trigger downstream scrubbers without changing file content, pass `--skip-etag-check` to upload every discovered file even when its content hash matches the remote object.
 :::
+
+## Options
+
+| Option | Purpose |
+| ------ | ------- |
+| `--skip-etag-check` | Upload every discovered file even when its content hash matches the remote object. Each upload emits `s3:ObjectCreated`, which re-triggers the scrubber Lambda on the private bucket. Default behavior (without this flag) skips unchanged files. |
 
 ## Configuration
 

--- a/src/services/Elastic.Changelog/Uploading/ChangelogUploadService.cs
+++ b/src/services/Elastic.Changelog/Uploading/ChangelogUploadService.cs
@@ -51,6 +51,12 @@ public record ChangelogUploadArguments
 	/// CLI via the precedence <c>--branch</c> &gt; the current git branch.
 	/// </summary>
 	public string? Branch { get; init; }
+
+	/// <summary>
+	/// When true, upload every discovered file even when its content hash matches the remote object.
+	/// Useful to re-trigger downstream scrubbers without changing file content.
+	/// </summary>
+	public bool SkipEtagCheck { get; init; }
 }
 
 public class ChangelogUploadService(
@@ -108,7 +114,7 @@ public class ChangelogUploadService(
 		var client = s3Client ?? defaultClient!;
 		var etagCalculator = new S3EtagCalculator(logFactory, _fileSystem);
 		var uploader = new S3IncrementalUploader(logFactory, client, _fileSystem, etagCalculator, args.S3BucketName);
-		var result = await uploader.Upload(targets, ctx);
+		var result = await uploader.Upload(targets, args.SkipEtagCheck, ctx);
 
 		_logger.LogInformation("Upload complete: {Uploaded} uploaded, {Skipped} skipped, {Failed} failed", result.Uploaded, result.Skipped, result.Failed);
 

--- a/src/services/Elastic.Documentation.Integrations/S3/S3IncrementalUploader.cs
+++ b/src/services/Elastic.Documentation.Integrations/S3/S3IncrementalUploader.cs
@@ -29,7 +29,7 @@ public class S3IncrementalUploader(
 {
 	private readonly ILogger _logger = logFactory.CreateLogger<S3IncrementalUploader>();
 
-	public async Task<UploadResult> Upload(IReadOnlyList<UploadTarget> targets, Cancel ctx = default)
+	public async Task<UploadResult> Upload(IReadOnlyList<UploadTarget> targets, bool skipEtagCheck = false, Cancel ctx = default)
 	{
 		var uploaded = 0;
 		var skipped = 0;
@@ -41,14 +41,21 @@ public class S3IncrementalUploader(
 
 			try
 			{
-				var remoteEtag = await GetRemoteEtag(target.S3Key, ctx);
-				var localEtag = await etagCalculator.CalculateS3ETag(target.LocalPath, ctx);
-
-				if (remoteEtag != null && localEtag == remoteEtag)
+				if (!skipEtagCheck)
 				{
-					_logger.LogDebug("Skipping {S3Key} (ETag match)", target.S3Key);
-					skipped++;
-					continue;
+					var remoteEtag = await GetRemoteEtag(target.S3Key, ctx);
+					var localEtag = await etagCalculator.CalculateS3ETag(target.LocalPath, ctx);
+
+					if (remoteEtag != null && localEtag == remoteEtag)
+					{
+						_logger.LogDebug("Skipping {S3Key} (ETag match)", target.S3Key);
+						skipped++;
+						continue;
+					}
+				}
+				else
+				{
+					_logger.LogDebug("Uploading {S3Key} (--skip-etag-check)", target.S3Key);
 				}
 
 				_logger.LogInformation("Uploading {LocalPath} → s3://{Bucket}/{S3Key}", target.LocalPath, bucketName, target.S3Key);

--- a/src/tooling/docs-builder/Commands/ChangelogCommand.cs
+++ b/src/tooling/docs-builder/Commands/ChangelogCommand.cs
@@ -1647,6 +1647,7 @@ internal sealed partial class ChangelogCommands(
 	/// <param name="repo">GitHub repository name, the second segment of changelog entry keys (changelog/{org}/{repo}/{branch}/...). Falls back to bundle.repo in changelog.yml, then the git remote origin. Required for changelog uploads; ignored for bundle uploads.</param>
 	/// <param name="owner">GitHub owner (org), the first segment of changelog entry keys (changelog/{org}/{repo}/{branch}/...). Falls back to bundle.owner in changelog.yml, then the git remote origin. Required for changelog uploads; ignored for bundle uploads.</param>
 	/// <param name="branch">Branch, the third segment of changelog entry keys (changelog/{org}/{repo}/{branch}/...), stored verbatim. Falls back to the current checkout's branch. Required for changelog uploads; ignored for bundle uploads.</param>
+	/// <param name="skipEtagCheck">Upload every discovered file even when its content hash matches the remote object. Use to re-trigger downstream scrubbers without changing file content.</param>
 	[NoOptionsInjection]
 	public async Task<int> Upload(
 		string artifactType,
@@ -1657,6 +1658,7 @@ internal sealed partial class ChangelogCommands(
 		string? repo = null,
 		string? owner = null,
 		string? branch = null,
+		bool skipEtagCheck = false,
 		CancellationToken ct = default
 	)
 	{
@@ -1698,7 +1700,8 @@ internal sealed partial class ChangelogCommands(
 			Directory = resolvedDirectory,
 			Repo = resolvedRepo,
 			Owner = resolvedOwner,
-			Branch = resolvedBranch
+			Branch = resolvedBranch,
+			SkipEtagCheck = skipEtagCheck
 		};
 		serviceInvoker.AddCommand(service, args,
 			static async (s, c, state, ct) => await s.Upload(c, state, ct)

--- a/tests/Elastic.Documentation.Integrations.Tests/S3/S3IncrementalUploaderTests.cs
+++ b/tests/Elastic.Documentation.Integrations.Tests/S3/S3IncrementalUploaderTests.cs
@@ -42,7 +42,7 @@ public class S3IncrementalUploaderTests
 
 		var uploader = CreateUploader();
 		var ct = TestContext.Current.CancellationToken;
-		var result = await uploader.Upload([new UploadTarget(path, "elasticsearch/changelog/entry.yaml")], ct);
+		var result = await uploader.Upload([new UploadTarget(path, "elasticsearch/changelog/entry.yaml")], ctx: ct);
 
 		result.Uploaded.Should().Be(1);
 		result.Skipped.Should().Be(0);
@@ -67,7 +67,7 @@ public class S3IncrementalUploaderTests
 
 		var uploader = CreateUploader();
 		var ct = TestContext.Current.CancellationToken;
-		var result = await uploader.Upload([new UploadTarget(path, "kibana/changelog/entry.yaml")], ct);
+		var result = await uploader.Upload([new UploadTarget(path, "kibana/changelog/entry.yaml")], ctx: ct);
 
 		result.Uploaded.Should().Be(0);
 		result.Skipped.Should().Be(1);
@@ -75,6 +75,37 @@ public class S3IncrementalUploaderTests
 
 		A.CallTo(() => _s3Client.PutObjectAsync(A<PutObjectRequest>._, A<Cancel>._))
 			.MustNotHaveHappened();
+	}
+
+	[Fact]
+	public async Task Upload_UnchangedFile_WithSkipEtagCheck_Uploads()
+	{
+		var content = "unchanged changelog"u8.ToArray();
+		var path = UniquePath("entry.yaml");
+		_fileSystem.AddFile(path, new MockFileData(content));
+		var localEtag = Convert.ToHexStringLower(MD5.HashData(content));
+
+		A.CallTo(() => _s3Client.GetObjectMetadataAsync(A<GetObjectMetadataRequest>._, A<Cancel>._))
+			.Returns(new GetObjectMetadataResponse { ETag = $"\"{localEtag}\"" });
+
+		A.CallTo(() => _s3Client.PutObjectAsync(A<PutObjectRequest>._, A<Cancel>._))
+			.Returns(new PutObjectResponse());
+
+		var uploader = CreateUploader();
+		var ct = TestContext.Current.CancellationToken;
+		var result = await uploader.Upload([new UploadTarget(path, "kibana/changelog/entry.yaml")], skipEtagCheck: true, ctx: ct);
+
+		result.Uploaded.Should().Be(1);
+		result.Skipped.Should().Be(0);
+		result.Failed.Should().Be(0);
+
+		A.CallTo(() => _s3Client.GetObjectMetadataAsync(A<GetObjectMetadataRequest>._, A<Cancel>._))
+			.MustNotHaveHappened();
+
+		A.CallTo(() => _s3Client.PutObjectAsync(
+			A<PutObjectRequest>.That.Matches(r => r.Key == "kibana/changelog/entry.yaml" && r.BucketName == BucketName),
+			A<Cancel>._
+		)).MustHaveHappenedOnceExactly();
 	}
 
 	[Fact]
@@ -91,7 +122,7 @@ public class S3IncrementalUploaderTests
 
 		var uploader = CreateUploader();
 		var ct = TestContext.Current.CancellationToken;
-		var result = await uploader.Upload([new UploadTarget(path, "elasticsearch/changelog/entry.yaml")], ct);
+		var result = await uploader.Upload([new UploadTarget(path, "elasticsearch/changelog/entry.yaml")], ctx: ct);
 
 		result.Uploaded.Should().Be(1);
 		result.Skipped.Should().Be(0);
@@ -112,7 +143,7 @@ public class S3IncrementalUploaderTests
 
 		var uploader = CreateUploader();
 		var ct = TestContext.Current.CancellationToken;
-		var result = await uploader.Upload([new UploadTarget(path, "elasticsearch/changelog/entry.yaml")], ct);
+		var result = await uploader.Upload([new UploadTarget(path, "elasticsearch/changelog/entry.yaml")], ctx: ct);
 
 		result.Uploaded.Should().Be(0);
 		result.Skipped.Should().Be(0);
@@ -146,7 +177,7 @@ public class S3IncrementalUploaderTests
 		var result = await uploader.Upload([
 			new UploadTarget(newPath, "es/changelog/new.yaml"),
 			new UploadTarget(unchangedPath, "es/changelog/unchanged.yaml")
-		], ct);
+		], ctx: ct);
 
 		result.Uploaded.Should().Be(1);
 		result.Skipped.Should().Be(1);
@@ -158,7 +189,7 @@ public class S3IncrementalUploaderTests
 	{
 		var uploader = CreateUploader();
 		var ct = TestContext.Current.CancellationToken;
-		var result = await uploader.Upload([], ct);
+		var result = await uploader.Upload([], ctx: ct);
 
 		result.Uploaded.Should().Be(0);
 		result.Skipped.Should().Be(0);


### PR DESCRIPTION
## Summary

Adds `--skip-etag-check` to `docs-builder changelog upload` so operators can re-upload unchanged changelog/bundle YAML to the private S3 bucket and re-trigger the scrubber Lambda without modifying file content.

By default, upload uses ETag-based incremental transfer and skips files whose content hash matches the remote object. With `--skip-etag-check`, every discovered file is uploaded via `PutObject`, emitting `s3:ObjectCreated` for each object.

## Motivation

When scrubber logic or allowlists change, there is no way to force re-scrubbing of existing artifacts unless the file content changes. Re-uploading is currently the only trigger path for the scrubber Lambda.

## Changes

- **`S3IncrementalUploader`**: Added `skipEtagCheck` parameter; when true, bypasses remote ETag comparison and always uploads.
- **`ChangelogUploadService` / `ChangelogUploadArguments`**: Threaded `SkipEtagCheck` through the upload pipeline.
- **`ChangelogCommand.Upload`**: Exposed as `--skip-etag-check` CLI flag.
- **Tests**: Added `Upload_UnchangedFile_WithSkipEtagCheck_Uploads`; updated existing tests to use named `ctx:` after signature change.
- **Docs**: Updated `docs/cli/changelog/cmd-upload.md` with option table, note, and example.
- **CLI schema**: Regenerated `docs/cli-schema.json`.

## Usage

```sh
docs-builder changelog upload \
  --artifact-type bundle \
  --target s3 \
  --s3-bucket-name my-changelog-bundles \
  --skip-etag-check
```

## Out of scope

- Does not force `registry.json` rewrite when manifest content is unchanged (`RegistryBuilder` may still skip unchanged manifests). YAML re-upload alone is sufficient to re-trigger scrubbers on content objects.
