### PR TITLE
Fix WaitForDrain race when reader task has not scheduled yet

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -44,6 +44,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Telemetry.Abstractions" Version="10.6.0" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" />
     <PackageVersion Include="Nullean.ScopedFileSystem" Version="0.4.0" />
     <PackageVersion Include="Pagefind.Net" Version="0.4.1" />
     <PackageVersion Include="Pagefind.Net.Frontend" Version="0.4.1" />

--- a/src/Elastic.Documentation/Diagnostics/DiagnosticsCollector.cs
+++ b/src/Elastic.Documentation/Diagnostics/DiagnosticsCollector.cs
@@ -7,10 +7,12 @@ using System.IO.Abstractions;
 
 namespace Elastic.Documentation.Diagnostics;
 
-public class DiagnosticsCollector(IReadOnlyCollection<IDiagnosticsOutput> outputs)
+public class DiagnosticsCollector(IReadOnlyCollection<IDiagnosticsOutput> outputs, TimeProvider? timeProvider = null)
 	: IDiagnosticsCollector
 {
 	public DiagnosticsChannel Channel { get; } = new();
+
+	public TimeProvider TimeProvider { get; } = timeProvider ?? TimeProvider.System;
 
 	private int _errors;
 	private int _warnings;

--- a/src/Elastic.Documentation/Diagnostics/DiagnosticsCollector.cs
+++ b/src/Elastic.Documentation/Diagnostics/DiagnosticsCollector.cs
@@ -37,6 +37,8 @@ public class DiagnosticsCollector(IReadOnlyCollection<IDiagnosticsOutput> output
 
 	public bool IsStarted => _readerStarted;
 
+	public bool IsStartRequested => _started is not null;
+
 	public virtual DiagnosticsCollector StartAsync(Cancel ctx)
 	{
 		_ = EnsureStarted(ctx);

--- a/src/Elastic.Documentation/Diagnostics/IDiagnosticsCollector.cs
+++ b/src/Elastic.Documentation/Diagnostics/IDiagnosticsCollector.cs
@@ -28,6 +28,10 @@ public interface IDiagnosticsCollector : IAsyncDisposable
 	/// requested but hasn't scheduled yet" from "StartAsync was never called at all".
 	bool IsStartRequested { get; }
 
+	/// Time source for drain waits and their timeouts; tests supply a fake to
+	/// exercise timeout paths in virtual time instead of wall-clock time.
+	TimeProvider TimeProvider { get; }
+
 	Task StartAsync(Cancel cancellationToken);
 	Task StopAsync(Cancel cancellationToken);
 
@@ -72,23 +76,22 @@ public interface IDiagnosticsCollector : IAsyncDisposable
 			// StartAsync was called but the Task.Run delegate hasn't been picked up by the
 			// thread pool yet (_readerStarted = true hasn't run). Spin briefly to let it start.
 			// In practice this resolves in < 1ms; the 2s deadline is a safety net.
-			var waitStart = DateTime.UtcNow;
+			var waitStart = TimeProvider.GetTimestamp();
 			while (!IsStarted)
 			{
-				await Task.Delay(10);
-				if (DateTime.UtcNow - waitStart > TimeSpan.FromSeconds(2))
+				await Task.Delay(TimeSpan.FromMilliseconds(10), TimeProvider);
+				if (TimeProvider.GetElapsedTime(waitStart) > TimeSpan.FromSeconds(2))
 					throw new InvalidOperationException(
 						"WaitForDrain timed out waiting for the background reader to start. " +
 						"StartAsync was called but the reader delegate did not start within the deadline.");
 			}
 		}
 
-		var start = DateTime.UtcNow;
+		var start = TimeProvider.GetTimestamp();
 		while (Channel.Reader.TryPeek(out _))
 		{
-			await Task.Delay(10);
-			var now = DateTime.UtcNow;
-			if (now - start > TimeSpan.FromSeconds(2))
+			await Task.Delay(TimeSpan.FromMilliseconds(10), TimeProvider);
+			if (TimeProvider.GetElapsedTime(start) > TimeSpan.FromSeconds(2))
 				throw new Exception("Could not iterate over all diagnostic messages in a timely fashion");
 		}
 	}

--- a/src/Elastic.Documentation/Diagnostics/IDiagnosticsCollector.cs
+++ b/src/Elastic.Documentation/Diagnostics/IDiagnosticsCollector.cs
@@ -23,6 +23,11 @@ public interface IDiagnosticsCollector : IAsyncDisposable
 	/// True once the background reader is actively draining the channel.
 	bool IsStarted { get; }
 
+	/// True if StartAsync has been called and a reader task is pending or running,
+	/// even if the background delegate has not yet executed. Distinguishes "start was
+	/// requested but hasn't scheduled yet" from "StartAsync was never called at all".
+	bool IsStartRequested { get; }
+
 	Task StartAsync(Cancel cancellationToken);
 	Task StopAsync(Cancel cancellationToken);
 
@@ -56,9 +61,26 @@ public interface IDiagnosticsCollector : IAsyncDisposable
 	{
 		if (!IsStarted)
 		{
-			throw new InvalidOperationException(
-				"WaitForDrain called on a collector that was never started; no reader is draining the channel. " +
-				"Call StartAsync first or dispose the collector to drain synchronously.");
+			// If StartAsync was never called, throw immediately — there is no pending reader.
+			if (!IsStartRequested)
+			{
+				throw new InvalidOperationException(
+					"WaitForDrain called on a collector that was never started; no reader is draining the channel. " +
+					"Call StartAsync first or dispose the collector to drain synchronously.");
+			}
+
+			// StartAsync was called but the Task.Run delegate hasn't been picked up by the
+			// thread pool yet (_readerStarted = true hasn't run). Spin briefly to let it start.
+			// In practice this resolves in < 1ms; the 2s deadline is a safety net.
+			var waitStart = DateTime.UtcNow;
+			while (!IsStarted)
+			{
+				await Task.Delay(10);
+				if (DateTime.UtcNow - waitStart > TimeSpan.FromSeconds(2))
+					throw new InvalidOperationException(
+						"WaitForDrain timed out waiting for the background reader to start. " +
+						"StartAsync was called but the reader delegate did not start within the deadline.");
+			}
 		}
 
 		var start = DateTime.UtcNow;

--- a/tests/Elastic.Changelog.Tests/Changelogs/DiagnosticsCollectorDisposeTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/DiagnosticsCollectorDisposeTests.cs
@@ -80,4 +80,27 @@ public class DiagnosticsCollectorDisposeTests
 		Func<Task> act = () => ((IDiagnosticsCollector)collector).WaitForDrain();
 		_ = await act.Should().ThrowAsync<InvalidOperationException>();
 	}
+
+	// Regression: ServiceInvoker calls StartAsync fire-and-forget from its field initializer.
+	// If the service command completes before the thread pool picks up the Task.Run delegate,
+	// _readerStarted is still false when WaitForDrain runs. Previously this threw; now it
+	// waits briefly for the reader to start and then drains successfully.
+	[Fact]
+	public async Task WaitForDrain_AfterStartAsync_WaitsForReaderEvenIfNotStartedYet()
+	{
+		var output = new RecordingOutput();
+		var collector = new DiagnosticsCollector([output]);
+		IDiagnosticsCollector iface = collector;
+
+		// StartAsync is called but we don't await — simulates the fire-and-forget in ServiceInvoker.
+		_ = iface.StartAsync(CancellationToken.None);
+		iface.EmitWarning(string.Empty, "should be drained");
+
+		// WaitForDrain must not throw even though IsStarted may still be false here.
+		await ShouldComplete(iface.WaitForDrain(), TimeSpan.FromSeconds(5),
+			"WaitForDrain must not throw when StartAsync was called but reader hasn't started yet");
+
+		collector.Warnings.Should().Be(1);
+		output.Items.Should().HaveCount(1, "the item must be drained once the reader starts");
+	}
 }

