### PR TITLE
Add local disk cache and concurrent downloads for changelog bundles

### DIFF
--- a/src/Elastic.Documentation.Configuration/ReleaseNotes/CdnChangelogFetcher.cs
+++ b/src/Elastic.Documentation.Configuration/ReleaseNotes/CdnChangelogFetcher.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Collections.Concurrent;
 using System.IO.Abstractions;
 using System.Net;
 using System.Text.Json;
@@ -18,9 +19,9 @@ namespace Elastic.Documentation.Configuration.ReleaseNotes;
 /// </summary>
 /// <remarks>
 /// <para>
-/// This is a pure async fetch engine: it owns no caching. Memoization is the caller's concern (see
-/// <see cref="ReleaseNotesFetcher"/>, which fetches all declared products once at startup and stores
-/// the result in an immutable <see cref="FetchedReleaseNotes"/>).
+/// Individual bundle files are cached locally keyed by <c>{product}-{fileName}-{etag}</c> so that
+/// repeated builds (and dev-server reloads) do not re-download unchanged content from the CDN.
+/// The registry itself is always fetched (it's small and provides fresh ETags).
 /// </para>
 /// <para>
 /// Resilience follows the manifest's consistency model: a registry that cannot be fetched or parsed
@@ -56,6 +57,8 @@ public sealed class CdnChangelogFetcher : IDisposable
 	private readonly ILogger _logger;
 	private readonly HttpClient _httpClient;
 	private readonly BundleLoader _bundleLoader;
+	private readonly IFileSystem _fileSystem;
+	private readonly ConcurrentDictionary<string, string> _memoryCache = new(StringComparer.Ordinal);
 
 	/// <summary>
 	/// Non-null only when a caller injects its own <see cref="HttpMessageHandler"/> (tests): in that case we
@@ -67,6 +70,7 @@ public sealed class CdnChangelogFetcher : IDisposable
 	public CdnChangelogFetcher(ILoggerFactory logFactory, IFileSystem fileSystem, HttpMessageHandler? handler = null)
 	{
 		_logger = logFactory.CreateLogger<CdnChangelogFetcher>();
+		_fileSystem = fileSystem;
 		_bundleLoader = new BundleLoader(fileSystem);
 
 		if (handler is null)
@@ -158,11 +162,9 @@ public sealed class CdnChangelogFetcher : IDisposable
 		Cancel ctx)
 	{
 		var selected = SelectBundles(version, registry.Bundles);
-		var contents = new List<(string FileName, string Content)>(selected.Count);
+		var tasks = new List<Task<(string FileName, string Content)?>>(selected.Count);
 		foreach (var bundle in selected)
 		{
-			ctx.ThrowIfCancellationRequested();
-
 			var fileName = bundle.File;
 			if (!ChangelogKeys.IsSafeFileName(fileName))
 			{
@@ -170,19 +172,40 @@ public sealed class CdnChangelogFetcher : IDisposable
 				continue;
 			}
 
-			var bundleUri = Combine(baseUri, [.. ChangelogKeys.BundleSegments(product), fileName]);
-			try
-			{
-				contents.Add((fileName, await FetchTextAsync(bundleUri, ctx).ConfigureAwait(false)));
-			}
-			catch (Exception ex) when (ex is not OperationCanceledException)
-			{
-				// The registry can reference a bundle whose scrubbed copy is not yet public; skip + warn.
-				emitWarning($"Could not fetch changelog bundle '{fileName}' for '{product}' from {bundleUri}: {ex.Message}");
-			}
+			tasks.Add(DownloadOrCacheBundleAsync(baseUri, product, fileName, bundle.ETag, emitWarning, ctx));
 		}
 
-		return contents;
+		var results = await Task.WhenAll(tasks).ConfigureAwait(false);
+		return results.Where(r => r is not null).Select(r => r!.Value).ToList();
+	}
+
+	private async Task<(string FileName, string Content)?> DownloadOrCacheBundleAsync(
+		Uri baseUri,
+		string product,
+		string fileName,
+		string? etag,
+		Action<string> emitWarning,
+		Cancel ctx)
+	{
+		var cached = TryGetCachedBundle(product, fileName, etag);
+		if (cached is not null)
+		{
+			_logger.LogInformation("Using locally cached bundle '{FileName}' for '{Product}'", fileName, product);
+			return (fileName, cached);
+		}
+
+		var bundleUri = Combine(baseUri, [.. ChangelogKeys.BundleSegments(product), fileName]);
+		try
+		{
+			var content = await FetchTextAsync(bundleUri, ctx).ConfigureAwait(false);
+			WriteCachedBundle(product, fileName, etag, content);
+			return (fileName, content);
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			emitWarning($"Could not fetch changelog bundle '{fileName}' for '{product}' from {bundleUri}: {ex.Message}");
+			return null;
+		}
 	}
 
 	/// <summary>
