### PR TITLE
Bundle highlight.js languages into one async chunk

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/hljs-languages.ts
+++ b/src/Elastic.Documentation.Site/Assets/hljs-languages.ts
@@ -1,0 +1,81 @@
+import esql from '@elastic/highlightjs-esql'
+import { LanguageFn } from 'highlight.js'
+import asciidoc from 'highlight.js/lib/languages/asciidoc'
+import bash from 'highlight.js/lib/languages/bash'
+import c from 'highlight.js/lib/languages/c'
+import csharp from 'highlight.js/lib/languages/csharp'
+import css from 'highlight.js/lib/languages/css'
+import dockerfile from 'highlight.js/lib/languages/dockerfile'
+import dos from 'highlight.js/lib/languages/dos'
+import ebnf from 'highlight.js/lib/languages/ebnf'
+import go from 'highlight.js/lib/languages/go'
+import gradle from 'highlight.js/lib/languages/gradle'
+import groovy from 'highlight.js/lib/languages/groovy'
+import handlebars from 'highlight.js/lib/languages/handlebars'
+import http from 'highlight.js/lib/languages/http'
+import ini from 'highlight.js/lib/languages/ini'
+import java from 'highlight.js/lib/languages/java'
+import javascript from 'highlight.js/lib/languages/javascript'
+import json from 'highlight.js/lib/languages/json'
+import kotlin from 'highlight.js/lib/languages/kotlin'
+import markdown from 'highlight.js/lib/languages/markdown'
+import nginx from 'highlight.js/lib/languages/nginx'
+import php from 'highlight.js/lib/languages/php'
+import plaintext from 'highlight.js/lib/languages/plaintext'
+import powershell from 'highlight.js/lib/languages/powershell'
+import properties from 'highlight.js/lib/languages/properties'
+import python from 'highlight.js/lib/languages/python'
+import ruby from 'highlight.js/lib/languages/ruby'
+import rust from 'highlight.js/lib/languages/rust'
+import scala from 'highlight.js/lib/languages/scala'
+import shell from 'highlight.js/lib/languages/shell'
+import sql from 'highlight.js/lib/languages/sql'
+import swift from 'highlight.js/lib/languages/swift'
+import typescript from 'highlight.js/lib/languages/typescript'
+import xml from 'highlight.js/lib/languages/xml'
+import yaml from 'highlight.js/lib/languages/yaml'
+
+function toLanguageFn(mod: unknown): LanguageFn {
+    const m = mod as { default?: LanguageFn }
+    return (typeof mod === 'function' ? mod : m.default) as LanguageFn
+}
+
+// All curated grammars in one async chunk. Loaded only when a page or message
+// contains code blocks.
+export const languages: Record<string, LanguageFn> = {
+    asciidoc: toLanguageFn(asciidoc),
+    bash: toLanguageFn(bash),
+    c: toLanguageFn(c),
+    csharp: toLanguageFn(csharp),
+    css: toLanguageFn(css),
+    dockerfile: toLanguageFn(dockerfile),
+    dos: toLanguageFn(dos),
+    ebnf: toLanguageFn(ebnf),
+    esql: toLanguageFn(esql),
+    go: toLanguageFn(go),
+    gradle: toLanguageFn(gradle),
+    groovy: toLanguageFn(groovy),
+    handlebars: toLanguageFn(handlebars),
+    http: toLanguageFn(http),
+    ini: toLanguageFn(ini),
+    java: toLanguageFn(java),
+    javascript: toLanguageFn(javascript),
+    json: toLanguageFn(json),
+    kotlin: toLanguageFn(kotlin),
+    markdown: toLanguageFn(markdown),
+    nginx: toLanguageFn(nginx),
+    php: toLanguageFn(php),
+    plaintext: toLanguageFn(plaintext),
+    powershell: toLanguageFn(powershell),
+    properties: toLanguageFn(properties),
+    python: toLanguageFn(python),
+    ruby: toLanguageFn(ruby),
+    rust: toLanguageFn(rust),
+    scala: toLanguageFn(scala),
+    shell: toLanguageFn(shell),
+    sql: toLanguageFn(sql),
+    swift: toLanguageFn(swift),
+    typescript: toLanguageFn(typescript),
+    xml: toLanguageFn(xml),
+    yaml: toLanguageFn(yaml),
+}

--- a/src/Elastic.Documentation.Site/Assets/hljs.ts
+++ b/src/Elastic.Documentation.Site/Assets/hljs.ts
@@ -11,60 +11,6 @@ export function toLanguageFn(mod: unknown): LanguageFn {
     return (typeof mod === 'function' ? mod : m.default) as LanguageFn
 }
 
