### PR TITLE
Add pivot.features in changelog configuration

### DIFF
--- a/config/changelog.example.yml
+++ b/config/changelog.example.yml
@@ -147,6 +147,18 @@ pivot:
   #   # 'elasticsearch 9.2.0':
   #   #   - ":feature/new-in-9.2"
 
+  # Feature ID definitions with labels (optional).
+  # Keys are feature-id values written to the changelog; values are label strings or lists.
+  # When a PR has a matching label and --feature-id is not set, that feature-id is applied.
+  # If multiple labels map to distinct feature-ids, a warning is emitted and the first match is used.
+  # Precedence: --feature-id CLI option > pivot.features label mapping.
+  # Unreleased feature IDs should also be listed under bundle.profiles.<name>.hide_features.
+  #
+  # features:
+  #   'feature:new-search-api':
+  #     - "feature-flag:new-search-api"
+  #     - ":Feature/NewSearchApi"
+
 # Rules configuration — controls which PRs create changelogs and which changelogs are published.
 # All list-like fields (exclude, include, exclude_types) accept BOTH forms:
 #   - Comma-separated string: "value1, value2, value3"

--- a/docs/cli/changelog/cmd-add.md
+++ b/docs/cli/changelog/cmd-add.md
@@ -87,6 +87,18 @@ The same order applies when using `--report` (after PR URLs are resolved from th
 
 If none of these steps yield at least one product, the command returns an error.
 
+## Feature ID resolution
+
+The optional `feature-id` field associates a changelog with a feature flag or project.
+The `changelog add` command resolves it in the following order:
+
+1. The `--feature-id` CLI option always takes priority.
+1. If `pivot.features` is defined in the changelog configuration file and the PR or issue has labels that match, that feature ID is used.
+   If the PR or issue has multiple labels that map to different feature IDs, the first match is used and a warning is emitted.
+
+When you map unreleased features in `pivot.features`, also list those feature IDs under the relevant bundle profile's [`hide_features`](/data/release-notes/configure-ref.md#bundle-profiles) setting so the entries stay commented out until the feature is ready to publish.
+For more information, refer to [](/data/release-notes/bundle.md#changelog-bundle-hide-features).
+
 ## Configuration checks
 
 By default, the command checks `docs/changelog.yml` for a configuration file. You can specify a different path with `--config`.

--- a/docs/data/release-notes/configure-ref.md
+++ b/docs/data/release-notes/configure-ref.md
@@ -253,6 +253,7 @@ Also controls how the `changelog add` command maps GitHub labels to various chan
 | Setting           | Description                                |
 | ----------------- | ------------------------------------------ |
 | `pivot.areas`     | Lists the valid area values. Optionally maps area names to GitHub labels (for example, `"Search Relevance": ":Search Relevance/Search"`). |
+| `pivot.features`  | Maps `feature-id` values to GitHub labels. When a PR or issue has a matching label, `changelog add` sets `feature-id` unless you pass `--feature-id`. If there are multiple feature labels, the first match is used and a warning is emitted. |
 | `pivot.highlight` | Defines labels that set the `highlight` flag on changelogs. |
 | `pivot.products`  | Maps product IDs (and optionally version and lifecycle) to GitHub labels. |
 | `pivot.types`     | Lists the valid type values (at a minimum, `feature`, `bug-fix`, and `breaking-change`). Optionally maps types to GitHub labels (for example, `bug-fix: ">bug"`). You can also optionally define breaking change subtypes. |
@@ -281,6 +282,10 @@ pivot:
       - ":product/elasticsearch"
     'cloud-serverless':
       - ":product/serverless"
+  features:
+    'feature:new-search-api':
+      - "feature-flag:new-search-api"
+      - ":Feature/NewSearchApi"
 ```
 
 ## Products [products]

--- a/docs/data/release-notes/configure.md
+++ b/docs/data/release-notes/configure.md
@@ -15,6 +15,8 @@ You can then set up a changelog configuration file to make the content workflow 
 
     1. Create labels for _areas_ (or "features" or "components") of your products. If you don't want to show categories (other than the default "type" categories) in your documentation, this step is not required.
 
+    1. Create labels for _feature IDs_ when there are significant features that span multiple changelogs. This step is not required unless you use feature flags or want to [hide unreleased features](/data/release-notes/bundle.md#changelog-bundle-hide-features) in release bundles.
+
     1. Create labels to opt in or out of changelogs. For example, create `non-issue` or `release_notes:skip` labels for PRs that _shouldn't_ have changelogs. Alternatively, create a `@Public` label to identify PRs that _should_ have changelogs. You can only choose one label strategy for this behavior: exclusion or inclusion.
 
     1. Create labels for _highlights_. This step is not required unless you want to publish release highlights.
@@ -76,7 +78,8 @@ docs-builder changelog init
      - To set the changelog file name pattern, update [filename](/data/release-notes/configure-ref.md#filename).
      - To control what is extracted from GitHub, update [extract](/data/release-notes/configure-ref.md#extract).
      - To change bundle default behaviour or create reusable profiles, update [bundle](/data/release-notes/configure-ref.md#bundle).
-     - If you have GitHub labels to set changelog areas, types, or products, update [pivot](/data/release-notes/configure-ref.md#pivot).
+     - If you have GitHub labels to set changelog areas, types, products, or feature IDs, update [pivot](/data/release-notes/configure-ref.md#pivot).
+     - If you map feature IDs with `pivot.features`, also list any unreleased feature IDs under the relevant bundle profile's [`hide_features`](/data/release-notes/configure-ref.md#bundle-profiles) setting so those changelogs stay commented out until the feature is ready to publish. For more information, refer to [](/data/release-notes/bundle.md#changelog-bundle-hide-features).
      - If you have GitHub labels to opt in or out of changelogs, update [rules.create](/data/release-notes/configure-ref.md#rules-create).
      - If you want to filter changelogs in or out of release bundles based on their area, type, or products, update [rules.bundle](/data/release-notes/configure-ref.md#rules-bundle).
 

--- a/src/Elastic.Documentation.Configuration/Changelog/ChangelogConfiguration.cs
+++ b/src/Elastic.Documentation.Configuration/Changelog/ChangelogConfiguration.cs
@@ -99,6 +99,13 @@ public record ChangelogConfiguration
 	public IReadOnlyDictionary<string, string>? LabelToProducts { get; init; }
 
 	/// <summary>
+	/// Mapping from GitHub label names to feature-id values (computed from Pivot.Features).
+	/// Each label maps to a feature-id string (e.g., "feature:new-search-api").
+	/// When a PR has labels matching multiple distinct feature-ids, the first match is used.
+	/// </summary>
+	public IReadOnlyDictionary<string, string>? LabelToFeatures { get; init; }
+
+	/// <summary>
 	/// Rules configuration for create and publish blockers
 	/// </summary>
 	public RulesConfiguration? Rules { get; init; }

--- a/src/Elastic.Documentation.Configuration/Changelog/ChangelogConfigurationLoader.cs
+++ b/src/Elastic.Documentation.Configuration/Changelog/ChangelogConfigurationLoader.cs
@@ -116,6 +116,7 @@ public class ChangelogConfigurationLoader(ILoggerFactory logFactory, IConfigurat
 		Dictionary<string, string>? labelToType;
 		Dictionary<string, List<string>>? labelToAreas;
 		Dictionary<string, string>? labelToProducts;
+		Dictionary<string, string>? labelToFeatures;
 		PivotConfiguration? pivot = null;
 
 		if (yamlConfig.Pivot != null)
@@ -216,6 +217,7 @@ public class ChangelogConfigurationLoader(ILoggerFactory logFactory, IConfigurat
 				}
 			}
 			labelToProducts = BuildLabelToProductsMapping(yamlConfig.Pivot.Products);
+			labelToFeatures = BuildLabelToFeaturesMapping(yamlConfig.Pivot.Features);
 		}
 		else
 		{
@@ -226,6 +228,7 @@ public class ChangelogConfigurationLoader(ILoggerFactory logFactory, IConfigurat
 			labelToType = null;
 			labelToAreas = null;
 			labelToProducts = null;
+			labelToFeatures = null;
 		}
 
 		// Process lifecycles
@@ -328,6 +331,7 @@ public class ChangelogConfigurationLoader(ILoggerFactory logFactory, IConfigurat
 			LabelToType = labelToType,
 			LabelToAreas = labelToAreasReadOnly,
 			LabelToProducts = labelToProducts,
+			LabelToFeatures = labelToFeatures,
 			Rules = rules,
 			HighlightLabels = highlightLabels,
 			ProductsConfiguration = productsConfig,
@@ -359,6 +363,7 @@ public class ChangelogConfigurationLoader(ILoggerFactory logFactory, IConfigurat
 			Subtypes = ConvertLenientDictToStringDict(yamlPivot.Subtypes),
 			Areas = ConvertLenientDictToStringDict(yamlPivot.Areas),
 			Products = ConvertLenientDictToStringDict(yamlPivot.Products),
+			Features = ConvertLenientDictToStringDict(yamlPivot.Features),
 			Highlight = JoinLenientList(yamlPivot.Highlight)
 		};
 	}
@@ -1217,5 +1222,28 @@ public class ChangelogConfigurationLoader(ILoggerFactory logFactory, IConfigurat
 		}
 
 		return labelToProducts.Count > 0 ? labelToProducts : null;
+	}
+
+	/// <summary>
+	/// Builds LabelToFeatures mapping by inverting pivot.features entries.
+	/// Each label in a feature entry maps to that feature-id string.
+	/// </summary>
+	private static Dictionary<string, string>? BuildLabelToFeaturesMapping(Dictionary<string, YamlLenientList?>? features)
+	{
+		if (features == null || features.Count == 0)
+			return null;
+
+		var labelToFeatures = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+		foreach (var (featureId, labelList) in features)
+		{
+			if (labelList?.Values == null)
+				continue;
+
+			foreach (var label in labelList.Values)
+				labelToFeatures[label] = featureId;
+		}
+
+		return labelToFeatures.Count > 0 ? labelToFeatures : null;
 	}
 }

--- a/src/Elastic.Documentation.Configuration/Changelog/ChangelogConfigurationYaml.cs
+++ b/src/Elastic.Documentation.Configuration/Changelog/ChangelogConfigurationYaml.cs
@@ -223,6 +223,13 @@ internal sealed record PivotConfigurationYaml
 	public Dictionary<string, YamlLenientList?>? Products { get; set; }
 
 	/// <summary>
+	/// Feature ID definitions with labels (string or list per value).
+	/// Keys are feature-id strings (e.g., "feature:new-search-api").
+	/// Values are label strings that trigger setting that feature-id.
+	/// </summary>
+	public Dictionary<string, YamlLenientList?>? Features { get; set; }
+
+	/// <summary>
 	/// Labels that trigger the highlight flag (string or list).
 	/// </summary>
 	public YamlLenientList? Highlight { get; set; }

--- a/src/Elastic.Documentation.Configuration/Changelog/PivotConfiguration.cs
+++ b/src/Elastic.Documentation.Configuration/Changelog/PivotConfiguration.cs
@@ -41,6 +41,14 @@ public record PivotConfiguration
 	public Dictionary<string, string?>? Products { get; init; }
 
 	/// <summary>
+	/// Feature ID definitions with labels mapped to feature-id values.
+	/// Keys are feature-id strings (e.g., "feature:new-search-api").
+	/// Values are label strings (e.g., "feature-flag:new-search-api").
+	/// When a PR has labels matching a feature entry, that feature-id is set on the changelog entry.
+	/// </summary>
+	public Dictionary<string, string?>? Features { get; init; }
+
+	/// <summary>
 	/// Labels that trigger the highlight flag (comma-separated string).
 	/// When a PR has any of these labels, highlight is set to true.
 	/// Example: ">highlight, >release-highlight"

--- a/src/services/Elastic.Changelog/Creation/ChangelogCreationService.cs
+++ b/src/services/Elastic.Changelog/Creation/ChangelogCreationService.cs
@@ -446,6 +446,7 @@ IEnvironmentVariables? env = null
 			Areas = derived.Areas != null && (input.Areas == null || input.Areas.Length == 0) ? derived.Areas : input.Areas,
 			Products = derived.Products is { Count: > 0 } && input.Products.Count == 0 ? derived.Products : input.Products,
 			Highlight = derived.Highlight ?? input.Highlight,
+			FeatureId = derived.FeatureId != null && string.IsNullOrWhiteSpace(input.FeatureId) ? derived.FeatureId : input.FeatureId,
 			Issues = derived.Issues != null && (input.Issues == null || input.Issues.Length == 0) ? derived.Issues : input.Issues,
 			Prs = derived.Prs != null && (input.Prs == null || input.Prs.Length == 0) ? derived.Prs : input.Prs
 		};

--- a/src/services/Elastic.Changelog/Creation/IssueInfoProcessor.cs
+++ b/src/services/Elastic.Changelog/Creation/IssueInfoProcessor.cs
@@ -191,6 +191,19 @@ public class IssueInfoProcessor(IGitHubPrService? githubService, ILogger logger)
 		else if (input.Products.Count > 0)
 			logger.LogDebug("Using explicitly provided products, ignoring issue labels");
 
+		// Map labels to feature-id if not explicitly provided
+		if (string.IsNullOrWhiteSpace(input.FeatureId) && config.LabelToFeatures != null)
+		{
+			var mappedFeatureId = PrInfoProcessor.MapLabelsToFeatureId(issueInfo.Labels.ToArray(), config.LabelToFeatures, collector);
+			if (mappedFeatureId != null)
+			{
+				derived.FeatureId = mappedFeatureId;
+				logger.LogInformation("Mapped issue labels to feature-id: {FeatureId}", mappedFeatureId);
+			}
+		}
+		else if (!string.IsNullOrWhiteSpace(input.FeatureId))
+			logger.LogDebug("Using explicitly provided feature-id, ignoring issue labels");
+
 		// Extract linked PRs from issue body
 		if ((input.ExtractIssues ?? false) && issueInfo.LinkedPrs.Count > 0)
 		{

--- a/src/services/Elastic.Changelog/Creation/PrInfoProcessor.cs
+++ b/src/services/Elastic.Changelog/Creation/PrInfoProcessor.cs
@@ -194,6 +194,19 @@ public class PrInfoProcessor(IGitHubPrService? githubPrService, ILogger logger)
 		else if (input.Products.Count > 0)
 			logger.LogDebug("Using explicitly provided products, ignoring PR labels");
 
+		// Map labels to feature-id if not explicitly provided
+		if (string.IsNullOrWhiteSpace(input.FeatureId) && config.LabelToFeatures != null)
+		{
+			var mappedFeatureId = MapLabelsToFeatureId(prInfo.Labels.ToArray(), config.LabelToFeatures, collector);
+			if (mappedFeatureId != null)
+			{
+				derived.FeatureId = mappedFeatureId;
+				logger.LogInformation("Mapped PR labels to feature-id: {FeatureId}", mappedFeatureId);
+			}
+		}
+		else if (!string.IsNullOrWhiteSpace(input.FeatureId))
+			logger.LogDebug("Using explicitly provided feature-id, ignoring PR labels");
+
 		// Extract linked issues from PR body if config enabled and issues not provided
 		if ((input.ExtractIssues ?? false) && (input.Issues == null || input.Issues.Length == 0))
 		{
@@ -429,6 +442,41 @@ public class PrInfoProcessor(IGitHubPrService? githubPrService, ILogger logger)
 
 		return products;
 	}
+
+	/// <summary>
+	/// Maps PR/issue labels to a single feature-id using the pivot.features mapping.
+	/// When multiple distinct feature-ids match, emits a warning and returns the first (PR label order).
+	/// </summary>
+	internal static string? MapLabelsToFeatureId(
+		string[] labels,
+		IReadOnlyDictionary<string, string> labelToFeaturesMapping,
+		IDiagnosticsCollector collector)
+	{
+		var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+		var featureIds = new List<string>();
+
+		foreach (var label in labels)
+		{
+			if (!labelToFeaturesMapping.TryGetValue(label, out var featureId))
+				continue;
+
+			if (!seen.Add(featureId))
+				continue;
+
+			featureIds.Add(featureId);
+		}
+
+		if (featureIds.Count == 0)
+			return null;
+
+		if (featureIds.Count > 1)
+		{
+			collector.EmitWarning(string.Empty,
+				$"Multiple feature-id values matched from labels ({string.Join(", ", featureIds)}). Using first match '{featureIds[0]}'. Provide --feature-id to override.");
+		}
+
+		return featureIds[0];
+	}
 }
 
 /// <summary>
@@ -453,6 +501,7 @@ public record DerivedPrFields
 	public string[]? Areas { get; set; }
 	public bool? Highlight { get; set; }
 	public string[]? Issues { get; set; }
+	public string? FeatureId { get; set; }
 
 	/// <summary>
 	/// Products derived from PR/issue labels via pivot.products mapping.

--- a/tests/Elastic.Changelog.Tests/Changelogs/ChangelogConfigurationTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/ChangelogConfigurationTests.cs
@@ -1141,6 +1141,55 @@ public class ChangelogConfigurationTests(ITestOutputHelper output) : ChangelogTe
 	}
 
 	[Fact]
+	public async Task LoadChangelogConfiguration_WithPivotFeatures_ComputesLabelToFeaturesMapping()
+	{
+		var configLoader = new ChangelogConfigurationLoader(LoggerFactory, ConfigurationContext, FileSystem);
+		var configDir = FileSystem.Path.Join(Paths.WorkingDirectoryRoot.FullName, Guid.NewGuid().ToString());
+		var docsDir = FileSystem.Path.Join(configDir, "docs");
+		FileSystem.Directory.CreateDirectory(docsDir);
+		var configPath = FileSystem.Path.Join(docsDir, "changelog.yml");
+		// language=yaml
+		var configContent =
+			"""
+			pivot:
+			  types:
+			    feature:
+			    bug-fix:
+			    breaking-change:
+			  features:
+			    'feature:new-search-api':
+			      - "feature-flag:new-search-api"
+			      - ":Feature/NewSearchApi"
+			    'feature:legacy': "legacy-flag"
+			""";
+		await FileSystem.File.WriteAllTextAsync(configPath, configContent, TestContext.Current.CancellationToken);
+
+		var originalDir = FileSystem.Directory.GetCurrentDirectory();
+		try
+		{
+			FileSystem.Directory.SetCurrentDirectory(configDir);
+
+			var config = await configLoader.LoadChangelogConfiguration(Collector, null, TestContext.Current.CancellationToken);
+
+			config.Should().NotBeNull();
+			Collector.Errors.Should().Be(0);
+			config.LabelToFeatures.Should().NotBeNull();
+			config.LabelToFeatures.Should().ContainKey("feature-flag:new-search-api");
+			config.LabelToFeatures!["feature-flag:new-search-api"].Should().Be("feature:new-search-api");
+			config.LabelToFeatures.Should().ContainKey(":Feature/NewSearchApi");
+			config.LabelToFeatures[":Feature/NewSearchApi"].Should().Be("feature:new-search-api");
+			config.LabelToFeatures.Should().ContainKey("legacy-flag");
+			config.LabelToFeatures["legacy-flag"].Should().Be("feature:legacy");
+			config.Pivot?.Features.Should().NotBeNull();
+			config.Pivot!.Features.Should().ContainKey("feature:new-search-api");
+		}
+		finally
+		{
+			FileSystem.Directory.SetCurrentDirectory(originalDir);
+		}
+	}
+
+	[Fact]
 	public async Task LoadChangelogConfiguration_WithPivotProducts_ProductSpecWithTarget_PreservesSpec()
 	{
 		// Arrange

--- a/tests/Elastic.Changelog.Tests/Changelogs/Create/LabelMappingTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/Create/LabelMappingTests.cs
@@ -582,4 +582,295 @@ public class LabelMappingTests(ITestOutputHelper output) : CreateChangelogTestBa
 		yamlContent.Should().Contain("- Search");
 		yamlContent.Should().Contain("- Observability");
 	}
+
+	[Fact]
+	public void MapLabelsToFeatureId_WithSingleMatch_ReturnsFeatureId()
+	{
+		var labelToFeatures = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+		{
+			["feature-flag:new-search-api"] = "feature:new-search-api"
+		};
+
+		var result = PrInfoProcessor.MapLabelsToFeatureId(
+			["feature-flag:new-search-api", "type:feature"],
+			labelToFeatures,
+			Collector);
+
+		result.Should().Be("feature:new-search-api");
+		Collector.Warnings.Should().Be(0);
+	}
+
+	[Fact]
+	public void MapLabelsToFeatureId_WithDuplicateMatchingLabels_ReturnsSameFeatureIdWithoutWarning()
+	{
+		var labelToFeatures = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+		{
+			["feature-flag:new-search-api"] = "feature:new-search-api",
+			[":Feature/NewSearchApi"] = "feature:new-search-api"
+		};
+
+		var result = PrInfoProcessor.MapLabelsToFeatureId(
+			["feature-flag:new-search-api", ":Feature/NewSearchApi"],
+			labelToFeatures,
+			Collector);
+
+		result.Should().Be("feature:new-search-api");
+		Collector.Warnings.Should().Be(0);
+	}
+
+	[Fact]
+	public void MapLabelsToFeatureId_WithMultipleDistinctMatches_WarnsAndReturnsFirst()
+	{
+		var labelToFeatures = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+		{
+			["feature-flag:foo"] = "feature:foo",
+			["feature-flag:bar"] = "feature:bar"
+		};
+
+		var result = PrInfoProcessor.MapLabelsToFeatureId(
+			["feature-flag:foo", "feature-flag:bar"],
+			labelToFeatures,
+			Collector);
+
+		result.Should().Be("feature:foo");
+		Collector.Warnings.Should().Be(1);
+		Collector.Diagnostics.Should().Contain(d =>
+			d.Message.Contains("Multiple feature-id values matched"));
+	}
+
+	[Fact]
+	public void MapLabelsToFeatureId_WithNoMatchingLabels_ReturnsNull()
+	{
+		var labelToFeatures = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+		{
+			["feature-flag:new-search-api"] = "feature:new-search-api"
+		};
+
+		var result = PrInfoProcessor.MapLabelsToFeatureId(
+			["type:feature", ">bug"],
+			labelToFeatures,
+			Collector);
+
+		result.Should().BeNull();
+		Collector.Warnings.Should().Be(0);
+	}
+
+	[Fact]
+	public async Task CreateChangelog_WithLabelFeatureMapping_DerivesFeatureIdFromLabels()
+	{
+		var prInfo = new GitHubPrInfo
+		{
+			Title = "Add new search API",
+			Labels = ["type:feature", "feature-flag:new-search-api"]
+		};
+
+		A.CallTo(() => MockGitHubService.FetchPrInfoAsync(
+				A<string>._,
+				A<string?>._,
+				A<string?>._,
+				A<CancellationToken>._))
+			.Returns(prInfo);
+
+		// language=yaml
+		var configContent =
+			"""
+			pivot:
+			  types:
+			    feature: "type:feature"
+			    bug-fix:
+			    breaking-change:
+			  features:
+			    'feature:new-search-api':
+			      - "feature-flag:new-search-api"
+			lifecycles:
+			  - ga
+			""";
+		var configPath = await CreateConfigDirectory(configContent);
+
+		var service = CreateService();
+		var input = new CreateChangelogArguments
+		{
+			Prs = ["https://github.com/elastic/elasticsearch/pull/12345"],
+			Products = [new ProductArgument { Product = "elasticsearch", Target = "9.2.0" }],
+			Config = configPath,
+			Output = CreateOutputDirectory()
+		};
+
+		var result = await service.CreateChangelog(Collector, input, TestContext.Current.CancellationToken);
+
+		if (!result)
+		{
+			foreach (var diagnostic in Collector.Diagnostics)
+				Output.WriteLine($"{diagnostic.Severity}: {diagnostic.Message}");
+		}
+
+		result.Should().BeTrue();
+		Collector.Errors.Should().Be(0);
+
+		var files = FileSystem.Directory.GetFiles(input.Output, "*.yaml");
+		var yamlContent = await FileSystem.File.ReadAllTextAsync(files[0], TestContext.Current.CancellationToken);
+		yamlContent.Should().Contain("feature-id: feature:new-search-api");
+	}
+
+	[Fact]
+	public async Task CreateChangelog_WithExplicitFeatureId_IgnoresLabelMapping()
+	{
+		var prInfo = new GitHubPrInfo
+		{
+			Title = "Add new search API",
+			Labels = ["type:feature", "feature-flag:new-search-api"]
+		};
+
+		A.CallTo(() => MockGitHubService.FetchPrInfoAsync(
+				A<string>._,
+				A<string?>._,
+				A<string?>._,
+				A<CancellationToken>._))
+			.Returns(prInfo);
+
+		// language=yaml
+		var configContent =
+			"""
+			pivot:
+			  types:
+			    feature: "type:feature"
+			    bug-fix:
+			    breaking-change:
+			  features:
+			    'feature:new-search-api':
+			      - "feature-flag:new-search-api"
+			lifecycles:
+			  - ga
+			""";
+		var configPath = await CreateConfigDirectory(configContent);
+
+		var service = CreateService();
+		var input = new CreateChangelogArguments
+		{
+			Prs = ["https://github.com/elastic/elasticsearch/pull/12345"],
+			Products = [new ProductArgument { Product = "elasticsearch", Target = "9.2.0" }],
+			FeatureId = "feature:cli-override",
+			Config = configPath,
+			Output = CreateOutputDirectory()
+		};
+
+		var result = await service.CreateChangelog(Collector, input, TestContext.Current.CancellationToken);
+
+		result.Should().BeTrue();
+		Collector.Errors.Should().Be(0);
+
+		var files = FileSystem.Directory.GetFiles(input.Output, "*.yaml");
+		var yamlContent = await FileSystem.File.ReadAllTextAsync(files[0], TestContext.Current.CancellationToken);
+		yamlContent.Should().Contain("feature-id: feature:cli-override");
+		yamlContent.Should().NotContain("feature-id: feature:new-search-api");
+	}
+
+	[Fact]
+	public async Task CreateChangelog_WithMultipleFeatureLabelMatches_WarnsAndUsesFirst()
+	{
+		var prInfo = new GitHubPrInfo
+		{
+			Title = "Cross-feature change",
+			Labels = ["type:feature", "feature-flag:foo", "feature-flag:bar"]
+		};
+
+		A.CallTo(() => MockGitHubService.FetchPrInfoAsync(
+				A<string>._,
+				A<string?>._,
+				A<string?>._,
+				A<CancellationToken>._))
+			.Returns(prInfo);
+
+		// language=yaml
+		var configContent =
+			"""
+			pivot:
+			  types:
+			    feature: "type:feature"
+			    bug-fix:
+			    breaking-change:
+			  features:
+			    'feature:foo':
+			      - "feature-flag:foo"
+			    'feature:bar':
+			      - "feature-flag:bar"
+			lifecycles:
+			  - ga
+			""";
+		var configPath = await CreateConfigDirectory(configContent);
+
+		var service = CreateService();
+		var input = new CreateChangelogArguments
+		{
+			Prs = ["https://github.com/elastic/elasticsearch/pull/12345"],
+			Products = [new ProductArgument { Product = "elasticsearch", Target = "9.2.0" }],
+			Config = configPath,
+			Output = CreateOutputDirectory()
+		};
+
+		var result = await service.CreateChangelog(Collector, input, TestContext.Current.CancellationToken);
+
+		result.Should().BeTrue();
+		Collector.Errors.Should().Be(0);
+		Collector.Warnings.Should().BeGreaterThan(0);
+		Collector.Diagnostics.Should().Contain(d =>
+			d.Message.Contains("Multiple feature-id values matched"));
+
+		var files = FileSystem.Directory.GetFiles(input.Output, "*.yaml");
+		var yamlContent = await FileSystem.File.ReadAllTextAsync(files[0], TestContext.Current.CancellationToken);
+		yamlContent.Should().Contain("feature-id: feature:foo");
+	}
+
+	[Fact]
+	public async Task CreateChangelog_WithNoMatchingFeatureLabels_OmitsFeatureId()
+	{
+		var prInfo = new GitHubPrInfo
+		{
+			Title = "Unrelated feature",
+			Labels = ["type:feature"]
+		};
+
+		A.CallTo(() => MockGitHubService.FetchPrInfoAsync(
+				A<string>._,
+				A<string?>._,
+				A<string?>._,
+				A<CancellationToken>._))
+			.Returns(prInfo);
+
+		// language=yaml
+		var configContent =
+			"""
+			pivot:
+			  types:
+			    feature: "type:feature"
+			    bug-fix:
+			    breaking-change:
+			  features:
+			    'feature:new-search-api':
+			      - "feature-flag:new-search-api"
+			lifecycles:
+			  - ga
+			""";
+		var configPath = await CreateConfigDirectory(configContent);
+
+		var service = CreateService();
+		var input = new CreateChangelogArguments
+		{
+			Prs = ["https://github.com/elastic/elasticsearch/pull/12345"],
+			Products = [new ProductArgument { Product = "elasticsearch", Target = "9.2.0" }],
+			Config = configPath,
+			Output = CreateOutputDirectory()
+		};
+
+		var result = await service.CreateChangelog(Collector, input, TestContext.Current.CancellationToken);
+
+		result.Should().BeTrue();
+		Collector.Errors.Should().Be(0);
+
+		var files = FileSystem.Directory.GetFiles(input.Output, "*.yaml");
+		var yamlContent = await FileSystem.File.ReadAllTextAsync(files[0], TestContext.Current.CancellationToken);
+		yamlContent.Split('\n')
+			.Should()
+			.NotContain(line => line.TrimStart().StartsWith("feature-id:", StringComparison.Ordinal));
+	}
 }


### PR DESCRIPTION
This PR adds an automated way to derive changelog `feature_id` values from PR/issue labels.

## Previous behaviour

The `feature-id` is set today only explicitly:

1. CLI: `--feature-id` on `changelog add`
2. Manual edit of the generated YAML

It’s documented as an optional free-form string (e.g. a feature-flag id) used later with `hide_features` at bundle/render time — not as something inferred from labels.

## New behaviour

Added a `pivot.features` optional setting in the `changelog.yml` that behaves the same as other `pivot` mappings that exist for areas, types, etc.

## AI summary

### What landed

- **`pivot.features`** config (same shape as `pivot.products`) → inverted to `LabelToFeatures`
- **`changelog add`** derives `feature-id` from PR/issue labels when `--feature-id` is unset
- Multi-match: warn + use first label match
- Docs: example yml, configure-ref, cmd-add, and configure.md (including `hide_features` guidance)
- Tests for mapping, loader, CLI override, conflict warn, and no-match


## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: Cursor Grok 4.5
