### PR TITLE
Add changelog registry reconcile and verify commands

### DIFF
--- a/docs/cli-schema.json
+++ b/docs/cli-schema.json
@@ -4433,7 +4433,230 @@
           ]
         }
       ],
-      "namespaces": []
+      "namespaces": [
+        {
+          "segment": "registry",
+          "summary": "Operate on the scrubber-owned public changelog registries.",
+          "options": [],
+          "commands": [
+            {
+              "path": [
+                "changelog",
+                "registry"
+              ],
+              "name": "reconcile",
+              "summary": "Send explicit reconcile messages to the scrubber queue so the Lambda performs a full group heal (object-level reconcile over the union of both buckets, then a registry rebuild from public state) for every planned group. This command never mutates S3 itself \u2014 the scrubber Lambda stays the public bucket\u0027s single writer. Convergent: re-running re-plans against current state. Enqueuing is not reconciling \u2014 gate on \u0060changelog registry verify\u0060 after the queue drains and the DLQ is empty.",
+              "usage": "docs-builder changelog registry reconcile --s3-bucket-name \u003Cstring\u003E --public-s3-bucket-name \u003Cstring\u003E --queue-url \u003Cstring\u003E [options]",
+              "examples": [],
+              "parameters": [
+                {
+                  "role": "flag",
+                  "name": "s3-bucket-name",
+                  "type": "string",
+                  "required": true,
+                  "summary": "Private changelog bundles bucket to plan from."
+                },
+                {
+                  "role": "flag",
+                  "name": "public-s3-bucket-name",
+                  "type": "string",
+                  "required": true,
+                  "summary": "Public (CDN) changelog bundles bucket to plan from."
+                },
+                {
+                  "role": "flag",
+                  "name": "queue-url",
+                  "type": "string",
+                  "required": true,
+                  "summary": "URL of the scrubber SQS queue to send reconcile messages to."
+                },
+                {
+                  "role": "flag",
+                  "name": "product",
+                  "type": "string",
+                  "required": false,
+                  "summary": "Only reconcile this bundle group (bundle/{product}/). Mutually exclusive with --owner/--repo/--branch."
+                },
+                {
+                  "role": "flag",
+                  "name": "owner",
+                  "type": "string",
+                  "required": false,
+                  "summary": "GitHub owner of a single changelog-pool group to reconcile."
+                },
+                {
+                  "role": "flag",
+                  "name": "repo",
+                  "type": "string",
+                  "required": false,
+                  "summary": "Repository of a single changelog-pool group to reconcile."
+                },
+                {
+                  "role": "flag",
+                  "name": "branch",
+                  "type": "string",
+                  "required": false,
+                  "summary": "Branch of a single changelog-pool group to reconcile (verbatim; slashes allowed)."
+                },
+                {
+                  "role": "dryRun",
+                  "name": "dry-run",
+                  "type": "boolean",
+                  "required": false,
+                  "summary": "Print the group plan without sending anything.",
+                  "defaultValue": "false"
+                },
+                {
+                  "role": "flag",
+                  "name": "yes",
+                  "type": "boolean",
+                  "required": false,
+                  "summary": "Skip the interactive confirmation (required when stdin is not a terminal).",
+                  "defaultValue": "false"
+                },
+                {
+                  "role": "flag",
+                  "name": "log-level",
+                  "shortName": "l",
+                  "type": "enum",
+                  "required": false,
+                  "summary": "Minimum log level. Default: information",
+                  "enumValues": [
+                    "trace",
+                    "debug",
+                    "information",
+                    "warning",
+                    "error",
+                    "critical",
+                    "none"
+                  ]
+                },
+                {
+                  "role": "flag",
+                  "name": "config-source",
+                  "shortName": "c",
+                  "type": "enum",
+                  "required": false,
+                  "summary": "Override the configuration source: local, remote",
+                  "enumValues": [
+                    "local",
+                    "remote",
+                    "embedded"
+                  ]
+                },
+                {
+                  "role": "flag",
+                  "name": "skip-private-repositories",
+                  "type": "boolean",
+                  "required": false,
+                  "summary": "Skip cloning private repositories"
+                }
+              ],
+              "intent": {
+                "destructive": true,
+                "idempotent": true,
+                "scope": "global",
+                "requiresAuth": true
+              }
+            },
+            {
+              "path": [
+                "changelog",
+                "registry"
+              ],
+              "name": "verify",
+              "summary": "Compare each planned group\u0027s public registry.json against what a reconcile of the current public listing would write, and report divergence (missing, stale, corrupt, object-divergent; unsupported schema reported distinctly). Strictly read-only. Zero divergence across the plan is the cutover completion gate \u2014 and the standing drift-diagnosis tool afterwards.",
+              "usage": "docs-builder changelog registry verify --s3-bucket-name \u003Cstring\u003E --public-s3-bucket-name \u003Cstring\u003E [options]",
+              "examples": [],
+              "parameters": [
+                {
+                  "role": "flag",
+                  "name": "s3-bucket-name",
+                  "type": "string",
+                  "required": true,
+                  "summary": "Private changelog bundles bucket to plan from."
+                },
+                {
+                  "role": "flag",
+                  "name": "public-s3-bucket-name",
+                  "type": "string",
+                  "required": true,
+                  "summary": "Public (CDN) changelog bundles bucket to verify."
+                },
+                {
+                  "role": "flag",
+                  "name": "product",
+                  "type": "string",
+                  "required": false,
+                  "summary": "Only verify this bundle group (bundle/{product}/). Mutually exclusive with --owner/--repo/--branch."
+                },
+                {
+                  "role": "flag",
+                  "name": "owner",
+                  "type": "string",
+                  "required": false,
+                  "summary": "GitHub owner of a single changelog-pool group to verify."
+                },
+                {
+                  "role": "flag",
+                  "name": "repo",
+                  "type": "string",
+                  "required": false,
+                  "summary": "Repository of a single changelog-pool group to verify."
+                },
+                {
+                  "role": "flag",
+                  "name": "branch",
+                  "type": "string",
+                  "required": false,
+                  "summary": "Branch of a single changelog-pool group to verify (verbatim; slashes allowed)."
+                },
+                {
+                  "role": "flag",
+                  "name": "log-level",
+                  "shortName": "l",
+                  "type": "enum",
+                  "required": false,
+                  "summary": "Minimum log level. Default: information",
+                  "enumValues": [
+                    "trace",
+                    "debug",
+                    "information",
+                    "warning",
+                    "error",
+                    "critical",
+                    "none"
+                  ]
+                },
+                {
+                  "role": "flag",
+                  "name": "config-source",
+                  "shortName": "c",
+                  "type": "enum",
+                  "required": false,
+                  "summary": "Override the configuration source: local, remote",
+                  "enumValues": [
+                    "local",
+                    "remote",
+                    "embedded"
+                  ]
+                },
+                {
+                  "role": "flag",
+                  "name": "skip-private-repositories",
+                  "type": "boolean",
+                  "required": false,
+                  "summary": "Skip cloning private repositories"
+                }
+              ],
+              "intent": {
+                "requiresAuth": true
+              }
+            }
+          ],
+          "namespaces": []
+        }
+      ]
     },
     {
       "segment": "codex",

--- a/docs/cli/changelog/registry/cmd-reconcile.md
+++ b/docs/cli/changelog/registry/cmd-reconcile.md
@@ -1,0 +1,31 @@
+## Description
+
+Sends one explicit reconcile message per planned group to the scrubber queue. For each message the Lambda performs a **full group heal**: an object-level reconcile over the union of both buckets' listings (scrub and copy whatever is live in the private bucket, delete public objects nothing backs), then a rebuild of the group's public `registry.json` from the public listing. This recovers drift that no pending S3 event would ever repair — lost or DLQ-expired scrub events, ad-hoc uploads, orphaned public objects.
+
+Without a scope filter, the plan is the union of groups discovered in **both** buckets, so orphan public groups (including groups that only have a leftover manifest) are covered. Use `--product`, or `--owner`/`--repo`/`--branch` together, to reconcile a single group.
+
+The command is convergent: re-running it re-plans against current state and the Lambda's writes are conditional, so overlapping runs cannot corrupt a manifest. It is also deliberately indirect — the CLI only sends queue messages, keeping the scrubber Lambda the sole writer of the public bucket.
+
+Every run stamps one correlation id on all its messages and prints a ledger line per group (`group`, SQS `message-id`, `correlation-id`). **Enqueuing is not reconciling**: after a run, watch the queue drain (oldest-message-age ≈ 0), triage anything that reaches the DLQ, and gate on [](/cli/changelog/registry/verify.md) reporting zero divergence.
+
+## Examples
+
+Preview the full plan without sending anything:
+
+```bash
+docs-builder changelog registry reconcile \
+  --s3-bucket-name elastic-docs-v3-changelog-bundles-private \
+  --public-s3-bucket-name elastic-docs-v3-changelog-bundles \
+  --queue-url https://sqs.us-east-1.amazonaws.com/<account>/elastic-docs-v3-changelog-scrub-queue \
+  --dry-run
+```
+
+Reconcile a single product's bundle registry non-interactively:
+
+```bash
+docs-builder changelog registry reconcile \
+  --s3-bucket-name elastic-docs-v3-changelog-bundles-private \
+  --public-s3-bucket-name elastic-docs-v3-changelog-bundles \
+  --queue-url https://sqs.us-east-1.amazonaws.com/<account>/elastic-docs-v3-changelog-scrub-queue \
+  --product elasticsearch --yes
+```

--- a/docs/cli/changelog/registry/cmd-verify.md
+++ b/docs/cli/changelog/registry/cmd-verify.md
@@ -1,0 +1,21 @@
+## Description
+
+Read-only drift diagnosis: for every planned group, compares the public `registry.json` against what a reconcile of the current public listing would write — the exact same listing spec and entry rules the scrubber Lambda uses — and reports each divergence:
+
+| Kind | Meaning |
+|---|---|
+| `Missing` | A public object (or the manifest itself) the registry should describe but doesn't. |
+| `Stale` | A manifest entry (or whole manifest) describing something no longer in the bucket, or manifest metadata a reconcile would rewrite. |
+| `Corrupt` | The manifest exists but cannot be parsed. |
+| `ObjectDivergent` | File present on both sides, but the recorded ETag or target disagrees with the object. |
+| `UnsupportedSchema` | The manifest declares a newer `schema_version` than this tool understands. Reported distinctly and never rewritten. |
+
+The command exits non-zero when any group diverges. Zero divergence across the plan is the completion gate after a [](/cli/changelog/registry/reconcile.md) run — and the standing way to answer "is the registry trustworthy right now?".
+
+## Examples
+
+```bash
+docs-builder changelog registry verify \
+  --s3-bucket-name elastic-docs-v3-changelog-bundles-private \
+  --public-s3-bucket-name elastic-docs-v3-changelog-bundles
+```

--- a/docs/cli/changelog/registry/index.md
+++ b/docs/cli/changelog/registry/index.md
@@ -1,0 +1,3 @@
+Operate on the public changelog bundle registries owned by the scrubber Lambda.
+
+Each group of published changelog artifacts — `bundle/{product}/` or `changelog/{org}/{repo}/{branch}/` — carries a `registry.json` manifest in the **public** bucket, produced exclusively by the scrubber Lambda from the bucket's actual state. These commands are the operator surface for that machinery: `reconcile` asks the Lambda to converge groups (via explicit queue messages — the CLI never writes to S3 itself), and `verify` reports, read-only, whether each public manifest matches its public listing.

--- a/src/infra/docs-lambda-changelog-scrubber/Program.cs
+++ b/src/infra/docs-lambda-changelog-scrubber/Program.cs
@@ -17,6 +17,10 @@ using Elastic.Documentation.Lambda.ChangelogScrubber;
 var publicBucketName = Environment.GetEnvironmentVariable("PUBLIC_BUCKET_NAME")
 	?? throw new InvalidOperationException("PUBLIC_BUCKET_NAME environment variable is required");
 
+// Optional: only explicit reconcile messages (full group heals) need to list the private bucket
+// by name — S3 events carry their source bucket. Without it, reconcile messages are rejected.
+var privateBucketName = Environment.GetEnvironmentVariable("PRIVATE_BUCKET_NAME");
+
 var allowRepos = BuildAllowlist();
 
 await LambdaBootstrapBuilder
@@ -55,7 +59,7 @@ async Task<SQSBatchResponse> Handler(SQSEvent ev, ILambdaContext context)
 	var metrics = new ReconcileMetrics();
 	var scrubber = new ChangelogContentScrubber(logFactory, allowRepos);
 	var reconciler = new RegistryReconciler(logFactory, s3Client, publicBucketName, metrics: metrics);
-	var processor = new ScrubberProcessor(logFactory, s3Client, publicBucketName, scrubber, reconciler, metrics);
+	var processor = new ScrubberProcessor(logFactory, s3Client, publicBucketName, scrubber, reconciler, metrics, privateBucketName);
 
 	var messages = ev.Records.Select(r => new ScrubberQueueMessage(r.MessageId, r.Body)).ToList();
 	var failedIds = await processor.ProcessAsync(messages, CancellationToken.None);

--- a/src/services/Elastic.Changelog/Elastic.Changelog.csproj
+++ b/src/services/Elastic.Changelog/Elastic.Changelog.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AWSSDK.SQS" />
     <PackageReference Include="GitHub.Actions.Core" />
     <PackageReference Include="NetEscapades.EnumGenerators" />
     <PackageReference Include="Vecc.YamlDotNet.Analyzers.StaticGenerator" />

--- a/src/services/Elastic.Changelog/Reconciliation/ChangelogGroupDiscovery.cs
+++ b/src/services/Elastic.Changelog/Reconciliation/ChangelogGroupDiscovery.cs
@@ -1,0 +1,66 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Amazon.S3;
+using Amazon.S3.Model;
+using Elastic.Documentation.Configuration.ReleaseNotes;
+
+namespace Elastic.Changelog.Reconciliation;
+
+/// <summary>
+/// Enumerates every registry group present in a bucket by walking the <c>bundle/</c> and
+/// <c>changelog/</c> prefixes and deriving each key's scope. Registry keys count too, so a group
+/// that only has an orphaned manifest left is still planned (its reconcile deletes the manifest).
+/// The reconcile/verify planners union this across both buckets so orphan public groups are
+/// covered as well.
+/// </summary>
+public static class ChangelogGroupDiscovery
+{
+	/// <summary>Every scope with at least one key in <paramref name="bucketName"/>, keyed by prefix.</summary>
+	public static async Task<IReadOnlyDictionary<string, ChangelogScope>> DiscoverGroupsAsync(
+		IAmazonS3 s3Client,
+		string bucketName,
+		Cancel ctx)
+	{
+		var scopes = new Dictionary<string, ChangelogScope>(StringComparer.Ordinal);
+		foreach (var prefix in new[] { ChangelogKeys.BundlePrefix, ChangelogKeys.ChangelogPrefix })
+		{
+			var request = new ListObjectsV2Request
+			{
+				BucketName = bucketName,
+				Prefix = prefix
+			};
+
+			ListObjectsV2Response response;
+			do
+			{
+				response = await s3Client.ListObjectsV2Async(request, ctx);
+				foreach (var obj in response.S3Objects ?? [])
+				{
+					if (ChangelogScope.TryFromKey(obj.Key, out var scope))
+						_ = scopes.TryAdd(scope.Prefix, scope);
+				}
+				request.ContinuationToken = response.NextContinuationToken;
+			} while (response.IsTruncated == true);
+		}
+
+		return scopes;
+	}
+
+	/// <summary>The union of both buckets' groups, ordered by prefix for a stable plan.</summary>
+	public static async Task<IReadOnlyList<ChangelogScope>> DiscoverUnionAsync(
+		IAmazonS3 s3Client,
+		string privateBucketName,
+		string publicBucketName,
+		Cancel ctx)
+	{
+		var union = new Dictionary<string, ChangelogScope>(StringComparer.Ordinal);
+		foreach (var (prefix, scope) in await DiscoverGroupsAsync(s3Client, privateBucketName, ctx))
+			_ = union.TryAdd(prefix, scope);
+		foreach (var (prefix, scope) in await DiscoverGroupsAsync(s3Client, publicBucketName, ctx))
+			_ = union.TryAdd(prefix, scope);
+
+		return [.. union.Values.OrderBy(s => s.Prefix, StringComparer.Ordinal)];
+	}
+}

--- a/src/services/Elastic.Changelog/Reconciliation/ChangelogRegistryArguments.cs
+++ b/src/services/Elastic.Changelog/Reconciliation/ChangelogRegistryArguments.cs
@@ -1,0 +1,88 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Documentation.Diagnostics;
+
+namespace Elastic.Changelog.Reconciliation;
+
+/// <summary>
+/// Scope selection shared by the registry commands: with no filter the plan covers every group
+/// discovered in the union of both buckets; a bundle scope is addressed by <see cref="Product"/>,
+/// a changelog-pool scope by <see cref="Owner"/>/<see cref="Repo"/>/<see cref="Branch"/>.
+/// </summary>
+public record ChangelogRegistryScopeArguments
+{
+	/// <summary>Product of a bundle scope (<c>bundle/{product}/</c>). Mutually exclusive with the owner/repo/branch form.</summary>
+	public string? Product { get; init; }
+
+	/// <summary>GitHub owner of a changelog-pool scope (<c>changelog/{org}/{repo}/{branch}/</c>).</summary>
+	public string? Owner { get; init; }
+
+	/// <summary>Repository of a changelog-pool scope.</summary>
+	public string? Repo { get; init; }
+
+	/// <summary>Branch of a changelog-pool scope (verbatim; slashes become key segments).</summary>
+	public string? Branch { get; init; }
+
+	/// <summary>The private changelog bundles bucket.</summary>
+	public required string S3BucketName { get; init; }
+
+	/// <summary>The scrubber-owned public bucket.</summary>
+	public required string PublicS3BucketName { get; init; }
+
+	/// <summary>
+	/// Resolves the optional scope filter. True with a null <paramref name="scope"/> when no
+	/// filter was given (plan every discovered group); false with an error when both forms are
+	/// mixed or a segment fails validation.
+	/// </summary>
+	public bool TryResolveScopeFilter(IDiagnosticsCollector collector, out ChangelogScope? scope)
+	{
+		scope = null;
+		var hasProduct = !string.IsNullOrWhiteSpace(Product);
+		var hasPool = !string.IsNullOrWhiteSpace(Owner) || !string.IsNullOrWhiteSpace(Repo) || !string.IsNullOrWhiteSpace(Branch);
+
+		if (!hasProduct && !hasPool)
+			return true;
+
+		if (hasProduct && hasPool)
+		{
+			collector.EmitError(string.Empty,
+				"Specify at most one scope: --product for a bundle scope, or --owner, --repo, and --branch together for a changelog scope.");
+			return false;
+		}
+
+		if (hasProduct)
+		{
+			if (ChangelogScope.TryCreateBundle(Product, out scope))
+				return true;
+
+			collector.EmitError(string.Empty, $"Invalid product \"{Product}\" (must match [a-zA-Z0-9_-]+).");
+			return false;
+		}
+
+		if (ChangelogScope.TryCreateChangelog(Owner, Repo, Branch, out scope))
+			return true;
+
+		collector.EmitError(string.Empty,
+			$"Invalid changelog scope \"{Owner ?? "<none>"}/{Repo ?? "<none>"}/{Branch ?? "<none>"}\": " +
+			"--owner, --repo, and --branch are all required and each segment must be a valid key segment.");
+		return false;
+	}
+}
+
+/// <summary>Arguments for <see cref="ChangelogRegistryReconcileService.Reconcile"/>.</summary>
+public sealed record ChangelogRegistryReconcileArguments : ChangelogRegistryScopeArguments
+{
+	/// <summary>URL of the scrubber SQS queue the reconcile messages are sent to.</summary>
+	public required string QueueUrl { get; init; }
+
+	/// <summary>Print the group plan without sending anything.</summary>
+	public bool DryRun { get; init; }
+
+	/// <summary>Skip the interactive confirmation (required in non-interactive contexts).</summary>
+	public bool AssumeYes { get; init; }
+}
+
+/// <summary>Arguments for <see cref="ChangelogRegistryVerifyService.Verify"/>.</summary>
+public sealed record ChangelogRegistryVerifyArguments : ChangelogRegistryScopeArguments;

--- a/src/services/Elastic.Changelog/Reconciliation/ChangelogRegistryReconcileService.cs
+++ b/src/services/Elastic.Changelog/Reconciliation/ChangelogRegistryReconcileService.cs
@@ -1,0 +1,108 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Amazon.S3;
+using Amazon.SQS;
+using Amazon.SQS.Model;
+using Elastic.Documentation.Diagnostics;
+using Elastic.Documentation.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Elastic.Changelog.Reconciliation;
+
+/// <summary>
+/// The cutover/heal entry point of elastic/docs-eng-team#688 Phase 2: plans the affected groups
+/// (one scope, or the union of both buckets' groups so orphan public groups are covered) and
+/// sends one explicit, versioned reconcile message per group to the scrubber queue. The Lambda
+/// does the actual work — this command never mutates S3 itself, which keeps the single-writer
+/// invariant intact. Convergent by design: re-running re-plans against current state.
+/// </summary>
+public sealed class ChangelogRegistryReconcileService(
+	ILoggerFactory logFactory,
+	IAmazonS3? s3Client = null,
+	IAmazonSQS? sqsClient = null,
+	Func<string?>? confirmationReader = null
+) : IService
+{
+	private readonly ILogger _logger = logFactory.CreateLogger<ChangelogRegistryReconcileService>();
+
+	public async Task<bool> Reconcile(IDiagnosticsCollector collector, ChangelogRegistryReconcileArguments args, Cancel ctx)
+	{
+		if (!args.TryResolveScopeFilter(collector, out var filter))
+			return false;
+
+		using var defaultS3 = s3Client is null ? new AmazonS3Client() : null;
+		var s3 = s3Client ?? defaultS3!;
+
+		var plan = filter is not null
+			? [filter]
+			: await ChangelogGroupDiscovery.DiscoverUnionAsync(s3, args.S3BucketName, args.PublicS3BucketName, ctx);
+
+		if (plan.Count == 0)
+		{
+			_logger.LogInformation("No registry groups found in {Private} or {Public}; nothing to reconcile", args.S3BucketName, args.PublicS3BucketName);
+			return true;
+		}
+
+		_logger.LogInformation("Reconcile plan: {Count} group(s)", plan.Count);
+		foreach (var scope in plan)
+			_logger.LogInformation("  {Kind,-9} {Group}", scope.Kind == ChangelogScopeKind.Bundle ? "bundle" : "changelog", scope.Group);
+
+		if (args.DryRun)
+		{
+			_logger.LogInformation("[dry-run] Would send {Count} reconcile message(s) to {QueueUrl}", plan.Count, args.QueueUrl);
+			return true;
+		}
+
+		if (!args.AssumeYes && !Confirm(plan.Count, collector))
+			return false;
+
+		// One correlation id per run ties every ledger line to this invocation; the cutover
+		// checkpoint replays this ledger through `registry verify`.
+		var correlationId = Guid.NewGuid().ToString("N");
+		using var defaultSqs = sqsClient is null ? new AmazonSQSClient() : null;
+		var sqs = sqsClient ?? defaultSqs!;
+
+		var sent = 0;
+		foreach (var scope in plan)
+		{
+			ctx.ThrowIfCancellationRequested();
+
+			var message = ReconcileQueueMessage.For(scope, correlationId);
+			var response = await sqs.SendMessageAsync(new SendMessageRequest
+			{
+				QueueUrl = args.QueueUrl,
+				MessageBody = message.ToJson()
+			}, ctx);
+			sent++;
+			_logger.LogInformation(
+				"ledger: group={Group} scope={Scope} message-id={MessageId} correlation-id={CorrelationId}",
+				scope.Group, message.Scope, response.MessageId, correlationId);
+		}
+
+		_logger.LogInformation(
+			"Sent {Sent} reconcile message(s) (correlation-id {CorrelationId}). Enqueuing is not reconciling: " +
+			"watch the queue drain, triage any DLQ entry, then gate on `changelog registry verify`.",
+			sent, correlationId);
+		return true;
+	}
+
+	private bool Confirm(int groupCount, IDiagnosticsCollector collector)
+	{
+		if (confirmationReader is null && Console.IsInputRedirected)
+		{
+			collector.EmitError(string.Empty,
+				"Refusing to send reconcile messages without confirmation in a non-interactive session; re-run with --yes (or --dry-run to preview).");
+			return false;
+		}
+
+		Console.Write($"Send reconcile messages for {groupCount} group(s)? Every public registry in the plan will be rewritten end-to-end. [y/N] ");
+		var answer = confirmationReader is not null ? confirmationReader() : Console.ReadLine();
+		if (string.Equals(answer?.Trim(), "y", StringComparison.OrdinalIgnoreCase))
+			return true;
+
+		collector.EmitError(string.Empty, "Aborted: confirmation declined.");
+		return false;
+	}
+}

--- a/src/services/Elastic.Changelog/Reconciliation/ChangelogRegistryVerifyService.cs
+++ b/src/services/Elastic.Changelog/Reconciliation/ChangelogRegistryVerifyService.cs
@@ -1,0 +1,76 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Amazon.S3;
+using Elastic.Documentation.Diagnostics;
+using Elastic.Documentation.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Elastic.Changelog.Reconciliation;
+
+/// <summary>
+/// The read-only sibling of <c>changelog registry reconcile</c> and the standing drift-diagnosis
+/// tool: for each planned group, compares the public manifest against what a reconcile of the
+/// current public listing would write — same listing spec and entry rules by construction
+/// (<see cref="RegistryReconciler.VerifyGroupAsync"/>) — and reports divergence. Zero divergence
+/// across the plan is the cutover completion gate of elastic/docs-eng-team#688.
+/// </summary>
+public sealed class ChangelogRegistryVerifyService(
+	ILoggerFactory logFactory,
+	IAmazonS3? s3Client = null
+) : IService
+{
+	private readonly ILogger _logger = logFactory.CreateLogger<ChangelogRegistryVerifyService>();
+
+	public async Task<bool> Verify(IDiagnosticsCollector collector, ChangelogRegistryVerifyArguments args, Cancel ctx)
+	{
+		if (!args.TryResolveScopeFilter(collector, out var filter))
+			return false;
+
+		using var defaultS3 = s3Client is null ? new AmazonS3Client() : null;
+		var s3 = s3Client ?? defaultS3!;
+
+		var plan = filter is not null
+			? [filter]
+			: await ChangelogGroupDiscovery.DiscoverUnionAsync(s3, args.S3BucketName, args.PublicS3BucketName, ctx);
+
+		if (plan.Count == 0)
+		{
+			_logger.LogInformation("No registry groups found in {Private} or {Public}; nothing to verify", args.S3BucketName, args.PublicS3BucketName);
+			return true;
+		}
+
+		var reconciler = new RegistryReconciler(logFactory, s3, args.PublicS3BucketName);
+		var divergentGroups = 0;
+		var findings = 0;
+
+		foreach (var scope in plan)
+		{
+			ctx.ThrowIfCancellationRequested();
+
+			var divergences = await reconciler.VerifyGroupAsync(scope, ctx);
+			if (divergences.Count == 0)
+			{
+				_logger.LogInformation("{Scope}: converged", scope);
+				continue;
+			}
+
+			divergentGroups++;
+			findings += divergences.Count;
+			foreach (var divergence in divergences)
+				collector.EmitWarning(string.Empty, $"{scope.Prefix}{divergence.File}: [{divergence.Kind}] {divergence.Detail}");
+		}
+
+		if (divergentGroups > 0)
+		{
+			collector.EmitError(string.Empty,
+				$"{divergentGroups} of {plan.Count} group(s) diverge from their public listing ({findings} finding(s)). " +
+				"Run `changelog registry reconcile` to converge them, then verify again.");
+			return false;
+		}
+
+		_logger.LogInformation("All {Count} group(s) converged: every public manifest matches its public listing", plan.Count);
+		return true;
+	}
+}

--- a/src/services/Elastic.Changelog/Reconciliation/ReconcileQueueMessage.cs
+++ b/src/services/Elastic.Changelog/Reconciliation/ReconcileQueueMessage.cs
@@ -1,0 +1,122 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Elastic.Changelog.Reconciliation;
+
+/// <summary>
+/// The explicit reconcile request `changelog registry reconcile` sends to the scrubber queue
+/// (elastic/docs-eng-team#688 Phase 2). A versioned, discriminated envelope: the scrubber treats
+/// any body whose <c>kind</c> is <c>reconcile</c> as one of these and performs a <em>full group
+/// heal</em> — object-level reconcile over the union of both buckets' group listings, then the
+/// group reconcile — which is what makes a lost or DLQ-expired scrub event recoverable by message.
+/// </summary>
+public sealed record ReconcileQueueMessage
+{
+	/// <summary>The discriminator value marking a body as a reconcile request.</summary>
+	public const string ReconcileKind = "reconcile";
+
+	/// <summary>The envelope version this producer writes and the consumer accepts.</summary>
+	public const int CurrentVersion = 1;
+
+	/// <summary>Body discriminator; always <see cref="ReconcileKind"/> for this type.</summary>
+	public string? Kind { get; init; }
+
+	/// <summary>Envelope version; the consumer rejects anything but <see cref="CurrentVersion"/>.</summary>
+	public int Version { get; init; }
+
+	/// <summary>The scope family: <c>bundle</c> or <c>changelog</c>.</summary>
+	public string? Scope { get; init; }
+
+	/// <summary>The group inside the scope: a product, or <c>{org}/{repo}/{branch}</c>.</summary>
+	public string? Group { get; init; }
+
+	/// <summary>Caller-chosen id tying this message to a cutover ledger entry.</summary>
+	public string? CorrelationId { get; init; }
+
+	/// <summary>True when <paramref name="body"/> parses as JSON whose <c>kind</c> is <see cref="ReconcileKind"/> — regardless of whether the rest validates.</summary>
+	public static bool TryRead(string body, [NotNullWhen(true)] out ReconcileQueueMessage? message)
+	{
+		message = null;
+		if (!body.Contains("\"kind\"", StringComparison.OrdinalIgnoreCase))
+			return false;
+		try
+		{
+			var parsed = JsonSerializer.Deserialize(body, ReconcileQueueMessageJsonContext.Default.ReconcileQueueMessage);
+			if (parsed is null || !string.Equals(parsed.Kind, ReconcileKind, StringComparison.Ordinal))
+				return false;
+			message = parsed;
+			return true;
+		}
+		catch (JsonException)
+		{
+			return false;
+		}
+	}
+
+	/// <summary>
+	/// Validates the envelope strictly — version, scope family, and every group segment (via
+	/// <see cref="ChangelogScope"/>, hence <c>ChangelogKeys</c>) — before anything derives an S3
+	/// listing from it. False with a reason when the message must be rejected.
+	/// </summary>
+	public bool TryResolveScope([NotNullWhen(true)] out ChangelogScope? scope, [NotNullWhen(false)] out string? error)
+	{
+		scope = null;
+		if (Version != CurrentVersion)
+		{
+			error = $"unsupported reconcile message version {Version} (supported: {CurrentVersion})";
+			return false;
+		}
+
+		switch (Scope)
+		{
+			case "bundle":
+				if (!ChangelogScope.TryCreateBundle(Group, out scope))
+				{
+					error = $"invalid bundle group \"{Group}\"";
+					return false;
+				}
+				break;
+			case "changelog":
+				var segments = Group?.Split('/') ?? [];
+				if (segments.Length < 3
+					|| !ChangelogScope.TryCreateChangelog(segments[0], segments[1], string.Join('/', segments[2..]), out scope))
+				{
+					error = $"invalid changelog group \"{Group}\" (expected {{org}}/{{repo}}/{{branch}})";
+					return false;
+				}
+				break;
+			default:
+				error = $"unknown reconcile scope \"{Scope}\"";
+				return false;
+		}
+
+		error = null;
+		return true;
+	}
+
+	/// <summary>Builds the message for one scope, stamped with the caller's correlation id.</summary>
+	public static ReconcileQueueMessage For(ChangelogScope scope, string correlationId) => new()
+	{
+		Kind = ReconcileKind,
+		Version = CurrentVersion,
+		Scope = scope.Kind == ChangelogScopeKind.Bundle ? "bundle" : "changelog",
+		Group = scope.Group,
+		CorrelationId = correlationId
+	};
+
+	/// <summary>Serializes with the same source-generated context the consumer parses with.</summary>
+	public string ToJson() =>
+		JsonSerializer.Serialize(this, ReconcileQueueMessageJsonContext.Default.ReconcileQueueMessage);
+}
+
+[JsonSourceGenerationOptions(
+	PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+	DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+)]
+[JsonSerializable(typeof(ReconcileQueueMessage))]
+public sealed partial class ReconcileQueueMessageJsonContext : JsonSerializerContext;

--- a/src/services/Elastic.Changelog/Reconciliation/RegistryDivergence.cs
+++ b/src/services/Elastic.Changelog/Reconciliation/RegistryDivergence.cs
@@ -1,0 +1,37 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic.Changelog.Reconciliation;
+
+/// <summary>How a group's public manifest diverges from its public listing.</summary>
+public enum RegistryDivergenceKind
+{
+	/// <summary>A public object (or the manifest itself) that the registry should describe but doesn't.</summary>
+	Missing,
+
+	/// <summary>A manifest entry (or the whole manifest) describing something no longer in the bucket, or metadata a reconcile would rewrite.</summary>
+	Stale,
+
+	/// <summary>The manifest exists but cannot be parsed.</summary>
+	Corrupt,
+
+	/// <summary>File present on both sides but the recorded ETag or target disagrees with the object.</summary>
+	ObjectDivergent,
+
+	/// <summary>The manifest declares a newer schema than this tool understands; reported distinctly, never rewritten.</summary>
+	UnsupportedSchema
+}
+
+/// <summary>One verify finding for a group.</summary>
+public sealed record RegistryDivergence
+{
+	/// <summary>The divergence family.</summary>
+	public required RegistryDivergenceKind Kind { get; init; }
+
+	/// <summary>The file inside the group's prefix (or <c>registry.json</c> for manifest-level findings).</summary>
+	public required string File { get; init; }
+
+	/// <summary>Human-readable specifics.</summary>
+	public required string Detail { get; init; }
+}

--- a/src/services/Elastic.Changelog/Reconciliation/RegistryReconciler.cs
+++ b/src/services/Elastic.Changelog/Reconciliation/RegistryReconciler.cs
@@ -155,41 +155,124 @@ public sealed class RegistryReconciler(
 	}
 
 	/// <summary>
-	/// The group's immediate <c>.yaml</c>/<c>.yml</c> children in the public bucket. The
-	/// <c>/</c> delimiter matters: branches are stored verbatim, so without it
-	/// <c>changelog/{org}/{repo}/main/</c> would also sweep in the <c>main/feature/…</c> pool.
+	/// Read-only diagnosis: compares the group's public manifest against what a reconcile of the
+	/// current public listing would write — same listing spec, same entry rules, zero writes.
+	/// An empty result means a reconcile would be a no-op for this group.
 	/// </summary>
-	private async Task<IReadOnlyList<S3Object>> ListGroupFiles(ChangelogScope scope, Cancel ctx)
+	public async Task<IReadOnlyList<RegistryDivergence>> VerifyGroupAsync(ChangelogScope scope, Cancel ctx)
 	{
-		var request = new ListObjectsV2Request
-		{
-			BucketName = publicBucketName,
-			Prefix = scope.Prefix,
-			Delimiter = "/"
-		};
+		var listing = await ListGroupFiles(scope, ctx);
+		var existing = await FetchManifest(scope.RegistryKey, ctx);
+		var divergences = new List<RegistryDivergence>();
 
-		var files = new List<S3Object>();
-		ListObjectsV2Response response;
-		do
+		if (listing.Count == 0)
 		{
-			response = await s3Client.ListObjectsV2Async(request, ctx);
-			foreach (var obj in response.S3Objects ?? [])
+			if (existing.Exists)
 			{
-				var file = obj.Key[scope.Prefix.Length..];
-				if (!IsYamlFileName(file) || string.Equals(file, ChangelogKeys.RegistryFileName, StringComparison.Ordinal))
-					continue;
-				files.Add(obj);
-				_metrics.IncrementObjectsListed();
+				divergences.Add(new RegistryDivergence
+				{
+					Kind = RegistryDivergenceKind.Stale,
+					File = ChangelogKeys.RegistryFileName,
+					Detail = "The group holds no objects but its manifest still exists; a reconcile would delete it (absent ≠ empty for consumers)."
+				});
 			}
-			request.ContinuationToken = response.NextContinuationToken;
-		} while (response.IsTruncated == true);
+			return divergences;
+		}
 
-		return files;
+		if (!existing.Exists)
+		{
+			divergences.Add(new RegistryDivergence
+			{
+				Kind = RegistryDivergenceKind.Missing,
+				File = ChangelogKeys.RegistryFileName,
+				Detail = $"The group holds {listing.Count} object(s) but no manifest."
+			});
+			return divergences;
+		}
+
+		if (existing.Corrupt)
+		{
+			divergences.Add(new RegistryDivergence
+			{
+				Kind = RegistryDivergenceKind.Corrupt,
+				File = ChangelogKeys.RegistryFileName,
+				Detail = "The manifest cannot be parsed; a reconcile would rebuild it from the listing."
+			});
+			return divergences;
+		}
+
+		var manifest = existing.Manifest!;
+		if (manifest.SchemaVersion > Registry.CurrentSchemaVersion)
+		{
+			divergences.Add(new RegistryDivergence
+			{
+				Kind = RegistryDivergenceKind.UnsupportedSchema,
+				File = ChangelogKeys.RegistryFileName,
+				Detail = $"The manifest declares schema_version {manifest.SchemaVersion} > supported {Registry.CurrentSchemaVersion}; this tool will not touch it."
+			});
+			return divergences;
+		}
+
+		var trusted = manifest.SchemaVersion == Registry.CurrentSchemaVersion
+			&& string.Equals(manifest.Producer, Producer, StringComparison.Ordinal)
+			&& string.Equals(manifest.Product, scope.Group, StringComparison.Ordinal);
+		if (!trusted)
+		{
+			divergences.Add(new RegistryDivergence
+			{
+				Kind = RegistryDivergenceKind.Stale,
+				File = ChangelogKeys.RegistryFileName,
+				Detail = $"Manifest metadata is not this producer's (producer \"{manifest.Producer}\", product \"{manifest.Product}\"); a reconcile would rewrite it."
+			});
+		}
+
+		var (desired, _) = await BuildEntries(scope, listing, trusted ? manifest.Bundles : [], ctx);
+		var desiredByFile = desired.ToDictionary(b => b.File, b => b, StringComparer.Ordinal);
+		var manifestByFile = manifest.Bundles.ToDictionary(b => b.File, b => b, StringComparer.Ordinal);
+
+		foreach (var (file, entry) in desiredByFile)
+		{
+			if (!manifestByFile.TryGetValue(file, out var recorded))
+			{
+				divergences.Add(new RegistryDivergence
+				{
+					Kind = RegistryDivergenceKind.Missing,
+					File = file,
+					Detail = "The object exists in the public bucket but the manifest does not list it."
+				});
+			}
+			else if (!string.Equals(recorded.ETag, entry.ETag, StringComparison.Ordinal)
+				|| !string.Equals(recorded.Target, entry.Target, StringComparison.Ordinal))
+			{
+				divergences.Add(new RegistryDivergence
+				{
+					Kind = RegistryDivergenceKind.ObjectDivergent,
+					File = file,
+					Detail = $"The manifest records (target: {recorded.Target ?? "null"}, etag: {recorded.ETag}) but a reconcile would write (target: {entry.Target ?? "null"}, etag: {entry.ETag})."
+				});
+			}
+		}
+
+		foreach (var file in manifestByFile.Keys.Where(f => !desiredByFile.ContainsKey(f)))
+		{
+			divergences.Add(new RegistryDivergence
+			{
+				Kind = RegistryDivergenceKind.Stale,
+				File = file,
+				Detail = "The manifest lists an object that is no longer in the public bucket."
+			});
+		}
+
+		return divergences;
 	}
 
