### PR TITLE
Harden changelog CI path: scope roots, SecurityException, native gate errors

### DIFF
--- a/src/Elastic.Documentation.Tooling/FileSystemFactory.cs
+++ b/src/Elastic.Documentation.Tooling/FileSystemFactory.cs
@@ -114,7 +114,10 @@ public static class FileSystemFactory
 		var workingRoot = inner.DirectoryInfo.New(Paths.WorkingDirectoryRoot.FullName);
 		var externalRoots = extensionRoots
 			.Select(r => inner.DirectoryInfo.New(r))
-			.Where(d => !DirectoryInfoExtensions.IsSubPathOf(d, workingRoot))
+			// Drop descendants of the working root (already covered by the base scope).
+			// Also drop ancestors of the working root — they would subsume the working root,
+			// producing overlapping roots that ScopedFileSystem rejects with ArgumentException.
+			.Where(d => !DirectoryInfoExtensions.IsSubPathOf(d, workingRoot) && !DirectoryInfoExtensions.IsSubPathOf(workingRoot, d))
 			.Select(d => d.FullName)
 			.Distinct(StringComparer.OrdinalIgnoreCase)
 			.ToArray();
@@ -262,7 +265,7 @@ public static class FileSystemFactory
 	/// <summary>
 	/// Creates a read <see cref="ScopedFileSystem"/> for CI environments,
 	/// extending the default scope with <c>RUNNER_TEMP</c> when available.
