### PR TITLE
Add source_url to MCP get_document_by_url output

### DIFF
--- a/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchMarkdownExporter.Export.cs
+++ b/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchMarkdownExporter.Export.cs
@@ -7,6 +7,7 @@ using Elastic.ApiExplorer.Export;
 using Elastic.Documentation;
 using Elastic.Documentation.AppliesTo;
 using Elastic.Documentation.Configuration.Inference;
+using Elastic.Documentation.Extensions;
 using Elastic.Documentation.Navigation;
 using Elastic.Documentation.Search;
 using Elastic.Documentation.Search.Contract;
@@ -205,6 +206,19 @@ public partial class ElasticsearchMarkdownExporter
 				Repository = p.Repository ?? inference.Repository
 			}).ToArray()
 			: null;
+
+		var gitHubRepo = fileContext.BuildContext.Git.GitHubRepository;
+		var branch = fileContext.BuildContext.Git.Branch;
+		if (gitHubRepo is not null
+			&& fileContext.BuildContext.Git != GitCheckoutInformation.Unavailable
+			&& fileContext.BuildContext.DocumentationCheckoutDirectory is { } checkoutDirectory)
+		{
+			var relativeSourcePath = Path.GetRelativePath(
+				checkoutDirectory.FullName,
+				fileContext.BuildContext.DocumentationSourceDirectory.FullName);
+			var path = UrlPath.Join(relativeSourcePath, file.RelativePath);
+			doc.SourceUrl = $"https://github.com/{gitHubRepo}/blob/{branch}/{path}";
+		}
 
 		CommonEnrichments(doc, currentNavigation);
 		AssignContentHash(doc);

--- a/src/api/Elastic.Documentation.Mcp.Remote/Gateways/DocumentGateway.cs
+++ b/src/api/Elastic.Documentation.Mcp.Remote/Gateways/DocumentGateway.cs
@@ -47,6 +47,7 @@ public class DocumentGateway(
 					e => e.AiQuestions,
 					e => e.AiUseCases,
 					e => e.LastUpdated,
+					e => e.SourceUrl,
 					e => e.Product,
 					e => e.RelatedProducts
 				))),
