### PR TITLE
Make bundle-amend files self-contained and version-discoverable

### DIFF
--- a/docs/cli/changelog/cmd-bundle-amend.md
+++ b/docs/cli/changelog/cmd-bundle-amend.md
@@ -25,12 +25,19 @@ You can override this behaviour:
 
 ## Output
 
-Amend bundles contain only the changes for that amend file, not a full repetition of the original bundle.
+Amend bundles contain the parent bundle's `products` plus only the changes for that amend file, not a full repetition of the original bundle's entries.
+
+The parent's complete `products` (including `target`, `repo`, and `owner`) are copied into every amend file so the amend is self-contained: upload destination discovery, the registry's per-product `target`, and `:version:`-filtered CDN consumption all derive from a bundle file's own products.
 
 Additions:
 
 ```yaml
 # 9.3.0.amend-1.yaml
+products:
+- product: elasticsearch
+  target: 9.3.0
+  repo: elasticsearch
+  owner: elastic
 entries:
 - file:
     name: late-addition.yaml
@@ -41,6 +48,11 @@ Removals:
 
 ```yaml
 # 9.3.0.amend-2.yaml
+products:
+- product: elasticsearch
+  target: 9.3.0
+  repo: elasticsearch
+  owner: elastic
 exclude-entries:
 - file:
     name: 138723.yaml
