### PR TITLE
Test MCP initialization without a User-Agent

### DIFF
--- a/src/Elastic.Documentation.Site/synthetics/journeys/mcp-server.journey.ts
+++ b/src/Elastic.Documentation.Site/synthetics/journeys/mcp-server.journey.ts
@@ -1,9 +1,15 @@
 import { journey, step, monitor, expect } from '@elastic/synthetics'
 
 const MCP_PATH = '/docs/_mcp'
-// Content-Type is set automatically by Playwright when `data` is an object; only
-// Accept is load-bearing here (required by the MCP streamable-HTTP transport).
-const MCP_ACCEPT_HEADER = { Accept: 'application/json, text/event-stream' }
+const MCP_PROTOCOL_VERSION = '2025-06-18'
+const MCP_HEADERS = {
+    Accept: 'application/json, text/event-stream',
+    'Content-Type': 'application/json',
+    'MCP-Protocol-Version': MCP_PROTOCOL_VERSION,
+}
+// Codex's RMCP client does not send a User-Agent. An empty value overrides the
+// synthetic client's default so this request exercises the same WAF behavior.
+const MCP_NO_USER_AGENT_HEADERS = { ...MCP_HEADERS, 'User-Agent': '' }
 
 // ponytail: duplicated from navigation-test.journey.ts — a 7-line pure helper across 2 files
 // isn't worth a shared module yet; extract to synthetics/lib.ts if a 3rd journey needs it.
@@ -35,12 +41,34 @@ if (env !== 'local') {
             expect(res.status()).toBe(200)
         })
 
-        step('MCP lists its tools', async () => {
+        step('MCP initializes without a User-Agent', async () => {
             const res = await request.post(mcpUrl, {
-                headers: MCP_ACCEPT_HEADER,
+                headers: MCP_NO_USER_AGENT_HEADERS,
                 data: {
                     jsonrpc: '2.0',
                     id: 1,
+                    method: 'initialize',
+                    params: {
+                        protocolVersion: MCP_PROTOCOL_VERSION,
+                        capabilities: {},
+                        clientInfo: {
+                            name: 'elastic-docs-synthetic',
+                            version: '1.0.0',
+                        },
+                    },
+                },
+            })
+            expect(res.status()).toBe(200)
+            expect(res.headers()['content-type']).toContain('text/event-stream')
+            expect(await res.text()).toContain('"protocolVersion"')
+        })
+
+        step('MCP lists its tools', async () => {
+            const res = await request.post(mcpUrl, {
+                headers: MCP_HEADERS,
+                data: {
+                    jsonrpc: '2.0',
+                    id: 2,
                     method: 'tools/list',
                     params: {},
                 },
@@ -51,10 +79,10 @@ if (env !== 'local') {
 
         step('MCP search_docs returns results', async () => {
             const res = await request.post(mcpUrl, {
-                headers: MCP_ACCEPT_HEADER,
+                headers: MCP_HEADERS,
                 data: {
                     jsonrpc: '2.0',
-                    id: 2,
+                    id: 3,
                     method: 'tools/call',
                     params: {
                         name: 'search_docs',


### PR DESCRIPTION
## Summary

- Add an MCP `initialize` request to the deployed-environment synthetic monitor.
- Override the synthetic client default with an empty `User-Agent` to reproduce Codex RMCP traffic.
- Assert a `200` response with `text/event-stream` before running the existing tool checks.

Companion regression coverage for elastic/docs-infra#373 and elastic/docs-infra#346.

## Validation

- `npm run compile:check`
- Prettier formatting
- Current edge: no-User-Agent initialize returns `403` as expected before the WAF fix is deployed.
- Current edge: identical initialize request with a User-Agent returns `200 text/event-stream`.