### PR TITLE
OpenAPI: add Lambda that maintains the spec version index

### DIFF
--- a/docs-builder.slnx
+++ b/docs-builder.slnx
@@ -50,6 +50,7 @@
     <Project Path="src/Elastic.Documentation.LinkIndex/Elastic.Documentation.LinkIndex.csproj" />
     <Project Path="src/Elastic.Documentation.Links/Elastic.Documentation.Links.csproj" />
     <Project Path="src/Elastic.Documentation.Navigation/Elastic.Documentation.Navigation.csproj" />
+    <Project Path="src/Elastic.Documentation.OpenApiIndex/Elastic.Documentation.OpenApiIndex.csproj" />
     <Project Path="src/Elastic.Documentation.ServiceDefaults/Elastic.Documentation.ServiceDefaults.csproj" />
     <Project Path="src/Elastic.Documentation.Site/Elastic.Documentation.Site.csproj" />
     <Project Path="src/Elastic.Documentation.Svg/Elastic.Documentation.Svg.csproj" />
@@ -67,6 +68,7 @@
   <Folder Name="/src/infra/">
 	  <Project Path="src/infra/docs-lambda-index-publisher/docs-lambda-index-publisher.csproj" />
 	  <Project Path="src/infra/docs-lambda-changelog-scrubber/docs-lambda-changelog-scrubber.csproj" />
+	  <Project Path="src/infra/docs-lambda-openapi-index/docs-lambda-openapi-index.csproj" />
   </Folder>
   <Folder Name="/src/services/">
     <Project Path="src/services/Elastic.Changelog/Elastic.Changelog.csproj" />
@@ -108,6 +110,7 @@
     <Project Path="tests/Elastic.Changelog.Tests/Elastic.Changelog.Tests.csproj" />
     <Project Path="tests/Elastic.Documentation.Integrations.Tests/Elastic.Documentation.Integrations.Tests.csproj" />
     <Project Path="tests/Elastic.SiteSearch.Tests/Elastic.SiteSearch.Tests.csproj" />
+    <Project Path="tests/Elastic.Documentation.OpenApiIndex.Tests/Elastic.Documentation.OpenApiIndex.Tests.csproj" />
   </Folder>
   <Project Path=".github/.github.csproj">
     <Build Project="false" />

--- a/src/Elastic.Documentation.OpenApiIndex/Elastic.Documentation.OpenApiIndex.csproj
+++ b/src/Elastic.Documentation.OpenApiIndex/Elastic.Documentation.OpenApiIndex.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsAotCompatible>true</IsAotCompatible>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="AWSSDK.S3" />
+    </ItemGroup>
+
+</Project>

--- a/src/Elastic.Documentation.OpenApiIndex/VersionIndex.cs
+++ b/src/Elastic.Documentation.OpenApiIndex/VersionIndex.cs
@@ -1,0 +1,24 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+// index.json at the root of the elastic-docs-openapi-specs bucket, keyed by "org/repo", then by spec
+// file name, then by "main" or a major version number. SortedDictionary at every level so that a
+// rebuild which changes nothing serializes to a byte-identical file.
+global using RootVersionIndex = System.Collections.Generic.SortedDictionary<string, System.Collections.Generic.SortedDictionary<string, System.Collections.Generic.SortedDictionary<string, Elastic.Documentation.OpenApiIndex.VersionIndexEntry>>>;
+
+using System.Text.Json.Serialization;
+
+namespace Elastic.Documentation.OpenApiIndex;
+
+/// <summary>One entry in a <see cref="RootVersionIndex"/>.</summary>
+public sealed record VersionIndexEntry
+{
+	/// <summary>The version this key resolves to: <c>main</c>, or the highest minor of its major, e.g. <c>9.5</c>.</summary>
+	public required string Version { get; init; }
+}
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
+[JsonSerializable(typeof(RootVersionIndex))]
+[JsonSerializable(typeof(VersionIndexEntry))]
+public sealed partial class VersionIndexJsonContext : JsonSerializerContext;

