### PR TITLE
feat: list pages and islands

### DIFF
--- a/src/Elastic.Documentation.Configuration/BuildContext.cs
+++ b/src/Elastic.Documentation.Configuration/BuildContext.cs
@@ -95,6 +95,7 @@ public record BuildContext : IDocumentationSetContext, IDocumentationConfigurati
 		GoogleTagManager = new GoogleTagManagerConfiguration { Enabled = false };
 		Optimizely = new OptimizelyConfiguration { Enabled = false };
 
+
 		ConfigurationYaml = ConfigurationPath.Exists
 			? DocumentationSetFile.LoadAndResolve(collector, ConfigurationPath, fileSystem.Read)
 			: new DocumentationSetFile();

--- a/src/Elastic.Documentation.Configuration/Toc/DocumentationSetFile.cs
+++ b/src/Elastic.Documentation.Configuration/Toc/DocumentationSetFile.cs
@@ -3,9 +3,11 @@
 // See the LICENSE file in the project root for more information
 
 using System.IO.Abstractions;
+using DotNet.Globbing;
 using Elastic.Documentation.Configuration.Products;
 using Elastic.Documentation.Configuration.Toc.CliReference;
 using Elastic.Documentation.Configuration.Toc.DetectionRules;
+using Elastic.Documentation.Configuration.Toc.Listing;
 using Elastic.Documentation.Diagnostics;
 using Elastic.Documentation.Extensions;
 using Elastic.Documentation.FileSystems;
@@ -186,6 +188,7 @@ public class DocumentationSetFile : TableOfContentsFile
 				IsolatedTableOfContentsRef tocRef => ResolveIsolatedToc(collector, tocRef, baseDirectory, fileSystem, parentPath, containerPath, context, suppressDiagnostics),
 				DetectionRuleOverviewRef ruleOverviewReference => ResolveRuleOverviewReference(collector, ruleOverviewReference, baseDirectory, fileSystem, parentPath, containerPath, context, suppressDiagnostics),
 				CliReferenceRef cliRef => ResolveCliReference(collector, cliRef, baseDirectory, fileSystem, parentPath, containerPath, context),
+				ListingRef listingRef => ResolveListingRef(collector, listingRef, baseDirectory, fileSystem, parentPath, containerPath, context),
 				FileRef fileRef => ResolveFileRef(collector, fileRef, baseDirectory, fileSystem, parentPath, containerPath, context, suppressDiagnostics),
 				FolderRef folderRef => ResolveFolderRef(collector, folderRef, baseDirectory, fileSystem, parentPath, containerPath, context, suppressDiagnostics),
 				CrossLinkRef crossLink => ResolveCrossLinkRef(collector, crossLink, baseDirectory, fileSystem, parentPath, containerPath, context),
@@ -727,6 +730,206 @@ public class DocumentationSetFile : TableOfContentsFile
 					CollectExcluded(children, result);
 			}
 		}
+	}
+
+	/// <summary>
+	/// Resolves a <see cref="ListingRef"/> by glob-matching all content files under the listing folder,
+	/// partitioning them into groups based on frontmatter, and emitting hidden <see cref="FileRef"/>s.
+	/// </summary>
+	private static ITableOfContentsItem? ResolveListingRef(
+		IDiagnosticsCollector collector,
+		ListingRef listingRef,
+		IDirectoryInfo baseDirectory,
+		IFileSystem fileSystem,
+		string parentPath,
+		string containerPath,
+		string context)
+	{
+		// Resolve the full path (same pattern as ResolveFolderRef)
+		string fullPath;
+		if (listingRef.PathRelativeToDocumentationSet.Contains('/'))
+		{
+			var contextDir = fileSystem.Path.GetDirectoryName(context) ?? "";
+			var contextRelativePath = fileSystem.Path.GetRelativePath(baseDirectory.FullName, contextDir);
+			if (contextRelativePath == ".")
+				contextRelativePath = "";
+			fullPath = string.IsNullOrEmpty(contextRelativePath)
+				? listingRef.PathRelativeToDocumentationSet
+				: $"{contextRelativePath}/{listingRef.PathRelativeToDocumentationSet}";
+		}
+		else
+		{
+			fullPath = string.IsNullOrEmpty(parentPath)
+				? listingRef.PathRelativeToDocumentationSet
+				: $"{parentPath}/{listingRef.PathRelativeToDocumentationSet}";
+		}
+
+		var pathRelativeToContainer = string.IsNullOrEmpty(containerPath)
+			? fullPath
+			: fullPath[(containerPath.Length + 1)..];
+
+		var options = listingRef.Options;
+		var globPattern = options.Glob ?? "**/*.md";
+
+		// Validate that non-.md globs must specify an extension
+		var hasNonMdGlob = !globPattern.EndsWith(".md", StringComparison.OrdinalIgnoreCase)
+			&& !globPattern.EndsWith("/*.md", StringComparison.OrdinalIgnoreCase)
+			&& !globPattern.Equals("**/*.md", StringComparison.OrdinalIgnoreCase);
+
+		if (hasNonMdGlob && string.IsNullOrEmpty(options.Extension))
+		{
+			collector.EmitError(context,
+				$"Listing '{fullPath}': glob '{globPattern}' may match non-.md files — 'extension:' is required to handle them.");
+		}
+
+		// Build exclude globs
+		var excludeGlobs = options.Exclude is { Count: > 0 }
+			? options.Exclude.Select(Glob.Parse).ToArray()
+			: [];
+
+		var listingDirAbsolute = fileSystem.Path.Join(baseDirectory.FullName, fullPath);
+		var listingDir = fileSystem.DirectoryInfo.New(listingDirAbsolute);
+
+		if (!listingDir.Exists)
+		{
+			collector.EmitError(context, $"Listing folder not found: {fullPath}");
+			return null;
+		}
+
+		// Glob-match files. We enumerate all files in the folder tree and test against the pattern.
+		var pattern = Glob.Parse(globPattern);
+		var allFiles = listingDir
+			.EnumerateFiles("*.*", SearchOption.AllDirectories)
+			.Where(f => !f.Attributes.HasFlag(FileAttributes.Hidden) && !f.Attributes.HasFlag(FileAttributes.System))
+			.Where(f => !f.Directory!.Attributes.HasFlag(FileAttributes.Hidden) && !f.Directory!.Attributes.HasFlag(FileAttributes.System))
+			.Where(f => f.LinkTarget == null)
+			.Where(f => !f.Name.StartsWith('_') && !f.Name.StartsWith('.'))
+			.Where(f =>
+			{
+				var rel = Path.GetRelativePath(listingDirAbsolute, f.FullName).Replace('\\', '/');
+				return pattern.IsMatch(rel);
+			})
+			.Where(f =>
+			{
+				if (excludeGlobs.Length == 0)
+					return true;
+				var rel = Path.GetRelativePath(listingDirAbsolute, f.FullName).Replace('\\', '/');
+				return !excludeGlobs.Any(g => g.IsMatch(rel));
+			})
+			.ToList();
+
+		if (allFiles.Count == 0)
+			return null;
+
+		// Read listing group from frontmatter of each .md file
+		var fileGroups = new Dictionary<IFileInfo, string?>(ReferenceEqualityComparer.Instance);
+		foreach (var file in allFiles)
+		{
+			if (file.Extension.Equals(".md", StringComparison.OrdinalIgnoreCase))
+				fileGroups[file] = ListingFrontMatterReader.ReadGroup(file);
+			else
+				fileGroups[file] = null; // extension will provide group via TryGetListingGroup
+		}
+
+		// Separate root/group index pages from content pages
+		var rootIndex = allFiles.FirstOrDefault(f =>
+			f.FullName.Equals(fileSystem.Path.Join(listingDirAbsolute, "index.md"), StringComparison.OrdinalIgnoreCase));
+
+		var groupIndexFiles = allFiles
+			.Where(f => f.Name.Equals("index.md", StringComparison.OrdinalIgnoreCase) && f != rootIndex)
+			.ToDictionary(
+				f => Path.GetRelativePath(listingDirAbsolute, f.Directory!.FullName).Replace('\\', '/'),
+				f => f,
+				StringComparer.OrdinalIgnoreCase);
+
+		var contentFiles = allFiles
+			.Where(f => f != rootIndex && !groupIndexFiles.ContainsValue(f))
+			.ToList();
+
+		// Sort content files
+		contentFiles = SortOrderExtensions.TryParse(options.Sort, out var sortOrder)
+			? sortOrder == SortOrder.Descending
+				? contentFiles.OrderByDescending(f => f.Name, NaturalStringComparer.Instance).ToList()
+				: contentFiles.OrderBy(f => f.Name, NaturalStringComparer.Instance).ToList()
+			: contentFiles.OrderBy(f => Path.GetRelativePath(listingDirAbsolute, f.FullName)).ToList();
+
+		// Partition content files into groups
+		var groupedFiles = new Dictionary<string, List<IFileInfo>>(StringComparer.OrdinalIgnoreCase);
+		var ungrouped = new List<IFileInfo>();
+
+		foreach (var file in contentFiles)
+		{
+			var group = fileGroups[file];
+			if (!string.IsNullOrEmpty(group))
+			{
+				if (!groupedFiles.ContainsKey(group))
+					groupedFiles[group] = [];
+				groupedFiles[group].Add(file);
+			}
+			else
+			{
+				ungrouped.Add(file);
+			}
+		}
+
+		// Determine group order: explicit groups first (in listed order), then remaining alphabetically
+		var orderedGroups = new List<string>();
+		if (options.Groups is { Count: > 0 })
+		{
+			foreach (var g in options.Groups)
+				orderedGroups.Add(g);
+		}
+		foreach (var g in groupedFiles.Keys.Where(k => !orderedGroups.Contains(k, StringComparer.OrdinalIgnoreCase)).OrderBy(k => k))
+			orderedGroups.Add(g);
+
+		var tocItems = new List<ITableOfContentsItem>();
+
+		// Root index (visible) — always emit; ListingDocsBuilderExtension creates a synthetic page if missing.
+		var rootRelPath = $"{fullPath}/index.md";
+		var rootRelContainer = string.IsNullOrEmpty(containerPath) ? rootRelPath : rootRelPath[(containerPath.Length + 1)..];
+		tocItems.Add(new IndexFileRef(rootRelPath, rootRelContainer, false, [], context));
+
+		// Group children
+		foreach (var groupKey in orderedGroups)
+		{
+			if (!groupedFiles.TryGetValue(groupKey, out var groupFiles))
+				continue;
+
+			// Always emit an IndexFileRef for the group — points to a real file if one exists,
+			// otherwise to the synthetic path that ListingDocsBuilderExtension will register.
+			var groupIndexPath = $"{fullPath}/{groupKey}/index.md";
+
+			var groupChildren = new List<ITableOfContentsItem>();
+
+			var groupIdxRelContainer = string.IsNullOrEmpty(containerPath) ? groupIndexPath : groupIndexPath[(containerPath.Length + 1)..];
+			groupChildren.Add(new IndexFileRef(groupIndexPath, groupIdxRelContainer, false, [], context));
+
+			// Content pages (always hidden)
+			foreach (var file in groupFiles)
+			{
+				var relToSet = Path.GetRelativePath(baseDirectory.FullName, file.FullName).Replace('\\', '/');
+				var relToContainer = string.IsNullOrEmpty(containerPath) ? relToSet : relToSet[(containerPath.Length + 1)..];
+				groupChildren.Add(new FileRef(relToSet, relToContainer, true, [], context));
+			}
+
+			tocItems.Add(new ListingGroupRef(groupKey, fullPath, pathRelativeToContainer, groupChildren, context));
+		}
+
+		// Ungrouped pages (always hidden)
+		foreach (var file in ungrouped)
+		{
+			var relToSet = Path.GetRelativePath(baseDirectory.FullName, file.FullName).Replace('\\', '/');
+			var relToContainer = string.IsNullOrEmpty(containerPath) ? relToSet : relToSet[(containerPath.Length + 1)..];
+			tocItems.Add(new FileRef(relToSet, relToContainer, true, [], context));
+		}
+
+		// Resolve explicit children (from YAML `children:`) last
+		var explicitChildren = listingRef.Children.Count > 0
+			? ResolveTableOfContents(collector, listingRef.Children, baseDirectory, fileSystem, fullPath, containerPath, context)
+			: [];
+		tocItems.AddRange(explicitChildren);
+
+		return new ListingRef(fullPath, pathRelativeToContainer, tocItems, context, options);
 	}
 
 	/// <summary>

--- a/src/Elastic.Documentation.Configuration/Toc/Listing/ListingFrontMatterReader.cs
+++ b/src/Elastic.Documentation.Configuration/Toc/Listing/ListingFrontMatterReader.cs
@@ -1,0 +1,104 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+
+namespace Elastic.Documentation.Configuration.Toc.Listing;
+
+/// <summary>
+/// Reads only the <c>listing:</c> frontmatter key from a Markdown file without fully parsing it.
+/// Supports both shorthand (<c>listing: group-name</c>) and full form (<c>listing: {group: name}</c>).
+/// </summary>
+public static class ListingFrontMatterReader
+{
+	/// <summary>
+	/// Returns the listing group name declared in the file's frontmatter, or <c>null</c> if none.
+	/// </summary>
+	public static string? ReadGroup(IFileInfo file)
+	{
+		try
+		{
+			var content = file.FileSystem.File.ReadAllText(file.FullName);
+			return ReadGroupFromContent(content);
+		}
+		catch
+		{
+			return null;
+		}
+	}
+
+	internal static string? ReadGroupFromContent(string content)
+	{
+		// Fast path: no frontmatter delimiter
+		if (!content.StartsWith("---", StringComparison.Ordinal))
+			return null;
+
+		// Extract frontmatter between the two --- delimiters
+		var start = content.IndexOf('\n');
+		if (start < 0)
+			return null;
+		var end = content.IndexOf("\n---", start, StringComparison.Ordinal);
+		if (end < 0)
+			return null;
+
+		var yaml = content[(start + 1)..end];
+
+		try
+		{
+			var reader = new StringReader(yaml);
+			var parser = new Parser(reader);
+			_ = parser.TryConsume<StreamStart>(out _);
+			_ = parser.TryConsume<DocumentStart>(out _);
+			if (!parser.TryConsume<MappingStart>(out _))
+				return null;
+
+			while (!parser.TryConsume<MappingEnd>(out _) && !parser.Accept<DocumentEnd>(out _) && !parser.Accept<StreamEnd>(out _))
+			{
+				if (!parser.TryConsume<Scalar>(out var key))
+				{
+					parser.SkipThisAndNestedEvents();
+					continue;
+				}
+
+				if (key.Value != "listing")
+				{
+					parser.SkipThisAndNestedEvents();
+					continue;
+				}
+
+				// Found the listing key — value is either a scalar (group name) or a mapping {group: name}
+				if (parser.TryConsume<Scalar>(out var scalar))
+					return string.IsNullOrWhiteSpace(scalar.Value) ? null : scalar.Value;
+
+				if (parser.TryConsume<MappingStart>(out _))
+				{
+					while (!parser.TryConsume<MappingEnd>(out _))
+					{
+						if (!parser.TryConsume<Scalar>(out var mapKey))
+						{
+							parser.SkipThisAndNestedEvents();
+							continue;
+						}
+						if (mapKey.Value == "group" && parser.TryConsume<Scalar>(out var groupVal))
+							return string.IsNullOrWhiteSpace(groupVal.Value) ? null : groupVal.Value;
+						parser.SkipThisAndNestedEvents();
+					}
+				}
+				else
+				{
+					parser.SkipThisAndNestedEvents();
+				}
+				return null;
+			}
+		}
+		catch
+		{
+			// Ignore parse errors — the frontmatter will be validated properly when the file is parsed
+		}
+
+		return null;
+	}
+}

