### PR TITLE
Fix streamed documentation layout shifts

### DIFF
--- a/src/Elastic.Codex/_GroupLayout.cshtml
+++ b/src/Elastic.Codex/_GroupLayout.cshtml
@@ -13,7 +13,7 @@
 				md:px-4
 	">
 		<div class="min-h-screen grid grid-cols-1 md:grid-cols-[var(--max-sidebar-width)_1fr] gap-4">
-			<main id="content-container" class="min-w-0 lg:grid lg:grid-cols-[minmax(0,var(--max-text-width))_minmax(0,var(--max-sidebar-width))] justify-center mx-4 gap-4 md:order-2">
+			<main id="content-container" class="min-w-0 lg:grid lg:grid-cols-[minmax(0,var(--max-text-width))_minmax(0,var(--max-sidebar-width))] justify-center mx-4 gap-4 md:col-start-2 md:row-start-1">
 				<div class="min-w-0">
 					@await RenderBodyAsync()
 				</div>

--- a/src/Elastic.Codex/_MarkdownLayout.cshtml
+++ b/src/Elastic.Codex/_MarkdownLayout.cshtml
@@ -25,7 +25,7 @@
 				md:px-4
 	">
 		<div class="min-h-screen grid grid-cols-1 md:grid-cols-[var(--max-sidebar-width)_1fr] gap-4">
-			<main id="content-container" class="min-w-0 flex flex-col lg:grid lg:grid-cols-[minmax(0,var(--max-text-width))_minmax(0,var(--max-sidebar-width))] justify-center mx-4 gap-4 md:order-2">
+			<main id="content-container" class="min-w-0 flex flex-col lg:grid lg:grid-cols-[minmax(0,var(--max-text-width))_minmax(0,var(--max-sidebar-width))] justify-center mx-4 gap-4 md:col-start-2 md:row-start-1">
 				<div class="mb-9 mt-0 min-w-0 order-2 lg:order-1">
 					@await RenderPartialAsync(_Breadcrumbs.Create(Model))
 					<article id="markdown-content" class="markdown-content min-w-0">

--- a/src/Elastic.Documentation.Site/Assets/assembler.css
+++ b/src/Elastic.Documentation.Site/Assets/assembler.css
@@ -12,6 +12,24 @@
 	}
 }
 
+/* Reserve the space used by elastic-nav.js before its asynchronous render.
+   These heights mirror the global nav's responsive navigation placeholder. */
+#elastic-nav-wrapper {
+	min-height: 102px;
+}
+
+@media screen and (min-width: 768px) {
+	#elastic-nav-wrapper {
+		min-height: 110px;
+	}
+}
+
+@media screen and (min-width: 1180px) {
+	#elastic-nav-wrapper {
+		min-height: 118px;
+	}
+}
+
 /* Air-gapped: uses elastic-docs-header web component instead of elastic nav */
 body.air-gapped {
 	--offset-top: 48px;

--- a/src/Elastic.Documentation.Site/Layout/_PagesNav.cshtml
+++ b/src/Elastic.Documentation.Site/Layout/_PagesNav.cshtml
@@ -1,5 +1,5 @@
 @inherits RazorSlice<Elastic.Documentation.Site.GlobalLayoutViewModel>
-<aside class="sidebar font-sans bg-white fixed md:sticky shadow-2xl md:shadow-none left-full group-has-[#pages-nav-hamburger:checked]/body:left-0 bottom-0 md:left-auto top-[calc(var(--offset-top)+1px)] w-[80%] md:w-auto shrink-0 border-r border-r-grey-20 z-[10000] md:z-auto transition-[top,max-height] duration-300 md:order-1">
+<aside class="sidebar font-sans bg-white fixed md:sticky shadow-2xl md:shadow-none left-full group-has-[#pages-nav-hamburger:checked]/body:left-0 bottom-0 md:left-auto top-[calc(var(--offset-top)+1px)] w-[80%] md:w-auto shrink-0 border-r border-r-grey-20 z-[10000] md:z-auto transition-[top,max-height] duration-300 md:col-start-1 md:row-start-1">
 	<nav
 		id="pages-nav"
 		class="sidebar-nav h-full simple-scrollbar">

--- a/src/Elastic.Documentation.Site/synthetics/journeys/navigation-test.journey.ts
+++ b/src/Elastic.Documentation.Site/synthetics/journeys/navigation-test.journey.ts
@@ -35,6 +35,24 @@ journey('navigation test', ({ page, params }) => {
         })
     })
 