@@ -53,7 +65,7 @@ When bundles are loaded (either via the `changelog render` command or the `{chan
 The result is rendered as a single release.
 
 :::{note}
-Amend bundles do not need to include `products` or `hide-features` fields — they inherit these from their parent bundle. If an amend bundle is found without a matching parent bundle, it remains standalone.
+Amend bundles created by older docs-builder versions may omit `products`; they are still accepted when loading and merge into their parent as before. `hide-features` is always inherited from the parent bundle. If an amend bundle is found without a matching parent bundle, it remains standalone.
 
 `rules.bundle` filtering does not apply to `changelog bundle-amend`. The command is a direct-injection escape hatch: the files you specify with `--add` are always included regardless of any product, type, or area filter configuration.
 :::

--- a/docs/development/changelog-bundle-registry.md
+++ b/docs/development/changelog-bundle-registry.md
@@ -87,7 +87,7 @@ Stored at `bundle/{product}/registry.json` (bundle index) or `changelog/{org}/{r
 | `product` | Grouping identifier — the product for a bundle index (`bundle/{product}/…`) or the `{org}/{repo}/{branch}` prefix for a changelog-entry index (`changelog/{org}/{repo}/{branch}/…`). |
 | `generated_at` | UTC timestamp of the last regeneration. |
 | `bundles[].file` | Bundle file name, resolved at `bundle/{product}/{file}` (or entry file at `changelog/{org}/{repo}/{branch}/{file}` for the entry index). |
-| `bundles[].target` | Target version/date from the bundle's declaration of **this** product (may be null). |
+| `bundles[].target` | Target version/date from the bundle's declaration of **this** product (may be null). For an amend sidecar (`{name}.amend-{N}.yaml`) that declares no products itself (created by older docs-builder versions), the parent bundle's target is recorded when the parent file is available in the same upload run. |
 | `bundles[].etag` | See the ETag caveat below. |
 
 Bundles are sorted by `target` descending (newest first) with a deterministic tiebreak on
@@ -280,7 +280,9 @@ logic still applies via `assembler.yml`, exactly as for local bundles.
   `hide-features` apply identically to CDN-sourced bundles.
 - **Version selection.** `:version:` renders a single target and works in both modes (shared match
   on registry `target` or bundle file name, see `ChangelogVersionMatch`). In CDN mode it filters the
-  prefetched bundles at render time.
+  prefetched bundles at render time. When the fetcher itself is asked for a single version, an amend
+  sidecar is additionally downloaded when its parent bundle matches, so amends published without
+  `products` (null registry `target`) still reach version-filtered consumers.
 - **Security.** The base URL is trusted configuration; the product and registry-supplied bundle
   file names are validated to single path segments so neither can traverse outside
   `bundle/{product}/`.

--- a/src/Elastic.Documentation.Configuration/ReleaseNotes/BundleAmendMerger.cs
+++ b/src/Elastic.Documentation.Configuration/ReleaseNotes/BundleAmendMerger.cs
@@ -13,7 +13,7 @@ namespace Elastic.Documentation.Configuration.ReleaseNotes;
 /// </summary>
 public static partial class BundleAmendMerger
 {
-	[GeneratedRegex(@"\.amend-(\d+)\.ya?ml$", RegexOptions.IgnoreCase)]
+	[GeneratedRegex(@"\.amend-(\d+)(\.ya?ml)$", RegexOptions.IgnoreCase)]
 	private static partial Regex AmendFileRegex();
 
 	/// <summary>Whether a path is an amend sidecar (<c>{name}.amend-{N}.yaml</c>).</summary>
@@ -26,6 +26,19 @@ public static partial class BundleAmendMerger
 		return match.Success && int.TryParse(match.Groups[1].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var number)
 			? number
 			: 0;
+	}
+
+	/// <summary>
+	/// Parent bundle path for an amend sidecar, keeping the amend's extension
+	/// (<c>repo-9.3.0.amend-1.yaml</c> → <c>repo-9.3.0.yaml</c>); null when
+	/// <paramref name="filePath"/> is not an amend file. Works on bare file names and full paths alike.
+	/// </summary>
+	public static string? GetParentBundlePath(string filePath)
+	{
+		var match = AmendFileRegex().Match(filePath);
+		return match.Success
+			? string.Concat(filePath.AsSpan(0, match.Index), match.Groups[2].Value)
+			: null;
 	}
 
 	/// <summary>

--- a/src/Elastic.Documentation.Configuration/ReleaseNotes/CdnChangelogFetcher.cs
+++ b/src/Elastic.Documentation.Configuration/ReleaseNotes/CdnChangelogFetcher.cs
@@ -82,7 +82,8 @@ public sealed class CdnChangelogFetcher : IDisposable
 	/// <summary>
 	/// Returns the loaded bundles for <paramref name="product"/> from the CDN at <paramref name="baseUri"/>.
 	/// Bundles are merged-by-amend but not yet merged-by-target or sorted (the caller owns presentation).
-	/// When <paramref name="version"/> is set, only the matching registry entry is downloaded.
+	/// When <paramref name="version"/> is set, only matching registry entries (and their amend sidecars)
+	/// are downloaded.
 	/// Returns an empty list on a registry-level failure.
 	/// </summary>
 	public async Task<IReadOnlyList<LoadedBundle>> FetchAsync(
@@ -156,15 +157,11 @@ public sealed class CdnChangelogFetcher : IDisposable
 		Action<string> emitWarning,
 		Cancel ctx)
 	{
-		var contents = new List<(string FileName, string Content)>(registry.Bundles.Count);
-		foreach (var bundle in registry.Bundles)
+		var selected = SelectBundles(version, registry.Bundles);
+		var contents = new List<(string FileName, string Content)>(selected.Count);
+		foreach (var bundle in selected)
 		{
 			ctx.ThrowIfCancellationRequested();
-
-			// When a single version is requested, only download the matching entry; the directive
-			// re-applies the same match after load, so this is purely a fetch optimization.
-			if (!string.IsNullOrWhiteSpace(version) && !ChangelogVersionMatch.Matches(version, bundle.Target, bundle.File))
-				continue;
 
 			var fileName = bundle.File;
 			if (!ChangelogKeys.IsSafeFileName(fileName))
@@ -186,6 +183,40 @@ public sealed class CdnChangelogFetcher : IDisposable
 		}
 
 		return contents;
+	}
+
+	/// <summary>
+	/// Registry entries to download. When a single version is requested, only matching entries are
+	/// selected; the directive re-applies the same match after load, so this is purely a fetch
+	/// optimization. An amend sidecar is additionally selected when its parent bundle matches:
+	/// amends published before products were copied from the parent carry a null registry
+	/// <c>target</c> and a file name (<c>{name}.amend-{N}.yaml</c>) the version can never equal, and the
+	/// post-load re-match cannot rescue an amend that was never fetched.
+	/// </summary>
+	private static List<ChangelogRegistryBundle> SelectBundles(string? version, IReadOnlyList<ChangelogRegistryBundle> bundles)
+	{
+		if (string.IsNullOrWhiteSpace(version))
+			return [.. bundles];
+
+		var selected = bundles
+			.Where(b => ChangelogVersionMatch.Matches(version, b.Target, b.File))
+			.ToList();
+
+		var selectedFiles = new HashSet<string>(
+			selected.Select(b => b.File).OfType<string>(),
+			StringComparer.OrdinalIgnoreCase);
+
+		foreach (var bundle in bundles)
+		{
+			if (bundle.File is null || selectedFiles.Contains(bundle.File) || !BundleAmendMerger.IsAmendFile(bundle.File))
+				continue;
+
+			var parentFile = BundleAmendMerger.GetParentBundlePath(bundle.File);
+			if (parentFile is not null && selectedFiles.Contains(parentFile))
+				selected.Add(bundle);
+		}
+
+		return selected;
 	}
 
 	private async Task<string> FetchTextAsync(Uri uri, Cancel ctx)

--- a/src/services/Elastic.Changelog/Bundling/ChangelogBundleAmendService.cs
+++ b/src/services/Elastic.Changelog/Bundling/ChangelogBundleAmendService.cs
@@ -246,9 +246,12 @@ public partial class ChangelogBundleAmendService(
 				entries.Count,
 				shouldResolve);
 
+			// Copy the parent's complete products (target, repo, owner) so the amend is self-contained:
+			// upload destination discovery, the registry's per-product target, and :version:-filtered
+			// CDN fetches all derive from a bundle file's own products.
 			var amendBundle = new Bundle
 			{
-				Products = [],
+				Products = parentBundle.Products,
 				ExcludeEntries = excludeEntries,
 				Entries = entries
 			};

--- a/src/services/Elastic.Changelog/Uploading/ChangelogUploadService.cs
+++ b/src/services/Elastic.Changelog/Uploading/ChangelogUploadService.cs
@@ -233,6 +233,21 @@ public class ChangelogUploadService(
 			}
 
 			var products = ReadProductsFromBundle(filePath);
+
+			// Amends published before products were copied from the parent omit them; derive the
+			// destination from the parent bundle next to the amend so they are not silently skipped.
+			if (products.Count == 0 && BundleAmendMerger.IsAmendFile(filePath))
+			{
+				products = ReadProductsFromParentBundle(filePath);
+				if (products.Count == 0)
+				{
+					collector.EmitWarning(filePath,
+						"Amend bundle declares no products and its parent bundle is missing or has none; " +
+						"skipping upload. Re-create the amend with a current docs-builder so it carries the parent's products.");
+					continue;
+				}
+			}
+
 			if (products.Count == 0)
 			{
 				_logger.LogDebug("No products found in bundle {File}, skipping", filePath);
@@ -255,6 +270,14 @@ public class ChangelogUploadService(
 		}
 
 		return targets;
+	}
+
+	private List<string> ReadProductsFromParentBundle(string amendFilePath)
+	{
+		var parentPath = BundleAmendMerger.GetParentBundlePath(amendFilePath);
+		return parentPath != null && _fileSystem.File.Exists(parentPath)
+			? ReadProductsFromBundle(parentPath)
+			: [];
 	}
 
 	private List<string> ReadProductsFromBundle(string filePath)

--- a/src/services/Elastic.Changelog/Uploading/RegistryBuilder.cs
+++ b/src/services/Elastic.Changelog/Uploading/RegistryBuilder.cs
@@ -171,8 +171,11 @@ internal sealed class RegistryBuilder(
 		{
 			var content = fileSystem.File.ReadAllText(localPath);
 			var bundle = ReleaseNotesSerialization.DeserializeBundle(content);
+
+			// Amends published before products were copied from the parent omit them; record the
+			// parent bundle's target so :version:-filtered consumers still discover the amend.
 			if (bundle.Products.Count == 0)
-				return null;
+				return ReadTargetFromParentBundle(localPath, product);
 
 			var match = bundle.Products.FirstOrDefault(p => string.Equals(p.ProductId, product, StringComparison.Ordinal));
 			return (match ?? bundle.Products[0]).Target;
@@ -182,6 +185,20 @@ internal sealed class RegistryBuilder(
 			collector.EmitWarning(localPath, $"Could not read bundle target for manifest: {ex.Message}");
 			return null;
 		}
+	}
+
+	private string? ReadTargetFromParentBundle(string amendFilePath, string product)
+	{
+		var parentPath = BundleAmendMerger.GetParentBundlePath(amendFilePath);
+		if (parentPath == null || !fileSystem.File.Exists(parentPath))
+			return null;
+
+		var parent = ReleaseNotesSerialization.DeserializeBundle(fileSystem.File.ReadAllText(parentPath));
+		if (parent.Products.Count == 0)
+			return null;
+
+		var match = parent.Products.FirstOrDefault(p => string.Equals(p.ProductId, product, StringComparison.Ordinal));
+		return (match ?? parent.Products[0]).Target;
 	}
 
 	private enum WriteOutcome { Updated, Unchanged, Failed }

--- a/tests/Elastic.Changelog.Tests/Changelogs/BundleAmendEndToEndTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/BundleAmendEndToEndTests.cs
@@ -1,0 +1,177 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Net;
+using Amazon.S3;
+using Amazon.S3.Model;
+using AwesomeAssertions;
+using Elastic.Changelog.Bundling;
+using Elastic.Changelog.Uploading;
+using Elastic.Documentation.Configuration;
+using Elastic.Documentation.Configuration.ReleaseNotes;
+using Elastic.Documentation.Integrations.S3;
+using FakeItEasy;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Elastic.Changelog.Tests.Changelogs;
+
+/// <summary>
+/// The full amend acceptance chain: <c>bundle-amend</c> materializes a self-contained amend
+/// (parent products copied) → upload destination discovery includes the amend → the registry
+/// records the amend's target → a <c>:version:</c>-filtered CDN fetch returns the amend and the
+/// <c>exclude-entries</c> retraction (matched by <c>file</c> identity) applies.
+/// </summary>
+public class BundleAmendEndToEndTests(ITestOutputHelper output) : ChangelogTestBase(output)
+{
+	[Fact]
+	public async Task AmendLifecycle_FromCreationToVersionFilteredCdnConsumption()
+	{
+		var ct = TestContext.Current.CancellationToken;
+
+		// -- Authoring fixtures -------------------------------------------------------------
+		var changelogDir = FileSystem.Path.Join(Paths.WorkingDirectoryRoot.FullName, Guid.NewGuid().ToString());
+		FileSystem.Directory.CreateDirectory(changelogDir);
+
+		// language=yaml
+		var retractedEntry =
+			"""
+			title: Retracted fix
+			type: bug-fix
+			products:
+			  - product: elasticsearch
+			    target: 9.3.0
+			prs:
+			- "100"
+			""";
+		var retractedFile = FileSystem.Path.Join(changelogDir, "1-old.yaml");
+		await FileSystem.File.WriteAllTextAsync(retractedFile, retractedEntry, ct);
+
+		// language=yaml
+		var addedEntry =
+			"""
+			title: Late addition
+			type: enhancement
+			products:
+			  - product: elasticsearch
+			    target: 9.3.0
+			prs:
+			- "200"
+			""";
+		var addedFile = FileSystem.Path.Join(changelogDir, "2-late.yaml");
+		await FileSystem.File.WriteAllTextAsync(addedFile, addedEntry, ct);
+
+		var bundleDir = FileSystem.Path.Join(Paths.WorkingDirectoryRoot.FullName, Guid.NewGuid().ToString());
+		FileSystem.Directory.CreateDirectory(bundleDir);
+		var parentPath = FileSystem.Path.Join(bundleDir, "elasticsearch-9.3.0.yaml");
+		// A resolved parent whose entry carries a file identity, so the retraction below can match it.
+		// language=yaml
+		await FileSystem.File.WriteAllTextAsync(parentPath, $"""
+			products:
+			- product: elasticsearch
+			  target: 9.3.0
+			  lifecycle: ga
+			  repo: elasticsearch
+			  owner: elastic
+			entries:
+			- file:
+			    name: 1-old.yaml
+			    checksum: {ComputeSha1(retractedEntry)}
+			  type: bug-fix
+			  title: Retracted fix
+			  prs:
+			  - "100"
+			""", ct);
+
+		// -- 1. bundle-amend materializes a self-contained amend -----------------------------
+		var amendService = new ChangelogBundleAmendService(LoggerFactory, FileSystem);
+		var amendResult = await amendService.AmendBundle(Collector, new AmendBundleArguments
+		{
+			BundlePath = parentPath,
+			AddFiles = [addedFile],
+			RemoveFiles = [retractedFile]
+		}, ct);
+
+		amendResult.Should().BeTrue();
+		Collector.Errors.Should().Be(0);
+
+		var amendFiles = ChangelogBundleAmendService.DiscoverAmendFiles(FileSystem, parentPath);
+		amendFiles.Should().ContainSingle();
+		var amend = ReleaseNotesSerialization.DeserializeBundle(await FileSystem.File.ReadAllTextAsync(amendFiles[0], ct));
+		amend.Products.Should().ContainSingle("the amend copies the parent's complete products");
+		amend.Products[0].Target.Should().Be("9.3.0");
+		amend.Products[0].Repo.Should().Be("elasticsearch");
+		amend.Products[0].Owner.Should().Be("elastic");
+
+		// -- 2. upload destination discovery includes the amend ------------------------------
+		var s3Client = A.Fake<IAmazonS3>();
+		var uploadCollector = new TestDiagnosticsCollector(Output);
+		var uploadService = new ChangelogUploadService(NullLoggerFactory.Instance, fileSystem: FileSystem, s3Client: s3Client);
+		var targets = uploadService.DiscoverBundleUploadTargets(uploadCollector, bundleDir);
+
+		targets.Select(t => t.S3Key).Should().BeEquivalentTo(
+			"bundle/elasticsearch/elasticsearch-9.3.0.yaml",
+			"bundle/elasticsearch/elasticsearch-9.3.0.amend-1.yaml");
+		uploadCollector.Errors.Should().Be(0);
+		uploadCollector.Warnings.Should().Be(0);
+
+		// -- 3. the registry records the amend's target --------------------------------------
+		var puts = new List<PutObjectRequest>();
+		A.CallTo(() => s3Client.GetObjectAsync(A<GetObjectRequest>._, A<CancellationToken>._))
+			.Throws(new AmazonS3Exception("Not Found") { StatusCode = HttpStatusCode.NotFound });
+		A.CallTo(() => s3Client.PutObjectAsync(A<PutObjectRequest>._, A<CancellationToken>._))
+			.Invokes((PutObjectRequest r, CancellationToken _) => puts.Add(r))
+			.Returns(new PutObjectResponse());
+
+		var registryCollector = new TestDiagnosticsCollector(Output);
+		var etagCalculator = new S3EtagCalculator(NullLoggerFactory.Instance, FileSystem);
+		var builder = new RegistryBuilder(NullLoggerFactory.Instance, FileSystem, s3Client, etagCalculator, "test-bucket");
+		var refresh = await builder.RefreshAsync(registryCollector, targets, ct);
+
+		refresh.Updated.Should().Be(1);
+		var registryPut = puts.Single(p => p.Key == "bundle/elasticsearch/registry.json");
+		registryPut.ContentBody.Should().Contain("elasticsearch-9.3.0.amend-1.yaml");
+
+		// -- 4. :version:-filtered CDN fetch returns the amend and applies the retraction ----
+		using var handler = new StubHandler(req =>
+		{
+			var path = req.RequestUri!.AbsolutePath;
+			if (path.EndsWith("/registry.json", StringComparison.Ordinal))
+				return Response(registryPut.ContentBody, "application/json");
+
+			var fileName = path[(path.LastIndexOf('/') + 1)..];
+			var localPath = FileSystem.Path.Join(bundleDir, fileName);
+			return FileSystem.File.Exists(localPath)
+				? Response(FileSystem.File.ReadAllText(localPath), "text/yaml")
+				: new HttpResponseMessage(HttpStatusCode.NotFound);
+		});
+
+		var fetchErrors = new List<string>();
+		var fetchWarnings = new List<string>();
+		using var fetcher = new CdnChangelogFetcher(NullLoggerFactory.Instance, FileSystem, handler);
+		var bundles = await fetcher.FetchAsync(
+			new Uri("https://cdn.example"),
+			"elasticsearch",
+			version: "9.3.0",
+			fetchErrors.Add,
+			fetchWarnings.Add,
+			ct);
+
+		fetchErrors.Should().BeEmpty();
+		fetchWarnings.Should().BeEmpty();
+		bundles.Should().ContainSingle("the amend merges into its parent");
+		bundles[0].Version.Should().Be("9.3.0");
+		bundles[0].Entries.Select(e => e.Title).Should().BeEquivalentTo(
+			["Late addition"],
+			"the added entry is present and the file-identity retraction removed the original entry");
+	}
+
+	private static HttpResponseMessage Response(string body, string mediaType) =>
+		new(HttpStatusCode.OK) { Content = new StringContent(body, System.Text.Encoding.UTF8, mediaType) };
+
+	private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
+	{
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+			Task.FromResult(responder(request));
+	}
+}

--- a/tests/Elastic.Changelog.Tests/Changelogs/BundleAmendMergerTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/BundleAmendMergerTests.cs
@@ -53,6 +53,21 @@ public class BundleAmendMergerTests
 		merged[0].File!.Name.Should().Be("two.yaml");
 	}
 
+	[Theory]
+	[InlineData("9.3.0.amend-1.yaml", "9.3.0.yaml")]
+	[InlineData("repo-9.3.0.amend-12.yml", "repo-9.3.0.yml")]
+	[InlineData("cloud-2025-11.AMEND-2.YAML", "cloud-2025-11.YAML")]
+	[InlineData("/releases/9.3.0.amend-1.yaml", "/releases/9.3.0.yaml")]
+	public void GetParentBundlePath_AmendFile_StripsAmendSuffix(string amendPath, string expectedParent) =>
+		BundleAmendMerger.GetParentBundlePath(amendPath).Should().Be(expectedParent);
+
+	[Theory]
+	[InlineData("9.3.0.yaml")]
+	[InlineData("9.3.0.amend-.yaml")]
+	[InlineData("9.3.0.amend-1.json")]
+	public void GetParentBundlePath_NonAmendFile_ReturnsNull(string path) =>
+		BundleAmendMerger.GetParentBundlePath(path).Should().BeNull();
+
 	private static BundledEntry CreateFileEntry(string name, string checksum) => new()
 	{
 		File = new BundledFile

--- a/tests/Elastic.Changelog.Tests/Changelogs/BundleAmendTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/BundleAmendTests.cs
@@ -7,6 +7,7 @@ using Elastic.Changelog.Bundling;
 using Elastic.Documentation.Configuration;
 using Elastic.Documentation.Configuration.ReleaseNotes;
 using Elastic.Documentation.Diagnostics;
+using Elastic.Documentation.ReleaseNotes;
 
 namespace Elastic.Changelog.Tests.Changelogs;
 
@@ -294,7 +295,8 @@ public class BundleAmendTests : ChangelogTestBase
 		var amendContent = await FileSystem.File.ReadAllTextAsync(amendFiles[0], ct);
 		amendContent.Should().Contain("exclude-entries:");
 		amendContent.Should().Contain("name: 1755268130-existing.yaml");
-		amendContent.TrimStart().Should().StartWith("exclude-entries:");
+		// The parent's products are copied first; the exclusions follow.
+		amendContent.TrimStart().Should().StartWith("products:");
 	}
 
 	[Fact]
@@ -395,6 +397,119 @@ public class BundleAmendTests : ChangelogTestBase
 		amendContent.Should().Contain("name: 1755268130-existing.yaml");
 		amendContent.Should().Contain("entries:");
 		amendContent.Should().Contain("name: 1755268200-new-feature.yaml");
+	}
+
+	/// <summary>
+	/// Writes a resolved parent bundle with a complete products block (target, lifecycle, repo, owner)
+	/// plus its referenced changelog entry, and returns the bundle path.
+	/// </summary>
+	private async Task<string> CreateBundleWithFullProducts(CancellationToken ct)
+	{
+		// language=yaml
+		var changelog =
+			"""
+			title: Existing feature
+			type: feature
+			products:
+			  - product: elasticsearch
+			    target: 9.3.0
+			prs:
+			- "100"
+			""";
+
+		var changelogFile = FileSystem.Path.Join(_changelogDir, "1755268130-existing.yaml");
+		await FileSystem.File.WriteAllTextAsync(changelogFile, changelog, ct);
+		var checksum = ComputeSha1(changelog);
+
+		var bundleDir = FileSystem.Path.Join(Paths.WorkingDirectoryRoot.FullName, Guid.NewGuid().ToString());
+		FileSystem.Directory.CreateDirectory(bundleDir);
+		var bundlePath = FileSystem.Path.Join(bundleDir, "elasticsearch-9.3.0.yaml");
+		// language=yaml
+		await FileSystem.File.WriteAllTextAsync(bundlePath, $"""
+			products:
+			- product: elasticsearch
+			  target: 9.3.0
+			  lifecycle: ga
+			  repo: elasticsearch
+			  owner: elastic
+			entries:
+			- file:
+			    name: 1755268130-existing.yaml
+			    checksum: {checksum}
+			  type: feature
+			  title: Existing feature
+			  prs:
+			  - "100"
+			""", ct);
+
+		return bundlePath;
+	}
+
+	[Fact]
+	public async Task AmendBundle_Add_CopiesParentProductsIntoAmend()
+	{
+		var ct = TestContext.Current.CancellationToken;
+		var bundlePath = await CreateBundleWithFullProducts(ct);
+		var newFile = await CreateNewChangelogFile(ct);
+
+		var amendCollector = new TestDiagnosticsCollector(Output);
+		var input = new AmendBundleArguments
+		{
+			BundlePath = bundlePath,
+			AddFiles = [newFile]
+		};
+
+		var result = await Service.AmendBundle(amendCollector, input, ct);
+
+		result.Should().BeTrue();
+		amendCollector.Errors.Should().Be(0);
+
+		var amendFiles = ChangelogBundleAmendService.DiscoverAmendFiles(FileSystem, bundlePath);
+		amendFiles.Should().HaveCount(1);
+
+		var amendContent = await FileSystem.File.ReadAllTextAsync(amendFiles[0], ct);
+		var amend = ReleaseNotesSerialization.DeserializeBundle(amendContent);
+
+		// The amend must be self-contained: complete parent products, including target, repo, and owner.
+		amend.Products.Should().ContainSingle();
+		amend.Products[0].Should().BeEquivalentTo(new BundledProduct
+		{
+			ProductId = "elasticsearch",
+			Target = "9.3.0",
+			Lifecycle = Lifecycle.Ga,
+			Repo = "elasticsearch",
+			Owner = "elastic"
+		});
+	}
+
+	[Fact]
+	public async Task AmendBundle_Remove_CopiesParentProductsIntoAmend()
+	{
+		var ct = TestContext.Current.CancellationToken;
+		var bundlePath = await CreateBundleWithFullProducts(ct);
+		var changelogFile = FileSystem.Path.Join(_changelogDir, "1755268130-existing.yaml");
+
+		var amendCollector = new TestDiagnosticsCollector(Output);
+		var input = new AmendBundleArguments
+		{
+			BundlePath = bundlePath,
+			RemoveFiles = [changelogFile]
+		};
+
+		var result = await Service.AmendBundle(amendCollector, input, ct);
+
+		result.Should().BeTrue();
+		amendCollector.Errors.Should().Be(0);
+
+		var amendFiles = ChangelogBundleAmendService.DiscoverAmendFiles(FileSystem, bundlePath);
+		amendFiles.Should().HaveCount(1);
+
+		var amend = ReleaseNotesSerialization.DeserializeBundle(await FileSystem.File.ReadAllTextAsync(amendFiles[0], ct));
+		amend.ExcludeEntries.Should().ContainSingle();
+		amend.Products.Should().ContainSingle();
+		amend.Products[0].Target.Should().Be("9.3.0");
+		amend.Products[0].Repo.Should().Be("elasticsearch");
+		amend.Products[0].Owner.Should().Be("elastic");
 	}
 
 	[Fact]

--- a/tests/Elastic.Changelog.Tests/Uploading/ChangelogUploadServiceTests.cs
+++ b/tests/Elastic.Changelog.Tests/Uploading/ChangelogUploadServiceTests.cs
@@ -617,6 +617,96 @@ public class ChangelogUploadServiceTests
 	}
 
 	[Fact]