--- a/src/Elastic.Documentation.Configuration/Toc/TableOfContentsItems.cs
+++ b/src/Elastic.Documentation.Configuration/Toc/TableOfContentsItems.cs
@@ -149,3 +149,75 @@ public record FolderRef(string PathRelativeToDocumentationSet, string PathRelati
 
 public record IsolatedTableOfContentsRef(string PathRelativeToDocumentationSet, string PathRelativeToContainer, IReadOnlyCollection<ITableOfContentsItem> Children, string Context)
 	: ITableOfContentsItem;
+
+/// <summary>Controls how much of the listing appears in the rendered navigation tree.</summary>
+public enum ListingVisual
+{
+	/// <summary>Only the listing root index page is visible in the nav tree (default).</summary>
+	None,
+
+	/// <summary>The listing root and one node per group (with their group index) are visible.</summary>
+	Groups,
+
+	/// <summary>Full depth — group nodes and all their pages are visible.</summary>
+	All
+}
+
+/// <summary>Parsing helpers for <see cref="ListingVisual"/>.</summary>
+public static class ListingVisualExtensions
+{
+	/// <summary>Tries to parse a YAML visual value (none, groups, all) into a <see cref="ListingVisual"/>.</summary>
+	public static bool TryParse(string? value, out ListingVisual result)
+	{
+		var normalized = value?.ToLowerInvariant();
+		(result, var valid) = normalized switch
+		{
+			"none" => (ListingVisual.None, true),
+			"groups" => (ListingVisual.Groups, true),
+			"all" => (ListingVisual.All, true),
+			_ => (ListingVisual.None, false)
+		};
+		return valid;
+	}
+}
+
+/// <summary>Optional knobs on a <see cref="ListingRef"/> entry beyond the mandatory path.</summary>
+public record ListingOptions(
+	string? Glob = null,
+	string? Sort = null,
+	IReadOnlyCollection<string>? Exclude = null,
+	ListingVisual Visual = ListingVisual.None,
+	IReadOnlyCollection<string>? Groups = null,
+	string? Extension = null
+);
+
+/// <summary>
+/// A listing entry in the TOC: glob-discovers files, hides them from the nav tree
+/// (subject to <see cref="ListingOptions.Visual"/>), and generates a grouped index page.
+/// </summary>
+public record ListingRef(
+	string PathRelativeToDocumentationSet,
+	string PathRelativeToContainer,
+	IReadOnlyCollection<ITableOfContentsItem> Children,
+	string Context,
+	ListingOptions Options
+) : ITableOfContentsItem;
+
+/// <summary>
+/// A resolved group bucket inside a <see cref="ListingRef"/>. Children are the pages belonging to this group.
+/// </summary>
+public record ListingGroupRef(
+	string GroupKey,
+	string PathRelativeToDocumentationSet,
+	string PathRelativeToContainer,
+	IReadOnlyCollection<ITableOfContentsItem> Children,
+	string Context
+) : ITableOfContentsItem;
+
+/// <summary>Frontmatter value for the <c>listing</c> key — both shorthand (<c>listing: group-name</c>)
+/// and full form (<c>listing: {group: group-name}</c>) parse to this.</summary>
+public class ListingFrontMatter
+{
+	/// <summary>The group key this page belongs to inside its listing.</summary>
+	public string? Group { get; set; }
+}

--- a/src/Elastic.Documentation.Configuration/Toc/TableOfContentsItems.cs
+++ b/src/Elastic.Documentation.Configuration/Toc/TableOfContentsItems.cs
@@ -160,7 +160,10 @@ public enum ListingVisual
 	Groups,
 
 	/// <summary>Full depth — group nodes and all their pages are visible.</summary>
-	All
+	All,
+
+	/// <summary>Hidden from main nav; listing pages get their own island sidebar nav.</summary>
+	Island
 }
 
 /// <summary>Parsing helpers for <see cref="ListingVisual"/>.</summary>
@@ -175,6 +178,7 @@ public static class ListingVisualExtensions
 			"none" => (ListingVisual.None, true),
 			"groups" => (ListingVisual.Groups, true),
 			"all" => (ListingVisual.All, true),
+			"island" => (ListingVisual.Island, true),
 			_ => (ListingVisual.None, false)
 		};
 		return valid;

--- a/src/Elastic.Documentation.Configuration/Toc/TableOfContentsItems.cs
+++ b/src/Elastic.Documentation.Configuration/Toc/TableOfContentsItems.cs
@@ -161,9 +161,6 @@ public enum ListingVisual
 
 	/// <summary>Full depth — group nodes and all their pages are visible.</summary>
 	All,
-
-	/// <summary>Hidden from main nav; listing pages get their own island sidebar nav.</summary>
-	Island
 }
 
 /// <summary>Parsing helpers for <see cref="ListingVisual"/>.</summary>
@@ -178,7 +175,6 @@ public static class ListingVisualExtensions
 			"none" => (ListingVisual.None, true),
 			"groups" => (ListingVisual.Groups, true),
 			"all" => (ListingVisual.All, true),
-			"island" => (ListingVisual.Island, true),
 			_ => (ListingVisual.None, false)
 		};
 		return valid;
@@ -192,7 +188,8 @@ public record ListingOptions(
 	IReadOnlyCollection<string>? Exclude = null,
 	ListingVisual Visual = ListingVisual.None,
 	IReadOnlyCollection<string>? Groups = null,
-	string? Extension = null
+	string? Extension = null,
+	bool Island = false
 );
 
 /// <summary>

--- a/src/Elastic.Documentation.Configuration/Toc/TableOfContentsYamlConverters.cs
+++ b/src/Elastic.Documentation.Configuration/Toc/TableOfContentsYamlConverters.cs
@@ -122,8 +122,10 @@ public class TocItemYamlConverter : IYamlTypeConverter
 			var listingVisual = ListingVisual.None;
 			if (dictionary.TryGetValue("visual", out var visualObj) && visualObj is string visualStr)
 				_ = ListingVisualExtensions.TryParse(visualStr, out listingVisual);
+			var island = dictionary.TryGetValue("island", out var islandObj) && islandObj is string islandStr
+				&& bool.TryParse(islandStr, out var islandBool) && islandBool;
 			// Reuse the already-captured sort and exclude variables from the outer scope
-			var options = new ListingOptions(glob, sort, exclude, listingVisual, groups, extension);
+			var options = new ListingOptions(glob, sort, exclude, listingVisual, groups, extension, island);
 			return new ListingRef(listing, listing, children, placeholderContext, options);
 		}
 

--- a/src/Elastic.Documentation.Configuration/Toc/TableOfContentsYamlConverters.cs
+++ b/src/Elastic.Documentation.Configuration/Toc/TableOfContentsYamlConverters.cs
@@ -73,7 +73,7 @@ public class TocItemYamlConverter : IYamlTypeConverter
 					}
 					value = childrenList;
 				}
-				else if (key.Value is "detection_rules" or "exclude" or "deprecated_detection_rules")
+				else if (key.Value is "detection_rules" or "exclude" or "deprecated_detection_rules" or "groups")
 				{
 					// Parse the children list manually
 					var childrenList = new List<string>();
@@ -111,6 +111,21 @@ public class TocItemYamlConverter : IYamlTypeConverter
 
 		// Capture exclude list for folder auto-discovery
 		var exclude = dictionary.TryGetValue("exclude", out var excludeObj) && excludeObj is string[] excludeArr ? excludeArr : null;
+
+		// Check for listing (listing: <folder>) — a glob-driven auto-discovered nav entry with generated index.
+		// Must come before folder: and file: so those keys can still appear on the entry as children context.
+		if (dictionary.TryGetValue("listing", out var listingPath) && listingPath is string listing)
+		{
+			var glob = dictionary.TryGetValue("glob", out var globObj) && globObj is string globStr ? globStr : null;
+			var extension = dictionary.TryGetValue("extension", out var extObj) && extObj is string extStr ? extStr : null;
+			var groups = dictionary.TryGetValue("groups", out var groupsObj) && groupsObj is string[] groupsArr ? (IReadOnlyCollection<string>)groupsArr : null;
+			var listingVisual = ListingVisual.None;
+			if (dictionary.TryGetValue("visual", out var visualObj) && visualObj is string visualStr)
+				_ = ListingVisualExtensions.TryParse(visualStr, out listingVisual);
+			// Reuse the already-captured sort and exclude variables from the outer scope
+			var options = new ListingOptions(glob, sort, exclude, listingVisual, groups, extension);
+			return new ListingRef(listing, listing, children, placeholderContext, options);
+		}
 
 		// Check for CLI reference (cli: schema.json, optional folder: supplemental-docs/)
 		// Must come before the folder+file check to prevent folder: from being consumed by that branch

--- a/src/Elastic.Documentation.Navigation/INavigationItem.cs
+++ b/src/Elastic.Documentation.Navigation/INavigationItem.cs
@@ -26,7 +26,19 @@ public interface INavigationItem
 	/// Gets or sets the parent navigation item.
 	INodeNavigationItem<INavigationModel, INavigationItem>? Parent { get; set; }
 
+	/// <summary>
+	/// Whether this item is hidden from the rendered navigation tree.
+	/// Used by <c>_TocTreeNav.cshtml</c> to skip rendering.
+	/// </summary>
 	bool Hidden { get; }
+
+	/// <summary>
+	/// Whether this item should be excluded from search indexing and the HTML <c>noindex</c> directive.
+	/// Defaults to <see cref="Hidden"/> so existing behavior is preserved.
+	/// Listing pages override this to <c>false</c> — they are hidden from the nav tree but should remain
+	/// indexed and searchable.
+	/// </summary>
+	bool ExcludeFromIndexing => Hidden;
 
 	int NavigationIndex { get; set; }
 }

--- a/src/Elastic.Documentation.Navigation/INavigationItem.cs
+++ b/src/Elastic.Documentation.Navigation/INavigationItem.cs
@@ -40,6 +40,18 @@ public interface INavigationItem
 	/// </summary>
 	bool ExcludeFromIndexing => Hidden;
 
+	/// <summary>
+	/// When non-null, this item is part of an island listing and this is its listing root node.
+	/// Island pages render a dedicated sidebar nav instead of the full tree.
+	/// </summary>
+	INodeNavigationItem<INavigationModel, INavigationItem>? IslandListingRoot => null;
+
+	/// <summary>
+	/// When true, this node IS the island listing root (the listing index page).
+	/// Used to render the island nav when viewing the listing overview page.
+	/// </summary>
+	bool IsIslandListing => false;
+
 	int NavigationIndex { get; set; }
 }
 

--- a/src/Elastic.Documentation.Navigation/INavigationItem.cs
+++ b/src/Elastic.Documentation.Navigation/INavigationItem.cs
@@ -2,6 +2,8 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using Elastic.Documentation.Configuration.Toc;
+
 namespace Elastic.Documentation.Navigation;
 
 /// Represents navigation model data for documentation elements.
@@ -51,6 +53,13 @@ public interface INavigationItem
 	/// Used to render the island nav when viewing the listing overview page.
 	/// </summary>
 	bool IsIslandListing => false;
+
+	/// <summary>
+	/// For island listing roots, controls what depth the island sidebar nav renders.
+	/// <see cref="ListingVisual.Groups"/> shows group headings only;
+	/// <see cref="ListingVisual.All"/> shows groups with their pages.
+	/// </summary>
+	ListingVisual IslandVisual => ListingVisual.None;
 
 	int NavigationIndex { get; set; }
 }