+    step('Global nav space is reserved before it renders', async () => {
+        const breakpoints = [
+            { width: 375, expectedHeight: 102 },
+            { width: 768, expectedHeight: 110 },
+            { width: 1280, expectedHeight: 118 },
+        ]
+
+        for (const { width, expectedHeight } of breakpoints) {
+            await page.setViewportSize({ width, height: 800 })
+            const minHeight = await page
+                .locator('#elastic-nav-wrapper')
+                .evaluate((element) =>
+                    Number.parseFloat(getComputedStyle(element).minHeight)
+                )
+            expect(minHeight).toBe(expectedHeight)
+        }
+    })
+
     step('Click on "Elastic Fundamentals"', async () => {
         await page
             .getByRole('link', { name: 'Elastic Fundamentals' })
@@ -51,6 +69,42 @@ journey('navigation test', ({ page, params }) => {
             if (navTree) navTree['__synthOriginal'] = true
         })
     })
+
+    step(
+        'Main content keeps its column while pages nav is absent',
+        async () => {
+            const placement = await page.evaluate(() => {
+                const content =
+                    document.querySelector<HTMLElement>('#content-container')
+                const grid = content?.parentElement
+                const sidebar =
+                    grid?.querySelector<HTMLElement>(':scope > .sidebar')
+                if (!content || !grid || !sidebar)
+                    throw new Error(
+                        'Expected documentation layout was not found'
+                    )
+
+                const marker = document.createComment('pages-nav-placeholder')
+                sidebar.replaceWith(marker)
+
+                const contentRect = content.getBoundingClientRect()
+                const gridRect = grid.getBoundingClientRect()
+                const firstColumnWidth = Number.parseFloat(
+                    getComputedStyle(grid).gridTemplateColumns
+                )
+
+                marker.replaceWith(sidebar)
+                return {
+                    contentLeft: contentRect.left,
+                    expectedMinimumLeft: gridRect.left + firstColumnWidth,
+                }
+            })
+
+            expect(placement.contentLeft).toBeGreaterThanOrEqual(
+                placement.expectedMinimumLeft
+            )
+        }
+    )
 
     step('Click on "deployment options" in nav', async () => {
         // Expand a collapsed nav section so we can assert its state survives

--- a/src/Elastic.Markdown/_Layout.cshtml
+++ b/src/Elastic.Markdown/_Layout.cshtml
@@ -35,7 +35,7 @@
 						md:px-4
 			">
 				<div class="min-h-screen grid grid-cols-1 md:grid-cols-[var(--max-sidebar-width)_1fr] gap-4">
-					<main id="content-container" class="min-w-0 flex flex-col lg:grid lg:grid-cols-[minmax(0,var(--max-text-width))_minmax(0,var(--max-sidebar-width))] justify-end mx-4 gap-4 md:order-2">
+					<main id="content-container" class="min-w-0 flex flex-col lg:grid lg:grid-cols-[minmax(0,var(--max-text-width))_minmax(0,var(--max-sidebar-width))] justify-end mx-4 gap-4 md:col-start-2 md:row-start-1">
 						@{
 							var breadcrumbs = Model.Breadcrumbs.ToList();
 							var breadcrumbVisible = breadcrumbs.Count > 0 && (breadcrumbs.Count > 1 || Model.BuildType != BuildType.Isolated);


### PR DESCRIPTION
## Why

Large documentation pages could briefly render their article in the narrow sidebar column while the HTML was still streaming. The asynchronous global navigation also pushed the entire page down after hydration.

## What

Explicit grid placement now keeps content and navigation in their intended columns before every element has been parsed. The assembler also reserves the responsive global-navigation height before its script renders, with synthetic checks covering both layout contracts.

## Test plan

- [x] Run all .NET unit tests
- [x] Run frontend Jest tests, TypeScript checks, lint, and formatting checks
- [x] Build production frontend assets
- [x] Verify throttled loading at desktop, tablet, and mobile breakpoints

Made with [Cursor](https://cursor.com)