### PR TITLE
Add Slack failure alerts to prerelease and release workflows

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -144,3 +144,17 @@ jobs:
           gh api repos/elastic/docs-internal-workflows/dispatches \
             -f event_type=docs-builder-prereleased \
             -F client_payload[sha]="$SHA"
+
+  notify-failure:
+    needs: [build, deploy]
+    if: always() && contains(needs.*.result, 'failure')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: elastic/docs-actions/slack/notify-status@v1
+        with:
+          channel: docs-alerts
+          status: failure
+          mention: S028C66K5EX
+          description: Pre-release failed. Edge containers, GitHub Pages, or edge deploy dispatch did not complete.

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -148,7 +148,7 @@ jobs:
   notify-failure:
     needs: [build, deploy]
     if: always() && contains(needs.*.result, 'failure')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -314,3 +314,25 @@ jobs:
           gh api repos/elastic/docs-internal-workflows/dispatches \
             -f event_type=docs-builder-released \
             -F client_payload[tag_name]="$TAG_NAME"
+
+  notify-failure:
+    needs:
+      - release-drafter
+      - containers
+      - build-link-index-lambda
+      - build-changelog-scrubber-lambda
+      - deploy-link-index-updater-lambda-prod
+      - deploy-changelog-scrubber-lambda-prod
+      - release
+      - publish-release
+    if: always() && contains(needs.*.result, 'failure')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: elastic/docs-actions/slack/notify-status@v1
+        with:
+          channel: docs-alerts
+          status: failure
+          mention: S028C66K5EX
+          description: Release failed. Containers, binaries, Lambda deploys, or publish did not complete.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -326,7 +326,7 @@ jobs:
       - release
       - publish-release
     if: always() && contains(needs.*.result, 'failure')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION
## Summary
- Add error-only Slack notifications to `prerelease.yml` and `release.yml` using `elastic/docs-actions/slack/notify-status@v1`
- Route alerts to `docs-alerts` and mention `@docs-engineers` (`S028C66K5EX`)
- Release workflow uses one aggregate alert across all release jobs

## Test plan
- [ ] Confirm a failed prerelease posts one Slack message to `docs-alerts`
- [ ] Confirm a failed release posts one aggregate Slack message
- [ ] Confirm cancelled runs do not notify

Made with [Cursor](https://cursor.com)