--- a/src/Elastic.Documentation.Navigation/Isolated/Leaf/FileNavigationLeaf.cs
+++ b/src/Elastic.Documentation.Navigation/Isolated/Leaf/FileNavigationLeaf.cs
@@ -69,6 +69,9 @@ public class FileNavigationLeaf<TModel>(TModel model, IFileInfo fileInfo, FileNa
 	public bool ExcludeFromIndexing { get; } = args.ExcludeFromIndexing ?? args.Hidden;
 
 	/// <inheritdoc />
+	public INodeNavigationItem<INavigationModel, INavigationItem>? IslandListingRoot => args.IslandListingRoot;
+
+	/// <inheritdoc />
 	public IRootNavigationItem<INavigationModel, INavigationItem> NavigationRoot => args.HomeAccessor.HomeProvider.NavigationRoot;
 
 	/// <inheritdoc />

--- a/src/Elastic.Documentation.Navigation/Isolated/Leaf/FileNavigationLeaf.cs
+++ b/src/Elastic.Documentation.Navigation/Isolated/Leaf/FileNavigationLeaf.cs
@@ -66,6 +66,9 @@ public class FileNavigationLeaf<TModel>(TModel model, IFileInfo fileInfo, FileNa
 	public bool Hidden { get; } = args.Hidden;
 
 	/// <inheritdoc />
+	public bool ExcludeFromIndexing { get; } = args.ExcludeFromIndexing ?? args.Hidden;
+
+	/// <inheritdoc />
 	public IRootNavigationItem<INavigationModel, INavigationItem> NavigationRoot => args.HomeAccessor.HomeProvider.NavigationRoot;
 
 	/// <inheritdoc />

--- a/src/Elastic.Documentation.Navigation/Isolated/NavigationArguments.cs
+++ b/src/Elastic.Documentation.Navigation/Isolated/NavigationArguments.cs
@@ -25,7 +25,8 @@ public record FileNavigationArgs(
 	int NavigationIndex,
 	INodeNavigationItem<INavigationModel, INavigationItem>? Parent,
 	INavigationHomeAccessor HomeAccessor,
-	bool? ExcludeFromIndexing = null
+	bool? ExcludeFromIndexing = null,
+	INodeNavigationItem<INavigationModel, INavigationItem>? IslandListingRoot = null
 );
 
 /// <summary>

--- a/src/Elastic.Documentation.Navigation/Isolated/NavigationArguments.cs
+++ b/src/Elastic.Documentation.Navigation/Isolated/NavigationArguments.cs
@@ -9,17 +9,23 @@ namespace Elastic.Documentation.Navigation.Isolated;
 /// </summary>
 /// <param name="RelativePathToDocumentationSet">The relative path from the documentation set root</param>
 /// <param name="RelativePathToTableOfContents">The relative path from the table of contents root</param>
-/// <param name="Hidden">Whether this navigation item should be hidden from navigation</param>
+/// <param name="Hidden">Whether this navigation item should be hidden from the rendered nav tree</param>
 /// <param name="NavigationIndex">The index position in navigation</param>
 /// <param name="Parent">The parent navigation item</param>
 /// <param name="HomeAccessor">The home accessor for this navigation item</param>
+/// <param name="ExcludeFromIndexing">
+/// When <c>true</c>, the page is excluded from search indexing and the HTML noindex directive.
+/// Defaults to <see langword="null"/>, which falls back to the value of <paramref name="Hidden"/>.
+/// Set explicitly to <c>false</c> for listing pages that are hidden from the nav tree but should still be indexed.
+/// </param>
 public record FileNavigationArgs(
 	string RelativePathToDocumentationSet,
 	string RelativePathToTableOfContents,
 	bool Hidden,
 	int NavigationIndex,
 	INodeNavigationItem<INavigationModel, INavigationItem>? Parent,
-	INavigationHomeAccessor HomeAccessor
+	INavigationHomeAccessor HomeAccessor,
+	bool? ExcludeFromIndexing = null
 );
 
 /// <summary>

--- a/src/Elastic.Documentation.Navigation/Isolated/Node/DocumentationSetNavigation.cs
+++ b/src/Elastic.Documentation.Navigation/Isolated/Node/DocumentationSetNavigation.cs
@@ -642,7 +642,9 @@ public class DocumentationSetNavigation<TModel>
 						// Group node visibility depends on `visual:`.
 						// FolderNavigation.Hidden is derived from its index page's Hidden flag,
 						// so we control group node visibility by setting Hidden on the index leaf.
-						var groupHidden = visual is ListingVisual.None;
+						// For island listings visual controls what the island sidebar renders, not the parent nav.
+						// Island groups are always hidden from the parent nav tree.
+						var groupHidden = isIsland || visual is ListingVisual.None;
 						// Derive the group folder path from the first child's parent dir so URL generation works
 						var groupFolderPath = groupRef.PathRelativeToDocumentationSet + "/" + groupRef.GroupKey;
 						var groupFolderNav = new FolderNavigation<TModel>(groupFolderPath, folderNavigation, homeAccessor) { NavigationIndex = childIndex++ };
@@ -719,7 +721,10 @@ public class DocumentationSetNavigation<TModel>
 
 		folderNavigation.SetNavigationItems(children);
 		if (isIsland)
+		{
 			folderNavigation.IsIslandListing = true;
+			folderNavigation.IslandVisual = visual;
+		}
 		return folderNavigation;
 	}
 

--- a/src/Elastic.Documentation.Navigation/Isolated/Node/DocumentationSetNavigation.cs
+++ b/src/Elastic.Documentation.Navigation/Isolated/Node/DocumentationSetNavigation.cs
@@ -610,7 +610,12 @@ public class DocumentationSetNavigation<TModel>
 	{
 		var visual = listingRef.Options.Visual;
 		var listingPath = listingRef.PathRelativeToDocumentationSet;
-		var isIsland = visual == ListingVisual.Island;
+		var isIsland = listingRef.Options.Island;
+		if (isIsland && visual == ListingVisual.None)
+		{
+			context.Collector.EmitError(listingRef.Context, $"Listing '{listingPath}' sets island: true with visual: none. Set visual: groups or visual: all so the listing is reachable from the main nav.");
+			return null;
+		}
 
 		// Root folder node for the listing
 		var folderNavigation = new FolderNavigation<TModel>(listingPath, parent, homeAccessor) { NavigationIndex = index };
@@ -637,7 +642,7 @@ public class DocumentationSetNavigation<TModel>
 						// Group node visibility depends on `visual:`.
 						// FolderNavigation.Hidden is derived from its index page's Hidden flag,
 						// so we control group node visibility by setting Hidden on the index leaf.
-						var groupHidden = visual is ListingVisual.None or ListingVisual.Island;
+						var groupHidden = visual is ListingVisual.None;
 						// Derive the group folder path from the first child's parent dir so URL generation works
 						var groupFolderPath = groupRef.PathRelativeToDocumentationSet + "/" + groupRef.GroupKey;
 						var groupFolderNav = new FolderNavigation<TModel>(groupFolderPath, folderNavigation, homeAccessor) { NavigationIndex = childIndex++ };

--- a/src/Elastic.Documentation.Navigation/Isolated/Node/DocumentationSetNavigation.cs
+++ b/src/Elastic.Documentation.Navigation/Isolated/Node/DocumentationSetNavigation.cs
@@ -610,6 +610,7 @@ public class DocumentationSetNavigation<TModel>
 	{
 		var visual = listingRef.Options.Visual;
 		var listingPath = listingRef.PathRelativeToDocumentationSet;
+		var isIsland = visual == ListingVisual.Island;
 
 		// Root folder node for the listing
 		var folderNavigation = new FolderNavigation<TModel>(listingPath, parent, homeAccessor) { NavigationIndex = index };
@@ -622,12 +623,12 @@ public class DocumentationSetNavigation<TModel>
 			{
 				case IndexFileRef indexRef:
 					{
-						// Root index page — always visible
+						// Root index page — always visible (it's the "back to" target for island nav)
 						var fileInfo = ResolveFileInfo(context, indexRef.PathRelativeToDocumentationSet);
 						var docFile = CreateDocumentationFile(fileInfo, context.ReadFileSystem, context);
 						if (docFile is null)
 							break;
-						var args = new FileNavigationArgs(indexRef.PathRelativeToDocumentationSet, indexRef.PathRelativeToContainer, false, childIndex++, folderNavigation, homeAccessor);
+						var args = new FileNavigationArgs(indexRef.PathRelativeToDocumentationSet, indexRef.PathRelativeToContainer, false, childIndex++, folderNavigation, homeAccessor, IslandListingRoot: null);
 						children.Add(DocumentationNavigationFactory.CreateFileNavigationLeaf(docFile, fileInfo, args));
 						break;
 					}
@@ -636,7 +637,7 @@ public class DocumentationSetNavigation<TModel>
 						// Group node visibility depends on `visual:`.
 						// FolderNavigation.Hidden is derived from its index page's Hidden flag,
 						// so we control group node visibility by setting Hidden on the index leaf.
-						var groupHidden = visual == ListingVisual.None;
+						var groupHidden = visual is ListingVisual.None or ListingVisual.Island;
 						// Derive the group folder path from the first child's parent dir so URL generation works
 						var groupFolderPath = groupRef.PathRelativeToDocumentationSet + "/" + groupRef.GroupKey;
 						var groupFolderNav = new FolderNavigation<TModel>(groupFolderPath, folderNavigation, homeAccessor) { NavigationIndex = childIndex++ };
@@ -668,13 +669,17 @@ public class DocumentationSetNavigation<TModel>
 							if (childDocFile is null)
 								continue;
 
-							var leafArgs = new FileNavigationArgs(pathDs, pathCont, pageHidden, groupChildIndex++, groupFolderNav, homeAccessor, ExcludeFromIndexing: excludeFromIndexing);
+							var leafArgs = new FileNavigationArgs(pathDs, pathCont, pageHidden, groupChildIndex++, groupFolderNav, homeAccessor,
+								ExcludeFromIndexing: excludeFromIndexing,
+								IslandListingRoot: isIsland ? folderNavigation : null);
 							groupChildren.Add(DocumentationNavigationFactory.CreateFileNavigationLeaf(childDocFile, childFileInfo, leafArgs));
 						}
 
 						if (groupChildren.Count == 0)
 							break;
 						groupFolderNav.SetNavigationItems(groupChildren);
+						if (isIsland)
+							groupFolderNav.IslandListingRoot = folderNavigation;
 						children.Add(groupFolderNav);
 						break;
 					}
@@ -685,7 +690,9 @@ public class DocumentationSetNavigation<TModel>
 						var docFile = CreateDocumentationFile(fileInfo, context.ReadFileSystem, context);
 						if (docFile is null)
 							break;
-						var args = new FileNavigationArgs(fileRef.PathRelativeToDocumentationSet, fileRef.PathRelativeToContainer, true, childIndex++, folderNavigation, homeAccessor, ExcludeFromIndexing: false);
+						var args = new FileNavigationArgs(fileRef.PathRelativeToDocumentationSet, fileRef.PathRelativeToContainer, true, childIndex++, folderNavigation, homeAccessor,
+							ExcludeFromIndexing: false,
+							IslandListingRoot: isIsland ? folderNavigation : null);
 						children.Add(DocumentationNavigationFactory.CreateFileNavigationLeaf(docFile, fileInfo, args));
 						break;
 					}
@@ -706,6 +713,8 @@ public class DocumentationSetNavigation<TModel>
 		}
 
 		folderNavigation.SetNavigationItems(children);
+		if (isIsland)
+			folderNavigation.IsIslandListing = true;
 		return folderNavigation;
 	}
 

--- a/src/Elastic.Documentation.Navigation/Isolated/Node/DocumentationSetNavigation.cs
+++ b/src/Elastic.Documentation.Navigation/Isolated/Node/DocumentationSetNavigation.cs
@@ -10,6 +10,9 @@ using Elastic.Documentation.Configuration.Toc.DetectionRules;
 using Elastic.Documentation.Extensions;
 using Elastic.Documentation.Links.CrossLinks;
 using Elastic.Documentation.Navigation.Isolated.Leaf;
+using ListingGroupRef = Elastic.Documentation.Configuration.Toc.ListingGroupRef;
+using ListingRef = Elastic.Documentation.Configuration.Toc.ListingRef;
+using ListingVisual = Elastic.Documentation.Configuration.Toc.ListingVisual;
 
 namespace Elastic.Documentation.Navigation.Isolated.Node;
 
@@ -176,6 +179,7 @@ public class DocumentationSetNavigation<TModel>
 			FolderRef folderRef => CreateFolderNavigation(folderRef, index, context, parent, homeAccessor),
 			IsolatedTableOfContentsRef tocRef => CreateTocNavigation(tocRef, index, context, parent, homeAccessor),
 			CliReferenceRef cliRef => CreateCliReferenceNavigation(cliRef, index, context, parent, homeAccessor),
+			ListingRef listingRef => CreateListingNavigation(listingRef, index, context, parent, homeAccessor),
 			_ => null
 		};
 
@@ -594,6 +598,115 @@ public class DocumentationSetNavigation<TModel>
 
 		var args = new FileNavigationArgs(syntheticPath, syntheticPath, false, index, parent, homeAccessor);
 		return DocumentationNavigationFactory.CreateFileNavigationLeaf(docFile, fileInfo, args);
+	}
+
+	private INavigationItem? CreateListingNavigation(
+		ListingRef listingRef,
+		int index,
+		IDocumentationSetContext context,
+		INodeNavigationItem<INavigationModel, INavigationItem>? parent,
+		INavigationHomeAccessor homeAccessor
+	)
+	{
+		var visual = listingRef.Options.Visual;
+		var listingPath = listingRef.PathRelativeToDocumentationSet;
+
+		// Root folder node for the listing
+		var folderNavigation = new FolderNavigation<TModel>(listingPath, parent, homeAccessor) { NavigationIndex = index };
+		var children = new List<INavigationItem>();
+		var childIndex = 0;
+
+		foreach (var tocItem in listingRef.Children)
+		{
+			switch (tocItem)
+			{
+				case IndexFileRef indexRef:
+					{
+						// Root index page — always visible
+						var fileInfo = ResolveFileInfo(context, indexRef.PathRelativeToDocumentationSet);
+						var docFile = CreateDocumentationFile(fileInfo, context.ReadFileSystem, context);
+						if (docFile is null)
+							break;
+						var args = new FileNavigationArgs(indexRef.PathRelativeToDocumentationSet, indexRef.PathRelativeToContainer, false, childIndex++, folderNavigation, homeAccessor);
+						children.Add(DocumentationNavigationFactory.CreateFileNavigationLeaf(docFile, fileInfo, args));
+						break;
+					}
+				case ListingGroupRef groupRef:
+					{
+						// Group node visibility depends on `visual:`.
+						// FolderNavigation.Hidden is derived from its index page's Hidden flag,
+						// so we control group node visibility by setting Hidden on the index leaf.
+						var groupHidden = visual == ListingVisual.None;
+						// Derive the group folder path from the first child's parent dir so URL generation works
+						var groupFolderPath = groupRef.PathRelativeToDocumentationSet + "/" + groupRef.GroupKey;
+						var groupFolderNav = new FolderNavigation<TModel>(groupFolderPath, folderNavigation, homeAccessor) { NavigationIndex = childIndex++ };
+						var groupChildren = new List<INavigationItem>();
+						var groupChildIndex = 0;
+
+						foreach (var groupItem in groupRef.Children)
+						{
+							var pathDs = groupItem switch { FileRef fr => fr.PathRelativeToDocumentationSet, _ => groupItem.PathRelativeToDocumentationSet };
+							var pathCont = groupItem switch { FileRef fr => fr.PathRelativeToContainer, _ => groupItem.PathRelativeToContainer };
+
+							// Group index page: hidden matches group-level visibility
+							// Content pages: always hidden from nav, but NOT excluded from indexing (so search still works)
+							bool pageHidden;
+							bool excludeFromIndexing;
+							if (groupItem is IndexFileRef)
+							{
+								pageHidden = groupHidden;
+								excludeFromIndexing = groupHidden; // group index excluded from indexing only when fully hidden
+							}
+							else
+							{
+								pageHidden = visual != ListingVisual.All;
+								excludeFromIndexing = false; // listing pages always indexed
+							}
+
+							var childFileInfo = ResolveFileInfo(context, pathDs);
+							var childDocFile = CreateDocumentationFile(childFileInfo, context.ReadFileSystem, context);
+							if (childDocFile is null)
+								continue;
+
+							var leafArgs = new FileNavigationArgs(pathDs, pathCont, pageHidden, groupChildIndex++, groupFolderNav, homeAccessor, ExcludeFromIndexing: excludeFromIndexing);
+							groupChildren.Add(DocumentationNavigationFactory.CreateFileNavigationLeaf(childDocFile, childFileInfo, leafArgs));
+						}
+
+						if (groupChildren.Count == 0)
+							break;
+						groupFolderNav.SetNavigationItems(groupChildren);
+						children.Add(groupFolderNav);
+						break;
+					}
+				case FileRef fileRef:
+					{
+						// Ungrouped page — hidden from nav, not excluded from indexing
+						var fileInfo = ResolveFileInfo(context, fileRef.PathRelativeToDocumentationSet);
+						var docFile = CreateDocumentationFile(fileInfo, context.ReadFileSystem, context);
+						if (docFile is null)
+							break;
+						var args = new FileNavigationArgs(fileRef.PathRelativeToDocumentationSet, fileRef.PathRelativeToContainer, true, childIndex++, folderNavigation, homeAccessor, ExcludeFromIndexing: false);
+						children.Add(DocumentationNavigationFactory.CreateFileNavigationLeaf(docFile, fileInfo, args));
+						break;
+					}
+				default:
+					{
+						var navItem = ConvertToNavigationItem(tocItem, childIndex++, context, folderNavigation, homeAccessor);
+						if (navItem != null)
+							children.Add(navItem);
+						break;
+					}
+			}
+		}
+
+		if (children.Count == 0)
+		{
+			context.Collector.EmitError(listingRef.Context, $"Listing navigation '{listingPath}' produced no navigation items");
+			return null;
+		}
+
+		folderNavigation.SetNavigationItems(children);
+		return folderNavigation;
 	}
 
 	// Synthetic path — clean command names (no cmd- prefix) matching CliReferenceDocsBuilderExtension.SyntheticPath