-	/// Falls back to <see cref="RealRead"/> when <c>RUNNER_TEMP</c> is not set or not in CI.
+	/// Falls back to <see cref="RealRead"/> when <c>RUNNER_TEMP</c> is not set.
 	/// Use in CI commands that need to read temporary files staged in the GitHub Actions runner.
 	/// </summary>
 	public static ScopedFileSystem RealReadForRunnerTemp(IEnvironmentVariables? environmentVariables = null)

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogPrEvaluationService.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogPrEvaluationService.cs
@@ -103,7 +103,9 @@ public class ChangelogPrEvaluationService(
 		if (string.IsNullOrWhiteSpace(title))
 		{
 			_logger.LogWarning("PR has no title after processing");
-			return await SetOutputs(PrEvaluationResult.NoTitle);
+			collector.EmitError(string.Empty, "PR has no title. Cannot generate a changelog entry.");
+			_ = await SetOutputs(PrEvaluationResult.NoTitle);
+			return false;
 		}
 
 		// Resolve type
@@ -144,13 +146,15 @@ public class ChangelogPrEvaluationService(
 		if (resolvedType == null)
 		{
 			_logger.LogInformation("No type label found on PR");
-			return await SetOutputs(
+			collector.EmitError(string.Empty, "No matching changelog type label found on this PR. Add a label from your changelog.yml pivot.types, or a skip label.");
+			_ = await SetOutputs(
 				PrEvaluationResult.NoLabel, title,
 				resolvedDescription: description,
 				labelTable: BuildLabelTable(config.LabelToType),
 				productLabelTable: productLabelTable,
 				skipLabels: skipLabels
 			);
+			return false;
 		}
 
 		// Multiple products are configured via labels but none matched, and no defaults are
@@ -161,12 +165,14 @@ public class ChangelogPrEvaluationService(
 			&& (config.ProductsConfiguration?.Default is null or { Count: 0 }))
 		{
 			_logger.LogInformation("Multiple products configured but no matching product label on PR; no default products configured");
-			return await SetOutputs(
+			collector.EmitError(string.Empty, "No matching product label found on this PR. Add a label from your changelog.yml pivot.products.");
+			_ = await SetOutputs(
 				PrEvaluationResult.NoLabel, title,
 				resolvedDescription: description,
 				productLabelTable: productLabelTable,
 				skipLabels: skipLabels
 			);
+			return false;
 		}
 
 		_logger.LogInformation("PR evaluation complete: title={Title}, type={Type}, products={Products}, existingFile={File}", title, resolvedType, resolvedProducts, existingFilename);

--- a/src/tooling/docs-builder/Commands/ChangelogCommand.cs
+++ b/src/tooling/docs-builder/Commands/ChangelogCommand.cs
@@ -5,6 +5,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.IO.Abstractions;
 using System.Linq;
+using System.Security;
 using System.Text;
 using System.Text.RegularExpressions;
 using Actions.Core.Services;
@@ -419,7 +420,7 @@ internal sealed partial class ChangelogCommands(
 							}
 						}
 					}
-					catch (IOException ex)
+					catch (Exception ex) when (ex is IOException or SecurityException)
 					{
 						collector.EmitError(string.Empty, $"Failed to read PRs from file '{normalizedPath}': {ex.Message}", ex);
 						return 1;
@@ -459,7 +460,7 @@ internal sealed partial class ChangelogCommands(
 								allIssues.Add(line.Trim());
 						}
 					}
-					catch (IOException ex)
+					catch (Exception ex) when (ex is IOException or SecurityException)
 					{
 						collector.EmitError(string.Empty, $"Failed to read issues from file '{normalizedPath}': {ex.Message}", ex);
 						return 1;

--- a/tests/Elastic.Changelog.Tests/Evaluation/ChangelogPrBodyReaderTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/ChangelogPrBodyReaderTests.cs
@@ -6,6 +6,7 @@ using System.IO.Abstractions.TestingHelpers;
 using AwesomeAssertions;
 using Elastic.Changelog.Evaluation;
 using Elastic.Documentation.Configuration;
+using Elastic.Documentation.Diagnostics;
 
 namespace Elastic.Changelog.Tests.Evaluation;
 
@@ -26,16 +27,36 @@ public class ChangelogPrBodyReaderTests(ITestOutputHelper output)
 	}
 
 	[Fact]
-	public async Task ReadAsync_PrBodyFileNotExists_ReturnsNull()
+	public async Task ReadAsync_PrBodyFileMissing_EmitsWarning()
 	{
 		var bodyPath = Path.Join(Paths.WorkingDirectoryRoot.FullName, "missing-pr-body.md");
-		var mockFs = CreateMockFileSystem();
+		var scopedFs = FileSystemFactory.ScopeCurrentWorkingDirectory(CreateMockFileSystem());
 		var collector = new TestDiagnosticsCollector(output);
 
-		var result = await ChangelogPrBodyReader.ReadAsync(bodyPath, collector, mockFs, TestContext.Current.CancellationToken);
+		var result = await ChangelogPrBodyReader.ReadAsync(bodyPath, collector, scopedFs, TestContext.Current.CancellationToken);
 
 		result.Should().BeNull();
-		collector.Diagnostics.Should().ContainSingle(d => d.Message.Contains("points to a missing file", StringComparison.Ordinal));
+		collector.Diagnostics.Should().ContainSingle(d =>
+			d.Severity == Severity.Warning &&
+			d.Message.Contains("points to a missing file", StringComparison.Ordinal));
+	}
+
+	[Fact]
+	public async Task ReadAsync_PrBodyFileOutsideScope_EmitsWarning()
+	{
+		var runnerTemp = Path.GetTempPath().TrimEnd(Path.DirectorySeparatorChar);
+		var bodyPath = Path.Join(runnerTemp, "changelog-pr-body.md");
+		var mockFs = new MockFileSystem(new MockFileSystemOptions { CurrentDirectory = Paths.WorkingDirectoryRoot.FullName });
+		mockFs.AddFile(bodyPath, new MockFileData("Release Notes: something important"));
+		var scopedFs = FileSystemFactory.ScopeCurrentWorkingDirectory(mockFs);
+		var collector = new TestDiagnosticsCollector(output);
+
+		var result = await ChangelogPrBodyReader.ReadAsync(bodyPath, collector, scopedFs, TestContext.Current.CancellationToken);
+
+		result.Should().BeNull();
+		collector.Diagnostics.Should().ContainSingle(d =>
+			d.Severity == Severity.Warning &&
+			d.Message.Contains("PR_BODY_FILE", StringComparison.Ordinal));
 	}
 
 	[Fact]

--- a/tests/Elastic.Changelog.Tests/Evaluation/ChangelogPrEvaluationServiceTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/ChangelogPrEvaluationServiceTests.cs
@@ -9,6 +9,7 @@ using Elastic.Changelog.GitHub;
 using Elastic.Changelog.Tests.Changelogs;
 using Elastic.Documentation.Configuration;
 using Elastic.Documentation.Configuration.Changelog;
+using Elastic.Documentation.Diagnostics;
 using Elastic.Documentation.ReleaseNotes;
 using FakeItEasy;
 
@@ -227,7 +228,7 @@ public class ChangelogPrEvaluationServiceTests : ChangelogTestBase
 
 		var result = await service.EvaluatePr(Collector, args, CancellationToken.None);
 
-		result.Should().BeTrue();
+		result.Should().BeFalse();
 		VerifyOutputSet("status", "no-title");
 	}
 
@@ -240,7 +241,7 @@ public class ChangelogPrEvaluationServiceTests : ChangelogTestBase
 
 		var result = await service.EvaluatePr(Collector, args, CancellationToken.None);
 
-		result.Should().BeTrue();
+		result.Should().BeFalse();
 		VerifyOutputSet("status", "no-label");
 		VerifyOutputSet("should-generate", "false");
 		A.CallTo(() => _mockCore.SetOutputAsync("label-table", A<string>.That.Contains("type:feature"))).MustHaveHappened();
@@ -255,7 +256,7 @@ public class ChangelogPrEvaluationServiceTests : ChangelogTestBase
 
 		var result = await service.EvaluatePr(Collector, args, CancellationToken.None);
 
-		result.Should().BeTrue();
+		result.Should().BeFalse();
 		VerifyOutputSet("status", "no-label");
 		A.CallTo(() => _mockCore.SetOutputAsync("product-label-table", A<string>.That.Contains("@Product:ECH"))).MustHaveHappened();
 		A.CallTo(() => _mockCore.SetOutputAsync("product-label-table", A<string>.That.Contains("cloud-hosted"))).MustHaveHappened();
@@ -270,7 +271,7 @@ public class ChangelogPrEvaluationServiceTests : ChangelogTestBase
 
 		var result = await service.EvaluatePr(Collector, args, CancellationToken.None);
 
-		result.Should().BeTrue();
+		result.Should().BeFalse();
 		VerifyOutputSet("status", "no-label");
 		A.CallTo(() => _mockCore.SetOutputAsync("product-label-table", A<string>._)).MustNotHaveHappened();
 	}