@@ -233,6 +256,61 @@ public sealed class CdnChangelogFetcher : IDisposable
 		var suffix = string.Join('/', segments.Select(Uri.EscapeDataString));
 		return new Uri($"{basePath}/{suffix}");
 	}
+
+	private string? TryGetCachedBundle(string product, string fileName, string? etag)
+	{
+		if (string.IsNullOrWhiteSpace(etag))
+			return null;
+
+		var cacheKey = CacheKey(product, fileName, etag);
+		if (_memoryCache.TryGetValue(cacheKey, out var cached))
+			return cached;
+
+		var cachePath = CachePath(cacheKey);
+		if (!_fileSystem.File.Exists(cachePath))
+			return null;
+
+		try
+		{
+			var content = _fileSystem.File.ReadAllText(cachePath);
+			_ = _memoryCache.TryAdd(cacheKey, content);
+			return content;
+		}
+		catch (Exception e)
+		{
+			_logger.LogError(e, "Failed to read cached changelog bundle {CachePath}", cachePath);
+			return null;
+		}
+	}
+
+	private void WriteCachedBundle(string product, string fileName, string? etag, string content)
+	{
+		if (string.IsNullOrWhiteSpace(etag))
+			return;
+
+		var cacheKey = CacheKey(product, fileName, etag);
+		_ = _memoryCache.TryAdd(cacheKey, content);
+
+		var cachePath = CachePath(cacheKey);
+		if (_fileSystem.File.Exists(cachePath))
+			return;
+
+		try
+		{
+			_ = _fileSystem.Directory.CreateDirectory(Path.GetDirectoryName(cachePath)!);
+			_fileSystem.File.WriteAllText(cachePath, content);
+		}
+		catch (Exception e)
+		{
+			_logger.LogError(e, "Failed to write cached changelog bundle {CachePath}", cachePath);
+		}
+	}
+
+	private static string CacheKey(string product, string fileName, string etag) =>
+		$"changelog-{product}-{fileName}-{etag}";
+
+	private static string CachePath(string cacheKey) =>
+		Path.Join(Paths.ApplicationData.FullName, "changelog-bundles", cacheKey);
 
 	/// <summary>
 	/// Disposes the per-instance <see cref="HttpClient"/> created for an injected handler. The shared

--- a/src/Elastic.Documentation.Configuration/ReleaseNotes/ChangelogRegistry.cs
+++ b/src/Elastic.Documentation.Configuration/ReleaseNotes/ChangelogRegistry.cs
@@ -36,9 +36,10 @@ public sealed record ChangelogRegistryBundle
 
 	/// <summary>
 	/// Best-effort change hint from the private bucket (pre-scrub). Not valid for public-object
-	/// integrity or HTTP cache validation; see the producer's documentation. Unused by the directive
-	/// today but retained for fidelity and future cache-keying.
+	/// integrity or HTTP cache validation; see the producer's documentation.
+	/// Used as the local disk-cache key so unchanged bundles are not re-downloaded.
 	/// </summary>
+	[JsonPropertyName("etag")]
 	public string? ETag { get; init; }
 }
 

--- a/tests/Elastic.Documentation.Configuration.Tests/ReleaseNotes/CdnChangelogFetcherTests.cs
+++ b/tests/Elastic.Documentation.Configuration.Tests/ReleaseNotes/CdnChangelogFetcherTests.cs
@@ -3,8 +3,10 @@
 // See the LICENSE file in the project root for more information
 
 using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
 using System.Net;
 using AwesomeAssertions;