-	private static bool IsYamlFileName(string file) =>
-		file.Length > 0
-		&& (file.EndsWith(".yaml", StringComparison.OrdinalIgnoreCase) || file.EndsWith(".yml", StringComparison.OrdinalIgnoreCase));
+	private async Task<IReadOnlyList<S3Object>> ListGroupFiles(ChangelogScope scope, Cancel ctx)
+	{
+		var files = await S3GroupListing.ListImmediateYamlObjectsAsync(s3Client, publicBucketName, scope, ctx);
+		for (var i = 0; i < files.Count; i++)
+			_metrics.IncrementObjectsListed();
+		return files;
+	}
 
 	private sealed record ManifestState(Registry? Manifest, string? ETag, bool Exists, bool Corrupt);
 

--- a/src/services/Elastic.Changelog/Reconciliation/S3GroupListing.cs
+++ b/src/services/Elastic.Changelog/Reconciliation/S3GroupListing.cs
@@ -1,0 +1,57 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Amazon.S3;
+using Amazon.S3.Model;
+using Elastic.Documentation.Configuration.ReleaseNotes;
+
+namespace Elastic.Changelog.Reconciliation;
+
+/// <summary>
+/// The one listing spec every registry operation shares (reconcile, full group heal, verify):
+/// a group's objects are the immediate <c>.yaml</c>/<c>.yml</c> children of its prefix. The
+/// <c>/</c> delimiter is load-bearing — branches are stored verbatim, so without it
+/// <c>changelog/{org}/{repo}/main/</c> would also sweep in the <c>main/feature/…</c> pool —
+/// and pagination runs to completion. The manifest itself and any other non-YAML keys are
+/// excluded.
+/// </summary>
+public static class S3GroupListing
+{
+	/// <summary>Lists the group's immediate YAML children in <paramref name="bucketName"/>.</summary>
+	public static async Task<IReadOnlyList<S3Object>> ListImmediateYamlObjectsAsync(
+		IAmazonS3 s3Client,
+		string bucketName,
+		ChangelogScope scope,
+		Cancel ctx)
+	{
+		var request = new ListObjectsV2Request
+		{
+			BucketName = bucketName,
+			Prefix = scope.Prefix,
+			Delimiter = "/"
+		};
+
+		var files = new List<S3Object>();
+		ListObjectsV2Response response;
+		do
+		{
+			response = await s3Client.ListObjectsV2Async(request, ctx);
+			foreach (var obj in response.S3Objects ?? [])
+			{
+				var file = obj.Key[scope.Prefix.Length..];
+				if (!IsYamlFileName(file) || string.Equals(file, ChangelogKeys.RegistryFileName, StringComparison.Ordinal))
+					continue;
+				files.Add(obj);
+			}
+			request.ContinuationToken = response.NextContinuationToken;
+		} while (response.IsTruncated == true);
+
+		return files;
+	}
+
+	/// <summary>True for a single-segment file name ending in <c>.yaml</c> or <c>.yml</c>.</summary>
+	public static bool IsYamlFileName(string file) =>
+		file.Length > 0
+		&& (file.EndsWith(".yaml", StringComparison.OrdinalIgnoreCase) || file.EndsWith(".yml", StringComparison.OrdinalIgnoreCase));
+}