+	public void DiscoverBundleUploadTargets_AmendWithProducts_MapsToProductKey()
+	{
+		var bundleDir = _mockFileSystem.Path.Join(Paths.WorkingDirectoryRoot.FullName, Guid.NewGuid().ToString(), "releases");
+		_mockFileSystem.Directory.CreateDirectory(bundleDir);
+		// Amend materialized by a current docs-builder: it carries the parent's complete products.
+		// language=yaml
+		_mockFileSystem.AddFile(_mockFileSystem.Path.Join(bundleDir, "elasticsearch-9.3.0.amend-1.yaml"), new MockFileData("""
+			products:
+			  - product: elasticsearch
+			    target: 9.3.0
+			    repo: elasticsearch
+			    owner: elastic
+			entries:
+			  - file:
+			      name: 2-late.yaml
+			      checksum: c0ffee
+			    type: enhancement
+			    title: Late addition
+			"""));
+
+		var targets = _service.DiscoverBundleUploadTargets(_collector, bundleDir);
+
+		targets.Should().ContainSingle();
+		targets[0].S3Key.Should().Be("bundle/elasticsearch/elasticsearch-9.3.0.amend-1.yaml");
+		_collector.Errors.Should().Be(0);
+		_collector.Warnings.Should().Be(0);
+	}
+
+	[Fact]
+	public void DiscoverBundleUploadTargets_LegacyAmendWithoutProducts_DerivesDestinationFromParent()
+	{
+		var bundleDir = _mockFileSystem.Path.Join(Paths.WorkingDirectoryRoot.FullName, Guid.NewGuid().ToString(), "releases");
+		_mockFileSystem.Directory.CreateDirectory(bundleDir);
+		// language=yaml
+		_mockFileSystem.AddFile(_mockFileSystem.Path.Join(bundleDir, "stack-9.3.0.yaml"), new MockFileData("""
+			products:
+			  - product: elasticsearch
+			    target: 9.3.0
+			    repo: elasticsearch
+			  - product: kibana
+			    target: 9.3.0
+			    repo: kibana
+			entries:
+			  - file:
+			      name: 1-old.yaml
+			      checksum: deadbeef
+			    type: bug-fix
+			    title: To be retracted
+			"""));
+		// Amend published before products were copied from the parent: exclusion only, no products.
+		// language=yaml
+		_mockFileSystem.AddFile(_mockFileSystem.Path.Join(bundleDir, "stack-9.3.0.amend-1.yaml"), new MockFileData("""
+			exclude-entries:
+			  - file:
+			      name: 1-old.yaml
+			      checksum: deadbeef
+			"""));
+
+		var targets = _service.DiscoverBundleUploadTargets(_collector, bundleDir);
+
+		targets.Should().HaveCount(4, "the amend fans out to the parent's products");
+		targets.Should().Contain(t => t.S3Key == "bundle/elasticsearch/stack-9.3.0.amend-1.yaml");
+		targets.Should().Contain(t => t.S3Key == "bundle/kibana/stack-9.3.0.amend-1.yaml");
+		_collector.Errors.Should().Be(0);
+		_collector.Warnings.Should().Be(0);
+	}
+
+	[Fact]
+	public void DiscoverBundleUploadTargets_OrphanLegacyAmend_WarnsAndSkips()
+	{
+		var bundleDir = _mockFileSystem.Path.Join(Paths.WorkingDirectoryRoot.FullName, Guid.NewGuid().ToString(), "releases");
+		_mockFileSystem.Directory.CreateDirectory(bundleDir);
+		// No parent bundle next to the amend, and the amend declares no products: the destination
+		// cannot be derived, but the skip must be visible instead of silent.
+		// language=yaml
+		_mockFileSystem.AddFile(_mockFileSystem.Path.Join(bundleDir, "stack-9.3.0.amend-1.yaml"), new MockFileData("""
+			exclude-entries:
+			  - file:
+			      name: 1-old.yaml
+			      checksum: deadbeef
+			"""));
+
+		var targets = _service.DiscoverBundleUploadTargets(_collector, bundleDir);
+
+		targets.Should().BeEmpty();
+		_collector.Errors.Should().Be(0);
+		_collector.Warnings.Should().BeGreaterThan(0);
+	}
+
+	[Fact]
 	public async Task Upload_BundleArtifactType_UploadsRegistryAlongsideBundle()
 	{
 		var bundleDir = _mockFileSystem.Path.Join(Paths.WorkingDirectoryRoot.FullName, Guid.NewGuid().ToString(), "releases");

--- a/tests/Elastic.Changelog.Tests/Uploading/RegistryBuilderTests.cs
+++ b/tests/Elastic.Changelog.Tests/Uploading/RegistryBuilderTests.cs
@@ -290,6 +290,88 @@ public class RegistryBuilderTests
 	}
 
 	[Fact]
