### PR TITLE
Fix docs-builder serve: wrong exporters, slow Ctrl+C, and missing build triggers

### DIFF
--- a/src/Elastic.Documentation.Tooling/Exporter.cs
+++ b/src/Elastic.Documentation.Tooling/Exporter.cs
@@ -23,4 +23,11 @@ public static class ExportOptions
 {
 	public static HashSet<Exporter> Default { get; } = [Exporter.Html, Exporter.LLMText, Exporter.Configuration, Exporter.DocumentationState, Exporter.LinkMetadata, Exporter.Redirects];
 	public static HashSet<Exporter> MetadataOnly { get; } = [Exporter.Configuration, Exporter.DocumentationState, Exporter.LinkMetadata, Exporter.Redirects];
+
+	/// <summary>
+	/// Used by the serve background validation build. HTML-only so that parsing runs
+	/// (and emits diagnostics) without running LLM export, config copy, link-index writes,
+	/// or redirect generation — none of which are meaningful in an in-memory build.
+	/// </summary>
+	public static HashSet<Exporter> Validation { get; } = [Exporter.Html];
 }

--- a/src/tooling/docs-builder/Http/DocumentationWebHost.cs
+++ b/src/tooling/docs-builder/Http/DocumentationWebHost.cs
@@ -24,6 +24,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Westwind.AspNetCore.LiveReload;
 
 namespace Documentation.Builder.Http;
@@ -87,6 +88,9 @@ public class DocumentationWebHost
 				s.FolderToMonitor = Context.DocumentationSourceDirectory.FullName;
 				s.ClientFileExtensions = ".md,.yml";
 			})
+			// Keep graceful-shutdown window short: SSE clients are signalled via ApplicationStopping
+			// (see RunAsync below) so there's no need to wait the default 30 s for them to drain.
+			.Configure<HostOptions>(o => o.ShutdownTimeout = TimeSpan.FromSeconds(3))
 			.AddSingleton<ReloadableGeneratorState>(_ => GeneratorState)
 			.AddSingleton(_ => InMemoryBuildState)
 			.AddHostedService<ReloadGeneratorService>(sp => new ReloadGeneratorService(GeneratorState, InMemoryBuildState, logFactory.CreateLogger<ReloadGeneratorService>()));
@@ -108,6 +112,11 @@ public class DocumentationWebHost
 
 	public async Task RunAsync(Cancel ctx)
 	{
+		// Complete all SSE client channels as soon as the host starts shutting down so that
+		// the long-lived /_api/diagnostics/stream requests exit before the graceful-shutdown
+		// timeout fires (which would otherwise stall Ctrl+C for up to 30 s).
+		_ = _webApplication.Lifetime.ApplicationStopping.Register(() => InMemoryBuildState.CompleteAllClients());
+
 		_ = _hostedService.StartAsync(ctx);
 		await _webApplication.RunAsync(ctx);
 	}

--- a/src/tooling/docs-builder/Http/DocumentationWebHost.cs
+++ b/src/tooling/docs-builder/Http/DocumentationWebHost.cs
@@ -138,6 +138,10 @@ public class DocumentationWebHost
 				{
 					await next(context);
 				}