--- a/src/services/Elastic.Changelog/Scrubbing/ScrubberProcessor.cs
+++ b/src/services/Elastic.Changelog/Scrubbing/ScrubberProcessor.cs
@@ -29,7 +29,8 @@ public sealed class ScrubberProcessor(
 	string publicBucketName,
 	IChangelogContentScrubber scrubber,
 	RegistryReconciler reconciler,
-	ReconcileMetrics? metrics = null
+	ReconcileMetrics? metrics = null,
+	string? privateBucketName = null
 )
 {
 	// Bounds the reread-and-redo loop of post-write source validation. Each redo only triggers
@@ -50,6 +51,9 @@ public sealed class ScrubberProcessor(
 	{
 		public ChangelogScope Scope { get; } = scope;
 		public HashSet<string> MessageIds { get; } = [with(StringComparer.Ordinal)];
+
+		/// <summary>Set by an explicit reconcile message: object-reconcile the union of both buckets' listings first.</summary>
+		public bool FullHeal { get; set; }
 	}
 
 	/// <summary>
@@ -66,6 +70,25 @@ public sealed class ScrubberProcessor(
 
 		foreach (var message in messages)
 		{
+			// Explicit reconcile requests (elastic/docs-eng-team#688 Phase 2) are a versioned,
+			// discriminated envelope; anything else is an S3 event notification. A recognized
+			// envelope that fails strict validation is rejected to the DLQ — redelivery cannot
+			// fix a malformed message, but the DLQ alarm makes the sender bug visible.
+			if (ReconcileQueueMessage.TryRead(message.Body, out var reconcile))
+			{
+				if (!reconcile.TryResolveScope(out var scope, out var error))
+				{
+					_logger.LogError("Rejecting reconcile message {MessageId}: {Error}", message.MessageId, error);
+					_ = failedIds.Add(message.MessageId);
+					continue;
+				}
+
+				_logger.LogInformation(
+					"Reconcile message for {Scope} (correlation: {CorrelationId})", scope, reconcile.CorrelationId ?? "none");
+				AddGroup(groupWork, scope, message.MessageId).FullHeal = true;
+				continue;
+			}
+
 			try
 			{
 				var s3Event = S3EventNotification.ParseJson(message.Body);
@@ -102,6 +125,8 @@ public sealed class ScrubberProcessor(
 			ctx.ThrowIfCancellationRequested();
 			try
 			{
+				if (work.FullHeal)
+					await HealGroupObjectsAsync(work.Scope, objectWork.Keys, ctx);
 				_ = await reconciler.ReconcileGroupAsync(work.Scope, ctx);
 			}
 			catch (Exception e) when (e is not OperationCanceledException)
@@ -131,7 +156,7 @@ public sealed class ScrubberProcessor(
 		if (ChangelogKeys.IsRegistry(key))
 		{
 			if (hasScope)
-				AddGroup(groupWork, scope!, messageId);
+				_ = AddGroup(groupWork, scope!, messageId);
 			return;
 		}
 
@@ -157,10 +182,10 @@ public sealed class ScrubberProcessor(
 		_ = work.MessageIds.Add(messageId);
 
 		if (hasScope)
-			AddGroup(groupWork, scope!, messageId);
+			_ = AddGroup(groupWork, scope!, messageId);
 	}
 
-	private static void AddGroup(Dictionary<string, GroupWork> groupWork, ChangelogScope scope, string messageId)
+	private static GroupWork AddGroup(Dictionary<string, GroupWork> groupWork, ChangelogScope scope, string messageId)
 	{
 		if (!groupWork.TryGetValue(scope.Prefix, out var work))
 		{
@@ -168,6 +193,36 @@ public sealed class ScrubberProcessor(
 			groupWork[scope.Prefix] = work;
 		}
 		_ = work.MessageIds.Add(messageId);
+		return work;
+	}
+
+	/// <summary>
+	/// The full group heal an explicit reconcile message asks for: object-level reconcile over the
+	/// union of both buckets' group listings — scrub/copy what is live in the private bucket,
+	/// delete what is not — so lost or DLQ-expired scrub events are recoverable by message. Keys
+	/// already reconciled by this batch's own S3 events are skipped.
+	/// </summary>
+	private async Task HealGroupObjectsAsync(ChangelogScope scope, IReadOnlyCollection<string> alreadyReconciled, Cancel ctx)
+	{
+		if (privateBucketName is null)
+		{
+			throw new InvalidOperationException(
+				"A reconcile message arrived but no private bucket is configured (PRIVATE_BUCKET_NAME); cannot perform a full group heal.");
+		}
+
+		var privateObjects = await S3GroupListing.ListImmediateYamlObjectsAsync(s3Client, privateBucketName, scope, ctx);
+		var publicObjects = await S3GroupListing.ListImmediateYamlObjectsAsync(s3Client, publicBucketName, scope, ctx);
+		var keys = new SortedSet<string>(StringComparer.Ordinal);
+		keys.UnionWith(privateObjects.Select(o => o.Key));
+		keys.UnionWith(publicObjects.Select(o => o.Key));
+
+		_logger.LogInformation("Full heal of {Scope}: {Count} key(s) in the union of both buckets", scope, keys.Count);
+
+		foreach (var key in keys.Where(k => !alreadyReconciled.Contains(k)))
+		{
+			ctx.ThrowIfCancellationRequested();
+			await ReconcileObjectAsync(privateBucketName, key, ctx);
+		}
 	}
 
 	/// <summary>

--- a/src/services/Elastic.Changelog/Uploading/Registry.cs
+++ b/src/services/Elastic.Changelog/Uploading/Registry.cs
@@ -83,6 +83,9 @@ public sealed record RegistryBundle
 	/// for integrity checks or HTTP cache validation against the public bucket; use the CDN response's
 	/// own ETag for that. It is safe to use to detect whether a bundle changed between manifest reads.
 	/// </remarks>
+	// The snake_case policy would emit "e_tag"; the documented manifest format — and what the
+	// consumer-side ChangelogRegistryBundle reads — is "etag".
+	[JsonPropertyName("etag")]
 	public required string ETag { get; init; }
 }
 

--- a/src/tooling/docs-builder/Commands/ChangelogRegistryCommands.cs
+++ b/src/tooling/docs-builder/Commands/ChangelogRegistryCommands.cs
@@ -1,0 +1,115 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Changelog.Reconciliation;
+using Elastic.Documentation.Diagnostics;
+using Elastic.Documentation.Services;
+using Microsoft.Extensions.Logging;
+using Nullean.Argh;
+using Nullean.Argh.Documentation;
+
+namespace Documentation.Builder.Commands;
+
+/// <summary>Operate on the scrubber-owned public changelog registries.</summary>
+internal sealed class ChangelogRegistryCommands(
+	ILoggerFactory logFactory,
+	IDiagnosticsCollector collector
+)
+{
+	/// <summary>
+	/// Send explicit reconcile messages to the scrubber queue so the Lambda performs a full group
+	/// heal (object-level reconcile over the union of both buckets, then a registry rebuild from
+	/// public state) for every planned group. This command never mutates S3 itself — the scrubber
+	/// Lambda stays the public bucket's single writer. Convergent: re-running re-plans against
+	/// current state. Enqueuing is not reconciling — gate on `changelog registry verify` after the
+	/// queue drains and the DLQ is empty.
+	/// </summary>
+	/// <param name="s3BucketName">Private changelog bundles bucket to plan from.</param>
+	/// <param name="publicS3BucketName">Public (CDN) changelog bundles bucket to plan from.</param>
+	/// <param name="queueUrl">URL of the scrubber SQS queue to send reconcile messages to.</param>
+	/// <param name="product">Only reconcile this bundle group (<c>bundle/{product}/</c>). Mutually exclusive with --owner/--repo/--branch.</param>
+	/// <param name="owner">GitHub owner of a single changelog-pool group to reconcile.</param>
+	/// <param name="repo">Repository of a single changelog-pool group to reconcile.</param>
+	/// <param name="branch">Branch of a single changelog-pool group to reconcile (verbatim; slashes allowed).</param>
+	/// <param name="dryRun">Print the group plan without sending anything.</param>
+	/// <param name="yes">Skip the interactive confirmation (required when stdin is not a terminal).</param>
+	[RequiresAuth]
+	[CommandIntent(Intent.Destructive | Intent.Idempotent)]
+	[MutationScope(MutationScope.Global)]
+	[NoOptionsInjection]
+	public async Task<int> Reconcile(
+		string s3BucketName,
+		string publicS3BucketName,
+		string queueUrl,
+		string? product = null,
+		string? owner = null,
+		string? repo = null,
+		string? branch = null,
+		[DryRun] bool dryRun = false,
+		bool yes = false,
+		Cancel ct = default
+	)
+	{
+		await using var serviceInvoker = new ServiceInvoker(collector);
+		var service = new ChangelogRegistryReconcileService(logFactory);
+		var args = new ChangelogRegistryReconcileArguments
+		{
+			S3BucketName = s3BucketName,
+			PublicS3BucketName = publicS3BucketName,
+			QueueUrl = queueUrl,
+			Product = product,
+			Owner = owner,
+			Repo = repo,
+			Branch = branch,
+			DryRun = dryRun,
+			AssumeYes = yes
+		};
+		serviceInvoker.AddCommand(service, args,
+			static async (s, c, state, ct) => await s.Reconcile(c, state, ct)
+		);
+		return await serviceInvoker.InvokeAsync(ct);
+	}
+
+	/// <summary>
+	/// Compare each planned group's public <c>registry.json</c> against what a reconcile of the
+	/// current public listing would write, and report divergence (missing, stale, corrupt,
+	/// object-divergent; unsupported schema reported distinctly). Strictly read-only. Zero
+	/// divergence across the plan is the cutover completion gate — and the standing
+	/// drift-diagnosis tool afterwards.
+	/// </summary>
+	/// <param name="s3BucketName">Private changelog bundles bucket to plan from.</param>
+	/// <param name="publicS3BucketName">Public (CDN) changelog bundles bucket to verify.</param>
+	/// <param name="product">Only verify this bundle group (<c>bundle/{product}/</c>). Mutually exclusive with --owner/--repo/--branch.</param>
+	/// <param name="owner">GitHub owner of a single changelog-pool group to verify.</param>
+	/// <param name="repo">Repository of a single changelog-pool group to verify.</param>
+	/// <param name="branch">Branch of a single changelog-pool group to verify (verbatim; slashes allowed).</param>
+	[RequiresAuth]
+	[NoOptionsInjection]
+	public async Task<int> Verify(
+		string s3BucketName,
+		string publicS3BucketName,
+		string? product = null,
+		string? owner = null,
+		string? repo = null,
+		string? branch = null,
+		Cancel ct = default
+	)
+	{
+		await using var serviceInvoker = new ServiceInvoker(collector);
+		var service = new ChangelogRegistryVerifyService(logFactory);
+		var args = new ChangelogRegistryVerifyArguments
+		{
+			S3BucketName = s3BucketName,
+			PublicS3BucketName = publicS3BucketName,
+			Product = product,
+			Owner = owner,
+			Repo = repo,
+			Branch = branch
+		};
+		serviceInvoker.AddCommand(service, args,
+			static async (s, c, state, ct) => await s.Verify(c, state, ct)
+		);
+		return await serviceInvoker.InvokeAsync(ct);
+	}
+}

--- a/src/tooling/docs-builder/Program.cs
+++ b/src/tooling/docs-builder/Program.cs
@@ -49,7 +49,10 @@ _ = builder.Services.AddArgh(args, app =>
 	_ = app.Map<RefactorCommands>();
 	_ = app.Map<ServeCommand>();
 	_ = app.Map<IndexCommand>();
-	_ = app.MapNamespace<ChangelogCommands>("changelog");
+	_ = app.MapNamespace<ChangelogCommands>("changelog", g =>
+	{
+		_ = g.MapNamespace<ChangelogRegistryCommands>("registry");
+	});
 	_ = app.MapNamespace<InboundLinkCommands>("inbound-links");
 
 	_ = app.Map<AssembleOneShotCommand>();

--- a/tests/Elastic.Changelog.Tests/Reconciliation/ChangelogRegistryServiceTests.cs
+++ b/tests/Elastic.Changelog.Tests/Reconciliation/ChangelogRegistryServiceTests.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Diagnostics.CodeAnalysis;
 using Amazon.SQS;
 using Amazon.SQS.Model;
 using AwesomeAssertions;
@@ -11,6 +12,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Elastic.Changelog.Tests.Reconciliation;
 
+[SuppressMessage("Usage", "CA1001:Types that own disposable fields should be disposable")]
 public class ChangelogRegistryServiceTests
 {
 	private const string PrivateBucket = "private-bucket";

--- a/tests/Elastic.Changelog.Tests/Reconciliation/ChangelogRegistryServiceTests.cs
+++ b/tests/Elastic.Changelog.Tests/Reconciliation/ChangelogRegistryServiceTests.cs
@@ -1,0 +1,178 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Amazon.SQS;
+using Amazon.SQS.Model;
+using AwesomeAssertions;
+using Elastic.Changelog.Reconciliation;
+using FakeItEasy;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Elastic.Changelog.Tests.Reconciliation;
+
+public class ChangelogRegistryServiceTests
+{
+	private const string PrivateBucket = "private-bucket";
+	private const string PublicBucket = "public-bucket";
+
+	private readonly FakeS3 _s3 = new(PrivateBucket, PublicBucket);
+	private readonly IAmazonSQS _sqs = A.Fake<IAmazonSQS>();
+	private readonly List<SendMessageRequest> _sent = [];
+	private readonly TestDiagnosticsCollector _collector;
+
+	public ChangelogRegistryServiceTests(ITestOutputHelper output)
+	{
+		_collector = new TestDiagnosticsCollector(output);
+		_ = A.CallTo(() => _sqs.SendMessageAsync(A<SendMessageRequest>._, A<CancellationToken>._))
+			.Invokes((SendMessageRequest r, CancellationToken _) => _sent.Add(r))
+			.ReturnsLazily((SendMessageRequest _, CancellationToken _) =>
+				Task.FromResult(new SendMessageResponse { MessageId = $"sqs-{_sent.Count}" }));
+	}
+
+	private ChangelogRegistryReconcileService ReconcileService(Func<string?>? confirm = null) =>
+		new(NullLoggerFactory.Instance, _s3.Client, _sqs, confirm ?? (() => "y"));
+
+	private static ChangelogRegistryReconcileArguments ReconcileArgs(
+		bool dryRun = false, bool yes = false, string? product = null) => new()
+		{
+			S3BucketName = PrivateBucket,
+			PublicS3BucketName = PublicBucket,
+			QueueUrl = "https://sqs.example/queue",
+			DryRun = dryRun,
+			AssumeYes = yes,
+			Product = product
+		};
+
+	private Cancel Ctx => TestContext.Current.CancellationToken;
+
+	[Fact]
+	public async Task Reconcile_DiscoversTheUnionOfBothBuckets_IncludingOrphanPublicGroups()
+	{
+		// Private: one bundle group and one pool. Public: an orphan group (nothing private backs
+		// it) that only a union discovery would plan — its reconcile is what deletes the leftovers.
+		_ = _s3.Seed(PrivateBucket, "bundle/elasticsearch/es-9.1.0.yaml", "a");
+		_ = _s3.Seed(PrivateBucket, "changelog/elastic/repo/main/entry.yaml", "b");
+		_ = _s3.Seed(PublicBucket, "bundle/orphaned/old.yaml", "c");
+		_ = _s3.Seed(PublicBucket, "bundle/manifest-only/registry.json", "{}");
+
+		var ok = await ReconcileService().Reconcile(_collector, ReconcileArgs(yes: true), Ctx);
+
+		ok.Should().BeTrue();
+		var bodies = _sent.Select(r => r.MessageBody).ToList();
+		bodies.Should().HaveCount(4);
+		bodies.Should().Contain(b => b.Contains("\"scope\":\"bundle\"", StringComparison.Ordinal) && b.Contains("\"group\":\"elasticsearch\"", StringComparison.Ordinal));
+		bodies.Should().Contain(b => b.Contains("\"scope\":\"changelog\"", StringComparison.Ordinal) && b.Contains("\"group\":\"elastic/repo/main\"", StringComparison.Ordinal));
+		bodies.Should().Contain(b => b.Contains("\"group\":\"orphaned\"", StringComparison.Ordinal));
+		bodies.Should().Contain(b => b.Contains("\"group\":\"manifest-only\"", StringComparison.Ordinal),
+			"a group holding only an orphaned manifest still needs its reconcile");
+		bodies.Should().OnlyContain(b => b.Contains("\"kind\":\"reconcile\"", StringComparison.Ordinal) && b.Contains("\"version\":1", StringComparison.Ordinal));
+	}
+
+	[Fact]
+	public async Task Reconcile_EveryMessageValidatesAndSharesOneCorrelationId()
+	{
+		_ = _s3.Seed(PrivateBucket, "bundle/elasticsearch/es-9.1.0.yaml", "a");
+		_ = _s3.Seed(PrivateBucket, "bundle/kibana/kb-9.1.0.yaml", "b");
+
+		var ok = await ReconcileService().Reconcile(_collector, ReconcileArgs(yes: true), Ctx);
+
+		ok.Should().BeTrue();
+		var correlationIds = new HashSet<string>(StringComparer.Ordinal);
+		foreach (var request in _sent)
+		{
+			_ = ReconcileQueueMessage.TryRead(request.MessageBody, out var message);
+			message.Should().NotBeNull();
+			message!.TryResolveScope(out _, out _).Should().BeTrue("the CLI must only ever send messages the Lambda accepts");
+			_ = correlationIds.Add(message.CorrelationId!);
+		}
+		correlationIds.Should().ContainSingle("one run stamps one correlation id on its whole ledger");
+	}
+
+	[Fact]
+	public async Task Reconcile_DryRun_SendsNothing()
+	{
+		_ = _s3.Seed(PrivateBucket, "bundle/elasticsearch/es-9.1.0.yaml", "a");
+
+		var ok = await ReconcileService().Reconcile(_collector, ReconcileArgs(dryRun: true), Ctx);
+
+		ok.Should().BeTrue();
+		_sent.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task Reconcile_DeclinedConfirmation_Aborts()
+	{
+		_ = _s3.Seed(PrivateBucket, "bundle/elasticsearch/es-9.1.0.yaml", "a");
+
+		var ok = await ReconcileService(confirm: () => "n").Reconcile(_collector, ReconcileArgs(), Ctx);
+
+		ok.Should().BeFalse();
+		_sent.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task Reconcile_SingleScopeFilter_PlansOnlyThatGroup()
+	{
+		_ = _s3.Seed(PrivateBucket, "bundle/elasticsearch/es-9.1.0.yaml", "a");
+		_ = _s3.Seed(PrivateBucket, "bundle/kibana/kb-9.1.0.yaml", "b");
+
+		var ok = await ReconcileService().Reconcile(_collector, ReconcileArgs(yes: true, product: "kibana"), Ctx);
+
+		ok.Should().BeTrue();
+		_sent.Should().ContainSingle().Which.MessageBody.Should().Contain("\"group\":\"kibana\"");
+	}
+
+	[Fact]
+	public async Task Reconcile_MixedScopeForms_IsRejected()
+	{
+		var args = ReconcileArgs(yes: true, product: "kibana") with { Owner = "elastic", Repo = "repo", Branch = "main" };
+
+		var ok = await ReconcileService().Reconcile(_collector, args, Ctx);
+
+		ok.Should().BeFalse();
+		_sent.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task Verify_ReportsDivergenceAcrossThePlanAndFails()
+	{
+		// elasticsearch is converged; kibana has objects but no manifest.
+		var yaml = "products:\n  - product: elasticsearch\n    target: 9.1.0\n    repo: elasticsearch\n    owner: elastic\n";
+		var etag = _s3.Seed(PublicBucket, "bundle/elasticsearch/es-9.1.0.yaml", yaml);
+		_ = _s3.Seed(PublicBucket, "bundle/elasticsearch/registry.json",
+			"{\"schema_version\":1,\"product\":\"elasticsearch\",\"producer\":\"" + RegistryReconciler.Producer +
+			"\",\"generated_at\":\"2026-07-01T00:00:00+00:00\",\"bundles\":[{\"file\":\"es-9.1.0.yaml\",\"target\":\"9.1.0\",\"etag\":\"" + etag + "\"}]}");
+		_ = _s3.Seed(PublicBucket, "bundle/kibana/kb-9.1.0.yaml", "kb");
+
+		var service = new ChangelogRegistryVerifyService(NullLoggerFactory.Instance, _s3.Client);
+		var ok = await service.Verify(_collector, new ChangelogRegistryVerifyArguments
+		{
+			S3BucketName = PrivateBucket,
+			PublicS3BucketName = PublicBucket
+		}, Ctx);
+
+		ok.Should().BeFalse("kibana diverges");
+		_s3.Puts.Should().BeEmpty("verify is strictly read-only");
+		_s3.Deletes.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task Verify_ConvergedPlan_Succeeds()
+	{
+		var yaml = "products:\n  - product: elasticsearch\n    target: 9.1.0\n    repo: elasticsearch\n    owner: elastic\n";
+		var etag = _s3.Seed(PublicBucket, "bundle/elasticsearch/es-9.1.0.yaml", yaml);
+		_ = _s3.Seed(PublicBucket, "bundle/elasticsearch/registry.json",
+			"{\"schema_version\":1,\"product\":\"elasticsearch\",\"producer\":\"" + RegistryReconciler.Producer +
+			"\",\"generated_at\":\"2026-07-01T00:00:00+00:00\",\"bundles\":[{\"file\":\"es-9.1.0.yaml\",\"target\":\"9.1.0\",\"etag\":\"" + etag + "\"}]}");
+
+		var service = new ChangelogRegistryVerifyService(NullLoggerFactory.Instance, _s3.Client);
+		var ok = await service.Verify(_collector, new ChangelogRegistryVerifyArguments
+		{
+			S3BucketName = PrivateBucket,
+			PublicS3BucketName = PublicBucket
+		}, Ctx);
+
+		ok.Should().BeTrue();
+	}
+}

--- a/tests/Elastic.Changelog.Tests/Reconciliation/RegistryVerifyTests.cs
+++ b/tests/Elastic.Changelog.Tests/Reconciliation/RegistryVerifyTests.cs
@@ -1,0 +1,185 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text.Json;
+using AwesomeAssertions;
+using Elastic.Changelog.Reconciliation;
+using Elastic.Changelog.Uploading;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Elastic.Changelog.Tests.Reconciliation;
+
+public class RegistryVerifyTests
+{
+	private const string PublicBucket = "public-bucket";
+
+	private readonly FakeS3 _s3 = new(PublicBucket);
+	private readonly RegistryReconciler _reconciler;
+
+	public RegistryVerifyTests() =>
+		_reconciler = new RegistryReconciler(NullLoggerFactory.Instance, _s3.Client, PublicBucket, retryBaseDelay: TimeSpan.Zero);
+
+	private static ChangelogScope Scope
+	{
+		get
+		{
+			_ = ChangelogScope.TryCreateBundle("elasticsearch", out var scope);
+			return scope!;
+		}
+	}
+
+	// language=yaml
+	private const string BundleYaml = """
+		products:
+		  - product: elasticsearch
+		    target: 9.1.0
+		    repo: elasticsearch
+		    owner: elastic
+		entries:
+		  - file:
+		      name: 1-feature.yaml
+		      checksum: deadbeef
+		    type: enhancement
+		    title: Sample
+		""";
+
+	private void SeedManifest(int schemaVersion = Registry.CurrentSchemaVersion, string? producer = RegistryReconciler.Producer, params RegistryBundle[] bundles)
+	{
+		var manifest = new Registry
+		{
+			SchemaVersion = schemaVersion,
+			Product = "elasticsearch",
+			Producer = producer,
+			GeneratedAt = new DateTimeOffset(2026, 7, 1, 0, 0, 0, TimeSpan.Zero),
+			Bundles = bundles
+		};
+		_ = _s3.Seed(PublicBucket, Scope.RegistryKey, JsonSerializer.Serialize(manifest, RegistryJsonContext.Default.Registry));
+	}
+
+	private Cancel Ctx => TestContext.Current.CancellationToken;
+
+	[Fact]
+	public async Task Verify_ConvergedGroup_ReportsNothingAndWritesNothing()
+	{
+		var etag = _s3.Seed(PublicBucket, Scope.Prefix + "es-9.1.0.yaml", BundleYaml);
+		SeedManifest(bundles: new RegistryBundle { File = "es-9.1.0.yaml", Target = "9.1.0", ETag = etag });
+
+		var divergences = await _reconciler.VerifyGroupAsync(Scope, Ctx);
+
+		divergences.Should().BeEmpty();
+		_s3.Puts.Should().BeEmpty();
+		_s3.Deletes.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task Verify_ObjectsWithoutManifest_ReportsMissingManifest()
+	{
+		_ = _s3.Seed(PublicBucket, Scope.Prefix + "es-9.1.0.yaml", BundleYaml);
+
+		var divergences = await _reconciler.VerifyGroupAsync(Scope, Ctx);
+
+		var finding = divergences.Should().ContainSingle().Subject;
+		finding.Kind.Should().Be(RegistryDivergenceKind.Missing);
+		finding.File.Should().Be("registry.json");
+	}
+
+	[Fact]
+	public async Task Verify_ManifestForEmptyGroup_ReportsStaleManifest()
+	{
+		SeedManifest();
+
+		var divergences = await _reconciler.VerifyGroupAsync(Scope, Ctx);
+
+		var finding = divergences.Should().ContainSingle().Subject;
+		finding.Kind.Should().Be(RegistryDivergenceKind.Stale);
+		finding.File.Should().Be("registry.json");
+	}
+
+	[Fact]
+	public async Task Verify_UnlistedObject_ReportsMissingEntry()
+	{
+		var etag = _s3.Seed(PublicBucket, Scope.Prefix + "es-9.1.0.yaml", BundleYaml);
+		_ = _s3.Seed(PublicBucket, Scope.Prefix + "es-9.2.0.yaml", BundleYaml);
+		SeedManifest(bundles: new RegistryBundle { File = "es-9.1.0.yaml", Target = "9.1.0", ETag = etag });
+
+		var divergences = await _reconciler.VerifyGroupAsync(Scope, Ctx);
+
+		var finding = divergences.Should().ContainSingle().Subject;
+		finding.Kind.Should().Be(RegistryDivergenceKind.Missing);
+		finding.File.Should().Be("es-9.2.0.yaml");
+	}
+
+	[Fact]
+	public async Task Verify_EntryWhoseObjectIsGone_ReportsStaleEntry()
+	{
+		var etag = _s3.Seed(PublicBucket, Scope.Prefix + "es-9.1.0.yaml", BundleYaml);
+		SeedManifest(bundles:
+		[
+			new RegistryBundle { File = "es-9.1.0.yaml", Target = "9.1.0", ETag = etag },
+			new RegistryBundle { File = "gone.yaml", Target = "9.0.0", ETag = "dead" }
+		]);
+
+		var divergences = await _reconciler.VerifyGroupAsync(Scope, Ctx);
+
+		var finding = divergences.Should().ContainSingle().Subject;
+		finding.Kind.Should().Be(RegistryDivergenceKind.Stale);
+		finding.File.Should().Be("gone.yaml");
+	}
+
+	[Fact]
+	public async Task Verify_EntryWithWrongETag_ReportsObjectDivergent()
+	{
+		_ = _s3.Seed(PublicBucket, Scope.Prefix + "es-9.1.0.yaml", BundleYaml);
+		SeedManifest(bundles: new RegistryBundle { File = "es-9.1.0.yaml", Target = "9.1.0", ETag = "outdated" });
+
+		var divergences = await _reconciler.VerifyGroupAsync(Scope, Ctx);
+
+		var finding = divergences.Should().ContainSingle().Subject;
+		finding.Kind.Should().Be(RegistryDivergenceKind.ObjectDivergent);
+		finding.File.Should().Be("es-9.1.0.yaml");
+	}
+
+	[Fact]
+	public async Task Verify_CorruptManifest_ReportsCorrupt()
+	{
+		_ = _s3.Seed(PublicBucket, Scope.Prefix + "es-9.1.0.yaml", BundleYaml);
+		_ = _s3.Seed(PublicBucket, Scope.RegistryKey, "{ not json ");
+
+		var divergences = await _reconciler.VerifyGroupAsync(Scope, Ctx);
+
+		divergences.Should().ContainSingle().Subject.Kind.Should().Be(RegistryDivergenceKind.Corrupt);
+	}
+
+	[Fact]
+	public async Task Verify_NewerSchema_ReportsUnsupportedSchemaDistinctly()
+	{
+		_ = _s3.Seed(PublicBucket, Scope.Prefix + "es-9.1.0.yaml", BundleYaml);
+		SeedManifest(schemaVersion: Registry.CurrentSchemaVersion + 1);
+
+		var divergences = await _reconciler.VerifyGroupAsync(Scope, Ctx);
+
+		divergences.Should().ContainSingle().Subject.Kind.Should().Be(RegistryDivergenceKind.UnsupportedSchema);
+	}
+
+	[Fact]
+	public async Task Verify_LegacyProducerManifest_ReportsStaleMetadataEvenWhenEntriesMatch()
+	{
+		var etag = _s3.Seed(PublicBucket, Scope.Prefix + "es-9.1.0.yaml", BundleYaml);
+		SeedManifest(producer: null, bundles: new RegistryBundle { File = "es-9.1.0.yaml", Target = "9.1.0", ETag = etag });
+
+		var divergences = await _reconciler.VerifyGroupAsync(Scope, Ctx);
+
+		var finding = divergences.Should().ContainSingle().Subject;
+		finding.Kind.Should().Be(RegistryDivergenceKind.Stale);
+		finding.File.Should().Be("registry.json");
+	}
+
+	[Fact]
+	public async Task Verify_EmptyGroupWithoutManifest_ReportsNothing()
+	{
+		var divergences = await _reconciler.VerifyGroupAsync(Scope, Ctx);
+
+		divergences.Should().BeEmpty();
+	}
+}

--- a/tests/Elastic.Changelog.Tests/Scrubbing/ScrubberProcessorTests.cs
+++ b/tests/Elastic.Changelog.Tests/Scrubbing/ScrubberProcessorTests.cs
@@ -33,7 +33,7 @@ public class ScrubberProcessorTests
 		var reconciler = new RegistryReconciler(
 			NullLoggerFactory.Instance, _s3.Client, PublicBucket, retryBaseDelay: TimeSpan.Zero, metrics: _metrics);
 		_processor = new ScrubberProcessor(
-			NullLoggerFactory.Instance, _s3.Client, PublicBucket, _scrubber, reconciler, _metrics);
+			NullLoggerFactory.Instance, _s3.Client, PublicBucket, _scrubber, reconciler, _metrics, PrivateBucket);
 	}
 
 	private Cancel Ctx => TestContext.Current.CancellationToken;
@@ -267,6 +267,101 @@ public class ScrubberProcessorTests
 
 		failed.Should().BeEmpty();
 		_metrics.GroupReconciles.Should().Be(1);
+	}
+
+	private static ScrubberQueueMessage Reconcile(string scope, string group, int version = 1)
+	{
+		var id = $"msg-{Interlocked.Increment(ref MessageCounter)}";
+		var body = "{\"kind\":\"reconcile\",\"version\":" + version + ",\"scope\":\"" + scope +
+			"\",\"group\":\"" + group + "\",\"correlation_id\":\"test-run\"}";
+		return new ScrubberQueueMessage(id, body);
+	}
+
+	[Fact]
+	public async Task Process_ReconcileMessage_PerformsAFullGroupHeal()
+	{
+		// A full heal reconciles the union of both buckets: live private objects are (re)copied,
+		// the orphan public object is deleted, and the manifest is rebuilt — recovering drift no
+		// pending S3 event would ever repair (lost/DLQ-expired scrub events).
+		_ = _s3.Seed(PrivateBucket, "bundle/elasticsearch/es-9.1.0.yaml", "one");
+		_ = _s3.Seed(PrivateBucket, "bundle/elasticsearch/es-9.2.0.yaml", "two");
+		_ = _s3.Seed(PublicBucket, "bundle/elasticsearch/es-9.1.0.yaml", "stale-copy");
+		_ = _s3.Seed(PublicBucket, "bundle/elasticsearch/orphan.yaml", "orphan");
+
+		var failed = await _processor.ProcessAsync([Reconcile("bundle", "elasticsearch")], Ctx);
+
+		failed.Should().BeEmpty();
+		_s3.ContentOf(PublicBucket, "bundle/elasticsearch/es-9.1.0.yaml").Should().Be("scrubbed: one");
+		_s3.ContentOf(PublicBucket, "bundle/elasticsearch/es-9.2.0.yaml").Should().Be("scrubbed: two");
+		_s3.Exists(PublicBucket, "bundle/elasticsearch/orphan.yaml").Should().BeFalse("nothing in the private bucket backs it");
+		PublicManifest("bundle/elasticsearch/registry.json").Bundles.Select(b => b.File)
+			.Should().BeEquivalentTo(["es-9.1.0.yaml", "es-9.2.0.yaml"]);
+	}
+
+	[Fact]
+	public async Task Process_ReconcileMessage_ForAGroupEmptyInBothBuckets_DeletesTheManifest()
+	{
+		_ = _s3.Seed(PublicBucket, "bundle/elasticsearch/registry.json",
+			/*lang=json,strict*/ """{"schema_version":1,"product":"elasticsearch","generated_at":"2026-01-01T00:00:00+00:00","bundles":[]}""");
+
+		var failed = await _processor.ProcessAsync([Reconcile("bundle", "elasticsearch")], Ctx);
+
+		failed.Should().BeEmpty();
+		_s3.Exists(PublicBucket, "bundle/elasticsearch/registry.json").Should().BeFalse();
+	}
+
+	[Theory]
+	[InlineData("bundle", "../escape")]
+	[InlineData("bundle", "")]
+	[InlineData("changelog", "elastic/repo")]
+	[InlineData("changelog", "elastic/re po/main")]
+	[InlineData("pool", "elasticsearch")]
+	public async Task Process_MalformedReconcileMessage_IsRejected(string scope, string group)
+	{
+		var message = Reconcile(scope, group);
+
+		var failed = await _processor.ProcessAsync([message], Ctx);
+
+		failed.Should().ContainSingle().Which.Should().Be(message.MessageId);
+		_s3.Puts.Should().BeEmpty();
+		_s3.Deletes.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task Process_ReconcileMessageWithUnsupportedVersion_IsRejected()
+	{
+		var message = Reconcile("bundle", "elasticsearch", version: 2);
+
+		var failed = await _processor.ProcessAsync([message], Ctx);
+
+		failed.Should().ContainSingle().Which.Should().Be(message.MessageId);
+	}
+
+	[Fact]
+	public async Task Process_ReconcileMessage_WithoutPrivateBucketConfigured_FailsTheMessage()
+	{
+		var reconciler = new RegistryReconciler(
+			NullLoggerFactory.Instance, _s3.Client, PublicBucket, retryBaseDelay: TimeSpan.Zero, metrics: _metrics);
+		var processor = new ScrubberProcessor(
+			NullLoggerFactory.Instance, _s3.Client, PublicBucket, _scrubber, reconciler, _metrics);
+		var message = Reconcile("bundle", "elasticsearch");
+
+		var failed = await processor.ProcessAsync([message], Ctx);
+
+		failed.Should().ContainSingle().Which.Should().Be(message.MessageId);
+	}
+
+	[Fact]
+	public async Task Process_ReconcileMessage_ForABranchWithSlashes_HealsTheRightPool()
+	{
+		_ = _s3.Seed(PrivateBucket, "changelog/elastic/repo/main/feature/entry.yaml", "entry");
+
+		var failed = await _processor.ProcessAsync([Reconcile("changelog", "elastic/repo/main/feature")], Ctx);
+
+		failed.Should().BeEmpty();
+		_s3.Exists(PublicBucket, "changelog/elastic/repo/main/feature/entry.yaml").Should().BeTrue();
+		PublicManifest("changelog/elastic/repo/main/feature/registry.json").Bundles.Select(b => b.File)
+			.Should().Equal("entry.yaml");
 	}
 
 	// language=yaml


### PR DESCRIPTION
## Why

Phase 2 of [elastic/docs-eng-team#688](https://github.com/elastic/docs-eng-team/issues/688), stacked on #3738. Once the scrubber Lambda owns the public `registry.json` (Phase 1), two things are still missing: a way to trigger the cutover heal (every existing public manifest is a legacy pass-through copy that needs one authoritative rebuild — and historical drift needs repairing retroactively), and a way to *prove* convergence before Phase 3 retires the client-side refresh.

## What

- **`changelog registry reconcile`** plans the affected groups — a single scope, or the union of groups discovered in *both* buckets, so orphan public groups (including manifest-only leftovers) are covered — and sends one explicit reconcile message per group to the scrubber queue: `{"kind":"reconcile","version":1,"scope":"bundle"|"changelog","group":"…","correlation_id":"…"}`, strictly validated through `ChangelogKeys` on both ends and serialized with the same source-generated context the Lambda parses with (AOT). The CLI never mutates S3 — the Lambda stays the public bucket's single writer. `--dry-run` prints the plan; the non-dry-run path asks for confirmation (`--yes` for non-interactive use). Each run stamps one correlation id and prints a ledger line (group, SQS message id, correlation id) for the cutover checkpoint. Attributes: `[RequiresAuth]`, `[CommandIntent(Intent.Destructive | Intent.Idempotent)]`, `[MutationScope(MutationScope.Global)]`.
- **On a reconcile message the Lambda performs a full group heal**: object-level reconcile over the union of both buckets' group listings — scrub/copy what is live in the private bucket, conditionally delete what isn't — then the group reconcile. This is what makes a lost or DLQ-expired scrub event recoverable by message (it subsumes #3717's `republish`). Reads the (already-provisioned) `PRIVATE_BUCKET_NAME` Lambda env var — S3 events keep working without it since they carry their source bucket. Malformed reconcile messages are rejected to the DLQ, where the Phase 0 alarm makes the sender bug visible — redelivery can't fix a bad message.
- **`changelog registry verify`** is the read-only sibling and the cutover gate: for each planned group it compares the public manifest against what a reconcile of the current public listing would write — same listing spec and entry rules *by construction* (`RegistryReconciler.VerifyGroupAsync`) — and reports divergence using #3717's taxonomy: `Missing` / `Stale` / `Corrupt` / `ObjectDivergent`, with `UnsupportedSchema` reported distinctly. Non-zero exit on any divergence.
- **Manifest ETag wire-format fix**: the snake_case naming policy serialized the producer-side `ETag` as `"e_tag"`, while the consumer contract (`ChangelogRegistryBundle`) and the documented format read `"etag"` — every recorded ETag has been invisible to every consumer. `[JsonPropertyName("etag")]` aligns the writer with the documented format; old `"e_tag"` manifests now parse as corrupt and get rebuilt, which the cutover forces anyway via the `producer` mismatch.
- `docs/cli-schema.json` regenerated; supplemental CLI pages added under `docs/cli/changelog/registry/`.

Part of elastic/docs-eng-team#688 (Phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
