### PR TITLE
Site: fix breadcrumb and heading spacing

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/markdown/typography.css
+++ b/src/Elastic.Documentation.Site/Assets/markdown/typography.css
@@ -2,7 +2,7 @@
 	@apply text-ink font-body text-base text-pretty;
 
 	h1 {
-		@apply text-ink-dark text-5xl font-semibold;
+		@apply text-ink-dark mt-6 text-5xl font-semibold;
 		line-height: 1.2em;
 	}
 

--- a/src/Elastic.Markdown/Layout/_Breadcrumbs.cshtml
+++ b/src/Elastic.Markdown/Layout/_Breadcrumbs.cshtml
@@ -11,7 +11,7 @@
 
 @if (crumbs.Count > 0 && (crumbs.Count > 1 || Model.BuildType != BuildType.Isolated))
 {
-<ol id="breadcrumbs" class="flex flex-wrap gap-1 items-center w-full py-6">
+<ol id="breadcrumbs" class="flex flex-wrap gap-1 items-center w-full pt-6">
 	@for (var i = 0; i < crumbs.Count; i++)
 	{
 		var item = crumbs[i];

--- a/src/Elastic.Markdown/_Layout.cshtml
+++ b/src/Elastic.Markdown/_Layout.cshtml
@@ -36,11 +36,7 @@
 			">
 				<div class="min-h-screen grid grid-cols-1 md:grid-cols-[var(--max-sidebar-width)_1fr] gap-4">
 					<main id="content-container" class="min-w-0 flex flex-col lg:grid lg:grid-cols-[minmax(0,var(--max-text-width))_minmax(0,var(--max-sidebar-width))] lg:justify-end lg:gap-4 mx-4 md:col-start-2 md:row-start-1">
-						@{
-							var breadcrumbs = Model.Breadcrumbs.ToList();
-							var breadcrumbVisible = breadcrumbs.Count > 0 && (breadcrumbs.Count > 1 || Model.BuildType != BuildType.Isolated);
-						}
-						<div class="mb-9 mt-0 min-w-0 order-2 lg:order-1 @(breadcrumbVisible ? "" : "pt-6")">
+						<div class="mb-9 mt-0 min-w-0 order-2 lg:order-1">
 							@await RenderPartialAsync(_Breadcrumbs.Create(Model))
 							<article id="markdown-content" class="markdown-content min-w-0" data-pagefind-body>
 								<input type="checkbox" class="hidden" id="pages-nav-hamburger">


### PR DESCRIPTION
## What

- Keep page heading spacing consistent with and without breadcrumbs.

## Why

- Pages without breadcrumbs render the main heading too close to the surrounding layout.

## Notes

- The frontend build passes.
- The Markdown project build is blocked by the existing missing `HtmlSection` type on `origin/main`.

Made with [Cursor](https://cursor.com)