### PR TITLE
Reserve space for applies-to badges before they hydrate

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/markdown/applies-to.css
+++ b/src/Elastic.Documentation.Site/Assets/markdown/applies-to.css
@@ -70,6 +70,10 @@
 
 	.applies.applies-block {
 		@apply border-b-grey-20 flex flex-wrap gap-2 border-b-1 pb-4;
+		/* One badge row before applies-to-popover hydrates (border-box). */
+		min-height: calc(
+			1.875rem + 1rem + 1px
+		); /* 30px badge + pb-4 + border */
 	}
 
 	.applies.applies-inline {


### PR DESCRIPTION
Each `applies-to-popover` in the page-level applies row keeps a 30×47 box until `.applicable-info` appears. Content below the title no longer jumps when the web component loads.

**Affects:** Site UI

**Prompt summary:** Reserve space for the page-level applies block so content below the title does not jump when the web component loads.

## Why

`applies-to-popover` uses `display: contents`. A host with no badge then takes no box. Several badges wrap after hydration, and the first content below the title shifts down.

## What

#### Host box until the badge exists

Until `.applicable-info` is in the host, each `applies-to-popover` in `.applies-block` is an inline-block 30px tall and 47px wide. Several hosts can wrap. After React paints the badge, the host returns to `display: contents`.

**Out of scope:** Placeholder width is a fixed 47px, not the hydrated label width. A long badge can still wrap later than its placeholder.

## Verify

Open a page with several page-level applies badges. Narrow the viewport until the row wraps. Confirm the gap under the title does not jump when the badges appear.