+	public async Task Refresh_AmendWithProducts_RecordsTargetFromOwnProducts()
+	{
+		var path = _mockFileSystem.Path.Join(_bundleDir, "9.3.0.amend-1.yaml");
+		// Amend materialized by a current docs-builder: it carries the parent's complete products.
+		// language=yaml
+		_mockFileSystem.AddFile(path, new MockFileData("""
+			products:
+			  - product: elasticsearch
+			    target: 9.3.0
+			    repo: elasticsearch
+			    owner: elastic
+			entries:
+			  - file:
+			      name: 2-late.yaml
+			      checksum: c0ffee
+			    type: enhancement
+			    title: Late addition
+			"""));
+		var targets = new List<UploadTarget> { new(path, "bundle/elasticsearch/9.3.0.amend-1.yaml") };
+		StubExistingManifestNotFound();
+
+		var result = await _builder.RefreshAsync(_collector, targets, TestContext.Current.CancellationToken);
+
+		result.Updated.Should().Be(1);
+		var manifest = Deserialize(_puts[0].ContentBody);
+		manifest.Bundles.Should().ContainSingle();
+		manifest.Bundles[0].File.Should().Be("9.3.0.amend-1.yaml");
+		manifest.Bundles[0].Target.Should().Be("9.3.0");
+	}
+
+	[Fact]
+	public async Task Refresh_LegacyAmendWithoutProducts_RecordsParentTarget()
+	{
+		var parent = AddBundle("9.3.0.yaml", "elasticsearch", "9.3.0");
+		var amend = _mockFileSystem.Path.Join(_bundleDir, "9.3.0.amend-1.yaml");
+		// Amend published before products were copied from the parent: exclusion only, no products.
+		// language=yaml
+		_mockFileSystem.AddFile(amend, new MockFileData("""
+			exclude-entries:
+			  - file:
+			      name: 1-feature.yaml
+			      checksum: deadbeef
+			"""));
+		var targets = new List<UploadTarget>
+		{
+			new(parent, "bundle/elasticsearch/9.3.0.yaml"),
+			new(amend, "bundle/elasticsearch/9.3.0.amend-1.yaml")
+		};
+		StubExistingManifestNotFound();
+
+		var result = await _builder.RefreshAsync(_collector, targets, TestContext.Current.CancellationToken);
+
+		result.Updated.Should().Be(1);
+		var manifest = Deserialize(_puts[0].ContentBody);
+		manifest.Bundles.Should().HaveCount(2);
+		var amendEntry = manifest.Bundles.Single(b => b.File == "9.3.0.amend-1.yaml");
+		amendEntry.Target.Should().Be("9.3.0", "the amend inherits the parent bundle's target");
+	}
+
+	[Fact]
+	public async Task Refresh_OrphanLegacyAmendWithoutParent_RecordsEntryWithoutTarget()
+	{
+		var amend = _mockFileSystem.Path.Join(_bundleDir, "9.3.0.amend-1.yaml");
+		// language=yaml
+		_mockFileSystem.AddFile(amend, new MockFileData("""
+			exclude-entries:
+			  - file:
+			      name: 1-feature.yaml
+			      checksum: deadbeef
+			"""));
+		var targets = new List<UploadTarget> { new(amend, "bundle/elasticsearch/9.3.0.amend-1.yaml") };
+		StubExistingManifestNotFound();
+
+		var result = await _builder.RefreshAsync(_collector, targets, TestContext.Current.CancellationToken);
+
+		result.Updated.Should().Be(1);
+		var manifest = Deserialize(_puts[0].ContentBody);
+		manifest.Bundles.Should().ContainSingle();
+		manifest.Bundles[0].Target.Should().BeNull();
+	}
+
+	[Fact]
 	public async Task Refresh_UnchangedManifest_SkipsWrite()
 	{
 		var path = AddBundle("9.3.0.yaml", "elasticsearch", "9.3.0");

--- a/tests/Elastic.Documentation.Configuration.Tests/ReleaseNotes/CdnChangelogFetcherTests.cs
+++ b/tests/Elastic.Documentation.Configuration.Tests/ReleaseNotes/CdnChangelogFetcherTests.cs
@@ -80,6 +80,145 @@ public class CdnChangelogFetcherTests
 	}
 
 	[Fact]
