### PR TITLE
CI: build and package OpenAPI index Lambda for release

### DIFF
--- a/.github/workflows/build-openapi-index-lambda.yml
+++ b/.github/workflows/build-openapi-index-lambda.yml
@@ -1,0 +1,46 @@
+---
+# This workflow builds the OpenAPI version-index Lambda bootstrap binary
+# that can be deployed to AWS Lambda.
+name: Build OpenAPI Index Lambda
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      ref:
+        required: false
+        type: string
+        default: ${{ github.ref }}
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      BINARY_PATH: .artifacts/docs-lambda-openapi-index/release_linux-x64/bootstrap
+    steps:
+      - uses: actions/checkout@v7.0.0
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+      - name: Amazon Linux 2023 build
+        run: |
+          docker build . -t openapi-index:latest -f src/infra/docs-lambda-openapi-index/lambda.DockerFile
+      - name: Get bootstrap binary
+        run: |
+          docker cp "$(docker create --name tc openapi-index:latest)":/app/.artifacts/publish ./.artifacts && docker rm tc
+      - name: Inspect bootstrap binary
+        run: |
+          tree .artifacts
+          stat "${BINARY_PATH}"
+      - name: Archive artifact
+        id: upload-artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: openapi-index-updater-lambda-binary
+          retention-days: 1
+          if-no-files-found: error
+          path: ${{ env.BINARY_PATH }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
   build-link-index-updater-lambda:
     uses: ./.github/workflows/build-link-index-updater-lambda.yml
 
+  build-openapi-index-lambda:
+    uses: ./.github/workflows/build-openapi-index-lambda.yml
+
   synthetics:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,6 +148,48 @@ jobs:
     with:
       ref: ${{ needs.release-drafter.outputs.tag_name }}
 
+  build-openapi-index-lambda:
+    permissions:
+      contents: read
+    needs:
+      - release-drafter
+    uses: ./.github/workflows/build-openapi-index-lambda.yml
+    with:
+      ref: ${{ needs.release-drafter.outputs.tag_name }}
+
+  package-openapi-index-updater-lambda:
+    runs-on: ubuntu-latest
+    needs:
+      - build-openapi-index-lambda
+      - release-drafter
+    permissions:
+      contents: write
+      attestations: write
+      id-token: write
+    env:
+      ZIP_FILE: openapi-index-updater-lambda.zip
+    steps:
+      - name: Download bootstrap binary
+        uses: actions/download-artifact@v8
+        with:
+          name: openapi-index-updater-lambda-binary
+
+      - name: Create zip
+        run: |
+          zip -j "${ZIP_FILE}" ./bootstrap
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: openapi-index-updater-lambda.zip
+
+      - name: Attach distribution to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ needs.release-drafter.outputs.tag_name }}
+          REPO: ${{ github.repository }}
+        run: gh release upload --repo "$REPO" "$TAG_NAME" "${ZIP_FILE}"
+
   deploy-link-index-updater-lambda-prod:
     environment: 
       name: link-index-updater-prod
@@ -287,6 +329,7 @@ jobs:
       - release-drafter
       - deploy-link-index-updater-lambda-prod
       - deploy-changelog-scrubber-lambda-prod
+      - package-openapi-index-updater-lambda
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -321,6 +364,8 @@ jobs:
       - containers
       - build-link-index-lambda
       - build-changelog-scrubber-lambda
+      - build-openapi-index-lambda
+      - package-openapi-index-updater-lambda
       - deploy-link-index-updater-lambda-prod
       - deploy-changelog-scrubber-lambda-prod
       - release


### PR DESCRIPTION
## What

- Add a reusable workflow to build the OpenAPI version-index Lambda on pull requests and release
- Package the bootstrap binary as `openapi-index-updater-lambda.zip`, attest it, and attach it to the docs-builder GitHub release
- Block release publication until the OpenAPI Lambda asset is uploaded

## Why

- Production deployment of this Lambda moves to docs-internal-workflows; docs-builder only builds and publishes the deployable ZIP
- Part of https://github.com/elastic/docs-eng-team/issues/716

## Notes

- This workflow does not use AWS credentials or deploy the Lambda
- Merge after the docs-infra IAM update is applied


Made with [Cursor](https://cursor.com)