### PR TITLE
Move page actions into breadcrumb bar on smaller viewports

### DIFF
--- a/src/Elastic.Markdown/Layout/_Breadcrumbs.cshtml
+++ b/src/Elastic.Markdown/Layout/_Breadcrumbs.cshtml
@@ -1,3 +1,4 @@
+@using Elastic.Documentation.Configuration.Toc
 @inherits RazorSlice<Elastic.Markdown.MarkdownLayoutViewModel>
 @functions {
 	static string StripBadge(string t) =>
@@ -7,27 +8,63 @@
 @{
 	var targets = Model.Breadcrumbs;
 	var crumbs = targets.ToList();
+	var showBreadcrumbs = crumbs.Count > 0 && (crumbs.Count > 1 || Model.BuildType != BuildType.Isolated);
+	var showReportIssue = Model.Features.PrimaryNavEnabled && Model.BuildType != BuildType.Codex && Model.Branding is null;
+	var showEditPage = !string.IsNullOrEmpty(Model.GithubEditUrl);
+	var showVersionDropdown = Model.Features.PrimaryNavEnabled && !Model.VersioningSystem.IsVersionless && Model.BuildType != BuildType.Codex && Model.Branding is null;
+	var hasActions = showReportIssue || showEditPage || showVersionDropdown;
 }
 
-@if (crumbs.Count > 0 && (crumbs.Count > 1 || Model.BuildType != BuildType.Isolated))
-{
-<ol id="breadcrumbs" class="flex flex-wrap gap-1 items-center w-full py-6">
-	@for (var i = 0; i < crumbs.Count; i++)
+<div id="breadcrumb-bar" class="flex flex-wrap-reverse items-center gap-x-4 gap-y-1 pt-4 @(showBreadcrumbs || hasActions ? "pb-2" : "")">
+	@if (showBreadcrumbs)
 	{
-		var item = crumbs[i];
-		<li class="text-ink-light text-sm leading-[1.2em]">
-			<a
-				itemprop="item"
-				href="@item.Url"
-				@(i == 0 ? "hx-disable=true" : "")
-				preload="mousedown">
-				<span class="hover:text-black">@StripBadge(item.NavigationTitle)</span>
-			</a>
-			@if (i < crumbs.Count - 1)
+		<ol id="breadcrumbs" class="flex flex-wrap gap-1 items-center">
+			@for (var i = 0; i < crumbs.Count; i++)
 			{
-				<span class="px-1">/</span>
+				var item = crumbs[i];
+				<li class="text-ink-light text-sm leading-[1.2em]">
+					<a
+						itemprop="item"
+						href="@item.Url"
+						@(i == 0 ? "hx-disable=true" : "")
+						preload="mousedown">
+						<span class="hover:text-black">@StripBadge(item.NavigationTitle)</span>
+					</a>
+					@if (i < crumbs.Count - 1)
+					{
+						<span class="px-1">/</span>
+					}
+				</li>
 			}
-		</li>
+		</ol>
 	}
-</ol>
-}
+	@if (hasActions)
+	{
+		<div class="flex items-center gap-4 ml-auto lg:hidden">
+			@if (showReportIssue)
+			{
+				<a href="@Model.ReportIssueUrl" class="link text-sm whitespace-nowrap" target="_blank">
+					<svg class="link-icon" viewBox="0 0 98 96" xmlns="http://www.w3.org/2000/svg">
+						<path fill-rule="evenodd" clip-rule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" fill="currentColor"/>
+					</svg>
+					Report a docs issue
+				</a>
+			}
+			@if (showEditPage)
+			{
+				<a href="@Model.GithubEditUrl" class="link text-sm whitespace-nowrap @(Model.HideEditThisPage ? "hidden" : string.Empty)" target="_blank">
+					<svg class="link-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+						<path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125"/>
+					</svg>
+					Edit this page
+				</a>
+			}
+			@if (showVersionDropdown)
+			{
+				<version-dropdown all-versions-url="@Model.AllVersionsUrl" current-version='@(Model.CurrentVersion)' items='@(new HtmlString(Model.VersionDropdownSerializedModel))'>
+					<div class="h-8">@*height of dropdown button*@</div>
+				</version-dropdown>
+			}
+		</div>
+	}
+</div>

--- a/src/Elastic.Markdown/Layout/_TableOfContents.cshtml
+++ b/src/Elastic.Markdown/Layout/_TableOfContents.cshtml
@@ -2,21 +2,8 @@
 @using Elastic.Documentation.Svg
 @using Microsoft.AspNetCore.Html
 @inherits RazorSlice<Elastic.Markdown.MarkdownLayoutViewModel>
-<aside class="sidebar md:block w-full lg:max-w-65 order-1 lg:order-2">
-	<nav id="toc-nav" class="sidebar-nav lg:h-full flex flex-row-reverse lg:block items-center justify-between md:justify-start gap-4 pb-3 md:pb-9 simple-scrollbar">
-		@if (Model.Features.PrimaryNavEnabled && !Model.VersioningSystem.IsVersionless && Model.BuildType != BuildType.Codex && Model.Branding is null)
-		{
-			<div class="mt-4">
-				<version-dropdown all-versions-url="@Model.AllVersionsUrl" current-version='@(Model.CurrentVersion)' items='@(new HtmlString(Model.VersionDropdownSerializedModel))'>
-					<div class="h-8">@*height of dropdown button*@</div>
-				</version-dropdown>
-			</div>
-		}
-		else
-		{
-			<div>@* empty placeholder so flebox still works as expected*@</div>
-		}
-
+<aside class="sidebar md:hidden lg:block w-full lg:max-w-65 order-1 lg:order-2">
+	<nav id="toc-nav" class="sidebar-nav lg:h-full lg:block pb-3 md:pb-9 simple-scrollbar">
 		@if (Model.RenderHamburgerIcon)
 		{
 			@* ReSharper disable once Html.IdNotResolved *@
@@ -28,9 +15,17 @@
 				</svg>
 			</label>
 		}
-		
-		<ul class="mt-4 hidden md:flex items-center lg:block gap-4">
-			<li class="view-as-markdown hidden lg:block lg:not-first:mt-1">
+		@if (Model.Features.PrimaryNavEnabled && !Model.VersioningSystem.IsVersionless && Model.BuildType != BuildType.Codex && Model.Branding is null)
+		{
+			<div class="mt-4 hidden lg:block">
+				<version-dropdown all-versions-url="@Model.AllVersionsUrl" current-version='@(Model.CurrentVersion)' items='@(new HtmlString(Model.VersionDropdownSerializedModel))'>
+					<div class="h-8">@*height of dropdown button*@</div>
+				</version-dropdown>
+			</div>
+		}
+
+		<ul class="mt-4 hidden lg:block">
+			<li class="view-as-markdown lg:not-first:mt-1">
 				<a href="@Model.MarkdownUrl" class="link text-sm" target="_blank">
 					<svg class="link-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 -1 24 24">
 						<path fill="currentColor" d="M22.131725 19.247H1.9386225C1.0239525 19.247 0.25 18.47305 0.25 17.558375v-11.11675c0 -0.914675 0.7739525 -1.688625 1.6886225 -1.688625H22.061375c0.914675 0 1.688625 0.77395 1.688625 1.688625v11.11675c0 0.914675 -0.7036 1.688625 -1.618275 1.688625ZM1.9386225 5.87875c-0.2814375 0 -0.562875 0.281425 -0.562875 0.562875v11.11675c0 0.3518 0.2814375 0.562875 0.562875 0.562875H22.061375c0.3518 0 0.562875 -0.281425 0.562875 -0.562875v-11.11675c0 -0.3518 -0.281425 -0.562875 -0.562875 -0.562875l-20.1227525 0ZM3.62725 15.86975V8.130225h2.2515l2.2515 2.814375 2.251475 -2.814375h2.2515V15.86975h-2.2515V11.437125L8.13025 14.2515l-2.2515 -2.814375V15.86975h-2.2515Zm14.1422 0L14.392225 12.140725h2.251475v-4.0105h2.2515v3.940125h2.2515L17.76945 15.86975Z" stroke-width="0.25"></path>
@@ -62,7 +57,7 @@
 			}
 			@if (Model.Features.PrimaryNavEnabled && Model.BuildType != BuildType.Codex && Model.Branding is null)
 			{
-				<li class="learn-how-to-contribute hidden lg:block lg:not-first:mt-1">
+				<li class="learn-how-to-contribute lg:not-first:mt-1">
 					<a href="https://www.elastic.co/docs/contribute-docs/" class="link text-sm" target="_blank">
 						<svg class="link-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
 							<path fill="currentColor" d="M8.8,0 C9.074,0 9.337,0.113 9.526,0.312 L12.726,3.74 C12.902,3.926 13,4.173 13,4.429 L13,13 C13,13.552 12.552,14 12,14 L2,14 C1.448,14 1,13.552 1,13 L1,1 C1,0.448 1.448,0 2,0 L8.8,0 Z M12,5 L8.5,5 C8.224,5 8,4.776 8,4.5 L8,1 L2,1 L2,13 L12,13 L12,5 Z M4.5,11 C4.22385763,11 4,10.7761424 4,10.5 C4,10.2238576 4.22385763,10 4.5,10 L9.5,10 C9.7761424,10 10,10.2238576 10,10.5 C10,10.7761424 9.7761424,11 9.5,11 L4.5,11 Z M4.5,8 C4.22385763,8 4,7.77614237 4,7.5 C4,7.22385763 4.22385763,7 4.5,7 L9.5,7 C9.7761424,7 10,7.22385763 10,7.5 C10,7.77614237 9.7761424,8 9.5,8 L4.5,8 Z M5.5,16 C5.22385763,16 5,15.7761424 5,15.5 C5,15.2238576 5.22385763,15 5.5,15 L14,15 L14,6.5 C14,6.22385763 14.2238576,6 14.5,6 C14.7761424,6 15,6.22385763 15,6.5 L15,15 C15,15.5522847 14.5522847,16 14,16 L5.5,16 Z"/>

--- a/src/Elastic.Markdown/_Layout.cshtml
+++ b/src/Elastic.Markdown/_Layout.cshtml
@@ -35,12 +35,8 @@
 						md:px-4
 			">
 				<div class="min-h-screen grid grid-cols-1 md:grid-cols-[var(--max-sidebar-width)_1fr] gap-4">
-					<main id="content-container" class="min-w-0 flex flex-col lg:grid lg:grid-cols-[minmax(0,var(--max-text-width))_minmax(0,var(--max-sidebar-width))] justify-end mx-4 gap-4 md:col-start-2 md:row-start-1">
-						@{
-							var breadcrumbs = Model.Breadcrumbs.ToList();
-							var breadcrumbVisible = breadcrumbs.Count > 0 && (breadcrumbs.Count > 1 || Model.BuildType != BuildType.Isolated);
-						}
-						<div class="mb-9 mt-0 min-w-0 order-2 lg:order-1 @(breadcrumbVisible ? "" : "pt-6")">
+					<main id="content-container" class="min-w-0 flex flex-col lg:grid lg:grid-cols-[minmax(0,var(--max-text-width))_minmax(0,var(--max-sidebar-width))] lg:justify-end mx-4 gap-4 md:col-start-2 md:row-start-1">
+						<div class="mb-9 mt-0 min-w-0 order-2 lg:order-1">
 							@await RenderPartialAsync(_Breadcrumbs.Create(Model))
 							<article id="markdown-content" class="markdown-content min-w-0">
 								<input type="checkbox" class="hidden" id="pages-nav-hamburger">


### PR DESCRIPTION
## Why

On medium and smaller viewports the right sidebar (TOC column) is hidden, but the page action links ("Report a docs issue", "Edit this page", version dropdown) were still rendered inside it — either invisible or pushing content down with empty block space. Short-content pages looked especially broken with large gaps above the heading.

## What

The breadcrumb bar now includes the page actions on non-lg screens, right-aligned via `ml-auto` and using `flex-wrap-reverse` so actions sit above breadcrumbs when the row wraps. On lg+ the actions remain in the right sidebar as before — no duplication thanks to paired `lg:hidden` / `hidden lg:block` classes.

Also scopes `justify-end` on the main content container to `lg:` only, fixing a layout issue where content was pushed to the bottom of the flex-col container on medium viewports.

## Before


https://github.com/user-attachments/assets/581d0276-7bda-49f7-b7d8-42d9cf6d0099

## After


https://github.com/user-attachments/assets/77c873f1-daba-4c04-aa3c-a1e52e87cb18



Made with [Cursor](https://cursor.com)