--- a/src/Elastic.Documentation.OpenApiIndex/VersionIndexBuilder.cs
+++ b/src/Elastic.Documentation.OpenApiIndex/VersionIndexBuilder.cs
@@ -1,0 +1,95 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Globalization;
+
+namespace Elastic.Documentation.OpenApiIndex;
+
+/// <summary>
+/// Builds a <see cref="RootVersionIndex"/> from the object keys in the <c>elastic-docs-openapi-specs</c>
+/// bucket, keeping the highest minor published for each major. Keys are expected in the shape written by
+/// <c>elastic/docs-actions/openapi/upload</c>: <c>{org}/{repo}/{version}/{fileName}</c>, where
+/// <c>version</c> is either <c>main</c> or a validated <c>{major}.{minor}</c> release version.
+/// </summary>
+public static class VersionIndexBuilder
+{
+	/// <summary>
+	/// Returns the index, plus any keys that did not match the expected shape. Such a key cannot have come
+	/// from the version-validating uploader, so it is reported and skipped rather than failing the build.
+	/// </summary>
+	public static (RootVersionIndex Index, IReadOnlyList<string> InvalidKeys) Build(IEnumerable<string> keys)
+	{
+		Dictionary<(string Repo, string File, string Major), (string Version, int Minor)> highest = [];
+		List<string> invalidKeys = [];
+
+		foreach (var key in keys)
+		{
+			if (!TryParseKey(key, out var repo, out var version, out var file) ||
+				!TryParseVersion(version, out var major, out var minor))
+			{
+				invalidKeys.Add(key);
+				continue;
+			}
+
+			if (!highest.TryGetValue((repo, file, major), out var current) || minor > current.Minor)
+				highest[(repo, file, major)] = (version, minor);
+		}
+
+		// An explicit ordinal comparer at every level, so the serialized key order is locale-independent.
+		// The collection expression the analyzer suggests below cannot carry that comparer.
+#pragma warning disable IDE0028
+		RootVersionIndex index = new(StringComparer.Ordinal);
+		foreach (var ((repo, file, major), (version, _)) in highest)
+		{
+			if (!index.TryGetValue(repo, out var byFile))
+				index[repo] = byFile = new(StringComparer.Ordinal);
+			if (!byFile.TryGetValue(file, out var byMajor))
+				byFile[file] = byMajor = new(StringComparer.Ordinal);
+			byMajor[major] = new VersionIndexEntry { Version = version };
+		}
+#pragma warning restore IDE0028
+
+		return (index, invalidKeys);
+	}
+
+	/// <summary>False for anything not shaped as exactly four non-empty segments.</summary>
+	private static bool TryParseKey(string key, out string repo, out string version, out string file)
+	{
+		repo = version = file = "";
+		var parts = key.Split('/');
+		if (parts.Length != 4 || Array.Exists(parts, string.IsNullOrEmpty))
+			return false;
+
+		repo = $"{parts[0]}/{parts[1]}";
+		version = parts[2];
+		file = parts[3];
+		return true;
+	}
+
+	/// <summary>Resolves the index key ("main", or the major number) and a sortable minor for a version segment.</summary>
+	private static bool TryParseVersion(string version, out string major, out int minor)
+	{
+		if (version == "main")
+		{
+			major = "main";
+			minor = 0;
+			return true;
+		}
+
+		major = "";
+		minor = 0;
+		var dot = version.IndexOf('.');
+		if (dot <= 0 || dot == version.Length - 1)
+			return false;
+
+		// NumberStyles.None, so a segment carrying a sign or surrounding whitespace cannot reach the index
+		// under a key that no longer matches the text it was parsed from.
+		if (!int.TryParse(version[..dot], NumberStyles.None, CultureInfo.InvariantCulture, out _) ||
+			!int.TryParse(version[(dot + 1)..], NumberStyles.None, CultureInfo.InvariantCulture, out minor))
+			return false;
+
+		major = version[..dot];
+		return true;
+	}
+}

