### PR TITLE
Adds a new product id in preparation of the product release

### DIFF
--- a/config/products.yml
+++ b/config/products.yml
@@ -247,6 +247,9 @@ products:
   serverless-security:
     display: 'Elastic Security Serverless'
     versioning: 'all'
+  serverless-vector-database:
+    display: 'Elasticsearch Vector Database Serverless'
+    versioning: 'serverless'
   transport-go:
     display: 'Elastic Transport Go'
     repository: 'elastic-transport-go'


### PR DESCRIPTION
Fixes [#1534](https://github.com/elastic/docs-content-internal/issues/1534)

## Description

Docs need a canonical product ID for the new Elasticsearch Vector Database Serverless project type, for {{product.serverless-vector-database}} substitutions, page front-matter products, and search filters.

Details:

```
ID: serverless-vector-database
Display: Elasticsearch Vector Database Serverless
Versioning: serverless (same system as other Serverless projects)
```


## Changes

Added `serverless-vector-database` to `config/products.yml` in docs-builder.


## For reviewers 

Please let me know if there's anything else I need to add to this PR.