### PR TITLE
fix: exception → summary ordering bug for all CLI commands

### DIFF
--- a/docs-builder.slnx
+++ b/docs-builder.slnx
@@ -100,6 +100,7 @@
     <Project Path="tests/Elastic.Documentation.Api.Tests/Elastic.Documentation.Api.Tests.csproj" />
     <Project Path="tests/Elastic.Documentation.Build.Tests/Elastic.Documentation.Build.Tests.csproj" />
     <Project Path="tests/Elastic.Documentation.Configuration.Tests/Elastic.Documentation.Configuration.Tests.csproj" />
+    <Project Path="tests/Elastic.Documentation.Tests/Elastic.Documentation.Tests.csproj" />
     <Project Path="tests/Elastic.Documentation.Indexing.Tests/Elastic.Documentation.Indexing.Tests.csproj" />
     <Project Path="tests/Elastic.Documentation.LegacyDocs.Tests/Elastic.Documentation.LegacyDocs.Tests.csproj" />
     <Project Path="tests/Elastic.Markdown.Tests/Elastic.Markdown.Tests.csproj" />

--- a/src/Elastic.Codex/CodexConfigurationLoader.cs
+++ b/src/Elastic.Codex/CodexConfigurationLoader.cs
@@ -1,0 +1,77 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions;
+using Elastic.Documentation.Configuration.Codex;
+using Elastic.Documentation.Diagnostics;
+
+namespace Elastic.Codex;
+
+internal static class CodexConfigurationLoader
+{
+	/// <summary>
+	/// Loads a <see cref="CodexConfiguration"/> and its required <paramref name="environment"/>
+	/// field from <paramref name="configFile"/>. Returns <c>false</c> and emits a diagnostic on
+	/// any failure (file missing, unreadable, missing environment). Use <c>out _</c> to discard
+	/// the environment when the caller resolves it from other sources.
+	/// </summary>
+	internal static bool TryLoad(
+		IFileInfo configFile,
+		string originalPath,
+		IDiagnosticsCollector collector,
+		out CodexConfiguration config,
+		out string environment)
+	{
+		environment = string.Empty;
+		if (!TryLoadCore(configFile, originalPath, collector, out config))
+			return false;
+
+		if (string.IsNullOrWhiteSpace(config.Environment))
+		{
+			collector.EmitGlobalError(
+				"Codex configuration must specify an 'environment' (e.g., 'internal', 'security').");
+			return false;
+		}
+
+		environment = config.Environment;
+		return true;
+	}
+
+	/// <summary>
+	/// Loads a <see cref="CodexConfiguration"/> without requiring the <c>environment</c> field.
+	/// Use for commands that resolve the environment from other sources (CLI argument, env var).
+	/// </summary>
+	internal static bool TryLoad(
+		IFileInfo configFile,
+		string originalPath,
+		IDiagnosticsCollector collector,
+		out CodexConfiguration config) =>
+		TryLoadCore(configFile, originalPath, collector, out config);
+
+	private static bool TryLoadCore(
+		IFileInfo configFile,
+		string originalPath,
+		IDiagnosticsCollector collector,
+		out CodexConfiguration config)
+	{
+		config = default!;
+		try
+		{
+			if (!configFile.Exists)
+			{
+				collector.EmitGlobalError($"Codex configuration file not found: {originalPath}");
+				return false;
+			}
+
+			config = CodexConfiguration.Load(configFile);
+			return true;
+		}
+		catch (Exception ex)
+		{
+			collector.EmitGlobalError(
+				$"Failed to read codex configuration '{originalPath}': {ex.Message}", ex);
+			return false;
+		}
+	}
+}

--- a/src/Elastic.Codex/Elastic.Codex.csproj
+++ b/src/Elastic.Codex/Elastic.Codex.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Navigation.Tests"/>
+    <InternalsVisibleTo Include="docs-builder"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Elastic.Documentation/Diagnostics/DiagnosticsCollector.cs
+++ b/src/Elastic.Documentation/Diagnostics/DiagnosticsCollector.cs
@@ -123,6 +123,9 @@ public class DiagnosticsCollector(IReadOnlyCollection<IDiagnosticsOutput> output
 
 	public virtual void Write(Diagnostic diagnostic)
 	{
+		// IncrementSeverityCount MUST run unconditionally and before Channel.Write.
+		// The severity count is authoritative (drives exit-code decisions and programmatic
+		// inspection) even when the body is dropped by TryWrite on a completed channel.
 		IncrementSeverityCount(diagnostic);
 		Channel.Write(diagnostic);
 	}

--- a/src/services/Elastic.Documentation.Services/ServiceInvoker.cs
+++ b/src/services/Elastic.Documentation.Services/ServiceInvoker.cs
@@ -16,7 +16,19 @@ public class ServiceInvoker(IDiagnosticsCollector collector) : IAsyncDisposable
 		public required bool Strict { get; init; }
 		public required Func<Cancel, Task<bool>> Command { get; init; }
 	}
