### PR TITLE
Fix CopyBrandingResources failure during serve in-memory build

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/web-components/Header/Header.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/Header/Header.tsx
@@ -29,6 +29,8 @@ interface Props {
      * component does not have to infer branding state from other optional props.
      */
     branded?: boolean
+    /** When true the git remote belongs to the `elastic` GitHub organization. Controls whether the Elastic logo is shown as default. */
+    elasticOrg?: boolean
     /** Custom header background CSS colour. Only used when branded=true; defaults to #000000. */
     headerBg?: string
     /** Custom icon image URL. When set (and branded=true), renders an <img> instead of the title text. */
@@ -45,6 +47,7 @@ export const Header = ({
     githubRef,
     airGapped = false,
     branded = false,
+    elasticOrg = false,
     headerBg,
     iconSrc,
 }: Props) => {
@@ -92,8 +95,8 @@ export const Header = ({
                 {title}
             </a>
         )
-    ) : (
-        // Default: Elastic-branded logo (light-mode styling)
+    ) : elasticOrg ? (
+        // Default for elastic org: Elastic-branded logo (light-mode styling)
         <span ref={containerRef}>
             <EuiHeaderLogo
                 href={logoHref}
@@ -112,6 +115,27 @@ export const Header = ({
             >
                 {title}
             </EuiHeaderLogo>
+        </span>
+    ) : (
+        // Non-elastic org, no branding: title text only, no logo
+        <span ref={containerRef}>
+            <a
+                href={logoHref}
+                css={css`
+                    display: inline-flex;
+                    align-items: center;
+                    padding: ${euiTheme.size.s};
+                    font-weight: ${euiTheme.font.weight.bold};
+                    color: ${euiTheme.colors.textInk};
+                    text-decoration: none;
+                    border-radius: ${euiTheme.border.radius.small};
+                    &:hover {
+                        background: rgba(0, 0, 0, 0.06);
+                    }
+                `}
+            >
+                {title}
+            </a>
         </span>
     )
 
@@ -197,6 +221,7 @@ customElements.define(
             githubRef: 'string',
             airGapped: 'boolean',
             branded: 'boolean',
+            elasticOrg: 'boolean',
             headerBg: 'string',
             iconSrc: 'string',
         },

--- a/src/Elastic.Documentation.Site/Assets/web-components/Header/Header.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/Header/Header.tsx
@@ -14,7 +14,7 @@ import { useRef } from 'react'
 
 interface Props {
     title: string
-    logoHref: string
+    logoHref?: string
     githubRepository?: string
     githubLink?: string
     gitBranch: string
@@ -55,51 +55,65 @@ export const Header = ({
     const containerRef = useRef<HTMLSpanElement>(null)
     useHtmxContainer(containerRef)
 
-    const logoSection = branded ? (
-        iconSrc ? (
-            // Branded with icon — plain <a>, no HTMX (no containerRef)
-            <a
-                href={logoHref}
+    const brandedIconContent = iconSrc ? (
+        <>
+            <img
+                src={iconSrc}
+                alt={title}
                 css={css`
-                    display: inline-flex;
-                    align-items: center;
-                    gap: ${euiTheme.size.s};
-                    color: var(--color-white);
-                    text-decoration: none;
-                    padding: ${euiTheme.size.s};
+                    height: 32px;
+                    width: auto;
                 `}
-            >
-                <img
-                    src={iconSrc}
-                    alt={title}
-                    css={css`
-                        height: 32px;
-                        width: auto;
-                    `}
-                />
-                {title}
+            />
+            {title}
+        </>
+    ) : (
+        <>{title}</>
+    )
+
+    const brandedStyles = iconSrc
+        ? css`
+              display: inline-flex;
+              align-items: center;
+              gap: ${euiTheme.size.s};
+              color: var(--color-white);
+              text-decoration: none;
+              padding: ${euiTheme.size.s};
+          `
+        : css`
+              display: inline-flex;
+              align-items: center;
+              color: var(--color-white);
+              text-decoration: none;
+              padding: ${euiTheme.size.s};
+              font-weight: ${euiTheme.font.weight.bold};
+          `
+
+    const plainStyles = css`
+        display: inline-flex;
+        align-items: center;
+        padding: ${euiTheme.size.s};
+        font-weight: ${euiTheme.font.weight.bold};
+        color: ${euiTheme.colors.textInk};
+        text-decoration: none;
+        border-radius: ${euiTheme.border.radius.small};
+        &:hover {
+            background: rgba(0, 0, 0, 0.06);
+        }
+    `
+
+    const logoSection = branded ? (
+        logoHref ? (
+            <a href={logoHref} css={brandedStyles}>
+                {brandedIconContent}
             </a>
         ) : (
-            // Branded without icon — title text only, no HTMX
-            <a
-                href={logoHref}
-                css={css`
-                    display: inline-flex;
-                    align-items: center;
-                    color: var(--color-white);
-                    text-decoration: none;
-                    padding: ${euiTheme.size.s};
-                    font-weight: ${euiTheme.font.weight.bold};
-                `}
-            >
-                {title}
-            </a>
+            <span css={brandedStyles}>{brandedIconContent}</span>
         )
     ) : elasticOrg ? (
-        // Default for elastic org: Elastic-branded logo (light-mode styling)
         <span ref={containerRef}>
             <EuiHeaderLogo
-                href={logoHref}
+                href={logoHref ?? undefined}
                 css={css`
                     padding-block: 7px;
                     height: auto;
@@ -117,25 +131,14 @@ export const Header = ({
             </EuiHeaderLogo>
         </span>
     ) : (
-        // Non-elastic org, no branding: title text only, no logo
         <span ref={containerRef}>
-            <a
-                href={logoHref}
-                css={css`
-                    display: inline-flex;
-                    align-items: center;
-                    padding: ${euiTheme.size.s};
-                    font-weight: ${euiTheme.font.weight.bold};
-                    color: ${euiTheme.colors.textInk};
-                    text-decoration: none;
-                    border-radius: ${euiTheme.border.radius.small};
-                    &:hover {
-                        background: rgba(0, 0, 0, 0.06);
-                    }
-                `}
-            >
-                {title}
-            </a>
+            {logoHref ? (
+                <a href={logoHref} css={plainStyles}>
+                    {title}
+                </a>
+            ) : (
+                <span css={plainStyles}>{title}</span>
+            )}
         </span>
     )
 

--- a/src/Elastic.Documentation.Site/Layout/_IsolatedHeader.cshtml
+++ b/src/Elastic.Documentation.Site/Layout/_IsolatedHeader.cshtml
@@ -8,6 +8,7 @@
 	                     git-commit="@(Model.GitCommitShort)"
 	                     github-ref="@(Model.GitHubRef)"
 	                     branded="@(Model.Branding != null ? "true" : "false")"
+	                     elastic-org="@(Model.IsElasticOrg ? "true" : "false")"
 	                     header-bg="@(Model.Branding?.HeaderBg)"
 	                     icon-src="@(Model.BrandingIconStaticPath)">
 	</elastic-docs-header>

--- a/src/Elastic.Documentation.Site/_ViewModels.cs
+++ b/src/Elastic.Documentation.Site/_ViewModels.cs
@@ -76,6 +76,10 @@ public record GlobalLayoutViewModel
 
 	public bool RenderHamburgerIcon { get; init; } = true;
 
+	/// <summary>Whether the git remote belongs to the <c>elastic</c> GitHub organization.</summary>
+	public bool IsElasticOrg =>
+		GitRepository?.StartsWith("elastic/", StringComparison.OrdinalIgnoreCase) == true;
+
 	/// <summary>White-label branding overrides. When non-null, all Elastic-specific chrome is suppressed.</summary>
 	public BrandingConfiguration? Branding { get; init; }
 

--- a/src/Elastic.Markdown/DocumentationGenerator.cs
+++ b/src/Elastic.Markdown/DocumentationGenerator.cs
@@ -232,8 +232,19 @@ public partial class DocumentationGenerator
 			}
 
 			var destination = _writeFileSystem.FileInfo.New(Path.Join(outputStaticDir, source.Name));
-			_ = source.CopyTo(destination.FullName, overwrite: true);
+			CopyFileAcrossFileSystems(source, destination);
 			_logger.LogInformation("Copied branding asset {Source} -> {Destination}", source.FullName, destination.FullName);
+		}
+	}
+
+	private void CopyFileAcrossFileSystems(IFileInfo source, IFileInfo destination)
+	{
+		if (Context.ReadFileSystem == _writeFileSystem)
+			Context.ReadFileSystem.File.Copy(source.FullName, destination.FullName, overwrite: true);
+		else
+		{
+			var bytes = Context.ReadFileSystem.File.ReadAllBytes(source.FullName);
+			_writeFileSystem.File.WriteAllBytes(destination.FullName, bytes);
 		}
 	}
 

--- a/tests/Elastic.Markdown.Tests/BrandingCopyTests.cs
+++ b/tests/Elastic.Markdown.Tests/BrandingCopyTests.cs
@@ -1,0 +1,60 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions.TestingHelpers;
+using AwesomeAssertions;
+using Elastic.Documentation;
+using Elastic.Documentation.Configuration;
+using Elastic.Documentation.Diagnostics;
+using Elastic.Markdown.IO;
+
+namespace Elastic.Markdown.Tests;
+
+public class BrandingCopyTests(ITestOutputHelper output)
+{
+	[Fact]
+	public async Task CopyBrandingResources_SeparateFileSystems_DoesNotThrow()
+	{
+		var logger = new TestLoggerFactory(output);
+
+		var readFs = new MockFileSystem(new Dictionary<string, MockFileData>
+		{
+			{ "docs/docset.yml",
+				//language=yaml
+				new MockFileData("""
+project: test
+toc:
+- file: index.md
+branding:
+  icon: assets/logo.svg
+""") },
+			{ "docs/index.md", new MockFileData("# Hello") },
+			{ "docs/assets/logo.svg", new MockFileData("<svg/>") }
+		}, new MockFileSystemOptions
+		{
+			CurrentDirectory = Paths.WorkingDirectoryRoot.FullName
+		});
+
+		var writeFs = new MockFileSystem(new MockFileSystemOptions
+		{
+			CurrentDirectory = Paths.WorkingDirectoryRoot.FullName
+		});
+
+		await using var collector = new DiagnosticsCollector([]).StartAsync(TestContext.Current.CancellationToken);
+		var configurationContext = TestHelpers.CreateConfigurationContext(readFs);
+		var readScoped = FileSystemFactory.ScopeCurrentWorkingDirectory(readFs);
+		var writeScoped = FileSystemFactory.ScopeCurrentWorkingDirectoryForWrite(writeFs);
+		var context = new BuildContext(collector, readScoped, writeScoped, configurationContext, ExportOptions.Default);
+
+		var linkResolver = new TestCrossLinkResolver();
+		var set = new DocumentationSet(context, logger, linkResolver);
+		var generator = new DocumentationGenerator(set, logger);
+
+		await generator.GenerateAll(TestContext.Current.CancellationToken);
+		await collector.StopAsync(TestContext.Current.CancellationToken);
+
+		var outputStaticDir = Path.Join(set.OutputDirectory.FullName, "_static");
+		writeFs.File.Exists(Path.Join(outputStaticDir, "logo.svg")).Should().BeTrue();
+	}
+}


### PR DESCRIPTION
## Why

Two issues with branding in isolated builds:

1. When a docset has `branding: icon:` configured, `docs-builder serve` throws a `DirectoryNotFoundException` during the in-memory validation build. The serve command uses separate read (real disk) and write (in-memory) filesystems, but `CopyBrandingResources` called `source.CopyTo()` which operates within the read filesystem — targeting a `_static` directory that only exists on the write side.

2. Non-elastic orgs using docs-builder see the Elastic logo in the isolated header by default, which is incorrect for white-label use.

## What

- Replaced `source.CopyTo()` in `CopyBrandingResources` with a filesystem-aware copy that follows the same pattern as `DocumentationFileExporterBase.CopyFileFsAware`: when read and write filesystems differ, bytes are read from the source and written via the write filesystem. Added a regression test.

- The isolated header now checks the git remote org and only renders the Elastic `EuiHeaderLogo` when the org is `elastic`. Non-elastic repos get a plain title link with no logo.