### PR TITLE
Frontend: Fix lazy highlight.js aliases and autodetection

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/hljs.test.ts
+++ b/src/Elastic.Documentation.Site/Assets/hljs.test.ts
@@ -7,12 +7,14 @@ async function loadModule(): Promise<HljsModule> {
     return await import('./hljs')
 }
 
-function setCodeBlocks(...languages: string[]) {
+function setCodeBlocks(...languages: (string | null)[]) {
     const blocks = languages
-        .map(
-            (language) =>
-                `<pre><code class="language-${language}">echo hello</code></pre>`
-        )
+        .map((language) => {
+            if (language === null) {
+                return '<pre><code>const x = 1</code></pre>'
+            }
+            return `<pre><code class="language-${language}">echo hello</code></pre>`
+        })
         .join('')
     document.body.innerHTML = `<div id="markdown-content">${blocks}</div>`
 }
@@ -22,14 +24,15 @@ afterEach(() => {
 })
 
 describe('initHighlight', () => {
-    it('loads only the languages referenced on the page', async () => {
+    it('loads all curated languages when any code block is present', async () => {
         const { initHighlight, hljs } = await loadModule()
         setCodeBlocks('bash')
 
         await initHighlight()
 
         expect(hljs.listLanguages()).toContain('bash')
-        expect(hljs.listLanguages()).not.toContain('python')
+        expect(hljs.listLanguages()).toContain('python')
+        expect(hljs.listLanguages()).toContain('javascript')
     })
 
     it('loads no node_modules language when there are no code blocks', async () => {
@@ -52,26 +55,60 @@ describe('initHighlight', () => {
         expect(block?.getAttribute('data-highlighted')).toBe('yes')
     })
 
-    it('loads a newly encountered language on a later swap', async () => {
-        const { initHighlight, hljs } = await loadModule()
-        setCodeBlocks('bash')
-        await initHighlight()
-        expect(hljs.listLanguages()).not.toContain('python')
+    it('highlights alias language-js via javascript aliases', async () => {
+        const { initHighlight } = await loadModule()
+        setCodeBlocks('js')
 
-        // Simulate an htmx swap introducing a language not present initially.
-        setCodeBlocks('python')
         await initHighlight()
 
-        expect(hljs.listLanguages()).toContain('python')
+        const block = document.querySelector('#markdown-content pre code')
+        expect(block?.getAttribute('data-highlighted')).toBe('yes')
+        expect(block?.className).toContain('language-javascript')
     })
 
-    it('resolves aliases to their canonical language', async () => {
+    it('highlights alias language-ts via typescript aliases', async () => {
+        const { initHighlight } = await loadModule()
+        setCodeBlocks('ts')
+
+        await initHighlight()
+
+        const block = document.querySelector('#markdown-content pre code')
+        expect(block?.getAttribute('data-highlighted')).toBe('yes')
+        expect(block?.className).toContain('language-typescript')
+    })
+
+    it('highlights alias language-jsx via javascript aliases', async () => {
+        const { initHighlight } = await loadModule()
+        setCodeBlocks('jsx')
+
+        await initHighlight()
+
+        const block = document.querySelector('#markdown-content pre code')
+        expect(block?.getAttribute('data-highlighted')).toBe('yes')
+        expect(block?.className).toContain('language-javascript')
+    })
+
+    it('autodetects an unlabeled code block', async () => {
+        const { initHighlight } = await loadModule()
+        setCodeBlocks(null)
+
+        await initHighlight()
+
+        const block = document.querySelector('#markdown-content pre code')
+        expect(block?.getAttribute('data-highlighted')).toBe('yes')
+        expect(block?.querySelector('.hljs-keyword')).not.toBeNull()
+    })
+
+    it('resolves sh alias to shell', async () => {
         const { initHighlight, hljs } = await loadModule()
         setCodeBlocks('sh')
 
         await initHighlight()
 
         expect(hljs.listLanguages()).toContain('shell')
+        const block = document.querySelector('#markdown-content pre code')
+        expect(block?.getAttribute('data-highlighted')).toBe('yes')
+        expect(block?.className).toContain('language-shell')
     })
 
     it('does not re-highlight a block when invoked concurrently', async () => {
@@ -97,6 +134,28 @@ describe('initHighlight', () => {
         const blocks = document.querySelectorAll('#markdown-content pre code')
         const bashBlock = blocks[1]
         expect(bashBlock.getAttribute('data-highlighted')).toBe('yes')
+    })
+})
+
+describe('highlightCodeBlocks', () => {
+    it('scopes highlighting to the supplied root', async () => {
+        const { highlightCodeBlocks } = await loadModule()
+        document.body.innerHTML = `
+            <div id="inside"><pre><code class="language-bash">echo inside</code></pre></div>
+            <div id="outside"><pre><code class="language-bash">echo outside</code></pre></div>
+        `
+
+        const inside = document.querySelector('#inside')!
+        await highlightCodeBlocks(inside)
+
+        expect(
+            inside.querySelector('code')?.getAttribute('data-highlighted')
+        ).toBe('yes')
+        expect(
+            document
+                .querySelector('#outside code')
+                ?.getAttribute('data-highlighted')
+        ).not.toBe('yes')
     })
 })
 

--- a/src/Elastic.Documentation.Site/Assets/hljs.test.ts
+++ b/src/Elastic.Documentation.Site/Assets/hljs.test.ts
@@ -55,38 +55,23 @@ describe('initHighlight', () => {
         expect(block?.getAttribute('data-highlighted')).toBe('yes')
     })
 
-    it('highlights alias language-js via javascript aliases', async () => {
-        const { initHighlight } = await loadModule()
-        setCodeBlocks('js')
+    it.each([
+        ['js', 'javascript'],
+        ['ts', 'typescript'],
+        ['jsx', 'javascript'],
+    ])(
+        'highlights alias language-%s via %s aliases',
+        async (alias, canonical) => {
+            const { initHighlight } = await loadModule()
+            setCodeBlocks(alias)
 
-        await initHighlight()
+            await initHighlight()
 
-        const block = document.querySelector('#markdown-content pre code')
-        expect(block?.getAttribute('data-highlighted')).toBe('yes')
-        expect(block?.className).toContain('language-javascript')
-    })
-
-    it('highlights alias language-ts via typescript aliases', async () => {
-        const { initHighlight } = await loadModule()
-        setCodeBlocks('ts')
-
-        await initHighlight()
-
-        const block = document.querySelector('#markdown-content pre code')
-        expect(block?.getAttribute('data-highlighted')).toBe('yes')
-        expect(block?.className).toContain('language-typescript')
-    })
-
-    it('highlights alias language-jsx via javascript aliases', async () => {
-        const { initHighlight } = await loadModule()
-        setCodeBlocks('jsx')
-
-        await initHighlight()
-
-        const block = document.querySelector('#markdown-content pre code')
-        expect(block?.getAttribute('data-highlighted')).toBe('yes')
-        expect(block?.className).toContain('language-javascript')
-    })
+            const block = document.querySelector('#markdown-content pre code')
+            expect(block?.getAttribute('data-highlighted')).toBe('yes')
+            expect(block?.className).toContain(`language-${canonical}`)
+        }
+    )
 
     it('autodetects an unlabeled code block', async () => {
         const { initHighlight } = await loadModule()

--- a/src/Elastic.Documentation.Site/Assets/hljs.ts
+++ b/src/Elastic.Documentation.Site/Assets/hljs.ts
@@ -1,7 +1,6 @@
 import { mergeHTMLPlugin } from './hljs-merge-html-plugin'
 import { LanguageFn } from 'highlight.js'
 import hljs from 'highlight.js/lib/core'
-import { $$optional } from 'select-dom'
 
 // highlight.js language modules and the esql plugin default-export the LanguageFn.
 // Parcel's dynamic import() resolves to the module's exports directly (the function),
@@ -13,8 +12,7 @@ export function toLanguageFn(mod: unknown): LanguageFn {
 }
 
 // Each entry lazily imports one highlight.js language module (or the esql plugin) so
-// only the languages actually present on a page are downloaded, instead of eagerly
-// bundling all of them into the entry chunk.
+// grammars stay out of the entry chunk until a page or message contains code.
 const languageLoaders: Record<string, () => Promise<LanguageFn>> = {
     asciidoc: () =>
         import('highlight.js/lib/languages/asciidoc').then(toLanguageFn),
@@ -67,37 +65,43 @@ const languageLoaders: Record<string, () => Promise<LanguageFn>> = {
     yaml: () => import('highlight.js/lib/languages/yaml').then(toLanguageFn),
 }
 
-// Alias -> canonical language name. Aliases are registered with hljs once their
-// canonical module has loaded so `language-sh` etc. resolve correctly.
-const languageAliases: Record<string, string> = {
-    sh: 'shell',
+const CODE_BLOCK_SELECTOR = 'pre code:not([data-highlighted])'
+
+let allLanguagesReady: Promise<void> | null = null
+
+function ensureHighlightReady(): Promise<void> {
+    if (allLanguagesReady) return allLanguagesReady
+
+    allLanguagesReady = Promise.all(
+        Object.entries(languageLoaders).map(async ([name, loader]) => {
+            hljs.registerLanguage(name, toLanguageFn(await loader()))
+        })
+    ).then(() => {
+        hljs.registerAliases(['sh'], { languageName: 'shell' })
+    })
+
+    return allLanguagesReady
 }
 
-// Caches the registration promise per canonical language so concurrent code blocks
-// (and later htmx swaps) share a single import instead of re-fetching the module.
-const registrations = new Map<string, Promise<void>>()
+function queryCodeBlocks(root: ParentNode): HTMLElement[] {
+    return [...root.querySelectorAll<HTMLElement>(CODE_BLOCK_SELECTOR)]
+}
 
-// Imports and registers a language (plus any aliases pointing at it) exactly once.
-// Unknown languages have no loader and resolve immediately so callers can await
-// unconditionally.
-function ensureLanguage(name: string): Promise<void> {
-    const canonical = languageAliases[name] ?? name
-    const loader = languageLoaders[canonical]
-    if (!loader) return Promise.resolve()
+export async function highlightCodeBlocks(root: ParentNode): Promise<void> {
+    const blocks = queryCodeBlocks(root)
+    if (blocks.length === 0) return
 
-    const cached = registrations.get(canonical)
-    if (cached) return cached
+    await ensureHighlightReady()
 
-    const registration = loader().then((languageFn) => {
-        hljs.registerLanguage(canonical, languageFn)
-        for (const [alias, target] of Object.entries(languageAliases)) {
-            if (target === canonical) {
-                hljs.registerAliases([alias], { languageName: canonical })
-            }
-        }
-    })
-    registrations.set(canonical, registration)
-    return registration
+    for (const block of blocks) {
+        if (!block.dataset.highlighted) hljs.highlightElement(block)
+    }
+}
+
+export async function initHighlight(): Promise<void> {
+    const root = document.querySelector('#markdown-content')
+    if (!root) return
+    await highlightCodeBlocks(root)
 }
 
 hljs.registerLanguage('apiheader', function () {
@@ -229,40 +233,6 @@ hljs.addPlugin(mergeHTMLPlugin)
 // The unescaped HTML warning is caused by the mergeHTMLPlugin which we are using
 // for code callouts
 hljs.configure({ ignoreUnescapedHTML: true })
-
-function getLanguageFromClassList(element: Element): string | undefined {
-    for (const className of element.classList) {
-        if (className.startsWith('language-')) {
-            return className.slice('language-'.length)
-        }
-    }
-    return undefined
-}
-
-export async function initHighlight() {
-    const blocks = $$optional(
-        '#markdown-content pre code:not([data-highlighted])'
-    )
-    if (blocks.length === 0) return
-
-    // Import only the language modules referenced by the unprocessed blocks before
-    // highlighting. Unknown/plain-text languages have no loader and resolve immediately;
-    // hljs.highlightElement then degrades gracefully without breaking other blocks.
-    const requiredLanguages = new Set<string>()
-    for (const block of blocks) {
-        const language = getLanguageFromClassList(block)
-        if (language) requiredLanguages.add(language)
-    }
-
-    await Promise.all([...requiredLanguages].map(ensureLanguage))
-
-    // Re-check data-highlighted after awaiting: a concurrent initHighlight (e.g. a
-    // second htmx:load fired while the language import was pending) may already have
-    // highlighted these captured blocks, and hljs warns if asked to redo one.
-    blocks.forEach((block) => {
-        if (!block.dataset.highlighted) hljs.highlightElement(block)
-    })
-}
 
 // Export the configured hljs instance for reuse
 export { hljs }

--- a/src/Elastic.Documentation.Site/Assets/hljs.ts
+++ b/src/Elastic.Documentation.Site/Assets/hljs.ts
@@ -83,12 +83,8 @@ function ensureHighlightReady(): Promise<void> {
     return allLanguagesReady
 }
 
-function queryCodeBlocks(root: ParentNode): HTMLElement[] {
-    return [...root.querySelectorAll<HTMLElement>(CODE_BLOCK_SELECTOR)]
-}
-
 export async function highlightCodeBlocks(root: ParentNode): Promise<void> {
-    const blocks = queryCodeBlocks(root)
+    const blocks = root.querySelectorAll<HTMLElement>(CODE_BLOCK_SELECTOR)
     if (blocks.length === 0) return
 
     await ensureHighlightReady()

--- a/src/Elastic.Documentation.Site/Assets/marked-code-renderer.ts
+++ b/src/Elastic.Documentation.Site/Assets/marked-code-renderer.ts
@@ -1,0 +1,24 @@
+import { Marked, RendererObject, Tokens } from 'marked'
+
+function escapeHtml(text: string): string {
+    return text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+}
+
+export function createDocsMarkedRenderer(): Marked {
+    const renderer: RendererObject = {
+        code({ text, lang }: Tokens.Code): string {
+            const cls = lang ? ` class="language-${lang}"` : ''
+            return `<div class="highlight"><pre><code${cls}>${escapeHtml(text)}</code></pre></div>`
+        },
+        table(token: Tokens.Table): string {
+            const defaultMarked = new Marked()
+            const defaultTableHtml = defaultMarked.parse(token.raw)
+            return `<div class="table-wrapper">${defaultTableHtml}</div>`
+        },
+    }
+    return new Marked({ renderer })
+}

--- a/src/Elastic.Documentation.Site/Assets/web-components/AskAi/ChatMessage.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/AskAi/ChatMessage.tsx
@@ -2,7 +2,7 @@ import { initCopyButton } from '../../copybutton'
 import { highlightCodeBlocks } from '../../hljs'
 import { ApiError } from '../shared/errorHandling'
 import { useHtmxContainer } from '../shared/htmx/useHtmxContainer'
-import { createMarkdownRenderer } from '../shared/markdownRenderer'
+import { markdownRenderer } from '../shared/markdownRenderer'
 import { AskAiEvent, ChunkEvent, EventTypes } from './AskAiEvent'
 import { aiGradients } from './ElasticAiAssistantButton'
 import { GeneratingStatus } from './GeneratingStatus'
@@ -25,8 +25,6 @@ import {
 import { css } from '@emotion/react'
 import DOMPurify from 'dompurify'
 import { useEffect, useMemo, useRef } from 'react'
-
-const markedInstance = createMarkdownRenderer()
 
 interface ChatMessageProps {
     message: ChatMessageType
@@ -359,7 +357,7 @@ export const ChatMessage = ({
     }, [content, isComplete])
 
     const parsed = useMemo(() => {
-        const html = markedInstance.parse(mainContent) as string
+        const html = markdownRenderer.parse(mainContent, { async: false })
         return DOMPurify.sanitize(html)
     }, [mainContent])
 

--- a/src/Elastic.Documentation.Site/Assets/web-components/AskAi/ChatMessage.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/AskAi/ChatMessage.tsx
@@ -1,8 +1,8 @@
 import { initCopyButton } from '../../copybutton'
 import { highlightCodeBlocks } from '../../hljs'
-import { createDocsMarkedRenderer } from '../../marked-code-renderer'
 import { ApiError } from '../shared/errorHandling'
 import { useHtmxContainer } from '../shared/htmx/useHtmxContainer'
+import { createMarkdownRenderer } from '../shared/markdownRenderer'
 import { AskAiEvent, ChunkEvent, EventTypes } from './AskAiEvent'
 import { aiGradients } from './ElasticAiAssistantButton'
 import { GeneratingStatus } from './GeneratingStatus'
@@ -26,7 +26,7 @@ import { css } from '@emotion/react'
 import DOMPurify from 'dompurify'
 import { useEffect, useMemo, useRef } from 'react'
 
-const markedInstance = createDocsMarkedRenderer()
+const markedInstance = createMarkdownRenderer()
 
 interface ChatMessageProps {
     message: ChatMessageType

--- a/src/Elastic.Documentation.Site/Assets/web-components/AskAi/ChatMessage.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/AskAi/ChatMessage.tsx
@@ -1,5 +1,6 @@
 import { initCopyButton } from '../../copybutton'
-import { hljs } from '../../hljs'
+import { highlightCodeBlocks } from '../../hljs'
+import { createDocsMarkedRenderer } from '../../marked-code-renderer'
 import { ApiError } from '../shared/errorHandling'
 import { useHtmxContainer } from '../shared/htmx/useHtmxContainer'
 import { AskAiEvent, ChunkEvent, EventTypes } from './AskAiEvent'
@@ -23,38 +24,9 @@ import {
 } from '@elastic/eui'
 import { css } from '@emotion/react'
 import DOMPurify from 'dompurify'
-import { Marked, RendererObject, Tokens } from 'marked'
 import { useEffect, useMemo, useRef } from 'react'
 
-// Create the marked instance once globally (renderer never changes)
-const createMarkedInstance = () => {
-    const renderer: RendererObject = {
-        code({ text, lang }: Tokens.Code): string {
-            let highlighted: string
-            try {
-                highlighted = lang
-                    ? hljs.highlight(text, { language: lang }).value
-                    : hljs.highlightAuto(text).value
-            } catch {
-                // Fallback to auto highlighting if the specified language is not found
-                highlighted = hljs.highlightAuto(text).value
-            }
-            return `<div class="highlight">
-                <pre>
-                    <code class="language-${lang}">${highlighted}</code>
-                </pre>
-            </div>`
-        },
-        table(token: Tokens.Table): string {
-            const defaultMarked = new Marked()
-            const defaultTableHtml = defaultMarked.parse(token.raw)
-            return `<div class="table-wrapper">${defaultTableHtml}</div>`
-        },
-    }
-    return new Marked({ renderer })
-}
-
-const markedInstance = createMarkedInstance()
+const markedInstance = createDocsMarkedRenderer()
 
 interface ChatMessageProps {
     message: ChatMessageType
@@ -402,21 +374,26 @@ export const ChatMessage = ({
     const ref = useRef<HTMLDivElement>(null)
 
     useEffect(() => {
-        if (isComplete && ref.current) {
-            const timer = setTimeout(() => {
-                try {
-                    initCopyButton(
-                        '.highlight pre',
-                        ref.current!,
-                        'ai-message-codecell-'
-                    )
-                } catch (error) {
-                    console.error('Failed to initialize copy buttons:', error)
-                }
-            }, 100)
-            return () => clearTimeout(timer)
+        if (!ref.current || !parsed) return
+
+        let cancelled = false
+        void highlightCodeBlocks(ref.current).then(() => {
+            if (cancelled || !isComplete || !ref.current) return
+            try {
+                initCopyButton(
+                    '.highlight pre',
+                    ref.current,
+                    'ai-message-codecell-'
+                )
+            } catch (error) {
+                console.error('Failed to initialize copy buttons:', error)
+            }
+        })
+
+        return () => {
+            cancelled = true
         }
-    }, [isComplete])
+    }, [parsed, isComplete])
 
     // Process internal docs links for htmx navigation
     useHtmxContainer(ref, [parsed])

--- a/src/Elastic.Documentation.Site/Assets/web-components/shared/MarkdownContent.test.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/shared/MarkdownContent.test.tsx
@@ -1,0 +1,40 @@
+import { MarkdownContent } from './MarkdownContent'
+import { EuiProvider } from '@elastic/eui'
+import { render, waitFor } from '@testing-library/react'
+
+jest.mock('../../copybutton', () => ({
+    initCopyButton: jest.fn(),
+}))
+
+const renderMarkdown = (content: string) =>
+    render(
+        <EuiProvider
+            colorMode="light"
+            globalStyles={false}
+            utilityClasses={false}
+        >
+            <MarkdownContent content={content} enableCopyButtons={false} />
+        </EuiProvider>
+    )
+
+describe('MarkdownContent', () => {
+    it('highlights alias fences after mount', async () => {
+        renderMarkdown('```js\nconst x = 1\n```')
+
+        await waitFor(() => {
+            const block = document.querySelector('.markdown-content pre code')
+            expect(block?.getAttribute('data-highlighted')).toBe('yes')
+            expect(block?.className).toContain('language-javascript')
+        })
+    })
+
+    it('autodetects unlabeled fences after mount', async () => {
+        renderMarkdown('```\nconst x = 1\n```')
+
+        await waitFor(() => {
+            const block = document.querySelector('.markdown-content pre code')
+            expect(block?.getAttribute('data-highlighted')).toBe('yes')
+            expect(block?.querySelector('.hljs-keyword')).not.toBeNull()
+        })
+    })
+})

--- a/src/Elastic.Documentation.Site/Assets/web-components/shared/MarkdownContent.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/shared/MarkdownContent.tsx
@@ -1,12 +1,12 @@
 import { initCopyButton } from '../../copybutton'
 import { highlightCodeBlocks } from '../../hljs'
-import { createDocsMarkedRenderer } from '../../marked-code-renderer'
+import { createMarkdownRenderer } from './markdownRenderer'
 import { useEuiTheme } from '@elastic/eui'
 import { css } from '@emotion/react'
 import DOMPurify from 'dompurify'
 import { useEffect, useMemo, useRef } from 'react'
 
-const markedInstance = createDocsMarkedRenderer()
+const markedInstance = createMarkdownRenderer()
 
 interface MarkdownContentProps {
     content: string

--- a/src/Elastic.Documentation.Site/Assets/web-components/shared/MarkdownContent.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/shared/MarkdownContent.tsx
@@ -1,12 +1,10 @@
 import { initCopyButton } from '../../copybutton'
 import { highlightCodeBlocks } from '../../hljs'
-import { createMarkdownRenderer } from './markdownRenderer'
+import { markdownRenderer } from './markdownRenderer'
 import { useEuiTheme } from '@elastic/eui'
 import { css } from '@emotion/react'
 import DOMPurify from 'dompurify'
 import { useEffect, useMemo, useRef } from 'react'
-
-const markedInstance = createMarkdownRenderer()
 
 interface MarkdownContentProps {
     content: string
@@ -23,12 +21,12 @@ export const MarkdownContent = ({
     const ref = useRef<HTMLDivElement>(null)
 
     const parsed = useMemo(() => {
-        const html = markedInstance.parse(content) as string
+        const html = markdownRenderer.parse(content, { async: false })
         return DOMPurify.sanitize(html)
     }, [content])
 
     useEffect(() => {
-        if (!ref.current || !content) return
+        if (!ref.current) return
 
         let cancelled = false
         void highlightCodeBlocks(ref.current).then(() => {
@@ -43,7 +41,7 @@ export const MarkdownContent = ({
         return () => {
             cancelled = true
         }
-    }, [content, enableCopyButtons, copyButtonPrefix, parsed])
+    }, [enableCopyButtons, copyButtonPrefix, parsed])
 
     return (
         <div

--- a/src/Elastic.Documentation.Site/Assets/web-components/shared/MarkdownContent.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/shared/MarkdownContent.tsx
@@ -1,39 +1,12 @@
 import { initCopyButton } from '../../copybutton'
-import { hljs } from '../../hljs'
+import { highlightCodeBlocks } from '../../hljs'
+import { createDocsMarkedRenderer } from '../../marked-code-renderer'
 import { useEuiTheme } from '@elastic/eui'
 import { css } from '@emotion/react'
 import DOMPurify from 'dompurify'
-import { Marked, RendererObject, Tokens } from 'marked'
 import { useEffect, useMemo, useRef } from 'react'
 
-// Create the marked instance once globally
-const createMarkedInstance = () => {
-    const renderer: RendererObject = {
-        code({ text, lang }: Tokens.Code): string {
-            let highlighted: string
-            try {
-                highlighted = lang
-                    ? hljs.highlight(text, { language: lang }).value
-                    : hljs.highlightAuto(text).value
-            } catch {
-                highlighted = hljs.highlightAuto(text).value
-            }
-            return `<div class="highlight">
-                <pre>
-                    <code class="language-${lang}">${highlighted}</code>
-                </pre>
-            </div>`
-        },
-        table(token: Tokens.Table): string {
-            const defaultMarked = new Marked()
-            const defaultTableHtml = defaultMarked.parse(token.raw)
-            return `<div class="table-wrapper">${defaultTableHtml}</div>`
-        },
-    }
-    return new Marked({ renderer })
-}
-
-const markedInstance = createMarkedInstance()
+const markedInstance = createDocsMarkedRenderer()
 
 interface MarkdownContentProps {
     content: string
@@ -55,21 +28,22 @@ export const MarkdownContent = ({
     }, [content])
 
     useEffect(() => {
-        if (enableCopyButtons && ref.current && content) {
-            const timer = setTimeout(() => {
-                try {
-                    initCopyButton(
-                        '.highlight pre',
-                        ref.current!,
-                        copyButtonPrefix
-                    )
-                } catch (error) {
-                    console.error('Failed to initialize copy buttons:', error)
-                }
-            }, 100)
-            return () => clearTimeout(timer)
+        if (!ref.current || !content) return
+
+        let cancelled = false
+        void highlightCodeBlocks(ref.current).then(() => {
+            if (cancelled || !enableCopyButtons || !ref.current) return
+            try {
+                initCopyButton('.highlight pre', ref.current, copyButtonPrefix)
+            } catch (error) {
+                console.error('Failed to initialize copy buttons:', error)
+            }
+        })
+
+        return () => {
+            cancelled = true
         }
-    }, [content, enableCopyButtons, copyButtonPrefix])
+    }, [content, enableCopyButtons, copyButtonPrefix, parsed])
 
     return (
         <div

--- a/src/Elastic.Documentation.Site/Assets/web-components/shared/markdownRenderer.test.ts
+++ b/src/Elastic.Documentation.Site/Assets/web-components/shared/markdownRenderer.test.ts
@@ -1,0 +1,14 @@
+import { markdownRenderer } from './markdownRenderer'
+
+describe('markdownRenderer', () => {
+    it('wraps and escapes fenced code with its language class', () => {
+        const html = markdownRenderer.parse(
+            '```jsx\nconst element = <div>test</div>\n```',
+            { async: false }
+        )
+
+        expect(html).toBe(
+            '<div class="highlight"><pre><code class="language-jsx">const element = &lt;div&gt;test&lt;/div&gt;\n</code></pre>\n</div>'
+        )
+    })
+})

--- a/src/Elastic.Documentation.Site/Assets/web-components/shared/markdownRenderer.ts
+++ b/src/Elastic.Documentation.Site/Assets/web-components/shared/markdownRenderer.ts
@@ -8,7 +8,7 @@ function escapeHtml(text: string): string {
         .replace(/"/g, '&quot;')
 }
 
-export function createDocsMarkedRenderer(): Marked {
+export function createMarkdownRenderer(): Marked {
     const renderer: RendererObject = {
         code({ text, lang }: Tokens.Code): string {
             const cls = lang ? ` class="language-${lang}"` : ''

--- a/src/Elastic.Documentation.Site/Assets/web-components/shared/markdownRenderer.ts
+++ b/src/Elastic.Documentation.Site/Assets/web-components/shared/markdownRenderer.ts
@@ -1,24 +1,14 @@
-import { Marked, RendererObject, Tokens } from 'marked'
+import { Marked, Renderer, RendererObject, Tokens } from 'marked'
 
-function escapeHtml(text: string): string {
-    return text
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
+const defaultRenderer = new Renderer()
+
+const renderer: RendererObject = {
+    code(token: Tokens.Code): string {
+        return `<div class="highlight">${defaultRenderer.code.call(this, token)}</div>`
+    },
+    table(token: Tokens.Table): string {
+        return `<div class="table-wrapper">${defaultRenderer.table.call(this, token)}</div>`
+    },
 }
 
-export function createMarkdownRenderer(): Marked {
-    const renderer: RendererObject = {
-        code({ text, lang }: Tokens.Code): string {
-            const cls = lang ? ` class="language-${lang}"` : ''
-            return `<div class="highlight"><pre><code${cls}>${escapeHtml(text)}</code></pre></div>`
-        },
-        table(token: Tokens.Table): string {
-            const defaultMarked = new Marked()
-            const defaultTableHtml = defaultMarked.parse(token.raw)
-            return `<div class="table-wrapper">${defaultTableHtml}</div>`
-        },
-    }
-    return new Marked({ renderer })
-}
+export const markdownRenderer = new Marked({ renderer })


### PR DESCRIPTION
## What

- Load all curated highlight.js grammars when a page or message contains any code block
- Route static docs and React Markdown through one async DOM highlighter
- Add tests for language aliases (`js`, `ts`, `jsx`) and unlabeled fence autodetection

## Why

- The lazy-load change from #3692 broke alias fences such as `js` and `ts`, and reduced autodetection to only eagerly registered grammars
- Authors and AI responses often use short language names, so blocks stayed uncolored

## Notes

- Pages without code blocks still load zero language chunks
- The first code-bearing page loads all curated grammars once per session, then caches them for later swaps and messages

Made with [Cursor](https://cursor.com)