+using Elastic.Documentation.Configuration;
 using Elastic.Documentation.Configuration.ReleaseNotes;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -282,6 +284,116 @@ public class CdnChangelogFetcherTests
 		bundles.Should().BeEmpty();
 		errors.Should().ContainSingle().Which.Should().Contain("Invalid changelog product");
 		handler.RequestedPaths.Should().BeEmpty("validation must happen before any CDN request");
+	}
+
+	[Fact]
+	public async Task FetchAsync_WithETag_UsesCachedBundleOnSecondCall()
+	{
+		var handler = new StubHandler(req =>
+			req.RequestUri!.AbsolutePath.EndsWith("/registry.json", StringComparison.Ordinal)
+				? Json(/*lang=json,strict*/ """{ "schema_version": 1, "product": "elasticsearch", "bundles": [ { "file": "9.3.0.yaml", "target": "9.3.0", "etag": "abc123" } ] }""")
+				: Yaml(SampleBundle));
+		var (errors, warnings, emitError, emitWarning) = Diagnostics();
+		var fs = new MockFileSystem();
+
+		using var fetcher = new CdnChangelogFetcher(NullLoggerFactory.Instance, fs, handler);
+
+		// First call — should fetch from CDN
+		var bundles = await fetcher.FetchAsync(BaseUri, "elasticsearch", version: null, emitError, emitWarning, TestContext.Current.CancellationToken);
+		bundles.Should().ContainSingle();
+		handler.CallCount.Should().Be(2, "registry + bundle");
+
+		// Second call — bundle should come from cache (only registry re-fetched)
+		var bundles2 = await fetcher.FetchAsync(BaseUri, "elasticsearch", version: null, emitError, emitWarning, TestContext.Current.CancellationToken);
+		bundles2.Should().ContainSingle();
+		handler.CallCount.Should().Be(3, "only registry fetched again; bundle served from memory cache");
+		errors.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task FetchAsync_WithETag_WritesCacheToDisk()
+	{
+		var handler = new StubHandler(req =>
+			req.RequestUri!.AbsolutePath.EndsWith("/registry.json", StringComparison.Ordinal)
+				? Json(/*lang=json,strict*/ """{ "schema_version": 1, "product": "elasticsearch", "bundles": [ { "file": "9.3.0.yaml", "target": "9.3.0", "etag": "deadbeef" } ] }""")
+				: Yaml(SampleBundle));
+		var (errors, _, emitError, emitWarning) = Diagnostics();
+		var fs = new MockFileSystem();
+
+		using var fetcher = new CdnChangelogFetcher(NullLoggerFactory.Instance, fs, handler);
+		_ = await fetcher.FetchAsync(BaseUri, "elasticsearch", version: null, emitError, emitWarning, TestContext.Current.CancellationToken);
+
+		var expectedPath = Path.Join(Paths.ApplicationData.FullName, "changelog-bundles", "changelog-elasticsearch-9.3.0.yaml-deadbeef");
+		fs.File.Exists(expectedPath).Should().BeTrue("bundle should be written to disk cache");
+		errors.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task FetchAsync_WithETag_ReadsCacheFromDisk()
+	{
+		// Pre-populate the disk cache
+		var fs = new MockFileSystem();
+		var cachePath = Path.Join(Paths.ApplicationData.FullName, "changelog-bundles", "changelog-elasticsearch-9.3.0.yaml-cached1");
+		fs.Directory.CreateDirectory(Path.GetDirectoryName(cachePath)!);
+		fs.File.WriteAllText(cachePath, SampleBundle);
+
+		var handler = new StubHandler(req =>
+			req.RequestUri!.AbsolutePath.EndsWith("/registry.json", StringComparison.Ordinal)
+				? Json(/*lang=json,strict*/ """{ "schema_version": 1, "product": "elasticsearch", "bundles": [ { "file": "9.3.0.yaml", "target": "9.3.0", "etag": "cached1" } ] }""")
+				: throw new InvalidOperationException("Should not fetch bundle from CDN"));
+		var (errors, warnings, emitError, emitWarning) = Diagnostics();
+
+		using var fetcher = new CdnChangelogFetcher(NullLoggerFactory.Instance, fs, handler);
+		var bundles = await fetcher.FetchAsync(BaseUri, "elasticsearch", version: null, emitError, emitWarning, TestContext.Current.CancellationToken);
+
+		bundles.Should().ContainSingle();
+		handler.CallCount.Should().Be(1, "only registry should be fetched; bundle served from disk");
+		errors.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task FetchAsync_NullETag_AlwaysFetchesFromCdn()
+	{
+		var handler = new StubHandler(req =>
+			req.RequestUri!.AbsolutePath.EndsWith("/registry.json", StringComparison.Ordinal)
+				? Json(/*lang=json,strict*/ """{ "schema_version": 1, "product": "elasticsearch", "bundles": [ { "file": "9.3.0.yaml", "target": "9.3.0", "etag": null } ] }""")
+				: Yaml(SampleBundle));
+		var (errors, _, emitError, emitWarning) = Diagnostics();
+		var fs = new MockFileSystem();
+
+		using var fetcher = new CdnChangelogFetcher(NullLoggerFactory.Instance, fs, handler);
+
+		// First call
+		_ = await fetcher.FetchAsync(BaseUri, "elasticsearch", version: null, emitError, emitWarning, TestContext.Current.CancellationToken);
+		handler.CallCount.Should().Be(2);
+
+		// Second call — no caching, so bundle is fetched again
+		_ = await fetcher.FetchAsync(BaseUri, "elasticsearch", version: null, emitError, emitWarning, TestContext.Current.CancellationToken);
+		handler.CallCount.Should().Be(4, "without ETag, both registry and bundle are fetched each time");
+		errors.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task FetchAsync_ChangedETag_FetchesNewBundle()
+	{
+		var etag = "v1";
+		var handler = new StubHandler(req =>
+			req.RequestUri!.AbsolutePath.EndsWith("/registry.json", StringComparison.Ordinal)
+				? Json($$"""{ "schema_version": 1, "product": "elasticsearch", "bundles": [ { "file": "9.3.0.yaml", "target": "9.3.0", "etag": "{{etag}}" } ] }""")
+				: Yaml(SampleBundle));
+		var (errors, _, emitError, emitWarning) = Diagnostics();
+		var fs = new MockFileSystem();
+
+		using var fetcher = new CdnChangelogFetcher(NullLoggerFactory.Instance, fs, handler);
+
+		_ = await fetcher.FetchAsync(BaseUri, "elasticsearch", version: null, emitError, emitWarning, TestContext.Current.CancellationToken);
+		handler.CallCount.Should().Be(2);
+
+		// Simulate a new etag by creating a new fetcher (in real usage the registry returns a different etag)
+		etag = "v2";
+		_ = await fetcher.FetchAsync(BaseUri, "elasticsearch", version: null, emitError, emitWarning, TestContext.Current.CancellationToken);
+		handler.CallCount.Should().Be(4, "new ETag means cache miss, bundle re-downloaded");
+		errors.Should().BeEmpty();
 	}
 
 	private static HttpResponseMessage Json(string body) =>


### PR DESCRIPTION
## Why

Every `docs-builder` invocation (and every dev-server file-change reload) re-downloads all changelog bundle YAML files from CloudFront, even though they rarely change. This adds noticeable latency to builds, especially in the `serve` path where reloads are frequent. The cross-link fetcher already avoids this with ETag-based local caching; changelogs had no equivalent.

## What

- Individual changelog bundle files are now cached on disk at `~/.../elastic/docs-builder/changelog-bundles/` keyed by `{product}-{fileName}-{etag}`, mirroring the CrossLinkFetcher pattern. The registry.json is always fetched (it's small and provides fresh ETags for cache validation).
- Bundle downloads within a product are now concurrent (`Task.WhenAll`) instead of sequential.
- Fixed `ChangelogRegistryBundle.ETag` deserialization by adding an explicit `[JsonPropertyName("etag")]` — the `SnakeCaseLower` naming policy was producing `e_tag` which never matched the CDN's actual field name, so the field was always null.

Made with [Cursor](https://cursor.com)