### PR TITLE
Assets: Lazy-load OTel and highlight.js languages

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/hljs.test.ts
+++ b/src/Elastic.Documentation.Site/Assets/hljs.test.ts
@@ -85,3 +85,22 @@ describe('initHighlight', () => {
         expect(bashBlock.getAttribute('data-highlighted')).toBe('yes')
     })
 })
+
+describe('toLanguageFn', () => {
+    // Parcel's dynamic import() resolves a language module to the LanguageFn directly,
+    // while Babel/Jest wrap it as { default: fn }. Both must yield the function; a
+    // regression here silently breaks highlighting only in the Parcel production build.
+    it('returns the function when the module is the function itself (Parcel)', async () => {
+        const { toLanguageFn } = await loadModule()
+        const fn = () => ({ contains: [] })
+
+        expect(toLanguageFn(fn)).toBe(fn)
+    })
+
+    it('returns the default export when wrapped in a namespace (Babel/Jest)', async () => {
+        const { toLanguageFn } = await loadModule()
+        const fn = () => ({ contains: [] })
+
+        expect(toLanguageFn({ default: fn })).toBe(fn)
+    })
+})

--- a/src/Elastic.Documentation.Site/Assets/hljs.test.ts
+++ b/src/Elastic.Documentation.Site/Assets/hljs.test.ts
@@ -74,6 +74,20 @@ describe('initHighlight', () => {
         expect(hljs.listLanguages()).toContain('shell')
     })
 
