### PR TITLE
Fix speculative build matching for CD-workflow repositories

### DIFF
--- a/src/Elastic.Documentation.Configuration/Assembler/AssemblyConfiguration.cs
+++ b/src/Elastic.Documentation.Configuration/Assembler/AssemblyConfiguration.cs
@@ -169,7 +169,9 @@ public record AssemblyConfiguration
 		var current = r.GetBranch(ContentSource.Current);
 		var next = r.GetBranch(ContentSource.Next);
 		var edge = r.GetBranch(ContentSource.Edge);
-		logger.LogInformation("Active content-sources for {Repository}. current: {Current}, next: {Next}, edge: {Edge}' ", repository, current, next, edge);
+		var isCdWorkflow = current == next && next == edge;
+		logger.LogInformation("Active content-sources for {Repository}. current: {Current}, next: {Next}, edge: {Edge} (branching strategy: {Strategy})",
+			repository, current, next, edge, isCdWorkflow ? "cd/continuous-deployment" : "tagged-release");
 		if (current == branchOrTag)
 		{
 			logger.LogInformation("Content-Source current: {Current} matches: {Branch}", current, branchOrTag);

--- a/src/services/Elastic.Documentation.Assembler/ContentSources/RepositoryBuildMatchingService.cs
+++ b/src/services/Elastic.Documentation.Assembler/ContentSources/RepositoryBuildMatchingService.cs
@@ -62,11 +62,15 @@ public class RepositoryBuildMatchingService(
 		if (string.IsNullOrEmpty(refName))
 			throw new ArgumentNullException(nameof(branchOrTag));
 
+		// the link registry uses short repository names (e.g. "kibana"), not full names (e.g. "elastic/kibana")
+		var repoTokens = repo.Split('/');
+		var repositoryName = repoTokens.Last();
+
 		// environment does not matter to check the configuration, defaulting to dev
 		var linkIndexProvider = Aws3LinkIndexReader.CreateAnonymous();
 		var linkRegistry = await GetRegistryWithRetry(linkIndexProvider, ctx);
-		var alreadyPublishing = linkRegistry.Repositories.ContainsKey(repo);
-		_logger.LogInformation("'{Repository}' publishing to link registry: {PublishState} ", repo, alreadyPublishing);
+		var alreadyPublishing = linkRegistry.Repositories.ContainsKey(repositoryName);
+		_logger.LogInformation("'{Repository}' (registry key: '{RepositoryName}') publishing to link registry: {PublishState} ", repo, repositoryName, alreadyPublishing);
 		var assembleContext = new AssembleContext(configuration, configurationContext, "dev", collector, fileSystem, fileSystem, null, null);
 		var product = assembleContext.ProductsConfiguration.GetProductByRepositoryName(repo);
 		var matches = assembleContext.Configuration.Match(logFactory, repo, refName, product, alreadyPublishing);


### PR DESCRIPTION
## Why

Repositories using the CD (continuous deployment) branching strategy — where `current`, `next`, and `edge` all point to `main` — were incorrectly getting speculative builds triggered for version branches like `9.5`.

We already had logic to prevent this: the `Match` method checks whether a repo is "already publishing" to the link registry, and if so, skips speculative builds for version branches on CD-workflow repos. The guard was correct, but a key-format mismatch in the caller silently defeated it.

Surfaced via: https://github.com/elastic/kibana/actions/runs/30279228305/job/90021040764#step:5:1

Kibana is configured as a CD-workflow repo (`current = next = edge = main`), yet branch `9.5` matched as a speculative build because the `alreadyPublishing` flag was always `false`.

## What

The link registry uses **short** repository names as keys (e.g. `"kibana"`), but the matching service was looking up the **full** GitHub name (e.g. `"elastic/kibana"`). `ContainsKey` silently returned `false`, so every repository appeared "not yet publishing" — bypassing the guard that blocks speculative builds for CD-workflow repos that are already in the registry.

Both `Match()` and `GetProductByRepositoryName()` already split the full name and use the short form. The registry lookup was the one place that didn't.

The fix extracts the short repository name before the lookup and adds logging for:
- The registry key actually used (so this kind of mismatch is immediately visible)
- The detected branching strategy (`cd/continuous-deployment` vs `tagged-release`)

Made with [Cursor](https://cursor.com)