### PR TITLE
Load frontend web components only when hosts are present

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/main.ts
+++ b/src/Elastic.Documentation.Site/Assets/main.ts
@@ -23,6 +23,7 @@ import {
     ATTR_URL_FULL,
 } from './telemetry/semconv'
 import { initTocNav } from './toc-nav'
+import { loadWebComponents } from './web-components/loadWebComponents'
 import {
     getPathFromUrl,
     isExternalDocsUrl,
@@ -46,13 +47,6 @@ if (config.telemetryEnabled) {
         debug: false,
     })
 }
-
-// Dynamically import web components after telemetry is initialized.
-// Parcel code-splits these into separate chunks loaded on demand.
-import('./web-components/VersionDropdown')
-import('./web-components/AppliesToPopover')
-import('./web-components/Diagnostics/DiagnosticsComponent')
-import('./web-components/StorybookStory/StorybookStoryComponent')
 
 if (config.buildType === 'isolated' || config.airGapped) {
     import('./isolated')
@@ -189,6 +183,7 @@ function initCtaImpressions() {
 // Initialize on initial page load
 document.addEventListener('DOMContentLoaded', function () {
     runInitSteps([
+        ['loadWebComponents', loadWebComponents],
         ['initMath', initMath],
         ['initMermaid', initMermaid],
         ['initCtaImpressions', initCtaImpressions],
@@ -197,6 +192,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
 document.addEventListener('htmx:load', function () {
     runInitSteps([
+        ['loadWebComponents', loadWebComponents],
         ['initTocNav', initTocNav],
         ['initHighlight', initHighlight],
         ['initCopyButton', initCopyButton],

--- a/src/Elastic.Documentation.Site/Assets/web-components/loadWebComponents.test.ts
+++ b/src/Elastic.Documentation.Site/Assets/web-components/loadWebComponents.test.ts
@@ -1,0 +1,103 @@
+import { createWebComponentLoader } from './loadWebComponents'
+
+describe('web component loader', () => {
+    beforeEach(() => {
+        document.body.innerHTML = ''
+    })
+
+    it('does not load a component when its host is absent', async () => {
+        const load = jest.fn().mockResolvedValue(undefined)
+        const loadWebComponents = createWebComponentLoader({
+            'absent-component': load,
+        })
+
+        await loadWebComponents()
+
+        expect(load).not.toHaveBeenCalled()
+    })
+
+    it('loads a component when its host is present', async () => {
+        const load = jest.fn().mockImplementation(async () => {
+            customElements.define(
+                'present-component',
+                class extends HTMLElement {}
+            )
+        })
+        const loadWebComponents = createWebComponentLoader({
+            'present-component': load,
+        })
+        document.body.innerHTML = '<present-component></present-component>'
+
+        await loadWebComponents()
+
+        expect(load).toHaveBeenCalledTimes(1)
+        expect(customElements.get('present-component')).toBeDefined()
+    })
+
+    it('loads a component introduced before a subsequent scan', async () => {
+        const load = jest.fn().mockResolvedValue(undefined)
+        const loadWebComponents = createWebComponentLoader({
+            'swapped-component': load,
+        })
+
+        await loadWebComponents()
+        document.body.innerHTML = '<swapped-component></swapped-component>'
+        await loadWebComponents()
+
+        expect(load).toHaveBeenCalledTimes(1)
+    })
+
+    it('deduplicates concurrent and repeated loads', async () => {
+        let resolveLoad: () => void
+        const pendingLoad = new Promise<void>((resolve) => {
+            resolveLoad = resolve
+        })
+        const load = jest.fn(() => pendingLoad)
+        const loadWebComponents = createWebComponentLoader({
+            'deduplicated-component': load,
+        })
+        document.body.innerHTML =
+            '<deduplicated-component></deduplicated-component>'
+
+        const firstLoad = loadWebComponents()
+        const secondLoad = loadWebComponents()
+        resolveLoad!()
+        await Promise.all([firstLoad, secondLoad])
+        await loadWebComponents()
+
+        expect(load).toHaveBeenCalledTimes(1)
+    })
+
+    it('skips a component that is already registered', async () => {
+        customElements.define(
+            'registered-component',
+            class extends HTMLElement {}
+        )
+        const load = jest.fn().mockResolvedValue(undefined)
+        const loadWebComponents = createWebComponentLoader({
+            'registered-component': load,
+        })
+        document.body.innerHTML =
+            '<registered-component></registered-component>'
+
+        await loadWebComponents()
+
+        expect(load).not.toHaveBeenCalled()
+    })
+
+    it('retries a component after its load fails', async () => {
+        const load = jest
+            .fn()
+            .mockRejectedValueOnce(new Error('load failed'))
+            .mockResolvedValueOnce(undefined)
+        const loadWebComponents = createWebComponentLoader({
+            'retry-component': load,
+        })
+        document.body.innerHTML = '<retry-component></retry-component>'
+
+        await expect(loadWebComponents()).rejects.toThrow('load failed')
+        await expect(loadWebComponents()).resolves.toBeUndefined()
+
+        expect(load).toHaveBeenCalledTimes(2)
+    })
+})

--- a/src/Elastic.Documentation.Site/Assets/web-components/loadWebComponents.ts
+++ b/src/Elastic.Documentation.Site/Assets/web-components/loadWebComponents.ts
@@ -2,42 +2,36 @@ type ComponentLoader = () => Promise<unknown>
 type ComponentLoaders = Readonly<Record<string, ComponentLoader>>
 
 export function createWebComponentLoader(componentLoaders: ComponentLoaders) {
-    const loadingComponents = new Map<string, Promise<void>>()
+    const loadingComponents = new Map<string, Promise<unknown>>()
 
     return async function loadWebComponents(
         root: ParentNode = document
     ): Promise<void> {
-        const loads = Object.entries(componentLoaders).flatMap(
-            ([tagName, load]) => {
-                if (
-                    !root.querySelector(tagName) ||
-                    customElements.get(tagName)
-                ) {
-                    return []
-                }
+        const loads: Promise<unknown>[] = []
 
-                const existingLoad = loadingComponents.get(tagName)
-                if (existingLoad) return [existingLoad]
+        for (const [tagName, load] of Object.entries(componentLoaders)) {
+            if (!root.querySelector(tagName)) continue
+            if (customElements.get(tagName)) continue
 
-                const componentLoad = load()
-                    .then(() => undefined)
-                    .catch((error) => {
-                        loadingComponents.delete(tagName)
-                        throw error
-                    })
-                loadingComponents.set(tagName, componentLoad)
-                return [componentLoad]
+            const existingLoad = loadingComponents.get(tagName)
+            if (existingLoad) {
+                loads.push(existingLoad)
+                continue
             }
-        )
+
+            const componentLoad = load().catch((error) => {
+                loadingComponents.delete(tagName)
+                throw error
+            })
+            loadingComponents.set(tagName, componentLoad)
+            loads.push(componentLoad)
+        }
 
         await Promise.all(loads)
     }
 }
 
 export const loadWebComponents = createWebComponentLoader({
-    'navigation-search': () =>
-        import('./NavigationSearch/NavigationSearchComponent'),
-    'ask-ai': () => import('./AskAi/AskAi'),
     'version-dropdown': () => import('./VersionDropdown'),
     'applies-to-popover': () => import('./AppliesToPopover'),
     'diagnostics-panel': () => import('./Diagnostics/DiagnosticsComponent'),

--- a/src/Elastic.Documentation.Site/Assets/web-components/loadWebComponents.ts
+++ b/src/Elastic.Documentation.Site/Assets/web-components/loadWebComponents.ts
@@ -40,8 +40,6 @@ export const loadWebComponents = createWebComponentLoader({
     'ask-ai': () => import('./AskAi/AskAi'),
     'version-dropdown': () => import('./VersionDropdown'),
     'applies-to-popover': () => import('./AppliesToPopover'),
-    'full-page-search': () =>
-        import('./FullPageSearch/FullPageSearchComponent'),
     'diagnostics-panel': () => import('./Diagnostics/DiagnosticsComponent'),
     'storybook-story': () => import('./StorybookStory/StorybookStoryComponent'),
 })

--- a/src/Elastic.Documentation.Site/Assets/web-components/loadWebComponents.ts
+++ b/src/Elastic.Documentation.Site/Assets/web-components/loadWebComponents.ts
@@ -1,0 +1,47 @@
+type ComponentLoader = () => Promise<unknown>
+type ComponentLoaders = Readonly<Record<string, ComponentLoader>>
+
+export function createWebComponentLoader(componentLoaders: ComponentLoaders) {
+    const loadingComponents = new Map<string, Promise<void>>()
+
+    return async function loadWebComponents(
+        root: ParentNode = document
+    ): Promise<void> {
+        const loads = Object.entries(componentLoaders).flatMap(
+            ([tagName, load]) => {
+                if (
+                    !root.querySelector(tagName) ||
+                    customElements.get(tagName)
+                ) {
+                    return []
+                }
+
+                const existingLoad = loadingComponents.get(tagName)
+                if (existingLoad) return [existingLoad]
+
+                const componentLoad = load()
+                    .then(() => undefined)
+                    .catch((error) => {
+                        loadingComponents.delete(tagName)
+                        throw error
+                    })
+                loadingComponents.set(tagName, componentLoad)
+                return [componentLoad]
+            }
+        )
+
+        await Promise.all(loads)
+    }
+}
+
+export const loadWebComponents = createWebComponentLoader({
+    'navigation-search': () =>
+        import('./NavigationSearch/NavigationSearchComponent'),
+    'ask-ai': () => import('./AskAi/AskAi'),
+    'version-dropdown': () => import('./VersionDropdown'),
+    'applies-to-popover': () => import('./AppliesToPopover'),
+    'full-page-search': () =>
+        import('./FullPageSearch/FullPageSearchComponent'),
+    'diagnostics-panel': () => import('./Diagnostics/DiagnosticsComponent'),
+    'storybook-story': () => import('./StorybookStory/StorybookStoryComponent'),
+})


### PR DESCRIPTION
## Why

Ordinary documentation pages were still requesting web-component chunks whose host elements are absent, which wasted first-party transfer and left large amounts of unused JavaScript on the critical path (see #3686).

## What

Introduces a host-aware loader that imports each custom-element module only when its tag exists in the document, with deduplicated in-flight/completed loads and retries after failures. The loader runs on initial DOM readiness and again after htmx body swaps so components introduced by same-tab navigation still register.

Verified with unit tests for absent/present/swapped hosts, concurrent dedup, already-registered skips, and retry-after-failure; production build still emits separate component chunks; a host-free page fetched only `main.js`, and inserting `<version-dropdown>` then dispatching `htmx:load` registered the element and fetched its chunk.

Closes #3686

Made with [Cursor](https://cursor.com)