### PR TITLE
Update ECS version per 9.5 release

### DIFF
--- a/config/assembler.yml
+++ b/config/assembler.yml
@@ -95,7 +95,7 @@ references:
   apm-aws-lambda:
   apm-k8s-attacher:
   ecs:
-    current: 9.4 # releases do not always align with the Stack version
+    current: 9.5 # releases do not always align with the Stack version
     next: main
   ecs-dotnet:
   ecs-logging-go-logrus:

--- a/config/versions.yml
+++ b/config/versions.yml
@@ -23,7 +23,7 @@ versioning_systems:
   ess: *all
   ecs:
     base: 9.0
-    current: 9.4.0
+    current: 9.5.0
   self: *stack
   ecctl:
     base: 1.0


### PR DESCRIPTION
In preparation for the ECS 9.5.0 release, bumping the versions for docs-builder.

(referenced previous release PR here: https://github.com/elastic/docs-builder/pull/3252)
