### PR TITLE
Add safe and selective backfill mode to changelog upload

### DIFF
--- a/docs/cli-schema.json
+++ b/docs/cli-schema.json
@@ -4305,7 +4305,7 @@
           ],
           "name": "upload",
           "summary": "Upload changelog entries or bundle artifacts to S3 or Elasticsearch.",
-          "notes": "Uses content-hash\u2013based incremental transfer \u2014 only changed files are uploaded.\n\n\nChangelog entries are uploaded once under changelog/{org}/{repo}/{branch}/{file}, keyed by the\nauthoring owner (--owner \u003E bundle.owner \u003E git remote), repository (--repo\n\u003E bundle.repo \u003E git remote), and branch (--branch \u003E the current checkout\u0027s\nbranch). The branch is stored verbatim, so a branch\u0027s / become real key separators. Bundles\nare uploaded under bundle/{product}/{file}, product-scoped from the bundle YAML, and do not\nrequire an owner/repo/branch.",
+          "notes": "Uses content-hash\u2013based incremental transfer \u2014 only changed files are uploaded.\n\n\nChangelog entries are uploaded once under changelog/{org}/{repo}/{branch}/{file}, keyed by the\nauthoring owner (--owner \u003E bundle.owner \u003E git remote), repository (--repo\n\u003E bundle.repo \u003E git remote), and branch (--branch \u003E the current checkout\u0027s\nbranch). The branch is stored verbatim, so a branch\u0027s / become real key separators. Bundles\nare uploaded under bundle/{product}/{file}, product-scoped from the bundle YAML, and do not\nrequire an owner/repo/branch.\n\n\n\nWith --backfill, the command switches to backfill publishing mode for historical bundles:\nonly the files named via --files are uploaded (no directory discovery), objects are written\ncreate-only (an existing key with different content is a conflict, never an overwrite), and a\nregistry manifest that cannot be reconciled fails the operation.",
           "usage": "docs-builder changelog upload --artifact-type \u003Cstring\u003E --target \u003Cstring\u003E [options]",
           "examples": [],
           "parameters": [
@@ -4357,7 +4357,7 @@
               "name": "directory",
               "type": "string",
               "required": false,
-              "summary": "Override changelog directory instead of reading it from config.",
+              "summary": "Override changelog directory instead of reading it from config. With --backfill it is not scanned; it only serves as the base directory for resolving relative --files paths.",
               "validations": [
                 {
                   "kind": "rejectSymbolicLinks"
@@ -4390,7 +4390,24 @@
               "name": "skip-etag-check",
               "type": "boolean",
               "required": false,
-              "summary": "Upload every discovered file even when its content hash matches the remote object. Use to re-trigger downstream scrubbers without changing file content.",
+              "summary": "Upload every discovered file even when its content hash matches the remote object. Use to re-trigger downstream scrubbers without changing file content. Mutually exclusive with --backfill.",
+              "defaultValue": "false"
+            },
+            {
+              "role": "flag",
+              "name": "files",
+              "type": "array",
+              "required": false,
+              "summary": "Exact bundle YAML paths to upload (comma-separated), or a path to a newline-delimited path list file. Can be specified multiple times. Relative paths resolve against the bundle directory. Requires --backfill; nothing outside this selection is uploaded.",
+              "repeatable": true,
+              "elementType": "string"
+            },
+            {
+              "role": "flag",
+              "name": "backfill",
+              "type": "boolean",
+              "required": false,
+              "summary": "Backfill publishing mode: upload only the files given via --files, write objects create-only (conditional PUT with If-None-Match; an existing key with different content is a conflict, never an overwrite), and fail the operation when a registry manifest cannot be reconciled. Only valid with --artifact-type bundle; mutually exclusive with --skip-etag-check.",
               "defaultValue": "false"
             },
             {

--- a/docs/cli/changelog/cmd-upload.md
+++ b/docs/cli/changelog/cmd-upload.md
@@ -2,6 +2,8 @@
 
 Upload changelog entries or bundle artifacts to S3 or Elasticsearch. The command discovers `.yaml` and `.yml` files in a local directory and uploads only files whose content hash changed since the last run. Changelog entries are uploaded once under `changelog/{org}/{repo}/{branch}/{file}`, keyed by the authoring owner, repository, and branch; bundles are uploaded under `bundle/{product}/{file}`, product-scoped from the bundle YAML.
 
+For historical backfill runs, pass `--backfill` to switch to [backfill mode](#backfill-mode): explicit file selection instead of directory discovery, create-only writes instead of overwrites, and strict registry failure semantics.
+
 To create bundles first, use [](/cli/changelog/bundle.md).
 For the end-to-end workflow, see [](/contribute/bundle-changelogs.md).
 
@@ -111,18 +113,35 @@ s3://{bucket}/bundle/{product}/registry.json                  # bundle uploads
 
 When several repositories publish bundles for the same shared product (for example `cloud-serverless`), use a `{repo}-{dateOrVersion}.yaml` bundle filename convention so they don't overwrite each other under `bundle/{product}/`.
 
-The registry refresh is best-effort: upload failures block the run, but a stale manifest does not fail an otherwise successful upload.
+In live mode the registry refresh is best-effort: upload failures block the run, but a stale manifest does not fail an otherwise successful upload. In [backfill mode](#backfill-mode) a registry refresh failure fails the operation.
 
 :::{note}
 Upload uses content-hash–based incremental transfer. Unchanged files are skipped. Re-running the same command is safe and idempotent.
 If it's necessary to re-trigger downstream scrubbers without changing file content, pass `--skip-etag-check` to upload every discovered file even when its content hash matches the remote object.
 :::
 
+## Backfill mode
+
+`--backfill` switches the command to backfill publishing semantics for historical bundles. Three things change relative to a live upload:
+
+1. **Explicit selection, no directory discovery.** Only the files named via `--files` are uploaded. `--files` accepts comma-separated bundle YAML paths or a path to a newline-delimited path list file, and can be repeated; relative paths resolve against the bundle directory. A selected file that cannot be mapped to a destination (missing file, no `products`, invalid product name) is an error that aborts the run before any write — never a silent skip.
+2. **Create-only writes.** An object is only ever created, never replaced. The write is a conditional PUT (`If-None-Match: *`), so even a concurrent writer that creates the key between inspection and write surfaces as a conflict instead of an overwrite. Per key:
+   - Key absent → created.
+   - Key exists with identical content → skipped (reported as such; re-runs stay idempotent).
+   - Key exists with different content → conflict; the run fails and the object is untouched. Correcting a published bundle requires the explicit corrections workflow — there is intentionally no force flag.
+3. **Strict registry semantics.** A registry manifest that cannot be reconciled (after the bounded optimistic-concurrency retries, or due to an S3 error) fails the operation with a non-zero exit code, because uploaded objects that are not enumerable by consumers leave the backfill incomplete. Conflicted objects are excluded from the registry refresh so the manifest never misrepresents what is actually published.
+
+Backfill mode only supports `--artifact-type bundle` (the backfill publishes bundles only) and cannot be combined with `--skip-etag-check`, whose forced re-upload semantics are the opposite of create-only.
+
+Live (non-backfill) uploads are unaffected: without `--backfill`, discovery, overwrite, and best-effort registry behavior are unchanged.
+
 ## Options
 
 | Option | Purpose |
 | ------ | ------- |
-| `--skip-etag-check` | Upload every discovered file even when its content hash matches the remote object. Each upload emits `s3:ObjectCreated`, which re-triggers the scrubber Lambda on the private bucket. Default behavior (without this flag) skips unchanged files. |
+| `--skip-etag-check` | Upload every discovered file even when its content hash matches the remote object. Each upload emits `s3:ObjectCreated`, which re-triggers the scrubber Lambda on the private bucket. Default behavior (without this flag) skips unchanged files. Mutually exclusive with `--backfill`. |
+| `--files` | Exact bundle YAML paths to upload (comma-separated), or a path to a newline-delimited path list file. Can be specified multiple times. Requires `--backfill`; nothing outside this selection is uploaded. |
+| `--backfill` | Backfill publishing mode: explicit `--files` selection, create-only conditional writes, and registry refresh failures fail the operation. See [Backfill mode](#backfill-mode). |
 
 ## Configuration
 
@@ -183,4 +202,28 @@ docs-builder changelog upload \
   --target s3 \
   --s3-bucket-name my-changelog-bundles \
   --config ./config/changelog.yml
+```
+
+### Backfill exactly two historical bundles
+
+Upload only the two named bundles, refusing to touch any existing object and failing if the registry cannot be reconciled:
+
+```sh
+docs-builder changelog upload \
+  --artifact-type bundle \
+  --target s3 \
+  --s3-bucket-name my-changelog-bundles \
+  --backfill \
+  --files "elasticsearch-8.9.0.yaml,elasticsearch-8.9.1.yaml"
+```
+
+A path list file works too — one bundle path per line:
+
+```sh
+docs-builder changelog upload \
+  --artifact-type bundle \
+  --target s3 \
+  --s3-bucket-name my-changelog-bundles \
+  --backfill \
+  --files ./backfill-plan.txt
 ```

--- a/docs/development/changelog-bundle-registry.md
+++ b/docs/development/changelog-bundle-registry.md
@@ -131,8 +131,31 @@ re-merges, and retries (bounded retries). This mirrors the link-index writer
 (`AwsS3LinkIndexReaderWriter.SaveRegistry`). If the merge result already equals what's
 published, the write is skipped so re-uploads stay idempotent.
 
-The refresh is **best-effort**: any failure is logged and surfaced as a warning but never
-fails the upload, because the bundle objects themselves are already in S3.
+In live mode the refresh is **best-effort**: any failure is logged and surfaced as a warning
+but never fails the upload, because the bundle objects themselves are already in S3. In
+**backfill mode** (`changelog upload --backfill`) an unreconciled registry is an incomplete
+operation: a refresh failure — an S3 error or exhausting the optimistic-concurrency retries —
+is surfaced as an error and fails the run.
+
+### Backfill mode: explicit selection and create-only writes
+
+`changelog upload --backfill --files …` exists for historical backfill runs, where directory
+discovery and overwrite semantics are unsafe. It changes the producer path in three ways:
+
+- **Explicit selection.** Only the bundle YAMLs named via `--files` are uploaded — no
+  directory globbing, so unrelated artifacts cannot reach the wrong scope. A selected file
+  that cannot be mapped to a destination is an error that aborts the run before any write.
+- **Create-only object writes.** Bundle objects are written with a conditional PUT
+  (`If-None-Match: *`) — the same guard the registry writer uses on create. An existing key
+  with identical content is skipped; different content is a conflict that fails the run
+  without touching the object. The pre-write ETag inspection is informative only; the
+  conditional PUT is the race guard, so a concurrent create between inspection and write
+  surfaces as a conflict (`412`), never an overwrite. Conflicted objects are excluded from
+  the registry refresh so the manifest never records content that is not actually published.
+- **Strict registry semantics**, as described above.
+
+Live uploads keep their overwrite semantics, and registries keep their concurrent
+conditional-update path in both modes.
 
 ### Buckets and infrastructure
 

--- a/src/services/Elastic.Changelog/Uploading/ChangelogUploadService.cs
+++ b/src/services/Elastic.Changelog/Uploading/ChangelogUploadService.cs
@@ -4,6 +4,7 @@
 
 using System.IO.Abstractions;
 using Amazon.S3;
+using Elastic.Changelog.Bundling;
 using Elastic.Documentation;
 using Elastic.Documentation.Configuration;
 using Elastic.Documentation.Configuration.Changelog;
@@ -55,8 +56,24 @@ public record ChangelogUploadArguments
 	/// <summary>
 	/// When true, upload every discovered file even when its content hash matches the remote object.
 	/// Useful to re-trigger downstream scrubbers without changing file content.
+	/// Incompatible with <see cref="Backfill"/>, whose create-only semantics rely on the content comparison.
 	/// </summary>
 	public bool SkipEtagCheck { get; init; }
+
+	/// <summary>
+	/// Backfill publishing mode for historical bundles. Only the files in <see cref="Files"/> are
+	/// uploaded (no directory discovery), objects are written create-only (an existing key with
+	/// different content is a conflict, never an overwrite), and a registry that cannot be reconciled
+	/// fails the operation. Only valid for <see cref="ArtifactType.Bundle"/> uploads.
+	/// </summary>
+	public bool Backfill { get; init; }
+
+	/// <summary>
+	/// Exact bundle YAML files to upload in <see cref="Backfill"/> mode. Values are file paths or a
+	/// newline-delimited path-list file; relative paths resolve against the bundle directory. Required
+	/// when <see cref="Backfill"/> is set; not valid otherwise.
+	/// </summary>
+	public IReadOnlyList<string> Files { get; init; } = [];
 }
 
 public class ChangelogUploadService(
@@ -80,6 +97,9 @@ public class ChangelogUploadService(
 			return true;
 		}
 
+		if (!ValidateBackfillArguments(collector, args))
+			return false;
+
 		var directory = args.ArtifactType == ArtifactType.Bundle
 			? await ResolveBundleDirectory(collector, args, ctx)
 			: await ResolveChangelogDirectory(collector, args, ctx);
@@ -87,18 +107,13 @@ public class ChangelogUploadService(
 		if (directory == null)
 			return false;
 
-		if (!_fileSystem.Directory.Exists(directory))
-		{
-			_logger.LogInformation("{ArtifactType} directory {Directory} does not exist; nothing to upload", args.ArtifactType, directory);
+		var targets = await ResolveUploadTargets(collector, args, directory, ctx);
+		if (targets == null)
 			return true;
-		}
 
-		var targets = args.ArtifactType == ArtifactType.Bundle
-			? DiscoverBundleUploadTargets(collector, directory)
-			: DiscoverUploadTargets(collector, directory, args.Owner, args.Repo, args.Branch);
-
-		// Entry uploads abort (rather than no-op) when the repo cannot be resolved: the keys would be
-		// unscoped and a silent skip would look like "nothing to upload".
+		// Aborts (rather than no-ops) when a key cannot be derived: entry uploads with an unresolved
+		// repo would produce unscoped keys, and a backfill selection that cannot be mapped in full must
+		// fail before any write. A silent skip would look like "nothing to upload".
 		if (collector.Errors > 0)
 			return false;
 
@@ -114,28 +129,106 @@ public class ChangelogUploadService(
 		var client = s3Client ?? defaultClient!;
 		var etagCalculator = new S3EtagCalculator(logFactory, _fileSystem);
 		var uploader = new S3IncrementalUploader(logFactory, client, _fileSystem, etagCalculator, args.S3BucketName);
-		var result = await uploader.Upload(targets, args.SkipEtagCheck, ctx);
+		var writePolicy = args.Backfill ? S3WritePolicy.CreateOnly : S3WritePolicy.Overwrite;
+		var result = await uploader.Upload(targets, args.SkipEtagCheck, writePolicy, ctx);
 
-		_logger.LogInformation("Upload complete: {Uploaded} uploaded, {Skipped} skipped, {Failed} failed", result.Uploaded, result.Skipped, result.Failed);
+		_logger.LogInformation("Upload complete: {Uploaded} uploaded, {Skipped} skipped, {Conflicted} conflicted, {Failed} failed",
+			result.Uploaded, result.Skipped, result.Conflicts.Count, result.Failed);
 
 		if (result.Failed > 0)
 			collector.EmitError(string.Empty, $"{result.Failed} file(s) failed to upload");
+
+		foreach (var conflict in result.Conflicts)
+		{
+			collector.EmitError(conflict.LocalPath,
+				$"Refusing to overwrite s3://{args.S3BucketName}/{conflict.S3Key}: the key already exists with different content. " +
+				"Backfill uploads are create-only; correcting a published bundle requires the explicit corrections workflow.");
+		}
 
 		// On a successful upload, refresh the per-product registry.json so consumers can enumerate
 		// content without an S3 listing: the bundle index (consumed by the changelog directive in
 		// cdn: mode) for bundle uploads, and the changelog-entry index (consumed by `changelog
 		// bundle` when sourcing entries from the CDN) for changelog uploads.
-		// Failures here are logged but don't fail the upload — the objects themselves are already in S3.
+		var registryReconciled = true;
 		if (result.Failed == 0 && targets.Count > 0)
 		{
 			var scope = args.ArtifactType == ArtifactType.Bundle ? RegistryScope.Bundle : RegistryScope.Changelog;
-			await RefreshRegistries(collector, client, etagCalculator, args, targets, scope, ctx);
+
+			// Conflicted targets are excluded: their remote content differs from the local file, so
+			// registering the local ETag would misrepresent what is actually published.
+			var registryTargets = result.Conflicts.Count == 0
+				? targets
+				: targets.Where(t => !result.Conflicts.Contains(t)).ToList();
+
+			if (registryTargets.Count > 0)
+				registryReconciled = await RefreshRegistries(collector, client, etagCalculator, args, registryTargets, scope, ctx);
 		}
 
-		return result.Failed == 0;
+		// In backfill mode an unreconciled registry is an incomplete operation.
+		if (args.Backfill && !registryReconciled)
+			return false;
+
+		return result.Failed == 0 && result.Conflicts.Count == 0;
 	}
 
-	private async Task RefreshRegistries(
+	private bool ValidateBackfillArguments(IDiagnosticsCollector collector, ChangelogUploadArguments args)
+	{
+		if (!args.Backfill)
+		{
+			if (args.Files.Count > 0)
+			{
+				collector.EmitError(string.Empty, "--files requires --backfill: explicit file selection is only supported in backfill mode.");
+				return false;
+			}
+			return true;
+		}
+
+		if (args.ArtifactType != ArtifactType.Bundle)
+		{
+			collector.EmitError(string.Empty, "--backfill only supports --artifact-type bundle; the backfill publishes bundles only.");
+			return false;
+		}
+
+		if (args.Files.Count == 0)
+		{
+			collector.EmitError(string.Empty, "--backfill requires an explicit file selection via --files; directory discovery is not allowed in backfill mode.");
+			return false;
+		}
+
+		if (args.SkipEtagCheck)
+		{
+			collector.EmitError(string.Empty, "--skip-etag-check cannot be combined with --backfill: create-only uploads rely on the content comparison to distinguish an idempotent re-run from a conflict.");
+			return false;
+		}
+
+		return true;
+	}
+
+	/// <summary>
+	/// Builds the upload target list: explicit selection in backfill mode, directory discovery otherwise.
+	/// Returns null when the source directory does not exist (a discovery no-op, reported as success).
+	/// </summary>
+	private async Task<IReadOnlyList<UploadTarget>?> ResolveUploadTargets(
+		IDiagnosticsCollector collector,
+		ChangelogUploadArguments args,
+		string directory,
+		Cancel ctx)
+	{
+		if (args.Backfill)
+			return await SelectBundleUploadTargets(collector, args.Files, directory, ctx);
+
+		if (!_fileSystem.Directory.Exists(directory))
+		{
+			_logger.LogInformation("{ArtifactType} directory {Directory} does not exist; nothing to upload", args.ArtifactType, directory);
+			return null;
+		}
+
+		return args.ArtifactType == ArtifactType.Bundle
+			? DiscoverBundleUploadTargets(collector, directory)
+			: DiscoverUploadTargets(collector, directory, args.Owner, args.Repo, args.Branch);
+	}
+
+	private async Task<bool> RefreshRegistries(
 		IDiagnosticsCollector collector,
 		IAmazonS3 client,
 		IS3EtagCalculator etagCalculator,
@@ -150,12 +243,30 @@ public class ChangelogUploadService(
 			var result = await builder.RefreshAsync(collector, uploadTargets, ctx, scope);
 			_logger.LogInformation("Registry refresh ({Scope}): {Updated} updated, {Unchanged} unchanged, {Failed} failed",
 				scope, result.Updated, result.Unchanged, result.Failed);
+
+			if (result.Failed > 0 && args.Backfill)
+			{
+				collector.EmitError(string.Empty,
+					$"Registry refresh failed for {result.Failed} manifest(s); the uploaded objects are not enumerable by consumers and the backfill operation is incomplete. Re-run once the concurrent writes settle.");
+			}
+
+			return result.Failed == 0;
 		}
 		catch (Exception ex) when (ex is not OperationCanceledException)
 		{
-			// Leaving the manifest stale is non-fatal — bundle objects are unaffected.
+			if (args.Backfill)
+			{
+				// An unreconciled registry leaves the uploaded objects invisible to consumers; backfill
+				// must treat that as an incomplete operation, not a stale-manifest inconvenience.
+				collector.EmitError(string.Empty,
+					$"Failed to refresh registry manifest(s): {ex.Message}. The backfill operation is incomplete; re-run to reconcile the registry.", ex);
+				return false;
+			}
+
+			// Leaving the manifest stale is non-fatal in live mode — bundle objects are unaffected.
 			_logger.LogWarning(ex, "Registry refresh failed; bundles uploaded successfully but manifests may be stale");
 			collector.EmitWarning(string.Empty, $"Failed to refresh registry manifest(s): {ex.Message}");
+			return false;
 		}
 	}
 
@@ -232,44 +343,103 @@ public class ChangelogUploadService(
 				continue;
 			}
 
-			var products = ReadProductsFromBundle(filePath);
-
-			// Amends published before products were copied from the parent omit them; derive the
-			// destination from the parent bundle next to the amend so they are not silently skipped.
-			if (products.Count == 0 && BundleAmendMerger.IsAmendFile(filePath))
-			{
-				products = ReadProductsFromParentBundle(filePath);
-				if (products.Count == 0)
-				{
-					collector.EmitWarning(filePath,
-						"Amend bundle declares no products and its parent bundle is missing or has none; " +
-						"skipping upload. Re-create the amend with a current docs-builder so it carries the parent's products.");
-					continue;
-				}
-			}
-
-			if (products.Count == 0)
-			{
-				_logger.LogDebug("No products found in bundle {File}, skipping", filePath);
-				continue;
-			}
-
-			var fileName = _fileSystem.Path.GetFileName(filePath);
-
-			foreach (var product in products)
-			{
-				if (!ChangelogKeys.IsValidProduct(product))
-				{
-					collector.EmitWarning(filePath, $"Skipping invalid product name \"{product}\" (must match [a-zA-Z0-9_-]+)");
-					continue;
-				}
-
-				var s3Key = ChangelogKeys.BundleFileKey(product, fileName);
-				targets.Add(new UploadTarget(filePath, s3Key));
-			}
+			targets.AddRange(CreateBundleTargetsForFile(collector, filePath, explicitSelection: false));
 		}
 
 		return targets;
+	}
+
+	/// <summary>
+	/// Resolves an explicit backfill selection (file paths or a newline-delimited path-list file) into
+	/// bundle upload targets. Unlike <see cref="DiscoverBundleUploadTargets"/>, every problem is an
+	/// error: an operator-selected file that cannot be mapped to a destination must abort the run
+	/// before any write instead of being skipped silently.
+	/// </summary>
+	internal async Task<IReadOnlyList<UploadTarget>> SelectBundleUploadTargets(
+		IDiagnosticsCollector collector,
+		IReadOnlyList<string> files,
+		string? baseDirectory,
+		Cancel ctx)
+	{
+		var loader = new FileFilterLoader(_fileSystem);
+		var filterResult = await loader.LoadFilesAsync(collector, [.. files], baseDirectory, ctx);
+		if (!filterResult.IsValid)
+			return [];
+
+		var targets = new List<UploadTarget>();
+
+		foreach (var filePath in filterResult.FilePaths.Distinct(StringComparer.Ordinal))
+		{
+			var fileInfo = _fileSystem.FileInfo.New(filePath);
+			if (fileInfo.Directory is { } parentDir && SymlinkValidator.ValidateFileAccess(fileInfo, parentDir) is { } accessError)
+			{
+				collector.EmitError(filePath, $"Cannot upload: {accessError}");
+				continue;
+			}
+
+			targets.AddRange(CreateBundleTargetsForFile(collector, filePath, explicitSelection: true));
+		}
+
+		return targets;
+	}
+
+	/// <summary>
+	/// Maps one bundle YAML to its per-product upload targets. With <paramref name="explicitSelection"/>
+	/// a file that yields no destination is an error (the operator named it); during directory
+	/// discovery it is skipped with the historical warning/debug diagnostics.
+	/// </summary>
+	private List<UploadTarget> CreateBundleTargetsForFile(IDiagnosticsCollector collector, string filePath, bool explicitSelection)
+	{
+		var products = ReadProductsFromBundle(filePath);
+
+		// Amends published before products were copied from the parent omit them; derive the
+		// destination from the parent bundle next to the amend so they are not silently skipped.
+		if (products.Count == 0 && BundleAmendMerger.IsAmendFile(filePath))
+		{
+			products = ReadProductsFromParentBundle(filePath);
+			if (products.Count == 0)
+			{
+				EmitSelectionDiagnostic(collector, filePath, explicitSelection,
+					"Amend bundle declares no products and its parent bundle is missing or has none; " +
+					"skipping upload. Re-create the amend with a current docs-builder so it carries the parent's products.");
+				return [];
+			}
+		}
+
+		if (products.Count == 0)
+		{
+			if (explicitSelection)
+				collector.EmitError(filePath, "Bundle declares no products; an upload destination cannot be derived.");
+			else
+				_logger.LogDebug("No products found in bundle {File}, skipping", filePath);
+			return [];
+		}
+
+		var fileName = _fileSystem.Path.GetFileName(filePath);
+		var targets = new List<UploadTarget>();
+
+		foreach (var product in products)
+		{
+			if (!ChangelogKeys.IsValidProduct(product))
+			{
+				EmitSelectionDiagnostic(collector, filePath, explicitSelection,
+					$"Skipping invalid product name \"{product}\" (must match [a-zA-Z0-9_-]+)");
+				continue;
+			}
+
+			var s3Key = ChangelogKeys.BundleFileKey(product, fileName);
+			targets.Add(new UploadTarget(filePath, s3Key));
+		}
+
+		return targets;
+	}
+
+	private static void EmitSelectionDiagnostic(IDiagnosticsCollector collector, string filePath, bool explicitSelection, string message)
+	{
+		if (explicitSelection)
+			collector.EmitError(filePath, message);
+		else
+			collector.EmitWarning(filePath, message);
 	}
 
 	private List<string> ReadProductsFromParentBundle(string amendFilePath)

--- a/src/services/Elastic.Documentation.Integrations/S3/S3IncrementalUploader.cs
+++ b/src/services/Elastic.Documentation.Integrations/S3/S3IncrementalUploader.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System.IO.Abstractions;
+using System.Net;
 using Amazon.S3;
 using Amazon.S3.Model;
 using Microsoft.Extensions.Logging;
@@ -12,8 +13,30 @@ namespace Elastic.Documentation.Integrations.S3;
 /// <summary>Describes a file to upload: its local path and intended S3 key.</summary>
 public record UploadTarget(string LocalPath, string S3Key);
 
+/// <summary>How the uploader treats a destination key that already holds different content.</summary>
+public enum S3WritePolicy
+{
+	/// <summary>Live behavior: changed content replaces the remote object.</summary>
+	Overwrite,
+
+	/// <summary>
+	/// Backfill behavior: never replace an existing object. Identical content is skipped; different
+	/// content is a conflict. The write itself is a conditional PUT (<c>If-None-Match: *</c>) so a
+	/// concurrent writer that creates the key first also surfaces as a conflict, never an overwrite.
+	/// </summary>
+	CreateOnly
+}
+
 /// <summary>Result of an incremental upload run.</summary>
-public record UploadResult(int Uploaded, int Skipped, int Failed);
+public record UploadResult(int Uploaded, int Skipped, int Failed)
+{
+	/// <summary>
+	/// Targets refused under <see cref="S3WritePolicy.CreateOnly"/> because the destination key already
+	/// exists with different content (or was created concurrently). Always empty under
+	/// <see cref="S3WritePolicy.Overwrite"/>.
+	/// </summary>
+	public IReadOnlyList<UploadTarget> Conflicts { get; init; } = [];
+}
 
 /// <summary>
 /// Uploads files to S3, skipping those whose content has not changed (ETag comparison).
@@ -29,11 +52,23 @@ public class S3IncrementalUploader(
 {
 	private readonly ILogger _logger = logFactory.CreateLogger<S3IncrementalUploader>();
 
-	public async Task<UploadResult> Upload(IReadOnlyList<UploadTarget> targets, bool skipEtagCheck = false, Cancel ctx = default)
+	private enum TargetOutcome { Uploaded, Skipped, Conflict }
+
+	public async Task<UploadResult> Upload(
+		IReadOnlyList<UploadTarget> targets,
+		bool skipEtagCheck = false,
+		S3WritePolicy writePolicy = S3WritePolicy.Overwrite,
+		Cancel ctx = default)
 	{
+		// The content comparison is what distinguishes an idempotent re-run (skip) from a conflict, so
+		// it cannot be turned off for create-only runs.
+		if (writePolicy == S3WritePolicy.CreateOnly && skipEtagCheck)
+			throw new ArgumentException("skipEtagCheck cannot be combined with create-only writes.", nameof(skipEtagCheck));
+
 		var uploaded = 0;
 		var skipped = 0;
 		var failed = 0;
+		var conflicts = new List<UploadTarget>();
 
 		foreach (var target in targets)
 		{
@@ -41,26 +76,22 @@ public class S3IncrementalUploader(
 
 			try
 			{
-				if (!skipEtagCheck)
-				{
-					var remoteEtag = await GetRemoteEtag(target.S3Key, ctx);
-					var localEtag = await etagCalculator.CalculateS3ETag(target.LocalPath, ctx);
+				var outcome = writePolicy == S3WritePolicy.CreateOnly
+					? await CreateObject(target, ctx)
+					: await OverwriteObjectIfChanged(target, skipEtagCheck, ctx);
 
-					if (remoteEtag != null && localEtag == remoteEtag)
-					{
-						_logger.LogDebug("Skipping {S3Key} (ETag match)", target.S3Key);
+				switch (outcome)
+				{
+					case TargetOutcome.Uploaded:
+						uploaded++;
+						break;
+					case TargetOutcome.Skipped:
 						skipped++;
-						continue;
-					}
+						break;
+					default:
+						conflicts.Add(target);
+						break;
 				}
-				else
-				{
-					_logger.LogDebug("Uploading {S3Key} (--skip-etag-check)", target.S3Key);
-				}
-
-				_logger.LogInformation("Uploading {LocalPath} → s3://{Bucket}/{S3Key}", target.LocalPath, bucketName, target.S3Key);
-				await PutObject(target, ctx);
-				uploaded++;
 			}
 			catch (Exception ex) when (ex is not OperationCanceledException)
 			{
@@ -69,7 +100,66 @@ public class S3IncrementalUploader(
 			}
 		}
 
-		return new UploadResult(uploaded, skipped, failed);
+		return new UploadResult(uploaded, skipped, failed) { Conflicts = conflicts };
+	}
+
+	private async Task<TargetOutcome> OverwriteObjectIfChanged(UploadTarget target, bool skipEtagCheck, Cancel ctx)
+	{
+		if (!skipEtagCheck)
+		{
+			var remoteEtag = await GetRemoteEtag(target.S3Key, ctx);
+			var localEtag = await etagCalculator.CalculateS3ETag(target.LocalPath, ctx);
+
+			if (remoteEtag != null && localEtag == remoteEtag)
+			{
+				_logger.LogDebug("Skipping {S3Key} (ETag match)", target.S3Key);
+				return TargetOutcome.Skipped;
+			}
+		}
+		else
+		{
+			_logger.LogDebug("Uploading {S3Key} (--skip-etag-check)", target.S3Key);
+		}
+
+		_logger.LogInformation("Uploading {LocalPath} → s3://{Bucket}/{S3Key}", target.LocalPath, bucketName, target.S3Key);
+		await PutObject(target, createOnly: false, ctx);
+		return TargetOutcome.Uploaded;
+	}
+
+	private async Task<TargetOutcome> CreateObject(UploadTarget target, Cancel ctx)
+	{
+		// This inspection is informative only (friendly skip/conflict reporting); the conditional PUT
+		// below is the actual race guard between inspection and write.
+		var remoteEtag = await GetRemoteEtag(target.S3Key, ctx);
+		var localEtag = await etagCalculator.CalculateS3ETag(target.LocalPath, ctx);
+
+		if (remoteEtag != null)
+		{
+			if (localEtag == remoteEtag)
+			{
+				_logger.LogInformation("Skipping {S3Key}: already exists with identical content", target.S3Key);
+				return TargetOutcome.Skipped;
+			}
+
+			_logger.LogError(
+				"Conflict on s3://{Bucket}/{S3Key}: key already exists with different content (remote ETag {RemoteEtag}, local {LocalEtag}); refusing to overwrite",
+				bucketName, target.S3Key, remoteEtag, localEtag);
+			return TargetOutcome.Conflict;
+		}
+
+		_logger.LogInformation("Creating {LocalPath} → s3://{Bucket}/{S3Key} (If-None-Match: *)", target.LocalPath, bucketName, target.S3Key);
+		try
+		{
+			await PutObject(target, createOnly: true, ctx);
+			return TargetOutcome.Uploaded;
+		}
+		catch (AmazonS3Exception ex) when (ex.StatusCode == HttpStatusCode.PreconditionFailed)
+		{
+			_logger.LogError(
+				"Conflict on s3://{Bucket}/{S3Key}: object was created concurrently (precondition failed); refusing to overwrite",
+				bucketName, target.S3Key);
+			return TargetOutcome.Conflict;
+		}
 	}
 
 	private async Task<string?> GetRemoteEtag(string key, Cancel ctx)
@@ -83,13 +173,13 @@ public class S3IncrementalUploader(
 			}, ctx);
 			return response.ETag.Trim('"');
 		}
-		catch (AmazonS3Exception ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+		catch (AmazonS3Exception ex) when (ex.StatusCode == HttpStatusCode.NotFound)
 		{
 			return null;
 		}
 	}
 
-	private async Task PutObject(UploadTarget target, Cancel ctx)
+	private async Task PutObject(UploadTarget target, bool createOnly, Cancel ctx)
 	{
 		await using var stream = fileSystem.FileStream.New(target.LocalPath, FileMode.Open, FileAccess.Read, FileShare.Read);
 		var request = new PutObjectRequest
@@ -99,6 +189,10 @@ public class S3IncrementalUploader(
 			InputStream = stream,
 			ChecksumAlgorithm = ChecksumAlgorithm.SHA256
 		};
+
+		if (createOnly)
+			request.IfNoneMatch = "*";
+
 		_ = await s3Client.PutObjectAsync(request, ctx);
 	}
 }

--- a/src/tooling/docs-builder/Commands/ChangelogCommand.cs
+++ b/src/tooling/docs-builder/Commands/ChangelogCommand.cs
@@ -1639,16 +1639,24 @@ internal sealed partial class ChangelogCommands(
 	/// are uploaded under <c>bundle/{product}/{file}</c>, product-scoped from the bundle YAML, and do not
 	/// require an owner/repo/branch.
 	/// </para>
+	/// <para>
+	/// With <c>--backfill</c>, the command switches to backfill publishing mode for historical bundles:
+	/// only the files named via <c>--files</c> are uploaded (no directory discovery), objects are written
+	/// create-only (an existing key with different content is a conflict, never an overwrite), and a
+	/// registry manifest that cannot be reconciled fails the operation.
+	/// </para>
 	/// </remarks>
 	/// <param name="artifactType">Artifact type to upload: 'changelog' (individual entries) or 'bundle' (consolidated bundles).</param>
 	/// <param name="target">Upload destination: 's3' or 'elasticsearch'.</param>
 	/// <param name="s3BucketName">S3 bucket name (required when target is 's3').</param>
 	/// <param name="config">Path to changelog.yml configuration file. Defaults to docs/changelog.yml.</param>
-	/// <param name="directory">Override changelog directory instead of reading it from config.</param>
+	/// <param name="directory">Override changelog directory instead of reading it from config. With --backfill it is not scanned; it only serves as the base directory for resolving relative --files paths.</param>
 	/// <param name="repo">GitHub repository name, the second segment of changelog entry keys (changelog/{org}/{repo}/{branch}/...). Falls back to bundle.repo in changelog.yml, then the git remote origin. Required for changelog uploads; ignored for bundle uploads.</param>
 	/// <param name="owner">GitHub owner (org), the first segment of changelog entry keys (changelog/{org}/{repo}/{branch}/...). Falls back to bundle.owner in changelog.yml, then the git remote origin. Required for changelog uploads; ignored for bundle uploads.</param>
 	/// <param name="branch">Branch, the third segment of changelog entry keys (changelog/{org}/{repo}/{branch}/...), stored verbatim. Falls back to the current checkout's branch. Required for changelog uploads; ignored for bundle uploads.</param>
-	/// <param name="skipEtagCheck">Upload every discovered file even when its content hash matches the remote object. Use to re-trigger downstream scrubbers without changing file content.</param>
+	/// <param name="skipEtagCheck">Upload every discovered file even when its content hash matches the remote object. Use to re-trigger downstream scrubbers without changing file content. Mutually exclusive with --backfill.</param>
+	/// <param name="files">Exact bundle YAML paths to upload (comma-separated), or a path to a newline-delimited path list file. Can be specified multiple times. Relative paths resolve against the bundle directory. Requires --backfill; nothing outside this selection is uploaded.</param>
+	/// <param name="backfill">Backfill publishing mode: upload only the files given via --files, write objects create-only (conditional PUT with If-None-Match; an existing key with different content is a conflict, never an overwrite), and fail the operation when a registry manifest cannot be reconciled. Only valid with --artifact-type bundle; mutually exclusive with --skip-etag-check.</param>
 	[NoOptionsInjection]
 	public async Task<int> Upload(
 		string artifactType,
@@ -1660,6 +1668,8 @@ internal sealed partial class ChangelogCommands(
 		string? owner = null,
 		string? branch = null,
 		bool skipEtagCheck = false,
+		string[]? files = null,
+		bool backfill = false,
 		CancellationToken ct = default
 	)
 	{
@@ -1702,7 +1712,9 @@ internal sealed partial class ChangelogCommands(
 			Repo = resolvedRepo,
 			Owner = resolvedOwner,
 			Branch = resolvedBranch,
-			SkipEtagCheck = skipEtagCheck
+			SkipEtagCheck = skipEtagCheck,
+			Backfill = backfill,
+			Files = ExpandCommaSeparated(files)
 		};
 		serviceInvoker.AddCommand(service, args,
 			static async (s, c, state, ct) => await s.Upload(c, state, ct)

--- a/tests/Elastic.Changelog.Tests/Uploading/ChangelogUploadBackfillTests.cs
+++ b/tests/Elastic.Changelog.Tests/Uploading/ChangelogUploadBackfillTests.cs
@@ -1,0 +1,444 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Diagnostics.CodeAnalysis;
+using System.IO.Abstractions.TestingHelpers;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using Amazon.S3;
+using Amazon.S3.Model;
+using AwesomeAssertions;
+using Elastic.Changelog.Tests.Changelogs;
+using Elastic.Changelog.Uploading;
+using Elastic.Documentation.Configuration;
+using FakeItEasy;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nullean.ScopedFileSystem;
+
+namespace Elastic.Changelog.Tests.Uploading;
+
+/// <summary>
+/// Backfill-mode behavior of <see cref="ChangelogUploadService"/>: explicit file selection,
+/// create-only writes, and strict registry failure semantics — plus proof that live (non-backfill)
+/// behavior is unchanged.
+/// </summary>
+[SuppressMessage("Usage", "CA1001:Types that own disposable fields should be disposable")]
+[SuppressMessage("Security", "CA5351:Do Not Use Broken Cryptographic Algorithms")]
+public class ChangelogUploadBackfillTests
+{
+	private readonly MockFileSystem _mockFileSystem;
+	private readonly ScopedFileSystem _fileSystem;
+	private readonly IAmazonS3 _s3Client = A.Fake<IAmazonS3>();
+	private readonly ChangelogUploadService _service;
+	private readonly TestDiagnosticsCollector _collector;
+	private readonly string _bundleDir;
+
+	// language=yaml
+	private const string ElasticsearchBundleYaml = """
+		products:
+		  - product: elasticsearch
+		    target: 9.0.0
+		    lifecycle: ga
+		    repo: elasticsearch
+		    owner: elastic
+		entries:
+		  - file:
+		      name: 1234-feature.yaml
+		      checksum: abc123def456
+		    type: enhancement
+		    title: Historical feature
+		    prs:
+		      - https://github.com/elastic/elasticsearch/pull/1234
+		""";
+
+	public ChangelogUploadBackfillTests(ITestOutputHelper output)
+	{
+		_mockFileSystem = new MockFileSystem(new MockFileSystemOptions
+		{
+			CurrentDirectory = Paths.WorkingDirectoryRoot.FullName
+		});
+		_fileSystem = FileSystemFactory.ScopeCurrentWorkingDirectory(_mockFileSystem);
+		_service = new ChangelogUploadService(NullLoggerFactory.Instance, fileSystem: _fileSystem, s3Client: _s3Client);
+		_collector = new TestDiagnosticsCollector(output);
+		_bundleDir = _mockFileSystem.Path.Join(Paths.WorkingDirectoryRoot.FullName, Guid.NewGuid().ToString(), "releases");
+		_mockFileSystem.Directory.CreateDirectory(_bundleDir);
+	}
+
+	private string AddBundle(string fileName, string yaml)
+	{
+		var path = _mockFileSystem.Path.Join(_bundleDir, fileName);
+		_mockFileSystem.AddFile(path, new MockFileData(Encoding.UTF8.GetBytes(yaml)));
+		return path;
+	}
+
+	private static string S3Etag(string yaml) =>
+		Convert.ToHexStringLower(MD5.HashData(Encoding.UTF8.GetBytes(yaml)));
+
+	private ChangelogUploadArguments BackfillArgs(params string[] files) => new()
+	{
+		ArtifactType = ArtifactType.Bundle,
+		Target = UploadTargetKind.S3,
+		S3BucketName = "test-bucket",
+		Directory = _bundleDir,
+		Backfill = true,
+		Files = files
+	};
+
+	private void RemoteObjectsAbsent() =>
+		A.CallTo(() => _s3Client.GetObjectMetadataAsync(A<GetObjectMetadataRequest>._, A<CancellationToken>._))
+			.Throws(new AmazonS3Exception("Not Found") { StatusCode = HttpStatusCode.NotFound });
+
+	private void RegistriesAbsent() =>
+		A.CallTo(() => _s3Client.GetObjectAsync(A<GetObjectRequest>._, A<CancellationToken>._))
+			.Throws(new AmazonS3Exception("Not Found") { StatusCode = HttpStatusCode.NotFound });
+
+	private void PutsSucceed() =>
+		A.CallTo(() => _s3Client.PutObjectAsync(A<PutObjectRequest>._, A<CancellationToken>._))
+			.Returns(new PutObjectResponse());
+
+	[Fact]
+	public async Task Upload_Backfill_UploadsExactlySelectedFiles()
+	{
+		var selected = AddBundle("elasticsearch-9.0.0.yaml", ElasticsearchBundleYaml);
+		_ = AddBundle("elasticsearch-9.1.0.yaml", ElasticsearchBundleYaml.Replace("9.0.0", "9.1.0"));
+
+		RemoteObjectsAbsent();
+		RegistriesAbsent();
+		PutsSucceed();
+
+		var ct = TestContext.Current.CancellationToken;
+		var result = await _service.Upload(_collector, BackfillArgs(selected), ct);
+
+		result.Should().BeTrue();
+		_collector.Errors.Should().Be(0);
+
+		// The selected file is written create-only; the unselected sibling in the same directory is untouched.
+		A.CallTo(() => _s3Client.PutObjectAsync(
+			A<PutObjectRequest>.That.Matches(r => r.Key == "bundle/elasticsearch/elasticsearch-9.0.0.yaml" && r.IfNoneMatch == "*"),
+			A<CancellationToken>._
+		)).MustHaveHappenedOnceExactly();
+
+		A.CallTo(() => _s3Client.PutObjectAsync(
+			A<PutObjectRequest>.That.Matches(r => r.Key == "bundle/elasticsearch/elasticsearch-9.1.0.yaml"),
+			A<CancellationToken>._
+		)).MustNotHaveHappened();
+
+		A.CallTo(() => _s3Client.PutObjectAsync(
+			A<PutObjectRequest>.That.Matches(r => r.Key == "bundle/elasticsearch/registry.json"),
+			A<CancellationToken>._
+		)).MustHaveHappenedOnceExactly();
+	}
+
+	[Fact]
+	public async Task Upload_Backfill_RelativeSelection_ResolvesAgainstBundleDirectory()
+	{
+		_ = AddBundle("elasticsearch-9.0.0.yaml", ElasticsearchBundleYaml);
+
+		RemoteObjectsAbsent();
+		RegistriesAbsent();
+		PutsSucceed();
+
+		var ct = TestContext.Current.CancellationToken;
+		var result = await _service.Upload(_collector, BackfillArgs("elasticsearch-9.0.0.yaml"), ct);
+
+		result.Should().BeTrue();
+		_collector.Errors.Should().Be(0);
+
+		A.CallTo(() => _s3Client.PutObjectAsync(
+			A<PutObjectRequest>.That.Matches(r => r.Key == "bundle/elasticsearch/elasticsearch-9.0.0.yaml"),
+			A<CancellationToken>._
+		)).MustHaveHappenedOnceExactly();
+	}
+
+	[Fact]
+	public async Task Upload_Backfill_MultiProductBundle_CreatesTargetPerProduct()
+	{
+		// language=yaml
+		var selected = AddBundle("stack-9.0.0.yaml", """
+			products:
+			  - product: elasticsearch
+			    target: 9.0.0
+			    repo: elasticsearch
+			  - product: kibana
+			    target: 9.0.0
+			    repo: kibana
+			entries:
+			  - file:
+			      name: 9999-cross-product.yaml
+			      checksum: aaa111bbb222
+			    type: enhancement
+			    title: Cross-product improvement
+			""");
+
+		RemoteObjectsAbsent();
+		RegistriesAbsent();
+		PutsSucceed();
+
+		var ct = TestContext.Current.CancellationToken;
+		var result = await _service.Upload(_collector, BackfillArgs(selected), ct);
+
+		result.Should().BeTrue();
+		_collector.Errors.Should().Be(0);
+
+		A.CallTo(() => _s3Client.PutObjectAsync(
+			A<PutObjectRequest>.That.Matches(r => r.Key == "bundle/elasticsearch/stack-9.0.0.yaml" && r.IfNoneMatch == "*"),
+			A<CancellationToken>._
+		)).MustHaveHappenedOnceExactly();
+
+		A.CallTo(() => _s3Client.PutObjectAsync(
+			A<PutObjectRequest>.That.Matches(r => r.Key == "bundle/kibana/stack-9.0.0.yaml" && r.IfNoneMatch == "*"),
+			A<CancellationToken>._
+		)).MustHaveHappenedOnceExactly();
+	}
+
+	[Fact]
+	public async Task Upload_Backfill_IdenticalRemoteContent_SkipsAndSucceeds()
+	{
+		var selected = AddBundle("elasticsearch-9.0.0.yaml", ElasticsearchBundleYaml);
+
+		A.CallTo(() => _s3Client.GetObjectMetadataAsync(A<GetObjectMetadataRequest>._, A<CancellationToken>._))
+			.Returns(new GetObjectMetadataResponse { ETag = $"\"{S3Etag(ElasticsearchBundleYaml)}\"" });
+		RegistriesAbsent();
+		PutsSucceed();
+
+		var ct = TestContext.Current.CancellationToken;
+		var result = await _service.Upload(_collector, BackfillArgs(selected), ct);
+
+		result.Should().BeTrue();
+		_collector.Errors.Should().Be(0);
+
+		// The bundle object is skipped (identical content), but the registry is still reconciled.
+		A.CallTo(() => _s3Client.PutObjectAsync(
+			A<PutObjectRequest>.That.Matches(r => r.Key == "bundle/elasticsearch/elasticsearch-9.0.0.yaml"),
+			A<CancellationToken>._
+		)).MustNotHaveHappened();
+
+		A.CallTo(() => _s3Client.PutObjectAsync(
+			A<PutObjectRequest>.That.Matches(r => r.Key == "bundle/elasticsearch/registry.json"),
+			A<CancellationToken>._
+		)).MustHaveHappenedOnceExactly();
+	}
+
+	[Fact]
+	public async Task Upload_Backfill_ExistingKeyDifferentContent_FailsWithoutOverwrite()
+	{
+		var selected = AddBundle("elasticsearch-9.0.0.yaml", ElasticsearchBundleYaml);
+
+		A.CallTo(() => _s3Client.GetObjectMetadataAsync(A<GetObjectMetadataRequest>._, A<CancellationToken>._))
+			.Returns(new GetObjectMetadataResponse { ETag = "\"different-remote-content\"" });
+
+		var ct = TestContext.Current.CancellationToken;
+		var result = await _service.Upload(_collector, BackfillArgs(selected), ct);
+
+		result.Should().BeFalse();
+		_collector.Errors.Should().BeGreaterThan(0);
+
+		// Nothing is written: neither the conflicting object nor a registry entry misrepresenting it.
+		A.CallTo(() => _s3Client.PutObjectAsync(A<PutObjectRequest>._, A<CancellationToken>._))
+			.MustNotHaveHappened();
+	}
+
+	[Fact]
+	public async Task Upload_Backfill_ConcurrentCreateLosesRace_FailsAsConflict()
+	{
+		var selected = AddBundle("elasticsearch-9.0.0.yaml", ElasticsearchBundleYaml);
+
+		// The key is absent at inspection time, but the conditional PUT loses the race (412).
+		RemoteObjectsAbsent();
+		A.CallTo(() => _s3Client.PutObjectAsync(A<PutObjectRequest>._, A<CancellationToken>._))
+			.Throws(new AmazonS3Exception("Precondition Failed") { StatusCode = HttpStatusCode.PreconditionFailed });
+
+		var ct = TestContext.Current.CancellationToken;
+		var result = await _service.Upload(_collector, BackfillArgs(selected), ct);
+
+		result.Should().BeFalse();
+		_collector.Errors.Should().BeGreaterThan(0);
+
+		// The conflicted target is excluded from registry reconciliation.
+		A.CallTo(() => _s3Client.PutObjectAsync(
+			A<PutObjectRequest>.That.Matches(r => r.Key == "bundle/elasticsearch/registry.json"),
+			A<CancellationToken>._
+		)).MustNotHaveHappened();
+	}
+
+	[Fact]
+	public async Task Upload_Backfill_RegistryRefreshException_FailsOperation()
+	{
+		var selected = AddBundle("elasticsearch-9.0.0.yaml", ElasticsearchBundleYaml);
+
+		RemoteObjectsAbsent();
+		PutsSucceed();
+		A.CallTo(() => _s3Client.GetObjectAsync(A<GetObjectRequest>._, A<CancellationToken>._))
+			.Throws(new AmazonS3Exception("Internal Server Error") { StatusCode = HttpStatusCode.InternalServerError });
+
+		var ct = TestContext.Current.CancellationToken;
+		var result = await _service.Upload(_collector, BackfillArgs(selected), ct);
+
+		result.Should().BeFalse();
+		_collector.Errors.Should().BeGreaterThan(0);
+	}
+
+	[Fact]
+	public async Task Upload_Backfill_RegistryConcurrencyExhaustion_FailsOperation()
+	{
+		var selected = AddBundle("elasticsearch-9.0.0.yaml", ElasticsearchBundleYaml);
+
+		RemoteObjectsAbsent();
+		RegistriesAbsent();
+		A.CallTo(() => _s3Client.PutObjectAsync(
+			A<PutObjectRequest>.That.Matches(r => r.Key == "bundle/elasticsearch/elasticsearch-9.0.0.yaml"),
+			A<CancellationToken>._
+		)).Returns(new PutObjectResponse());
+		// Every conditional registry write loses the optimistic-concurrency race.
+		A.CallTo(() => _s3Client.PutObjectAsync(
+			A<PutObjectRequest>.That.Matches(r => r.Key == "bundle/elasticsearch/registry.json"),
+			A<CancellationToken>._
+		)).Throws(new AmazonS3Exception("Precondition Failed") { StatusCode = HttpStatusCode.PreconditionFailed });
+
+		var ct = TestContext.Current.CancellationToken;
+		var result = await _service.Upload(_collector, BackfillArgs(selected), ct);
+
+		result.Should().BeFalse();
+		_collector.Errors.Should().BeGreaterThan(0);
+	}
+
+	[Fact]
+	public async Task Upload_Live_RegistryRefreshException_DoesNotFailUpload()
+	{
+		// Live (non-backfill) semantics are unchanged: a registry refresh failure is a warning,
+		// not an error, because the bundle objects themselves are already in S3.
+		_ = AddBundle("elasticsearch-9.0.0.yaml", ElasticsearchBundleYaml);
+
+		RemoteObjectsAbsent();
+		PutsSucceed();
+		A.CallTo(() => _s3Client.GetObjectAsync(A<GetObjectRequest>._, A<CancellationToken>._))
+			.Throws(new AmazonS3Exception("Internal Server Error") { StatusCode = HttpStatusCode.InternalServerError });
+
+		var args = new ChangelogUploadArguments
+		{
+			ArtifactType = ArtifactType.Bundle,
+			Target = UploadTargetKind.S3,
+			S3BucketName = "test-bucket",
+			Directory = _bundleDir
+		};
+		var ct = TestContext.Current.CancellationToken;
+		var result = await _service.Upload(_collector, args, ct);
+
+		result.Should().BeTrue();
+		_collector.Errors.Should().Be(0);
+		_collector.Warnings.Should().BeGreaterThan(0);
+	}
+
+	[Fact]
+	public async Task Upload_Backfill_WithoutFiles_FailsWithoutS3Calls()
+	{
+		_ = AddBundle("elasticsearch-9.0.0.yaml", ElasticsearchBundleYaml);
+
+		var ct = TestContext.Current.CancellationToken;
+		var result = await _service.Upload(_collector, BackfillArgs(), ct);
+
+		result.Should().BeFalse();
+		_collector.Errors.Should().BeGreaterThan(0);
+
+		A.CallTo(() => _s3Client.PutObjectAsync(A<PutObjectRequest>._, A<CancellationToken>._))
+			.MustNotHaveHappened();
+	}
+
+	[Fact]
+	public async Task Upload_Backfill_ChangelogArtifactType_Rejected()
+	{
+		var args = new ChangelogUploadArguments
+		{
+			ArtifactType = ArtifactType.Changelog,
+			Target = UploadTargetKind.S3,
+			S3BucketName = "test-bucket",
+			Directory = _bundleDir,
+			Backfill = true,
+			Files = ["entry.yaml"]
+		};
+		var ct = TestContext.Current.CancellationToken;
+		var result = await _service.Upload(_collector, args, ct);
+
+		result.Should().BeFalse();
+		_collector.Errors.Should().BeGreaterThan(0);
+
+		A.CallTo(() => _s3Client.PutObjectAsync(A<PutObjectRequest>._, A<CancellationToken>._))
+			.MustNotHaveHappened();
+	}
+
+	[Fact]
+	public async Task Upload_Backfill_WithSkipEtagCheck_Rejected()
+	{
+		var selected = AddBundle("elasticsearch-9.0.0.yaml", ElasticsearchBundleYaml);
+
+		var args = BackfillArgs(selected) with { SkipEtagCheck = true };
+		var ct = TestContext.Current.CancellationToken;
+		var result = await _service.Upload(_collector, args, ct);
+
+		result.Should().BeFalse();
+		_collector.Errors.Should().BeGreaterThan(0);
+
+		A.CallTo(() => _s3Client.PutObjectAsync(A<PutObjectRequest>._, A<CancellationToken>._))
+			.MustNotHaveHappened();
+	}
+
+	[Fact]
+	public async Task Upload_FilesWithoutBackfill_Rejected()
+	{
+		var selected = AddBundle("elasticsearch-9.0.0.yaml", ElasticsearchBundleYaml);
+
+		var args = BackfillArgs(selected) with { Backfill = false };
+		var ct = TestContext.Current.CancellationToken;
+		var result = await _service.Upload(_collector, args, ct);
+
+		result.Should().BeFalse();
+		_collector.Errors.Should().BeGreaterThan(0);
+
+		A.CallTo(() => _s3Client.PutObjectAsync(A<PutObjectRequest>._, A<CancellationToken>._))
+			.MustNotHaveHappened();
+	}
+
+	[Fact]
+	public async Task Upload_Backfill_MissingSelectedFile_FailsBeforeAnyWrite()
+	{
+		var missing = _mockFileSystem.Path.Join(_bundleDir, "does-not-exist.yaml");
+
+		var ct = TestContext.Current.CancellationToken;
+		var result = await _service.Upload(_collector, BackfillArgs(missing), ct);
+
+		result.Should().BeFalse();
+		_collector.Errors.Should().BeGreaterThan(0);
+
+		A.CallTo(() => _s3Client.PutObjectAsync(A<PutObjectRequest>._, A<CancellationToken>._))
+			.MustNotHaveHappened();
+	}
+
+	[Fact]
+	public async Task Upload_Backfill_SelectedBundleWithoutProducts_FailsBeforeAnyWrite()
+	{
+		// A silently skipped selection would violate "uploads exactly the selected files":
+		// a file the operator named but that cannot be mapped to a destination is an error.
+		// language=yaml
+		var selected = AddBundle("no-products.yaml", """
+			entries:
+			  - file:
+			      name: 1-old.yaml
+			      checksum: deadbeef
+			    type: bug-fix
+			    title: No destination derivable
+			""");
+		_ = AddBundle("elasticsearch-9.0.0.yaml", ElasticsearchBundleYaml);
+
+		var ct = TestContext.Current.CancellationToken;
+		var result = await _service.Upload(_collector, BackfillArgs(selected, _mockFileSystem.Path.Join(_bundleDir, "elasticsearch-9.0.0.yaml")), ct);
+
+		result.Should().BeFalse();
+		_collector.Errors.Should().BeGreaterThan(0);
+
+		// Fails before any write — including the valid file in the same selection.
+		A.CallTo(() => _s3Client.PutObjectAsync(A<PutObjectRequest>._, A<CancellationToken>._))
+			.MustNotHaveHappened();
+	}
+}

--- a/tests/Elastic.Documentation.Integrations.Tests/S3/S3IncrementalUploaderTests.cs
+++ b/tests/Elastic.Documentation.Integrations.Tests/S3/S3IncrementalUploaderTests.cs
@@ -195,4 +195,148 @@ public class S3IncrementalUploaderTests
 		result.Skipped.Should().Be(0);
 		result.Failed.Should().Be(0);
 	}
+
+	[Fact]
+	public async Task Upload_DefaultPolicy_DoesNotUseConditionalPut()
+	{
+		// Live overwrite semantics are unchanged: no If-None-Match guard on the PUT.
+		var path = UniquePath("entry.yaml");
+		_fileSystem.AddFile(path, new MockFileData("updated changelog"u8.ToArray()));
+
+		A.CallTo(() => _s3Client.GetObjectMetadataAsync(A<GetObjectMetadataRequest>._, A<Cancel>._))
+			.Returns(new GetObjectMetadataResponse { ETag = "\"stale-etag\"" });
+
+		A.CallTo(() => _s3Client.PutObjectAsync(A<PutObjectRequest>._, A<Cancel>._))
+			.Returns(new PutObjectResponse());
+
+		var uploader = CreateUploader();
+		var ct = TestContext.Current.CancellationToken;
+		var result = await uploader.Upload([new UploadTarget(path, "bundle/elasticsearch/entry.yaml")], ctx: ct);
+
+		result.Uploaded.Should().Be(1);
+		result.Conflicts.Should().BeEmpty();
+
+		A.CallTo(() => _s3Client.PutObjectAsync(
+			A<PutObjectRequest>.That.Matches(r => r.Key == "bundle/elasticsearch/entry.yaml" && r.IfNoneMatch == null),
+			A<Cancel>._
+		)).MustHaveHappenedOnceExactly();
+	}
+
+	[Fact]
+	public async Task Upload_CreateOnly_NewKey_UsesConditionalPut()
+	{
+		var path = UniquePath("bundle.yaml");
+		_fileSystem.AddFile(path, new MockFileData("new bundle"u8.ToArray()));
+
+		A.CallTo(() => _s3Client.GetObjectMetadataAsync(A<GetObjectMetadataRequest>._, A<Cancel>._))
+			.Throws(new AmazonS3Exception("Not Found") { StatusCode = HttpStatusCode.NotFound });
+
+		A.CallTo(() => _s3Client.PutObjectAsync(A<PutObjectRequest>._, A<Cancel>._))
+			.Returns(new PutObjectResponse());
+
+		var uploader = CreateUploader();
+		var ct = TestContext.Current.CancellationToken;
+		var result = await uploader.Upload(
+			[new UploadTarget(path, "bundle/elasticsearch/bundle.yaml")],
+			writePolicy: S3WritePolicy.CreateOnly, ctx: ct);
+
+		result.Uploaded.Should().Be(1);
+		result.Skipped.Should().Be(0);
+		result.Failed.Should().Be(0);
+		result.Conflicts.Should().BeEmpty();
+
+		A.CallTo(() => _s3Client.PutObjectAsync(
+			A<PutObjectRequest>.That.Matches(r => r.Key == "bundle/elasticsearch/bundle.yaml" && r.IfNoneMatch == "*"),
+			A<Cancel>._
+		)).MustHaveHappenedOnceExactly();
+	}
+
+	[Fact]
+	public async Task Upload_CreateOnly_IdenticalRemoteContent_SkipsWithoutPut()
+	{
+		var content = "identical bundle"u8.ToArray();
+		var path = UniquePath("bundle.yaml");
+		_fileSystem.AddFile(path, new MockFileData(content));
+		var localEtag = Convert.ToHexStringLower(MD5.HashData(content));
+
+		A.CallTo(() => _s3Client.GetObjectMetadataAsync(A<GetObjectMetadataRequest>._, A<Cancel>._))
+			.Returns(new GetObjectMetadataResponse { ETag = $"\"{localEtag}\"" });
+
+		var uploader = CreateUploader();
+		var ct = TestContext.Current.CancellationToken;
+		var result = await uploader.Upload(
+			[new UploadTarget(path, "bundle/elasticsearch/bundle.yaml")],
+			writePolicy: S3WritePolicy.CreateOnly, ctx: ct);
+
+		result.Uploaded.Should().Be(0);
+		result.Skipped.Should().Be(1);
+		result.Failed.Should().Be(0);
+		result.Conflicts.Should().BeEmpty();
+
+		A.CallTo(() => _s3Client.PutObjectAsync(A<PutObjectRequest>._, A<Cancel>._))
+			.MustNotHaveHappened();
+	}
+
+	[Fact]
+	public async Task Upload_CreateOnly_DifferentRemoteContent_ConflictsWithoutPut()
+	{
+		var path = UniquePath("bundle.yaml");
+		_fileSystem.AddFile(path, new MockFileData("local content"u8.ToArray()));
+
+		A.CallTo(() => _s3Client.GetObjectMetadataAsync(A<GetObjectMetadataRequest>._, A<Cancel>._))
+			.Returns(new GetObjectMetadataResponse { ETag = "\"different-remote-etag\"" });
+
+		var uploader = CreateUploader();
+		var ct = TestContext.Current.CancellationToken;
+		var target = new UploadTarget(path, "bundle/elasticsearch/bundle.yaml");
+		var result = await uploader.Upload([target], writePolicy: S3WritePolicy.CreateOnly, ctx: ct);
+
+		result.Uploaded.Should().Be(0);
+		result.Skipped.Should().Be(0);
+		result.Failed.Should().Be(0);
+		result.Conflicts.Should().ContainSingle().Which.Should().Be(target);
+
+		A.CallTo(() => _s3Client.PutObjectAsync(A<PutObjectRequest>._, A<Cancel>._))
+			.MustNotHaveHappened();
+	}
+
+	[Fact]
+	public async Task Upload_CreateOnly_ConditionalPutLosesRace_ConflictsInsteadOfOverwriting()
+	{
+		// Between the informative pre-check (key absent) and the PUT, another writer creates the key.
+		// The conditional PUT fails with 412 and the target surfaces as a conflict, never an overwrite.
+		var path = UniquePath("bundle.yaml");
+		_fileSystem.AddFile(path, new MockFileData("racing content"u8.ToArray()));
+
+		A.CallTo(() => _s3Client.GetObjectMetadataAsync(A<GetObjectMetadataRequest>._, A<Cancel>._))
+			.Throws(new AmazonS3Exception("Not Found") { StatusCode = HttpStatusCode.NotFound });
+
+		A.CallTo(() => _s3Client.PutObjectAsync(A<PutObjectRequest>._, A<Cancel>._))
+			.Throws(new AmazonS3Exception("Precondition Failed") { StatusCode = HttpStatusCode.PreconditionFailed });
+
+		var uploader = CreateUploader();
+		var ct = TestContext.Current.CancellationToken;
+		var target = new UploadTarget(path, "bundle/elasticsearch/bundle.yaml");
+		var result = await uploader.Upload([target], writePolicy: S3WritePolicy.CreateOnly, ctx: ct);
+
+		result.Uploaded.Should().Be(0);
+		result.Failed.Should().Be(0);
+		result.Conflicts.Should().ContainSingle().Which.Should().Be(target);
+
+		A.CallTo(() => _s3Client.PutObjectAsync(
+			A<PutObjectRequest>.That.Matches(r => r.IfNoneMatch == "*"),
+			A<Cancel>._
+		)).MustHaveHappenedOnceExactly();
+	}
+
+	[Fact]
+	public async Task Upload_CreateOnly_WithSkipEtagCheck_Throws()
+	{
+		var uploader = CreateUploader();
+		var ct = TestContext.Current.CancellationToken;
+
+		var act = async () => await uploader.Upload([], skipEtagCheck: true, writePolicy: S3WritePolicy.CreateOnly, ctx: ct);
+
+		await act.Should().ThrowAsync<ArgumentException>();
+	}
 }


### PR DESCRIPTION
## Summary

Delivers the upload-path prerequisites for the release-notes backfill (items 1–3 of the epic's "Current system and prerequisites"): `changelog upload --backfill` now provides explicit file selection, create-only bundle writes, and strict registry failure semantics.

- **Explicit selection** (`ChangelogUploadService`): in backfill mode the operator supplies the exact bundle YAMLs via `--files` (comma-separated paths or a newline-delimited path list file, aligned with `changelog bundle --files`); there is no directory globbing. A selected file that cannot be mapped to a destination — missing, no `products`, invalid product — is an error that aborts the run before any write, never a silent skip.
- **Create-only writes** (`S3IncrementalUploader`): a new `S3WritePolicy.CreateOnly` writes bundle objects with a conditional PUT (`If-None-Match: *`). Identical remote content → skip (reported as such); different content → conflict, surfaced per key, never an overwrite. The ETag pre-check (existing `S3EtagCalculator`) is informative only — the conditional PUT is the race guard, so a concurrent create between inspection and write surfaces as a conflict (`412 PreconditionFailed`). There is intentionally no force flag; corrections are a separately approved workflow.
- **Registry failure semantics**: in backfill mode an unreconciled registry (S3 error or exhausted optimistic-concurrency retries) is an incomplete operation — it emits a clear error and fails the run. Conflicted objects are excluded from the registry refresh so the manifest never records content that is not actually published.

## Design notes

- **How backfill mode is surfaced**: a single `--backfill` flag switches the mode, with `--files` as its required selection input. The pairing is validated in `ChangelogUploadService` (testable regardless of caller): `--backfill` requires `--files` and `--artifact-type bundle` (the backfill publishes bundles only, per the epic), and rejects `--skip-etag-check`, whose forced re-upload semantics would turn every idempotent re-run into a conflict. `--files` without `--backfill` is rejected so live behavior cannot drift.
- **Why live behavior is untouched**: `S3WritePolicy` defaults to `Overwrite` and the create-only path is only reachable via `args.Backfill`; without the flag, discovery, overwrite, and best-effort registry refresh are byte-for-byte the previous code paths. Registries keep their existing concurrent conditional-update path (`If-Match`/`If-None-Match` + bounded retries) in both modes. Proven by the untouched pre-existing upload tests plus new explicit tests (`Upload_DefaultPolicy_DoesNotUseConditionalPut`, `Upload_Live_RegistryRefreshException_DoesNotFailUpload`).
- `docs/cli-schema.json` regenerated; supplemental docs updated (`docs/cli/changelog/cmd-upload.md`, `docs/development/changelog-bundle-registry.md`). Expected to conflict on the schema with the concurrent #670 PR — whoever merges second rebases and regenerates.

## Test plan

New tests in `Elastic.Documentation.Integrations.Tests` (uploader) and `Elastic.Changelog.Tests` (service orchestration), following the existing FakeItEasy `IAmazonS3` fake + `MockFileSystem` patterns:

- Exact selection: unselected files in the same directory are not uploaded; relative paths resolve against the bundle directory; multi-product bundles fan out per product.
- Create-only conflict: existing key with different content → run fails, object untouched, no registry write for the conflicted target.
- Skip on identical content: reported as skip, run succeeds, registry still reconciled.
- Concurrency race: conditional PUT loses (`412`) → conflict, not overwrite.
- Registry refresh failure (S3 exception and retry exhaustion) fails the backfill operation; the same failure in live mode remains a warning.
- Mode guards: `--backfill` without `--files`, with `changelog` artifact type, or with `--skip-etag-check`; `--files` without `--backfill`; missing selected file and productless selected bundle fail before any write.

Checks run locally: `dotnet format` clean · `./build.sh build --skip-dirty-check` ✓ · AOT publish with zero trim/AOT warnings ✓ · `./build.sh unit-test` 4,247 passed / 0 failed ✓ · schema diff empty ✓.

Closes elastic/docs-eng-team#668