### PR TITLE
Assets: Fix laggy TOC scroll tracking

### DIFF
--- a/src/Elastic.ApiExplorer/_Partials/Layout/_ApiToc.cshtml
+++ b/src/Elastic.ApiExplorer/_Partials/Layout/_ApiToc.cshtml
@@ -7,11 +7,11 @@
 				<div class="font-sans">
 					<div class="font-bold mb-2">On this page</div>
 					<div class="relative toc-progress-container font-body">
-						<div class="toc-progress-indicator absolute top-0 h-0 w-[1px] bg-blue-elastic transition-all duration-200 ease-out"></div>
+						<div class="toc-progress-indicator absolute top-0 h-0 w-[1px] bg-blue-elastic transition-[transform,height] duration-200 ease-out"></div>
 						<ul class="block w-full">
 							@foreach (var item in Model)
 							{
-								<li class="has-[:hover]:border-l-grey-80 items-center px-4 border-l-1 border-l-grey-20 has-[.current]:border-l-blue-elastic!">
+								<li class="has-[:hover]:border-l-grey-80 items-center px-4 border-l-1 border-l-grey-20 has-[.toc-current]:border-l-blue-elastic!">
 									<a class="sidebar-link inline-block my-1.5 @(item.Level == 3 ? "ml-4" : string.Empty)"
 									   href="#@item.Slug">
 										@item.Heading

--- a/src/Elastic.Documentation.Site/Assets/styles.css
+++ b/src/Elastic.Documentation.Site/Assets/styles.css
@@ -83,7 +83,7 @@ body {
 	}
 }
 
-#toc-nav a.current {
+#toc-nav a.toc-current {
 	color: var(--color-blue-elastic);
 	&:hover {
 		color: var(--color-blue-elastic);

--- a/src/Elastic.Documentation.Site/Assets/toc-nav.test.ts
+++ b/src/Elastic.Documentation.Site/Assets/toc-nav.test.ts
@@ -14,7 +14,114 @@ function createRect(top: number, height: number): DOMRect {
     }
 }
 
