### PR TITLE
CI: add warn-only accessibility synthetics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,10 @@ jobs:
         working-directory: src/Elastic.Documentation.Site
         run: npm run synthetics:test
 
+      - name: Run accessibility synthetics
+        working-directory: src/Elastic.Documentation.Site
+        run: npm run synthetics:test:accessibility
+
   npm:
     runs-on: ubuntu-latest
     defaults: 

--- a/src/Elastic.Documentation.Site/package-lock.json
+++ b/src/Elastic.Documentation.Site/package-lock.json
@@ -48,6 +48,7 @@
         "zustand": "5.0.13"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.12.1",
         "@babel/core": "7.29.6",
         "@babel/preset-env": "7.29.0",
         "@babel/preset-react": "7.28.5",
@@ -125,6 +126,19 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
+      "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.12.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -25585,6 +25599,16 @@
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
       "integrity": "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
       }

--- a/src/Elastic.Documentation.Site/package.json
+++ b/src/Elastic.Documentation.Site/package.json
@@ -20,6 +20,7 @@
     "synthetics:test:staging": "DOCS_ENV=staging npm run synthetics:test",
     "synthetics:test:edge": "DOCS_ENV=edge npm run synthetics:test",
     "synthetics:test:local": "DOCS_ENV=local npm run synthetics:test",
+    "synthetics:test:accessibility": "npx @elastic/synthetics ./synthetics/ci/accessibility.ci.ts --config=./synthetics/synthetics.config.ts",
     "synthetics:test:mcp": "npx @elastic/synthetics ./synthetics/journeys/mcp-server.journey.ts --config=./synthetics/synthetics.config.ts",
     "synthetics:test:mcp:prod": "DOCS_ENV=prod npm run synthetics:test:mcp",
     "synthetics:test:mcp:staging": "DOCS_ENV=staging npm run synthetics:test:mcp",
@@ -60,6 +61,7 @@
   },
   "private": true,
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@babel/core": "7.29.6",
     "@babel/preset-env": "7.29.0",
     "@babel/preset-react": "7.28.5",

--- a/src/Elastic.Documentation.Site/synthetics/ci/accessibility.ci.ts
+++ b/src/Elastic.Documentation.Site/synthetics/ci/accessibility.ci.ts
@@ -1,0 +1,70 @@
+import AxeBuilder from '@axe-core/playwright'
+import { journey, step } from '@elastic/synthetics'
+
+const docsPaths = [
+    '/docs',
+    '/docs/get-started',
+    '/docs/get-started/deployment-options',
+    '/docs/deploy-manage/deploy/elastic-cloud',
+    '/docs/reference',
+]
+
+const wcagTags = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa']
+
+type AxeViolation = Awaited<
+    ReturnType<AxeBuilder['analyze']>
+>['violations'][number]
+
+function escapeWorkflowCommand(value: string) {
+    return value
+        .replaceAll('%', '%25')
+        .replaceAll('\r', '%0D')
+        .replaceAll('\n', '%0A')
+}
+
+function escapeWorkflowProperty(value: string) {
+    return escapeWorkflowCommand(value)
+        .replaceAll(':', '%3A')
+        .replaceAll(',', '%2C')
+}
+
+function reportViolations(path: string, violations: AxeViolation[]) {
+    if (violations.length === 0) {
+        console.log(`No accessibility violations found on ${path}`)
+        return
+    }
+
+    for (const violation of violations) {
+        const selectors = violation.nodes
+            .map((node) => JSON.stringify(node.target))
+            .join(', ')
+        const message = [
+            `${path}: ${violation.help}`,
+            `Impact: ${violation.impact ?? 'unknown'}`,
+            `Help: ${violation.helpUrl}`,
+            `Selectors: ${selectors}`,
+        ].join(' | ')
+        const title = `Accessibility ${violation.id}`
+
+        console.warn(
+            `::warning title=${escapeWorkflowProperty(title)}::${escapeWorkflowCommand(message)}`
+        )
+    }
+}
+
+journey('CI accessibility audit', ({ page, params }) => {
+    for (const path of docsPaths) {
+        step(`Audit ${path}`, async () => {
+            await page.goto(`${params.baseUrl}${path}`, {
+                timeout: 60000,
+                waitUntil: 'load',
+            })
+
+            const results = await new AxeBuilder({ page })
+                .withTags(wcagTags)
+                .analyze()
+
+            reportViolations(path, results.violations)
+        })
+    }
+})


### PR DESCRIPTION
## What

- Add a CI-only synthetics accessibility check that runs axe against key docs pages
- Report WCAG 2.1 A/AA violations as GitHub Actions warnings without failing the job

## Why

- Start measuring docs accessibility in this repo's CI without blocking merges or deployment quality gates
- Keep the existing synthetics suite unchanged for pipelines that run before production deploys

## Notes

- The new check lives outside `synthetics/journeys` and uses a separate npm script so `synthetics:test` and `synthetics:push:*` stay unchanged
- Violations are warn-only for now so follow-up PRs can fix issues before making the check blocking


Made with [Cursor](https://cursor.com)