### PR TITLE
Improve error message when a doc is not in the table of contents

### DIFF
--- a/src/Elastic.Documentation.Navigation/IDocumentationFile.cs
+++ b/src/Elastic.Documentation.Navigation/IDocumentationFile.cs
@@ -16,4 +16,7 @@ public interface IDocumentationFile : INavigationModel
 
 	/// Gets the title to display in navigation for this documentation file.
 	string NavigationTitle { get; }
+
+	/// Gets the source file path relative to the documentation root, or null for synthetic pages.
+	string? SourcePath => null;
 }

--- a/src/Elastic.Documentation.Navigation/INavigationTraversable.cs
+++ b/src/Elastic.Documentation.Navigation/INavigationTraversable.cs
@@ -105,7 +105,10 @@ public interface INavigationTraversable
 
 	INavigationItem GetNavigationFor(IDocumentationFile file) =>
 		NavigationDocumentationFileLookup.TryGetValue(file, out var navigation)
-			? navigation : throw new InvalidOperationException($"Could not find {file.NavigationTitle} in navigation");
+			? navigation : throw new InvalidOperationException(
+				file.SourcePath is { } path
+					? $"'{file.NavigationTitle}' ({path}) is not listed in the table of contents. Add it to the toc.yml for this documentation set."
+					: $"'{file.NavigationTitle}' is not listed in the table of contents.");
 
 	INavigationItem[] GetParents(INavigationItem current) => current.GetParents();
 

--- a/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRuleFile.cs
+++ b/src/Elastic.Markdown/Extensions/DetectionRules/DetectionRuleFile.cs
@@ -157,12 +157,12 @@ public record DetectionRuleFile : MarkdownFile
 		BuildContext build
 	) : base(sourceFile, rootPath, parser, build)
 	{
-		RuleSourceMarkdownPath = SourcePath(sourceFile, build);
+		RuleSourceMarkdownPath = GetRuleSourcePath(sourceFile, build);
 		LinkReferenceRelativePath = Path.GetRelativePath(build.DocumentationSourceDirectory.FullName, RuleSourceMarkdownPath.FullName);
 		Rule = DetectionRule.From(sourceFile);
 	}
 
-	private static IFileInfo SourcePath(IFileInfo rulePath, BuildContext build)
+	private static IFileInfo GetRuleSourcePath(IFileInfo rulePath, BuildContext build)
 	{
 		var checkoutDir = build.DocumentationCheckoutDirectory ?? build.DocumentationSourceDirectory.Parent!;
 		var relative = Path.GetRelativePath(checkoutDir.FullName, rulePath.FullName);

--- a/src/Elastic.Markdown/IO/MarkdownFile.cs
+++ b/src/Elastic.Markdown/IO/MarkdownFile.cs
@@ -94,6 +94,7 @@ public record MarkdownFile : DocumentationFile, ITableOfContentsScope, IDocument
 
 	public string FilePath { get; }
 	public string FileName { get; }
+	public string? SourcePath => RelativePath;
 
 	private bool _instructionsParsed;
 


### PR DESCRIPTION
## Why

When a documentation file is missing from the table of contents, the build fails with a message like `Could not find Fleet Smoke Tests 401 Unauthorized in navigation`. This tells the author the page title but not the file path, and gives no guidance on how to fix it — making it hard to diagnose, especially for contributors unfamiliar with the codebase.

## What

Added a `SourcePath` default interface member to `IDocumentationFile` (returns `null` for synthetic/virtual pages). `MarkdownFile` overrides it to return its `RelativePath`. The error message in `GetNavigationFor` now includes the relative path when available and tells the author exactly what to do:

```
'Fleet Smoke Tests 401 Unauthorized' (docs/fleet/smoke-tests-401.md) is not listed in the table of contents. Add it to the toc.yml for this documentation set.
```

Also renamed a private static `SourcePath()` method in `DetectionRuleFile` to `GetRuleSourcePath()` to avoid a name collision with the new property on the base class.