--- a/tests/Elastic.Changelog.Tests/Changelogs/DiagnosticsCollectorDisposeTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/DiagnosticsCollectorDisposeTests.cs
@@ -123,7 +123,7 @@ public class DiagnosticsCollectorDisposeTests
 		for (var i = 0; i < 100 && !drain.IsCompleted; i++)
 		{
 			timeProvider.Advance(TimeSpan.FromMilliseconds(500));
-			await Task.Delay(10); // real delay so the awaiting continuation observes the fired timer
+			await Task.Delay(10, TestContext.Current.CancellationToken); // real delay so the awaiting continuation observes the fired timer
 		}
 
 		drain.IsCompleted.Should().BeTrue("the 2s virtual deadline must trip long before 50s of virtual time");

--- a/tests/Elastic.Changelog.Tests/Changelogs/DiagnosticsCollectorDisposeTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/DiagnosticsCollectorDisposeTests.cs
@@ -4,6 +4,7 @@
 
 using AwesomeAssertions;
 using Elastic.Documentation.Diagnostics;
+using Microsoft.Extensions.Time.Testing;
 
 namespace Elastic.Changelog.Tests.Changelogs;
 
@@ -102,5 +103,32 @@ public class DiagnosticsCollectorDisposeTests
 
 		collector.Warnings.Should().Be(1);
 		output.Items.Should().HaveCount(1, "the item must be drained once the reader starts");
