### PR TITLE
Fix overlapping scope roots for nested Codex config paths

### DIFF
--- a/src/Elastic.Documentation.Tooling/FileSystemFactory.cs
+++ b/src/Elastic.Documentation.Tooling/FileSystemFactory.cs
@@ -109,11 +109,14 @@ public static class FileSystemFactory
 		if (extensionRoots is null)
 			return ScopeCurrentWorkingDirectory(inner);
 
-		var roots = new[] { Paths.WorkingDirectoryRoot.FullName, Paths.ApplicationData.FullName }
-			.Concat(extensionRoots)
-			.Distinct(StringComparer.OrdinalIgnoreCase)
-			.ToArray();
-		if (roots.Length == 2)
+		var roots = NormalizeDisjointRoots([
+			Paths.WorkingDirectoryRoot.FullName,
+			Paths.ApplicationData.FullName,
+			.. extensionRoots,
+		]);
+		if (roots.Length == 2
+			&& roots.Contains(NormalizeRootPath(Paths.WorkingDirectoryRoot.FullName), StringComparer.OrdinalIgnoreCase)
+			&& roots.Contains(NormalizeRootPath(Paths.ApplicationData.FullName), StringComparer.OrdinalIgnoreCase))
 			return ScopeCurrentWorkingDirectory(inner);
 
 		return new ScopedFileSystem(inner, new ScopedFileSystemOptions(roots)
@@ -121,6 +124,46 @@ public static class FileSystemFactory
 			AllowedHiddenFolderNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".git", ".artifacts" },
 			AllowedHiddenFileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".git", ".doc.state" }
 		});
+	}
+
+	private static string NormalizeRootPath(string path) =>
+		Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+	private static bool IsSameOrSubPathOf(string path, string possibleAncestor)
+	{
+		path = NormalizeRootPath(path);
+		possibleAncestor = NormalizeRootPath(possibleAncestor);
+		if (path.Equals(possibleAncestor, StringComparison.OrdinalIgnoreCase))
+			return true;
+
+		return path.StartsWith(possibleAncestor + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase)
+			|| path.StartsWith(possibleAncestor + Path.AltDirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+	}
+
+	private static string[] NormalizeDisjointRoots(IEnumerable<string> roots)
+	{
+		var normalized = roots
+			.Select(NormalizeRootPath)
+			.Distinct(StringComparer.OrdinalIgnoreCase)
+			.OrderBy(static root => root.Length)
+			.ToList();
+
+		var kept = new List<string>();
+		foreach (var root in normalized)
+		{
+			if (kept.Exists(existing => IsSameOrSubPathOf(root, existing)))
+				continue;
+
+			for (var i = kept.Count - 1; i >= 0; i--)
+			{
+				if (IsSameOrSubPathOf(kept[i], root))
+					kept.RemoveAt(i);
+			}
+
+			kept.Add(root);
+		}
+
+		return [.. kept];
 	}
 
 	// Builds write options that include AllowedSpecialFolders.Temp PLUS the inner FS's own

--- a/tests/Elastic.Documentation.Configuration.Tests/FileSystemFactoryTests.cs
+++ b/tests/Elastic.Documentation.Configuration.Tests/FileSystemFactoryTests.cs
@@ -1,0 +1,44 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions.TestingHelpers;
+using AwesomeAssertions;
+
+namespace Elastic.Documentation.Configuration.Tests;
+
+public class FileSystemFactoryTests
+{
+	[Fact]
+	public void ScopeCurrentWorkingDirectory_NestedExtensionRoot_DoesNotThrow()
+	{
+		var workingRoot = Paths.WorkingDirectoryRoot.FullName;
+		var nestedConfigDir = Path.Join(workingRoot, "environments", "internal");
+		var configPath = Path.Join(nestedConfigDir, "config.yml");
+		var mockFs = new MockFileSystem(new Dictionary<string, MockFileData>
+		{
+			{ configPath, new MockFileData("environment: internal") }
+		});
+
+		var act = () => FileSystemFactory.ScopeCurrentWorkingDirectory(mockFs, [nestedConfigDir]);
+
+		act.Should().NotThrow();
+		var scoped = FileSystemFactory.ScopeCurrentWorkingDirectory(mockFs, [nestedConfigDir]);
+		scoped.File.Exists(configPath).Should().BeTrue();
+	}
+
+	[Fact]
+	public void ScopeCurrentWorkingDirectory_ExternalExtensionRoot_AllowsReadingExternalConfig()
+	{
+		var externalRoot = Path.Join(Path.GetTempPath(), $"external-codex-{Guid.NewGuid():N}");
+		var configPath = Path.Join(externalRoot, "codex.yml");
+		var mockFs = new MockFileSystem(new Dictionary<string, MockFileData>
+		{
+			{ configPath, new MockFileData("environment: internal") }
+		});
+
+		var scoped = FileSystemFactory.ScopeCurrentWorkingDirectory(mockFs, [externalRoot]);
+
+		scoped.File.Exists(configPath).Should().BeTrue();
+	}
+}


### PR DESCRIPTION
## Why

docs-builder 1.29.0 scopes Codex commands with `FindGitRoot(config.FullName)` as an extension root. For configs under `environments/internal/config.yml`, that root sits inside `WorkingDirectoryRoot`, and `ScopedFileSystem` throws `Scope roots must be disjoint`. This breaks `codex-environments` CI (`docs-builder codex clone`) on every run since 1.29.0 shipped.

## What

Normalize extension roots in `FileSystemFactory.ScopeCurrentWorkingDirectory` before building scoped filesystem options: deduplicate paths and drop roots already covered by an ancestor. Adds regression tests for nested in-repo configs and genuinely external config roots.

After merge and release, `codex-environments` workflows using `version: latest` should recover automatically. Until then, that repo can pin docs-builder to `1.28.0` as a workaround.

Made with [Cursor](https://cursor.com)