+				catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested)
+				{
+					// Client disconnected or navigated away — normal, no need to log or rethrow.
+				}
 				catch (Exception ex)
 				{
 					Console.WriteLine($"[UNHANDLED EXCEPTION] {ex.GetType().Name}: {ex.Message}");

--- a/src/tooling/docs-builder/Http/InMemoryBuildState.cs
+++ b/src/tooling/docs-builder/Http/InMemoryBuildState.cs
@@ -49,7 +49,12 @@ public class InMemoryBuildState(ILoggerFactory loggerFactory, IConfigurationCont
 	private readonly ILoggerFactory _loggerFactory = loggerFactory;
 	private readonly IConfigurationContext _configurationContext = configurationContext;
 	private readonly ILogger<InMemoryBuildState> _logger = loggerFactory.CreateLogger<InMemoryBuildState>();
-	private readonly SemaphoreSlim _buildSemaphore = new(1, 1);
+	// Capacity-1 bounded channel: a new trigger while a build is running queues one more run;
+	// additional triggers drop the queued one (DropOldest) so only the latest matters.
+	// The build loop (RunAsync) is the sole reader and never cancels a running build on file events.
+	private readonly Channel<string> _buildChannel = Channel.CreateBounded<string>(
+		new BoundedChannelOptions(1) { FullMode = BoundedChannelFullMode.DropOldest, SingleReader = true });
+
 	private readonly Lock _diagnosticsLock = new();
 	private readonly List<DiagnosticDto> _diagnostics = [];
 
@@ -61,10 +66,6 @@ public class InMemoryBuildState(ILoggerFactory loggerFactory, IConfigurationCont
 	// Broadcast: maintain list of connected client channels
 	private readonly Lock _clientsLock = new();
 	private readonly List<Channel<BuildEvent>> _clientChannels = [];
-
-	private readonly Lock _buildStateLock = new();
-	private CancellationTokenSource? _currentBuildCts;
-	private Task? _currentBuildTask;
 
 	private int _errorCount;
 	private int _warningCount;
@@ -113,60 +114,37 @@ public class InMemoryBuildState(ILoggerFactory loggerFactory, IConfigurationCont
 		_logger.LogDebug("Client unsubscribed from diagnostics stream. Total clients: {Count}", _clientChannels.Count);
 	}
 
-	public async Task StartBuildAsync(string sourcePath, Cancel externalCt)
+	/// <summary>
+	/// Enqueues a validation build request. If a build is already queued but not yet started,
+	/// it is replaced by this one (DropOldest). A running build is never cancelled; instead the
+	/// new request waits in the single-slot queue and runs as soon as the current build finishes.
+	/// </summary>
+	public void ScheduleBuild(string sourcePath) =>
+		_ = _buildChannel.Writer.TryWrite(sourcePath);
+
+	/// <summary>
+	/// Runs the build loop until <paramref name="shutdownCt"/> is cancelled. Only <paramref name="shutdownCt"/>
+	/// can cancel a running build — file-edit triggers enqueue via <see cref="ScheduleBuild"/> and never
+	/// interrupt the current build.
+	/// </summary>
+	public async Task RunAsync(Cancel shutdownCt)
 	{
-		CancellationTokenSource? previousCts;
-		Task? previousTask;
-		CancellationTokenSource newCts;
-
-		lock (_buildStateLock)
+		try
 		{
-			previousCts = _currentBuildCts;
-			previousTask = _currentBuildTask;
-			newCts = CancellationTokenSource.CreateLinkedTokenSource(externalCt);
-			_currentBuildCts = newCts;
-			_currentBuildTask = null; // set after ExecuteBuildAsync is created below
+			await foreach (var sourcePath in _buildChannel.Reader.ReadAllAsync(shutdownCt))
+				await ExecuteBuildAsync(sourcePath, shutdownCt);
 		}
-
-		// Cancel the prior build outside the lock (CancelAsync is safe to call without holding the lock)
-		if (previousCts != null)
+		catch (OperationCanceledException)
 		{
-			_logger.LogDebug("Cancelling previous in-memory build");
-			await previousCts.CancelAsync();
-			previousCts.Dispose();
+			_logger.LogDebug("Background build loop stopped");
 		}
-
-		// Wait for the previous build body to finish — use externalCt so Ctrl+C interrupts the wait
-		if (previousTask != null)
-		{
-			try
-			{
-				await previousTask.WaitAsync(TimeSpan.FromSeconds(5), externalCt);
-			}
-			catch (TimeoutException)
-			{
-				_logger.LogWarning("Previous build did not complete within timeout");
-			}
-			catch (OperationCanceledException)
-			{
-				// Expected on both build-cancel and Ctrl+C
-			}
-		}
-
-		// Start the new build and record the task
-		var buildTask = ExecuteBuildAsync(sourcePath, newCts.Token);
-		lock (_buildStateLock)
-			_currentBuildTask = buildTask;
-
-		await buildTask;
 	}
 
 	private async Task ExecuteBuildAsync(string sourcePath, Cancel ct)
 	{
-		await _buildSemaphore.WaitAsync(ct);
+		Status = BuildStatus.Building;
 		try
 		{
-			Status = BuildStatus.Building;
 			_ = Interlocked.Exchange(ref _errorCount, 0);
 			_ = Interlocked.Exchange(ref _warningCount, 0);
 			_ = Interlocked.Exchange(ref _hintCount, 0);
@@ -253,10 +231,6 @@ public class InMemoryBuildState(ILoggerFactory loggerFactory, IConfigurationCont
 				Warnings: WarningCount,
 				Hints: HintCount
 			));
-		}
-		finally
-		{
-			_ = _buildSemaphore.Release();
 		}
 	}
 
@@ -349,17 +323,13 @@ public class InMemoryBuildState(ILoggerFactory loggerFactory, IConfigurationCont
 
 	public void Dispose()
 	{
-		_currentBuildCts?.Cancel();
-		_currentBuildCts?.Dispose();
-		_buildSemaphore.Dispose();
+		_ = _buildChannel.Writer.TryComplete();
 
 		// Close all client channels
 		lock (_clientsLock)
 		{
 			foreach (var channel in _clientChannels)
-			{
 				_ = channel.Writer.TryComplete();
-			}
 			_clientChannels.Clear();
 		}
 

--- a/src/tooling/docs-builder/Http/InMemoryBuildState.cs
+++ b/src/tooling/docs-builder/Http/InMemoryBuildState.cs
@@ -62,6 +62,7 @@ public class InMemoryBuildState(ILoggerFactory loggerFactory, IConfigurationCont
 	private readonly Lock _clientsLock = new();
 	private readonly List<Channel<BuildEvent>> _clientChannels = [];
 
+	private readonly Lock _buildStateLock = new();
 	private CancellationTokenSource? _currentBuildCts;
 	private Task? _currentBuildTask;
 
@@ -114,37 +115,50 @@ public class InMemoryBuildState(ILoggerFactory loggerFactory, IConfigurationCont
 
 	public async Task StartBuildAsync(string sourcePath, Cancel externalCt)
 	{
-		// Cancel any existing build
-		if (_currentBuildCts != null)
+		CancellationTokenSource? previousCts;
+		Task? previousTask;
+		CancellationTokenSource newCts;
+
+		lock (_buildStateLock)
+		{
+			previousCts = _currentBuildCts;
+			previousTask = _currentBuildTask;
+			newCts = CancellationTokenSource.CreateLinkedTokenSource(externalCt);
+			_currentBuildCts = newCts;
+			_currentBuildTask = null; // set after ExecuteBuildAsync is created below
+		}
+
+		// Cancel the prior build outside the lock (CancelAsync is safe to call without holding the lock)
+		if (previousCts != null)
 		{
 			_logger.LogDebug("Cancelling previous in-memory build");
-			await _currentBuildCts.CancelAsync();
+			await previousCts.CancelAsync();
+			previousCts.Dispose();
+		}
 
-			// Wait for the previous build to complete (with timeout)
-			if (_currentBuildTask != null)
+		// Wait for the previous build body to finish — use externalCt so Ctrl+C interrupts the wait
+		if (previousTask != null)
+		{
+			try
 			{
-				try
-				{
-					await _currentBuildTask.WaitAsync(TimeSpan.FromSeconds(5), CancellationToken.None);
-				}
-				catch (TimeoutException)
-				{
-					_logger.LogWarning("Previous build did not complete within timeout");
-				}
-				catch (OperationCanceledException)
-				{
-					// Expected
-				}
+				await previousTask.WaitAsync(TimeSpan.FromSeconds(5), externalCt);
+			}
+			catch (TimeoutException)
+			{
+				_logger.LogWarning("Previous build did not complete within timeout");
+			}
+			catch (OperationCanceledException)
+			{
+				// Expected on both build-cancel and Ctrl+C
 			}
 		}
 
-		// Create a new CTS linked to the external token
-		_currentBuildCts = CancellationTokenSource.CreateLinkedTokenSource(externalCt);
-		var buildCt = _currentBuildCts.Token;
+		// Start the new build and record the task
+		var buildTask = ExecuteBuildAsync(sourcePath, newCts.Token);
+		lock (_buildStateLock)
+			_currentBuildTask = buildTask;
 
-		// Start the new build
-		_currentBuildTask = ExecuteBuildAsync(sourcePath, buildCt);
-		await _currentBuildTask;
+		await buildTask;
 	}
 
 	private async Task ExecuteBuildAsync(string sourcePath, Cancel ct)
@@ -191,7 +205,9 @@ public class InMemoryBuildState(ILoggerFactory loggerFactory, IConfigurationCont
 					Strict = false,
 					AllowIndexing = false,
 					MetadataOnly = false,
-					Exporters = ExportOptions.Default,
+					// Validation-only: parse + emit diagnostics without LLM export, config copy,
+					// link-index, or redirect generation — none make sense for an in-memory build.
+					Exporters = ExportOptions.Validation,
 					SkipApi = true,
 					SkipCrossLinks = false
 				},
@@ -302,6 +318,21 @@ public class InMemoryBuildState(ILoggerFactory loggerFactory, IConfigurationCont
 		lock (_diagnosticsLock)
 		{
 			return [.. _diagnostics];
+		}
+	}
+
+	/// <summary>
+	/// Completes all subscribed SSE client channels so their <c>ReadAllAsync</c> loops exit
+	/// promptly. Call from <c>IHostApplicationLifetime.ApplicationStopping</c> to unblock
+	/// in-flight SSE requests before the graceful-shutdown timeout fires.
+	/// </summary>
+	public void CompleteAllClients()
+	{
+		lock (_clientsLock)
+		{
+			foreach (var channel in _clientChannels)
+				_ = channel.Writer.TryComplete();
+			_clientChannels.Clear();
 		}
 	}
 

--- a/src/tooling/docs-builder/Http/ReloadGeneratorService.cs
+++ b/src/tooling/docs-builder/Http/ReloadGeneratorService.cs
@@ -37,23 +37,26 @@ public sealed class ReloadGeneratorService(
 
 	private FileSystemWatcher? _watcher;
 	private CancellationTokenSource? _serviceCts;
-	private Task? _initialBuildTask;
+	private Task? _backgroundBuildTask;
 	private ReloadableGeneratorState ReloadableGenerator { get; } = reloadableGenerator;
 	private InMemoryBuildState InMemoryBuildState { get; } = inMemoryBuildState;
 	private ILogger Logger { get; } = logger;
 
-	private readonly Debouncer _debouncer = new(TimeSpan.FromMilliseconds(200));
+	private readonly Debouncer _debouncer = new(TimeSpan.FromMilliseconds(500));
 
 	public async Task StartAsync(Cancel cancellationToken)
 	{
 		_serviceCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
 		// Await the live-reload generator so the server can serve pages immediately.
-		// The full validation build runs in the background — the HUD populates when it finishes.
 		var sourcePath = ReloadableGenerator.Generator.Context.DocumentationCheckoutDirectory?.FullName
 			?? ReloadableGenerator.Generator.Context.DocumentationSourceDirectory.FullName;
 		await ReloadableGenerator.ReloadAsync(cancellationToken);
-		_initialBuildTask = InMemoryBuildState.StartBuildAsync(sourcePath, _serviceCts.Token);
+
+		// Start the build loop; only shutdownCt (Ctrl+C / app exit) can cancel a running build.
+		// File-edit triggers enqueue via ScheduleBuild and never interrupt the current build.
+		_backgroundBuildTask = InMemoryBuildState.RunAsync(_serviceCts.Token);
+		InMemoryBuildState.ScheduleBuild(sourcePath);
 
 		// ReSharper disable once RedundantAssignment
 		var directory = ReloadableGenerator.Generator.DocumentationSet.SourceDirectory.FullName;
@@ -97,20 +100,17 @@ public sealed class ReloadGeneratorService(
 	private void Reload(bool reloadConfiguration = false)
 	{
 		var token = _serviceCts?.Token ?? Cancel.None;
-		_ = _debouncer.ExecuteAsync(async ctx =>
+		_debouncer.Schedule(async ctx =>
 		{
 			await ReloadableGenerator.ReloadAsync(ctx, reloadConfiguration);
 			Logger.LogInformation("Reload complete!");
 			_ = LiveReloadMiddleware.RefreshWebSocketRequest();
 
-			// Only run the full validation build for structural changes (config/toc edits, file add/delete).
-			// Content-only .md edits are picked up on the next request via ParseFullAsync.
-			if (reloadConfiguration)
-			{
-				var sourcePath = ReloadableGenerator.Generator.Context.DocumentationCheckoutDirectory?.FullName
-					?? ReloadableGenerator.Generator.Context.DocumentationSourceDirectory.FullName;
-				await InMemoryBuildState.StartBuildAsync(sourcePath, ctx);
-			}
+			// Schedule a validation build after every reload — both content edits and structural changes.
+			// The build loop coalesces rapid triggers: a new request while a build runs queues one more.
+			var sourcePath = ReloadableGenerator.Generator.Context.DocumentationCheckoutDirectory?.FullName
+				?? ReloadableGenerator.Generator.Context.DocumentationSourceDirectory.FullName;
+			InMemoryBuildState.ScheduleBuild(sourcePath);
 		}, token);
 	}
 
@@ -123,16 +123,16 @@ public sealed class ReloadGeneratorService(
 			_serviceCts = null;
 		}
 
-		// Wait briefly for the initial/background build to acknowledge cancellation.
-		if (_initialBuildTask is not null)
+		// Wait briefly for the build loop to exit cleanly.
+		if (_backgroundBuildTask is not null)
 		{
 			try
 			{
-				await _initialBuildTask.WaitAsync(TimeSpan.FromSeconds(2), CancellationToken.None);
+				await _backgroundBuildTask.WaitAsync(TimeSpan.FromSeconds(2), CancellationToken.None);
 			}
 			catch (TimeoutException)
 			{
-				Logger.LogDebug("Background validation build did not stop within timeout during shutdown");
+				Logger.LogDebug("Background build loop did not stop within timeout during shutdown");
 			}
 			catch (OperationCanceledException)
 			{
@@ -240,33 +240,46 @@ public sealed class ReloadGeneratorService(
 		_debouncer.Dispose();
 	}
 
+	/// <summary>
+	/// True debounce: each call to <see cref="Schedule"/> resets the timer. The action fires only
+	/// after the window elapses without another call. Pending but not-yet-fired actions are cancelled
+	/// when a newer one arrives, which also cancels any in-progress <see cref="ReloadAsync"/> —
+	/// the generator falls back to its previous state until the next debounced action completes.
+	/// </summary>
 	private sealed class Debouncer(TimeSpan window) : IDisposable
 	{
-		private readonly SemaphoreSlim _semaphore = new(1, 1);
-		private readonly long _windowInTicks = window.Ticks;
-		private long _nextRun;
+		private readonly Lock _lock = new();
+		private CancellationTokenSource? _pendingCts;
 
-		public async Task ExecuteAsync(Func<Cancel, Task> innerAction, Cancel cancellationToken)
+		public void Schedule(Func<Cancel, Task> action, Cancel cancellationToken)
 		{
-			var requestStart = DateTime.UtcNow.Ticks;
-
-			try
+			CancellationTokenSource newCts;
+			lock (_lock)
 			{
-				await _semaphore.WaitAsync(cancellationToken);
-
-				if (requestStart <= _nextRun)
-					return;
-
-				await innerAction(cancellationToken);
-
-				_nextRun = requestStart + _windowInTicks;
+				_pendingCts?.Cancel();
+				_pendingCts?.Dispose();
+				newCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+				_pendingCts = newCts;
 			}
-			finally
+			_ = Task.Run(async () =>
 			{
-				_ = _semaphore.Release();
-			}
+				try
+				{
+					await Task.Delay(window, newCts.Token);
+					await action(newCts.Token);
+				}
+				catch (OperationCanceledException) { }
+			}, newCts.Token);
 		}
 
-		public void Dispose() => _semaphore.Dispose();
+		public void Dispose()
+		{
+			lock (_lock)
+			{
+				_pendingCts?.Cancel();
+				_pendingCts?.Dispose();
+				_pendingCts = null;
+			}
+		}
 	}
 }

--- a/src/tooling/docs-builder/Http/ReloadGeneratorService.cs
+++ b/src/tooling/docs-builder/Http/ReloadGeneratorService.cs
@@ -37,6 +37,7 @@ public sealed class ReloadGeneratorService(
 
 	private FileSystemWatcher? _watcher;
 	private CancellationTokenSource? _serviceCts;
+	private Task? _initialBuildTask;
 	private ReloadableGeneratorState ReloadableGenerator { get; } = reloadableGenerator;
 	private InMemoryBuildState InMemoryBuildState { get; } = inMemoryBuildState;
 	private ILogger Logger { get; } = logger;
@@ -47,13 +48,12 @@ public sealed class ReloadGeneratorService(
 	{
 		_serviceCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
-		// Run live reload and in-memory validation build in parallel
+		// Await the live-reload generator so the server can serve pages immediately.
+		// The full validation build runs in the background — the HUD populates when it finishes.
 		var sourcePath = ReloadableGenerator.Generator.Context.DocumentationCheckoutDirectory?.FullName
 			?? ReloadableGenerator.Generator.Context.DocumentationSourceDirectory.FullName;
-		await Task.WhenAll(
-			ReloadableGenerator.ReloadAsync(cancellationToken),
-			InMemoryBuildState.StartBuildAsync(sourcePath, cancellationToken)
-		);
+		await ReloadableGenerator.ReloadAsync(cancellationToken);
+		_initialBuildTask = InMemoryBuildState.StartBuildAsync(sourcePath, _serviceCts.Token);
 
 		// ReSharper disable once RedundantAssignment
 		var directory = ReloadableGenerator.Generator.DocumentationSet.SourceDirectory.FullName;
@@ -122,6 +122,24 @@ public sealed class ReloadGeneratorService(
 			_serviceCts.Dispose();
 			_serviceCts = null;
 		}
+
+		// Wait briefly for the initial/background build to acknowledge cancellation.
+		if (_initialBuildTask is not null)
+		{
+			try
+			{
+				await _initialBuildTask.WaitAsync(TimeSpan.FromSeconds(2), CancellationToken.None);
+			}
+			catch (TimeoutException)
+			{
+				Logger.LogDebug("Background validation build did not stop within timeout during shutdown");
+			}
+			catch (OperationCanceledException)
+			{
+				// Expected
+			}
+		}
+
 		_watcher?.Dispose();
 	}
 

--- a/src/tooling/docs-builder/Http/StaticWebHost.cs
+++ b/src/tooling/docs-builder/Http/StaticWebHost.cs
@@ -64,6 +64,10 @@ public class StaticWebHost
 			{
 				await next(context);
 			}
+			catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested)
+			{
+				// Client disconnected or navigated away — normal, no need to log or rethrow.
+			}
 			catch (Exception ex)
 			{
 				Console.WriteLine($"[UNHANDLED EXCEPTION] {ex.GetType().Name}: {ex.Message}");


### PR DESCRIPTION
## What broke and what we fixed

### 1. Background validation build crashed with `DirectoryNotFoundException`

When serving docs, a background build runs in memory to surface errors in the diagnostics HUD. It was mistakenly configured with the same exporter set as a full publish build (`ExportOptions.Default`), which includes the LLM text exporter and the config file exporter. Both of those tried to write real output files — `llm.zip` and config copies — into an in-memory filesystem that didn't have the expected directories, causing an immediate crash.

**Fix:** Added a new `ExportOptions.Validation` preset (`[Exporter.Html]`) that only runs the HTML pass. This is all that's needed to parse files and emit diagnostics — no side outputs.

### 2. Ctrl+C with an open browser tab took up to 30 seconds to exit

The diagnostics HUD uses a Server-Sent Events stream (`/_api/diagnostics/stream`). ASP.NET's default graceful shutdown timeout is 30 seconds, and with a browser tab holding the SSE connection open, the server would wait the full 30 seconds before force-closing it. Also, the server blocked on completing the first validation build before it started accepting HTTP requests.

**Fix:** Three changes together make shutdown instant:
- `CompleteAllClients()` is called on `ApplicationStopping` so all SSE connections drain cleanly as soon as Ctrl+C is pressed.
- `HostOptions.ShutdownTimeout` lowered to 3 seconds as a backstop for anything else that might linger.
- Startup no longer waits for the first build to finish — the server starts accepting requests immediately and the build runs in the background.

### 3. Rapid edits never triggered a background build

Two separate problems meant editing a file quickly could result in no background build running:

- The old debouncer was a throttle, not a true debounce: it recorded when it last ran and dropped any calls that arrived before the window expired. Rapid edits all got dropped.
- Editing a `.md` file (as opposed to a config file) didn't trigger a background build at all — only structural changes did.

**Fix:** Replaced the debouncer with a proper 500ms debounce that resets on every event and only fires after things settle. Changed the file watcher so any edit — content or structural — schedules a background build. The build loop uses a single-slot bounded channel so a new trigger while a build is running queues exactly one follow-up run and never cancels the in-flight build.

### 4. `[UNHANDLED EXCEPTION] TaskCanceledException` noise in serve output

When live-reload fired and the browser refreshed the page, any in-flight HTML render request would be cancelled mid-stream (the browser navigated away). The debug exception middleware was catching and logging these as unhandled exceptions, which cluttered the output and obscured real errors.

**Fix:** Added a `when (context.RequestAborted.IsCancellationRequested)` guard before the general catch so normal client-disconnect cancellations are silently swallowed.

## Test plan

- [ ] `dotnet build` passes
- [ ] `dotnet run --project src/tooling/docs-builder -- serve` starts and immediately serves pages (no wait for first build)
- [ ] Edit a `.md` file — background build triggers after ~500ms quiet period; HUD updates
- [ ] Edit rapidly — only one build runs after edits settle, no crash
- [ ] Open a browser tab, press Ctrl+C — process exits in ~1 second, not 30
- [ ] No `[UNHANDLED EXCEPTION] TaskCanceledException` lines appear on page refresh or live-reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)