+	public async Task FetchAsync_WithVersion_DownloadsAmendCarryingParentProducts()
+	{
+		// Amend materialized by a current docs-builder: it carries the parent's complete products,
+		// so its registry entry has a target and matches the version on its own.
+		// language=yaml
+		const string amendBundle = """
+			products:
+			  - product: elasticsearch
+			    target: 9.3.0
+			    repo: elasticsearch
+			    owner: elastic
+			entries:
+			  - type: bug-fix
+			    title: Amended fix
+			""";
+		var handler = new StubHandler(req => req.RequestUri!.AbsolutePath switch
+		{
+			var p when p.EndsWith("/registry.json", StringComparison.Ordinal) =>
+				Json(/*lang=json,strict*/ """{ "schema_version": 1, "product": "elasticsearch", "bundles": [ { "file": "9.4.0.yaml", "target": "9.4.0" }, { "file": "9.3.0.yaml", "target": "9.3.0" }, { "file": "9.3.0.amend-1.yaml", "target": "9.3.0" } ] }"""),
+			var p when p.EndsWith("/9.3.0.amend-1.yaml", StringComparison.Ordinal) => Yaml(amendBundle),
+			_ => Yaml(SampleBundle)
+		});
+		var (errors, warnings, emitError, emitWarning) = Diagnostics();
+
+		using var fetcher = CreateFetcher(handler);
+		var bundles = await fetcher.FetchAsync(BaseUri, "elasticsearch", version: "9.3.0", emitError, emitWarning, TestContext.Current.CancellationToken);
+
+		errors.Should().BeEmpty();
+		warnings.Should().BeEmpty();
+		handler.RequestedPaths.Should().Contain("/bundle/elasticsearch/9.3.0.amend-1.yaml");
+		handler.RequestedPaths.Should().NotContain(p => p.EndsWith("/9.4.0.yaml", StringComparison.Ordinal));
+
+		bundles.Should().ContainSingle("the amend merges into its parent");
+		bundles[0].Version.Should().Be("9.3.0");
+		bundles[0].Entries.Select(e => e.Title)
+			.Should().BeEquivalentTo("Sample enhancement", "Amended fix");
+	}
+
+	[Fact]
+	public async Task FetchAsync_WithVersion_DownloadsLegacyAmendWhoseParentMatches()
+	{
+		// Amend published before products were copied from the parent: null registry target and a
+		// file name the version can never equal. It must still be fetched when its parent matches.
+		// language=yaml
+		const string amendBundle = """
+			entries:
+			  - type: bug-fix
+			    title: Amended fix
+			""";
+		var handler = new StubHandler(req => req.RequestUri!.AbsolutePath switch
+		{
+			var p when p.EndsWith("/registry.json", StringComparison.Ordinal) =>
+				Json(/*lang=json,strict*/ """{ "schema_version": 1, "product": "elasticsearch", "bundles": [ { "file": "9.3.0.yaml", "target": "9.3.0" }, { "file": "9.3.0.amend-1.yaml", "target": null } ] }"""),
+			var p when p.EndsWith("/9.3.0.amend-1.yaml", StringComparison.Ordinal) => Yaml(amendBundle),
+			_ => Yaml(SampleBundle)
+		});
+		var (errors, warnings, emitError, emitWarning) = Diagnostics();
+
+		using var fetcher = CreateFetcher(handler);
+		var bundles = await fetcher.FetchAsync(BaseUri, "elasticsearch", version: "9.3.0", emitError, emitWarning, TestContext.Current.CancellationToken);
+
+		errors.Should().BeEmpty();
+		warnings.Should().BeEmpty();
+		handler.RequestedPaths.Should().Contain("/bundle/elasticsearch/9.3.0.amend-1.yaml");
+
+		bundles.Should().ContainSingle();
+		bundles[0].Entries.Select(e => e.Title)
+			.Should().BeEquivalentTo("Sample enhancement", "Amended fix");
+	}
+
+	[Fact]
+	public async Task FetchAsync_WithOtherVersion_DoesNotDownloadUnrelatedAmend()
+	{
+		var handler = new StubHandler(req =>
+			req.RequestUri!.AbsolutePath.EndsWith("/registry.json", StringComparison.Ordinal)
+				? Json(/*lang=json,strict*/ """{ "schema_version": 1, "product": "elasticsearch", "bundles": [ { "file": "9.4.0.yaml", "target": "9.4.0" }, { "file": "9.3.0.yaml", "target": "9.3.0" }, { "file": "9.3.0.amend-1.yaml", "target": null } ] }""")
+				: Yaml(SampleBundle));
+		var (errors, _, emitError, emitWarning) = Diagnostics();
+
+		using var fetcher = CreateFetcher(handler);
+		_ = await fetcher.FetchAsync(BaseUri, "elasticsearch", version: "9.4.0", emitError, emitWarning, TestContext.Current.CancellationToken);
+
+		errors.Should().BeEmpty();
+		handler.RequestedPaths.Should().Contain(p => p.EndsWith("/9.4.0.yaml", StringComparison.Ordinal));
+		handler.RequestedPaths.Should().NotContain(p => p.EndsWith("/9.3.0.yaml", StringComparison.Ordinal));
+		handler.RequestedPaths.Should().NotContain(p => p.EndsWith("/9.3.0.amend-1.yaml", StringComparison.Ordinal));
+	}
+
+	[Fact]
+	public async Task FetchAsync_WithVersion_FileIdentityRetractionApplies()
+	{
+		// A resolved parent whose entries carry file identities, and a legacy amend that retracts one
+		// of them by file identity: the version-filtered fetch must return the amended result.
+		// language=yaml
+		const string parentBundle = """
+			products:
+			  - product: elasticsearch
+			    target: 9.3.0
+			    repo: elasticsearch
+			    owner: elastic
+			entries:
+			  - file:
+			      name: 1-old.yaml
+			      checksum: deadbeef
+			    type: bug-fix
+			    title: Retracted fix
+			  - file:
+			      name: 2-keep.yaml
+			      checksum: c0ffee
+			    type: enhancement
+			    title: Kept enhancement
+			""";
+		// language=yaml
+		const string amendBundle = """
+			exclude-entries:
+			  - file:
+			      name: 1-old.yaml
+			      checksum: deadbeef
+			""";
+		var handler = new StubHandler(req => req.RequestUri!.AbsolutePath switch
+		{
+			var p when p.EndsWith("/registry.json", StringComparison.Ordinal) =>
+				Json(/*lang=json,strict*/ """{ "schema_version": 1, "product": "elasticsearch", "bundles": [ { "file": "9.3.0.yaml", "target": "9.3.0" }, { "file": "9.3.0.amend-1.yaml", "target": null } ] }"""),
+			var p when p.EndsWith("/9.3.0.amend-1.yaml", StringComparison.Ordinal) => Yaml(amendBundle),
+			_ => Yaml(parentBundle)
+		});
+		var (errors, warnings, emitError, emitWarning) = Diagnostics();
+
+		using var fetcher = CreateFetcher(handler);
+		var bundles = await fetcher.FetchAsync(BaseUri, "elasticsearch", version: "9.3.0", emitError, emitWarning, TestContext.Current.CancellationToken);
+
+		errors.Should().BeEmpty();
+		warnings.Should().BeEmpty();
+		bundles.Should().ContainSingle();
+		bundles[0].Entries.Select(e => e.Title)
+			.Should().BeEquivalentTo(["Kept enhancement"], "the amend retracts the entry by file identity");
+	}
+
+	[Fact]
 	public async Task FetchAsync_RegistryNotFound_EmitsErrorAndReturnsEmpty()
 	{
 		var handler = new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.NotFound));


