### PR TITLE
Codex: prefer environment-matching docset over public docs/

### DIFF
--- a/docs/documentation/codex/configure/index.md
+++ b/docs/documentation/codex/configure/index.md
@@ -67,3 +67,15 @@ codex:
 toc:
   - file: index.md
 ```
+
+### Repositories with multiple docsets
+
+A repository can publish both a public docset (for elastic.co/docs) and a separate codex docset,
+colocated in the same repository. For example, `docs/docset.yml` with no `registry` (public) and
+`docs-dev/docset.yml` with `registry: my-environment`.
+
+When discovering a repository's docset, codex prefers the docset whose `registry` matches the
+codex `environment`, and only falls back to the default search order (`docs/docset.yml`,
+`docs/_docset.yml`, `docset.yml`, `_docset.yml`, then a recursive search) when no docset declares
+that registry. This lets a repository keep its internal documentation next to its code instead of
+moving it to a separate repository.

--- a/src/Elastic.Codex/Building/CodexBuildService.cs
+++ b/src/Elastic.Codex/Building/CodexBuildService.cs
@@ -184,6 +184,9 @@ public class CodexBuildService(
 			// Repository clone root must be BuildContext `source`: FindGitRoot(..., ceiling: rootFolder) only
 			// discovers .git inside that ceiling (#3115). Using DocsDirectory alone would cap the ceiling
 			// at the docs subtree and return null above repo/.git, breaking GithubEditUrl generation.
+			// The docset file itself is passed explicitly so build reuses the docset clone discovery already
+			// selected (which may prefer a non-default path such as `docs-dev/`), rather than rediscovering
+			// one from the repository root and always landing on `docs/`.
 			var buildContext = new BuildContext(
 				context.Collector,
 				fileSystem,
@@ -192,7 +195,8 @@ public class CodexBuildService(
 				ExportOptions.Default,
 				checkout.RepositoryDirectory.FullName,
 				outputPath,
-				git)
+				git,
+				configurationFile: checkout.DocsetFile)
 			{
 				UrlPathPrefix = pathPrefix,
 				SiteRootPath = siteRootPath,

--- a/src/Elastic.Codex/Sourcing/CodexCloneService.cs
+++ b/src/Elastic.Codex/Sourcing/CodexCloneService.cs
@@ -21,6 +21,11 @@ public class CodexCloneService(ILoggerFactory logFactory, ILinkIndexReader linkI
 {
 	private const string LinkRegistrySnapshotFileName = "link-index.snapshot.json";
 	private static readonly string[] DocsetSearchPaths = ["docs/docset.yml", "docs/_docset.yml", "docset.yml", "_docset.yml"];
+
+	// A registry mismatch on a known-path docset now triggers a recursive walk (see FindDocsetFile), so
+	// this excludes common large generated/vendor directories in addition to .git and node_modules to
+	// keep that walk cheap.
+	private static readonly string[] RecursiveSearchExcludedDirectories = [".git", "node_modules", "vendor", "dist", "build", "target", ".yarn"];
 	private readonly ILogger _logger = logFactory.CreateLogger<CodexCloneService>();
 
 	/// <summary>
@@ -57,7 +62,7 @@ public class CodexCloneService(ILoggerFactory logFactory, ILinkIndexReader linkI
 			if (entry == null)
 				continue;
 
-			var docsetFile = FindDocsetFile(context.ReadFileSystem, subDir);
+			var docsetFile = FindDocsetFile(context.ReadFileSystem, subDir, context.EnvironmentName);
 			if (docsetFile == null)
 				continue;
 
@@ -85,7 +90,7 @@ public class CodexCloneService(ILoggerFactory logFactory, ILinkIndexReader linkI
 			}
 
 			var docSetRef = CreateDocumentationSetReference(repoName, entry, docsPathForRef, docSet);
-			checkouts.Add(new CodexCheckout(docSetRef, subDir, docsDirectory, currentCommit));
+			checkouts.Add(new CodexCheckout(docSetRef, subDir, docsDirectory, docsetFile, currentCommit));
 		}
 
 		return new CodexCloneResult(checkouts, linkRegistry);
@@ -215,7 +220,7 @@ public class CodexCloneService(ILoggerFactory logFactory, ILinkIndexReader linkI
 			var currentCommit = git.GetCurrentCommit();
 
 			// Find docset.yml and read codex metadata
-			var docsetFile = FindDocsetFile(context.ReadFileSystem, repoDir);
+			var docsetFile = FindDocsetFile(context.ReadFileSystem, repoDir, context.EnvironmentName);
 			if (docsetFile == null)
 			{
 				context.Collector.EmitWarning(context.ConfigurationPath,
@@ -232,7 +237,7 @@ public class CodexCloneService(ILoggerFactory logFactory, ILinkIndexReader linkI
 				: docsPath.Replace('\\', '/');
 			var docSetRef = CreateDocumentationSetReference(repoName, entry, docsPathForRef, docSet);
 
-			return new CodexCheckout(docSetRef, repoDir, docsDirectory, currentCommit);
+			return new CodexCheckout(docSetRef, repoDir, docsDirectory, docsetFile, currentCommit);
 		}
 		catch (Exception ex)
 		{
@@ -245,36 +250,65 @@ public class CodexCloneService(ILoggerFactory logFactory, ILinkIndexReader linkI
 		}
 	}
 
-	internal static IFileInfo? FindDocsetFile(IFileSystem fileSystem, IDirectoryInfo repoDir)
+	/// <summary>
+	/// Finds the docset file to use for a repository. When multiple docsets exist (for example a public
+	/// <c>docs/</c> set alongside an internal <c>docs-dev/</c> set), prefers the one whose <c>registry</c>
+	/// matches <paramref name="environment"/>, falling back to the first hit in the historical search
+	/// order (known paths, then a recursive walk) when no docset declares that registry.
+	/// </summary>
+	internal static IFileInfo? FindDocsetFile(IFileSystem fileSystem, IDirectoryInfo repoDir, string environment)
 	{
+		// A known-path candidate is re-encountered by the recursive walk below (e.g. `docs/docset.yml`
+		// lives inside `docs/`), so metadata is cached per call to avoid parsing the same file twice.
+		var metadataCache = new Dictionary<string, DocumentationSetFile>();
+		bool MatchesEnvironment(IFileInfo file)
+		{
+			if (!metadataCache.TryGetValue(file.FullName, out var docSet))
+			{
+				docSet = DocumentationSetFile.LoadMetadata(file);
+				metadataCache[file.FullName] = docSet;
+			}
+			return string.Equals(docSet.Registry, environment, StringComparison.OrdinalIgnoreCase);
+		}
+
+		IFileInfo? firstKnownPathFile = null;
 		foreach (var candidate in DocsetSearchPaths)
 		{
 			var path = Path.Join(repoDir.FullName, candidate);
 			var file = fileSystem.FileInfo.New(path);
-			if (file.Exists)
+			if (!file.Exists)
+				continue;
+
+			firstKnownPathFile ??= file;
+			if (MatchesEnvironment(file))
 				return file;
 		}
 
-		// Recursive search
-		return SearchForDocsetRecursive(fileSystem, repoDir);
+		IFileInfo? firstRecursiveHit = null;
+		var recursiveMatch = SearchForDocsetRecursive(fileSystem, repoDir, MatchesEnvironment, ref firstRecursiveHit);
+		return recursiveMatch ?? firstKnownPathFile ?? firstRecursiveHit;
 	}
 
-	private static IFileInfo? SearchForDocsetRecursive(IFileSystem fileSystem, IDirectoryInfo directory)
+	private static IFileInfo? SearchForDocsetRecursive(IFileSystem fileSystem, IDirectoryInfo directory, Func<IFileInfo, bool> matchesEnvironment, ref IFileInfo? firstHit)
 	{
 		try
 		{
-			foreach (var file in directory.GetFiles())
+			foreach (var file in directory.EnumerateFiles())
 			{
-				if (file.Name is "docset.yml" or "_docset.yml")
+				if (file.Name is not ("docset.yml" or "_docset.yml"))
+					continue;
+
+				firstHit ??= file;
+				if (matchesEnvironment(file))
 					return file;
 			}
 
-			foreach (var subDir in directory.GetDirectories())
+			foreach (var subDir in directory.EnumerateDirectories())
 			{
-				if (subDir.Name is ".git" or "node_modules")
+				if (RecursiveSearchExcludedDirectories.Contains(subDir.Name))
 					continue;
 
-				var found = SearchForDocsetRecursive(fileSystem, subDir);
+				var found = SearchForDocsetRecursive(fileSystem, subDir, matchesEnvironment, ref firstHit);
 				if (found != null)
 					return found;
 			}
@@ -338,4 +372,5 @@ public record CodexCheckout(
 	CodexDocumentationSetReference Reference,
 	IDirectoryInfo RepositoryDirectory,
 	IDirectoryInfo DocsDirectory,
+	IFileInfo DocsetFile,
 	string CommitHash);

--- a/src/Elastic.Codex/Sourcing/CodexCloneService.cs
+++ b/src/Elastic.Codex/Sourcing/CodexCloneService.cs
@@ -72,6 +72,7 @@ public class CodexCloneService(ILoggerFactory logFactory, ILinkIndexReader linkI
 			var docsPathForRef = string.IsNullOrEmpty(docsPath) || docsPath == "."
 				? "."
 				: docsPath.Replace('\\', '/');
+			WarnIfRegistryMismatch(context, repoName, docSet, docsPathForRef);
 
 			string currentCommit;
 			try
@@ -235,6 +236,7 @@ public class CodexCloneService(ILoggerFactory logFactory, ILinkIndexReader linkI
 			var docsPathForRef = string.IsNullOrEmpty(docsPath) || docsPath == "."
 				? "."
 				: docsPath.Replace('\\', '/');
+			WarnIfRegistryMismatch(context, repoName, docSet, docsPathForRef);
 			var docSetRef = CreateDocumentationSetReference(repoName, entry, docsPathForRef, docSet);
 
 			return new CodexCheckout(docSetRef, repoDir, docsDirectory, docsetFile, currentCommit);
@@ -319,6 +321,24 @@ public class CodexCloneService(ILoggerFactory logFactory, ILinkIndexReader linkI
 		}
 
 		return null;
+	}
+
+	/// <summary>
+	/// Warns when the docset chosen for a repository does not declare the codex environment as its
+	/// <c>registry</c> (including when <c>registry</c> is absent entirely). This only ever happens via
+	/// the fallback search order in <see cref="FindDocsetFile"/>, since a matching docset is always
+	/// preferred when one exists — so a mismatch usually means the repository has not opted in yet.
+	/// Kept as a warning rather than a hard error so existing repositories are not broken outright.
+	/// </summary>
+	private static void WarnIfRegistryMismatch(CodexContext context, string repoName, DocumentationSetFile docSet, string docsPath)
+	{
+		if (string.Equals(docSet.Registry, context.EnvironmentName, StringComparison.OrdinalIgnoreCase))
+			return;
+
+		var registryDescription = string.IsNullOrEmpty(docSet.Registry) ? "no registry" : $"registry: {docSet.Registry}";
+		context.Collector.EmitWarning(context.ConfigurationPath,
+			$"Repository '{repoName}' docset '{docsPath}' declares {registryDescription}, not registry: {context.EnvironmentName}; " +
+			"using it via fallback discovery. Set 'registry' in its docset.yml to opt in explicitly.");
 	}
 
 	internal static CodexDocumentationSetReference CreateDocumentationSetReference(

--- a/src/Elastic.Documentation.Configuration/BuildContext.cs
+++ b/src/Elastic.Documentation.Configuration/BuildContext.cs
@@ -92,7 +92,8 @@ public record BuildContext : IDocumentationSetContext, IDocumentationConfigurati
 		string? source = null,
 		string? output = null,
 		GitCheckoutInformation? gitCheckoutInformation = null,
-		IEnvironmentVariables? environment = null
+		IEnvironmentVariables? environment = null,
+		IFileInfo? configurationFile = null
 	)
 	{
 		Collector = collector;
@@ -111,7 +112,12 @@ public record BuildContext : IDocumentationSetContext, IDocumentationConfigurati
 			? ReadFileSystem.DirectoryInfo.New(source)
 			: ReadFileSystem.DirectoryInfo.New(Path.Join(Paths.WorkingDirectoryRoot.FullName));
 
-		(DocumentationSourceDirectory, ConfigurationPath) = Paths.FindDocsFolderFromRoot(ReadFileSystem, rootFolder);
+		// When the caller already discovered the docset (e.g. Codex clone discovery, which may prefer
+		// a non-default docset such as `docs-dev/` over `docs/`), use it directly instead of letting
+		// Paths.FindDocsFolderFromRoot rediscover a different one from `source`.
+		(DocumentationSourceDirectory, ConfigurationPath) = configurationFile is not null
+			? (configurationFile.Directory!, configurationFile)
+			: Paths.FindDocsFolderFromRoot(ReadFileSystem, rootFolder);
 
 		DocumentationCheckoutDirectory = Paths.FindGitRoot(DocumentationSourceDirectory, ceiling: rootFolder);
 

--- a/tests/Elastic.Markdown.Tests/BuildContextConfigurationFileTests.cs
+++ b/tests/Elastic.Markdown.Tests/BuildContextConfigurationFileTests.cs
@@ -1,0 +1,87 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions.TestingHelpers;
+using AwesomeAssertions;
+using Elastic.Documentation;
+using Elastic.Documentation.Configuration;
+using Elastic.Documentation.Configuration.Builder;
+using Nullean.ScopedFileSystem;
+using Xunit;
+
+namespace Elastic.Markdown.Tests;
+
+/// <summary>
+/// Regression for https://github.com/elastic/docs-builder/issues/3767: Codex clone discovery may
+/// prefer a non-default docset (e.g. `docs-dev/` with `registry: internal`) over a sibling public
+/// `docs/docset.yml`. Build must honor that explicit choice instead of rediscovering `docs/` from
+/// the repository root via <see cref="Paths.FindDocsFolderFromRoot"/>.
+/// </summary>
+public class BuildContextConfigurationFileTests(ITestOutputHelper output)
+{
+	[Fact]
+	public void ExplicitConfigurationFile_OverridesDefaultDiscovery()
+	{
+		var root = Paths.WorkingDirectoryRoot.FullName;
+		var repoPath = Path.Combine(root, "codex-configuration-file-test");
+		var publicDocsetPath = Path.Combine(repoPath, "docs", "docset.yml");
+		var internalDocsetPath = Path.Combine(repoPath, "docs-dev", "docset.yml");
+
+		var fs = new MockFileSystem(new MockFileSystemOptions { CurrentDirectory = root });
+		fs.AddDirectory(Path.Combine(repoPath, ".git"));
+		fs.AddFile(publicDocsetPath, new MockFileData("toc: []\n"));
+		fs.AddFile(internalDocsetPath, new MockFileData("registry: internal\ntoc: []\n"));
+
+		var readFs = FileSystemFactory.ScopeCurrentWorkingDirectory(fs);
+		var writeFs = FileSystemFactory.ScopeCurrentWorkingDirectory(fs);
+		var collector = new TestDiagnosticsCollector(output);
+		_ = collector.StartAsync(TestContext.Current.CancellationToken);
+		var configurationContext = TestHelpers.CreateConfigurationContext(fs);
+
+		var context = new BuildContext(
+			collector,
+			readFs,
+			writeFs,
+			configurationContext,
+			ExportOptions.Default,
+			source: repoPath,
+			output: Path.Combine(root, "codex-configuration-file-test-out"),
+			configurationFile: readFs.FileInfo.New(internalDocsetPath));
+
+		context.ConfigurationPath.FullName.Should().Be(internalDocsetPath);
+		context.DocumentationSourceDirectory.FullName.Should().Be(Path.Combine(repoPath, "docs-dev"));
+		// source stays the repository root so #3115's git-ceiling behavior is unaffected.
+		context.DocumentationCheckoutDirectory.Should().NotBeNull();
+		context.DocumentationCheckoutDirectory.FullName.Should().Be(repoPath);
+	}
+
+	[Fact]
+	public void NoExplicitConfigurationFile_FallsBackToDefaultDiscovery()
+	{
+		var root = Paths.WorkingDirectoryRoot.FullName;
+		var repoPath = Path.Combine(root, "codex-configuration-file-fallback-test");
+		var publicDocsetPath = Path.Combine(repoPath, "docs", "docset.yml");
+
+		var fs = new MockFileSystem(new MockFileSystemOptions { CurrentDirectory = root });
+		fs.AddDirectory(Path.Combine(repoPath, ".git"));
+		fs.AddFile(publicDocsetPath, new MockFileData("toc: []\n"));
+
+		var readFs = FileSystemFactory.ScopeCurrentWorkingDirectory(fs);
+		var writeFs = FileSystemFactory.ScopeCurrentWorkingDirectory(fs);
+		var collector = new TestDiagnosticsCollector(output);
+		_ = collector.StartAsync(TestContext.Current.CancellationToken);
+		var configurationContext = TestHelpers.CreateConfigurationContext(fs);
+
+		var context = new BuildContext(
+			collector,
+			readFs,
+			writeFs,
+			configurationContext,
+			ExportOptions.Default,
+			source: repoPath,
+			output: Path.Combine(root, "codex-configuration-file-fallback-test-out"));
+
+		context.ConfigurationPath.FullName.Should().Be(publicDocsetPath);
+	}
+}

--- a/tests/Navigation.Tests/Codex/FindDocsetFileTests.cs
+++ b/tests/Navigation.Tests/Codex/FindDocsetFileTests.cs
@@ -12,6 +12,8 @@ namespace Elastic.Documentation.Navigation.Tests.Codex;
 
 public class FindDocsetFileTests
 {
+	private const string Environment = "internal";
+
 	private static readonly string RepoRoot = Path.Join(Paths.WorkingDirectoryRoot.FullName, "repo");
 
 	private static ScopedFileSystem CreateScopedFs(MockFileSystem mockFs) =>
@@ -25,7 +27,7 @@ public class FindDocsetFileTests
 			{ Path.Join(RepoRoot, "docs/docset.yml"), new MockFileData("project: test") }
 		});
 
-		var result = CodexCloneService.FindDocsetFile(mockFs, mockFs.DirectoryInfo.New(RepoRoot));
+		var result = CodexCloneService.FindDocsetFile(mockFs, mockFs.DirectoryInfo.New(RepoRoot), Environment);
 
 		result.Should().NotBeNull();
 		result.Name.Should().Be("docset.yml");
@@ -39,7 +41,7 @@ public class FindDocsetFileTests
 			{ Path.Join(RepoRoot, "docs-codex/docset.yml"), new MockFileData("project: test") }
 		});
 
-		var result = CodexCloneService.FindDocsetFile(mockFs, mockFs.DirectoryInfo.New(RepoRoot));
+		var result = CodexCloneService.FindDocsetFile(mockFs, mockFs.DirectoryInfo.New(RepoRoot), Environment);
 
 		result.Should().NotBeNull();
 		result.Name.Should().Be("docset.yml");
@@ -55,7 +57,7 @@ public class FindDocsetFileTests
 		});
 		var scopedFs = CreateScopedFs(mockFs);
 
-		var result = CodexCloneService.FindDocsetFile(scopedFs, scopedFs.DirectoryInfo.New(RepoRoot));
+		var result = CodexCloneService.FindDocsetFile(scopedFs, scopedFs.DirectoryInfo.New(RepoRoot), Environment);
 
 		result.Should().NotBeNull();
 		result.Name.Should().Be("docset.yml");
@@ -69,7 +71,7 @@ public class FindDocsetFileTests
 			{ Path.Join(RepoRoot, "src/main.py"), new MockFileData("print('hello')") }
 		});
 
-		var result = CodexCloneService.FindDocsetFile(mockFs, mockFs.DirectoryInfo.New(RepoRoot));
+		var result = CodexCloneService.FindDocsetFile(mockFs, mockFs.DirectoryInfo.New(RepoRoot), Environment);
 
 		result.Should().BeNull();
 	}
@@ -82,8 +84,53 @@ public class FindDocsetFileTests
 			{ Path.Join(RepoRoot, "node_modules/some-pkg/docset.yml"), new MockFileData("project: fake") }
 		});
 
-		var result = CodexCloneService.FindDocsetFile(mockFs, mockFs.DirectoryInfo.New(RepoRoot));
+		var result = CodexCloneService.FindDocsetFile(mockFs, mockFs.DirectoryInfo.New(RepoRoot), Environment);
 
 		result.Should().BeNull();
+	}
+
+	[Fact]
+	public void MultipleDocsets_PrefersRegistryMatchingEnvironment()
+	{
+		var mockFs = new MockFileSystem(new Dictionary<string, MockFileData>
+		{
+			{ Path.Join(RepoRoot, "docs/docset.yml"), new MockFileData("project: test") },
+			{ Path.Join(RepoRoot, "docs-dev/docset.yml"), new MockFileData("registry: internal") }
+		});
+
+		var result = CodexCloneService.FindDocsetFile(mockFs, mockFs.DirectoryInfo.New(RepoRoot), Environment);
+
+		result.Should().NotBeNull();
+		result.Directory!.Name.Should().Be("docs-dev");
+	}
+
+	[Fact]
+	public void MultipleDocsets_NoRegistryMatch_FallsBackToFirstKnownPath()
+	{
+		var mockFs = new MockFileSystem(new Dictionary<string, MockFileData>
+		{
+			{ Path.Join(RepoRoot, "docs/docset.yml"), new MockFileData("project: test") },
+			{ Path.Join(RepoRoot, "docs-dev/docset.yml"), new MockFileData("registry: internal") }
+		});
+
+		var result = CodexCloneService.FindDocsetFile(mockFs, mockFs.DirectoryInfo.New(RepoRoot), "security");
+
+		result.Should().NotBeNull();
+		result.Directory!.Name.Should().Be("docs");
+	}
+
+	[Fact]
+	public void CustomEnvironment_MatchesArbitraryRegistryValueViaRecursion()
+	{
+		var mockFs = new MockFileSystem(new Dictionary<string, MockFileData>
+		{
+			{ Path.Join(RepoRoot, "docs/docset.yml"), new MockFileData("project: test") },
+			{ Path.Join(RepoRoot, "docs-dev/docset.yml"), new MockFileData("registry: my-environment") }
+		});
+
+		var result = CodexCloneService.FindDocsetFile(mockFs, mockFs.DirectoryInfo.New(RepoRoot), "my-environment");
+
+		result.Should().NotBeNull();
+		result.Directory!.Name.Should().Be("docs-dev");
 	}
 }


### PR DESCRIPTION
## What

- Codex discovery now prefers the `docset.yml` whose `registry` matches the codex environment, instead of always resolving `docs/docset.yml` first.
- The build step reuses the docset that discovery already selected, instead of rediscovering one from the repository root.

## Why

- A repository that publishes both public docs (`docs/`) and internal Codex docs could not be onboarded to Elastic Internal Docs: discovery always landed on the public docset, so live publish would ship the wrong content.
- This lets a repository keep internal documentation next to its code, colocated with a public docset, instead of moving it to a separate repository.
- Fixes https://github.com/elastic/docs-builder/issues/3767

## Notes

- Matching is based on `registry` vs. the codex `environment` string (not a hardcoded `internal` check), per the discussion on the issue, so it also works for other codex environments.
- Falls back to the historical search order (known paths, then a recursive walk) when no docset declares a matching registry, so single-docset repos are unaffected.
- The recursive fallback now runs more often (whenever a known-path docset exists but doesn't match), so the excluded-directory list was widened beyond `.git`/`node_modules` to keep it cheap on large repos.

Made with [Cursor](https://cursor.com)