--- a/src/Elastic.Documentation.Navigation/Isolated/Node/FolderNavigation.cs
+++ b/src/Elastic.Documentation.Navigation/Isolated/Node/FolderNavigation.cs
@@ -32,6 +32,12 @@ public class FolderNavigation<TModel>(
 	public INodeNavigationItem<INavigationModel, INavigationItem>? Parent { get; set; } = parent;
 
 	/// <inheritdoc />
+	public INodeNavigationItem<INavigationModel, INavigationItem>? IslandListingRoot { get; internal set; }
+
+	/// <inheritdoc />
+	public bool IsIslandListing { get; internal set; }
+
+	/// <inheritdoc />
 	public bool Hidden { get; private set; }
 
 	/// <inheritdoc />

--- a/src/Elastic.Documentation.Navigation/Isolated/Node/FolderNavigation.cs
+++ b/src/Elastic.Documentation.Navigation/Isolated/Node/FolderNavigation.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System.Diagnostics;
+using Elastic.Documentation.Configuration.Toc;
 using Elastic.Documentation.Extensions;
 
 namespace Elastic.Documentation.Navigation.Isolated.Node;
@@ -36,6 +37,9 @@ public class FolderNavigation<TModel>(
 
 	/// <inheritdoc />
 	public bool IsIslandListing { get; internal set; }
+
+	/// <inheritdoc />
+	public ListingVisual IslandVisual { get; internal set; }
 
 	/// <inheritdoc />
 	public bool Hidden { get; private set; }

--- a/src/Elastic.Documentation.Navigation/NavigationItemExtensions.cs
+++ b/src/Elastic.Documentation.Navigation/NavigationItemExtensions.cs
@@ -16,7 +16,13 @@ public static class NavigationItemExtensions
 	)
 		where TModel : class, IDocumentationFile
 	{
-		var index = LookupIndex(preferVisible: true);
+		// Path match first — works even when the index leaf is Hidden (e.g. island listing groups
+		// where the index is hidden to suppress it from the main nav tree but must still be the
+		// folder's canonical index so QueryIndex returns it correctly).
+		var index = items.OfType<ILeafNavigationItem<TModel>>()
+			.FirstOrDefault(l => l.Model.SourcePath == fallbackPath);
+
+		index ??= LookupIndex(preferVisible: true);
 		index ??= LookupIndex(preferVisible: false);
 		ArgumentNullException.ThrowIfNull(index);
 

--- a/src/Elastic.Documentation.Site/Assets/listing.test.ts
+++ b/src/Elastic.Documentation.Site/Assets/listing.test.ts
@@ -1,0 +1,244 @@
+import { cardIsVisible, initListing, ListingFilterState } from './listing'
+
+// ---------------------------------------------------------------------------
+// Pure predicate tests — no DOM needed
+// ---------------------------------------------------------------------------
+
+describe('cardIsVisible predicate', () => {
+    const allGroups: ListingFilterState = { query: '', activeGroups: new Set() }
+
+    it('shows every card when state is empty', () => {
+        expect(cardIsVisible('rfc-0001 title', 'accepted', allGroups)).toBe(
+            true
+        )
+    })
+
+    it('matches query case-insensitively', () => {
+        const state: ListingFilterState = {
+            query: 'RFC',
+            activeGroups: new Set(),
+        }
+        expect(cardIsVisible('rfc-0001 title', 'accepted', state)).toBe(true)
+        expect(cardIsVisible('unrelated page', 'accepted', state)).toBe(false)
+    })
+
+    it('filters by a single active group', () => {
+        const state: ListingFilterState = {
+            query: '',
+            activeGroups: new Set(['accepted']),
+        }
+        expect(cardIsVisible('any title', 'accepted', state)).toBe(true)
+        expect(cardIsVisible('any title', 'draft', state)).toBe(false)
+    })
+
+    it('shows cards matching any of multiple active groups', () => {
+        const state: ListingFilterState = {
+            query: '',
+            activeGroups: new Set(['accepted', 'draft']),
+        }
+        expect(cardIsVisible('any title', 'accepted', state)).toBe(true)
+        expect(cardIsVisible('any title', 'draft', state)).toBe(true)
+        expect(cardIsVisible('any title', 'deprecated', state)).toBe(false)
+    })
+
+    it('applies both query and group filter simultaneously', () => {
+        const state: ListingFilterState = {
+            query: 'search',
+            activeGroups: new Set(['accepted']),
+        }
+        expect(cardIsVisible('search-something', 'accepted', state)).toBe(true)
+        expect(cardIsVisible('unrelated', 'accepted', state)).toBe(false)
+        expect(cardIsVisible('search-something', 'draft', state)).toBe(false)
+    })
+
+    it('shows ungrouped cards (empty group) when no groups are active', () => {
+        expect(cardIsVisible('title', '', allGroups)).toBe(true)
+    })
+
+    it('hides ungrouped cards when specific groups are active', () => {
+        const state: ListingFilterState = {
+            query: '',
+            activeGroups: new Set(['accepted']),
+        }
+        expect(cardIsVisible('title', '', state)).toBe(false)
+    })
+})
+
+// ---------------------------------------------------------------------------
+// DOM-based integration tests
+// ---------------------------------------------------------------------------
+
+function buildListingHtml() {
+    return `
+        <div class="listing-root" data-listing-total="4">
+          <div class="listing-filter-bar">
+            <input class="listing-filter-input" type="search" />
+            <div class="listing-group-chips">
+              <button class="listing-chip listing-chip-all listing-chip-active" data-group="">All</button>
+              <span>|</span>
+              <button class="listing-chip" data-group="accepted">Accepted</button>
+              <button class="listing-chip" data-group="draft">Draft</button>
+            </div>
+          </div>
+          <div class="listing-group" data-group-key="accepted">
+            <h2 class="listing-group-heading" id="accepted">Accepted</h2>
+            <a class="page-card" href="/rfcs/001" data-listing-group="accepted" data-listing-title="first rfc about search">First RFC about Search</a>
+            <a class="page-card" href="/rfcs/002" data-listing-group="accepted" data-listing-title="second rfc about indexing">Second RFC about Indexing</a>
+          </div>
+          <div class="listing-group" data-group-key="draft">
+            <h2 class="listing-group-heading" id="draft">Draft</h2>
+            <a class="page-card" href="/rfcs/003" data-listing-group="draft" data-listing-title="draft rfc about storage">Draft RFC about Storage</a>
+          </div>
+          <div class="listing-group" data-group-key="">
+            <a class="page-card" href="/rfcs/004" data-listing-group="" data-listing-title="ungrouped rfc">Ungrouped RFC</a>
+          </div>
+          <p class="listing-no-results hidden">No pages match your filter.</p>
+        </div>
+    `
+}
+
+function cards(doc = document) {
+    return Array.from(
+        doc.querySelectorAll<HTMLAnchorElement>('a[data-listing-title]')
+    )
+}
+
+function visibleCards(doc = document) {
+    return cards(doc).filter((c) => c.style.display !== 'none')
+}
+
+describe('initListing DOM behaviour', () => {
+    beforeEach(() => {
+        document.body.innerHTML = buildListingHtml()
+        initListing()
+    })
+
+    it('shows all cards on init', () => {
+        expect(visibleCards()).toHaveLength(4)
+    })
+
+    it('filters cards by text input', () => {
+        const input = document.querySelector<HTMLInputElement>(
+            '.listing-filter-input'
+        )!
+        input.value = 'search'
+        input.dispatchEvent(new Event('input'))
+
+        const visible = visibleCards()
+        expect(visible).toHaveLength(1)
+        expect(visible[0].dataset.listingTitle).toContain('search')
+    })
+
+    it('hides group section when all its cards are filtered out by text', () => {
+        const input = document.querySelector<HTMLInputElement>(
+            '.listing-filter-input'
+        )!
+        input.value = 'storage'
+        input.dispatchEvent(new Event('input'))
+
+        const acceptedGroup = document.querySelector<HTMLElement>(
+            '[data-group-key="accepted"]'
+        )!
+        expect(acceptedGroup.style.display).toBe('none')
+    })
+
+    it('toggles a single group chip on click', () => {
+        const draftChip = document.querySelector<HTMLButtonElement>(
+            '[data-group="draft"]'
+        )!
+        draftChip.click()
+
+        const visible = visibleCards()
+        expect(visible).toHaveLength(1)
+        expect(visible[0].dataset.listingGroup).toBe('draft')
+    })
+
+    it('allows selecting multiple group chips independently', () => {
+        const acceptedChip = document.querySelector<HTMLButtonElement>(
+            '[data-group="accepted"]'
+        )!
+        const draftChip = document.querySelector<HTMLButtonElement>(
+            '[data-group="draft"]'
+        )!
+        acceptedChip.click()
+        draftChip.click()
+
+        // Both groups visible, ungrouped hidden
+        const visible = visibleCards()
+        expect(visible).toHaveLength(3)
+        expect(visible.every((c) => c.dataset.listingGroup !== '')).toBe(true)
+    })
+
+    it('deselects a chip by clicking it again', () => {
+        const draftChip = document.querySelector<HTMLButtonElement>(
+            '[data-group="draft"]'
+        )!
+        draftChip.click() // select
+        draftChip.click() // deselect → back to all
+
+        expect(visibleCards()).toHaveLength(4)
+    })
+
+    it('All chip clears all active groups', () => {
+        const draftChip = document.querySelector<HTMLButtonElement>(
+            '[data-group="draft"]'
+        )!
+        draftChip.click()
+
+        const allChip =
+            document.querySelector<HTMLButtonElement>('.listing-chip-all')!
+        allChip.click()
+
+        expect(visibleCards()).toHaveLength(4)
+    })
+
+    it('All chip becomes active when no groups are selected', () => {
+        const draftChip = document.querySelector<HTMLButtonElement>(
+            '[data-group="draft"]'
+        )!
+        draftChip.click()
+
+        const allChip =
+            document.querySelector<HTMLButtonElement>('.listing-chip-all')!
+        allChip.click()
+
+        expect(allChip.classList.contains('listing-chip-active')).toBe(true)
+    })
+
+    it('All chip loses active state when a group chip is selected', () => {
+        const draftChip = document.querySelector<HTMLButtonElement>(
+            '[data-group="draft"]'
+        )!
+        draftChip.click()
+
+        const allChip =
+            document.querySelector<HTMLButtonElement>('.listing-chip-all')!
+        expect(allChip.classList.contains('listing-chip-active')).toBe(false)
+    })
+
+    it('shows no-results paragraph when nothing matches', () => {
+        const input = document.querySelector<HTMLInputElement>(
+            '.listing-filter-input'
+        )!
+        input.value = 'zzznomatch'
+        input.dispatchEvent(new Event('input'))
+
+        const noResults = document.querySelector<HTMLElement>(
+            '.listing-no-results'
+        )!
+        expect(noResults.classList.contains('hidden')).toBe(false)
+    })
+
+    it('hides no-results paragraph when something matches', () => {
+        const input = document.querySelector<HTMLInputElement>(
+            '.listing-filter-input'
+        )!
+        input.value = 'rfc'
+        input.dispatchEvent(new Event('input'))
+
+        const noResults = document.querySelector<HTMLElement>(
+            '.listing-no-results'
+        )!
+        expect(noResults.classList.contains('hidden')).toBe(true)
+    })
+})

--- a/src/Elastic.Documentation.Site/Assets/listing.ts
+++ b/src/Elastic.Documentation.Site/Assets/listing.ts
@@ -1,0 +1,129 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+/**
+ * Client-side filter for `.listing-root` pages.
+ *
+ * Supports:
+ * - Text input: hides cards whose `data-listing-title` does not include the query.
+ * - Group chips: independent toggles; a card is visible when its group is in the
+ *   active set (or when no groups are selected = show all). "All" clears the set.
+ * - Hides group headings when all their cards are hidden.
+ * - Shows a "No pages match" notice when no card is visible.
+ */
+
+export interface ListingFilterState {
+    query: string
+    activeGroups: Set<string> // empty = all groups shown
+}
+
+/** Returns true when a card should be visible given the current filter state. */
+export function cardIsVisible(
+    cardTitle: string,
+    cardGroup: string,
+    state: ListingFilterState
+): boolean {
+    if (state.activeGroups.size > 0 && !state.activeGroups.has(cardGroup))
+        return false
+    if (state.query !== '' && !cardTitle.includes(state.query.toLowerCase()))
+        return false
+    return true
+}
+
+function applyFilter(root: HTMLElement, state: ListingFilterState) {
+    const cards = root.querySelectorAll<HTMLAnchorElement>(
+        'a[data-listing-title]'
+    )
+    let visibleCount = 0
+
+    cards.forEach((card) => {
+        const title = card.dataset.listingTitle ?? ''
+        const group = card.dataset.listingGroup ?? ''
+        const visible = cardIsVisible(title, group, state)
+        card.style.display = visible ? '' : 'none'
+        if (visible) visibleCount++
+    })
+
+    // Show / hide group sections based on whether any card in them is visible
+    root.querySelectorAll<HTMLElement>('[data-group-key]').forEach(
+        (groupEl) => {
+            const visibleInGroup = Array.from(
+                groupEl.querySelectorAll<HTMLAnchorElement>(
+                    'a[data-listing-title]'
+                )
+            ).some((c) => c.style.display !== 'none')
+            groupEl.style.display = visibleInGroup ? '' : 'none'
+        }
+    )
+
+    const noResults = root.querySelector<HTMLElement>('.listing-no-results')
+    if (noResults) {
+        noResults.classList.toggle('hidden', visibleCount > 0)
+    }
+}
+
+function updateChipStyles(
+    allChip: HTMLButtonElement | null,
+    groupChips: NodeListOf<HTMLButtonElement>,
+    state: ListingFilterState
+) {
+    const noneSelected = state.activeGroups.size === 0
+
+    if (allChip) {
+        allChip.classList.toggle('listing-chip-active', noneSelected)
+        allChip.classList.toggle('border-blue-elastic', noneSelected)
+        allChip.classList.toggle('text-blue-elastic', noneSelected)
+        allChip.classList.toggle('border-grey-20', !noneSelected)
+        allChip.classList.toggle('text-ink-light', !noneSelected)
+    }
+
+    groupChips.forEach((chip) => {
+        const active = state.activeGroups.has(chip.dataset.group ?? '')
+        chip.classList.toggle('listing-chip-active', active)
+        chip.classList.toggle('border-blue-elastic', active)
+        chip.classList.toggle('text-blue-elastic', active)
+        chip.classList.toggle('border-grey-20', !active)
+        chip.classList.toggle('text-ink-light', !active)
+    })
+}
+
+function initListingRoot(root: HTMLElement) {
+    const input = root.querySelector<HTMLInputElement>('.listing-filter-input')
+    const allChip = root.querySelector<HTMLButtonElement>('.listing-chip-all')
+    const groupChips = root.querySelectorAll<HTMLButtonElement>(
+        '.listing-chip:not(.listing-chip-all)'
+    )
+
+    const state: ListingFilterState = { query: '', activeGroups: new Set() }
+
+    input?.addEventListener('input', () => {
+        state.query = input.value
+        applyFilter(root, state)
+    })
+
+    allChip?.addEventListener('click', () => {
+        state.activeGroups.clear()
+        updateChipStyles(allChip, groupChips, state)
+        applyFilter(root, state)
+    })
+
+    groupChips.forEach((chip) => {
+        chip.addEventListener('click', () => {
+            const group = chip.dataset.group ?? ''
+            if (state.activeGroups.has(group)) {
+                state.activeGroups.delete(group)
+            } else {
+                state.activeGroups.add(group)
+            }
+            updateChipStyles(allChip, groupChips, state)
+            applyFilter(root, state)
+        })
+    })
+}
+
+export function initListing() {
+    document
+        .querySelectorAll<HTMLElement>('.listing-root')
+        .forEach(initListingRoot)
+}

--- a/src/Elastic.Documentation.Site/Assets/main.ts
+++ b/src/Elastic.Documentation.Site/Assets/main.ts
@@ -5,6 +5,7 @@ import { config } from './config'
 import { initCopyButton } from './copybutton'
 import { initHighlight } from './hljs'
 import { initImageCarousel } from './image-carousel'
+import { initListing } from './listing'
 import { initMermaid } from './mermaid'
 import { openDetailsWithAnchor } from './open-details-with-anchor'
 import { initNav } from './pages-nav'
@@ -217,6 +218,7 @@ document.addEventListener('htmx:load', function () {
         ['initImageCarousel', initImageCarousel],
         ['initTable', initTable],
         ['initApiDocs', initApiDocs],
+        ['initListing', initListing],
         ['applyEditParam', applyEditParam],
         ['initCtaImpressions', initCtaImpressions],
     ])

--- a/src/Elastic.Documentation.Site/Navigation/IslandNavViewModel.cs
+++ b/src/Elastic.Documentation.Site/Navigation/IslandNavViewModel.cs
@@ -2,6 +2,8 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using Elastic.Documentation.Configuration.Toc;
+
 namespace Elastic.Documentation.Site.Navigation;
 
 public class IslandNavViewModel
@@ -11,6 +13,7 @@ public class IslandNavViewModel
 	public required string ListingRootUrl { get; init; }
 	public required string ListingRootTitle { get; init; }
 	public required IReadOnlyList<IslandNavGroup> Groups { get; init; }
+	public ListingVisual Visual { get; init; }
 }
 
 public record IslandNavGroup(string Title, string Url, IReadOnlyList<IslandNavPage> Pages);

--- a/src/Elastic.Documentation.Site/Navigation/IslandNavViewModel.cs
+++ b/src/Elastic.Documentation.Site/Navigation/IslandNavViewModel.cs
@@ -1,0 +1,17 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic.Documentation.Site.Navigation;
+
+public class IslandNavViewModel
+{
+	public required string BackLinkUrl { get; init; }
+	public required string BackLinkTitle { get; init; }
+	public required string ListingRootUrl { get; init; }
+	public required string ListingRootTitle { get; init; }
+	public required IReadOnlyList<IslandNavGroup> Groups { get; init; }
+}
+
+public record IslandNavGroup(string Title, string Url, IReadOnlyList<IslandNavPage> Pages);
+public record IslandNavPage(string Title, string Url);

--- a/src/Elastic.Documentation.Site/Navigation/IsolatedBuildNavigationHtmlWriter.cs
+++ b/src/Elastic.Documentation.Site/Navigation/IsolatedBuildNavigationHtmlWriter.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Collections.Concurrent;
 using Elastic.Documentation.Configuration;
 using Elastic.Documentation.Navigation;
 using RazorSlices;
@@ -12,8 +13,9 @@ public class IsolatedBuildNavigationHtmlWriter(BuildContext context, IRootNaviga
 	: INavigationHtmlWriter
 {
 	private readonly NavigationRenderCache _renderedNavigationCache = new();
+	private readonly ConcurrentDictionary<string, string> _islandHtmlCache = [];
 
-	public Task<NavigationRenderResult> RenderNavigation(
+	public async Task<NavigationRenderResult> RenderNavigation(
 		IRootNavigationItem<INavigationModel, INavigationItem> currentRootNavigation,
 		INavigationItem currentNavigationItem,
 		Cancel ctx = default)
@@ -24,7 +26,7 @@ public class IsolatedBuildNavigationHtmlWriter(BuildContext context, IRootNaviga
 			return await RenderIslandNavigation(listingRoot, ctx);
 
 		var navigation = SelectNavigationRoot(currentRootNavigation);
-		return _renderedNavigationCache.GetOrRenderAsync(
+		return await _renderedNavigationCache.GetOrRenderAsync(
 			navigation,
 			() => ((INavigationHtmlWriter)this).Render(CreateNavigationModel(navigation), ctx));
 	}
@@ -32,15 +34,15 @@ public class IsolatedBuildNavigationHtmlWriter(BuildContext context, IRootNaviga
 	private async Task<NavigationRenderResult> RenderIslandNavigation(
 		INodeNavigationItem<INavigationModel, INavigationItem> islandRoot, Cancel ctx)
 	{
-		var cacheKey = $"island:{islandRoot.Id}";
-		if (_renderedNavigationCache.TryGetValue(cacheKey, out var html))
-			return new NavigationRenderResult { Html = html, Id = islandRoot.Id };
+		var cacheKey = islandRoot.Id;
+		if (_islandHtmlCache.TryGetValue(cacheKey, out var html))
+			return new NavigationRenderResult { Html = html, Id = cacheKey };
 
 		var model = CreateIslandNavModel(islandRoot);
 		var slice = _IslandNav.Create(model);
 		html = await slice.RenderAsync(cancellationToken: ctx);
-		_renderedNavigationCache[cacheKey] = html;
-		return new NavigationRenderResult { Html = html, Id = islandRoot.Id };
+		_islandHtmlCache[cacheKey] = html;
+		return new NavigationRenderResult { Html = html, Id = cacheKey };
 	}
 
 	private static IslandNavViewModel CreateIslandNavModel(

--- a/src/Elastic.Documentation.Site/Navigation/IsolatedBuildNavigationHtmlWriter.cs
+++ b/src/Elastic.Documentation.Site/Navigation/IsolatedBuildNavigationHtmlWriter.cs
@@ -4,6 +4,7 @@
 
 using Elastic.Documentation.Configuration;
 using Elastic.Documentation.Navigation;
+using RazorSlices;
 
 namespace Elastic.Documentation.Site.Navigation;
 
@@ -17,10 +18,55 @@ public class IsolatedBuildNavigationHtmlWriter(BuildContext context, IRootNaviga
 		INavigationItem currentNavigationItem,
 		Cancel ctx = default)
 	{
+		if (currentNavigationItem.IslandListingRoot is { } islandRoot)
+			return await RenderIslandNavigation(islandRoot, ctx);
+		if (currentNavigationItem is INodeNavigationItem<INavigationModel, INavigationItem> { IsIslandListing: true } listingRoot)
+			return await RenderIslandNavigation(listingRoot, ctx);
+
 		var navigation = SelectNavigationRoot(currentRootNavigation);
 		return _renderedNavigationCache.GetOrRenderAsync(
 			navigation,
 			() => ((INavigationHtmlWriter)this).Render(CreateNavigationModel(navigation), ctx));
+	}
+
+	private async Task<NavigationRenderResult> RenderIslandNavigation(
+		INodeNavigationItem<INavigationModel, INavigationItem> islandRoot, Cancel ctx)
+	{
+		var cacheKey = $"island:{islandRoot.Id}";
+		if (_renderedNavigationCache.TryGetValue(cacheKey, out var html))
+			return new NavigationRenderResult { Html = html, Id = islandRoot.Id };
+
+		var model = CreateIslandNavModel(islandRoot);
+		var slice = _IslandNav.Create(model);
+		html = await slice.RenderAsync(cancellationToken: ctx);
+		_renderedNavigationCache[cacheKey] = html;
+		return new NavigationRenderResult { Html = html, Id = islandRoot.Id };
+	}
+
+	private static IslandNavViewModel CreateIslandNavModel(
+		INodeNavigationItem<INavigationModel, INavigationItem> islandRoot)
+	{
+		var groups = islandRoot.NavigationItems
+			.OfType<INodeNavigationItem<INavigationModel, INavigationItem>>()
+			.Select(group =>
+			{
+				var pages = group.NavigationItems
+					.OfType<ILeafNavigationItem<INavigationModel>>()
+					.Select(p => new IslandNavPage(p.NavigationTitle, p.Url))
+					.ToList();
+				return new IslandNavGroup(group.NavigationTitle, group.Url, pages);
+			})
+			.ToList();
+
+		var backTarget = islandRoot.Parent ?? (INavigationItem)islandRoot;
+		return new IslandNavViewModel
+		{
+			BackLinkUrl = backTarget.Url,
+			BackLinkTitle = backTarget.NavigationTitle,
+			ListingRootUrl = islandRoot.Url,
+			ListingRootTitle = islandRoot.NavigationTitle,
+			Groups = groups
+		};
 	}
 
 	/// <summary>

--- a/src/Elastic.Documentation.Site/Navigation/IsolatedBuildNavigationHtmlWriter.cs
+++ b/src/Elastic.Documentation.Site/Navigation/IsolatedBuildNavigationHtmlWriter.cs
@@ -65,7 +65,8 @@ public class IsolatedBuildNavigationHtmlWriter(BuildContext context, IRootNaviga
 			BackLinkTitle = backTarget.NavigationTitle,
 			ListingRootUrl = islandRoot.Url,
 			ListingRootTitle = islandRoot.NavigationTitle,
-			Groups = groups
+			Groups = groups,
+			Visual = islandRoot.IslandVisual
 		};
 	}
 

--- a/src/Elastic.Documentation.Site/Navigation/NavigationRenderModel.cs
+++ b/src/Elastic.Documentation.Site/Navigation/NavigationRenderModel.cs
@@ -12,7 +12,8 @@ namespace Elastic.Documentation.Site.Navigation;
 public enum NavigationRenderNodeKind
 {
 	Leaf,
-	Node
+	Node,
+	Island
 }
 
 /// <summary>A fully resolved navigation tree node; the only tree data the nav templates consume.</summary>
@@ -116,6 +117,18 @@ public sealed record NavigationRenderModel
 	private static NavigationRenderNode CreateNode(INodeNavigationItem<INavigationModel, INavigationItem> node, bool isTopLevel)
 	{
 		var (badge, navigationTitle) = ParseNavTitle(node.NavigationTitle);
+		if (node.IsIslandListing)
+		{
+			return new NavigationRenderNode
+			{
+				Kind = NavigationRenderNodeKind.Island,
+				IsTopLevel = isTopLevel,
+				NavigationTitle = navigationTitle,
+				Badge = badge,
+				Url = node.Url,
+				Id = node.Id
+			};
+		}
 		return new NavigationRenderNode
 		{
 			Kind = NavigationRenderNodeKind.Node,

--- a/src/Elastic.Documentation.Site/Navigation/_IslandNav.cshtml
+++ b/src/Elastic.Documentation.Site/Navigation/_IslandNav.cshtml
@@ -4,7 +4,7 @@
 <div class="pb-9 pl-3 md:pl-0 font-body">
 	<div class="sticky top-0 z-10 bg-white pt-4 pb-2 px-4">
 		<a href="@Model.BackLinkUrl"
-		   class="flex w-full items-center gap-2 h-10 px-4 text-sm font-semibold rounded-sm border-2 border-blue-elastic text-blue-elastic hover:text-blue-elastic-100 hover:border-blue-elastic-100 no-underline transition-colors">
+		   class="flex w-full items-center gap-2 h-10 px-4 text-sm font-semibold rounded-sm border border-grey-20 text-ink hover:border-blue-elastic hover:text-blue-elastic no-underline transition-colors">
 			<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-3.5 shrink-0">
 				<path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"/>
 			</svg>

--- a/src/Elastic.Documentation.Site/Navigation/_IslandNav.cshtml
+++ b/src/Elastic.Documentation.Site/Navigation/_IslandNav.cshtml
@@ -1,3 +1,4 @@
+@using Elastic.Documentation.Configuration.Toc
 @using Elastic.Documentation.Site.Navigation
 @inherits RazorSlice<Elastic.Documentation.Site.Navigation.IslandNavViewModel>
 <div class="pb-9 pl-3 md:pl-0 font-body">
@@ -20,7 +21,7 @@
 				<div class="w-full">
 					<a href="@group.Url" class="sidebar-link nav-folder-link font-semibold">@group.Title</a>
 				</div>
-				@if (group.Pages.Count > 0)
+				@if (Model.Visual == ListingVisual.All && group.Pages.Count > 0)
 				{
 					<ul class="nav-subtree" style="display:block">
 						@foreach (var navPage in group.Pages)

--- a/src/Elastic.Documentation.Site/Navigation/_IslandNav.cshtml
+++ b/src/Elastic.Documentation.Site/Navigation/_IslandNav.cshtml
@@ -4,7 +4,7 @@
 <div class="pb-9 pl-3 md:pl-0 font-body">
 	<div class="sticky top-0 z-10 bg-white pt-4 pb-2 px-4">
 		<a href="@Model.BackLinkUrl"
-		   class="flex w-full items-center gap-2 h-10 px-4 text-sm font-semibold rounded-sm border border-grey-20 text-ink hover:border-blue-elastic hover:text-blue-elastic no-underline transition-colors">
+		   class="flex w-full items-center gap-2 h-10 px-4 text-sm font-semibold rounded-sm border-2 border-grey-20 text-ink hover:border-blue-elastic hover:text-blue-elastic no-underline transition-colors">
 			<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-3.5 shrink-0">
 				<path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"/>
 			</svg>

--- a/src/Elastic.Documentation.Site/Navigation/_IslandNav.cshtml
+++ b/src/Elastic.Documentation.Site/Navigation/_IslandNav.cshtml
@@ -3,7 +3,7 @@
 <div class="pb-9 pl-3 md:pl-0 font-body">
 	<div class="sticky top-0 z-10 bg-white pt-4 pb-2 px-4">
 		<a href="@Model.BackLinkUrl"
-		   class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-sm border border-grey-20 text-ink-light hover:border-grey-80 hover:text-ink hover:bg-grey-5 transition-colors">
+		   class="flex w-full items-center gap-2 h-10 px-4 text-sm font-semibold rounded-sm border-2 border-blue-elastic text-blue-elastic hover:text-blue-elastic-100 hover:border-blue-elastic-100 no-underline transition-colors">
 			<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-3.5 shrink-0">
 				<path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"/>
 			</svg>

--- a/src/Elastic.Documentation.Site/Navigation/_IslandNav.cshtml
+++ b/src/Elastic.Documentation.Site/Navigation/_IslandNav.cshtml
@@ -1,0 +1,37 @@
+@using Elastic.Documentation.Site.Navigation
+@inherits RazorSlice<Elastic.Documentation.Site.Navigation.IslandNavViewModel>
+<div class="pb-9 pl-3 md:pl-0 font-body">
+	<div class="sticky top-0 z-10 bg-white pt-4 pb-2 px-4">
+		<a href="@Model.BackLinkUrl"
+		   class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-sm border border-grey-20 text-ink-light hover:border-grey-80 hover:text-ink hover:bg-grey-5 transition-colors">
+			<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-3.5 shrink-0">
+				<path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"/>
+			</svg>
+			<span>@Model.BackLinkTitle</span>
+		</a>
+	</div>
+	<ul class="block px-4">
+		<li class="flex group/li pr-8 mt-6">
+			<a href="@Model.ListingRootUrl" class="sidebar-link nav-link font-semibold">@Model.ListingRootTitle</a>
+		</li>
+		@foreach (var group in Model.Groups)
+		{
+			<li class="nav-folder mt-6">
+				<div class="w-full">
+					<a href="@group.Url" class="sidebar-link nav-folder-link font-semibold">@group.Title</a>
+				</div>
+				@if (group.Pages.Count > 0)
+				{
+					<ul class="nav-subtree" style="display:block">
+						@foreach (var navPage in group.Pages)
+						{
+							<li class="flex group/li pr-8 mt-4">
+								<a href="@navPage.Url" class="sidebar-link nav-link">@navPage.Title</a>
+							</li>
+						}
+					</ul>
+				}
+			</li>
+		}
+	</ul>
+</div>

--- a/src/Elastic.Documentation.Site/Navigation/_IslandNav.cshtml
+++ b/src/Elastic.Documentation.Site/Navigation/_IslandNav.cshtml
@@ -17,22 +17,18 @@
 		</li>
 		@foreach (var group in Model.Groups)
 		{
-			<li class="nav-folder mt-6">
-				<div class="w-full">
-					<a href="@group.Url" class="sidebar-link nav-folder-link font-semibold">@group.Title</a>
-				</div>
-				@if (Model.Visual == ListingVisual.All && group.Pages.Count > 0)
-				{
-					<ul class="nav-subtree" style="display:block">
-						@foreach (var navPage in group.Pages)
-						{
-							<li class="flex group/li pr-8 mt-4">
-								<a href="@navPage.Url" class="sidebar-link nav-link">@navPage.Title</a>
-							</li>
-						}
-					</ul>
-				}
+			<li class="flex group/li pr-8 mt-6">
+				<a href="@group.Url" class="sidebar-link nav-link font-semibold">@group.Title</a>
 			</li>
+			@if (Model.Visual == ListingVisual.All && group.Pages.Count > 0)
+			{
+				@foreach (var navPage in group.Pages)
+				{
+					<li class="flex group/li pr-8 mt-4 ml-4">
+						<a href="@navPage.Url" class="sidebar-link nav-link">@navPage.Title</a>
+					</li>
+				}
+			}
 		}
 	</ul>
 </div>

--- a/src/Elastic.Documentation.Site/Navigation/_TocTreeNav.cshtml
+++ b/src/Elastic.Documentation.Site/Navigation/_TocTreeNav.cshtml
@@ -11,6 +11,22 @@
 			</a>
 		</li>
 	}
+	else if (item.Kind == NavigationRenderNodeKind.Island)
+	{
+		<li class="nav-folder @(item.IsTopLevel ? "mt-6" : "mt-4")">
+			<div class="peer grid grid-cols-[1fr_auto] w-full">
+				<a href="@item.Url" class="sidebar-link nav-folder-link@(item.IsTopLevel ? " font-semibold" : "")">
+					<span>@item.NavigationTitle</span>
+					@if (item.Badge is not null) { <span class="nav-badge nav-badge-@item.Badge">@item.Badge</span> }
+				</a>
+				<a href="@item.Url" class="group/label flex mr-2 items-start">
+					<div class="nav-toggle-btn">
+						<svg class="nav-chevron" viewBox="0 0 24 24"><use href="#icon-chevron-double-down"/></svg>
+					</div>
+				</a>
+			</div>
+		</li>
+	}
 	else
 	{
 		<li class="nav-folder @(item.IsTopLevel ? "mt-6" : "mt-4")">

--- a/src/Elastic.Documentation.Site/_GlobalLayout.cshtml
+++ b/src/Elastic.Documentation.Site/_GlobalLayout.cshtml
@@ -20,6 +20,9 @@
 		<symbol id="icon-chevron-down" viewBox="0 0 24 24">
 			<path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/>
 		</symbol>
+		<symbol id="icon-chevron-double-down" viewBox="0 0 24 24">
+			<path stroke-linecap="round" stroke-linejoin="round" d="m19.5 4.5-7.5 7.5-7.5-7.5m15 7.5-7.5 7.5-7.5-7.5"/>
+		</symbol>
 	</defs>
 </svg>
 @if (Model.GoogleTagManager.Enabled)

--- a/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchMarkdownExporter.Export.cs
+++ b/src/Elastic.Markdown/Exporters/Elasticsearch/ElasticsearchMarkdownExporter.Export.cs
@@ -186,7 +186,7 @@ public partial class ElasticsearchMarkdownExporter
 				Path = i.Url
 			}).Reverse().ToArray(),
 			Headings = headings,
-			Hidden = fileContext.NavigationItem.Hidden
+			Hidden = fileContext.NavigationItem.ExcludeFromIndexing
 		};
 
 		// Infer product and repository metadata

--- a/src/Elastic.Markdown/Extensions/Listing/ListingDocsBuilderExtension.cs
+++ b/src/Elastic.Markdown/Extensions/Listing/ListingDocsBuilderExtension.cs
@@ -1,0 +1,158 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions;
+using Elastic.Documentation.Configuration;
+using Elastic.Documentation.Configuration.Toc;
+using Elastic.Documentation.Navigation;
+using Elastic.Markdown.Exporters;
+using Elastic.Markdown.IO;
+using Elastic.Markdown.Myst;
+
+namespace Elastic.Markdown.Extensions.Listing;
+
+/// <summary>
+/// Auto-enabled when the TOC contains a <c>listing:</c> entry.
+/// Generates synthetic <c>index.md</c> pages for listing roots and groups that don't have a
+/// real file on disk, and augments real index pages by appending the <c>{listing}</c> directive.
+/// </summary>
+public class ListingDocsBuilderExtension(BuildContext build, MarkdownParser markdownParser) : IDocsBuilderExtension
+{
+	private BuildContext Build { get; } = build;
+	private MarkdownParser MarkdownParser { get; } = markdownParser;
+
+	public IDocumentationFileExporter? FileExporter => null;
+
+	// Absolute paths of all listing root / group index pages (synthetic + real), populated on first use.
+	private HashSet<string>? _listingIndexPaths;
+	// Absolute paths of synthetic (non-existing) index files we need to register.
+	private List<IFileInfo>? _syntheticIndexFiles;
+
+	private void EnsureInitialized()
+	{
+		if (_listingIndexPaths is not null)
+			return;
+
+		_listingIndexPaths = [];
+		_syntheticIndexFiles = [];
+
+		CollectListingRefs(Build.ConfigurationYaml.TableOfContents);
+	}
+
+	private void CollectListingRefs(IReadOnlyCollection<ITableOfContentsItem> items)
+	{
+		foreach (var item in items)
+		{
+			if (item is ListingRef listingRef)
+				RegisterListingRef(listingRef);
+
+			var children = item switch
+			{
+				FileRef f => f.Children,
+				FolderRef f => f.Children,
+				IsolatedTableOfContentsRef t => t.Children,
+				ListingRef lr => lr.Children,
+				_ => null
+			};
+			if (children is { Count: > 0 })
+				CollectListingRefs(children);
+		}
+	}
+
+	private void RegisterListingRef(ListingRef listingRef)
+	{
+		var rootDir = Build.ReadFileSystem.Path.Join(
+			Build.DocumentationSourceDirectory.FullName,
+			listingRef.PathRelativeToDocumentationSet);
+
+		// Root index
+		RegisterIndexPath(Build.ReadFileSystem.Path.Join(rootDir, "index.md"));
+
+		// Group index pages
+		foreach (var child in listingRef.Children)
+		{
+			if (child is not ListingGroupRef groupRef)
+				continue;
+
+			// Find the IndexFileRef inside the group children (the first child of type IndexFileRef)
+			var groupIndex = groupRef.Children.OfType<IndexFileRef>().FirstOrDefault();
+			if (groupIndex is null)
+			{
+				// Synthesize <rootDir>/<groupKey>/index.md
+				var groupIndexPath = Build.ReadFileSystem.Path.Join(
+					Build.DocumentationSourceDirectory.FullName,
+					listingRef.PathRelativeToDocumentationSet,
+					groupRef.GroupKey,
+					"index.md");
+				RegisterIndexPath(groupIndexPath);
+			}
+			else
+			{
+				RegisterIndexPath(Build.ReadFileSystem.Path.Join(
+					Build.DocumentationSourceDirectory.FullName,
+					groupIndex.PathRelativeToDocumentationSet));
+			}
+		}
+	}
+
+	private void RegisterIndexPath(string absolutePath)
+	{
+		var normalized = Path.GetFullPath(absolutePath);
+		_ = _listingIndexPaths!.Add(normalized);
+
+		var fileInfo = Build.ReadFileSystem.FileInfo.New(normalized);
+		if (!fileInfo.Exists)
+			_syntheticIndexFiles!.Add(fileInfo);
+	}
+
+	public DocumentationFile? CreateDocumentationFile(IFileInfo file, MarkdownParser markdownParser)
+	{
+		EnsureInitialized();
+		var normalized = Path.GetFullPath(file.FullName);
+		if (!_listingIndexPaths!.Contains(normalized))
+			return null;
+		// Let CreateMarkdownFile handle this; CreateDocumentationFile is for non-.md files.
+		return null;
+	}
+
+	public MarkdownFile? CreateMarkdownFile(IFileInfo file, IDirectoryInfo sourceDirectory, MarkdownParser markdownParser)
+	{
+		EnsureInitialized();
+		var normalized = Path.GetFullPath(file.FullName);
+		if (!_listingIndexPaths!.Contains(normalized))
+			return null;
+		// Both real and synthetic listing index pages get the listing appended
+		return new ListingIndexFile(file, sourceDirectory, markdownParser, Build);
+	}
+
+	public bool TryGetDocumentationFileBySlug(DocumentationSet documentationSet, string slug, out DocumentationFile? documentationFile)
+	{
+		documentationFile = null;
+		return false;
+	}
+
+	public IReadOnlyCollection<(IFileInfo, DocumentationFile)> ScanDocumentationFiles(
+		Func<IFileInfo, IDirectoryInfo, DocumentationFile> defaultFileHandling)
+	{
+		EnsureInitialized();
+		if (_syntheticIndexFiles is not { Count: > 0 })
+			return [];
+
+		var results = new List<(IFileInfo, DocumentationFile)>();
+		foreach (var fileInfo in _syntheticIndexFiles)
+		{
+			// Skip if it was intercepted during the main scan (real file that existed)
+			if (fileInfo.Exists)
+				continue;
+			// Synthetic listing index pages must be ListingIndexFile, not ExcludedFile.
+			// defaultFileHandling returns ExcludedFile for .md files it doesn't recognise,
+			// which then gets filtered from Files and causes navigation lookup failures.
+			var doc = new ListingIndexFile(fileInfo, Build.DocumentationSourceDirectory, MarkdownParser, Build);
+			results.Add((fileInfo, doc));
+		}
+		return results;
+	}
+
+	public void VisitNavigation(INavigationItem navigation, IDocumentationFile model) { }
+}

--- a/src/Elastic.Markdown/Extensions/Listing/ListingIndexFile.cs
+++ b/src/Elastic.Markdown/Extensions/Listing/ListingIndexFile.cs
@@ -1,0 +1,67 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions;
+using Elastic.Documentation.Configuration;
+using Elastic.Markdown.Myst;
+using Markdig.Syntax;
+
+namespace Elastic.Markdown.Extensions.Listing;
+
+/// <summary>
+/// A listing root or group index page. When a real <c>index.md</c> exists on disk its content is
+/// preserved and the <c>{listing}</c> directive is appended. When no file exists a minimal synthetic
+/// page is generated from the folder name.
+/// </summary>
+public record ListingIndexFile : IO.MarkdownFile
+{
+	public ListingIndexFile(
+		IFileInfo sourceFile,
+		IDirectoryInfo rootPath,
+		MarkdownParser parser,
+		BuildContext build
+	) : base(sourceFile, rootPath, parser, build)
+	{
+	}
+
+	protected override Task<MarkdownDocument> GetMinimalParseDocumentAsync(Cancel ctx)
+	{
+		var markdown = BuildMarkdown();
+		return Task.FromResult(MarkdownParser.MinimalParseStringAsync(markdown, SourceFile, null));
+	}
+
+	protected override Task<MarkdownDocument> GetParseDocumentAsync(Cancel ctx)
+	{
+		var markdown = BuildMarkdown();
+		return Task.FromResult(MarkdownParser.ParseStringAsync(markdown, SourceFile, null));
+	}
+
+	private string BuildMarkdown()
+	{
+		string body;
+		if (SourceFile.Exists)
+		{
+			body = SourceFile.FileSystem.File.ReadAllText(SourceFile.FullName);
+		}
+		else
+		{
+			// Generate a minimal title from the folder name
+			var folderName = SourceFile.Directory?.Name ?? "Index";
+			var title = HumanizeFolderName(folderName);
+			body = $"# {title}\n";
+		}
+
+		// Append the listing directive
+		return body.TrimEnd() + "\n\n:::{listing}\n:::\n";
+	}
+
+	private static string HumanizeFolderName(string name)
+	{
+		// "detection-rules" → "Detection Rules", "rfcs" → "Rfcs"
+		var words = name.Replace('_', '-').Split('-');
+		return string.Join(" ", words.Select(w => w.Length > 0
+			? char.ToUpperInvariant(w[0]) + w[1..]
+			: w));
+	}
+}

--- a/src/Elastic.Markdown/HtmlWriter.cs
+++ b/src/Elastic.Markdown/HtmlWriter.cs
@@ -188,7 +188,7 @@ public class HtmlWriter(
 			AppliesTo = markdown.YamlFrontMatter?.AppliesTo,
 			GithubEditUrl = editUrl,
 			MarkdownUrl = current.Url == "/" ? "/index.md" : current.Url.TrimEnd('/') + ".md",
-			AllowIndexing = DocumentationSet.Context.AllowIndexing && markdown.YamlFrontMatter?.NoIndex != true && (markdown.CrossLink.Equals("docs-content://index.md", StringComparison.OrdinalIgnoreCase) || markdown is DetectionRuleFile || !current.Hidden),
+			AllowIndexing = DocumentationSet.Context.AllowIndexing && markdown.YamlFrontMatter?.NoIndex != true && (markdown.CrossLink.Equals("docs-content://index.md", StringComparison.OrdinalIgnoreCase) || markdown is DetectionRuleFile || !current.ExcludeFromIndexing),
 			CanonicalBaseUrl = DocumentationSet.Context.CanonicalBaseUrl,
 			GoogleTagManager = DocumentationSet.Context.GoogleTagManager,
 			Optimizely = DocumentationSet.Context.Optimizely,

--- a/src/Elastic.Markdown/HtmlWriter.cs
+++ b/src/Elastic.Markdown/HtmlWriter.cs
@@ -90,7 +90,10 @@ public class HtmlWriter(
 
 		// For hidden nav items (e.g. individual detection rule pages) there is no rendered nav link,
 		// so JS can't mark anything as current. Point it at the nearest visible ancestor instead.
-		var navActiveUrl = current.Hidden ? parents.FirstOrDefault(p => !p.Hidden)?.Url : null;
+		// Island pages have their own sidebar nav so JS uses window.location directly — skip the parent lookup.
+		var navActiveUrl = current.Hidden && current.IslandListingRoot is null
+			? parents.FirstOrDefault(p => !p.Hidden)?.Url
+			: null;
 		var gitHubRepo = DocumentationSet.Context.Git.GitHubRepository;
 		var branch = DocumentationSet.Context.Git.Branch;
 		string? editUrl = null;

--- a/src/Elastic.Markdown/IO/DocumentationSet.cs
+++ b/src/Elastic.Markdown/IO/DocumentationSet.cs
@@ -21,6 +21,7 @@ using Elastic.Documentation.Site.Navigation;
 using Elastic.Markdown.Extensions;
 using Elastic.Markdown.Extensions.CliReference;
 using Elastic.Markdown.Extensions.DetectionRules;
+using Elastic.Markdown.Extensions.Listing;
 using Elastic.Markdown.Myst;
 using Microsoft.Extensions.Logging;
 
@@ -73,8 +74,6 @@ public class DocumentationSet : INavigationTraversable
 		CrossLinkResolver = linkResolver;
 		ReleaseNotesResolver = releaseNotesResolver ?? NoopReleaseNotesResolver.Instance;
 		Configuration = context.Configuration;
-		EnabledExtensions = InstantiateExtensions();
-
 		var resolver = new ParserResolvers
 		{
 			CrossLinkResolver = CrossLinkResolver,
@@ -84,6 +83,8 @@ public class DocumentationSet : INavigationTraversable
 			NavigationTraversable = this
 		};
 		MarkdownParser = new MarkdownParser(context, resolver);
+
+		EnabledExtensions = InstantiateExtensions();
 
 		var fileFactory = new MarkdownFileFactory(context, MarkdownParser, EnabledExtensions);
 		Navigation = new DocumentationSetNavigation<MarkdownFile>(context.ConfigurationYaml, context, fileFactory, null, null, context.UrlPathPrefix, CrossLinkResolver);
@@ -287,7 +288,7 @@ public class DocumentationSet : INavigationTraversable
 					return new LinkMetadata
 					{
 						Anchors = anchors,
-						Hidden = tuple.Navigation.Hidden
+						Hidden = tuple.Navigation.ExcludeFromIndexing
 					};
 				});
 
@@ -326,6 +327,10 @@ public class DocumentationSet : INavigationTraversable
 		if (HasCliReferenceRef(Context.ConfigurationYaml.TableOfContents))
 			list.Add(new CliReferenceDocsBuilderExtension(Context));
 
+		// Auto-enable listing extension when the TOC contains a listing: entry
+		if (HasListingRef(Context.ConfigurationYaml.TableOfContents))
+			list.Add(new ListingDocsBuilderExtension(Context, MarkdownParser));
+
 		return list.AsReadOnly();
 	}
 
@@ -344,6 +349,26 @@ public class DocumentationSet : INavigationTraversable
 				_ => null
 			};
 			if (children is { Count: > 0 } && HasCliReferenceRef(children))
+				return true;
+		}
+		return false;
+	}
+
+	private static bool HasListingRef(IReadOnlyCollection<ITableOfContentsItem> items)
+	{
+		foreach (var item in items)
+		{
+			if (item is ListingRef)
+				return true;
+
+			var children = item switch
+			{
+				FileRef f => f.Children,
+				FolderRef f => f.Children,
+				IsolatedTableOfContentsRef t => t.Children,
+				_ => null
+			};
+			if (children is { Count: > 0 } && HasListingRef(children))
 				return true;
 		}
 		return false;

--- a/src/Elastic.Markdown/Myst/Directives/DirectiveBlockParser.cs
+++ b/src/Elastic.Markdown/Myst/Directives/DirectiveBlockParser.cs
@@ -12,6 +12,7 @@ using Elastic.Markdown.Myst.Directives.CliModifiers;
 using Elastic.Markdown.Myst.Directives.CsvInclude;
 using Elastic.Markdown.Myst.Directives.Image;
 using Elastic.Markdown.Myst.Directives.Include;
+using Elastic.Markdown.Myst.Directives.Listing;
 using Elastic.Markdown.Myst.Directives.Math;
 using Elastic.Markdown.Myst.Directives.PageCard;
 using Elastic.Markdown.Myst.Directives.Settings;
@@ -174,6 +175,9 @@ public class DirectiveBlockParser : FencedBlockParserBase<DirectiveBlock>
 
 		if (info.IndexOf("{list-sub-pages}") > 0)
 			return new ListSubPagesBlock(this, context);
+
+		if (info.IndexOf("{listing}") > 0)
+			return new ListingBlock(this, context);
 
 		if (info.IndexOf("{table}") > 0)
 			return new TableDirectiveBlock(this, context);

--- a/src/Elastic.Markdown/Myst/Directives/DirectiveHtmlRenderer.cs
+++ b/src/Elastic.Markdown/Myst/Directives/DirectiveHtmlRenderer.cs
@@ -18,6 +18,7 @@ using Elastic.Markdown.Myst.Directives.CsvInclude;
 using Elastic.Markdown.Myst.Directives.Dropdown;
 using Elastic.Markdown.Myst.Directives.Image;
 using Elastic.Markdown.Myst.Directives.Include;
+using Elastic.Markdown.Myst.Directives.Listing;
 using Elastic.Markdown.Myst.Directives.Math;
 using Elastic.Markdown.Myst.Directives.PageCard;
 using Elastic.Markdown.Myst.Directives.Settings;
@@ -120,6 +121,9 @@ public class DirectiveHtmlRenderer : HtmlObjectRenderer<DirectiveBlock>
 				return;
 			case ListSubPagesBlock listSubPagesBlock:
 				WriteListSubPages(renderer, listSubPagesBlock);
+				return;
+			case ListingBlock listingBlock:
+				WriteListing(renderer, listingBlock);
 				return;
 			case TableDirectiveBlock tableDirectiveBlock:
 				WriteTableDirective(renderer, tableDirectiveBlock);
@@ -246,6 +250,16 @@ public class DirectiveHtmlRenderer : HtmlObjectRenderer<DirectiveBlock>
 		{
 			DirectiveBlock = block,
 			SubPages = block.SubPages
+		});
+		RenderRazorSlice(slice, renderer);
+	}
+
+	private static void WriteListing(HtmlRenderer renderer, ListingBlock block)
+	{
+		var slice = ListingView.Create(new ListingViewModel
+		{
+			DirectiveBlock = block,
+			Entries = block.Entries
 		});
 		RenderRazorSlice(slice, renderer);
 	}

--- a/src/Elastic.Markdown/Myst/Directives/Listing/ListingBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Listing/ListingBlock.cs
@@ -1,0 +1,94 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Documentation.Navigation;
+
+namespace Elastic.Markdown.Myst.Directives.Listing;
+
+/// <summary>A single page-card entry in a listing group.</summary>
+public record ListingEntry(string Title, string Url, string? Description, string? GroupKey, string? GroupTitle);
+
+/// <summary>
+/// Internal directive emitted by <c>ListingDocsBuilderExtension</c> into generated listing index pages.
+/// Renders a grouped page-card index with a client-side filter and group chips.
+/// Not intended as a public authoring syntax.
+/// </summary>
+public class ListingBlock(DirectiveBlockParser parser, ParserContext context) : DirectiveBlock(parser, context)
+{
+	public override string Directive => "listing";
+
+	public ParserContext Context { get; } = context;
+
+	public IReadOnlyList<ListingEntry> Entries { get; private set; } = [];
+
+	public override void FinalizeAndValidate(ParserContext context)
+	{
+		var entries = new List<ListingEntry>();
+		var sourcePath = context.MarkdownParentPath ?? context.MarkdownSourcePath;
+		var document = context.TryFindDocument(sourcePath);
+
+		if (document is not IDocumentationFile docFile)
+		{
+			Entries = entries;
+			return;
+		}
+
+		if (!context.NavigationTraversable.NavigationDocumentationFileLookup.TryGetValue(docFile, out var lookupResult))
+		{
+			Entries = entries;
+			return;
+		}
+
+		// We want the listing root node (FolderNavigation) that owns this index page.
+		// If lookup returned the leaf (index page), get its parent.
+		var listingNode = lookupResult is INodeNavigationItem<INavigationModel, INavigationItem> node && node.Index.Model == docFile
+			? node
+			: lookupResult.Parent;
+
+		if (listingNode is null)
+		{
+			Entries = entries;
+			return;
+		}
+
+		CollectEntries(listingNode, entries, groupKey: null, groupTitle: null, isRoot: true);
+		Entries = entries;
+	}
+
+	private static void CollectEntries(
+		INodeNavigationItem<INavigationModel, INavigationItem> node,
+		List<ListingEntry> entries,
+		string? groupKey,
+		string? groupTitle,
+		bool isRoot)
+	{
+		foreach (var item in node.NavigationItems)
+		{
+			switch (item)
+			{
+				// Group folder node — recurse with its key and title
+				case INodeNavigationItem<INavigationModel, INavigationItem> groupNode when isRoot:
+					var gTitle = groupNode.NavigationTitle;
+					CollectEntries(groupNode, entries, groupNode.Url, gTitle, isRoot: false);
+					break;
+
+				// Content page leaf — add as a card
+				case ILeafNavigationItem<IDocumentationFile> leaf:
+					entries.Add(new ListingEntry(
+						leaf.NavigationTitle,
+						leaf.Url,
+						leaf.Model.Description,
+						groupKey,
+						groupTitle
+					));
+					break;
+
+				// Folder inside a group — flatten
+				case INodeNavigationItem<INavigationModel, INavigationItem> subNode:
+					CollectEntries(subNode, entries, groupKey, groupTitle, isRoot: false);
+					break;
+			}
+		}
+	}
+}

--- a/src/Elastic.Markdown/Myst/Directives/Listing/ListingView.cshtml
+++ b/src/Elastic.Markdown/Myst/Directives/Listing/ListingView.cshtml
@@ -1,0 +1,70 @@
+@using Elastic.Markdown.Myst.Directives.Listing
+@inherits RazorSlice<ListingViewModel>
+@{
+	var groups = Model.Entries
+		.GroupBy(e => e.GroupKey)
+		.OrderBy(g => g.Key is null ? 1 : 0)
+		.ToList();
+	var groupTitles = Model.Entries
+		.Where(e => e.GroupKey is not null && e.GroupTitle is not null)
+		.DistinctBy(e => e.GroupKey)
+		.ToDictionary(e => e.GroupKey!, e => e.GroupTitle!);
+	var hasGroups = groups.Any(g => g.Key is not null);
+	var totalCount = Model.Entries.Count;
+}
+<div class="listing-root" data-listing-total="@totalCount">
+@if (totalCount > 0)
+{
+	<div class="listing-filter-bar mt-4 mb-6">
+		<input
+			type="search"
+			class="listing-filter-input w-full border border-grey-20 rounded-lg px-4 py-2 text-sm focus:outline-none focus:border-blue-elastic"
+			placeholder="Filter @totalCount page@(totalCount == 1 ? "" : "s")…"
+			aria-label="Filter pages"
+		/>
+		@if (hasGroups)
+		{
+			<div class="listing-group-chips flex flex-wrap items-center gap-2 mt-3">
+				<button class="listing-chip listing-chip-all listing-chip-active px-3 py-1 text-xs rounded-full border border-blue-elastic text-blue-elastic" data-group="">All</button>
+				<span class="text-grey-20 select-none">|</span>
+				@foreach (var kvp in groupTitles)
+				{
+					<button class="listing-chip px-3 py-1 text-xs rounded-full border border-grey-20 text-ink-light hover:border-blue-elastic hover:text-blue-elastic" data-group="@kvp.Key">@kvp.Value</button>
+				}
+			</div>
+		}
+	</div>
+}
+@foreach (var group in groups)
+{
+	var gKey = group.Key;
+	var gTitle = gKey is not null && groupTitles.TryGetValue(gKey, out var t) ? t : null;
+	<div class="listing-group" data-group-key="@(gKey ?? "")">
+		@if (gTitle is not null)
+		{
+			<h2 class="listing-group-heading" id="@(gKey ?? "")">@gTitle</h2>
+		}
+		@foreach (var entry in group)
+		{
+			<a href="@entry.Url" style="text-decoration:none;"
+			   class="page-card flex items-center justify-between w-full border border-grey-20 rounded-lg px-6 py-4 mt-2 hover:border-grey-80 hover:bg-grey-5 group"
+			   data-listing-group="@(entry.GroupKey ?? "")"
+			   data-listing-title="@entry.Title.ToLowerInvariant()"
+			>
+				<div class="min-w-0">
+					<div class="font-semibold text-blue-elastic group-hover:underline">@entry.Title</div>
+					@if (!string.IsNullOrWhiteSpace(entry.Description))
+					{
+						<div class="text-sm text-ink-light mt-0.5 font-normal" style="text-decoration:none;">@entry.Description</div>
+					}
+				</div>
+				<svg class="size-5 shrink-0 ml-4 text-ink-light" xmlns="http://www.w3.org/2000/svg"
+					 fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+					<path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5"/>
+				</svg>
+			</a>
+		}
+	</div>
+}
+<p class="listing-no-results hidden text-sm text-ink-light mt-4">No pages match your filter.</p>
+</div>

--- a/src/Elastic.Markdown/Myst/Directives/Listing/ListingViewModel.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Listing/ListingViewModel.cs
@@ -1,0 +1,10 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic.Markdown.Myst.Directives.Listing;
+
+public class ListingViewModel : DirectiveViewModel
+{
+	public required IReadOnlyList<ListingEntry> Entries { get; init; }
+}

--- a/src/Elastic.Markdown/Myst/FrontMatter/FrontMatterParser.cs
+++ b/src/Elastic.Markdown/Myst/FrontMatter/FrontMatterParser.cs
@@ -4,6 +4,7 @@
 
 using Elastic.Documentation.AppliesTo;
 using Elastic.Documentation.Configuration.Products;
+using Elastic.Documentation.Configuration.Toc;
 using Elastic.Documentation.Configuration.Versions;
 using YamlDotNet.Serialization;
 
@@ -46,6 +47,13 @@ public class YamlFrontMatter
 	/// </summary>
 	[YamlMember(Alias = "cta")]
 	public CtaFrontMatter? Cta { get; set; }
+
+	/// <summary>
+	/// Declares which listing group this page belongs to.
+	/// Accepts both shorthand (<c>listing: group-name</c>) and full form (<c>listing: {group: group-name}</c>).
+	/// </summary>
+	[YamlMember(Alias = "listing")]
+	public ListingFrontMatter? Listing { get; set; }
 }
 
 /// <summary>