+	}
+
+	// A pre-canceled token makes Task.Run return a canceled task without ever executing
+	// the reader delegate: start is requested but the reader never comes up, so WaitForDrain
+	// must hit its 2s deadline. FakeTimeProvider advances that deadline virtually.
+	[Fact]
+	public async Task WaitForDrain_ReaderNeverStarts_TimesOutInVirtualTime()
+	{
+		var timeProvider = new FakeTimeProvider();
+		var collector = new DiagnosticsCollector([], timeProvider);
+		IDiagnosticsCollector iface = collector;
+
+		using var cts = new CancellationTokenSource();
+		await cts.CancelAsync();
+		_ = iface.StartAsync(cts.Token);
+
+		var drain = iface.WaitForDrain();
+		for (var i = 0; i < 100 && !drain.IsCompleted; i++)
+		{
+			timeProvider.Advance(TimeSpan.FromMilliseconds(500));
+			await Task.Delay(10); // real delay so the awaiting continuation observes the fired timer
+		}
+
+		drain.IsCompleted.Should().BeTrue("the 2s virtual deadline must trip long before 50s of virtual time");
+		Func<Task> act = () => drain;
+		_ = (await act.Should().ThrowAsync<InvalidOperationException>())
+			.WithMessage("*timed out waiting for the background reader to start*");
 	}
 }

--- a/tests/Elastic.Changelog.Tests/Elastic.Changelog.Tests.csproj
+++ b/tests/Elastic.Changelog.Tests/Elastic.Changelog.Tests.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="FakeItEasy" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Nullean.ScopedFileSystem" />
   </ItemGroup>
 


### PR DESCRIPTION
## Why

`ServiceInvoker` starts the diagnostics reader fire-and-forget (`_ = collector.StartAsync(...)`). A command that completes almost instantly can reach `WaitForDrain` before the thread pool has picked up the `Task.Run` delegate, so `IsStarted` is still `false` and `WaitForDrain` throws `InvalidOperationException: WaitForDrain called on a collector that was never started`. This failed elastic-otel-java's `changelog-upload` job during their 1.12.0 release ([run](https://github.com/elastic/elastic-otel-java/actions/runs/30614459135)) — the upload found zero changelog files and returned fast enough to lose the race.

## What

`WaitForDrain` now distinguishes two cases that previously both threw:

- `StartAsync` was never called → still throws immediately (the #3348 guard stays intact; there is genuinely no reader coming).
- `StartAsync` was called but the reader delegate hasn't been scheduled yet → wait for the reader to come up (bounded at 2s, same deadline the drain loop below already uses) and then drain normally.

A new `IsStartRequested` property on the collector exposes the "start requested but not yet running" state. Includes a regression test simulating the fire-and-forget start followed by an immediate `WaitForDrain`.