### PR DESCRIPTION
## Summary

`bundle-amend` files could omit `products`, which broke them in two places, not one:

1. **Upload**: bundle upload derives destinations only from each file's own products, so amends without them were *silently skipped* and never reached `bundle/{product}/`.
2. **Registry**: `RegistryBuilder.BuildLocalEntries` recorded `target: null` for them.

Because the CDN fetcher downloads only objects whose `target` or file name matches a requested version (`CdnChangelogFetcher.DownloadBundlesAsync` — and the post-load re-match cannot rescue an amend that was never fetched), a file like `repo-9.3.0.amend-1.yaml` never matched `9.3.0` and vanished from `:version:`-filtered consumption.

This PR fixes the live `bundle-amend` contract end to end:

- **`changelog bundle-amend` materializes self-contained amends**: the parent bundle's complete `products` (including `target`, `lifecycle`, `repo`, and `owner`) are copied into every amend file (`ChangelogBundleAmendService`).
- **Upload destination discovery works for amends**: a legacy amend without its own `products` falls back to the parent bundle next to it; when neither provides products, the skip is now a visible warning instead of a debug-level silent skip (`ChangelogUploadService.DiscoverBundleUploadTargets`).
- **The registry records the correct `target` for amends**: for legacy amends without `products`, the parent bundle's target is recorded when the parent file is present in the same upload run (`RegistryBuilder`).
- **`:version:`-filtered discovery returns amends**: the fetcher's download-time version filter additionally selects amend sidecars whose parent bundle matches the requested version (`CdnChangelogFetcher`), so amends are fetched, merged into their parent, and survive the post-load re-match.
- `BundleAmendMerger` gains a shared `GetParentBundlePath` helper (file-name-based parent linkage) used by all three call sites.

