### PR TITLE
nav: swap elastic-agent nav entry edot-collector → otel-collector, remove phantom

### DIFF
--- a/config/navigation.yml
+++ b/config/navigation.yml
@@ -12,9 +12,6 @@ phantoms:
   - toc: docs-content://release-notes/apm-agents
   - toc: docs-content://
   - toc: cloud://release-notes
-  # Temporary: elastic-agent renames reference/edot-collector → reference/otel-collector (elastic/elastic-agent#16022).
-  # Remove this phantom and update the nav entry below once that PR merges.
-  - toc: elastic-agent://reference/otel-collector
 
 toc:
   #############
@@ -478,8 +475,8 @@ toc:
                     path_prefix: reference/opentelemetry/edot-cloud-forwarder/azure
                   - toc: opentelemetry://reference/edot-cloud-forwarder/gcp
                     path_prefix: reference/opentelemetry/edot-cloud-forwarder/gcp
-              - toc: elastic-agent://reference/edot-collector
-                path_prefix: reference/edot-collector
+              - toc: elastic-agent://reference/otel-collector
+                path_prefix: reference/otel-collector
               - toc: apm-agent-android://reference/edot-android
                 path_prefix: reference/opentelemetry/edot-sdks/android
               - toc: elastic-otel-dotnet://reference/edot-dotnet

--- a/config/navigation_preview.yml
+++ b/config/navigation_preview.yml
@@ -361,8 +361,8 @@ toc:
                         path_prefix: reference/opentelemetry/edot-cloud-forwarder/azure
                       - toc: opentelemetry://reference/edot-cloud-forwarder/gcp
                         path_prefix: reference/opentelemetry/edot-cloud-forwarder/gcp
-                  - toc: elastic-agent://reference/edot-collector
-                    path_prefix: reference/edot-collector
+                  - toc: elastic-agent://reference/otel-collector
+                    path_prefix: reference/otel-collector
                     island: true
                   - toc: apm-agent-android://reference/edot-android
                     path_prefix: reference/opentelemetry/edot-sdks/android

--- a/config/navigation_preview.yml
+++ b/config/navigation_preview.yml
@@ -13,9 +13,6 @@ phantoms:
   - toc: docs-content://release-notes/apm-agents
   - toc: docs-content://
   - toc: cloud://release-notes
-  # Temporary: elastic-agent renames reference/edot-collector → reference/otel-collector (elastic/elastic-agent#16022).
-  # Remove this phantom and update the nav entry below once that PR merges.
-  - toc: elastic-agent://reference/otel-collector
 
 toc:
   ##########


### PR DESCRIPTION
## Summary

Follows elastic/elastic-agent#16022, elastic/docs-content#7807, and elastic/opentelemetry#654 merging. Swaps the global nav entry from `edot-collector` to `otel-collector` and removes the temporary phantom added in #3903.

**CI note:** `validate-assembler` fails until docs-content#7807 and opentelemetry#654 merge (other repos still have `edot-collector` cross-links). `build` (assembler-preview) fails until elastic-agent#16022 merges (nav entry can't resolve `otel-collector` toc against elastic-agent main). Both checks go green once all three prerequisite PRs have landed — no admin bypass needed.

## Merge sequence (all 5 PRs)

This is a coordinated 5-PR rename. ~~elastic/docs-builder#3795~~ is already merged via #3903.

Merge in order:

1. ~~**elastic/docs-builder#3795**~~ ✓ merged via #3903
2. **elastic/elastic-agent#16022** — renames `reference/edot-collector/` → `reference/otel-collector/`; publishes new link index
3. **elastic/docs-content#7807 + elastic/opentelemetry#654** — simultaneously; CI unblocks once the elastic-agent link index updates
4. **This PR** — swaps nav entry + removes phantom; both CI checks are green at this point (no admin bypass needed)

Tracked by [elastic/docs-content#7801](https://github.com/elastic/docs-content/issues/7801).

🤖 Generated with [Claude Code](https://claude.com/claude-code)