### PR TITLE
Fix changelog directive link-visibility default with CDN bundles

### DIFF
--- a/docs/syntax/changelog.md
+++ b/docs/syntax/changelog.md
@@ -121,7 +121,7 @@ Bundles whose repo is listed as private in `assembler.yml` hide links by default
 
 | Value | Behavior |
 |-------|----------|
-| `auto` | Hide all PR and issue links for bundles from private repos; show links for public repos. |
+| `auto` | Hide all PR and issue links for bundles from private repos; show links for public repos. When [`:cdn:`](#cdn) is set, **keep** links (CDN bundles are scrubbed for public delivery and assembler private-repo hiding does not apply). |
 | `keep-links` | Show PR and issue links even when the bundle source repo is private (does not undo bundle-time private-target sanitization)). |
 | `hide-links` | Hide all PR and issue links for this directive block. Refer to [Hiding links](#hide-links). |
 
@@ -206,6 +206,8 @@ The value names a product defined in [`products.yml`](https://github.com/elastic
 
 If the product cannot be inferred, or is not declared under `release_notes`, the block emits an error rather than rendering empty. When `:cdn:` is set, the local-folder argument is ignored. All other options (`:type:`, `:link-visibility:`, `:description-visibility:`, `:dropdowns:`, `:release-dates:`, `:subsections:`) and `hide-features` apply identically to CDN-sourced bundles.
 
+With `:link-visibility: auto` (the default), PR and issue links from CDN bundles are shown as-is. Public CDN copies are scrubbed before delivery, so the directive does not re-hide links based on `assembler.yml` private repositories. Explicit `:link-visibility: hide-links` still hides links for CDN-sourced bundles.
+
 The CDN base URL is build configuration, not authored per page: it defaults to the public changelog bundles distribution and can be overridden with the `DOCS_BUILDER_CHANGELOG_CDN` environment variable (an absolute `http`/`https` URL) for staging or local testing.
 
 Bundles are fetched **once at build startup** for every declared product, not per directive. If a declared product's registry cannot be fetched the build fails; an individual bundle that is missing from the CDN is skipped with a warning. For the full design — including the manifest format and infrastructure — see [Changelog bundle registry and CDN delivery](/development/changelog-bundle-registry.md).
@@ -285,15 +287,16 @@ For more details, go to [Hide features in bundles](../contribute/bundle-changelo
 
 A changelog can reference multiple pull requests and issues in the `prs` and `issues` array fields.
 
-PR and issue links are automatically hidden (commented out) for bundles from private repositories.
+PR and issue links are automatically hidden (commented out) for bundles from private repositories when loading from a **local** bundles folder.
 When links are hidden, **all** PR and issue links for an affected entry are hidden together.
 This is determined by checking the `assembler.yml` configuration:
 
 - Repositories marked with `private: true` in `assembler.yml` will have their links hidden
-- For merged bundles (for example, `elasticsearch+kibana`), links are hidden if ANY component repository is private
+- For merged bundles loaded locally (for example, `elasticsearch+kibana`), links are hidden if ANY component repository is private
 - In standalone builds without `assembler.yml`, all links are shown by default
+- When [`:cdn:`](#cdn) is set, `:link-visibility: auto` keeps links (CDN bundles are already scrubbed for public delivery). You do not need `:link-visibility: keep-links` on CDN pages for this reason alone.
 
-Use `:link-visibility: keep-links` or `hide-links` on the `{changelog}` directive to override this behavior.
+Use `:link-visibility: keep-links` or `hide-links` on the `{changelog}` directive to override this behavior. For local merged bundles where a private repo's entries were already sanitized at bundle time with [`link_allow_repos`](/contribute/configure-changelogs-ref.md#bundle-basic), use `:link-visibility: keep-links` so public constituents' links are not hidden with the private repo's.
 
 ## Bundle merging
 

--- a/src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogInlineRenderer.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogInlineRenderer.cs
@@ -32,7 +32,8 @@ public static class ChangelogInlineRenderer
 			DescriptionVisibility = block.DescriptionVisibility,
 			PrivateRepositories = block.PrivateRepositories,
 			HideFeatures = block.HideFeatures,
-			PublishBlocker = block.PublishBlocker
+			PublishBlocker = block.PublishBlocker,
+			FromCdn = block.CdnProduct is not null
 		};
 
 		// Render each bundle as a version section (already sorted by semver descending)
@@ -122,6 +123,7 @@ public static class ChangelogInlineRenderer
 		{
 			ChangelogLinkVisibility.KeepLinks => false,
 			ChangelogLinkVisibility.HideLinks => true,
+			_ when options.FromCdn => false,
 			_ => ShouldHideLinksForRepo(bundle.Repo, options.PrivateRepositories)
 		};
 

--- a/src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogRenderOptions.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogRenderOptions.cs
@@ -22,4 +22,6 @@ internal sealed record ChangelogRenderOptions
 	public required HashSet<string> PrivateRepositories { get; init; }
 	public required HashSet<string> HideFeatures { get; init; }
 	public PublishBlocker? PublishBlocker { get; init; }
+	/// <summary>True when bundles are loaded from the CDN via <c>:cdn:</c> (scrubbed public copies).</summary>
+	public required bool FromCdn { get; init; }
 }

--- a/tests/Elastic.Markdown.Tests/Directives/ChangelogHideLinksTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/ChangelogHideLinksTests.cs
@@ -684,18 +684,16 @@ public class ChangelogLinkVisibilityInvalidTests : DirectiveTest<ChangelogBlock>
 /// CDN-sourced bundles are scrubbed for public delivery; :link-visibility: auto keeps links even when
 /// assembler.yml marks source repos private (including merged bundles with a private constituent).
 /// </summary>
-public class ChangelogCdnLinkVisibilityAutoTests : DirectiveTest<ChangelogBlock>
-{
-	private const string Product = "cloud-serverless";
-
-	public ChangelogCdnLinkVisibilityAutoTests(ITestOutputHelper output) : base(output,
-		// language=markdown
-		"""
+public class ChangelogCdnLinkVisibilityAutoTests(ITestOutputHelper output) : DirectiveTest<ChangelogBlock>(output,
+	// language=markdown
+	"""
 		:::{changelog}
 		:cdn: cloud-serverless
 		:link-visibility: auto
 		:::
-		""") { }
+		""")
+{
+	private const string Product = "cloud-serverless";
 
 	protected override IReleaseNotesResolver GetReleaseNotesResolver() =>
 		ChangelogCdnTestResolver.For(Product,

--- a/tests/Elastic.Markdown.Tests/Directives/ChangelogHideLinksTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/ChangelogHideLinksTests.cs
@@ -4,6 +4,7 @@
 
 using System.IO.Abstractions.TestingHelpers;
 using AwesomeAssertions;
+using Elastic.Documentation.Configuration.ReleaseNotes;
 using Elastic.Markdown.Myst.Directives.Changelog;
 
 namespace Elastic.Markdown.Tests.Directives;
@@ -677,4 +678,78 @@ public class ChangelogLinkVisibilityInvalidTests : DirectiveTest<ChangelogBlock>
 	[Fact]
 	public void EmitsWarning() =>
 		Collector.Warnings.Should().BeGreaterThan(0);
+}
+
+/// <summary>
+/// CDN-sourced bundles are scrubbed for public delivery; :link-visibility: auto keeps links even when
+/// assembler.yml marks source repos private (including merged bundles with a private constituent).
+/// </summary>
+public class ChangelogCdnLinkVisibilityAutoTests : DirectiveTest<ChangelogBlock>
+{
+	private const string Product = "cloud-serverless";
+
+	public ChangelogCdnLinkVisibilityAutoTests(ITestOutputHelper output) : base(output,
+		// language=markdown
+		"""
+		:::{changelog}
+		:cdn: cloud-serverless
+		:link-visibility: auto
+		:::
+		""") { }
+
+	protected override IReleaseNotesResolver GetReleaseNotesResolver() =>
+		ChangelogCdnTestResolver.For(Product,
+			("cloud-2026-07-07.yaml",
+				// language=yaml
+				"""
+				products:
+				- product: cloud-serverless
+				  target: 2026-07-07
+				  repo: cloud
+				  owner: elastic
+				entries:
+				- title: Cloud Feature
+				  type: feature
+				  products:
+				  - product: cloud-serverless
+				    target: 2026-07-07
+				  prs:
+				  - https://github.com/elastic/roadmap/issues/39
+				"""),
+			("kibana-2026-07-07.yaml",
+				// language=yaml
+				"""
+				products:
+				- product: cloud-serverless
+				  target: 2026-07-07
+				  repo: kibana
+				  owner: elastic
+				entries:
+				- title: Kibana Feature
+				  type: feature
+				  products:
+				  - product: cloud-serverless
+				    target: 2026-07-07
+				  prs:
+				  - https://github.com/elastic/kibana/pull/275693
+				"""));
+
+	public override async ValueTask InitializeAsync()
+	{
+		await base.InitializeAsync();
+		Block!.PrivateRepositories.Add("cloud");
+		Block!.PrivateRepositories.Add("kibana");
+	}
+
+	[Fact]
+	public void ShowsLinksForMergedCdnBundleWhenAuto()
+	{
+		var markdown = ChangelogInlineRenderer.RenderChangelogMarkdown(Block!);
+
+		markdown.Should().Contain("Cloud Feature");
+		markdown.Should().Contain("Kibana Feature");
+		markdown.Should().Contain("github.com/elastic/kibana/pull/275693");
+		markdown.Should().Contain("github.com/elastic/roadmap/issues/39");
+		markdown.Should().NotContain("%");
+	}
 }


### PR DESCRIPTION
## Background

When the changelog directive merges private and public bundles, it's hiding all links which is unnecessary in the case where bundles are coming from (scrubbed) S3 buckets.
The work-around is to explicitly add `:link-visibility: keep-links` to the directive, as I did in https://github.com/elastic/docs-content/pull/6599

## Desired behavior

| Mode | Link Auto today | After |
|------|-----------------|-------|
| Local folder, private repo | Hide links | Unchanged |
| Local folder, merged public+private (`cloud+kibana`) | Hide all (ANY private) | **Unchanged** — document `keep-links` if needed |
| `:cdn:` + Auto | Hide when any/all assembler-private | **Keep links** (do not apply assembler private-repo hiding) |
| Explicit `keep-links` / `hide-links` | Overrides | Unchanged |

Description Auto: unchanged.

## Solution

Implemented CDN Auto keep-links.

**Code**
- [`ChangelogRenderOptions.cs`](src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogRenderOptions.cs) — added `FromCdn`
- [`ChangelogInlineRenderer.cs`](src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogInlineRenderer.cs) — sets `FromCdn` when `block.CdnProduct` is set; `:link-visibility: auto` + CDN skips assembler private-repo hiding

**Tests**
- [`ChangelogHideLinksTests.cs`](tests/Elastic.Markdown.Tests/Directives/ChangelogHideLinksTests.cs) — `ChangelogCdnLinkVisibilityAutoTests` covers merged `cloud+kibana` CDN bundle with private repos in assembler; links stay visible

**Docs**
- [`docs/syntax/changelog.md`](docs/syntax/changelog.md) — CDN Auto keeps links; local merged bundles still need `keep-links` when appropriate

All targeted tests passed. CDN pages like the serverless changelog no longer need `:link-visibility: keep-links` for this case (though leaving it in place is harmless).

## Tests

I verified that when I removed the explicit `links-visibility` clauses from the directives in https://github.com/elastic/docs-content/pull/6599, it didn't cause all the links to disappear again from the July 7 release section.