### PR TITLE
Simplify scope root normalization for nested extension roots

### DIFF
--- a/src/Elastic.Documentation.Tooling/FileSystemFactory.cs
+++ b/src/Elastic.Documentation.Tooling/FileSystemFactory.cs
@@ -4,7 +4,9 @@
 
 using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
+using Elastic.Documentation.Extensions;
 using Nullean.ScopedFileSystem;
+using DirectoryInfoExtensions = Elastic.Documentation.Extensions.IDirectoryInfoExtensions;
 
 // ReSharper disable once CheckNamespace — intentionally preserving the original namespace so consumers need no using changes
 #pragma warning disable IDE0130
@@ -109,61 +111,26 @@ public static class FileSystemFactory
 		if (extensionRoots is null)
 			return ScopeCurrentWorkingDirectory(inner);
 
-		var roots = NormalizeDisjointRoots([
-			Paths.WorkingDirectoryRoot.FullName,
-			Paths.ApplicationData.FullName,
-			.. extensionRoots,
-		]);
-		if (roots.Length == 2
-			&& roots.Contains(NormalizeRootPath(Paths.WorkingDirectoryRoot.FullName), StringComparer.OrdinalIgnoreCase)
-			&& roots.Contains(NormalizeRootPath(Paths.ApplicationData.FullName), StringComparer.OrdinalIgnoreCase))
+		var workingRoot = inner.DirectoryInfo.New(Paths.WorkingDirectoryRoot.FullName);
+		var externalRoots = extensionRoots
+			.Select(r => inner.DirectoryInfo.New(r))
+			.Where(d => !DirectoryInfoExtensions.IsSubPathOf(d, workingRoot))
+			.Select(d => d.FullName)
+			.Distinct(StringComparer.OrdinalIgnoreCase)
+			.ToArray();
+
+		if (externalRoots.Length == 0)
 			return ScopeCurrentWorkingDirectory(inner);
+
+		var roots = new[] { Paths.WorkingDirectoryRoot.FullName, Paths.ApplicationData.FullName }
+			.Concat(externalRoots)
+			.ToArray();
 
 		return new ScopedFileSystem(inner, new ScopedFileSystemOptions(roots)
 		{
 			AllowedHiddenFolderNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".git", ".artifacts" },
 			AllowedHiddenFileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".git", ".doc.state" }
 		});
-	}
-
-	private static string NormalizeRootPath(string path) =>
-		Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-
-	private static bool IsSameOrSubPathOf(string path, string possibleAncestor)
-	{
-		path = NormalizeRootPath(path);
-		possibleAncestor = NormalizeRootPath(possibleAncestor);
-		if (path.Equals(possibleAncestor, StringComparison.OrdinalIgnoreCase))
-			return true;
-
-		return path.StartsWith(possibleAncestor + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase)
-			|| path.StartsWith(possibleAncestor + Path.AltDirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
-	}
-
-	private static string[] NormalizeDisjointRoots(IEnumerable<string> roots)
-	{
-		var normalized = roots
-			.Select(NormalizeRootPath)
-			.Distinct(StringComparer.OrdinalIgnoreCase)
-			.OrderBy(static root => root.Length)
-			.ToList();
-
-		var kept = new List<string>();
-		foreach (var root in normalized)
-		{
-			if (kept.Exists(existing => IsSameOrSubPathOf(root, existing)))
-				continue;
-
-			for (var i = kept.Count - 1; i >= 0; i--)
-			{
-				if (IsSameOrSubPathOf(kept[i], root))
-					kept.RemoveAt(i);
-			}
-
-			kept.Add(root);
-		}
-
-		return [.. kept];
 	}
 
 	// Builds write options that include AllowedSpecialFolders.Temp PLUS the inner FS's own
@@ -285,7 +252,7 @@ public static class FileSystemFactory
 		if (output is not null)
 		{
 			var absOutput = Path.IsPathRooted(output) ? output : Path.GetFullPath(output);
-			if (!plain.DirectoryInfo.New(absOutput).IsSubPathOf(plain.DirectoryInfo.New(gitRoot)))
+			if (!DirectoryInfoExtensions.IsSubPathOf(plain.DirectoryInfo.New(absOutput), plain.DirectoryInfo.New(gitRoot)))
 				roots.Add(absOutput);
 		}
 


### PR DESCRIPTION
## Why

Follow-up to #3719. That PR fixes the `ScopedFileSystem` disjoint-roots crash for nested Codex configs by introducing a generic `NormalizeDisjointRoots` that sorts all roots by length and collapses parent–child pairs. This treats `WorkingDirectoryRoot`, `ApplicationData`, and extension roots as equals, but `WorkingDirectoryRoot` and `ApplicationData` are fixed and always disjoint — only extension roots can collide with `WorkingDirectoryRoot`.

### Root cause

The `codex-environments` repo has configs nested inside the checkout:

```
/home/runner/work/codex-environments/codex-environments/   ← WorkingDirectoryRoot (has .git)
├── .git/
├── environments/
│   └── internal/
│       └── config.yml   ← config passed to `docs-builder codex clone`
└── ...
```

When a Codex command runs, it calls:

```csharp
FileSystemFactory.ScopeCurrentWorkingDirectory(fs, [Paths.FindGitRoot(config.FullName)]);
```

`FindGitRoot` starts from the config file's directory and walks up looking for `.git`, but has a **depth-1 limit** in release builds. The `.git` is 2 levels up:

```
environments/internal/   ← depth 0: no .git
environments/            ← depth 1: no .git
repo root/               ← depth 2: .git found, but depth > 1 → REJECTED
```

Since `.git` is "too deep", `FindGitRoot` falls back to returning `startDir` — the config's own directory:

```
FindGitRoot("…/environments/internal/config.yml")
  → "/home/runner/…/codex-environments/environments/internal"
```

Now the original `ScopeCurrentWorkingDirectory` builds scope roots:

```
roots = [
  WorkingDirectoryRoot  →  "/home/runner/…/codex-environments"          ← ROOT
  ApplicationData       →  "/home/runner/.local/share/elastic/docs-builder"
  extensionRoot         →  "/home/runner/…/codex-environments/environments/internal"  ← CHILD OF ROOT!
]
```

`.Distinct()` doesn't remove anything (they're different strings). `roots.Length == 3 ≠ 2`, so it doesn't hit the fast path. `ScopedFileSystem` then enforces that **all scope roots must be disjoint** (no parent–child relationships):

```
   ❌ BOOM: ancestor/descendant relationship detected

   /home/runner/…/codex-environments/           ← scope root A
   └── environments/
       └── internal/                            ← scope root B (child of A)
```

`ScopedFileSystem` throws here by design — nested roots create policy ambiguity (which root's hidden-file/folder allowlist wins?), so the library forces callers to provide disjoint roots.

## What

Replace the generic shortest-first normalizer from #3719 with a targeted filter: drop extension roots that are already covered by `WorkingDirectoryRoot` using the existing `IsSubPathOf` extension. No new helper methods needed.

Includes the same two regression tests from #3719 (nested in-repo config, genuinely external config root).