+    it('does not re-highlight a block when invoked concurrently', async () => {
+        const { initHighlight, hljs } = await loadModule()
+        setCodeBlocks('bash')
+        const spy = jest.spyOn(hljs, 'highlightElement')
+
+        await Promise.all([initHighlight(), initHighlight()])
+
+        const block = document.querySelector('#markdown-content pre code')
+        const callsForBlock = spy.mock.calls.filter(
+            (call) => call[0] === block
+        ).length
+        expect(callsForBlock).toBe(1)
+    })
+
     it('ignores unknown languages without breaking other blocks', async () => {
         const { initHighlight } = await loadModule()
         setCodeBlocks('this-language-does-not-exist', 'bash')

--- a/src/Elastic.Documentation.Site/Assets/hljs.test.ts
+++ b/src/Elastic.Documentation.Site/Assets/hljs.test.ts
@@ -1,0 +1,87 @@
+type HljsModule = typeof import('./hljs')
+
+async function loadModule(): Promise<HljsModule> {
+    // Re-import per test so the module-level registration cache and the shared hljs
+    // singleton start clean, isolating what each test loads.
+    jest.resetModules()
+    return await import('./hljs')
+}
+
+function setCodeBlocks(...languages: string[]) {
+    const blocks = languages
+        .map(
+            (language) =>
+                `<pre><code class="language-${language}">echo hello</code></pre>`
+        )
+        .join('')
+    document.body.innerHTML = `<div id="markdown-content">${blocks}</div>`
+}
+
+afterEach(() => {
+    document.body.innerHTML = ''
+})
+
+describe('initHighlight', () => {
+    it('loads only the languages referenced on the page', async () => {
+        const { initHighlight, hljs } = await loadModule()
+        setCodeBlocks('bash')
+
+        await initHighlight()
+
+        expect(hljs.listLanguages()).toContain('bash')
+        expect(hljs.listLanguages()).not.toContain('python')
+    })
+
+    it('loads no node_modules language when there are no code blocks', async () => {
+        const { initHighlight, hljs } = await loadModule()
+        document.body.innerHTML = '<div id="markdown-content"></div>'
+
+        await initHighlight()
+
+        expect(hljs.listLanguages()).not.toContain('bash')
+        expect(hljs.listLanguages()).not.toContain('python')
+    })
+
+    it('highlights a supported language block', async () => {
+        const { initHighlight } = await loadModule()
+        setCodeBlocks('bash')
+
+        await initHighlight()
+
+        const block = document.querySelector('#markdown-content pre code')
+        expect(block?.getAttribute('data-highlighted')).toBe('yes')
+    })
+
+    it('loads a newly encountered language on a later swap', async () => {
+        const { initHighlight, hljs } = await loadModule()
+        setCodeBlocks('bash')
+        await initHighlight()
+        expect(hljs.listLanguages()).not.toContain('python')
+
+        // Simulate an htmx swap introducing a language not present initially.
+        setCodeBlocks('python')
+        await initHighlight()
+
+        expect(hljs.listLanguages()).toContain('python')
+    })
+
+    it('resolves aliases to their canonical language', async () => {
+        const { initHighlight, hljs } = await loadModule()
+        setCodeBlocks('sh')
+
+        await initHighlight()
+
+        expect(hljs.listLanguages()).toContain('shell')
+    })
+
+    it('ignores unknown languages without breaking other blocks', async () => {
+        const { initHighlight } = await loadModule()
+        setCodeBlocks('this-language-does-not-exist', 'bash')
+
+        await expect(initHighlight()).resolves.toBeUndefined()
+
+        const blocks = document.querySelectorAll('#markdown-content pre code')
+        const bashBlock = blocks[1]
+        expect(bashBlock.getAttribute('data-highlighted')).toBe('yes')
+    })
+})

--- a/src/Elastic.Documentation.Site/Assets/hljs.ts
+++ b/src/Elastic.Documentation.Site/Assets/hljs.ts
@@ -1,91 +1,110 @@
 import { mergeHTMLPlugin } from './hljs-merge-html-plugin'
-import esql from '@elastic/highlightjs-esql'
 import { LanguageFn } from 'highlight.js'
 import hljs from 'highlight.js/lib/core'
-import asciidoc from 'highlight.js/lib/languages/asciidoc'
-import bash from 'highlight.js/lib/languages/bash'
-import c from 'highlight.js/lib/languages/c'
-import csharp from 'highlight.js/lib/languages/csharp'
-import css from 'highlight.js/lib/languages/css'
-import dockerfile from 'highlight.js/lib/languages/dockerfile'
-import dos from 'highlight.js/lib/languages/dos'
-import ebnf from 'highlight.js/lib/languages/ebnf'
-import go from 'highlight.js/lib/languages/go'
-import gradle from 'highlight.js/lib/languages/gradle'
-import groovy from 'highlight.js/lib/languages/groovy'
-import handlebars from 'highlight.js/lib/languages/handlebars'
-import http from 'highlight.js/lib/languages/http'
-import ini from 'highlight.js/lib/languages/ini'
-import java from 'highlight.js/lib/languages/java'
-import javascript from 'highlight.js/lib/languages/javascript'
-import json from 'highlight.js/lib/languages/json'
-import kotlin from 'highlight.js/lib/languages/kotlin'
-import markdown from 'highlight.js/lib/languages/markdown'
-import nginx from 'highlight.js/lib/languages/nginx'
-import php from 'highlight.js/lib/languages/php'
-import plaintext from 'highlight.js/lib/languages/plaintext'
-import powershell from 'highlight.js/lib/languages/powershell'
-import properties from 'highlight.js/lib/languages/properties'
-import python from 'highlight.js/lib/languages/python'
-import ruby from 'highlight.js/lib/languages/ruby'
-import rust from 'highlight.js/lib/languages/rust'
-import scala from 'highlight.js/lib/languages/scala'
-import shell from 'highlight.js/lib/languages/shell'
-import sql from 'highlight.js/lib/languages/sql'
-import swift from 'highlight.js/lib/languages/swift'
-import typescript from 'highlight.js/lib/languages/typescript'
-import xml from 'highlight.js/lib/languages/xml'
-import yaml from 'highlight.js/lib/languages/yaml'
 import { $$optional } from 'select-dom'
 
-const languages: Array<{
-    name: string
-    module: LanguageFn
-    aliases?: string[]
-}> = [
-    { name: 'asciidoc', module: asciidoc },
-    { name: 'bash', module: bash },
-    { name: 'c', module: c },
-    { name: 'csharp', module: csharp },
-    { name: 'css', module: css },
-    { name: 'dockerfile', module: dockerfile },
-    { name: 'dos', module: dos },
-    { name: 'ebnf', module: ebnf },
-    { name: 'esql', module: esql },
-    { name: 'go', module: go },
-    { name: 'gradle', module: gradle },
-    { name: 'groovy', module: groovy },
-    { name: 'handlebars', module: handlebars },
-    { name: 'http', module: http },
-    { name: 'ini', module: ini },
-    { name: 'java', module: java },
-    { name: 'javascript', module: javascript },
-    { name: 'json', module: json },
-    { name: 'kotlin', module: kotlin },
-    { name: 'markdown', module: markdown },
-    { name: 'nginx', module: nginx },
-    { name: 'php', module: php },
-    { name: 'plaintext', module: plaintext },
-    { name: 'powershell', module: powershell },
-    { name: 'properties', module: properties },
-    { name: 'python', module: python },
-    { name: 'ruby', module: ruby },
-    { name: 'rust', module: rust },
-    { name: 'scala', module: scala },
-    { name: 'shell', module: shell, aliases: ['sh'] },
-    { name: 'sql', module: sql },
-    { name: 'swift', module: swift },
-    { name: 'typescript', module: typescript },
-    { name: 'xml', module: xml },
-    { name: 'yaml', module: yaml },
-]
+// Each entry lazily imports one highlight.js language module (or the esql plugin) so
+// only the languages actually present on a page are downloaded, instead of eagerly
+// bundling all of them into the entry chunk. Modules default-export the LanguageFn.
+const languageLoaders: Record<string, () => Promise<LanguageFn>> = {
+    asciidoc: () =>
+        import('highlight.js/lib/languages/asciidoc').then((m) => m.default),
+    bash: () =>
+        import('highlight.js/lib/languages/bash').then((m) => m.default),
+    c: () => import('highlight.js/lib/languages/c').then((m) => m.default),
+    csharp: () =>
+        import('highlight.js/lib/languages/csharp').then((m) => m.default),
+    css: () => import('highlight.js/lib/languages/css').then((m) => m.default),
+    dockerfile: () =>
+        import('highlight.js/lib/languages/dockerfile').then((m) => m.default),
+    dos: () => import('highlight.js/lib/languages/dos').then((m) => m.default),
+    ebnf: () =>
+        import('highlight.js/lib/languages/ebnf').then((m) => m.default),
+    esql: () => import('@elastic/highlightjs-esql').then((m) => m.default),
+    go: () => import('highlight.js/lib/languages/go').then((m) => m.default),
+    gradle: () =>
+        import('highlight.js/lib/languages/gradle').then((m) => m.default),
+    groovy: () =>
+        import('highlight.js/lib/languages/groovy').then((m) => m.default),
+    handlebars: () =>
+        import('highlight.js/lib/languages/handlebars').then((m) => m.default),
+    http: () =>
+        import('highlight.js/lib/languages/http').then((m) => m.default),
+    ini: () => import('highlight.js/lib/languages/ini').then((m) => m.default),
+    java: () =>
+        import('highlight.js/lib/languages/java').then((m) => m.default),
+    javascript: () =>
+        import('highlight.js/lib/languages/javascript').then((m) => m.default),
+    json: () =>
+        import('highlight.js/lib/languages/json').then((m) => m.default),
+    kotlin: () =>
+        import('highlight.js/lib/languages/kotlin').then((m) => m.default),
+    markdown: () =>
+        import('highlight.js/lib/languages/markdown').then((m) => m.default),
+    nginx: () =>
+        import('highlight.js/lib/languages/nginx').then((m) => m.default),
+    php: () => import('highlight.js/lib/languages/php').then((m) => m.default),
+    plaintext: () =>
+        import('highlight.js/lib/languages/plaintext').then((m) => m.default),
+    powershell: () =>
+        import('highlight.js/lib/languages/powershell').then((m) => m.default),
+    properties: () =>
+        import('highlight.js/lib/languages/properties').then((m) => m.default),
+    python: () =>
+        import('highlight.js/lib/languages/python').then((m) => m.default),
+    ruby: () =>
+        import('highlight.js/lib/languages/ruby').then((m) => m.default),
+    rust: () =>
+        import('highlight.js/lib/languages/rust').then((m) => m.default),
+    scala: () =>
+        import('highlight.js/lib/languages/scala').then((m) => m.default),
+    shell: () =>
+        import('highlight.js/lib/languages/shell').then((m) => m.default),
+    sql: () => import('highlight.js/lib/languages/sql').then((m) => m.default),
+    swift: () =>
+        import('highlight.js/lib/languages/swift').then((m) => m.default),
+    typescript: () =>
+        import('highlight.js/lib/languages/typescript').then((m) => m.default),
+    xml: () => import('highlight.js/lib/languages/xml').then((m) => m.default),
+    yaml: () =>
+        import('highlight.js/lib/languages/yaml').then((m) => m.default),
+}
 
-languages.forEach((lang) => {
-    hljs.registerLanguage(lang.name, lang.module)
-    if (lang.aliases) {
-        hljs.registerAliases(lang.aliases, { languageName: lang.name })
-    }
-})
+// Alias -> canonical language name. Aliases are registered with hljs once their
+// canonical module has loaded so `language-sh` etc. resolve correctly.
+const languageAliases: Record<string, string> = {
+    sh: 'shell',
+}
+
+// Caches the registration promise per canonical language so concurrent code blocks
+// (and later htmx swaps) share a single import instead of re-fetching the module.
+const registrations = new Map<string, Promise<void>>()
+
+function resolveLanguageName(name: string): string {
+    return languageAliases[name] ?? name
+}
+
+// Imports and registers a single language (plus any aliases pointing at it) exactly
+// once. Unknown names resolve to undefined and are skipped by the caller.
+function ensureLanguage(name: string): Promise<void> | undefined {
+    const canonical = resolveLanguageName(name)
+    const loader = languageLoaders[canonical]
+    if (!loader) return undefined
+
+    const cached = registrations.get(canonical)
+    if (cached) return cached
+
+    const registration = loader().then((languageFn) => {
+        hljs.registerLanguage(canonical, languageFn)
+        for (const [alias, target] of Object.entries(languageAliases)) {
+            if (target === canonical) {
+                hljs.registerAliases([alias], { languageName: canonical })
+            }
+        }
+    })
+    registrations.set(canonical, registration)
+    return registration
+}
 
 hljs.registerLanguage('apiheader', function () {
     return {
@@ -217,10 +236,39 @@ hljs.addPlugin(mergeHTMLPlugin)
 // for code callouts
 hljs.configure({ ignoreUnescapedHTML: true })
 
-export function initHighlight() {
-    $$optional('#markdown-content pre code:not([data-highlighted])').forEach(
-        hljs.highlightElement
+function getLanguageFromClassList(element: Element): string | undefined {
+    for (const className of element.classList) {
+        if (className.startsWith('language-')) {
+            return className.slice('language-'.length)
+        }
+    }
+    return undefined
+}
+
+export async function initHighlight() {
+    const blocks = $$optional(
+        '#markdown-content pre code:not([data-highlighted])'
     )
+    if (blocks.length === 0) return
+
+    // Import only the language modules referenced by the unprocessed blocks before
+    // highlighting. Unknown/plain-text languages resolve to undefined and are skipped;
+    // hljs.highlightElement then degrades gracefully without breaking other blocks.
+    const requiredLanguages = new Set<string>()
+    for (const block of blocks) {
+        const language = getLanguageFromClassList(block)
+        if (language) requiredLanguages.add(language)
+    }
+
+    await Promise.all(
+        [...requiredLanguages]
+            .map((language) => ensureLanguage(language))
+            .filter(
+                (promise): promise is Promise<void> => promise !== undefined
+            )
+    )
+
+    blocks.forEach(hljs.highlightElement)
 }
 
 // Export the configured hljs instance for reuse

--- a/src/Elastic.Documentation.Site/Assets/hljs.ts
+++ b/src/Elastic.Documentation.Site/Assets/hljs.ts
@@ -3,71 +3,68 @@ import { LanguageFn } from 'highlight.js'
 import hljs from 'highlight.js/lib/core'
 import { $$optional } from 'select-dom'
 
+// highlight.js language modules and the esql plugin default-export the LanguageFn.
+// Parcel's dynamic import() resolves to the module's exports directly (the function),
+// whereas other bundlers/test runners (Babel/Jest) wrap it as a namespace with a
+// `default`. Normalize both so registerLanguage always receives the function.
+export function toLanguageFn(mod: unknown): LanguageFn {
+    const m = mod as { default?: LanguageFn }
+    return (typeof mod === 'function' ? mod : m.default) as LanguageFn
+}
+
 // Each entry lazily imports one highlight.js language module (or the esql plugin) so
 // only the languages actually present on a page are downloaded, instead of eagerly
-// bundling all of them into the entry chunk. Modules default-export the LanguageFn.
+// bundling all of them into the entry chunk.
 const languageLoaders: Record<string, () => Promise<LanguageFn>> = {
     asciidoc: () =>
-        import('highlight.js/lib/languages/asciidoc').then((m) => m.default),
-    bash: () =>
-        import('highlight.js/lib/languages/bash').then((m) => m.default),
-    c: () => import('highlight.js/lib/languages/c').then((m) => m.default),
+        import('highlight.js/lib/languages/asciidoc').then(toLanguageFn),
+    bash: () => import('highlight.js/lib/languages/bash').then(toLanguageFn),
+    c: () => import('highlight.js/lib/languages/c').then(toLanguageFn),
     csharp: () =>
-        import('highlight.js/lib/languages/csharp').then((m) => m.default),
-    css: () => import('highlight.js/lib/languages/css').then((m) => m.default),
+        import('highlight.js/lib/languages/csharp').then(toLanguageFn),
+    css: () => import('highlight.js/lib/languages/css').then(toLanguageFn),
     dockerfile: () =>
-        import('highlight.js/lib/languages/dockerfile').then((m) => m.default),
-    dos: () => import('highlight.js/lib/languages/dos').then((m) => m.default),
-    ebnf: () =>
-        import('highlight.js/lib/languages/ebnf').then((m) => m.default),
-    esql: () => import('@elastic/highlightjs-esql').then((m) => m.default),
-    go: () => import('highlight.js/lib/languages/go').then((m) => m.default),
+        import('highlight.js/lib/languages/dockerfile').then(toLanguageFn),
+    dos: () => import('highlight.js/lib/languages/dos').then(toLanguageFn),
+    ebnf: () => import('highlight.js/lib/languages/ebnf').then(toLanguageFn),
+    esql: () => import('@elastic/highlightjs-esql').then(toLanguageFn),
+    go: () => import('highlight.js/lib/languages/go').then(toLanguageFn),
     gradle: () =>
-        import('highlight.js/lib/languages/gradle').then((m) => m.default),
+        import('highlight.js/lib/languages/gradle').then(toLanguageFn),
     groovy: () =>
-        import('highlight.js/lib/languages/groovy').then((m) => m.default),
+        import('highlight.js/lib/languages/groovy').then(toLanguageFn),
     handlebars: () =>
-        import('highlight.js/lib/languages/handlebars').then((m) => m.default),
-    http: () =>
-        import('highlight.js/lib/languages/http').then((m) => m.default),
-    ini: () => import('highlight.js/lib/languages/ini').then((m) => m.default),
-    java: () =>
-        import('highlight.js/lib/languages/java').then((m) => m.default),
+        import('highlight.js/lib/languages/handlebars').then(toLanguageFn),
+    http: () => import('highlight.js/lib/languages/http').then(toLanguageFn),
+    ini: () => import('highlight.js/lib/languages/ini').then(toLanguageFn),
+    java: () => import('highlight.js/lib/languages/java').then(toLanguageFn),
     javascript: () =>
-        import('highlight.js/lib/languages/javascript').then((m) => m.default),
-    json: () =>
-        import('highlight.js/lib/languages/json').then((m) => m.default),
+        import('highlight.js/lib/languages/javascript').then(toLanguageFn),
+    json: () => import('highlight.js/lib/languages/json').then(toLanguageFn),
     kotlin: () =>
-        import('highlight.js/lib/languages/kotlin').then((m) => m.default),
+        import('highlight.js/lib/languages/kotlin').then(toLanguageFn),
     markdown: () =>
-        import('highlight.js/lib/languages/markdown').then((m) => m.default),
-    nginx: () =>
-        import('highlight.js/lib/languages/nginx').then((m) => m.default),
-    php: () => import('highlight.js/lib/languages/php').then((m) => m.default),
+        import('highlight.js/lib/languages/markdown').then(toLanguageFn),
+    nginx: () => import('highlight.js/lib/languages/nginx').then(toLanguageFn),
+    php: () => import('highlight.js/lib/languages/php').then(toLanguageFn),
     plaintext: () =>
-        import('highlight.js/lib/languages/plaintext').then((m) => m.default),
+        import('highlight.js/lib/languages/plaintext').then(toLanguageFn),
     powershell: () =>
-        import('highlight.js/lib/languages/powershell').then((m) => m.default),
+        import('highlight.js/lib/languages/powershell').then(toLanguageFn),
     properties: () =>
-        import('highlight.js/lib/languages/properties').then((m) => m.default),
+        import('highlight.js/lib/languages/properties').then(toLanguageFn),
     python: () =>
-        import('highlight.js/lib/languages/python').then((m) => m.default),
-    ruby: () =>
-        import('highlight.js/lib/languages/ruby').then((m) => m.default),
-    rust: () =>
-        import('highlight.js/lib/languages/rust').then((m) => m.default),
-    scala: () =>
-        import('highlight.js/lib/languages/scala').then((m) => m.default),
-    shell: () =>
-        import('highlight.js/lib/languages/shell').then((m) => m.default),
-    sql: () => import('highlight.js/lib/languages/sql').then((m) => m.default),
-    swift: () =>
-        import('highlight.js/lib/languages/swift').then((m) => m.default),
+        import('highlight.js/lib/languages/python').then(toLanguageFn),
+    ruby: () => import('highlight.js/lib/languages/ruby').then(toLanguageFn),
+    rust: () => import('highlight.js/lib/languages/rust').then(toLanguageFn),
+    scala: () => import('highlight.js/lib/languages/scala').then(toLanguageFn),
+    shell: () => import('highlight.js/lib/languages/shell').then(toLanguageFn),
+    sql: () => import('highlight.js/lib/languages/sql').then(toLanguageFn),
+    swift: () => import('highlight.js/lib/languages/swift').then(toLanguageFn),
     typescript: () =>
-        import('highlight.js/lib/languages/typescript').then((m) => m.default),
-    xml: () => import('highlight.js/lib/languages/xml').then((m) => m.default),
-    yaml: () =>
-        import('highlight.js/lib/languages/yaml').then((m) => m.default),
+        import('highlight.js/lib/languages/typescript').then(toLanguageFn),
+    xml: () => import('highlight.js/lib/languages/xml').then(toLanguageFn),
+    yaml: () => import('highlight.js/lib/languages/yaml').then(toLanguageFn),
 }
 
 // Alias -> canonical language name. Aliases are registered with hljs once their

--- a/src/Elastic.Documentation.Site/Assets/hljs.ts
+++ b/src/Elastic.Documentation.Site/Assets/hljs.ts
@@ -265,7 +265,12 @@ export async function initHighlight() {
             )
     )
 
-    blocks.forEach(hljs.highlightElement)
+    // Re-check data-highlighted after awaiting: a concurrent initHighlight (e.g. a
+    // second htmx:load fired while the language import was pending) may already have
+    // highlighted these captured blocks, and hljs warns if asked to redo one.
+    blocks.forEach((block) => {
+        if (!block.dataset.highlighted) hljs.highlightElement(block)
+    })
 }
 
 // Export the configured hljs instance for reuse

--- a/src/Elastic.Documentation.Site/Assets/hljs.ts
+++ b/src/Elastic.Documentation.Site/Assets/hljs.ts
@@ -77,16 +77,13 @@ const languageAliases: Record<string, string> = {
 // (and later htmx swaps) share a single import instead of re-fetching the module.
 const registrations = new Map<string, Promise<void>>()
 
-function resolveLanguageName(name: string): string {
-    return languageAliases[name] ?? name
-}
-
-// Imports and registers a single language (plus any aliases pointing at it) exactly
-// once. Unknown names resolve to undefined and are skipped by the caller.
-function ensureLanguage(name: string): Promise<void> | undefined {
-    const canonical = resolveLanguageName(name)
+// Imports and registers a language (plus any aliases pointing at it) exactly once.
+// Unknown languages have no loader and resolve immediately so callers can await
+// unconditionally.
+function ensureLanguage(name: string): Promise<void> {
+    const canonical = languageAliases[name] ?? name
     const loader = languageLoaders[canonical]
-    if (!loader) return undefined
+    if (!loader) return Promise.resolve()
 
     const cached = registrations.get(canonical)
     if (cached) return cached
@@ -249,7 +246,7 @@ export async function initHighlight() {
     if (blocks.length === 0) return
 
     // Import only the language modules referenced by the unprocessed blocks before
-    // highlighting. Unknown/plain-text languages resolve to undefined and are skipped;
+    // highlighting. Unknown/plain-text languages have no loader and resolve immediately;
     // hljs.highlightElement then degrades gracefully without breaking other blocks.
     const requiredLanguages = new Set<string>()
     for (const block of blocks) {
@@ -257,13 +254,7 @@ export async function initHighlight() {
         if (language) requiredLanguages.add(language)
     }
 
-    await Promise.all(
-        [...requiredLanguages]
-            .map((language) => ensureLanguage(language))
-            .filter(
-                (promise): promise is Promise<void> => promise !== undefined
-            )
-    )
+    await Promise.all([...requiredLanguages].map(ensureLanguage))
 
     // Re-check data-highlighted after awaiting: a concurrent initHighlight (e.g. a
     // second htmx:load fired while the language import was pending) may already have

--- a/src/Elastic.Documentation.Site/Assets/main.ts
+++ b/src/Elastic.Documentation.Site/Assets/main.ts
@@ -11,7 +11,6 @@ import { initNav } from './pages-nav'
 import { initSmoothScroll } from './smooth-scroll'
 import { initTable } from './table'
 import { initTabs } from './tabs'
-import { initializeOtel } from './telemetry/instrumentation'
 import { logError, logInfo } from './telemetry/logging'
 import {
     ATTR_CTA_NAME,
@@ -36,29 +35,36 @@ import { UAParser } from 'ua-parser-js'
 const DOCS_BUILDER_VERSION =
     process.env.DOCS_BUILDER_VERSION?.trim() ?? '0.0.0-dev'
 
-// Initialize OpenTelemetry FIRST, before any other code runs (when enabled)
-// This must happen early so all subsequent code is instrumented
-if (config.telemetryEnabled) {
-    initializeOtel({
-        serviceName: config.serviceName,
-        serviceVersion: DOCS_BUILDER_VERSION,
-        baseUrl: config.rootPath,
-        debug: false,
-    })
+// Initialize OpenTelemetry FIRST, before any other code runs (when enabled).
+// The implementation (the OTel SDK) is dynamically imported so pages built with
+// telemetry disabled never fetch it. When enabled we await it before importing the
+// web components below, so all subsequent instrumented work runs after init.
+async function bootstrap() {
+    if (config.telemetryEnabled) {
+        const { initializeOtel } = await import('./telemetry/instrumentation')
+        initializeOtel({
+            serviceName: config.serviceName,
+            serviceVersion: DOCS_BUILDER_VERSION,
+            baseUrl: config.rootPath,
+            debug: false,
+        })
+    }
+
+    // Dynamically import web components after telemetry is initialized.
+    // Parcel code-splits these into separate chunks loaded on demand.
+    import('./web-components/VersionDropdown')
+    import('./web-components/AppliesToPopover')
+    import('./web-components/Diagnostics/DiagnosticsComponent')
+    import('./web-components/StorybookStory/StorybookStoryComponent')
+
+    if (config.buildType === 'isolated' || config.airGapped) {
+        import('./isolated')
+    } else if (config.buildType === 'codex') {
+        import('./codex')
+    }
 }
 
-// Dynamically import web components after telemetry is initialized.
-// Parcel code-splits these into separate chunks loaded on demand.
-import('./web-components/VersionDropdown')
-import('./web-components/AppliesToPopover')
-import('./web-components/Diagnostics/DiagnosticsComponent')
-import('./web-components/StorybookStory/StorybookStoryComponent')
-
-if (config.buildType === 'isolated' || config.airGapped) {
-    import('./isolated')
-} else if (config.buildType === 'codex') {
-    import('./codex')
-}
+void bootstrap()
 
 const { getOS } = new UAParser()
 

--- a/src/Elastic.Documentation.Site/Assets/main.ts
+++ b/src/Elastic.Documentation.Site/Assets/main.ts
@@ -35,10 +35,9 @@ import { UAParser } from 'ua-parser-js'
 const DOCS_BUILDER_VERSION =
     process.env.DOCS_BUILDER_VERSION?.trim() ?? '0.0.0-dev'
 
-// Initialize OpenTelemetry FIRST, before any other code runs (when enabled).
-// The implementation (the OTel SDK) is dynamically imported so pages built with
-// telemetry disabled never fetch it. When enabled we await it before importing the
-// web components below, so all subsequent instrumented work runs after init.
+// Initialize OpenTelemetry before the web components when telemetry is enabled, so
+// their instrumented work runs after init. The OTel SDK is dynamically imported, so
+// pages built with telemetry disabled never fetch it.
 async function bootstrap() {
     if (config.telemetryEnabled) {
         const { initializeOtel } = await import('./telemetry/instrumentation')


### PR DESCRIPTION
Closes https://github.com/elastic/docs-builder/issues/3688

## Why

The documentation entry bundle (`main.js`) was ~629 KiB transferred, with Lighthouse attributing ~265 KiB unused and ~463 ms of script evaluation to it (TBT 962 ms, main-thread work 3.3 s). Two large feature families were statically reachable from `main.ts` even on pages that never use them:

- The OpenTelemetry SDK, pulled in eagerly via `telemetry/instrumentation.ts` despite init being gated on `config.telemetryEnabled`.
- ~35 highlight.js language modules, all registered eagerly even though a page typically uses zero or a few.

Ref: elastic/docs-builder#3688.

## What

- Telemetry: the OTel implementation now loads through `await import('./telemetry/instrumentation')` inside the existing `config.telemetryEnabled` branch. Startup is wrapped in an async `bootstrap()` that awaits telemetry before importing the web components, preserving the "telemetry initializes before instrumented work" ordering; event listeners stay registered synchronously so no early events are missed. The lightweight `@opentelemetry/api-logs` (logging/semconv) stays static.
- Highlighting: language modules (and the esql plugin) are now imported on demand. `initHighlight` scans unprocessed `#markdown-content pre code` blocks, imports only the `language-*` modules present, caches each registration (deduped across blocks and htmx swaps), resolves aliases, and skips unknown/plain-text languages gracefully. The cheap inline custom grammars (`apiheader`, `eql`, `painless`, `kuery`/`kql`) remain eager.
- Tests: new `hljs.test.ts` covers selective loading, no-code-block pages, an htmx swap introducing a new language, alias resolution, and graceful unknown-language handling.

Measured on the production Parcel build, uncompressed entry `main.js` drops from ~520 KB to ~286 KB (~45%); OTel SDK symbols and language grammars are confirmed absent from `main.js` and now live in async chunks. Transfer (gzip) size, Lighthouse unused bytes, and TBT should be re-measured against a deployed preview.

Made with [Cursor](https://cursor.com)