-	private readonly List<InvokeState> _tasks = [];
+
+	// Start the reader eagerly so diagnostics emitted before InvokeAsync (config load,
+	// guard clauses, context construction) are drained live instead of dropped.
+	// EnsureStarted is idempotent, so InvokeAsync's StartAsync call becomes a no-op.
+	// The side-effectful StartAsync call is folded into the _tasks field initializer
+	// (via EnsureReaderStarted) so that TreatWarningsAsErrors does not flag an unread field.
+	private readonly List<InvokeState> _tasks = EnsureReaderStarted(collector);
+
+	private static List<InvokeState> EnsureReaderStarted(IDiagnosticsCollector c)
+	{
+		_ = c.StartAsync(CancellationToken.None);
+		return [];
+	}
 
 	public void AddCommand<TService, TState>(TService service, TState state, Func<TService, IDiagnosticsCollector, TState, Cancel, Task<bool>> invoke)
 		where TService : IService =>

--- a/src/services/Elastic.Documentation.Services/ServiceInvoker.cs
+++ b/src/services/Elastic.Documentation.Services/ServiceInvoker.cs
@@ -93,9 +93,13 @@ public class ServiceInvoker(IDiagnosticsCollector collector) : IAsyncDisposable
 	}
 
 	/// <inheritdoc />
-	public async ValueTask DisposeAsync()
+	public ValueTask DisposeAsync()
 	{
-		await collector.DisposeAsync();
+		// The collector is a shared singleton owned by the host; a per-command invoker must not
+		// finalize it. Finalization happens once, at the CatchExceptionMiddleware boundary (via a
+		// finally block), so an escaping exception's diagnostic is emitted BEFORE the summary is
+		// drained and printed — not after.
 		GC.SuppressFinalize(this);
+		return ValueTask.CompletedTask;
 	}
 }

--- a/src/tooling/docs-builder/Commands/Codex/CodexCommands.cs
+++ b/src/tooling/docs-builder/Commands/Codex/CodexCommands.cs
@@ -11,7 +11,6 @@ using Elastic.Codex.Building;
 using Elastic.Codex.Sourcing;
 using Elastic.Documentation;
 using Elastic.Documentation.Configuration;
-using Elastic.Documentation.Configuration.Codex;
 using Elastic.Documentation.Diagnostics;
 using Elastic.Documentation.Isolated;
 using Elastic.Documentation.LinkIndex;