--- a/src/Elastic.Documentation.OpenApiIndex/VersionIndexPublisher.cs
+++ b/src/Elastic.Documentation.OpenApiIndex/VersionIndexPublisher.cs
@@ -1,0 +1,101 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Net;
+using System.Text.Json;
+using Amazon.S3;
+using Amazon.S3.Model;
+
+namespace Elastic.Documentation.OpenApiIndex;
+
+/// <summary>
+/// Rebuilds <c>index.json</c> at the root of the <c>elastic-docs-openapi-specs</c> bucket from a full LIST
+/// of that bucket, and writes it back under an ETag precondition.
+/// </summary>
+/// <remarks>
+/// Rebuilding from the listing rather than merging the triggering event is what keeps this correct: it
+/// self-heals after a missed event, and a deleted object simply cannot produce an entry. A failed
+/// precondition is deliberately not retried in process — it throws, the caller hands the message back to
+/// SQS, and redelivery re-runs this same LIST-rebuild-PUT.
+/// </remarks>
+public sealed class VersionIndexPublisher(IAmazonS3 s3Client, string bucketName)
+{
+	public const string IndexKey = "index.json";
+
+	/// <summary>
+	/// Rebuilds the index and writes it back unless it is byte-identical to what is already published.
+	/// Returns the object keys that were ignored because they did not match the expected key shape.
+	/// </summary>
+	public async Task<IReadOnlyList<string>> RefreshAsync(Cancel ctx)
+	{
+		var keys = await ListSpecKeysAsync(ctx).ConfigureAwait(false);
+		var (index, invalidKeys) = VersionIndexBuilder.Build(keys);
+		var json = JsonSerializer.Serialize(index, VersionIndexJsonContext.Default.SortedDictionaryStringSortedDictionaryStringSortedDictionaryStringVersionIndexEntry);
+
+		var existing = await TryGetExistingIndexAsync(ctx).ConfigureAwait(false);
+		if (!string.Equals(existing?.Body, json, StringComparison.Ordinal))
+			await PutIndexAsync(json, existing?.ETag, ctx).ConfigureAwait(false);
+
+		return invalidKeys;
+	}
+
+	private async Task<List<string>> ListSpecKeysAsync(Cancel ctx)
+	{
+		var keys = new List<string>();
+		var request = new ListObjectsV2Request { BucketName = bucketName };
+
+		ListObjectsV2Response response;
+		do
+		{
+			response = await s3Client.ListObjectsV2Async(request, ctx).ConfigureAwait(false);
+			foreach (var s3Object in response.S3Objects ?? [])
+			{
+				if (!string.Equals(s3Object.Key, IndexKey, StringComparison.Ordinal))
+					keys.Add(s3Object.Key);
+			}
+			request.ContinuationToken = response.NextContinuationToken;
+		} while (response.IsTruncated == true);
+
+		return keys;
+	}
+
+	/// <summary>The published index's ETag and raw body, or null when it does not exist yet. The body is compared, never parsed.</summary>
+	private async Task<(string? ETag, string Body)?> TryGetExistingIndexAsync(Cancel ctx)
+	{
+		try
+		{
+			using var response = await s3Client.GetObjectAsync(new GetObjectRequest
+			{
+				BucketName = bucketName,
+				Key = IndexKey
+			}, ctx).ConfigureAwait(false);
+
+			using var reader = new StreamReader(response.ResponseStream);
+			return (response.ETag, await reader.ReadToEndAsync(ctx).ConfigureAwait(false));
+		}
+		catch (AmazonS3Exception ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+		{
+			return null;
+		}
+	}
+
+	private async Task PutIndexAsync(string json, string? etag, Cancel ctx)
+	{
+		var request = new PutObjectRequest
+		{
+			BucketName = bucketName,
+			Key = IndexKey,
+			ContentBody = json,
+			ContentType = "application/json"
+		};
+
+		// Optimistic concurrency: update only if unchanged, create only if still absent.
+		if (etag is null)
+			request.IfNoneMatch = "*";
+		else
+			request.IfMatch = etag;
+
+		_ = await s3Client.PutObjectAsync(request, ctx).ConfigureAwait(false);
+	}
+}

--- a/src/infra/docs-lambda-openapi-index/Program.cs
+++ b/src/infra/docs-lambda-openapi-index/Program.cs
@@ -1,0 +1,45 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.RuntimeSupport;
+using Amazon.Lambda.Serialization.SystemTextJson;
+using Amazon.Lambda.SQSEvents;
+using Amazon.S3;
+using Elastic.Documentation.Lambda.OpenApiIndex;
+using Elastic.Documentation.OpenApiIndex;
+
+const string bucketName = "elastic-docs-openapi-specs";
+
+// Built once per execution environment, so credential and endpoint resolution happens during Lambda's
+// init phase instead of on every invocation.
+var publisher = new VersionIndexPublisher(new AmazonS3Client(), bucketName);
+
+await LambdaBootstrapBuilder.Create<SQSEvent, SQSBatchResponse>(Handler, new SourceGeneratorLambdaJsonSerializer<SerializerContext>())
+	.Build()
+	.RunAsync();
+
+return;
+
+// The SQS queue is configured to trigger on S3 ObjectCreated/ObjectRemoved events anywhere in the bucket.
+// Every invocation rebuilds the whole index rather than inspecting which key triggered it — see
+// VersionIndexPublisher for why.
+async Task<SQSBatchResponse> Handler(SQSEvent ev, ILambdaContext context)
+{
+	try
+	{
+		var ignoredKeys = await publisher.RefreshAsync(CancellationToken.None);
+		if (ignoredKeys.Count > 0)
+			context.Logger.LogWarning("Ignored {ignoredCount} object key(s) not shaped as org/repo/version/file: {ignoredKeys}", ignoredKeys.Count, string.Join(", ", ignoredKeys));
+		context.Logger.LogInformation("Refreshed {bucketName}/{indexKey} from {recordCount} triggering event(s).", bucketName, VersionIndexPublisher.IndexKey, ev.Records.Count);
+		return new SQSBatchResponse([]);
+	}
+	catch (Exception ex)
+	{
+		// Return every message in the batch to the queue: the rebuild reads the whole bucket, so
+		// retrying only some of the batch would just repeat the exact same LIST-and-rebuild anyway.
+		context.Logger.LogError(ex, "Failed to refresh {bucketName}/{indexKey}. Returning all {recordCount} message(s) to the queue.", bucketName, VersionIndexPublisher.IndexKey, ev.Records.Count);
+		return new SQSBatchResponse(ev.Records.Select(r => new SQSBatchResponse.BatchItemFailure { ItemIdentifier = r.MessageId }).ToList());
+	}
+}

--- a/src/infra/docs-lambda-openapi-index/README.md
+++ b/src/infra/docs-lambda-openapi-index/README.md
@@ -1,0 +1,20 @@
+# OpenAPI Version Index Lambda Function
+
+From a linux `x86_64` machine you can use the following to build a AOT binary that will run
+on a vanilla `Amazon Linux 2023` without any dependencies.
+
+```bash
+docker build . -t openapi-version-index:latest -f src/infra/docs-lambda-openapi-index/lambda.DockerFile
+```
+
+Then you can copy the published artifacts from the image using:
+
+```bash
+docker cp (docker create --name tc openapi-version-index:latest):/app/.artifacts/publish ./.artifacts && docker rm tc
+```
+
+The `bootstrap` binary should now be available under:
+
+```
+.artifacts/publish/docs-lambda-openapi-index/release_linux-x64/bootstrap
+```

--- a/src/infra/docs-lambda-openapi-index/SerializerContext.cs
+++ b/src/infra/docs-lambda-openapi-index/SerializerContext.cs
@@ -1,0 +1,12 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text.Json.Serialization;
+using Amazon.Lambda.SQSEvents;
+
+namespace Elastic.Documentation.Lambda.OpenApiIndex;
+
+[JsonSerializable(typeof(SQSEvent))]
+[JsonSerializable(typeof(SQSBatchResponse))]
+public partial class SerializerContext : JsonSerializerContext;

--- a/src/infra/docs-lambda-openapi-index/aws-lambda-tools-defaults.json
+++ b/src/infra/docs-lambda-openapi-index/aws-lambda-tools-defaults.json
@@ -1,0 +1,15 @@
+{
+  "Information": [
+    "This file provides default values for the deployment wizard inside Visual Studio and the AWS Lambda commands added to the .NET Core CLI.",
+    "To learn more about the Lambda commands with the .NET Core CLI execute the following command at the command line in the project root directory.",
+    "dotnet lambda help",
+    "All the command line options for the Lambda command can be specified in this file."
+  ],
+  "profile": "default",
+  "region": "us-west-2",
+  "configuration": "Release",
+  "function-runtime": "provided.al2023",
+  "function-memory-size": 256,
+  "function-timeout": 30,
+  "function-handler": "Elastic.Documentation.Lambda.OpenApiIndex"
+}

--- a/src/infra/docs-lambda-openapi-index/docs-lambda-openapi-index.csproj
+++ b/src/infra/docs-lambda-openapi-index/docs-lambda-openapi-index.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <InvariantGlobalization>true</InvariantGlobalization>
+
+    <AssemblyName>bootstrap</AssemblyName>
+    <AWSProjectType>Lambda</AWSProjectType>
+
+    <IsPublishable>true</IsPublishable>
+    <PublishAot>true</PublishAot>
+    <PublishTrimmed>true</PublishTrimmed>
+    <EnableSdkContainerSupport>true</EnableSdkContainerSupport>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+
+    <RootNamespace>Elastic.Documentation.Lambda.OpenApiIndex</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.RuntimeSupport" />
+    <PackageReference Include="Amazon.Lambda.Core" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" />
+    <PackageReference Include="Amazon.Lambda.SQSEvents" />
+    <PackageReference Include="AWSSDK.Core" />
+    <PackageReference Include="AWSSDK.S3" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Elastic.Documentation.OpenApiIndex\Elastic.Documentation.OpenApiIndex.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/infra/docs-lambda-openapi-index/lambda.DockerFile
+++ b/src/infra/docs-lambda-openapi-index/lambda.DockerFile
@@ -1,0 +1,34 @@
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023 AS base
+
+ARG TARGETARCH
+ARG TARGETOS
+
+WORKDIR /app
+
+RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc
+
+RUN dnf update -y
+RUN dnf install -y npm
+RUN dnf install -y git
+RUN dnf install -y clang
+
+## temporary see: https://github.com/amazonlinux/amazon-linux-2023/issues/1025
+RUN dnf install -y tar
+RUN dnf install -y findutils
+RUN curl -L https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh
+RUN chmod +x ./dotnet-install.sh
+RUN ./dotnet-install.sh
+ENV PATH="$PATH:/root/.dotnet"
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
+# /end temporary
+
+COPY . .
+
+ENV DOTNET_NOLOGO=true \
+    DOTNET_CLI_TELEMETRY_OPTOUT=true
+
+RUN arch=$TARGETARCH \
+    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
+    && echo $TARGETOS-$arch > /tmp/rid
+
+RUN dotnet publish src/infra/docs-lambda-openapi-index -r linux-x64 -c Release

--- a/tests/Elastic.Documentation.OpenApiIndex.Tests/Elastic.Documentation.OpenApiIndex.Tests.csproj
+++ b/tests/Elastic.Documentation.OpenApiIndex.Tests/Elastic.Documentation.OpenApiIndex.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Elastic.Documentation.OpenApiIndex\Elastic.Documentation.OpenApiIndex.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FakeItEasy" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Elastic.Documentation.OpenApiIndex.Tests/VersionIndexBuilderTests.cs
+++ b/tests/Elastic.Documentation.OpenApiIndex.Tests/VersionIndexBuilderTests.cs
@@ -1,0 +1,140 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using AwesomeAssertions;
+
+namespace Elastic.Documentation.OpenApiIndex.Tests;
+
+public class VersionIndexBuilderTests
+{
+	[Fact]
+	public void Build_SingleVersion_CreatesMajorEntry()
+	{
+		var index = VersionIndexBuilder.Build(["elastic/elasticsearch/8.16/openapi.json"]).Index;
+
+		index.Should().ContainKey("elastic/elasticsearch");
+		index["elastic/elasticsearch"]["openapi.json"]["8"].Version.Should().Be("8.16");
+	}
+
+	[Fact]
+	public void Build_NewMajorAddedToExistingIndex_CreatesSeparateEntry()
+	{
+		var index = VersionIndexBuilder.Build([
+			"elastic/elasticsearch/8.16/openapi.json",
+			"elastic/elasticsearch/9.0/openapi.json"
+		]).Index;
+
+		var byMajor = index["elastic/elasticsearch"]["openapi.json"];
+		byMajor.Should().HaveCount(2);
+		byMajor["8"].Version.Should().Be("8.16");
+		byMajor["9"].Version.Should().Be("9.0");
+	}
+
+	[Fact]
+	public void Build_MinorBumpWithinExistingMajor_KeepsHighestMinor()
+	{
+		var index = VersionIndexBuilder.Build([
+			"elastic/elasticsearch/8.16/openapi.json",
+			"elastic/elasticsearch/8.17/openapi.json"
+		]).Index;
+
+		index["elastic/elasticsearch"]["openapi.json"]["8"].Version.Should().Be("8.17");
+	}
+
+	[Fact]
+	public void Build_OutOfOrderArrival_HigherMinorListedBeforeLower_KeepsHighestMinor()
+	{
+		var index = VersionIndexBuilder.Build([
+			"elastic/elasticsearch/8.17/openapi.json",
+			"elastic/elasticsearch/8.16/openapi.json"
+		]).Index;
+
+		index["elastic/elasticsearch"]["openapi.json"]["8"].Version.Should().Be("8.17");
+	}
+
+	[Fact]
+	public void Build_MainVersion_CreatesMainEntry()
+	{
+		var index = VersionIndexBuilder.Build(["elastic/elasticsearch/main/openapi.json"]).Index;
+
+		index["elastic/elasticsearch"]["openapi.json"]["main"].Version.Should().Be("main");
+	}
+
+	[Fact]
+	public void Build_MainAndReleaseVersions_KeepsBothSeparately()
+	{
+		var index = VersionIndexBuilder.Build([
+			"elastic/elasticsearch/main/openapi.json",
+			"elastic/elasticsearch/8.16/openapi.json"
+		]).Index;
+
+		var byMajor = index["elastic/elasticsearch"]["openapi.json"];
+		byMajor.Should().HaveCount(2);
+		byMajor["main"].Version.Should().Be("main");
+		byMajor["8"].Version.Should().Be("8.16");
+	}
+
+	[Fact]
+	public void Build_MultipleSpecFilesInSameRepo_IndexesEachIndependently()
+	{
+		// Two spec files from one repo may share a version: they are separate objects in the bucket.
+		var index = VersionIndexBuilder.Build([
+			"elastic/kibana/8.16/kibana.json",
+			"elastic/kibana/8.16/kibana-serverless.json"
+		]).Index;
+
+		var byFile = index["elastic/kibana"];
+		byFile.Should().HaveCount(2);
+		byFile["kibana.json"]["8"].Version.Should().Be("8.16");
+		byFile["kibana-serverless.json"]["8"].Version.Should().Be("8.16");
+	}
+
+	[Fact]
+	public void Build_MultipleRepos_KeepsSeparateEntriesPerRepo()
+	{
+		var index = VersionIndexBuilder.Build([
+			"elastic/elasticsearch/8.16/openapi.json",
+			"elastic/kibana/8.16/kibana.json"
+		]).Index;
+
+		index.Should().HaveCount(2);
+		index["elastic/elasticsearch"]["openapi.json"]["8"].Version.Should().Be("8.16");
+		index["elastic/kibana"]["kibana.json"]["8"].Version.Should().Be("8.16");
+	}
+
+	[Fact]
+	public void Build_EmptyKeys_ReturnsEmptyIndex() => VersionIndexBuilder.Build([]).Index.Should().BeEmpty();
+
+	[Theory]
+	[InlineData("elastic/elasticsearch/openapi.json")] // missing version segment
+	[InlineData("elastic/elasticsearch/8.16/nested/openapi.json")] // too many segments
+	[InlineData("elastic//8.16/openapi.json")] // empty repo segment
+	[InlineData("elastic/elasticsearch/8.16/")] // empty file segment
+	[InlineData("elastic/elasticsearch/master/openapi.json")] // not "main" or <major>.<minor>
+	[InlineData("elastic/elasticsearch/8/openapi.json")] // missing minor
+	[InlineData("elastic/elasticsearch/8./openapi.json")] // missing minor after the dot
+	[InlineData("elastic/elasticsearch/8.x/openapi.json")] // non-numeric minor
+	[InlineData("elastic/elasticsearch/.16/openapi.json")] // missing major
+	[InlineData("elastic/elasticsearch/+8.16/openapi.json")] // signed major
+	public void Build_KeyOfUnexpectedShape_IsReportedAndSkipped(string key)
+	{
+		var (index, invalidKeys) = VersionIndexBuilder.Build([key]);
+
+		index.Should().BeEmpty();
+		invalidKeys.Should().ContainSingle().Which.Should().Be(key);
+	}
+
+	[Fact]
+	public void Build_MixOfValidAndInvalidKeys_IndexesValidAndReportsInvalidOnly()
+	{
+		var (index, invalidKeys) = VersionIndexBuilder.Build([
+			"elastic/elasticsearch/8.16/openapi.json",
+			"not-a-valid-key",
+			"elastic/elasticsearch/master/openapi.json"
+		]);
+
+		index["elastic/elasticsearch"]["openapi.json"]["8"].Version.Should().Be("8.16");
+		invalidKeys.Should().BeEquivalentTo(["not-a-valid-key", "elastic/elasticsearch/master/openapi.json"]);
+	}
+}

--- a/tests/Elastic.Documentation.OpenApiIndex.Tests/VersionIndexPublisherTests.cs
+++ b/tests/Elastic.Documentation.OpenApiIndex.Tests/VersionIndexPublisherTests.cs
@@ -1,0 +1,146 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Net;
+using System.Text;
+using Amazon.S3;
+using Amazon.S3.Model;
+using AwesomeAssertions;
+using FakeItEasy;
+
+namespace Elastic.Documentation.OpenApiIndex.Tests;
+
+public class VersionIndexPublisherTests
+{
+	private const string BucketName = "test-bucket";
+	private readonly IAmazonS3 _s3Client = A.Fake<IAmazonS3>();
+	private readonly List<PutObjectRequest> _puts = [];
+
+	public VersionIndexPublisherTests() =>
+		A.CallTo(() => _s3Client.PutObjectAsync(A<PutObjectRequest>._, A<Cancel>._))
+			.Invokes((PutObjectRequest request, Cancel _) => _puts.Add(request))
+			.Returns(new PutObjectResponse());
+
+	private VersionIndexPublisher CreatePublisher() => new(_s3Client, BucketName);
+
+	private void GivenBucketContains(params string[] keys) =>
+		A.CallTo(() => _s3Client.ListObjectsV2Async(A<ListObjectsV2Request>._, A<Cancel>._))
+			.Returns(new ListObjectsV2Response
+			{
+				S3Objects = [.. keys.Select(k => new S3Object { Key = k })],
+				IsTruncated = false
+			});
+
+	private void GivenNoPublishedIndex() =>
+		A.CallTo(() => _s3Client.GetObjectAsync(A<GetObjectRequest>._, A<Cancel>._))
+			.Throws(new AmazonS3Exception("Not Found") { StatusCode = HttpStatusCode.NotFound });
+
+	private void GivenPublishedIndex(string body, string etag = "\"etag-1\"") =>
+		A.CallTo(() => _s3Client.GetObjectAsync(A<GetObjectRequest>._, A<Cancel>._))
+			.Returns(new GetObjectResponse { ETag = etag, ResponseStream = new MemoryStream(Encoding.UTF8.GetBytes(body)) });
+
+	[Fact]
+	public async Task RefreshAsync_NoPublishedIndex_CreatesWithIfNoneMatch()
+	{
+		GivenBucketContains("elastic/elasticsearch/8.16/openapi.json");
+		GivenNoPublishedIndex();
+
+		await CreatePublisher().RefreshAsync(TestContext.Current.CancellationToken);
+
+		var put = _puts.Should().ContainSingle().Subject;
+		put.BucketName.Should().Be(BucketName);
+		put.Key.Should().Be(VersionIndexPublisher.IndexKey);
+		put.IfNoneMatch.Should().Be("*");
+		put.IfMatch.Should().BeNull();
+		put.ContentBody.Should().Be("""{"elastic/elasticsearch":{"openapi.json":{"8":{"version":"8.16"}}}}""");
+	}
+
+	[Fact]
+	public async Task RefreshAsync_PublishedIndexIsStale_UpdatesWithIfMatch()
+	{
+		GivenBucketContains("elastic/elasticsearch/8.17/openapi.json");
+		GivenPublishedIndex("""{"elastic/elasticsearch":{"openapi.json":{"8":{"version":"8.16"}}}}""", "\"stale-etag\"");
+
+		await CreatePublisher().RefreshAsync(TestContext.Current.CancellationToken);
+
+		var put = _puts.Should().ContainSingle().Subject;
+		put.IfMatch.Should().Be("\"stale-etag\"");
+		put.IfNoneMatch.Should().BeNull();
+		put.ContentBody.Should().Contain("8.17");
+	}
+
+	[Fact]
+	public async Task RefreshAsync_RebuildMatchesPublishedIndexByteForByte_SkipsWrite()
+	{
+		GivenBucketContains("elastic/elasticsearch/8.16/openapi.json");
+		GivenPublishedIndex("""{"elastic/elasticsearch":{"openapi.json":{"8":{"version":"8.16"}}}}""");
+
+		await CreatePublisher().RefreshAsync(TestContext.Current.CancellationToken);
+
+		_puts.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task RefreshAsync_ConditionalWriteConflict_ThrowsWithoutRetrying()
+	{
+		// A conflict means another invocation updated index.json concurrently. RefreshAsync does not retry
+		// in process — it throws, so the handler returns the message to the queue and SQS redelivers it.
+		GivenBucketContains("elastic/elasticsearch/8.16/openapi.json");
+		GivenNoPublishedIndex();
+		A.CallTo(() => _s3Client.PutObjectAsync(A<PutObjectRequest>._, A<Cancel>._))
+			.Throws(new AmazonS3Exception("Precondition Failed") { StatusCode = HttpStatusCode.PreconditionFailed });
+
+		var act = () => CreatePublisher().RefreshAsync(TestContext.Current.CancellationToken);
+
+		await act.Should().ThrowAsync<AmazonS3Exception>();
+		A.CallTo(() => _s3Client.PutObjectAsync(A<PutObjectRequest>._, A<Cancel>._)).MustHaveHappenedOnceExactly();
+	}
+
+	[Fact]
+	public async Task RefreshAsync_KeyOfUnexpectedShape_IsReturnedAndTheRestIndexed()
+	{
+		GivenBucketContains("elastic/elasticsearch/8.16/openapi.json", "not-a-valid-key");
+		GivenNoPublishedIndex();
+
+		var ignoredKeys = await CreatePublisher().RefreshAsync(TestContext.Current.CancellationToken);
+
+		ignoredKeys.Should().ContainSingle().Which.Should().Be("not-a-valid-key");
+		_puts.Should().ContainSingle().Which.ContentBody.Should().Contain("8.16");
+	}
+
+	[Fact]
+	public async Task RefreshAsync_IndexKeyItselfInListing_IsExcludedFromRebuild()
+	{
+		GivenBucketContains("elastic/elasticsearch/8.16/openapi.json", VersionIndexPublisher.IndexKey);
+		GivenNoPublishedIndex();
+
+		var ignoredKeys = await CreatePublisher().RefreshAsync(TestContext.Current.CancellationToken);
+
+		ignoredKeys.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task RefreshAsync_PaginatedListing_CombinesAllPages()
+	{
+		A.CallTo(() => _s3Client.ListObjectsV2Async(A<ListObjectsV2Request>.That.Matches(r => r.ContinuationToken == null), A<Cancel>._))
+			.Returns(new ListObjectsV2Response
+			{
+				S3Objects = [new S3Object { Key = "elastic/elasticsearch/8.16/openapi.json" }],
+				IsTruncated = true,
+				NextContinuationToken = "page-2"
+			});
+		A.CallTo(() => _s3Client.ListObjectsV2Async(A<ListObjectsV2Request>.That.Matches(r => r.ContinuationToken == "page-2"), A<Cancel>._))
+			.Returns(new ListObjectsV2Response
+			{
+				S3Objects = [new S3Object { Key = "elastic/kibana/8.16/kibana.json" }],
+				IsTruncated = false
+			});
+		GivenNoPublishedIndex();
+
+		await CreatePublisher().RefreshAsync(TestContext.Current.CancellationToken);
+
+		var put = _puts.Should().ContainSingle().Subject;
+		put.ContentBody.Should().Contain("elasticsearch").And.Contain("kibana");
+	}
+}

--- a/tests/Elastic.Documentation.OpenApiIndex.Tests/VersionIndexPublisherTests.cs
+++ b/tests/Elastic.Documentation.OpenApiIndex.Tests/VersionIndexPublisherTests.cs
@@ -14,6 +14,10 @@ namespace Elastic.Documentation.OpenApiIndex.Tests;
 public class VersionIndexPublisherTests
 {
 	private const string BucketName = "test-bucket";
+
+	/// <summary>The exact serialized index for a bucket holding only <c>elastic/elasticsearch/8.16/openapi.json</c>.</summary>
+	private const string Index816Json = /*lang=json,strict*/ """{"elastic/elasticsearch":{"openapi.json":{"8":{"version":"8.16"}}}}""";
+
 	private readonly IAmazonS3 _s3Client = A.Fake<IAmazonS3>();
 	private readonly List<PutObjectRequest> _puts = [];
 
@@ -53,14 +57,14 @@ public class VersionIndexPublisherTests
 		put.Key.Should().Be(VersionIndexPublisher.IndexKey);
 		put.IfNoneMatch.Should().Be("*");
 		put.IfMatch.Should().BeNull();
-		put.ContentBody.Should().Be("""{"elastic/elasticsearch":{"openapi.json":{"8":{"version":"8.16"}}}}""");
+		put.ContentBody.Should().Be(Index816Json);
 	}
 
 	[Fact]
 	public async Task RefreshAsync_PublishedIndexIsStale_UpdatesWithIfMatch()
 	{
 		GivenBucketContains("elastic/elasticsearch/8.17/openapi.json");
-		GivenPublishedIndex("""{"elastic/elasticsearch":{"openapi.json":{"8":{"version":"8.16"}}}}""", "\"stale-etag\"");
+		GivenPublishedIndex(Index816Json, "\"stale-etag\"");
 
 		await CreatePublisher().RefreshAsync(TestContext.Current.CancellationToken);
 
@@ -74,7 +78,7 @@ public class VersionIndexPublisherTests
 	public async Task RefreshAsync_RebuildMatchesPublishedIndexByteForByte_SkipsWrite()
 	{
 		GivenBucketContains("elastic/elasticsearch/8.16/openapi.json");
-		GivenPublishedIndex("""{"elastic/elasticsearch":{"openapi.json":{"8":{"version":"8.16"}}}}""");
+		GivenPublishedIndex(Index816Json);
 
 		await CreatePublisher().RefreshAsync(TestContext.Current.CancellationToken);
 


### PR DESCRIPTION
## What

- Add a Lambda that maintains `index.json` at the root of the `elastic-docs-openapi-specs` bucket. The index resolves each published major version of an OpenAPI spec to its highest minor, and keeps `main` as its own entry.
- Add `Elastic.Documentation.OpenApiIndex`, a shared library that holds the index format, the build logic, and the S3 publish logic, with unit tests.

## Why

- Specs upload to `org/repo/version/file`. Today nothing maps a major version to the newest spec published for it, so a consumer must list the bucket and pick a winner itself.
- The index gives docs-builder a single stable file to read for that answer.
- This is a dependency for https://github.com/elastic/docs-eng-team/issues/718.

## Notes

- Each event rebuilds the whole index from a full bucket listing instead of merging the triggering event. The rebuild self-heals after a missed event, and a deleted object simply cannot produce an entry.
- The write uses an S3 ETag precondition. If a concurrent invocation wins, the message returns to the queue and SQS redelivery repeats the rebuild. There is no in-process retry.
- The `main` or `<major>.<minor>` version contract is enforced upstream in `elastic/docs-actions` `openapi/upload`, which ships separately. The Lambda logs and skips any key that does not match that shape.

Closes elastic/docs-eng-team#714