### PR TITLE
Remove assembler search and Ask AI UI

### DIFF
--- a/config/assembler.yml
+++ b/config/assembler.yml
@@ -10,8 +10,6 @@ environments:
     optimizely:
       enabled: false
       id: "18132920325"
-    feature_flags:
-      SEARCH_OR_ASK_AI: true
   staging:
     uri: https://staging-website.elastic.co
     path_prefix: docs
@@ -23,7 +21,6 @@ environments:
       preview: env-507
       cookies_win: x
     feature_flags:
-      SEARCH_OR_ASK_AI: true
       WEBSITE_SEARCH: true
     website_search_url: https://staging-website.elastic.co/search/elastic-website-search.js
   edge:
@@ -32,14 +29,11 @@ environments:
     content_source: edge
     google_tag_manager:
       enabled: false
-    feature_flags:
-      SEARCH_OR_ASK_AI: true
   dev:
     uri: http://localhost:4000
     content_source: current
     path_prefix: docs
     feature_flags:
-      SEARCH_OR_ASK_AI: true
       WEBSITE_SEARCH: true
     website_search_url: http://localhost:4078/elastic-website-search.js
   preview:
@@ -48,8 +42,6 @@ environments:
     content_source: current
     google_tag_manager:
       enabled: false
-    feature_flags:
-      SEARCH_OR_ASK_AI: true
   air-gapped:
     uri: http://localhost:8080
     path_prefix: docs

--- a/docs/_docset.yml
+++ b/docs/_docset.yml
@@ -7,7 +7,6 @@ cross_links:
   - docs-content
 exclude:
   - '_*.md'
-  - '!_search.md'
 subs:
   a-global-variable: "This was defined in docset.yml"
   serverless-short: Serverless
@@ -71,7 +70,6 @@ api:
 toc:
   - file: index.md
   - hidden: 404.md
-  - hidden: _search.md
   - hidden: developer-notes.md
   - hidden: contribute/cumulative-docs/index.md
   - hidden: contribute/cumulative-docs/guidelines.md

--- a/docs/_search.md
+++ b/docs/_search.md
@@ -1,6 +1,0 @@
----
-layout: full-search
-noindex: true
----
-
-# Elastic Documentation Search

--- a/src/Elastic.Documentation.Configuration/Builder/FeatureFlags.cs
+++ b/src/Elastic.Documentation.Configuration/Builder/FeatureFlags.cs
@@ -26,12 +26,6 @@ public class FeatureFlags(Dictionary<string, bool> initFeatureFlags)
 		set => _featureFlags["disable-github-edit-link"] = value;
 	}
 