+interface TocFixture {
+    headings: HTMLElement[]
+    headingRects: jest.SpyInstance<DOMRect, []>[]
+    links: HTMLAnchorElement[]
+    indicator: HTMLElement
+}
+
+let animationFrames: FrameRequestCallback[]
+
+function setWindowValue(property: string, value: number) {
+    Object.defineProperty(window, property, {
+        configurable: true,
+        value,
+    })
+}
+
+function flushAnimationFrame() {
+    const callbacks = animationFrames
+    animationFrames = []
+    callbacks.forEach((callback) => callback(0))
+}
+
+function scrollTo(scrollY: number) {
+    setWindowValue('scrollY', scrollY)
+    window.dispatchEvent(new Event('scroll'))
+    flushAnimationFrame()
+}
+
+function createTocFixture(documentTops: number[]): TocFixture {
+    const headings = documentTops
+        .map(
+            (_, index) => `
+                <div class="heading-wrapper" id="heading-${index}">
+                    <h2>Heading ${index}</h2>
+                </div>
+            `
+        )
+        .join('')
+    const links = documentTops
+        .map(
+            (_, index) =>
+                `<li><a href="#heading-${index}">Heading ${index}</a></li>`
+        )
+        .join('')
+
+    document.body.innerHTML = `
+        <main id="markdown-content">${headings}</main>
+        <nav id="toc-nav">
+            <div class="toc-progress-container">
+                <div class="toc-progress-indicator"></div>
+                <ul>${links}</ul>
+            </div>
+        </nav>
+    `
+
+    const headingElements = Array.from(
+        document.querySelectorAll<HTMLElement>('#markdown-content h2')
+    )
+    const headingRects = headingElements.map((heading, index) =>
+        jest
+            .spyOn(heading, 'getBoundingClientRect')
+            .mockImplementation(() =>
+                createRect(documentTops[index] - window.scrollY, 30)
+            )
+    )
+    const linkElements = Array.from(
+        document.querySelectorAll<HTMLAnchorElement>('#toc-nav a')
+    )
+    linkElements.forEach((link, index) => {
+        jest.spyOn(
+            link.closest('li')!,
+            'getBoundingClientRect'
+        ).mockImplementation(() => createRect(20 + index * 30, 24))
+    })
+    jest.spyOn(
+        document.querySelector('.toc-progress-container')!,
+        'getBoundingClientRect'
+    ).mockReturnValue(createRect(10, documentTops.length * 30))
+
+    return {
+        headings: headingElements,
+        headingRects,
+        links: linkElements,
+        indicator: document.querySelector('.toc-progress-indicator')!,
+    }
+}
+
 describe('TOC navigation', () => {
+    beforeEach(() => {
+        animationFrames = []
+        setWindowValue('innerHeight', 800)
+        setWindowValue('scrollY', 0)
+        Object.defineProperty(document.documentElement, 'scrollHeight', {
+            configurable: true,
+            value: 2000,
+        })
+        jest.spyOn(window, 'requestAnimationFrame').mockImplementation(
+            (callback) => {
+                animationFrames.push(callback)
+                return animationFrames.length
+            }
+        )
+    })
+
+    afterEach(() => {
+        jest.restoreAllMocks()
+    })
+
     it('marks a stepper heading with its own id as current', () => {
         document.body.innerHTML = `
             <main id="markdown-content">
@@ -33,19 +140,6 @@ describe('TOC navigation', () => {
                 </div>
             </nav>
         `
-
-        Object.defineProperty(window, 'innerHeight', {
-            configurable: true,
-            value: 800,
-        })
-        Object.defineProperty(window, 'scrollY', {
-            configurable: true,
-            value: 0,
-        })
-        Object.defineProperty(document.documentElement, 'scrollHeight', {
-            configurable: true,
-            value: 2000,
-        })
 
         const heading = document.querySelector('h2')!
         const tocContainer = document.querySelector('.toc-progress-container')!
@@ -66,7 +160,179 @@ describe('TOC navigation', () => {
         const indicator = document.querySelector(
             '.toc-progress-indicator'
         ) as HTMLElement
-        expect(tocLink).toHaveClass('current')
-        expect(indicator).toHaveStyle({ top: '10px', height: '24px' })
+        expect(tocLink).toHaveClass('toc-current')
+        expect(indicator).toHaveStyle({
+            top: '0px',
+            height: '24px',
+            transform: 'translateY(10px)',
+        })
+    })
+
+    it('marks an API heading using its data-section anchor as current', () => {
+        document.body.innerHTML = `
+            <main id="elastic-api-v3">
+                <h3 data-section="responses">Responses</h3>
+            </main>
+            <nav id="toc-nav">
+                <div class="toc-progress-container">
+                    <div class="toc-progress-indicator"></div>
+                    <ul><li><a href="#responses">Responses</a></li></ul>
+                </div>
+            </nav>
+        `
+        jest.spyOn(
+            document.querySelector('h3')!,
+            'getBoundingClientRect'
+        ).mockReturnValue(createRect(100, 30))
+        jest.spyOn(
+            document.querySelector('.toc-progress-container')!,
+            'getBoundingClientRect'
+        ).mockReturnValue(createRect(10, 100))
+        jest.spyOn(
+            document.querySelector('#toc-nav li')!,
+            'getBoundingClientRect'
+        ).mockReturnValue(createRect(20, 24))
+
+        initTocNav()
+
+        expect(document.querySelector('#toc-nav a')).toHaveClass('toc-current')
+    })
+
+    it('tracks headings while scrolling forward and backward', () => {
+        const fixture = createTocFixture([100, 300, 500])
+
+        initTocNav()
+
+        expect(fixture.links[0]).toHaveClass('toc-current')
+
+        scrollTo(200)
+        expect(fixture.links[0]).not.toHaveClass('toc-current')
+        expect(fixture.links[1]).toHaveClass('toc-current')
+
+        scrollTo(0)
+        expect(fixture.links[0]).toHaveClass('toc-current')
+        expect(fixture.links[1]).not.toHaveClass('toc-current')
+    })
+
+    it('marks headings at the same position as current', () => {
+        const fixture = createTocFixture([100, 300, 300, 500])
+
+        initTocNav()
+        scrollTo(200)
+
+        expect(fixture.links[1]).toHaveClass('toc-current')
+        expect(fixture.links[2]).toHaveClass('toc-current')
+    })
+
+    it('marks all visible headings at the bottom of the page', () => {
+        setWindowValue('innerHeight', 400)
+        Object.defineProperty(document.documentElement, 'scrollHeight', {
+            configurable: true,
+            value: 1000,
+        })
+        const fixture = createTocFixture([100, 650, 850, 950])
+
+        initTocNav()
+        scrollTo(600)
+
+        expect(fixture.links[1]).not.toHaveClass('toc-current')
+        expect(fixture.links[2]).toHaveClass('toc-current')
+        expect(fixture.links[3]).toHaveClass('toc-current')
+        expect(fixture.indicator).toHaveStyle({
+            transform: 'translateY(70px)',
+            height: '54px',
+        })
+    })
+
+    it('marks a visible heading at the bottom before it reaches the header', () => {
+        Object.defineProperty(document.documentElement, 'scrollHeight', {
+            configurable: true,
+            value: 1000,
+        })
+        const fixture = createTocFixture([400])
+
+        initTocNav()
+        scrollTo(200)
+
+        expect(fixture.links[0]).toHaveClass('toc-current')
+    })
+
+    it('coalesces repeated scroll events into one animation frame', () => {
+        const fixture = createTocFixture([100, 300, 500])
+        initTocNav()
+        fixture.headingRects.forEach((mock) => mock.mockClear())
+        jest.mocked(window.requestAnimationFrame).mockClear()
+
+        window.dispatchEvent(new Event('scroll'))
+        window.dispatchEvent(new Event('scroll'))
+        window.dispatchEvent(new Event('scroll'))
+
+        expect(window.requestAnimationFrame).toHaveBeenCalledTimes(1)
+        expect(
+            fixture.headingRects.reduce(
+                (calls, mock) => calls + mock.mock.calls.length,
+                0
+            )
+        ).toBe(0)
+
+        flushAnimationFrame()
+        expect(
+            fixture.headingRects.reduce(
+                (calls, mock) => calls + mock.mock.calls.length,
+                0
+            )
+        ).toBeGreaterThan(0)
+    })
+
+    it('does not rewrite classes when the current heading is unchanged', () => {
+        const fixture = createTocFixture([100, 300, 500])
+        initTocNav()
+        const removeSpies = fixture.links.map((link) =>
+            jest.spyOn(link.classList, 'remove')
+        )
+        const addSpies = fixture.links.map((link) =>
+            jest.spyOn(link.classList, 'add')
+        )
+
+        scrollTo(10)
+
+        expect(removeSpies.every((spy) => spy.mock.calls.length === 0)).toBe(
+            true
+        )
+        expect(addSpies.every((spy) => spy.mock.calls.length === 0)).toBe(true)
+    })
+
+    it('only reads nearby heading geometry during steady scrolling', () => {
+        const fixture = createTocFixture(
+            Array.from({ length: 50 }, (_, index) => 100 + index * 200)
+        )
+        initTocNav()
+        fixture.headingRects.forEach((mock) => mock.mockClear())
+
+        scrollTo(10)
+
+        const geometryReads = fixture.headingRects.reduce(
+            (calls, mock) => calls + mock.mock.calls.length,
+            0
+        )
+        expect(geometryReads).toBeLessThanOrEqual(3)
+    })
+
+    it('removes listeners from the previous initialization', () => {
+        const previousFixture = createTocFixture([100, 300])
+        initTocNav()
+        previousFixture.headingRects.forEach((mock) => mock.mockClear())
+
+        createTocFixture([100, 400])
+        initTocNav()
+        previousFixture.headingRects.forEach((mock) => mock.mockClear())
+
+        scrollTo(10)
+
+        expect(
+            previousFixture.headingRects.every(
+                (mock) => mock.mock.calls.length === 0
+            )
+        ).toBe(true)
     })
 })

--- a/src/Elastic.Documentation.Site/Assets/toc-nav.ts
+++ b/src/Elastic.Documentation.Site/Assets/toc-nav.ts
@@ -1,19 +1,28 @@
 import { $$optional, $optional } from 'select-dom'
 
+interface HeadingEntry {
+    heading: Element
+    link: HTMLAnchorElement | null
+}
+
 interface TocElements {
-    headings: Element[]
+    headings: HeadingEntry[]
     tocLinks: HTMLAnchorElement[]
     tocContainer: HTMLDivElement | null
-    progressIndicator: HTMLDivElement
+    progressIndicator: HTMLDivElement | null
 }
 
 // 34 is the height of the header + some padding
 // 4 is the base spacing unit
 const HEADING_OFFSET = 34 * 4
+const VISIBLE_HEADING_OFFSET = HEADING_OFFSET - 64
+const ACTIVE_CLASS = 'toc-current'
+
+let initializationController: AbortController | null = null
 
 function initializeTocElements(): TocElements {
     // Support both regular docs (#markdown-content) and API docs (#elastic-api-v3)
-    const headings = $$optional(
+    const headingElements = $$optional(
         '#markdown-content h2, #markdown-content h3, #elastic-api-v3 h3[data-section]'
     )
     const tocLinks = $$optional('#toc-nav li>a') as HTMLAnchorElement[]
@@ -23,7 +32,18 @@ function initializeTocElements(): TocElements {
     const progressIndicator = $optional(
         '.toc-progress-indicator',
         tocContainer
-    ) as HTMLDivElement
+    ) as HTMLDivElement | null
+    const linksByAnchor = new Map(
+        tocLinks.map((link) => [link.getAttribute('href'), link])
+    )
+    const headings = headingElements.map((heading) => {
+        const anchorId = getHeadingAnchorId(heading)
+        const link = anchorId ? linksByAnchor.get(`#${anchorId}`) : null
+        return {
+            heading,
+            link: link ?? null,
+        }
+    })
     return { headings, tocLinks, tocContainer, progressIndicator }
 }
 
@@ -40,155 +60,195 @@ function getHeadingAnchorId(heading: Element): string | null {
     return wrapper?.id || heading.id || null
 }
 
-// Find the current TOC links based on visible headings
-// It can return multiple links because headings in a tab can have the same position
-function findCurrentTocLinks(elements: TocElements): HTMLAnchorElement[] {
-    let currentTocLinks: HTMLAnchorElement[] = []
-    let currentTop: number | null = null
-    for (const heading of elements.headings) {
-        const rect = heading.getBoundingClientRect()
-        if (rect.top <= HEADING_OFFSET) {
-            if (currentTop !== null && Math.abs(rect.top - currentTop) > 1) {
-                currentTocLinks = []
-            }
-            currentTop = rect.top
-            const anchorId = getHeadingAnchorId(heading)
-            const foundLink = elements.tocLinks.find(
-                (link) => link.getAttribute('href') === `#${anchorId}`
-            )
-            if (foundLink) {
-                currentTocLinks.push(foundLink)
-            }
-        }
+function findCurrentHeadingIndex(
+    headings: HeadingEntry[],
+    currentIndex: number
+): number {
+    while (
+        currentIndex >= 0 &&
+        headings[currentIndex].heading.getBoundingClientRect().top >
+            HEADING_OFFSET
+    ) {
+        currentIndex--
     }
-    return currentTocLinks
-}
 
-// Get visible headings in viewport
-function getVisibleHeadings(elements: TocElements) {
-    return elements.headings.filter((heading) => {
-        const rect = heading.getBoundingClientRect()
-        return (
-            rect.top - HEADING_OFFSET + 64 >= 0 &&
-            rect.top <= window.innerHeight
-        )
-    })
-}
-
-// If the user has scrolled to the bottom of the page,
-// and there are still multiple headings visible, we need to
-// handle the progress indicator differently.
-// In this case it sets the indicator for all visible headings.
-function handleBottomScroll(elements: TocElements) {
-    const visibleHeadings = getVisibleHeadings(elements)
-    if (visibleHeadings.length === 0) return
-    const firstHeading = visibleHeadings[0]
-    const lastHeading = visibleHeadings[visibleHeadings.length - 1]
-    const firstAnchorId = getHeadingAnchorId(firstHeading)
-    const lastAnchorId = getHeadingAnchorId(lastHeading)
-
-    // Find all TOC links for visible headings and mark them as current
-    const visibleLinks = visibleHeadings
-        .map((h) => getHeadingAnchorId(h))
-        .filter((id): id is string => id !== null)
-        .map((id) =>
-            elements.tocLinks.find(
-                (link) => link.getAttribute('href') === `#${id}`
-            )
-        )
-        .filter((link): link is HTMLAnchorElement => link !== undefined)
-    updateCurrentClass(elements.tocLinks, visibleLinks)
-
-    const firstLink = elements.tocLinks
-        .find((link) => link.getAttribute('href') === `#${firstAnchorId}`)
-        ?.closest('li')
-    const lastLink = elements.tocLinks
-        .find((link) => link.getAttribute('href') === `#${lastAnchorId}`)
-        ?.closest('li')
-    if (firstLink && lastLink && elements.tocContainer) {
-        const tocRect = elements.tocContainer.getBoundingClientRect()
-        const firstRect = firstLink.getBoundingClientRect()
-        const lastRect = lastLink.getBoundingClientRect()
-        updateProgressIndicatorPosition(
-            elements.progressIndicator,
-            firstRect.top - tocRect.top,
-            lastRect.top + lastRect.height - firstRect.top
-        )
+    while (
+        currentIndex + 1 < headings.length &&
+        headings[currentIndex + 1].heading.getBoundingClientRect().top <=
+            HEADING_OFFSET
+    ) {
+        currentIndex++
     }
+    return currentIndex
 }
 
-function updateProgressIndicatorPosition(
-    indicator: HTMLDivElement,
-    top: number,
-    height: number
-) {
-    indicator.style.top = `${top}px`
-    indicator.style.height = `${height}px`
+function getCurrentLinks(
+    headings: HeadingEntry[],
+    currentIndex: number
+): HTMLAnchorElement[] {
+    if (currentIndex < 0) return []
+
+    const currentTop =
+        headings[currentIndex].heading.getBoundingClientRect().top
+    let firstIndex = currentIndex
+    while (firstIndex > 0) {
+        const previousTop =
+            headings[firstIndex - 1].heading.getBoundingClientRect().top
+        if (Math.abs(previousTop - currentTop) > 1) break
+        firstIndex--
+    }
+    return headings
+        .slice(firstIndex, currentIndex + 1)
+        .map(({ link }) => link)
+        .filter((link): link is HTMLAnchorElement => link !== null)
 }
 
-function updateCurrentClass(
-    allLinks: HTMLAnchorElement[],
+function getBottomLinks(
+    headings: HeadingEntry[],
+    currentIndex: number
+): HTMLAnchorElement[] {
+    let firstIndex = Math.max(currentIndex, 0)
+    while (
+        firstIndex > 0 &&
+        headings[firstIndex - 1].heading.getBoundingClientRect().top >=
+            VISIBLE_HEADING_OFFSET
+    ) {
+        firstIndex--
+    }
+
+    let lastIndex = firstIndex
+    while (
+        lastIndex + 1 < headings.length &&
+        headings[lastIndex + 1].heading.getBoundingClientRect().top <=
+            window.innerHeight
+    ) {
+        lastIndex++
+    }
+
+    return headings
+        .slice(firstIndex, lastIndex + 1)
+        .filter(({ heading }) => {
+            const top = heading.getBoundingClientRect().top
+            return top >= VISIBLE_HEADING_OFFSET && top <= window.innerHeight
+        })
+        .map(({ link }) => link)
+        .filter((link): link is HTMLAnchorElement => link !== null)
+}
+
+function linksAreEqual(
+    previousLinks: HTMLAnchorElement[],
     currentLinks: HTMLAnchorElement[]
 ) {
-    allLinks.forEach((link) => link.classList.remove('current'))
-    currentLinks.forEach((link) => link.classList.add('current'))
+    return (
+        previousLinks.length === currentLinks.length &&
+        previousLinks.every((link, index) => link === currentLinks[index])
+    )
 }
 
-function updateIndicator(elements: TocElements) {
-    if (!elements.tocContainer) return
+function updateActiveLinks(
+    elements: TocElements,
+    previousLinks: HTMLAnchorElement[],
+    currentLinks: HTMLAnchorElement[]
+) {
+    if (linksAreEqual(previousLinks, currentLinks)) return previousLinks
 
-    const isAtBottom =
-        window.innerHeight + window.scrollY >=
-        document.documentElement.scrollHeight - 10
-    const currentTocLinks = findCurrentTocLinks(elements)
+    const linkElements = currentLinks
+        .map((link) => link.closest('li'))
+        .filter((item): item is HTMLLIElement => item !== null)
+    const firstLinkRect = linkElements[0]?.getBoundingClientRect()
+    const lastLinkRect =
+        linkElements[linkElements.length - 1]?.getBoundingClientRect()
+    const tocRect = elements.tocContainer?.getBoundingClientRect()
 
-    // Update the current class on TOC links
-    updateCurrentClass(elements.tocLinks, currentTocLinks)
+    previousLinks.forEach((link) => link.classList.remove(ACTIVE_CLASS))
+    currentLinks.forEach((link) => link.classList.add(ACTIVE_CLASS))
 
-    if (isAtBottom) {
-        handleBottomScroll(elements)
-    } else if (currentTocLinks.length > 0) {
-        const tocRect = elements.tocContainer.getBoundingClientRect()
-        const linkElements = currentTocLinks
-            .map((link) => link.closest('li'))
-            .filter((li): li is HTMLLIElement => li !== null)
-        if (linkElements.length === 0) return
-        const firstLinkRect = linkElements[0].getBoundingClientRect()
-        const lastLinkRect =
-            linkElements[linkElements.length - 1].getBoundingClientRect()
-        updateProgressIndicatorPosition(
-            elements.progressIndicator,
-            firstLinkRect.top - tocRect.top,
+    if (
+        elements.progressIndicator &&
+        tocRect &&
+        firstLinkRect &&
+        lastLinkRect
+    ) {
+        const top = firstLinkRect.top - tocRect.top
+        const height =
             lastLinkRect.top + lastLinkRect.height - firstLinkRect.top
-        )
+        const transform = `translateY(${top}px)`
+        const heightValue = `${height}px`
+        if (elements.progressIndicator.style.transform !== transform)
+            elements.progressIndicator.style.transform = transform
+        if (elements.progressIndicator.style.height !== heightValue)
+            elements.progressIndicator.style.height = heightValue
     }
+    return currentLinks
 }
 
-function setupSmoothScrolling(elements: TocElements) {
+function setupSmoothScrolling(elements: TocElements, signal: AbortSignal) {
     elements.tocLinks.forEach((link) => {
-        link.addEventListener('click', (e) => {
-            const href = link.getAttribute('href')
-            if (href?.charAt(0) === '#') {
-                const target = document.getElementById(href.slice(1))
-                if (target) {
-                    e.preventDefault()
-                    target.scrollIntoView({ behavior: 'smooth' })
-                    history.pushState(null, '', href)
+        link.addEventListener(
+            'click',
+            (e) => {
+                const href = link.getAttribute('href')
+                if (href?.charAt(0) === '#') {
+                    const target = document.getElementById(href.slice(1))
+                    if (target) {
+                        e.preventDefault()
+                        target.scrollIntoView({ behavior: 'smooth' })
+                        history.pushState(null, '', href)
+                    }
                 }
-            }
-        })
+            },
+            { signal }
+        )
     })
 }
 
 export function initTocNav() {
+    initializationController?.abort()
+    initializationController = new window.AbortController()
+    const { signal } = initializationController
     const elements = initializeTocElements()
-    if (elements.progressIndicator != null) {
-        elements.progressIndicator.style.height = '0'
-        elements.progressIndicator.style.top = '0'
+    if (!elements.tocContainer || !elements.progressIndicator) return
+
+    elements.progressIndicator.style.height = '0'
+    elements.progressIndicator.style.top = '0'
+
+    let currentHeadingIndex = -1
+    let currentLinks = elements.tocLinks.filter((link) =>
+        link.classList.contains(ACTIVE_CLASS)
+    )
+    let animationFrame: number | null = null
+    const update = () => {
+        currentHeadingIndex = findCurrentHeadingIndex(
+            elements.headings,
+            currentHeadingIndex
+        )
+        const isAtBottom =
+            window.innerHeight + window.scrollY >=
+            document.documentElement.scrollHeight - 10
+        const nextLinks = isAtBottom
+            ? getBottomLinks(elements.headings, currentHeadingIndex)
+            : getCurrentLinks(elements.headings, currentHeadingIndex)
+        currentLinks = updateActiveLinks(elements, currentLinks, nextLinks)
     }
-    const update = () => updateIndicator(elements)
+    const scheduleUpdate = () => {
+        if (animationFrame !== null) return
+        animationFrame = window.requestAnimationFrame(() => {
+            animationFrame = null
+            update()
+        })
+    }
+
     update()
-    window.addEventListener('scroll', update, { passive: true })
-    window.addEventListener('resize', update, { passive: true })
-    setupSmoothScrolling(elements)
+    window.addEventListener('scroll', scheduleUpdate, {
+        passive: true,
+        signal,
+    })
+    window.addEventListener('resize', scheduleUpdate, {
+        passive: true,
+        signal,
+    })
+    signal.addEventListener('abort', () => {
+        if (animationFrame !== null) window.cancelAnimationFrame(animationFrame)
+    })
+    setupSmoothScrolling(elements, signal)
 }

--- a/src/Elastic.Markdown/Layout/_TableOfContents.cshtml
+++ b/src/Elastic.Markdown/Layout/_TableOfContents.cshtml
@@ -99,11 +99,11 @@
 				<div class="font-sans">
 					<div class="font-bold mb-2">On this page</div>
 					<div class="relative toc-progress-container font-body">
-						<div class="toc-progress-indicator absolute top-0 h-0 w-[1px] bg-blue-elastic transition-all duration-200 ease-out "></div>
+						<div class="toc-progress-indicator absolute top-0 h-0 w-[1px] bg-blue-elastic transition-[transform,height] duration-200 ease-out "></div>
 						<ul class="block w-full">
 							@foreach (var item in Model.PageTocItems)
 							{
-								<li class="has-[:hover]:border-l-grey-80 items-center px-4 border-l-1 border-l-grey-20 has-[.current]:border-l-blue-elastic!">
+								<li class="has-[:hover]:border-l-grey-80 items-center px-4 border-l-1 border-l-grey-20 has-[.toc-current]:border-l-blue-elastic!">
 									<a
 										class="sidebar-link inline-block my-1.5 @(item.Level == 3 ? "ml-4" : string.Empty)"
 										href="#@item.Slug">


### PR DESCRIPTION
## Why

Scrolling long documentation pages felt laggy. The on-page TOC scroll handler
ran on every native scroll event and rescanned the geometry of every heading
each time, forcing repeated layout reflows on the scroll hot path.

## What

Rewrites the TOC scroll tracking for smoothness:

- Coalesces scroll (and resize) events into a single `requestAnimationFrame` so work runs at most once per frame.
- Tracks the current heading incrementally — resuming from the last index instead of rescanning all headings — so only nearby heading geometry is read during steady scrolling.
- Precomputes the heading→TOC-link mapping once, and skips all class/style writes when the active set is unchanged.
- Moves the progress indicator with a GPU-friendly `transform: translateY(...)` instead of animating `top`.
- Tears down scroll/resize/click listeners via an `AbortController` on re-init, preventing stale-listener leaks across navigations.
- Renames the active class `.current` → `.toc-current` to disambiguate from the left-nav's own `.current`.

Covered by the expanded `toc-nav.test.ts` suite (forward/backward tracking, same-position headings, bottom-of-page fan-out, event coalescing, skip-when-unchanged, and listener teardown).