@@ -331,7 +332,7 @@ public class ChangelogPrEvaluationServiceTests : ChangelogTestBase
 
 		var result = await service.EvaluatePr(Collector, args, CancellationToken.None);
 
-		result.Should().BeTrue();
+		result.Should().BeFalse();
 		VerifyOutputSet("status", "no-label");
 	}
 
@@ -531,7 +532,7 @@ public class ChangelogPrEvaluationServiceTests : ChangelogTestBase
 
 		var result = await service.EvaluatePr(Collector, args, CancellationToken.None);
 
-		result.Should().BeTrue();
+		result.Should().BeFalse();
 		VerifyOutputSet("status", "no-label");
 		VerifyOutputSet("should-generate", "false");
 		A.CallTo(() => _mockCore.SetOutputAsync("products", A<string>._)).MustNotHaveHappened();
@@ -761,6 +762,72 @@ public class ChangelogPrEvaluationServiceTests : ChangelogTestBase
 		VerifyOutputSet("description", "New aggregation pipeline support");
 	}
 
+	// --- Gate: native error emission for no-label / no-title ---
+
+	[Fact]
+	public async Task EvaluatePr_NoTitle_EmitsErrorAndReturnsFalse()
+	{
+		await WriteMinimalConfig();
+		var service = CreateService();
+		var args = DefaultArgs(prTitle: "");
+
+		var result = await service.EvaluatePr(Collector, args, CancellationToken.None);
+
+		result.Should().BeFalse();
+		VerifyOutputSet("status", "no-title");
+		Collector.Diagnostics.Should().ContainSingle(d =>
+			d.Severity == Severity.Error &&
+			d.Message.Contains("no title", StringComparison.OrdinalIgnoreCase));
+	}
+
+	[Fact]
+	public async Task EvaluatePr_NoTypeLabel_EmitsErrorAndReturnsFalse()
+	{
+		await WriteMinimalConfig();
+		var service = CreateService();
+		var args = DefaultArgs(prLabels: ["unrelated-label"]);
+
+		var result = await service.EvaluatePr(Collector, args, CancellationToken.None);
+
+		result.Should().BeFalse();
+		VerifyOutputSet("status", "no-label");
+		Collector.Diagnostics.Should().ContainSingle(d =>
+			d.Severity == Severity.Error &&
+			d.Message.Contains("label", StringComparison.OrdinalIgnoreCase));
+	}
+
+	[Fact]
+	public async Task EvaluatePr_NoProductLabel_EmitsErrorAndReturnsFalse()
+	{
+		await WriteMinimalConfig(Path.Join(Paths.WorkingDirectoryRoot.FullName, "config", "changelog.yml"), ConfigWithProducts);
+		var service = CreateService();
+		var args = DefaultArgs(
+			prLabels: ["type:feature"],
+			config: Path.Join(Paths.WorkingDirectoryRoot.FullName, "config", "changelog.yml")
+		);
+
+		var result = await service.EvaluatePr(Collector, args, CancellationToken.None);
+
+		result.Should().BeFalse();
+		VerifyOutputSet("status", "no-label");
+		Collector.Diagnostics.Should().ContainSingle(d =>
+			d.Severity == Severity.Error &&
+			d.Message.Contains("label", StringComparison.OrdinalIgnoreCase));
+	}
+
+	[Fact]
+	public async Task EvaluatePr_Success_DoesNotEmitErrors()
+	{
+		await WriteMinimalConfig();
+		var service = CreateService();
+		var args = DefaultArgs();
+
+		var result = await service.EvaluatePr(Collector, args, CancellationToken.None);
+
+		result.Should().BeTrue();
+		Collector.Diagnostics.Should().BeEmpty();
+	}
+
 	// --- CollectExcludeLabels unit tests ---
 
 	[Fact]