-	public bool SearchOrAskAiEnabled
-	{
-		get => IsEnabled("search-or-ask-ai");
-		set => _featureFlags["search-or-ask-ai"] = value;
-	}
-
 	public bool StagingElasticNavEnabled
 	{
 		get => IsEnabled("staging-elastic-nav");

--- a/src/Elastic.Documentation.Site/Assets/main.ts
+++ b/src/Elastic.Documentation.Site/Assets/main.ts
@@ -49,11 +49,8 @@ if (config.telemetryEnabled) {
 
 // Dynamically import web components after telemetry is initialized.
 // Parcel code-splits these into separate chunks loaded on demand.
-import('./web-components/NavigationSearch/NavigationSearchComponent')
-import('./web-components/AskAi/AskAi')
 import('./web-components/VersionDropdown')
 import('./web-components/AppliesToPopover')
-import('./web-components/FullPageSearch/FullPageSearchComponent')
 import('./web-components/Diagnostics/DiagnosticsComponent')
 import('./web-components/StorybookStory/StorybookStoryComponent')
 

--- a/src/Elastic.Documentation.Site/Assets/styles.css
+++ b/src/Elastic.Documentation.Site/Assets/styles.css
@@ -466,25 +466,6 @@ math {
 	margin-top: 1.5rem;
 }
 
-/* Adjust look and feel of the navigation-search in the landing page hero */
-#hero navigation-search {
-	& > div > .euiHorizontalRule {
-		display: none;
-	}
-
-	& > div {
-		padding-right: 0;
-	}
-
-	& .euiPopover {
-		max-inline-size: 100%;
-
-		@media screen and (min-width: 1180px) {
-			max-inline-size: 500px;
-		}
-	}
-}
-
 * {
 	scrollbar-width: thin;
 	scrollbar-color: rgba(113, 134, 168, 0.5) transparent;

--- a/src/Elastic.Documentation.Site/Layout/_SecondaryNav.cshtml
+++ b/src/Elastic.Documentation.Site/Layout/_SecondaryNav.cshtml
@@ -1,6 +1,5 @@
 @inherits RazorSlice<Elastic.Documentation.Site.GlobalLayoutViewModel>
 <div class="relative md:sticky md:top-0 md:z-30 bg-grey-10">
-	<ask-ai id="ask-ai" hx-preserve></ask-ai>
 	<nav id="secondary-nav"
 	     class="bg-grey-10 border-b border-grey-20">
 		<div class="

--- a/src/Elastic.Documentation.Site/Navigation/_TocTree.cshtml
+++ b/src/Elastic.Documentation.Site/Navigation/_TocTree.cshtml
@@ -1,4 +1,3 @@
-@using Elastic.Documentation
 @using Elastic.Documentation.Site.Navigation
 @inherits RazorSlice<Elastic.Documentation.Site.Navigation.NavigationViewModel>
 
@@ -7,10 +6,6 @@
 		var currentTopLevelItem = Model.TopLevelItems.FirstOrDefault(i => i.Id == Model.Tree.Id) ?? Model.Tree;
 	} 
 	<div class="sticky top-0 z-10 bg-white">
-		@if (Model.BuildType != BuildType.Codex && Model.Branding is null)
-		{
-			<navigation-search id="navigation-search" hx-preserve></navigation-search>
-		}
 		<div id="nav-dropdown">
 		@if (Model.IsUsingNavigationDropdown)
 			{

--- a/src/Elastic.Markdown/Layout/_LandingPage.cshtml
+++ b/src/Elastic.Markdown/Layout/_LandingPage.cshtml
@@ -9,8 +9,7 @@
 				<p class="mt-4"><strong>Upgrading from an earlier version?</strong> Follow the <a href="@Model.Link("/deploy-manage/upgrade")"
 					class="link">upgrade guide</a> to plan and complete your upgrade. </p>
 
-				<div class="flex md:inline-flex flex-col gap-6 mt-6">
-					<navigation-search></navigation-search>
+				<div class="flex md:inline-flex flex-col mt-6">
 					<div class="flex gap-3">
 						<a href="@Model.Link("/get-started")"
 						   class="grow select-none cursor-pointer text-white text-nowrap bg-blue-elastic hover:bg-blue-elastic-110 focus:ring-4 focus:ring-blue-elastic-50 font-semibold font-sans rounded-sm px-6 py-2 focus:outline-none h-10 flex items-center justify-center">

--- a/tests/Elastic.Documentation.Configuration.Tests/PhysicalDocsetTests.cs
+++ b/tests/Elastic.Documentation.Configuration.Tests/PhysicalDocsetTests.cs
@@ -49,7 +49,7 @@ public class PhysicalDocsetTests
 		docSet.CrossLinks.Should().ContainSingle().Which.Should().Be("docs-content");
 
 		// Assert exclude patterns
-		docSet.Exclude.Should().HaveCount(2).And.Subject.First().Should().Be("_*.md");
+		docSet.Exclude.Should().ContainSingle().Which.Should().Be("_*.md");
 
 		// Assert substitutions
 		docSet.Subs.Should().NotBeEmpty();


### PR DESCRIPTION
## Why

The built-in Search and Ask AI experience is being retired from assembler before launch. Leaving its entry points active would continue loading hidden frontend code and probing the docs API even though the replacement website search integration is used instead.

## What

Assembler no longer renders or bundles the built-in navigation search, full-page search, or Ask AI entry points, and the obsolete assembler feature flag and search page are removed. The implementation remains available to Codex, and the backend APIs and website search integration are unchanged.

## Test plan

- [x] `npm run fmt:check`
- [x] `npm run compile:check`
- [x] `npm run build`
- [x] `dotnet build`
- [x] Pre-commit frontend checks
- [x] Pre-push .NET formatting check

Made with [Cursor](https://cursor.com)