--- a/src/Elastic.Markdown/Myst/YamlSerialization.cs
+++ b/src/Elastic.Markdown/Myst/YamlSerialization.cs
@@ -4,10 +4,13 @@
 
 using Elastic.Documentation.AppliesTo;
 using Elastic.Documentation.Configuration.Products;
+using Elastic.Documentation.Configuration.Toc;
 using Elastic.Markdown.Myst.Directives.Changelog;
 using Elastic.Markdown.Myst.Directives.Contributors;
 using Elastic.Markdown.Myst.Directives.Settings;
 using Elastic.Markdown.Myst.FrontMatter;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
@@ -25,11 +28,47 @@ public static class YamlSerialization
 			.WithTypeConverter(new SemVersionConverter())
 			.WithTypeConverter(new ProductConverter(products))
 			.WithTypeConverter(new ApplicableToYamlConverter(products.PublicReferenceProducts.Keys))
+			.WithTypeConverter(new ListingFrontMatterConverter())
 			.Build();
 
 		var frontMatter = deserializer.Deserialize<T>(input);
 		return frontMatter;
 	}
+}
+
+/// <summary>
+/// Handles both <c>listing: group-name</c> (scalar shorthand) and <c>listing: {group: name}</c> (mapping).
+/// </summary>
+internal class ListingFrontMatterConverter : IYamlTypeConverter
+{
+	public bool Accepts(Type type) => type == typeof(ListingFrontMatter);
+
+	public object? ReadYaml(IParser parser, Type type, ObjectDeserializer rootDeserializer)
+	{
+		if (parser.TryConsume<Scalar>(out var scalar))
+			return new ListingFrontMatter { Group = string.IsNullOrWhiteSpace(scalar.Value) ? null : scalar.Value };
+
+		if (!parser.TryConsume<MappingStart>(out _))
+			return null;
+
+		var result = new ListingFrontMatter();
+		while (!parser.TryConsume<MappingEnd>(out _))
+		{
+			if (!parser.TryConsume<Scalar>(out var key))
+			{
+				parser.SkipThisAndNestedEvents();
+				continue;
+			}
+			if (key.Value == "group" && parser.TryConsume<Scalar>(out var val))
+				result.Group = string.IsNullOrWhiteSpace(val.Value) ? null : val.Value;
+			else
+				parser.SkipThisAndNestedEvents();
+		}
+		return result;
+	}
+
+	public void WriteYaml(IEmitter emitter, object? value, Type type, ObjectSerializer serializer) =>
+		serializer.Invoke(value, type);
 }
 
 [YamlStaticContext]
