### PR TITLE
Reduce Dependabot pull request noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,34 @@ updates:
       interval: 'weekly'
       day: 'monday'
       time: '08:00'
+    groups:
+      # Batch routine updates, but keep unrelated major upgrades isolated.
+      github-actions-security:
+        applies-to: security-updates
+        patterns:
+          - '*'
+      github-actions-minor-patch:
+        applies-to: version-updates
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
+      github-actions-major-by-dependency:
+        applies-to: version-updates
+        group-by: dependency-name
+        update-types:
+          - 'major'
     labels:
       - chore
     cooldown:
       default-days: 14
+    # Elastic actions intentionally use floating major tags such as @v1.
+    ignore:
+      - dependency-name: 'elastic/*'
+        update-types:
+          - 'version-update:semver-minor'
+          - 'version-update:semver-patch'
   - package-ecosystem: npm
     directories:
       - '**/*'
@@ -21,19 +45,32 @@ updates:
       day: 'monday'
       time: '08:00'
     groups:
-      eslint:
-        patterns:
-          - 'eslint'
-          - '@eslint/*'
-          - 'typescript-eslint'
-      eui:
-        patterns:
-          - '@elastic/eui*'
+      # Keep the Tailwind toolchain compatible across dependency types.
       tailwindcss:
         patterns:
           - 'tailwindcss'
           - '@tailwindcss/postcss'
           - 'prettier-plugin-tailwindcss'
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - '*'
+      npm-development-minor-patch:
+        applies-to: version-updates
+        dependency-type: development
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
+      npm-production-minor-patch:
+        applies-to: version-updates
+        dependency-type: production
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
     labels:
       - chore
   - package-ecosystem: nuget
@@ -42,11 +79,23 @@ updates:
       interval: 'weekly'
       day: 'monday'
       time: '08:00'
-    groups: 
+    groups:
+      # The core package and testing helpers must update together.
       system-io-abstractions:
         patterns:
           - 'System.IO.Abstractions'
           - 'System.IO.Abstractions.*'
+      nuget-security:
+        applies-to: security-updates
+        patterns:
+          - '*'
+      nuget-minor-patch:
+        applies-to: version-updates
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
     labels:
       - chore
     cooldown:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,6 +45,14 @@ updates:
       day: 'monday'
       time: '08:00'
     groups:
+      eslint:
+        patterns:
+          - 'eslint'
+          - '@eslint/*'
+          - 'typescript-eslint'
+      eui:
+        patterns:
+          - '@elastic/eui*'
       # Keep the Tailwind toolchain compatible across dependency types.
       tailwindcss:
         patterns:


### PR DESCRIPTION
## Why

Dependabot currently creates large weekly bursts of unrelated and duplicate pull requests, increasing review and CI overhead. Elastic-owned actions also use intentional floating major tags that should not be replaced by exact minor versions.

## What

Group routine minor and patch updates by ecosystem while keeping unrelated major upgrades isolated. Preserve compatibility-sensitive Tailwind and System.IO.Abstractions families, consolidate repeated GitHub Action upgrades across directories, group security updates per ecosystem, and retain floating major tags for Elastic actions while still allowing major-version proposals.

Made with [Cursor](https://cursor.com)