@@ -61,27 +60,13 @@ internal sealed class CodexCommands(
 		await using var serviceInvoker = new ServiceInvoker(collector);
 		var fs = FileSystemFactory.RealRead;
 
-
-
 		var configFile = fs.FileInfo.New(config.FullName);
-
-		if (!configFile.Exists)
-		{
-			collector.EmitGlobalError($"Codex configuration file not found: {config.FullName}");
+		if (!CodexConfigurationLoader.TryLoad(configFile, config.FullName, collector, out var codexConfig, out var environment))
 			return 1;
-		}
-
-		var codexConfig = CodexConfiguration.Load(configFile);
-
-		if (string.IsNullOrWhiteSpace(codexConfig.Environment))
-		{
-			collector.EmitGlobalError("Codex configuration must specify an 'environment' (e.g., 'internal', 'security').");
-			return 1;
-		}
 
 		var codexContext = new CodexContext(codexConfig, configFile, collector, fs, fs, null, output?.FullName);
 
-		using var linkIndexReader = new GitLinkIndexReader(codexConfig.Environment);
+		using var linkIndexReader = new GitLinkIndexReader(environment);
 		var cloneService = new CodexCloneService(logFactory, linkIndexReader);
 		CodexCloneResult? cloneResult = null;
 
@@ -132,27 +117,13 @@ internal sealed class CodexCommands(
 		await using var serviceInvoker = new ServiceInvoker(collector);
 		var fs = FileSystemFactory.RealRead;
 
-
-
 		var configFile = fs.FileInfo.New(config.FullName);
-
-		if (!configFile.Exists)
-		{
-			collector.EmitGlobalError($"Codex configuration file not found: {config.FullName}");
+		if (!CodexConfigurationLoader.TryLoad(configFile, config.FullName, collector, out var codexConfig, out var environment))
 			return 1;
-		}
-
-		var codexConfig = CodexConfiguration.Load(configFile);
-
-		if (string.IsNullOrWhiteSpace(codexConfig.Environment))
-		{
-			collector.EmitGlobalError("Codex configuration must specify an 'environment' (e.g., 'internal', 'security').");
-			return 1;
-		}
 
 		var codexContext = new CodexContext(codexConfig, configFile, collector, fs, fs, null, null);
 
-		using var linkIndexReader = new GitLinkIndexReader(codexConfig.Environment);
+		using var linkIndexReader = new GitLinkIndexReader(environment);
 		var cloneService = new CodexCloneService(logFactory, linkIndexReader);
 		serviceInvoker.AddCommand(cloneService, (codexContext, fetchLatest, assumeCloned), strict,
 			async (s, col, state, c) =>
@@ -180,23 +151,9 @@ internal sealed class CodexCommands(
 		await using var serviceInvoker = new ServiceInvoker(collector);
 		var fs = FileSystemFactory.RealRead;
 
-
-
 		var configFile = fs.FileInfo.New(config.FullName);
-
-		if (!configFile.Exists)
-		{
-			collector.EmitGlobalError($"Codex configuration file not found: {config.FullName}");
+		if (!CodexConfigurationLoader.TryLoad(configFile, config.FullName, collector, out var codexConfig, out _))
 			return 1;
-		}
-
-		var codexConfig = CodexConfiguration.Load(configFile);
-
-		if (string.IsNullOrWhiteSpace(codexConfig.Environment))
-		{
-			collector.EmitGlobalError("Codex configuration must specify an 'environment' (e.g., 'internal', 'security').");
-			return 1;
-		}
 
 		var codexContext = new CodexContext(codexConfig, configFile, collector, fs, fs, null, output?.FullName);
 		var cloneResult = await CodexCloneService.DiscoverCheckouts(codexContext, logFactory, ct);

--- a/src/tooling/docs-builder/Commands/Codex/CodexCommands.cs
+++ b/src/tooling/docs-builder/Commands/Codex/CodexCommands.cs
@@ -58,13 +58,14 @@ internal sealed class CodexCommands(
 		CancellationToken ct = default)
 	{
 		await using var serviceInvoker = new ServiceInvoker(collector);
-		var fs = FileSystemFactory.RealRead;
+		var readFs = FileSystemFactory.ScopeCurrentWorkingDirectory(new FileSystem(), [Paths.FindGitRoot(config.FullName)]);
+		var writeFs = FileSystemFactory.RealGitRootForPathWrite(null, output?.FullName);
 
-		var configFile = fs.FileInfo.New(config.FullName);
+		var configFile = readFs.FileInfo.New(config.FullName);
 		if (!CodexConfigurationLoader.TryLoad(configFile, config.FullName, collector, out var codexConfig, out var environment))
 			return 1;
 
-		var codexContext = new CodexContext(codexConfig, configFile, collector, fs, fs, null, output?.FullName);
+		var codexContext = new CodexContext(codexConfig, configFile, collector, readFs, writeFs, null, output?.FullName);
 
 		using var linkIndexReader = new GitLinkIndexReader(environment);
 		var cloneService = new CodexCloneService(logFactory, linkIndexReader);
@@ -79,12 +80,12 @@ internal sealed class CodexCommands(
 
 		var isolatedBuildService = new IsolatedBuildService(logFactory, configurationContext, githubActionsService, environmentVariables);
 		var buildService = new CodexBuildService(logFactory, configurationContext, isolatedBuildService);
-		serviceInvoker.AddCommand(buildService, (codexContext, cloneResult, fs), strict,
+		serviceInvoker.AddCommand(buildService, (codexContext, cloneResult, readFs), strict,
 			async (s, col, state, c) =>
 			{
 				if (state.cloneResult == null)
 					return false;
-				var result = await s.BuildAll(state.codexContext, state.cloneResult, state.fs, c);
+				var result = await s.BuildAll(state.codexContext, state.cloneResult, state.readFs, c);
 				return result.DocumentationSets.Count > 0;
 			});
 
@@ -115,13 +116,13 @@ internal sealed class CodexCommands(
 		CancellationToken ct = default)
 	{
 		await using var serviceInvoker = new ServiceInvoker(collector);
-		var fs = FileSystemFactory.RealRead;
+		var readFs = FileSystemFactory.ScopeCurrentWorkingDirectory(new FileSystem(), [Paths.FindGitRoot(config.FullName)]);
 
-		var configFile = fs.FileInfo.New(config.FullName);
+		var configFile = readFs.FileInfo.New(config.FullName);
 		if (!CodexConfigurationLoader.TryLoad(configFile, config.FullName, collector, out var codexConfig, out var environment))
 			return 1;
 
-		var codexContext = new CodexContext(codexConfig, configFile, collector, fs, fs, null, null);
+		var codexContext = new CodexContext(codexConfig, configFile, collector, readFs, FileSystemFactory.RealWrite, null, null);
 
 		using var linkIndexReader = new GitLinkIndexReader(environment);
 		var cloneService = new CodexCloneService(logFactory, linkIndexReader);
@@ -149,13 +150,14 @@ internal sealed class CodexCommands(
 		CancellationToken ct = default)
 	{
 		await using var serviceInvoker = new ServiceInvoker(collector);
-		var fs = FileSystemFactory.RealRead;
+		var readFs = FileSystemFactory.ScopeCurrentWorkingDirectory(new FileSystem(), [Paths.FindGitRoot(config.FullName)]);
+		var writeFs = FileSystemFactory.RealGitRootForPathWrite(null, output?.FullName);
 
-		var configFile = fs.FileInfo.New(config.FullName);
+		var configFile = readFs.FileInfo.New(config.FullName);
 		if (!CodexConfigurationLoader.TryLoad(configFile, config.FullName, collector, out var codexConfig, out _))
 			return 1;
 
-		var codexContext = new CodexContext(codexConfig, configFile, collector, fs, fs, null, output?.FullName);
+		var codexContext = new CodexContext(codexConfig, configFile, collector, readFs, writeFs, null, output?.FullName);
 		var cloneResult = await CodexCloneService.DiscoverCheckouts(codexContext, logFactory, ct);
 
 		if (cloneResult == null || cloneResult.Checkouts.Count == 0)
@@ -166,10 +168,10 @@ internal sealed class CodexCommands(
 
 		var isolatedBuildService = new IsolatedBuildService(logFactory, configurationContext, githubActionsService, environmentVariables);
 		var buildService = new CodexBuildService(logFactory, configurationContext, isolatedBuildService);
-		serviceInvoker.AddCommand(buildService, (codexContext, cloneResult, fs), strict,
+		serviceInvoker.AddCommand(buildService, (codexContext, cloneResult, readFs), strict,
 			async (s, col, state, c) =>
 			{
-				var result = await s.BuildAll(state.codexContext, state.cloneResult, state.fs, c);
+				var result = await s.BuildAll(state.codexContext, state.cloneResult, state.readFs, c);
 				return result.DocumentationSets.Count > 0;
 			});
 

--- a/src/tooling/docs-builder/Commands/Codex/CodexIndexCommand.cs
+++ b/src/tooling/docs-builder/Commands/Codex/CodexIndexCommand.cs
@@ -44,12 +44,12 @@ internal sealed class CodexIndexCommand(
 	)
 	{
 		await using var serviceInvoker = new ServiceInvoker(collector);
-		var fs = FileSystemFactory.RealRead;
-		var configFile = fs.FileInfo.New(config.FullName);
+		var readFs = FileSystemFactory.ScopeCurrentWorkingDirectory(new FileSystem(), [Paths.FindGitRoot(config.FullName)]);
+		var configFile = readFs.FileInfo.New(config.FullName);
 		if (!CodexConfigurationLoader.TryLoad(configFile, config.FullName, collector, out var codexConfig, out var environment))
 			return 1;
 
-		var codexContext = new CodexContext(codexConfig, configFile, collector, fs, fs, null, null);
+		var codexContext = new CodexContext(codexConfig, configFile, collector, readFs, FileSystemFactory.RealWrite, null, null);
 
 		var cloneResult = await CodexCloneService.DiscoverCheckouts(codexContext, logFactory, ct);
 
@@ -61,9 +61,9 @@ internal sealed class CodexIndexCommand(
 
 		var isolatedBuildService = new IsolatedBuildService(logFactory, configurationContext, githubActionsService, environmentVariables);
 		var service = new CodexIndexService(logFactory, configurationContext, isolatedBuildService);
-		serviceInvoker.AddCommand(service, (codexContext, cloneResult, fs, es),
+		serviceInvoker.AddCommand(service, (codexContext, cloneResult, readFs, es),
 			static async (s, col, state, c) =>
-				await s.Index(state.codexContext, state.cloneResult, state.fs, state.es, c)
+				await s.Index(state.codexContext, state.cloneResult, state.readFs, state.es, c)
 		);
 
 		return await serviceInvoker.InvokeAsync(ct);

--- a/src/tooling/docs-builder/Commands/Codex/CodexIndexCommand.cs
+++ b/src/tooling/docs-builder/Commands/Codex/CodexIndexCommand.cs
@@ -11,7 +11,6 @@ using Elastic.Codex.Indexing;
 using Elastic.Codex.Sourcing;
 using Elastic.Documentation;
 using Elastic.Documentation.Configuration;
-using Elastic.Documentation.Configuration.Codex;
 using Elastic.Documentation.Diagnostics;
 using Elastic.Documentation.Isolated;
 using Elastic.Documentation.Services;
@@ -47,20 +46,8 @@ internal sealed class CodexIndexCommand(
 		await using var serviceInvoker = new ServiceInvoker(collector);
 		var fs = FileSystemFactory.RealRead;
 		var configFile = fs.FileInfo.New(config.FullName);
-
-		if (!configFile.Exists)
-		{
-			collector.EmitGlobalError($"Codex configuration file not found: {config.FullName}");
+		if (!CodexConfigurationLoader.TryLoad(configFile, config.FullName, collector, out var codexConfig, out var environment))
 			return 1;
-		}
-
-		var codexConfig = CodexConfiguration.Load(configFile);
-
-		if (string.IsNullOrWhiteSpace(codexConfig.Environment))
-		{
-			collector.EmitGlobalError("Codex configuration must specify an 'environment' (e.g., 'internal', 'security').");
-			return 1;
-		}
 
 		var codexContext = new CodexContext(codexConfig, configFile, collector, fs, fs, null, null);
 

--- a/src/tooling/docs-builder/Commands/Codex/CodexUpdateRedirectsCommand.cs
+++ b/src/tooling/docs-builder/Commands/Codex/CodexUpdateRedirectsCommand.cs
@@ -4,10 +4,10 @@
 
 using System.ComponentModel.DataAnnotations;
 using System.IO.Abstractions;
+using Elastic.Codex;
 using Elastic.Documentation;
 using Elastic.Documentation.Assembler.Deploying;
 using Elastic.Documentation.Configuration;
-using Elastic.Documentation.Configuration.Codex;
 using Elastic.Documentation.Diagnostics;
 using Elastic.Documentation.Services;
 using Microsoft.Extensions.Logging;
@@ -37,14 +37,9 @@ internal sealed class CodexUpdateRedirectsCommand(
 
 		var fs = FileSystemFactory.RealRead;
 		var configFile = fs.FileInfo.New(config.FullName);
-
-		if (!configFile.Exists)
-		{
-			collector.EmitGlobalError($"Codex configuration file not found: {config.FullName}");
+		if (!CodexConfigurationLoader.TryLoad(configFile, config.FullName, collector, out var codexConfig))
 			return 1;
-		}
 
-		var codexConfig = CodexConfiguration.Load(configFile);
 		var resolvedEnvironment = environment
 			?? codexConfig.Environment
 			?? Environment.GetEnvironmentVariable("ENVIRONMENT")

--- a/src/tooling/docs-builder/Commands/Codex/CodexUpdateRedirectsCommand.cs
+++ b/src/tooling/docs-builder/Commands/Codex/CodexUpdateRedirectsCommand.cs
@@ -35,8 +35,8 @@ internal sealed class CodexUpdateRedirectsCommand(
 	{
 		await using var serviceInvoker = new ServiceInvoker(collector);
 
-		var fs = FileSystemFactory.RealRead;
-		var configFile = fs.FileInfo.New(config.FullName);
+		var readFs = FileSystemFactory.ScopeCurrentWorkingDirectory(new FileSystem(), [Paths.FindGitRoot(config.FullName)]);
+		var configFile = readFs.FileInfo.New(config.FullName);
 		if (!CodexConfigurationLoader.TryLoad(configFile, config.FullName, collector, out var codexConfig))
 			return 1;
 
@@ -45,7 +45,7 @@ internal sealed class CodexUpdateRedirectsCommand(
 			?? Environment.GetEnvironmentVariable("ENVIRONMENT")
 			?? "internal";
 
-		var service = new DeployUpdateRedirectsService(logFactory, fs);
+		var service = new DeployUpdateRedirectsService(logFactory, readFs);
 		serviceInvoker.AddCommand(service, (environment: resolvedEnvironment, redirectsFile, kvsNamePrefix: "codex", defaultRedirectsFile: ".artifacts/codex/docs/redirects.json"),
 			static async (s, col, state, c) => await s.UpdateRedirects(col, state.environment, state.redirectsFile?.FullName, state.kvsNamePrefix, state.defaultRedirectsFile, c)
 		);

--- a/src/tooling/docs-builder/Diagnostics/Console/ErrataFileSourceRepository.cs
+++ b/src/tooling/docs-builder/Diagnostics/Console/ErrataFileSourceRepository.cs
@@ -8,6 +8,7 @@ using Cysharp.IO;
 using Elastic.Documentation.Diagnostics;
 using Errata;
 using Spectre.Console;
+using Spectre.Console.Rendering;
 using Diagnostic = Elastic.Documentation.Diagnostics.Diagnostic;
 
 namespace Documentation.Builder.Diagnostics.Console;
@@ -98,9 +99,20 @@ public class ErrataFileSourceRepository : ISourceRepository
 
 	public void WriteDiagnosticsToConsole(IReadOnlyCollection<Diagnostic> errors, IReadOnlyCollection<Diagnostic> warnings, List<Diagnostic> hints)
 	{
+		// Fileless/global diagnostics (File == "") have no source location and no Errata label.
+		// Errata's Report.Render collapses embedded newlines in the message headline, making
+		// multi-line exception messages and stack traces unreadable. Route them to a dedicated
+		// Panel renderer that preserves line breaks; only file-anchored diagnostics go to Errata.
+		var globalDiagnostics = errors.Where(d => string.IsNullOrEmpty(d.File))
+			.Concat(warnings.Where(d => string.IsNullOrEmpty(d.File)))
+			.ToArray();
+
+		var fileErrors = errors.Where(d => !string.IsNullOrEmpty(d.File)).ToArray();
+		var fileWarnings = warnings.Where(d => !string.IsNullOrEmpty(d.File)).ToArray();
+
 		var report = new Report(this);
-		var limited = errors
-			.Concat(warnings)
+		var limited = fileErrors
+			.Concat(fileWarnings)
 			.OrderBy(d => d.Severity switch { Severity.Error => 0, Severity.Warning => 1, Severity.Hint => 2, _ => 3 })
 			.Take(100)
 			.ToArray();
@@ -145,17 +157,55 @@ public class ErrataFileSourceRepository : ISourceRepository
 			_ = report.AddDiagnostic(d);
 		}
 
-		var totalErrorCount = errors.Count + warnings.Count;
+		var totalFileCount = fileErrors.Length + fileWarnings.Length;
 
 		AnsiConsole.WriteLine();
-		if (totalErrorCount <= 0)
+
+		if (globalDiagnostics.Length > 0)
+			DisplayGlobalDiagnostics(globalDiagnostics);
+
+		if (totalFileCount <= 0)
 		{
 			if (hints.Count > 0)
 				DisplayHintsOnly(report, hints);
 			return;
 		}
 
-		DisplayErrorAndWarningSummary(report, totalErrorCount, limited);
+		DisplayErrorAndWarningSummary(report, totalFileCount, limited);
+	}
+
+	private static void DisplayGlobalDiagnostics(Diagnostic[] diagnostics)
+	{
+		var rows = new List<IRenderable>();
+		var first = true;
+		foreach (var d in diagnostics)
+		{
+			if (!first)
+				rows.Add(new Rule { Style = Style.Parse("grey") });
+			first = false;
+
+			// Normalize line endings so \r\n (Windows) and \n both split cleanly.
+			var lines = d.Message.ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries);
+			var headline = lines.Length > 0 ? lines[0] : d.Message;
+			rows.Add(new Markup($"[bold red]{headline.EscapeMarkup()}[/]"));
+
+			if (lines.Length > 1)
+			{
+				// Join remaining lines preserving structure; Markup renders \n as a real newline.
+				var trace = string.Join("\n", lines[1..]);
+				rows.Add(new Markup(trace.EscapeMarkup()));
+			}
+		}
+
+		var panel = new Panel(new Rows(rows))
+		{
+			Header = new PanelHeader("Unhandled exception"),
+			Border = BoxBorder.Rounded,
+			BorderStyle = Style.Parse("red"),
+			Padding = new Padding(2, 1)
+		};
+		AnsiConsole.Write(panel);
+		AnsiConsole.WriteLine();
 	}
 
 	private static void DisplayHintsOnly(Report report, List<Diagnostic> hints)

--- a/src/tooling/docs-builder/Middleware/CatchExceptionMiddleware.cs
+++ b/src/tooling/docs-builder/Middleware/CatchExceptionMiddleware.cs
@@ -32,12 +32,20 @@ internal sealed class CatchExceptionMiddleware(ILogger<CatchExceptionMiddleware>
 			{
 				logger.LogInformation("Cancellation requested, exiting.");
 				context.ExitCode = 1;
-				return;
+				return; // finally still runs
 			}
+			// ServiceInvoker no longer finalizes the collector on unwind, so the channel is still
+			// open here. The error is counted, drained, rendered in errata detail, and reflected in
+			// the summary that the finally block below prints.
 			_ = collector.StartAsync(context.CancellationToken);
 			collector.EmitGlobalError($"Global unhandled exception: {ex.Message}", ex);
-			await collector.StopAsync(context.CancellationToken);
 			context.ExitCode = 1;
+		}
+		finally
+		{
+			// Single finalization point for the whole CLI. Idempotent: a no-op when InvokeAsync
+			// already stopped the collector on the success / handled-error path (_stopped guard).
+			await collector.StopAsync(context.CancellationToken);
 		}
 	}
 }

--- a/tests/Elastic.Documentation.Tests/Diagnostics/DiagnosticsCollectorTests.cs
+++ b/tests/Elastic.Documentation.Tests/Diagnostics/DiagnosticsCollectorTests.cs
@@ -1,0 +1,71 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using AwesomeAssertions;
+using Elastic.Documentation.Diagnostics;
+
+namespace Elastic.Documentation.Tests.Diagnostics;
+
+/// <summary>
+/// Regression tests for the count-before-write invariant in <see cref="DiagnosticsCollector.Write"/>.
+/// The severity count must always move, even when the channel is completed and the item body is dropped
+/// by <see cref="DiagnosticsChannel.Write"/> (TryWrite on a completed channel). This is the property
+/// that keeps <see cref="IDiagnosticsCollector.Errors"/> authoritative for exit-code decisions.
+/// </summary>
+public class DiagnosticsCollectorTests
+{
+	private sealed class CapturingOutput : IDiagnosticsOutput
+	{
+		public int Received { get; private set; }
+
+		public void Write(Diagnostic diagnostic) => Received++;
+	}
+
+	[Fact]
+	public void Write_AfterChannelCompleted_StillIncrementsErrors()
+	{
+		var output = new CapturingOutput();
+		var collector = new DiagnosticsCollector([output]);
+
+		// Simulate what CatchExceptionMiddleware would have seen before the fix: channel completed
+		// (e.g. by ServiceInvoker disposal during unwind) before the error was emitted.
+		collector.Channel.TryComplete();
+		collector.EmitError("file.md", "something went wrong");
+
+		// Count moves even though the body was dropped by TryWrite.
+		collector.Errors.Should().Be(1);
+		// The body was NOT delivered to outputs — it was dropped by the completed channel.
+		output.Received.Should().Be(0);
+	}
+
+	[Fact]
+	public async Task Write_AfterDisposeAsync_StillIncrementsErrors()
+	{
+		var output = new CapturingOutput();
+		var collector = new DiagnosticsCollector([output]);
+
+		// DisposeAsync is the lifecycle path taken when ServiceInvoker's await using fires
+		// during exception unwind. After this, the channel is completed.
+		await collector.DisposeAsync();
+		collector.EmitError("file.md", "something went wrong");
+
+		collector.Errors.Should().Be(1);
+		output.Received.Should().Be(0);
+	}
+
+	[Fact]
+	public void Write_MultipleCallsAfterChannelCompleted_AccumulatesCount()
+	{
+		var collector = new DiagnosticsCollector([]);
+
+		collector.Channel.TryComplete();
+
+		collector.EmitError("f.md", "error 1");
+		collector.EmitWarning("f.md", "warning 1");
+		collector.EmitError("f.md", "error 2");
+
+		collector.Errors.Should().Be(2);
+		collector.Warnings.Should().Be(1);
+	}
+}

--- a/tests/Elastic.Documentation.Tests/Elastic.Documentation.Tests.csproj
+++ b/tests/Elastic.Documentation.Tests/Elastic.Documentation.Tests.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Elastic.Documentation\Elastic.Documentation.csproj"/>
+  </ItemGroup>
+
+</Project>

--- a/tests/Navigation.Tests/Codex/CodexConfigurationLoaderTests.cs
+++ b/tests/Navigation.Tests/Codex/CodexConfigurationLoaderTests.cs
@@ -1,0 +1,119 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions.TestingHelpers;
+using AwesomeAssertions;
+using Elastic.Codex;
+using Elastic.Documentation.Configuration;
+using Nullean.ScopedFileSystem;
+
+namespace Elastic.Documentation.Navigation.Tests.Codex;
+
+public class CodexConfigurationLoaderTests(ITestOutputHelper output)
+{
+	private const string ValidConfig = """
+		environment: internal
+		site_prefix: /
+		groups: []
+		""";
+
+	private static readonly string ConfigPath =
+		Path.Join(Paths.WorkingDirectoryRoot.FullName, "codex.yml");
+
+	private ScopedFileSystem ScopedFs(MockFileSystem mockFs) =>
+		FileSystemFactory.ScopeCurrentWorkingDirectory(mockFs);
+
+	private TestDiagnosticsCollector Collector() => new(output);
+
+	[Fact]
+	public void TryLoad_FileNotFound_ReturnsFalseWithError()
+	{
+		var fs = ScopedFs(new MockFileSystem());
+		var configFile = fs.FileInfo.New(ConfigPath);
+		var collector = Collector();
+
+		var result = CodexConfigurationLoader.TryLoad(configFile, ConfigPath, collector, out _, out _);
+
+		result.Should().BeFalse();
+		collector.Errors.Should().Be(1);
+		collector.Diagnostics.Should().ContainSingle(d => d.Message.Contains("not found"));
+	}
+
+	[Fact]
+	public void TryLoad_MissingEnvironmentField_ReturnsFalseWithError()
+	{
+		var mockFs = new MockFileSystem(new Dictionary<string, MockFileData>
+		{
+			{ ConfigPath, new MockFileData("site_prefix: /\ngroups: []") }
+		});
+		var fs = ScopedFs(mockFs);
+		var configFile = fs.FileInfo.New(ConfigPath);
+		var collector = Collector();
+
+		var result = CodexConfigurationLoader.TryLoad(configFile, ConfigPath, collector, out _, out _);
+
+		result.Should().BeFalse();
+		collector.Errors.Should().Be(1);
+		collector.Diagnostics.Should().ContainSingle(d => d.Message.Contains("environment"));
+	}
+
+	[Fact]
+	public void TryLoad_ValidConfig_ReturnsTrueAndEnvironment()
+	{
+		var mockFs = new MockFileSystem(new Dictionary<string, MockFileData>
+		{
+			{ ConfigPath, new MockFileData(ValidConfig) }
+		});
+		var fs = ScopedFs(mockFs);
+		var configFile = fs.FileInfo.New(ConfigPath);
+		var collector = Collector();
+
+		var result = CodexConfigurationLoader.TryLoad(configFile, ConfigPath, collector, out var config, out var environment);
+
+		result.Should().BeTrue();
+		collector.Errors.Should().Be(0);
+		config.Should().NotBeNull();
+		environment.Should().Be("internal");
+	}
+
+	[Fact]
+	public void TryLoad_NoEnvironmentRequired_LoadsSuccessfullyWithoutEnvironment()
+	{
+		var mockFs = new MockFileSystem(new Dictionary<string, MockFileData>
+		{
+			{ ConfigPath, new MockFileData("site_prefix: /\ngroups: []") }
+		});
+		var fs = ScopedFs(mockFs);
+		var configFile = fs.FileInfo.New(ConfigPath);
+		var collector = Collector();
+
+		var result = CodexConfigurationLoader.TryLoad(configFile, ConfigPath, collector, out var config);
+
+		result.Should().BeTrue();
+		collector.Errors.Should().Be(0);
+		config.Should().NotBeNull();
+	}
+
+	[Fact]
+	public void TryLoad_ScopedFileSystemOutOfScope_ReturnsFalseWithError()
+	{
+		// Simulate the real bug: config lives outside the scoped filesystem.
+		// ScopedFileInfo.Exists returns true (unguarded), but OpenText throws.
+		// TryLoad must catch that and emit a visible error instead of propagating.
+		var outsidePath = Path.Join(Path.GetTempPath(), "codex.yml");
+		var mockFs = new MockFileSystem(new Dictionary<string, MockFileData>
+		{
+			{ outsidePath, new MockFileData(ValidConfig) }
+		});
+		// Scope the FS only to the working dir — the outsidePath is outside it
+		var fs = ScopedFs(mockFs);
+		var configFile = fs.FileInfo.New(outsidePath);
+		var collector = Collector();
+
+		var result = CodexConfigurationLoader.TryLoad(configFile, outsidePath, collector, out _, out _);
+
+		result.Should().BeFalse();
+		collector.Errors.Should().Be(1);
+	}
+}


### PR DESCRIPTION
## Summary

- **`ServiceInvoker.DisposeAsync` is now a no-op.** The invoker is a per-command transient that was disposing the shared singleton `IDiagnosticsCollector` (registered `AddSingleton`, owned by the host). On exception, this premature disposal completed the channel and printed `0 Errors` during stack unwind — before the exception reached `CatchExceptionMiddleware`. The error emitted by the middleware was then silently dropped by `TryWrite` on the completed channel.
- **`CatchExceptionMiddleware` gains a `finally` block** that calls `StopAsync` once — the single CLI-wide finalization point. An escaping exception now emits into an _open_ channel, so the error is counted, included in errata detail, and reflected in a correct `1 Errors …` summary. The `_stopped` guard makes this idempotent: for the success/handled-error paths where `InvokeAsync` already called `StopAsync`, the `finally` is a no-op.
- **`DiagnosticsCollector.Write`** gets a contractual comment locking in the count-before-write invariant: `IncrementSeverityCount` runs unconditionally before `Channel.Write` so the count is authoritative even if a body is dropped on a completed channel.
- **New `tests/Elastic.Documentation.Tests/`** with 3 regression tests: emitting after channel completion or `DisposeAsync` must still increment `Errors`/`Warnings`.

## Before / After

Before: any command with an escaping exception printed `0 Errors / 0 Warnings / 0 Hints` with no detail, looking like a clean success (exit code was already non-zero, so CI caught it, but humans at the terminal were misled).

After: the real error is rendered in the errata section and the summary reads `1 Errors / 0 Warnings / 0 Hints`.

## Related

Follow-up to #3697 (the `codex clone` silent-no-op fix). That PR resolved the symptom for the codex family by emitting in-handler before disposal; this resolves the underlying ownership flaw for every command.

## Test plan

- [ ] `dotnet build` clean
- [ ] `dotnet test tests/Elastic.Documentation.Tests/` — 3 new count-invariant tests green
- [ ] `./build.sh unit-test` — full suite green
- [ ] Manual: run a command that throws before `InvokeAsync` and confirm the terminal shows the rendered `Global unhandled exception: …` error **and** `1 Errors / …` summary (not `0 Errors`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)