@@ -41,4 +80,5 @@ public static class YamlSerialization
 [YamlSerializable(typeof(ContributorEntry))]
 [YamlSerializable(typeof(ChangelogDirectiveConfigYaml))]
 [YamlSerializable(typeof(ChangelogDirectiveBundleConfigYaml))]
+[YamlSerializable(typeof(ListingFrontMatter))]
 public partial class DocsBuilderYamlStaticContext;

--- a/src/services/Elastic.Documentation.Assembler/Navigation/GlobalNavigationHtmlWriter.cs
+++ b/src/services/Elastic.Documentation.Assembler/Navigation/GlobalNavigationHtmlWriter.cs
@@ -90,7 +90,8 @@ public class GlobalNavigationHtmlWriter(ILoggerFactory logFactory, SiteNavigatio
 			BackLinkTitle = backTarget.NavigationTitle,
 			ListingRootUrl = islandRoot.Url,
 			ListingRootTitle = islandRoot.NavigationTitle,
-			Groups = groups
+			Groups = groups,
+			Visual = islandRoot.IslandVisual
 		};
 	}
 

--- a/src/services/Elastic.Documentation.Assembler/Navigation/GlobalNavigationHtmlWriter.cs
+++ b/src/services/Elastic.Documentation.Assembler/Navigation/GlobalNavigationHtmlWriter.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Collections.Concurrent;
 using Elastic.Documentation.Diagnostics;
 using Elastic.Documentation.Navigation;
 using Elastic.Documentation.Navigation.Assembler;
