### PR TITLE
Make PR_BODY_FILE work in CI by scoping reads to RUNNER_TEMP

### DIFF
--- a/src/Elastic.Documentation.Tooling/FileSystemFactory.cs
+++ b/src/Elastic.Documentation.Tooling/FileSystemFactory.cs
@@ -265,7 +265,7 @@ public static class FileSystemFactory
 	/// Falls back to <see cref="RealRead"/> when <c>RUNNER_TEMP</c> is not set or not in CI.
 	/// Use in CI commands that need to read temporary files staged in the GitHub Actions runner.
 	/// </summary>
-	public static ScopedFileSystem RealReadForCI(IEnvironmentVariables? environmentVariables = null)
+	public static ScopedFileSystem RealReadForRunnerTemp(IEnvironmentVariables? environmentVariables = null)
 	{
 		var runnerTemp = environmentVariables?.GetEnvironmentVariable("RUNNER_TEMP");
 		if (string.IsNullOrWhiteSpace(runnerTemp))

--- a/src/Elastic.Documentation.Tooling/FileSystemFactory.cs
+++ b/src/Elastic.Documentation.Tooling/FileSystemFactory.cs
@@ -258,4 +258,19 @@ public static class FileSystemFactory
 
 		return new ScopedFileSystem(plain, BuildWriteOptions(plain, [.. roots]));
 	}
+
+	/// <summary>
+	/// Creates a read <see cref="ScopedFileSystem"/> for CI environments,
+	/// extending the default scope with <c>RUNNER_TEMP</c> when available.
+	/// Falls back to <see cref="RealRead"/> when <c>RUNNER_TEMP</c> is not set or not in CI.
+	/// Use in CI commands that need to read temporary files staged in the GitHub Actions runner.
+	/// </summary>
+	public static ScopedFileSystem RealReadForCI(IEnvironmentVariables? environmentVariables = null)
+	{
+		var runnerTemp = environmentVariables?.GetEnvironmentVariable("RUNNER_TEMP");
+		if (string.IsNullOrWhiteSpace(runnerTemp))
+			return RealRead;
+
+		return ScopeCurrentWorkingDirectory(new FileSystem(), [runnerTemp]);
+	}
 }

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogPrBodyReader.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogPrBodyReader.cs
@@ -1,0 +1,64 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Buffers;
+using System.IO.Abstractions;
+using System.Security;
+using System.Text;
+using Elastic.Documentation.Diagnostics;
+
+namespace Elastic.Changelog.Evaluation;
+
+public static class ChangelogPrBodyReader
+{
+	// PR_BODY can hit GitHub's 65,536-char limit and exceed runner env-var
+	// budgets when passed inline. PR_BODY_FILE lets callers stage the body
+	// in a file under RUNNER_TEMP and pass the path instead, which keeps
+	// the body off the env block entirely. Cap reads at 256 KiB to bound
+	// memory if a caller hands us a hostile path.
+	internal const int MaxPrBodyFileBytes = 256 * 1024;
+
+	public static async Task<string?> ReadAsync(
+		string? prBodyFile,
+		IDiagnosticsCollector collector,
+		IFileSystem fileSystem,
+		CancellationToken ct)
+	{
+		if (string.IsNullOrWhiteSpace(prBodyFile))
+			return null;
+
+		try
+		{
+			var info = fileSystem.FileInfo.New(prBodyFile);
+			if (!info.Exists)
+			{
+				collector.EmitWarning(string.Empty, $"PR_BODY_FILE points to a missing file: {prBodyFile}");
+				return null;
+			}
+
+			if (info.Length <= MaxPrBodyFileBytes)
+				return await fileSystem.File.ReadAllTextAsync(prBodyFile, ct);
+
+			collector.EmitHint(string.Empty, $"PR_BODY_FILE exceeds {MaxPrBodyFileBytes} bytes ({info.Length}); truncating.");
+
+			var buffer = ArrayPool<byte>.Shared.Rent(MaxPrBodyFileBytes);
+			try
+			{
+				await using var stream = info.OpenRead();
+				var slice = buffer.AsMemory(0, MaxPrBodyFileBytes);
+				await stream.ReadExactlyAsync(slice, ct);
+				return Encoding.UTF8.GetString(slice.Span);
+			}
+			finally
+			{
+				ArrayPool<byte>.Shared.Return(buffer);
+			}
+		}
+		catch (SecurityException ex)
+		{
+			collector.EmitWarning(string.Empty, $"PR_BODY_FILE is not readable: {prBodyFile} ({ex.Message})");
+			return null;
+		}
+	}
+}

