### PR TITLE
docs: set Logstash (stack) current branch to 9.5

### DIFF
--- a/config/assembler.yml
+++ b/config/assembler.yml
@@ -52,7 +52,7 @@ environments:
 
 shared_configuration:
   stack: &stack
-    current:  9.4
+    current:  9.5
     next: main
     edge: main
 


### PR DESCRIPTION
## Summary

- Bumps the `stack` shared configuration's `current` branch from `9.4` to `9.5`.
- `logstash` (and `beats`) inherit this via `*stack`.

## Why

Logstash 9.5.0 was released and its release notes were merged ([elastic/logstash#19356](https://github.com/elastic/logstash/pull/19356), backported to `main` via [#19376](https://github.com/elastic/logstash/pull/19376)). The `9.5` branch exists and docs-build runs successfully on it, but docs-deploy is a no-op because `9.5` is not registered as a content source. Setting `current: 9.5` fixes that.

## Test plan

- [ ] Verify docs-deploy runs (and succeeds) for the `9.5` branch on `elastic/logstash` after merge.
- [ ] Confirm `elastic.co/docs` serves Logstash 9.5 content as current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)