### PR TITLE
OpenAPI index Lambda: invalidate CloudFront after refresh (#717)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,6 +33,7 @@
     <PackageVersion Include="Amazon.Lambda.SQSEvents" Version="3.0.0" />
     <PackageVersion Include="AngleSharp" Version="1.5.1" />
     <PackageVersion Include="Aspire.Hosting" Version="13.4.3" />
+    <PackageVersion Include="AWSSDK.CloudFront" Version="4.0.5" />
     <PackageVersion Include="MessagePack" Version="2.5.302" />
     <PackageVersion Include="Aspire.Hosting.Testing" Version="13.4.3" />
     <PackageVersion Include="AWSSDK.Core" Version="4.0.9.7" />

--- a/src/Elastic.Documentation.OpenApiIndex/CloudFrontCacheInvalidator.cs
+++ b/src/Elastic.Documentation.OpenApiIndex/CloudFrontCacheInvalidator.cs
@@ -1,0 +1,39 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Amazon.CloudFront;
+using Amazon.CloudFront.Model;
+
+namespace Elastic.Documentation.OpenApiIndex;
+
+/// <summary>
+/// Invalidates CloudFront paths after OpenAPI spec or index updates.
+/// </summary>
+public sealed class CloudFrontCacheInvalidator(IAmazonCloudFront cloudFrontClient, string distributionId)
+{
+	/// <summary>
+	/// Creates a CloudFront invalidation for the given paths.
+	/// </summary>
+	public async Task InvalidateAsync(IReadOnlyList<string> paths, string callerReference, Cancel ctx)
+	{
+		if (paths.Count == 0)
+			return;
+
+		var request = new CreateInvalidationRequest
+		{
+			DistributionId = distributionId,
+			InvalidationBatch = new InvalidationBatch
+			{
+				CallerReference = callerReference,
+				Paths = new Paths
+				{
+					Quantity = paths.Count,
+					Items = [.. paths]
+				}
+			}
+		};
+
+		_ = await cloudFrontClient.CreateInvalidationAsync(request, ctx).ConfigureAwait(false);
+	}
+}

--- a/src/Elastic.Documentation.OpenApiIndex/Elastic.Documentation.OpenApiIndex.csproj
+++ b/src/Elastic.Documentation.OpenApiIndex/Elastic.Documentation.OpenApiIndex.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="AWSSDK.CloudFront" />
       <PackageReference Include="AWSSDK.S3" />
     </ItemGroup>
 

--- a/src/Elastic.Documentation.OpenApiIndex/OpenApiInvalidationPaths.cs
+++ b/src/Elastic.Documentation.OpenApiIndex/OpenApiInvalidationPaths.cs
@@ -1,0 +1,28 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic.Documentation.OpenApiIndex;
+
+/// <summary>
+/// Builds CloudFront invalidation paths for OpenAPI spec objects and the version index.
+/// </summary>
+public static class OpenApiInvalidationPaths
+{
+	/// <summary>
+	/// Returns <c>/index.json</c> plus a leading-slash path for each distinct object key.
+	/// </summary>
+	public static IReadOnlyList<string> Build(IEnumerable<string> objectKeys)
+	{
+		var paths = new HashSet<string>(StringComparer.Ordinal) { $"/{VersionIndexPublisher.IndexKey}" };
+		foreach (var key in objectKeys)
+		{
+			if (string.IsNullOrWhiteSpace(key))
+				continue;
+
+			_ = paths.Add($"/{key.TrimStart('/')}");
+		}
+
+		return [.. paths];
+	}
+}

--- a/src/infra/docs-lambda-openapi-index/Program.cs
+++ b/src/infra/docs-lambda-openapi-index/Program.cs
@@ -5,16 +5,23 @@
 using Amazon.Lambda.Core;
 using Amazon.Lambda.RuntimeSupport;
 using Amazon.Lambda.Serialization.SystemTextJson;
+using Amazon.Lambda.S3Events;
 using Amazon.Lambda.SQSEvents;
+using Amazon.CloudFront;
 using Amazon.S3;
+using Amazon.S3.Util;
 using Elastic.Documentation.Lambda.OpenApiIndex;
 using Elastic.Documentation.OpenApiIndex;
 
 const string bucketName = "elastic-docs-openapi-specs";
 
+var distributionId = Environment.GetEnvironmentVariable("CLOUDFRONT_DISTRIBUTION_ID")
+	?? throw new InvalidOperationException("CLOUDFRONT_DISTRIBUTION_ID environment variable is required");
+
 // Built once per execution environment, so credential and endpoint resolution happens during Lambda's
 // init phase instead of on every invocation.
 var publisher = new VersionIndexPublisher(new AmazonS3Client(), bucketName);
+var invalidator = new CloudFrontCacheInvalidator(new AmazonCloudFrontClient(), distributionId);
 
 await LambdaBootstrapBuilder.Create<SQSEvent, SQSBatchResponse>(Handler, new SourceGeneratorLambdaJsonSerializer<SerializerContext>())
 	.Build()
@@ -22,17 +29,27 @@ await LambdaBootstrapBuilder.Create<SQSEvent, SQSBatchResponse>(Handler, new Sou
 
 return;
 
-// The SQS queue is configured to trigger on S3 ObjectCreated/ObjectRemoved events anywhere in the bucket.
-// Every invocation rebuilds the whole index rather than inspecting which key triggered it — see
-// VersionIndexPublisher for why.
+// The SQS queue is configured to trigger on S3 ObjectCreated/ObjectRemoved events under elastic/.
+// Every invocation rebuilds the whole index rather than merging the event — see VersionIndexPublisher
+// for why — then invalidates CloudFront for index.json and the triggering object keys.
 async Task<SQSBatchResponse> Handler(SQSEvent ev, ILambdaContext context)
 {
 	try
 	{
-		var ignoredKeys = await publisher.RefreshAsync(CancellationToken.None);
+		var objectKeys = ExtractObjectKeys(ev);
+		var ignoredKeys = await publisher.RefreshAsync(CancellationToken.None).ConfigureAwait(false);
 		if (ignoredKeys.Count > 0)
 			context.Logger.LogWarning("Ignored {ignoredCount} object key(s) not shaped as org/repo/version/file: {ignoredKeys}", ignoredKeys.Count, string.Join(", ", ignoredKeys));
-		context.Logger.LogInformation("Refreshed {bucketName}/{indexKey} from {recordCount} triggering event(s).", bucketName, VersionIndexPublisher.IndexKey, ev.Records.Count);
+
+		var paths = OpenApiInvalidationPaths.Build(objectKeys);
+		await invalidator.InvalidateAsync(paths, context.AwsRequestId, CancellationToken.None).ConfigureAwait(false);
+
+		context.Logger.LogInformation(
+			"Refreshed {bucketName}/{indexKey} and invalidated {pathCount} CloudFront path(s) from {recordCount} triggering event(s).",
+			bucketName,
+			VersionIndexPublisher.IndexKey,
+			paths.Count,
+			ev.Records.Count);
 		return new SQSBatchResponse([]);
 	}
 	catch (Exception ex)
@@ -42,4 +59,17 @@ async Task<SQSBatchResponse> Handler(SQSEvent ev, ILambdaContext context)
 		context.Logger.LogError(ex, "Failed to refresh {bucketName}/{indexKey}. Returning all {recordCount} message(s) to the queue.", bucketName, VersionIndexPublisher.IndexKey, ev.Records.Count);
 		return new SQSBatchResponse(ev.Records.Select(r => new SQSBatchResponse.BatchItemFailure { ItemIdentifier = r.MessageId }).ToList());
 	}
+}
+
+static IReadOnlyList<string> ExtractObjectKeys(SQSEvent ev)
+{
+	var keys = new HashSet<string>(StringComparer.Ordinal);
+	foreach (var message in ev.Records)
+	{
+		var s3Event = S3EventNotification.ParseJson(message.Body);
+		foreach (var record in s3Event.Records)
+			keys.Add(Uri.UnescapeDataString(record.S3.Object.Key));
+	}
+
+	return [.. keys];
 }

--- a/src/infra/docs-lambda-openapi-index/Program.cs
+++ b/src/infra/docs-lambda-openapi-index/Program.cs
@@ -2,12 +2,12 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using Amazon.CloudFront;
 using Amazon.Lambda.Core;
 using Amazon.Lambda.RuntimeSupport;
-using Amazon.Lambda.Serialization.SystemTextJson;
 using Amazon.Lambda.S3Events;
+using Amazon.Lambda.Serialization.SystemTextJson;
 using Amazon.Lambda.SQSEvents;
-using Amazon.CloudFront;
 using Amazon.S3;
 using Amazon.S3.Util;
 using Elastic.Documentation.Lambda.OpenApiIndex;
@@ -68,7 +68,7 @@ static IReadOnlyList<string> ExtractObjectKeys(SQSEvent ev)
 	{
 		var s3Event = S3EventNotification.ParseJson(message.Body);
 		foreach (var record in s3Event.Records)
-			keys.Add(Uri.UnescapeDataString(record.S3.Object.Key));
+			_ = keys.Add(Uri.UnescapeDataString(record.S3.Object.Key));
 	}
 
 	return [.. keys];

--- a/src/infra/docs-lambda-openapi-index/docs-lambda-openapi-index.csproj
+++ b/src/infra/docs-lambda-openapi-index/docs-lambda-openapi-index.csproj
@@ -22,7 +22,9 @@
     <PackageReference Include="Amazon.Lambda.RuntimeSupport" />
     <PackageReference Include="Amazon.Lambda.Core" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" />
+    <PackageReference Include="Amazon.Lambda.S3Events" />
     <PackageReference Include="Amazon.Lambda.SQSEvents" />
+    <PackageReference Include="AWSSDK.CloudFront" />
     <PackageReference Include="AWSSDK.Core" />
     <PackageReference Include="AWSSDK.S3" />
   </ItemGroup>

--- a/tests/Elastic.Documentation.OpenApiIndex.Tests/CloudFrontCacheInvalidatorTests.cs
+++ b/tests/Elastic.Documentation.OpenApiIndex.Tests/CloudFrontCacheInvalidatorTests.cs
@@ -1,0 +1,62 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Amazon.CloudFront;
+using Amazon.CloudFront.Model;
+using AwesomeAssertions;
+using FakeItEasy;
+
+namespace Elastic.Documentation.OpenApiIndex.Tests;
+
+public class CloudFrontCacheInvalidatorTests
+{
+	private const string DistributionId = "E1234567890ABC";
+
+	private readonly IAmazonCloudFront _cloudFrontClient = A.Fake<IAmazonCloudFront>();
+	private readonly List<CreateInvalidationRequest> _requests = [];
+
+	public CloudFrontCacheInvalidatorTests() =>
+		A.CallTo(() => _cloudFrontClient.CreateInvalidationAsync(A<CreateInvalidationRequest>._, A<Cancel>._))
+			.Invokes((CreateInvalidationRequest request, Cancel _) => _requests.Add(request))
+			.Returns(new CreateInvalidationResponse());
+
+	private CloudFrontCacheInvalidator CreateInvalidator() => new(_cloudFrontClient, DistributionId);
+
+	[Fact]
+	public async Task InvalidateAsync_SendsExpectedPathsAndCallerReference()
+	{
+		var invalidator = CreateInvalidator();
+		var paths = new[] { "/index.json", "/elastic/elasticsearch/8.16/openapi.json" };
+
+		await invalidator.InvalidateAsync(paths, "request-id-1", TestContext.Current.CancellationToken);
+
+		var request = _requests.Should().ContainSingle().Subject;
+		request.DistributionId.Should().Be(DistributionId);
+		request.InvalidationBatch.CallerReference.Should().Be("request-id-1");
+		request.InvalidationBatch.Paths.Quantity.Should().Be(2);
+		request.InvalidationBatch.Paths.Items.Should().BeEquivalentTo(paths);
+	}
+
+	[Fact]
+	public async Task InvalidateAsync_EmptyPaths_DoesNotCallCloudFront()
+	{
+		var invalidator = CreateInvalidator();
+
+		await invalidator.InvalidateAsync([], "request-id-1", TestContext.Current.CancellationToken);
+
+		A.CallTo(() => _cloudFrontClient.CreateInvalidationAsync(A<CreateInvalidationRequest>._, A<Cancel>._))
+			.MustNotHaveHappened();
+	}
+
+	[Fact]
+	public async Task InvalidateAsync_CloudFrontFailure_PropagatesException()
+	{
+		A.CallTo(() => _cloudFrontClient.CreateInvalidationAsync(A<CreateInvalidationRequest>._, A<Cancel>._))
+			.Throws(new AmazonCloudFrontException("Access denied"));
+
+		var act = () => CreateInvalidator().InvalidateAsync(["/index.json"], "request-id-1", TestContext.Current.CancellationToken);
+
+		await act.Should().ThrowAsync<AmazonCloudFrontException>();
+	}
+}

--- a/tests/Elastic.Documentation.OpenApiIndex.Tests/OpenApiInvalidationPathsTests.cs
+++ b/tests/Elastic.Documentation.OpenApiIndex.Tests/OpenApiInvalidationPathsTests.cs
@@ -1,0 +1,50 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using AwesomeAssertions;
+
+namespace Elastic.Documentation.OpenApiIndex.Tests;
+
+public class OpenApiInvalidationPathsTests
+{
+	[Fact]
+	public void Build_AlwaysIncludesIndexJson()
+	{
+		var paths = OpenApiInvalidationPaths.Build([]);
+
+		paths.Should().ContainSingle().Which.Should().Be("/index.json");
+	}
+
+	[Fact]
+	public void Build_AddsLeadingSlashForEachObjectKey()
+	{
+		var paths = OpenApiInvalidationPaths.Build(["elastic/elasticsearch/8.16/openapi.json"]);
+
+		paths.Should().BeEquivalentTo(
+		[
+			"/index.json",
+			"/elastic/elasticsearch/8.16/openapi.json"
+		]);
+	}
+
+	[Fact]
+	public void Build_DeduplicatesRepeatedKeys()
+	{
+		var paths = OpenApiInvalidationPaths.Build(
+		[
+			"elastic/elasticsearch/8.16/openapi.json",
+			"elastic/elasticsearch/8.16/openapi.json"
+		]);
+
+		paths.Should().HaveCount(2);
+	}
+
+	[Fact]
+	public void Build_TrimsLeadingSlashFromObjectKeys()
+	{
+		var paths = OpenApiInvalidationPaths.Build(["/elastic/kibana/9.5/openapi.yaml"]);
+
+		paths.Should().Contain("/elastic/kibana/9.5/openapi.yaml");
+	}
+}


### PR DESCRIPTION
## Summary
- After each successful `index.json` refresh, call CloudFront `CreateInvalidation` for `/index.json` and every object key in the SQS batch
- Invalidation failures fail the invocation so SQS retries (fail+retry freshness guarantee)
- Add `CloudFrontCacheInvalidator`, `OpenApiInvalidationPaths`, and unit tests

## Test plan
- [x] `dotnet test tests/Elastic.Documentation.OpenApiIndex.Tests/` (34 passed)
- [ ] After merge: docs-builder Release packages `openapi-index-updater-lambda.zip`; docs-internal-workflows deploy job updates `elastic-docs-v3-openapi-index-updater`
- [ ] With docs-infra PR applied: mutate a version tip, wait for Lambda, `curl` CloudFront for object + `index.json` and confirm new body without waiting for TTL

Part of elastic/docs-eng-team#717.

Made with [Cursor](https://cursor.com)