### PR TITLE
Reject changelog bundles whose target diverges from entry targets

### DIFF
--- a/src/services/Elastic.Changelog/Bundling/BundleBuilder.cs
+++ b/src/services/Elastic.Changelog/Bundling/BundleBuilder.cs
@@ -46,6 +46,19 @@ public class BundleBuilder
 			};
 		}
 
+		// Guard against a bundle-level target that disagrees with the targets its own entries declare
+		// for the same product (for example a release version typed as 2027-07-20 while every entry says
+		// 2026-07-20). The bundle-level target drives the rendered release date, so a mismatch silently
+		// publishes entries under the wrong version/date. Refuse to build the bundle in that case.
+		if (!ValidateProductTargetConsistency(collector, bundledProducts, entries))
+		{
+			return new BundleBuildResult
+			{
+				IsValid = false,
+				Data = null
+			};
+		}
+
 		var bundledData = new Bundle
 		{
 			Products = bundledProducts,
@@ -133,6 +146,90 @@ public class BundleBuilder
 
 		return bundledProducts;
 	}
+
+	/// <summary>
+	/// Verifies that, for every bundle-level product that declares a target, each entry declaring the
+	/// same product declares a compatible target. A coarser bundle target may be a component-prefix of a
+	/// finer entry target (for example a monthly rollup <c>2026-05</c> covering an entry dated
+	/// <c>2026-05-15</c>), but genuinely divergent targets (for example <c>2027-07-20</c> vs
+	/// <c>2026-07-20</c>, or <c>9.5.0</c> vs <c>9.6.0</c>) are rejected. Entries whose product carries no
+	/// target, or a product the bundle does not declare, are not compared.
+	/// </summary>
+	/// <returns><c>true</c> when all entry targets are consistent with the bundle-level targets.</returns>
+	private static bool ValidateProductTargetConsistency(
+		IDiagnosticsCollector collector,
+		IReadOnlyList<BundledProduct> bundledProducts,
+		IReadOnlyList<MatchedChangelogFile> entries)
+	{
+		// Index the bundle-level targets by product id, keeping only products that declare a target.
+		var bundleTargetsByProduct = bundledProducts
+			.Where(p => !string.IsNullOrWhiteSpace(p.ProductId) && !string.IsNullOrWhiteSpace(p.Target))
+			.GroupBy(p => p.ProductId, StringComparer.OrdinalIgnoreCase)
+			.ToDictionary(g => g.Key, g => g.Select(p => p.Target!).ToList(), StringComparer.OrdinalIgnoreCase);
+
+		if (bundleTargetsByProduct.Count == 0)
+			return true;
+
+		var isValid = true;
+
+		foreach (var entry in entries)
+		{
+			if (entry.Data.Products == null)
+				continue;
+
+			foreach (var entryProduct in entry.Data.Products)
+			{
+				if (string.IsNullOrWhiteSpace(entryProduct.ProductId) || string.IsNullOrWhiteSpace(entryProduct.Target))
+					continue;
+
+				if (!bundleTargetsByProduct.TryGetValue(entryProduct.ProductId, out var bundleTargets))
+					continue;
+
+				if (bundleTargets.Any(bundleTarget => AreTargetsCompatible(bundleTarget, entryProduct.Target!)))
+					continue;
+
+				collector.EmitError(entry.FilePath,
+					$"Changelog entry '{entry.FileName}' declares target '{entryProduct.Target}' for product '{entryProduct.ProductId}', " +
+					$"but the bundle target for that product is '{string.Join("', '", bundleTargets)}'. " +
+					"A bundle target and its entries' targets for the same product must match (a coarser bundle target may be a prefix of a finer entry target). " +
+					"Check the release version passed to 'changelog bundle' / 'changelog gh-release'.");
+				isValid = false;
+			}
+		}
+
+		return isValid;
+	}
+
+	/// <summary>
+	/// Two targets are compatible when they are equal or when one is a component-wise prefix of the other.
+	/// Components are the dot- and dash-delimited parts of a version or date (for example <c>9.5.0</c> or
+	/// <c>2026-07-20</c>), so <c>2026-05</c> is compatible with <c>2026-05-15</c> but <c>2027-07-20</c> is
+	/// not compatible with <c>2026-07-20</c>.
+	/// </summary>
+	private static bool AreTargetsCompatible(string a, string b)
+	{
+		if (string.Equals(a.Trim(), b.Trim(), StringComparison.OrdinalIgnoreCase))
+			return true;
+
+		var componentsA = SplitTargetComponents(a);
+		var componentsB = SplitTargetComponents(b);
+		var shared = Math.Min(componentsA.Length, componentsB.Length);
+
+		if (shared == 0)
+			return false;
+
+		for (var i = 0; i < shared; i++)
+		{
+			if (!string.Equals(componentsA[i], componentsB[i], StringComparison.OrdinalIgnoreCase))
+				return false;
+		}
+
+		// Every shared leading component matched; one target is a prefix of the other.
+		return true;
+	}
+
+	private static string[] SplitTargetComponents(string target) =>
+		target.Split(['.', '-'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
 	private static Lifecycle? ParseLifecycle(string? value)
 	{

--- a/tests/Elastic.Changelog.Tests/Changelogs/BundleTargetConsistencyTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/BundleTargetConsistencyTests.cs
@@ -1,0 +1,144 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using AwesomeAssertions;
+using Elastic.Changelog.Bundling;
+using Elastic.Documentation.Configuration;
+using Elastic.Documentation.Diagnostics;
+
+namespace Elastic.Changelog.Tests.Changelogs;
+
+/// <summary>
+/// Guards against publishing a bundle whose bundle-level product target disagrees with the targets its
+/// own entries declare for the same product. This reproduces the class of defect where a release
+/// version was passed as <c>2027-07-20</c> while every entry (and the release date) said
+/// <c>2026-07-20</c>, which silently rendered the entries under the wrong date.
+/// </summary>
+public class BundleTargetConsistencyTests(ITestOutputHelper output) : ChangelogTestBase(output)
+{
+	private ChangelogBundlingService Service => new(LoggerFactory, null, FileSystem);
+
+	private string WriteChangelogDir(params (string fileName, string content)[] files)
+	{
+		var dir = FileSystem.Path.Join(Paths.WorkingDirectoryRoot.FullName, Guid.NewGuid().ToString());
+		FileSystem.Directory.CreateDirectory(dir);
+		foreach (var (fileName, content) in files)
+			FileSystem.File.WriteAllText(FileSystem.Path.Join(dir, fileName), content);
+		return dir;
+	}
+
+	private string NewOutputPath()
+	{
+		var outputPath = FileSystem.Path.Join(Paths.WorkingDirectoryRoot.FullName, Guid.NewGuid().ToString(), "bundle.yaml");
+		FileSystem.Directory.CreateDirectory(FileSystem.Path.GetDirectoryName(outputPath)!);
+		return outputPath;
+	}
+
+	[Fact]
+	public async Task BundleTarget_DivergesFromEntryTarget_FailsWithError()
+	{
+		// language=yaml
+		var entry =
+			"""
+			title: Prevent overriding inference API secret_parameters
+			type: breaking-change
+			products:
+			  - product: cloud-serverless
+			    target: 2026-07-20
+			prs:
+			  - https://github.com/elastic/elasticsearch/pull/153309
+			""";
+
+		var changelogDir = WriteChangelogDir(("153309.yaml", entry));
+		var outputPath = NewOutputPath();
+
+		var input = new BundleChangelogsArguments
+		{
+			Directory = changelogDir,
+			All = true,
+			Output = outputPath,
+			// Release version typed one year off — the real-world defect being guarded against.
+			OutputProducts = [new ProductArgument { Product = "cloud-serverless", Target = "2027-07-20" }]
+		};
+
+		var result = await Service.BundleChangelogs(Collector, input, TestContext.Current.CancellationToken);
+
+		result.Should().BeFalse("a bundle target inconsistent with its entry targets must not be produced");
+		Collector.Errors.Should().BeGreaterThan(0);
+		Collector.Diagnostics.Should().Contain(d =>
+			d.Severity == Severity.Error &&
+			d.Message.Contains("2027-07-20") &&
+			d.Message.Contains("2026-07-20") &&
+			d.Message.Contains("cloud-serverless"));
+		FileSystem.File.Exists(outputPath).Should().BeFalse("the inconsistent bundle must not be written");
+	}
+
+	[Fact]
+	public async Task BundleTarget_CoarserPrefixOfEntryTarget_Succeeds()
+	{
+		// A monthly rollup: bundle target is the coarser month, entries carry a specific day within it.
+		// language=yaml
+		var entry =
+			"""
+			title: Faster hosted search
+			type: feature
+			products:
+			  - product: cloud-hosted
+			    target: 2026-05-15
+			prs:
+			  - https://github.com/elastic/elasticsearch/pull/100
+			""";
+
+		var changelogDir = WriteChangelogDir(("100-feature.yaml", entry));
+		var outputPath = NewOutputPath();
+
+		var input = new BundleChangelogsArguments
+		{
+			Directory = changelogDir,
+			All = true,
+			Output = outputPath,
+			OutputProducts = [new ProductArgument { Product = "cloud-hosted", Target = "2026-05" }]
+		};
+
+		var result = await Service.BundleChangelogs(Collector, input, TestContext.Current.CancellationToken);
+
+		result.Should().BeTrue($"a coarser bundle target that is a prefix of the entry target is valid. Errors: {string.Join("; ", Collector.Diagnostics.Where(d => d.Severity == Severity.Error).Select(d => d.Message))}");
+		Collector.Errors.Should().Be(0);
+		FileSystem.File.Exists(outputPath).Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task BundleTarget_MatchesEntryTarget_Succeeds()
+	{
+		// language=yaml
+		var entry =
+			"""
+			title: Elasticsearch feature
+			type: feature
+			products:
+			  - product: elasticsearch
+			    target: 9.5.0
+			    lifecycle: ga
+			prs:
+			  - https://github.com/elastic/elasticsearch/pull/100
+			""";
+
+		var changelogDir = WriteChangelogDir(("100-feature.yaml", entry));
+		var outputPath = NewOutputPath();
+
+		var input = new BundleChangelogsArguments
+		{
+			Directory = changelogDir,
+			All = true,
+			Output = outputPath,
+			OutputProducts = [new ProductArgument { Product = "elasticsearch", Target = "9.5.0" }]
+		};
+
+		var result = await Service.BundleChangelogs(Collector, input, TestContext.Current.CancellationToken);
+
+		result.Should().BeTrue($"matching targets are valid. Errors: {string.Join("; ", Collector.Diagnostics.Where(d => d.Severity == Severity.Error).Select(d => d.Message))}");
+		Collector.Errors.Should().Be(0);
+		FileSystem.File.Exists(outputPath).Should().BeTrue();
+	}
+}


### PR DESCRIPTION
## Problem

A serverless breaking-change rendered on the public site under **July 20, 2027** (a year in the future): https://www.elastic.co/docs/release-notes/cloud-serverless/breaking-changes#july-20-2027

Root cause: the CDN bundle `bundle/cloud-serverless/elasticsearch-2026-07-20.yaml` had a bundle-level product target of `2027-07-20`, even though its filename, `release-date`, and **every one of its entries** declared `cloud-serverless` target `2026-07-20`. The `{changelog}` directive derives its date heading from `bundle.Products[0].Target` (`BundleLoader.GetVersionFromBundle`), so the whole bundle rendered under the wrong year.

The defect was possible because `BundleBuilder.BuildProducts` takes the bundle-level product target **verbatim** from the release-version argument (`--output-products` / profile `{version}`) and never validates it against the targets the entries themselves declare.

cc: @lcawl @cotti 

## Fix

Add a guardrail in `BundleBuilder.BuildBundle`: if a bundle-level product target is inconsistent with the targets its own entries declare for that same product, the build fails (returns an invalid result, so no bundle is written and the publish job fails loudly).

Compatibility is intentionally lenient in one direction to avoid false positives:

- A coarser bundle target may be a **component-prefix** of a finer entry target — e.g. a monthly rollup `2026-05` covering an entry dated `2026-05-15`. ✅ allowed
- Genuine divergence is rejected — e.g. `2027-07-20` vs `2026-07-20`, or `9.5.0` vs `9.6.0`. ❌ error

Entries whose product carries no target, or a product the bundle doesn't declare, are not compared.

## Tests

Adds `BundleTargetConsistencyTests`:
- divergent target (the real-world `2027` vs `2026` case) → bundle fails with a descriptive error, no file written
- coarser prefix (`2026-05` over `2026-05-15`) → succeeds
- exact match (`9.5.0`) → succeeds

Full `Elastic.Changelog.Tests` suite passes (807 tests).

## Note

This prevents recurrence. The already-published CDN bundle still needs to be corrected separately (re-publish the cloud-serverless bundle for `elasticsearch` with the correct `2026-07-20` target, then invalidate the CDN cache).

Made with [Cursor](https://cursor.com)