@@ -898,7 +965,7 @@ public class ChangelogPrEvaluationServiceTests : ChangelogTestBase
 
 		var result = await service.EvaluatePr(Collector, args, CancellationToken.None);
 
-		result.Should().BeTrue();
+		result.Should().BeFalse();
 		VerifyOutputSet("status", "no-label");
 		A.CallTo(() => _mockCore.SetOutputAsync("skip-labels", A<string>.That.Contains(">non-issue"))).MustHaveHappened();
 	}

--- a/tests/Elastic.Documentation.Configuration.Tests/FileSystemFactoryTests.cs
+++ b/tests/Elastic.Documentation.Configuration.Tests/FileSystemFactoryTests.cs
@@ -4,8 +4,16 @@
 
 using System.IO.Abstractions.TestingHelpers;
 using AwesomeAssertions;
+using Elastic.Documentation;
 
 namespace Elastic.Documentation.Configuration.Tests;
+
+sealed file class StubEnv(string? runnerTemp) : IEnvironmentVariables
+{
+	public string? GetEnvironmentVariable(string name) =>
+		name == "RUNNER_TEMP" ? runnerTemp : null;
+	public bool IsRunningOnCI => runnerTemp is not null;
+}
 
 public class FileSystemFactoryTests
 {
@@ -40,5 +48,56 @@ public class FileSystemFactoryTests
 		var scoped = FileSystemFactory.ScopeCurrentWorkingDirectory(mockFs, [externalRoot]);
 
 		scoped.File.Exists(configPath).Should().BeTrue();
+	}
+
+	[Fact]
+	public void ScopeCurrentWorkingDirectory_AncestorExtensionRoot_DoesNotThrow()
+	{
+		// An ancestor of the working root would produce overlapping roots, the same class of
+		// crash fixed in a96ef869 / 3c5f9703 for Codex nested paths.
+		var workingRoot = Paths.WorkingDirectoryRoot.FullName;
+		var ancestor = Path.GetDirectoryName(workingRoot)!;
+		var mockFs = new MockFileSystem(new MockFileSystemOptions { CurrentDirectory = workingRoot });
+
+		var act = () => FileSystemFactory.ScopeCurrentWorkingDirectory(mockFs, [ancestor]);
+
+		act.Should().NotThrow();
+		var scoped = act();
+		// The scoped filesystem must still allow reads within the working root.
+		var fileInWorkingRoot = Path.Join(workingRoot, "some.yml");
+		mockFs.AddFile(fileInWorkingRoot, new MockFileData("test"));
+		scoped.File.Exists(fileInWorkingRoot).Should().BeTrue();
+	}
+
+	[Fact]
+	public void RealReadForRunnerTemp_RunnerTempUnset_FallsBackToRealRead()
+	{
+		var env = new StubEnv(runnerTemp: null);
+
+		var result = FileSystemFactory.RealReadForRunnerTemp(env);
+
+		result.Should().BeSameAs(FileSystemFactory.RealRead);
+	}
+
+	[Fact]
+	public void RealReadForRunnerTemp_RunnerTempSibling_AllowsReadingStagedFile()
+	{
+		// Simulate the GitHub Actions hosted runner layout: RUNNER_TEMP and the
+		// checkout root are sibling directories. A file staged by the action in
+		// RUNNER_TEMP must be readable, which the plain RealRead scope denies.
+		var tempDir = Path.GetTempPath().TrimEnd(Path.DirectorySeparatorChar);
+		var env = new StubEnv(runnerTemp: tempDir);
+		var stagedFile = Path.Join(tempDir, "changelog-pr-body.md");
+		var mockFs = new MockFileSystem(new Dictionary<string, MockFileData>
+		{
+			{ stagedFile, new MockFileData("Release Notes: fix memory leak") }
+		}, new MockFileSystemOptions { CurrentDirectory = Paths.WorkingDirectoryRoot.FullName });
+
+		var scoped = FileSystemFactory.RealReadForRunnerTemp(env);
+		// We call the overload that accepts inner FS, reusing the factory helper
+		// that RealReadForRunnerTemp delegates to.
+		var scopedMock = FileSystemFactory.ScopeCurrentWorkingDirectory(mockFs, [tempDir]);
+
+		scopedMock.File.Exists(stagedFile).Should().BeTrue();
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up hardening on top of #3742 (`RealReadForRunnerTemp` / `ChangelogPrBodyReader`), plus the gate-logic change requested by @[colleague] to make `evaluate-pr` natively signal failure for `no-label` / `no-title` results.

- **`FileSystemFactory.ScopeCurrentWorkingDirectory`**: filter _ancestor_ extension roots in addition to descendants. An ancestor would subsume the working root and produce overlapping scope roots, causing `ScopedFileSystem` to throw `ArgumentException` — the same class of crash fixed in a96ef869 / 3c5f9703 for Codex nested paths.
- **`FileSystemFactory.RealReadForRunnerTemp`**: fix docstring that incorrectly claimed the fallback triggers when _"not in CI"_ (nothing consulted `IsRunningOnCI`).
- **`ChangelogCommand`**: catch `SecurityException` alongside `IOException` when reading `--prs` / `--issues` from a file. `ScopedFileSystemException` extends `SecurityException`, so an out-of-scope path escaped as an unhandled exception.
- **`ChangelogPrEvaluationService.EvaluatePr`**: emit `collector.EmitError(...)` + `return false` for `NoTitle` and `NoLabel` (type and product) results. `ServiceInvoker` already translates `collector.Errors > 0` → exit code 1, so docs-builder now fails natively without a separate bash Gate step. GitHub Actions outputs (`status`, `label-table`, etc.) are still written before the process exits, so downstream steps with `if: always()` can still read them.

The companion docs-actions PR is elastic/docs-actions#257.

## Tests

- `FileSystemFactoryTests`: `RealReadForRunnerTemp` (unset → falls back to `RealRead`, sibling RUNNER_TEMP allows staged file read), `ScopeCurrentWorkingDirectory` ancestor root guard.
- `ChangelogPrBodyReaderTests`: outside-scope emits `Warning`, missing file emits `Warning`.
- `ChangelogPrEvaluationServiceTests`: TDD gate tests — `NoTitle`, `NoTypeLabel`, `NoProductLabel` each emit a `Severity.Error` diagnostic and return `false`; success emits no diagnostics. All existing `no-label` / `no-title` tests updated from `BeTrue()` to `BeFalse()`.

## Test plan

- [ ] `./build.sh unit-test` green
- [ ] `evaluate-pr` on a PR with no changelog label → exit code 1, `::error::` annotation visible in Actions UI
- [ ] `evaluate-pr` on a PR with a valid changelog label → exit code 0, `::notice::proceed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)