### PR TITLE
Assembler: add retry with exponential backoff for git fetch and pull

### DIFF
--- a/src/Elastic.Documentation.Tooling/ExternalCommands/ExternalCommandExecutor.cs
+++ b/src/Elastic.Documentation.Tooling/ExternalCommands/ExternalCommandExecutor.cs
@@ -10,6 +10,16 @@ using ProcNet.Std;
 
 namespace Elastic.Documentation.ExternalCommands;
 
+/// <param name="MaxAttempts">Total attempts, including the first.</param>
+/// <param name="BaseDelay">Delay before the second attempt. Each later attempt doubles it.</param>
+public readonly record struct RetryPolicy(int MaxAttempts, TimeSpan BaseDelay)
+{
+	public static RetryPolicy None { get; } = new(1, TimeSpan.Zero);
+
+	public TimeSpan DelayBeforeAttempt(int attempt) =>
+		attempt <= 1 ? TimeSpan.Zero : BaseDelay * Math.Pow(2, attempt - 2);
+}
+
 public abstract class ExternalCommandExecutor(IDiagnosticsCollector collector, IDirectoryInfo workingDirectory, TimeSpan? timeout = null)
 {
 	protected abstract ILogger Logger { get; }
@@ -23,7 +33,8 @@ public abstract class ExternalCommandExecutor(IDiagnosticsCollector collector, I
 
 	protected IDirectoryInfo WorkingDirectory => workingDirectory;
 	protected IDiagnosticsCollector Collector => collector;
-	protected void ExecIn(Dictionary<string, string> environmentVars, string binary, params string[] args)
+
+	protected virtual int ExecInCore(Dictionary<string, string> environmentVars, string binary, params string[] args)
 	{
 		var arguments = new ExecArguments(binary, args)
 		{
@@ -31,9 +42,41 @@ public abstract class ExternalCommandExecutor(IDiagnosticsCollector collector, I
 			Environment = environmentVars,
 			Timeout = timeout
 		};
-		var result = Proc.Exec(arguments);
-		if (result != 0)
-			collector.EmitError("", $"Exit code: {result} while executing {binary} {string.Join(" ", args)} in {workingDirectory}");
+		return Proc.Exec(arguments);
+	}
+
+	protected void ExecIn(Dictionary<string, string> environmentVars, string binary, params string[] args) =>
+		_ = ExecInWithRetry(environmentVars, RetryPolicy.None, binary, args);
+
+	protected bool ExecInWithRetry(Dictionary<string, string> environmentVars, RetryPolicy retry, string binary, params string[] args)
+	{
+		var command = $"{binary} {string.Join(" ", args)}";
+		var exitCode = 0;
+		for (var attempt = 1; attempt <= retry.MaxAttempts; attempt++)
+		{
+			if (attempt > 1)
+				DelayBeforeRetry(retry.DelayBeforeAttempt(attempt));
+
+			exitCode = ExecInCore(environmentVars, binary, args);
+			if (exitCode == 0)
+				return true;
+
+			// Deliberately not routed through Log: a silent multi second stall is worse than extra local output.
+			if (attempt < retry.MaxAttempts)
+			{
+				Logger.LogWarning("[{Command}] Exit code {ExitCode}. Retrying ({Attempt}/{MaxAttempts}) in {WorkingDirectory}",
+					command, exitCode, attempt, retry.MaxAttempts, workingDirectory.FullName);
+			}
+		}
+
+		collector.EmitError("", $"Exit code: {exitCode} while executing {command} in {workingDirectory}");
+		return false;
+	}
+
+	protected virtual void DelayBeforeRetry(TimeSpan delay)
+	{
+		if (delay > TimeSpan.Zero)
+			Thread.Sleep(delay);
 	}
 
 	protected void ExecInSilent(Dictionary<string, string> environmentVars, string binary, params string[] args)

--- a/src/services/Elastic.Documentation.Assembler/Sourcing/GitFacade.cs
+++ b/src/services/Elastic.Documentation.Assembler/Sourcing/GitFacade.cs
@@ -28,9 +28,6 @@ public class SingleCommitOptimizedGitRepository(ILoggerFactory logFactory, IDiag
 	: ExternalCommandExecutor(collector, workingDirectory, Environment.GetEnvironmentVariable("CI") is null or "" ? null : TimeSpan.FromMinutes(10))
 		, IGitRepository
 {
-	/// <inheritdoc />
-	protected override ILogger Logger { get; } = logFactory.CreateLogger<SingleCommitOptimizedGitRepository>();
-
 	private static readonly Dictionary<string, string> EnvironmentVars = new()
 	{
 		// Disable git editor prompts:
@@ -39,12 +36,19 @@ public class SingleCommitOptimizedGitRepository(ILoggerFactory logFactory, IDiag
 		{ "GIT_EDITOR", "true" }
 	};
 
+	// Only the network bound commands retry. CloneRef wraps this with up to 3 wipe-and-reclone passes,
+	// so the effective worst case is 3 x 5 invocations.
+	private static readonly RetryPolicy NetworkRetry = new(MaxAttempts: 5, BaseDelay: TimeSpan.FromSeconds(1));
+
+	/// <inheritdoc />
+	protected override ILogger Logger { get; } = logFactory.CreateLogger<SingleCommitOptimizedGitRepository>();
+
 	public string GetCurrentCommit() => Capture("git", "rev-parse", "HEAD");
 
 	public void Init() => ExecIn(EnvironmentVars, "git", "init");
 	public bool IsInitialized() => Directory.Exists(Path.Join(WorkingDirectory.FullName, ".git"));
-	public void Pull(string branch) => ExecIn(EnvironmentVars, "git", "pull", "--depth", "1", "--allow-unrelated-histories", "--no-ff", "origin", branch);
-	public void Fetch(string reference) => ExecIn(EnvironmentVars, "git", "fetch", "--no-tags", "--prune", "--no-recurse-submodules", "--depth", "1", "origin", reference);
+	public void Pull(string branch) => _ = ExecInWithRetry(EnvironmentVars, NetworkRetry, "git", "pull", "--depth", "1", "--allow-unrelated-histories", "--no-ff", "origin", branch);
+	public void Fetch(string reference) => _ = ExecInWithRetry(EnvironmentVars, NetworkRetry, "git", "fetch", "--no-tags", "--prune", "--no-recurse-submodules", "--depth", "1", "origin", reference);
 	public void EnableSparseCheckout(string[] folders) => ExecIn(EnvironmentVars, "git", ["sparse-checkout", "set", "--no-cone", .. folders]);
 
 	public void DisableSparseCheckout() => ExecIn(EnvironmentVars, "git", "sparse-checkout", "disable");

--- a/tests/Elastic.Documentation.Build.Tests/ExternalCommandExecutorRetryTests.cs
+++ b/tests/Elastic.Documentation.Build.Tests/ExternalCommandExecutorRetryTests.cs
@@ -1,0 +1,119 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
+using AwesomeAssertions;
+using Elastic.Documentation.Diagnostics;
+using Elastic.Documentation.ExternalCommands;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Elastic.Documentation.Build.Tests;
+
+public class ExternalCommandExecutorRetryTests
+{
+	private static readonly RetryPolicy FiveAttempts = new(MaxAttempts: 5, BaseDelay: TimeSpan.FromSeconds(1));
+
+	[Fact]
+	public void ExecInWithRetry_SucceedsOnFirstAttempt_EmitsNoErrors()
+	{
+		var executor = CreateExecutor(0);
+
+		var succeeded = executor.Retry(FiveAttempts);
+
+		succeeded.Should().BeTrue();
+		executor.CallCount.Should().Be(1);
+		executor.Diagnostics.Errors.Should().Be(0);
+		executor.RecordedDelays.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void ExecInWithRetry_SucceedsAfterTransientFailures_EmitsNoErrors()
+	{
+		var executor = CreateExecutor(1, 1, 0);
+
+		var succeeded = executor.Retry(FiveAttempts);
+
+		succeeded.Should().BeTrue();
+		executor.CallCount.Should().Be(3);
+		executor.Diagnostics.Errors.Should().Be(0);
+		executor.RecordedDelays.Should().Equal(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+	}
+
+	[Fact]
+	public void ExecInWithRetry_ExhaustsAllAttempts_EmitsExactlyOneError()
+	{
+		var executor = CreateExecutor(1, 1, 1, 1, 1);
+
+		var succeeded = executor.Retry(FiveAttempts);
+
+		succeeded.Should().BeFalse();
+		executor.CallCount.Should().Be(5);
+		executor.Diagnostics.Errors.Should().Be(1);
+		executor.RecordedDelays.Should().Equal(
+			TimeSpan.FromSeconds(1),
+			TimeSpan.FromSeconds(2),
+			TimeSpan.FromSeconds(4),
+			TimeSpan.FromSeconds(8));
+	}
+
+	[Fact]
+	public void ExecInWithRetry_WithCustomPolicy_HonoursAttemptsAndBaseDelay()
+	{
+		var executor = CreateExecutor(1, 1, 1);
+
+		var succeeded = executor.Retry(new RetryPolicy(MaxAttempts: 3, BaseDelay: TimeSpan.FromSeconds(2)));
+
+		succeeded.Should().BeFalse();
+		executor.CallCount.Should().Be(3);
+		executor.Diagnostics.Errors.Should().Be(1);
+		executor.RecordedDelays.Should().Equal(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(4));
+	}
+
+	[Fact]
+	public void ExecIn_WhenCommandFails_EmitsOneErrorWithoutRetrying()
+	{
+		var executor = CreateExecutor(1);
+
+		executor.ExecOnce();
+
+		executor.CallCount.Should().Be(1);
+		executor.Diagnostics.Errors.Should().Be(1);
+		executor.RecordedDelays.Should().BeEmpty();
+	}
+
+	private static RetryTestCommandExecutor CreateExecutor(params int[] exitCodes)
+	{
+		var fileSystem = new MockFileSystem();
+		var workingDirectory = fileSystem.DirectoryInfo.New("/workspace/repo");
+		workingDirectory.Create();
+		return new RetryTestCommandExecutor(new DiagnosticsCollector([]), workingDirectory, exitCodes);
+	}
+
+	private sealed class RetryTestCommandExecutor(IDiagnosticsCollector collector, IDirectoryInfo workingDirectory, int[] exitCodes)
+		: ExternalCommandExecutor(collector, workingDirectory)
+	{
+		public int CallCount { get; private set; }
+
+		public List<TimeSpan> RecordedDelays { get; } = [];
+
+		public IDiagnosticsCollector Diagnostics => Collector;
+
+		protected override ILogger Logger { get; } = NullLogger.Instance;
+
+		protected override int ExecInCore(Dictionary<string, string> environmentVars, string binary, params string[] args)
+		{
+			if (CallCount >= exitCodes.Length)
+				throw new InvalidOperationException($"Unexpected invocation {CallCount + 1}, only {exitCodes.Length} exit codes were scripted");
+			return exitCodes[CallCount++];
+		}
+
+		protected override void DelayBeforeRetry(TimeSpan delay) => RecordedDelays.Add(delay);
+
+		public bool Retry(RetryPolicy policy) => ExecInWithRetry([], policy, "git", "fetch", "origin", "main");
+
+		public void ExecOnce() => ExecIn([], "git", "fetch", "origin", "main");
+	}
+}


### PR DESCRIPTION
## What

- Add retry with exponential backoff for `git fetch` and `git pull` during assembler clone
- Retry up to 5 times with delays of 1s, 2s, 4s, and 8s before reporting failure
- Emit an error only after all attempts fail, so a recovered retry does not fail the job

## Why

- Assembler clone fails intermittently due to transient network errors
- Retries should reduce flaky failures without changing the clone workflow

## Notes

- Local git operations (init, checkout, sparse-checkout) stay single-attempt
- `CloneRef` still has its own outer retry layer (up to 3 wipe-and-reclone passes)

Made with [Cursor](https://cursor.com)