@@ -15,8 +16,9 @@ public class GlobalNavigationHtmlWriter(ILoggerFactory logFactory, SiteNavigatio
 {
 	private readonly ILogger _logger = logFactory.CreateLogger<GlobalNavigationHtmlWriter>();
 	private readonly NavigationRenderCache _renderedNavigationCache = new();
+	private readonly ConcurrentDictionary<string, string> _islandHtmlCache = [];
 
-	public Task<NavigationRenderResult> RenderNavigation(
+	public async Task<NavigationRenderResult> RenderNavigation(
 		IRootNavigationItem<INavigationModel, INavigationItem> currentRootNavigation,
 		INavigationItem currentNavigationItem,
 		Cancel ctx = default
@@ -28,15 +30,15 @@ public class GlobalNavigationHtmlWriter(ILoggerFactory logFactory, SiteNavigatio
 			return await RenderIslandNavigation(listingRoot, ctx);
 
 		if (currentRootNavigation is SiteNavigation)
-			return Task.FromResult(NavigationRenderResult.Empty);
+			return NavigationRenderResult.Empty;
 
 		if (currentRootNavigation.Parent is null or not SiteNavigation)
 			collector.EmitGlobalError($"Passed root is not actually a top level navigation item {currentRootNavigation.NavigationTitle} ({currentRootNavigation.Id}) in {currentRootNavigation.Url}, trying to render: {currentNavigationItem.Url}");
 
 		if (currentRootNavigation is not INodeNavigationItem<INavigationModel, INavigationItem> group)
-			return Task.FromResult(NavigationRenderResult.Empty);
+			return NavigationRenderResult.Empty;
 
-		return _renderedNavigationCache.GetOrRenderAsync(currentRootNavigation, () =>
+		return await _renderedNavigationCache.GetOrRenderAsync(currentRootNavigation, () =>
 		{
 			_logger.LogInformation("Rendering navigation for {NavigationTitle} ({Id})", currentRootNavigation.NavigationTitle, currentRootNavigation.Id);
 			return ((INavigationHtmlWriter)this).Render(CreateNavigationModel(group), ctx);
@@ -46,26 +48,15 @@ public class GlobalNavigationHtmlWriter(ILoggerFactory logFactory, SiteNavigatio
 	private async Task<NavigationRenderResult> RenderIslandNavigation(
 		INodeNavigationItem<INavigationModel, INavigationItem> islandRoot, Cancel ctx)
 	{
-		var cacheKey = $"island:{islandRoot.Id}";
-		if (_renderedNavigationCache.TryGetValue(cacheKey, out var html))
-			return new NavigationRenderResult { Html = html, Id = islandRoot.Id };
+		var cacheKey = islandRoot.Id;
+		if (_islandHtmlCache.TryGetValue(cacheKey, out var html))
+			return new NavigationRenderResult { Html = html, Id = cacheKey };
 
-		await _semaphore.WaitAsync(ctx);
-		try
-		{
-			if (_renderedNavigationCache.TryGetValue(cacheKey, out html))
-				return new NavigationRenderResult { Html = html, Id = islandRoot.Id };
-
-			var model = CreateIslandNavModel(islandRoot);
-			var slice = _IslandNav.Create(model);
-			html = await slice.RenderAsync(cancellationToken: ctx);
-			_renderedNavigationCache[cacheKey] = html;
-			return new NavigationRenderResult { Html = html, Id = islandRoot.Id };
-		}
-		finally
-		{
-			_ = _semaphore.Release();
-		}
+		var model = CreateIslandNavModel(islandRoot);
+		var slice = _IslandNav.Create(model);
+		html = await slice.RenderAsync(cancellationToken: ctx);
+		_islandHtmlCache[cacheKey] = html;
+		return new NavigationRenderResult { Html = html, Id = cacheKey };
 	}
 
 	private static IslandNavViewModel CreateIslandNavModel(
@@ -95,25 +86,11 @@ public class GlobalNavigationHtmlWriter(ILoggerFactory logFactory, SiteNavigatio
 		};
 	}
 
-	private NavigationViewModel CreateNavigationModel(INodeNavigationItem<INavigationModel, INavigationItem> group)
-	{
-		var topLevelItems = globalNavigation.TopLevelItems;
-		return new NavigationViewModel
-		{
-			Title = group.NavigationTitle,
-			TitleUrl = group.Url,
-			Tree = group,
-			IsPrimaryNavEnabled = true,
-			IsUsingNavigationDropdown = true,
-			IsGlobalAssemblyBuild = true,
-			TopLevelItems = topLevelItems,
-			BuildType = BuildType.Assembler
-		};
-	}
-
-	public void Dispose()
-	{
-		_semaphore.Dispose();
-		GC.SuppressFinalize(this);
-	}
+	private NavigationRenderModel CreateNavigationModel(INodeNavigationItem<INavigationModel, INavigationItem> group) =>
+		NavigationRenderModel.Create(
+			tree: group,
+			topLevelItems: globalNavigation.TopLevelItems,
+			isUsingNavigationDropdown: true,
+			isPrimaryNavEnabled: true,
+			isGlobalAssemblyBuild: true);
 }

--- a/src/services/Elastic.Documentation.Assembler/Navigation/GlobalNavigationHtmlWriter.cs
+++ b/src/services/Elastic.Documentation.Assembler/Navigation/GlobalNavigationHtmlWriter.cs
@@ -7,6 +7,7 @@ using Elastic.Documentation.Navigation;
 using Elastic.Documentation.Navigation.Assembler;
 using Elastic.Documentation.Site.Navigation;
 using Microsoft.Extensions.Logging;
+using RazorSlices;
 
 namespace Elastic.Documentation.Assembler.Navigation;
 
@@ -17,12 +18,15 @@ public class GlobalNavigationHtmlWriter(ILoggerFactory logFactory, SiteNavigatio
 
 	public Task<NavigationRenderResult> RenderNavigation(
 		IRootNavigationItem<INavigationModel, INavigationItem> currentRootNavigation,
-#pragma warning disable IDE0060
-		INavigationItem currentNavigationItem, // temporary https://github.com/elastic/docs-content/pull/3730
-#pragma warning restore IDE0060
+		INavigationItem currentNavigationItem,
 		Cancel ctx = default
 	)
 	{
+		if (currentNavigationItem.IslandListingRoot is { } islandRoot)
+			return await RenderIslandNavigation(islandRoot, ctx);
+		if (currentNavigationItem is INodeNavigationItem<INavigationModel, INavigationItem> { IsIslandListing: true } listingRoot)
+			return await RenderIslandNavigation(listingRoot, ctx);
+
 		if (currentRootNavigation is SiteNavigation)
 			return Task.FromResult(NavigationRenderResult.Empty);
 
@@ -39,11 +43,76 @@ public class GlobalNavigationHtmlWriter(ILoggerFactory logFactory, SiteNavigatio
 		});
 	}
 
-	private NavigationRenderModel CreateNavigationModel(INodeNavigationItem<INavigationModel, INavigationItem> group) =>
-		NavigationRenderModel.Create(
-			tree: group,
-			topLevelItems: globalNavigation.TopLevelItems,
-			isUsingNavigationDropdown: true,
-			isPrimaryNavEnabled: true,
-			isGlobalAssemblyBuild: true);
+	private async Task<NavigationRenderResult> RenderIslandNavigation(
+		INodeNavigationItem<INavigationModel, INavigationItem> islandRoot, Cancel ctx)
+	{
+		var cacheKey = $"island:{islandRoot.Id}";
+		if (_renderedNavigationCache.TryGetValue(cacheKey, out var html))
+			return new NavigationRenderResult { Html = html, Id = islandRoot.Id };
+
+		await _semaphore.WaitAsync(ctx);
+		try
+		{
+			if (_renderedNavigationCache.TryGetValue(cacheKey, out html))
+				return new NavigationRenderResult { Html = html, Id = islandRoot.Id };
+
+			var model = CreateIslandNavModel(islandRoot);
+			var slice = _IslandNav.Create(model);
+			html = await slice.RenderAsync(cancellationToken: ctx);
+			_renderedNavigationCache[cacheKey] = html;
+			return new NavigationRenderResult { Html = html, Id = islandRoot.Id };
+		}
+		finally
+		{
+			_ = _semaphore.Release();
+		}
+	}
+
+	private static IslandNavViewModel CreateIslandNavModel(
+		INodeNavigationItem<INavigationModel, INavigationItem> islandRoot)
+	{
+		var groups = islandRoot.NavigationItems
+			.OfType<INodeNavigationItem<INavigationModel, INavigationItem>>()
+			.Select(group =>
+			{
+				var pages = group.NavigationItems
+					.OfType<ILeafNavigationItem<INavigationModel>>()
+					.Select(p => new IslandNavPage(p.NavigationTitle, p.Url))
+					.ToList();
+				return new IslandNavGroup(group.NavigationTitle, group.Url, pages);
+			})
+			.ToList();
+
+		var backTarget = islandRoot.Parent ?? (INavigationItem)islandRoot;
+		return new IslandNavViewModel
+		{
+			BackLinkUrl = backTarget.Url,
+			BackLinkTitle = backTarget.NavigationTitle,
+			ListingRootUrl = islandRoot.Url,
+			ListingRootTitle = islandRoot.NavigationTitle,
+			Groups = groups
+		};
+	}
+
+	private NavigationViewModel CreateNavigationModel(INodeNavigationItem<INavigationModel, INavigationItem> group)
+	{
+		var topLevelItems = globalNavigation.TopLevelItems;
+		return new NavigationViewModel
+		{
+			Title = group.NavigationTitle,
+			TitleUrl = group.Url,
+			Tree = group,
+			IsPrimaryNavEnabled = true,
+			IsUsingNavigationDropdown = true,
+			IsGlobalAssemblyBuild = true,
+			TopLevelItems = topLevelItems,
+			BuildType = BuildType.Assembler
+		};
+	}
+
+	public void Dispose()
+	{
+		_semaphore.Dispose();
+		GC.SuppressFinalize(this);
+	}
 }


### PR DESCRIPTION
## Summary

Implements a way to create listings/overview pages that automatically lists and groups pages nested pages. 

Great if you have data driven docs that you don't want to modify `docset.yml` for. Also if you have long running branches all trying to append a child in the toc (like our RFC docs) these tend to always merge conflict. This solves that.


```yaml
  - listing: rfcs
    glob: "**/*.md"
    groups: [release-notes, openapi, frontend, security]
    sort: asc
    visual: all
    island: true
```

Adds a `listing:` TOC entry type that glob-discovers documentation files, hides them from the main nav tree, and generates a grouped index page with a client-side filter.

- **`listing: <path>`** — declares a listing root; files are discovered via `glob:` and grouped by `listing:` frontmatter
- **`visual: none|groups|all`** — controls island nav depth: groups only, or groups + pages
- **`island: true`** — listing pages get a dedicated sidebar nav instead of the main tree; the listing appears as a single item with a `>` chevron in the parent nav
- **`groups: [...]`** — explicit group ordering with alphabetical fallback
- **`sort: asc|desc`** — page order within groups

### Overview pages

```
root
  - index.md <-- H1 and markdown appear before the generated listings and filters
  - group/index.md <-- same but creates the grouping H1 is used as group name
  - group/document.md <-- a doc that will be listed under `group`
```

### Visual

Dictates how much you want to see in the nav of the generated pages, the default is `none`.

#### visual: all

<img width="1053" height="716" alt="image" src="https://github.com/user-attachments/assets/2c136d15-64c5-4f43-a9f2-f5d336b3240a" />

#### visual: groups

<img width="1053" height="241" alt="image" src="https://github.com/user-attachments/assets/8680fffa-4428-4599-82b1-56d8aa76af57" />

#### visual: none

<img width="1053" height="241" alt="image" src="https://github.com/user-attachments/assets/9571b74c-d7ff-4ca6-95da-6937b26071bb" />


### Island nav


https://github.com/user-attachments/assets/332bdf21-4e6f-412e-a043-4c77b9a2ce63

An island creates a dedicated navigation for the generated tree, this is great if you have 100s of pages. This allows you to use `visual: all` in a way that doesn't bloat the overal parent navigation. 


## Depends on / Related

docs-eng-team usage: elastic/docs-eng-team#735 

A first usage of this feature to list our RFCs automatically.


## Follow ups

<img width="1053" height="241" alt="image" src="https://github.com/user-attachments/assets/845e27d3-c02f-4111-8046-f86dddee5497" />

We could extend `island: true` to `- folder` in the `toc` and allow nesting/stacking islands. This would do wonders for our reference docs where we can make e.g all top level items an island so our reference navigation is not HUGE. but also `clients` or `esql` could be a sub island because these are HUGE subnavigations of their own.


The other thing this unlocks is a much simpler extension mechanism for e.g detection rules.

## Test plan

- [ ] `dotnet build` passes
- [ ] `./build.sh unit-test` passes
- [ ] Point builder at `~/Projects/docs-eng-team/docs` with `listing: rfcs`, `visual: all`, `island: true` — RFC index shows grouped cards + filter; island sidebar renders correctly on all pages
- [ ] `visual: groups` — island sidebar shows group headings only (no individual pages)
- [ ] `island: true + visual: none` emits a build error
- [ ] Main nav shows listing as single item with `>` chevron (no children)

🤖 Generated with [Claude Code](https://claude.com/claude-code)