### PR TITLE
Tolerate removed bundle.resolve in changelog config

### DIFF
--- a/src/Elastic.Documentation.Configuration/Changelog/ChangelogConfigurationLoader.cs
+++ b/src/Elastic.Documentation.Configuration/Changelog/ChangelogConfigurationLoader.cs
@@ -446,6 +446,9 @@ public class ChangelogConfigurationLoader(ILoggerFactory logFactory, IConfigurat
 
 	private static BundleConfiguration? ParseBundleConfiguration(IDiagnosticsCollector collector, string configPath, BundleConfigurationYaml yaml)
 	{
+		if (yaml.Resolve != null)
+			collector.EmitWarning(configPath, "bundle.resolve is deprecated and ignored. Resolved bundles are now the only format. Remove 'resolve' from bundle in changelog.yml.");
+
 		if (!string.IsNullOrWhiteSpace(yaml.Repo) && yaml.Repo.Contains('+', StringComparison.Ordinal))
 		{
 			collector.EmitError(

--- a/src/Elastic.Documentation.Configuration/Changelog/ChangelogConfigurationYaml.cs
+++ b/src/Elastic.Documentation.Configuration/Changelog/ChangelogConfigurationYaml.cs
@@ -282,6 +282,13 @@ internal sealed record BundleConfigurationYaml
 	public bool? UseLocalChangelogs { get; set; }
 
 	/// <summary>
+	/// Deprecated and ignored. Resolved bundles are now the only format. Retained solely so existing
+	/// changelog.yml files carrying <c>bundle.resolve</c> deserialize without a hard error; a
+	/// deprecation warning is emitted when it is present. Remove it from changelog.yml.
+	/// </summary>
+	public bool? Resolve { get; set; }
+
+	/// <summary>
 	/// Default bundle description used when no profile-specific description is provided.
 	/// </summary>
 	public string? Description { get; set; }

--- a/src/Elastic.Documentation.Configuration/Changelog/ChangelogConfigurationYaml.cs
+++ b/src/Elastic.Documentation.Configuration/Changelog/ChangelogConfigurationYaml.cs
@@ -286,6 +286,7 @@ internal sealed record BundleConfigurationYaml
 	/// changelog.yml files carrying <c>bundle.resolve</c> deserialize without a hard error; a
 	/// deprecation warning is emitted when it is present. Remove it from changelog.yml.
 	/// </summary>
+	[Obsolete("bundle.resolve is deprecated and ignored; resolved bundles are the only format. This field will be removed in a future version.")]
 	public bool? Resolve { get; set; }
 
 	/// <summary>

--- a/tests/Elastic.Changelog.Tests/Changelogs/ChangelogConfigurationTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/ChangelogConfigurationTests.cs
@@ -1724,6 +1724,36 @@ public class ChangelogConfigurationTests(ITestOutputHelper output) : ChangelogTe
 	}
 
 	[Fact]
+	public async Task LoadChangelogConfiguration_BundleResolve_Deprecated_IgnoredAndWarningEmitted()
+	{
+		// Arrange — bundle.resolve was removed; a config still carrying it must load (no hard parse error) but warn.
+		var configLoader = new ChangelogConfigurationLoader(LoggerFactory, ConfigurationContext, FileSystem);
+		var configPath = FileSystem.Path.Join(Paths.WorkingDirectoryRoot.FullName, Guid.NewGuid().ToString(), "changelog.yml");
+		FileSystem.Directory.CreateDirectory(FileSystem.Path.GetDirectoryName(configPath)!);
+
+		// language=yaml
+		var configContent =
+			"""
+			bundle:
+			  directory: docs/changelog
+			  resolve: true
+			""";
+		await FileSystem.File.WriteAllTextAsync(configPath, configContent, TestContext.Current.CancellationToken);
+
+		// Act
+		var config = await configLoader.LoadChangelogConfiguration(Collector, configPath, TestContext.Current.CancellationToken);
+
+		// Assert
+		config.Should().NotBeNull();
+		Collector.Errors.Should().Be(0);
+		config.Bundle.Should().NotBeNull();
+		Collector.Warnings.Should().BeGreaterThan(0);
+		Collector.Diagnostics.Should().Contain(d =>
+			d.Severity == Severity.Warning &&
+			d.Message.Contains("bundle.resolve is deprecated and ignored"));
+	}
+
+	[Fact]
 	public async Task LoadChangelogConfiguration_UseLocalChangelogs_True_Parses()
 	{
 		var configLoader = new ChangelogConfigurationLoader(LoggerFactory, ConfigurationContext, FileSystem);


### PR DESCRIPTION
## Why

PR #3700 removed the `bundle.resolve` changelog config key. The changelog config is parsed by a strict YAML deserializer that hard-errors on any unknown key, so every consuming repo whose `docs/changelog.yml` still carries `resolve:` now fails `validate changelog` on **every** PR — including PRs that don't touch changelogs — with:

```
YAML parsing error in changelog configuration: Property 'resolve' not found on type
Elastic.Documentation.Configuration.Changelog.BundleConfigurationYaml
```

This already broke CI across elastic/cloud (and potentially other repos that were seeded with `resolve: true`). Removing a config key should degrade gracefully, not hard-break downstream builds with no migration window.

## What

Re-add `bundle.resolve` to the YAML DTO as a deprecated, ignored field and emit a deprecation warning when it is present, instead of failing to parse. The key stays out of the domain model (`BundleConfiguration`) and out of `changelog.example.yml`, so it is accepted for backward compatibility only and authors are nudged to remove it. This mirrors the existing `rules.publish` deprecation-warning pattern.

Consuming repos should still drop the dead key (e.g. elastic/cloud#157322), but they are no longer blocked while they do.