### PR TITLE
Publish usable source maps for production documentation bundles

### DIFF
--- a/src/Elastic.Documentation.Site/Elastic.Documentation.Site.csproj
+++ b/src/Elastic.Documentation.Site/Elastic.Documentation.Site.csproj
@@ -103,9 +103,9 @@
   <Target Name="EmbedGeneratedAssets" AfterTargets="NpmRunBuild">
     <ItemGroup>
       <EmbeddedResource Include="_static/*.js" Watch="false" />
-      <EmbeddedResource Include="_static/*.js.map" Watch="false" Condition="'$(Configuration)' == 'Debug'" />
+      <EmbeddedResource Include="_static/*.js.map" Watch="false" />
       <EmbeddedResource Include="_static/*.css" Watch="false" />
-      <EmbeddedResource Include="_static/*.css.map" Watch="false" Condition="'$(Configuration)' == 'Debug'" />
+      <EmbeddedResource Include="_static/*.css.map" Watch="false" />
       <EmbeddedResource Include="_static/*.svg" Watch="false" />
       <EmbeddedResource Include="_static/*.png" Watch="false" />
       <EmbeddedResource Include="_static/*.ttf" Watch="false" />


### PR DESCRIPTION
Release builds now ship the Parcel source maps that the bundles already reference. Production no longer 404s those `.map` files.

**Affects:** Site UI

**Prompt summary:** Publish usable source maps with the production documentation bundles. Confirm that old hashed maps cannot pile up in the AOT binary.

## Why

Release bundles already contain `sourceMappingURL` comments. The Site project only embedded `.js.map` and `.css.map` in Debug, so Lighthouse and production debuggers hit 404s ([#3689](https://github.com/elastic/docs-builder/issues/3689)). Parcel does not empty `distDir`. Old hashed maps used to accumulate and bloat the binary, which is why maps were Debug-only.

## What

#### Production source maps
`EmbedGeneratedAssets` includes `*.js.map` and `*.css.map` in every configuration. Static serving already maps `.map` to JSON.

#### Hashed asset cleanup
Cleanup no longer waits for `IsPublishing`. `NpmRunBuild` deletes hashed JS, CSS, and maps immediately before Parcel runs. Incremental builds that skip `NpmRunBuild` keep the current chunks.

## Verify

```bash
dotnet test tests/Elastic.Markdown.Tests/ --filter FullyQualifiedName~EmbeddedStaticAssetTests
# EmbedGeneratedAssets_includes_source_maps_unconditionally
# NpmRunBuild_deletes_hashed_source_maps_before_parcel
# Site_assembly_embeds_js_and_css_source_maps
```

**Out of scope:** The external `https://www.elastic.co/elastic-nav.js` map.

Closes https://github.com/elastic/docs-builder/issues/3689