## Backward compatibility

Already-published amends without `products` exist in the wild (registry entries with `target: null`). They are handled at every layer:

- **Fetching**: the CDN fetcher rescues them by parent-file-name linkage — an amend is downloaded whenever its parent bundle matches the requested version, regardless of its own (null) registry target. Unfiltered fetches (the production prefetch path uses `version: null`) were never affected.
- **Loading/merging**: `BundleLoader` merges amends into parents by file name, unchanged; amends with or without `products` merge identically. `hide-features` is still inherited from the parent.
- **Re-upload**: re-running `changelog upload --artifact-type bundle` over a directory containing a legacy amend now derives its destinations from the parent bundle and backfills the registry `target`, healing existing published state without re-creating the amend.
- **Retraction identity**: existing `file` identities (name + checksum) remain the exclusion contract; the end-to-end test proves an `exclude-entries` retraction via `file` identity applies through a version-filtered CDN fetch.

Non-goals (per the issue): no backfill-mode upload features (create-only writes, explicit file selection) and no synthetic-identity generation — those belong to separate issues.

## Test plan

- [x] `AmendBundle_Add_CopiesParentProductsIntoAmend` / `AmendBundle_Remove_CopiesParentProductsIntoAmend` — amend creation copies complete parent products (target/lifecycle/repo/owner).
- [x] `DiscoverBundleUploadTargets_AmendWithProducts_MapsToProductKey`, `…_LegacyAmendWithoutProducts_DerivesDestinationFromParent` (incl. multi-product fan-out), `…_OrphanLegacyAmend_WarnsAndSkips` — upload destination discovery.
- [x] `Refresh_AmendWithProducts_RecordsTargetFromOwnProducts`, `Refresh_LegacyAmendWithoutProducts_RecordsParentTarget`, `Refresh_OrphanLegacyAmendWithoutParent_RecordsEntryWithoutTarget` — registry `target` correctness.
- [x] `FetchAsync_WithVersion_DownloadsAmendCarryingParentProducts`, `…_DownloadsLegacyAmendWhoseParentMatches`, `FetchAsync_WithOtherVersion_DoesNotDownloadUnrelatedAmend`, `FetchAsync_WithVersion_FileIdentityRetractionApplies` — version-filtered fetch.
- [x] `BundleAmendEndToEndTests` — the full acceptance chain from the issue: amend created → materialized YAML carries full `products` → upload discovery includes the amend → registry records `target` → `:version:`-filtered CDN fetch returns the amend → `exclude-entries` retraction via `file` identity applies.
- [x] `GetParentBundlePath` unit coverage (case-insensitive, `.yml`/`.yaml`, paths, non-amends).
- [x] `dotnet format` clean; `./build.sh build --skip-dirty-check` succeeded; Release AOT publish with zero trim/AOT warnings; full unit suite green (`Elastic.Changelog.Tests` 822, `Elastic.Documentation.Configuration.Tests` 585, all other projects passing); CLI schema diff empty (no CLI surface change).

Docs updated: `docs/cli/changelog/cmd-bundle-amend.md` (amend output now shows the copied `products`; legacy note) and `docs/development/changelog-bundle-registry.md` (registry `target` for amend sidecars; version-selection amend rescue).

Closes elastic/docs-eng-team#669