--- a/src/tooling/docs-builder/Commands/ChangelogCommand.cs
+++ b/src/tooling/docs-builder/Commands/ChangelogCommand.cs
@@ -1389,7 +1389,7 @@ internal sealed partial class ChangelogCommands(
 		var ctx = ct;
 		await using var serviceInvoker = new ServiceInvoker(collector);
 
-		var fileSystem = FileSystemFactory.RealReadForCI(environmentVariables);
+		var fileSystem = FileSystemFactory.RealReadForRunnerTemp(environmentVariables);
 		IGitHubPrService prService = new GitHubPrService(logFactory);
 		var service = new ChangelogPrEvaluationService(logFactory, configurationContext, prService, githubActionsService, fileSystem);
 

--- a/src/tooling/docs-builder/Commands/ChangelogCommand.cs
+++ b/src/tooling/docs-builder/Commands/ChangelogCommand.cs
@@ -2,7 +2,6 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-using System.Buffers;
 using System.ComponentModel.DataAnnotations;
 using System.IO.Abstractions;
 using System.Linq;
@@ -1390,10 +1389,14 @@ internal sealed partial class ChangelogCommands(
 		var ctx = ct;
 		await using var serviceInvoker = new ServiceInvoker(collector);
 
+		var fileSystem = FileSystemFactory.RealReadForCI(environmentVariables);
 		IGitHubPrService prService = new GitHubPrService(logFactory);
-		var service = new ChangelogPrEvaluationService(logFactory, configurationContext, prService, githubActionsService);
+		var service = new ChangelogPrEvaluationService(logFactory, configurationContext, prService, githubActionsService, fileSystem);
 
-		var prBody = await ReadPrBodyFromEnvironmentAsync(ctx);
+		var prBodyFile = environmentVariables.GetEnvironmentVariable("PR_BODY_FILE");
+		var prBody = !string.IsNullOrWhiteSpace(prBodyFile)
+			? await ChangelogPrBodyReader.ReadAsync(prBodyFile, collector, fileSystem, ctx)
+			: environmentVariables.GetEnvironmentVariable("PR_BODY");
 
 		var args = new EvaluatePrArguments
 		{
@@ -1558,45 +1561,6 @@ internal sealed partial class ChangelogCommands(
 				result.Add(value);
 		}
 		return result;
-	}
-
-	// PR_BODY can hit GitHub's 65,536-char limit and exceed runner env-var
-	// budgets when passed inline. PR_BODY_FILE lets callers stage the body
-	// in a file under RUNNER_TEMP and pass the path instead, which keeps
-	// the body off the env block entirely. Cap reads at 256 KiB to bound
-	// memory if a caller hands us a hostile path.
-	private const int MaxPrBodyFileBytes = 256 * 1024;
-
-	private async Task<string?> ReadPrBodyFromEnvironmentAsync(CancellationToken ct)
-	{
-		var prBodyFile = environmentVariables.GetEnvironmentVariable("PR_BODY_FILE");
-		if (string.IsNullOrWhiteSpace(prBodyFile))
-			return environmentVariables.GetEnvironmentVariable("PR_BODY");
-
-		var info = _fileSystem.FileInfo.New(prBodyFile);
-		if (!info.Exists)
-		{
-			collector.EmitWarning(string.Empty, $"PR_BODY_FILE points to a missing file: {prBodyFile}");
-			return null;
-		}
-
-		if (info.Length <= MaxPrBodyFileBytes)
-			return await _fileSystem.File.ReadAllTextAsync(prBodyFile, ct);
-
-		collector.EmitHint(string.Empty, $"PR_BODY_FILE exceeds {MaxPrBodyFileBytes} bytes ({info.Length}); truncating.");
-
-		var buffer = ArrayPool<byte>.Shared.Rent(MaxPrBodyFileBytes);
-		try
-		{
-			await using var stream = info.OpenRead();
-			var slice = buffer.AsMemory(0, MaxPrBodyFileBytes);
-			await stream.ReadExactlyAsync(slice, ct);
-			return Encoding.UTF8.GetString(slice.Span);
-		}
-		finally
-		{
-			ArrayPool<byte>.Shared.Return(buffer);
-		}
 	}
 
 	private static string GetPathForConfig(string repoPath, string targetPath)
@@ -1784,4 +1748,3 @@ internal sealed partial class ChangelogCommands(
 	}
 
 }
-

--- a/tests/Elastic.Changelog.Tests/Evaluation/ChangelogPrBodyReaderTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/ChangelogPrBodyReaderTests.cs
@@ -1,0 +1,59 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions.TestingHelpers;
+using AwesomeAssertions;
+using Elastic.Changelog.Evaluation;
+using Elastic.Documentation.Configuration;
+
+namespace Elastic.Changelog.Tests.Evaluation;
+
+public class ChangelogPrBodyReaderTests(ITestOutputHelper output)
+{
+	[Fact]
+	public async Task ReadAsync_PrBodyFileUnderWorkingDir_ReadsBody()
+	{
+		var bodyPath = Path.Join(Paths.WorkingDirectoryRoot.FullName, "changelog-pr-body.md");
+		var mockFs = CreateMockFileSystem();
+		mockFs.AddFile(bodyPath, new MockFileData("Release Notes: adds billing metadata"));
+		var collector = new TestDiagnosticsCollector(output);
+
+		var result = await ChangelogPrBodyReader.ReadAsync(bodyPath, collector, mockFs, TestContext.Current.CancellationToken);
+
+		result.Should().Be("Release Notes: adds billing metadata");
+		collector.Diagnostics.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task ReadAsync_PrBodyFileNotExists_ReturnsNull()
+	{
+		var bodyPath = Path.Join(Paths.WorkingDirectoryRoot.FullName, "missing-pr-body.md");
+		var mockFs = CreateMockFileSystem();
+		var collector = new TestDiagnosticsCollector(output);
+
+		var result = await ChangelogPrBodyReader.ReadAsync(bodyPath, collector, mockFs, TestContext.Current.CancellationToken);
+
+		result.Should().BeNull();
+		collector.Diagnostics.Should().ContainSingle(d => d.Message.Contains("points to a missing file", StringComparison.Ordinal));
+	}
+
+	[Fact]
+	public async Task ReadAsync_PrBodyFileExceedsMaxSize_TruncatesAndHints()
+	{
+		var bodyPath = Path.Join(Paths.WorkingDirectoryRoot.FullName, "large-pr-body.md");
+		var largeContent = new string('x', ChangelogPrBodyReader.MaxPrBodyFileBytes + 1000);
+		var mockFs = CreateMockFileSystem();
+		mockFs.AddFile(bodyPath, new MockFileData(largeContent));
+		var collector = new TestDiagnosticsCollector(output);
+
+		var result = await ChangelogPrBodyReader.ReadAsync(bodyPath, collector, mockFs, TestContext.Current.CancellationToken);
+
+		result.Should().NotBeNull();
+		result.Length.Should().Be(ChangelogPrBodyReader.MaxPrBodyFileBytes);
+		collector.Diagnostics.Should().ContainSingle(d => d.Message.Contains("exceeds", StringComparison.Ordinal));
+	}
+
+	private static MockFileSystem CreateMockFileSystem() =>
+		new(new MockFileSystemOptions { CurrentDirectory = Paths.WorkingDirectoryRoot.FullName });
+}


### PR DESCRIPTION
## Why

`evaluate-pr` read `PR_BODY_FILE` through `FileSystemFactory.RealRead`, which is scoped to the working directory and app data. `RUNNER_TEMP` is under neither, so in GitHub Actions the path failed the scope check, emitted *"points to a missing file"*, and the PR body was silently dropped.

`PR_BODY_FILE` exists precisely because `PR_BODY` can hit GitHub's 65,536-char limit and blow the runner's env-var budget. Since the scoped read rejected every path it was ever given, that workaround never took effect — callers staging the body in `RUNNER_TEMP` got an empty body and no error.

## What

Adds `FileSystemFactory.RealReadForCI`, which extends the standard `RealRead` scope with `RUNNER_TEMP` when that variable is set, and uses it in `evaluate-pr`. It falls back to `RealRead` when the variable is absent, so local runs are unchanged.

Containment stays with the scoped filesystem rather than a hand-rolled path comparison in the caller: a path outside the allowed roots still fails the existence check and surfaces a warning, so the previous behaviour for genuinely out-of-scope paths is preserved.

The remaining body-reading logic — the 256 KiB cap and pooled-buffer truncation path — moves into `ChangelogPrBodyReader` so it can be tested without standing up a command harness.