-// Each entry lazily imports one highlight.js language module (or the esql plugin) so
-// grammars stay out of the entry chunk until a page or message contains code.
-const languageLoaders: Record<string, () => Promise<LanguageFn>> = {
-    asciidoc: () =>
-        import('highlight.js/lib/languages/asciidoc').then(toLanguageFn),
-    bash: () => import('highlight.js/lib/languages/bash').then(toLanguageFn),
-    c: () => import('highlight.js/lib/languages/c').then(toLanguageFn),
-    csharp: () =>
-        import('highlight.js/lib/languages/csharp').then(toLanguageFn),
-    css: () => import('highlight.js/lib/languages/css').then(toLanguageFn),
-    dockerfile: () =>
-        import('highlight.js/lib/languages/dockerfile').then(toLanguageFn),
-    dos: () => import('highlight.js/lib/languages/dos').then(toLanguageFn),
-    ebnf: () => import('highlight.js/lib/languages/ebnf').then(toLanguageFn),
-    esql: () => import('@elastic/highlightjs-esql').then(toLanguageFn),
-    go: () => import('highlight.js/lib/languages/go').then(toLanguageFn),
-    gradle: () =>
-        import('highlight.js/lib/languages/gradle').then(toLanguageFn),
-    groovy: () =>
-        import('highlight.js/lib/languages/groovy').then(toLanguageFn),
-    handlebars: () =>
-        import('highlight.js/lib/languages/handlebars').then(toLanguageFn),
-    http: () => import('highlight.js/lib/languages/http').then(toLanguageFn),
-    ini: () => import('highlight.js/lib/languages/ini').then(toLanguageFn),
-    java: () => import('highlight.js/lib/languages/java').then(toLanguageFn),
-    javascript: () =>
-        import('highlight.js/lib/languages/javascript').then(toLanguageFn),
-    json: () => import('highlight.js/lib/languages/json').then(toLanguageFn),
-    kotlin: () =>
-        import('highlight.js/lib/languages/kotlin').then(toLanguageFn),
-    markdown: () =>
-        import('highlight.js/lib/languages/markdown').then(toLanguageFn),
-    nginx: () => import('highlight.js/lib/languages/nginx').then(toLanguageFn),
-    php: () => import('highlight.js/lib/languages/php').then(toLanguageFn),
-    plaintext: () =>
-        import('highlight.js/lib/languages/plaintext').then(toLanguageFn),
-    powershell: () =>
-        import('highlight.js/lib/languages/powershell').then(toLanguageFn),
-    properties: () =>
-        import('highlight.js/lib/languages/properties').then(toLanguageFn),
-    python: () =>
-        import('highlight.js/lib/languages/python').then(toLanguageFn),
-    ruby: () => import('highlight.js/lib/languages/ruby').then(toLanguageFn),
-    rust: () => import('highlight.js/lib/languages/rust').then(toLanguageFn),
-    scala: () => import('highlight.js/lib/languages/scala').then(toLanguageFn),
-    shell: () => import('highlight.js/lib/languages/shell').then(toLanguageFn),
-    sql: () => import('highlight.js/lib/languages/sql').then(toLanguageFn),
-    swift: () => import('highlight.js/lib/languages/swift').then(toLanguageFn),
-    typescript: () =>
-        import('highlight.js/lib/languages/typescript').then(toLanguageFn),
-    xml: () => import('highlight.js/lib/languages/xml').then(toLanguageFn),
-    yaml: () => import('highlight.js/lib/languages/yaml').then(toLanguageFn),
-}
-
 const CODE_BLOCK_SELECTOR = 'pre code:not([data-highlighted])'
 
 let allLanguagesReady: Promise<void> | null = null
@@ -72,11 +18,10 @@ let allLanguagesReady: Promise<void> | null = null
 function ensureHighlightReady(): Promise<void> {
     if (allLanguagesReady) return allLanguagesReady
 
-    allLanguagesReady = Promise.all(
-        Object.entries(languageLoaders).map(async ([name, loader]) => {
-            hljs.registerLanguage(name, toLanguageFn(await loader()))
-        })
-    ).then(() => {
+    allLanguagesReady = import('./hljs-languages').then(({ languages }) => {
+        for (const [name, languageFn] of Object.entries(languages)) {
+            hljs.registerLanguage(name, languageFn)
+        }
         hljs.registerAliases(['sh'], { languageName: 'shell' })
     })
 


### PR DESCRIPTION
## Why

Pages with code blocks already load every curated highlight.js grammar, but the frontend still issued 35 separate dynamic import requests. That added unnecessary network overhead on code-heavy docs pages without reducing downloaded bytes.

## What

Collapse the curated grammars into a single lazy-loaded Parcel chunk via a new `hljs-languages` module. Highlighting behavior is unchanged: grammars still load only when a page has code blocks, aliases and autodetection still work, and custom languages remain in the main bundle.

Made with [Cursor](https://cursor.com)