@@ -79,6 +80,7 @@ public class DocumentGateway(
 				AiQuestions = doc.AiQuestions,
 				AiUseCases = doc.AiUseCases,
 				LastUpdated = doc.LastUpdated,
+				SourceUrl = doc.SourceUrl,
 				Product = doc.Product is { } productId ? new DocumentProduct
 				{
 					Id = productId,

--- a/src/api/Elastic.Documentation.Mcp.Remote/Gateways/IDocumentGateway.cs
+++ b/src/api/Elastic.Documentation.Mcp.Remote/Gateways/IDocumentGateway.cs
@@ -36,6 +36,7 @@ public record DocumentResult
 	public string[]? AiQuestions { get; init; }
 	public string[]? AiUseCases { get; init; }
 	public DateTimeOffset? LastUpdated { get; init; }
+	public string? SourceUrl { get; init; }
 	public DocumentParent[] Parents { get; init; } = [];
 	public string[] Headings { get; init; } = [];
 	public string[] Links { get; init; } = [];

--- a/src/api/Elastic.Documentation.Mcp.Remote/Responses/McpResponses.cs
+++ b/src/api/Elastic.Documentation.Mcp.Remote/Responses/McpResponses.cs
@@ -110,6 +110,7 @@ public sealed record DocumentResponse
 	public string[]? AiQuestions { get; init; }
 	public string[]? AiUseCases { get; init; }
 	public DateTimeOffset? LastUpdated { get; init; }
+	public string? SourceUrl { get; init; }
 	public required List<ParentDto> Parents { get; init; }
 	public required List<string> Headings { get; init; }
 	public ProductDto? Product { get; init; }

--- a/src/api/Elastic.Documentation.Mcp.Remote/Tools/DocumentTools.cs
+++ b/src/api/Elastic.Documentation.Mcp.Remote/Tools/DocumentTools.cs
@@ -68,6 +68,7 @@ public class DocumentTools(IDocumentGateway documentGateway, ILogger<DocumentToo
 				AiQuestions = result.AiQuestions,
 				AiUseCases = result.AiUseCases,
 				LastUpdated = result.LastUpdated,
+				SourceUrl = result.SourceUrl,
 				Parents = result.Parents.Select(p => new ParentDto
 				{
 					Title = p.Title,

--- a/src/services/search/Elastic.Documentation.Search.Contract/Docs/DocumentationDocument.cs
+++ b/src/services/search/Elastic.Documentation.Search.Contract/Docs/DocumentationDocument.cs
@@ -54,4 +54,13 @@ public record DocumentationDocument : SearchDocumentBase
 	/// </summary>
 	[JsonPropertyName("content_last_updated")]
 	public DateTimeOffset ContentLastUpdated { get; set; }
+
+	/// <summary>
+	/// GitHub blob URL for the Markdown source file. Null when git context is unavailable
+	/// (e.g. OpenAPI-exported API reference pages until Elastic.ApiExplorer lands).
+	/// </summary>
+	[Keyword]
+	[JsonPropertyName("source_url")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public string? SourceUrl { get; set; }
 }

--- a/tests-integration/Mcp.Remote.IntegrationTests/DocumentToolsIntegrationTests.cs
+++ b/tests-integration/Mcp.Remote.IntegrationTests/DocumentToolsIntegrationTests.cs
@@ -95,8 +95,7 @@ public class DocumentToolsIntegrationTests(ITestOutputHelper output) : McpToolsI
 		Output.WriteLine($"sourceUrl: {response!.SourceUrl ?? "(null — document predates indexing of this field)"}");
 
 		// sourceUrl is null for docs indexed before this field was added; when present it must be a GitHub blob URL
-		if (response.SourceUrl is not null)
-			response.SourceUrl.Should().StartWith("https://github.com/").And.Contain("/blob/");
+		response.SourceUrl?.Should().StartWith("https://github.com/").And.Contain("/blob/");
 	}
 
 	[Fact]

--- a/tests-integration/Mcp.Remote.IntegrationTests/DocumentToolsIntegrationTests.cs
+++ b/tests-integration/Mcp.Remote.IntegrationTests/DocumentToolsIntegrationTests.cs
@@ -73,6 +73,33 @@ public class DocumentToolsIntegrationTests(ITestOutputHelper output) : McpToolsI
 	}
 
 	[Fact]
+	public async Task GetDocumentByUrl_SourceUrlIsGitHubBlobUrlWhenPresent()
+	{
+		// Arrange
+		var (documentTools, clientAccessor) = CreateDocumentTools();
+		Assert.SkipUnless(documentTools is not null, "Elasticsearch is not configured");
+		LogDiagnostics(clientAccessor);
+		var canConnect = await clientAccessor!.CanConnect(TestContext.Current.CancellationToken);
+		Assert.SkipUnless(canConnect, "Elasticsearch is not connected");
+
+		// Act
+		var resultJson = await documentTools.GetDocumentByUrl(
+			"/docs/reference/elasticsearch",
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		if (resultJson.Contains("\"error\""))
+			Assert.Skip("Test document not found in index");
+
+		var response = JsonSerializer.Deserialize(resultJson, McpJsonContext.Default.DocumentResponse);
+		response.Should().NotBeNull();
+		Output.WriteLine($"sourceUrl: {response!.SourceUrl ?? "(null — document predates indexing of this field)"}");
+
+		// sourceUrl is null for docs indexed before this field was added; when present it must be a GitHub blob URL
+		if (response.SourceUrl is not null)
+			response.SourceUrl.Should().StartWith("https://github.com/").And.Contain("/blob/");
+	}
+
+	[Fact]
 	public async Task AnalyzeDocumentStructure_ReturnsStructure()
 	{
 		// Arrange

--- a/tests/Elastic.Markdown.Tests/Search/DocumentationDocumentSerializationTests.cs
+++ b/tests/Elastic.Markdown.Tests/Search/DocumentationDocumentSerializationTests.cs
@@ -420,4 +420,37 @@ public class DocumentationDocumentSerializationTests
 		lifecycles.Should().Contain("beta");
 		lifecycles.Should().Contain("deprecated");
 	}
+
+	[Fact]
+	public void SerializeDocument_IncludesSourceUrlAsSnakeCaseKeyword()
+	{
+		var doc = new DocumentationDocument
+		{
+			Path = "/docs/some-page",
+			Title = "Some Page",
+			SearchTitle = "Some Page",
+			SourceUrl = "https://github.com/elastic/docs-content/blob/main/docs/some-page.md"
+		};
+
+		var json = JsonSerializer.Serialize(doc, _options);
+		using var jsonDoc = JsonDocument.Parse(json);
+		jsonDoc.RootElement.GetProperty("source_url").GetString()
+			.Should().Be("https://github.com/elastic/docs-content/blob/main/docs/some-page.md");
+	}
+
+	[Fact]
+	public void SerializeDocument_OmitsSourceUrlWhenNull()
+	{
+		var doc = new DocumentationDocument
+		{
+			Path = "/docs/some-page",
+			Title = "Some Page",
+			SearchTitle = "Some Page",
+			SourceUrl = null
+		};
+
+		var json = JsonSerializer.Serialize(doc, _options);
+		using var jsonDoc = JsonDocument.Parse(json);
+		jsonDoc.RootElement.TryGetProperty("source_url", out _).Should().BeFalse();
+	}
 }

--- a/tests/Mcp.Remote.Tests/DocumentToolsTests.cs
+++ b/tests/Mcp.Remote.Tests/DocumentToolsTests.cs
@@ -1,0 +1,69 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text.Json;
+using AwesomeAssertions;
+using Elastic.Documentation.Mcp.Remote.Gateways;
+using Elastic.Documentation.Mcp.Remote.Responses;
+using Elastic.Documentation.Mcp.Remote.Tools;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Mcp.Remote.Tests;
+
+public class DocumentToolsTests
+{
+	[Fact]
+	public async Task GetDocumentByUrl_MapsSourceUrlIntoResponse()
+	{
+		const string expectedSourceUrl = "https://github.com/elastic/docs-content/blob/main/docs/some-page.md";
+		var gateway = new StubDocumentGateway(new DocumentResult
+		{
+			Url = "/docs/some-page",
+			Title = "Some Page",
+			Type = "doc",
+			SourceUrl = expectedSourceUrl
+		});
+		var tools = new DocumentTools(gateway, NullLogger<DocumentTools>.Instance);
+
+		var json = await tools.GetDocumentByUrl("/docs/some-page", cancellationToken: TestContext.Current.CancellationToken);
+
+		// MCP responses use camelCase (McpJsonContext); assert the wire key, not only the CLR property.
+		json.Should().Contain("\"sourceUrl\"");
+		var response = JsonSerializer.Deserialize(json, McpJsonContext.Default.DocumentResponse);
+		response.Should().NotBeNull();
+		response.SourceUrl.Should().Be(expectedSourceUrl);
+	}
+
+	[Fact]
+	public async Task GetDocumentByUrl_OmitsSourceUrlWhenNull()
+	{
+		var gateway = new StubDocumentGateway(new DocumentResult
+		{
+			Url = "/docs/some-page",
+			Title = "Some Page",
+			Type = "doc",
+			SourceUrl = null
+		});
+		var tools = new DocumentTools(gateway, NullLogger<DocumentTools>.Instance);
+
+		var json = await tools.GetDocumentByUrl("/docs/some-page", cancellationToken: TestContext.Current.CancellationToken);
+
+		using var doc = JsonDocument.Parse(json);
+		var hasNonNullSourceUrl = doc.RootElement.TryGetProperty("sourceUrl", out var sourceUrl)
+			&& sourceUrl.ValueKind is not JsonValueKind.Null and not JsonValueKind.Undefined;
+		hasNonNullSourceUrl.Should().BeFalse();
+		var response = JsonSerializer.Deserialize(json, McpJsonContext.Default.DocumentResponse);
+		response.Should().NotBeNull();
+		response.SourceUrl.Should().BeNull();
+	}
+
+	private sealed class StubDocumentGateway(DocumentResult? result) : IDocumentGateway
+	{
+		public Task<DocumentResult?> GetByUrlAsync(string url, CancellationToken ct = default) =>
+			Task.FromResult(result);
+
+		public Task<DocumentStructure?> GetStructureAsync(string url, CancellationToken ct = default) =>
+			Task.FromResult<DocumentStructure?>(null);
+	}
+}


### PR DESCRIPTION
## Why

Agents using MCP `get_document_by_url` need a reliable link back to the Markdown source on GitHub. That was blocked while `DocumentationDocument` lived in `elastic/website-search-data`; the search contract is back in this repo, so the change can land here alone.

Supersedes https://github.com/elastic/docs-builder/pull/3476 (same intent from @rjernst, rebased onto current `main`).

## What

Indexes a `source_url` keyword on docs documents at Elasticsearch export time using the same git checkout context as the site "edit this page" link, and returns it from MCP `get_document_by_url` as `sourceUrl`. API reference pages exported via the temporary OpenAPI path stay null until Elastic.ApiExplorer is wired up.

## Test plan

- [x] `dotnet test tests/Mcp.Remote.Tests/ --filter DocumentToolsTests`
- [x] `dotnet test tests/Elastic.Markdown.Tests/ --filter SerializeDocument_IncludesSourceUrl|SerializeDocument_OmitsSourceUrl`
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)