### PR TITLE
ApiExplorer: match bump.sh URL path scheme

### DIFF
--- a/src/Elastic.ApiExplorer/Export/OpenApiDocumentExporter.cs
+++ b/src/Elastic.ApiExplorer/Export/OpenApiDocumentExporter.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
+using Elastic.ApiExplorer.Infrastructure;
 using Elastic.ApiExplorer.Model;
 using Elastic.ApiExplorer.Operations;
 using Elastic.Documentation;
@@ -112,6 +113,8 @@ public partial class OpenApiDocumentExporter(
 	/// </summary>
 	internal IEnumerable<DocumentationDocument> ConvertToDocuments(OpenApiDocument openApiDocument, string product)
 	{
+		var productUrl = ApiUrlBuilder.ProductRoot("/docs", product);
+
 		foreach (var path in openApiDocument.Paths)
 		{
 			if (path.Value.Operations == null)
@@ -125,7 +128,8 @@ public partial class OpenApiDocumentExporter(
 				if (!ShouldIncludeOperation(operation.Value))
 					continue;
 
-				var url = $"/docs/api/doc/{product}/operation/operation-{operationId.ToLowerInvariant()}";
+				var operationMoniker = ApiUrlBuilder.OperationMoniker(operationId, path.Key);
+				var url = $"{productUrl}/operation/{operationMoniker}";
 
 				var productName = CultureInfo.InvariantCulture.TextInfo.ToTitleCase(product);
 				// Trim: spec summaries occasionally carry stray leading/trailing whitespace or a
@@ -191,7 +195,7 @@ public partial class OpenApiDocumentExporter(
 					Parents =
 					[
 						new ParentDocument { Title = "API Reference", Path = "/docs/api" },
-						new ParentDocument { Title = product, Path = $"/docs/api/doc/{product}" }
+						new ParentDocument { Title = product, Path = productUrl }
 					],
 					Product = inference?.Product?.Id,
 					RelatedProducts = inference?.RelatedProducts.Count > 0

--- a/src/Elastic.ApiExplorer/Infrastructure/ApiMarkdown.cs
+++ b/src/Elastic.ApiExplorer/Infrastructure/ApiMarkdown.cs
@@ -23,18 +23,10 @@ public static partial class ApiMarkdown
 			return HtmlString.Empty;
 
 		var escaped = MustachePattern().Replace(markdown, match => $"`{match.Value}`");
-		var rewritten = RewriteIntraApiLinks(escaped, ResolveApiBaseUrl(context.CurrentNavigation.Url));
+		var rewritten = RewriteIntraApiLinks(escaped, context.CurrentNavigation.NavigationRoot.Url);
 		var source = CreateVirtualSource(context);
 		var html = context.MarkdownRenderer.RenderApiDescription(rewritten, source);
 		return new HtmlString(html);
-	}
-
-	private static string ResolveApiBaseUrl(string currentNavigationUrl)
-	{
-		var match = ApiBaseUrlPattern().Match(currentNavigationUrl);
-		return match.Success
-			? match.Groups[1].Value
-			: currentNavigationUrl.TrimEnd('/') + "/";
 	}
 
 	private static string RewriteIntraApiLinks(string markdown, string apiBaseUrl)
@@ -61,9 +53,6 @@ public static partial class ApiMarkdown
 
 	[GeneratedRegex(@"\]\(\.\./operation/([^)#]+)\)")]
 	private static partial Regex OperationLinkPattern();
-
-	[GeneratedRegex(@"^(.*/api/doc/[^/]+/)")]
-	private static partial Regex ApiBaseUrlPattern();
 
 	// Regex to match mustache-style patterns like {{var}} or {{{var}}} that conflict with docs-builder substitutions
 	[GeneratedRegex(@"\{\{\{?[^}]+\}?\}\}")]

--- a/src/Elastic.ApiExplorer/Infrastructure/ApiMarkdown.cs
+++ b/src/Elastic.ApiExplorer/Infrastructure/ApiMarkdown.cs
@@ -62,7 +62,7 @@ public static partial class ApiMarkdown
 	[GeneratedRegex(@"\]\(\.\./operation/([^)#]+)\)")]
 	private static partial Regex OperationLinkPattern();
 
-	[GeneratedRegex(@"^(.*/api/[^/]+/)")]
+	[GeneratedRegex(@"^(.*/api/doc/[^/]+/)")]
 	private static partial Regex ApiBaseUrlPattern();
 
 	// Regex to match mustache-style patterns like {{var}} or {{{var}}} that conflict with docs-builder substitutions

--- a/src/Elastic.ApiExplorer/Infrastructure/ApiMarkdown.cs
+++ b/src/Elastic.ApiExplorer/Infrastructure/ApiMarkdown.cs
@@ -40,8 +40,8 @@ public static partial class ApiMarkdown
 	private static string RewriteIntraApiLinks(string markdown, string apiBaseUrl)
 	{
 		var baseUrl = apiBaseUrl.TrimEnd('/') + "/";
-		var rewritten = GroupLinkPattern().Replace(markdown, match => $"]({baseUrl}tags/{match.Groups[1].Value}/)");
-		return OperationLinkPattern().Replace(rewritten, match => $"]({baseUrl}{match.Groups[1].Value}/)");
+		var rewritten = GroupLinkPattern().Replace(markdown, match => $"]({baseUrl}group/{match.Groups[1].Value})");
+		return OperationLinkPattern().Replace(rewritten, match => $"]({baseUrl}operation/{match.Groups[1].Value})");
 	}
 
 	private static IFileInfo CreateVirtualSource(ApiRenderContext context)

--- a/src/Elastic.ApiExplorer/Infrastructure/ApiUrlBuilder.cs
+++ b/src/Elastic.ApiExplorer/Infrastructure/ApiUrlBuilder.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Text.RegularExpressions;
 using Elastic.ApiExplorer.Model;
 using Elastic.ApiExplorer.Operations;
 namespace Elastic.ApiExplorer.Infrastructure;
@@ -9,7 +10,7 @@ namespace Elastic.ApiExplorer.Infrastructure;
 /// <summary>
 /// The single source of URL path segments (monikers) for API explorer pages.
 /// </summary>
-public static class ApiUrlBuilder
+public static partial class ApiUrlBuilder
 {
 	/// <summary>
 	/// Deterministic URL leaf for an operation page under <c>.../operation/</c>: lowercase
@@ -36,13 +37,18 @@ public static class ApiUrlBuilder
 
 		var s = tagName.Trim();
 		s = string.Join(" ", s.Split(' ', StringSplitOptions.RemoveEmptyEntries));
+		s = ParentheticalSuffixPattern().Replace(s, "-$1");
 		s = s.Replace("{", string.Empty, StringComparison.Ordinal);
 		s = s.Replace("}", string.Empty, StringComparison.Ordinal);
 		s = s.Replace("/", "-", StringComparison.Ordinal);
 		s = s.Replace(" ", "-", StringComparison.Ordinal);
+		s = s.ToLowerInvariant();
 		if (string.IsNullOrEmpty(s))
 			return "endpoint-unknown";
 
 		return $"endpoint-{s}";
 	}
+
+	[GeneratedRegex(@"\s*\(([^)]+)\)")]
+	private static partial Regex ParentheticalSuffixPattern();
 }

--- a/src/Elastic.ApiExplorer/Infrastructure/ApiUrlBuilder.cs
+++ b/src/Elastic.ApiExplorer/Infrastructure/ApiUrlBuilder.cs
@@ -12,6 +12,9 @@ namespace Elastic.ApiExplorer.Infrastructure;
 /// </summary>
 public static partial class ApiUrlBuilder
 {
+	/// <summary>Product root URL: <c>{prefix}/api/doc/{key}</c> with no trailing slash.</summary>
+	public static string ProductRoot(string? urlPathPrefix, string apiUrlSuffix) =>
+		$"{urlPathPrefix?.TrimEnd('/')}/api/doc/{apiUrlSuffix}";
 	/// <summary>
 	/// Deterministic URL leaf for an operation page under <c>.../operation/</c>: lowercase
 	/// <c>operation-{id}</c> when an operation id is present, otherwise derived from the route.

--- a/src/Elastic.ApiExplorer/Infrastructure/ApiUrlBuilder.cs
+++ b/src/Elastic.ApiExplorer/Infrastructure/ApiUrlBuilder.cs
@@ -12,23 +12,27 @@ namespace Elastic.ApiExplorer.Infrastructure;
 public static class ApiUrlBuilder
 {
 	/// <summary>
-	/// Deterministic URL segment for an operation page: the operation id when present,
-	/// otherwise derived from the route (braces stripped, slashes to dashes).
+	/// Deterministic URL leaf for an operation page under <c>.../operation/</c>: lowercase
+	/// <c>operation-{id}</c> when an operation id is present, otherwise derived from the route.
 	/// </summary>
-	public static string OperationMoniker(string? operationId, string route) =>
-		!string.IsNullOrWhiteSpace(operationId)
+	public static string OperationMoniker(string? operationId, string route)
+	{
+		var id = !string.IsNullOrWhiteSpace(operationId)
 			? operationId
-			: route.Replace("}", "").Replace("{", "").Replace('/', '-');
+			: route.Replace("}", "").Replace("{", "").Replace('/', '-').Trim('-');
+
+		return $"operation-{id.ToLowerInvariant()}";
+	}
 
 	/// <summary>Deterministic URL segment for a schema type page under <c>.../types/</c>.</summary>
 	public static string SchemaMoniker(string schemaId) =>
 		schemaId.Replace('.', '-').ToLowerInvariant();
 
-	/// <summary>Deterministic single URL segment for <c>.../tags/{segment}/</c> from the canonical tag name.</summary>
+	/// <summary>Deterministic URL leaf for <c>.../group/{segment}</c> from the canonical tag name.</summary>
 	public static string TagMoniker(string? tagName)
 	{
 		if (string.IsNullOrWhiteSpace(tagName))
-			return "unknown";
+			return "endpoint-unknown";
 
 		var s = tagName.Trim();
 		s = string.Join(" ", s.Split(' ', StringSplitOptions.RemoveEmptyEntries));
@@ -37,8 +41,8 @@ public static class ApiUrlBuilder
 		s = s.Replace("/", "-", StringComparison.Ordinal);
 		s = s.Replace(" ", "-", StringComparison.Ordinal);
 		if (string.IsNullOrEmpty(s))
-			return "unknown";
+			return "endpoint-unknown";
 
-		return s;
+		return $"endpoint-{s}";
 	}
 }

--- a/src/Elastic.ApiExplorer/Infrastructure/ApiUrlBuilder.cs
+++ b/src/Elastic.ApiExplorer/Infrastructure/ApiUrlBuilder.cs
@@ -12,9 +12,12 @@ namespace Elastic.ApiExplorer.Infrastructure;
 /// </summary>
 public static partial class ApiUrlBuilder
 {
-	/// <summary>Product root URL: <c>{prefix}/api/doc/{key}</c> with no trailing slash.</summary>
+	public static string ApiRoot(string? urlPathPrefix) =>
+		$"{urlPathPrefix?.TrimEnd('/')}/api";
+
 	public static string ProductRoot(string? urlPathPrefix, string apiUrlSuffix) =>
-		$"{urlPathPrefix?.TrimEnd('/')}/api/doc/{apiUrlSuffix}";
+		$"{ApiRoot(urlPathPrefix)}/doc/{apiUrlSuffix}";
+
 	/// <summary>
 	/// Deterministic URL leaf for an operation page under <c>.../operation/</c>: lowercase
 	/// <c>operation-{id}</c> when an operation id is present, otherwise derived from the route.

--- a/src/Elastic.ApiExplorer/Landing/LandingNavigationItem.cs
+++ b/src/Elastic.ApiExplorer/Landing/LandingNavigationItem.cs
@@ -129,7 +129,7 @@ public class TagNavigationItem(
 )
 	: ApiGroupingNavigationItem<ApiTag, IEndpointOrOperationNavigationItem>(tag, rootNavigation, parent)
 {
-	private readonly string _url = $"{urlPathPrefix?.TrimEnd('/')}/api/{apiUrlSuffix}/group/{tag.TagUrlSegment}";
+	private readonly string _url = $"{ApiUrlBuilder.ProductRoot(urlPathPrefix, apiUrlSuffix)}/group/{tag.TagUrlSegment}";
 
 	/// <inheritdoc />
 	public override string Url => _url;

--- a/src/Elastic.ApiExplorer/Landing/LandingNavigationItem.cs
+++ b/src/Elastic.ApiExplorer/Landing/LandingNavigationItem.cs
@@ -129,7 +129,7 @@ public class TagNavigationItem(
 )
 	: ApiGroupingNavigationItem<ApiTag, IEndpointOrOperationNavigationItem>(tag, rootNavigation, parent)
 {
-	private readonly string _url = $"{urlPathPrefix?.TrimEnd('/')}/api/{apiUrlSuffix}/tags/{tag.TagUrlSegment}/";
+	private readonly string _url = $"{urlPathPrefix?.TrimEnd('/')}/api/{apiUrlSuffix}/group/{tag.TagUrlSegment}";
 
 	/// <inheritdoc />
 	public override string Url => _url;

--- a/src/Elastic.ApiExplorer/Landing/SimpleMarkdownNavigationItem.cs
+++ b/src/Elastic.ApiExplorer/Landing/SimpleMarkdownNavigationItem.cs
@@ -49,7 +49,7 @@ public class SimpleMarkdownNavigationItem(
 	/// <summary>Throws if the slug collides with reserved API Explorer path segments.</summary>
 	public static void ValidateSlugForCollisions(string slug, string productKey, string filePath)
 	{
-		string[] reservedSegments = ["types", "group", "operation", "doc"];
+		string[] reservedSegments = ["types", "group", "operation"];
 
 		if (reservedSegments.Contains(slug, StringComparer.OrdinalIgnoreCase))
 		{

--- a/src/Elastic.ApiExplorer/Landing/SimpleMarkdownNavigationItem.cs
+++ b/src/Elastic.ApiExplorer/Landing/SimpleMarkdownNavigationItem.cs
@@ -46,21 +46,15 @@ public class SimpleMarkdownNavigationItem(
 			.Replace('_', '-');
 	}
 
-	/// <summary>Throws if the slug collides with reserved API Explorer segments or an operation moniker.</summary>
-	public static void ValidateSlugForCollisions(string slug, string productKey, string filePath, HashSet<string>? operationMonikers = null)
+	/// <summary>Throws if the slug collides with reserved API Explorer path segments.</summary>
+	public static void ValidateSlugForCollisions(string slug, string productKey, string filePath)
 	{
-		string[] reservedSegments = ["types", "tags"];
+		string[] reservedSegments = ["types", "group", "operation"];
 
 		if (reservedSegments.Contains(slug, StringComparer.OrdinalIgnoreCase))
 		{
 			throw new InvalidOperationException(
 				$"Markdown file slug '{slug}' (from '{filePath}') conflicts with reserved API Explorer segment in product '{productKey}'. Reserved segments: {string.Join(", ", reservedSegments)}");
-		}
-
-		if (operationMonikers != null && operationMonikers.Contains(slug))
-		{
-			throw new InvalidOperationException(
-				$"Markdown file slug '{slug}' (from '{filePath}') conflicts with existing operation moniker in product '{productKey}'. Consider renaming the markdown file to avoid this collision.");
 		}
 	}
 

--- a/src/Elastic.ApiExplorer/Landing/SimpleMarkdownNavigationItem.cs
+++ b/src/Elastic.ApiExplorer/Landing/SimpleMarkdownNavigationItem.cs
@@ -49,7 +49,7 @@ public class SimpleMarkdownNavigationItem(
 	/// <summary>Throws if the slug collides with reserved API Explorer path segments.</summary>
 	public static void ValidateSlugForCollisions(string slug, string productKey, string filePath)
 	{
-		string[] reservedSegments = ["types", "group", "operation"];
+		string[] reservedSegments = ["types", "group", "operation", "doc"];
 
 		if (reservedSegments.Contains(slug, StringComparer.OrdinalIgnoreCase))
 		{

--- a/src/Elastic.ApiExplorer/Navigation/ApiNavigationBuilder.cs
+++ b/src/Elastic.ApiExplorer/Navigation/ApiNavigationBuilder.cs
@@ -140,14 +140,6 @@ public class ApiNavigationBuilder(ILogger logger, BuildContext context)
 		// Add schema type pages for shared types
 		CreateSchemaNavigationItems(apiUrlSuffix, openApiDocument, rootNavigation, topLevelNavigationItems);
 
-		// Collect operation monikers for collision detection
-		var operationMonikers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-		foreach (var path in openApiDocument.Paths)
-		{
-			foreach (var operation in path.Value.Operations ?? [])
-				_ = operationMonikers.Add(ApiUrlBuilder.OperationMoniker(operation.Value.OperationId, path.Key));
-		}
-
 		// Add explicit children declared via 'children:' below the landing page and before the
 		// generated OpenAPI groups, in declared order.
 		var finalNavigationItems = new List<INavigationItem>();
@@ -157,7 +149,7 @@ public class ApiNavigationBuilder(ILogger logger, BuildContext context)
 		{
 			foreach (var childFile in apiConfig.Children)
 			{
-				var childNavItem = CreateMarkdownNavigationItem(apiUrlSuffix, childFile, rootNavigation, rootNavigation, operationMonikers, markdownSlugs);
+				var childNavItem = CreateMarkdownNavigationItem(apiUrlSuffix, childFile, rootNavigation, rootNavigation, markdownSlugs);
 				finalNavigationItems.Add(childNavItem);
 			}
 		}
@@ -180,7 +172,6 @@ public class ApiNavigationBuilder(ILogger logger, BuildContext context)
 		IFileInfo markdownFile,
 		LandingNavigationItem rootNavigation,
 		INodeNavigationItem<INavigationModel, INavigationItem> parent,
-		HashSet<string> operationMonikers,
 		HashSet<string> markdownSlugs)
 	{
 		var slug = SimpleMarkdownNavigationItem.CreateSlugFromFile(markdownFile);
@@ -193,7 +184,7 @@ public class ApiNavigationBuilder(ILogger logger, BuildContext context)
 				$"File: {markdownFile.FullName}");
 		}
 
-		SimpleMarkdownNavigationItem.ValidateSlugForCollisions(slug, apiUrlSuffix, markdownFile.FullName, operationMonikers);
+		SimpleMarkdownNavigationItem.ValidateSlugForCollisions(slug, apiUrlSuffix, markdownFile.FullName);
 
 		var url = $"{context.UrlPathPrefix}/api/{apiUrlSuffix}/{slug}/";
 		var title = MarkdownNavigationTitleReader.GetNavigationTitle(context.ReadFileSystem, markdownFile);

--- a/src/Elastic.ApiExplorer/Navigation/ApiNavigationBuilder.cs
+++ b/src/Elastic.ApiExplorer/Navigation/ApiNavigationBuilder.cs
@@ -29,7 +29,7 @@ public class ApiNavigationBuilder(ILogger logger, BuildContext context)
 
 	public LandingNavigationItem CreateNavigation(string apiUrlSuffix, OpenApiDocument openApiDocument, ResolvedApiConfiguration? apiConfig = null)
 	{
-		var url = $"{context.UrlPathPrefix}/api/" + apiUrlSuffix;
+		var url = ApiUrlBuilder.ProductRoot(context.UrlPathPrefix, apiUrlSuffix);
 		var rootNavigation = new LandingNavigationItem(url);
 
 		var tagMetadataByName = OpenApiExtensionReader.ParseTagMetadata(openApiDocument);
@@ -186,7 +186,7 @@ public class ApiNavigationBuilder(ILogger logger, BuildContext context)
 
 		SimpleMarkdownNavigationItem.ValidateSlugForCollisions(slug, apiUrlSuffix, markdownFile.FullName);
 
-		var url = $"{context.UrlPathPrefix}/api/{apiUrlSuffix}/{slug}/";
+		var url = $"{ApiUrlBuilder.ProductRoot(context.UrlPathPrefix, apiUrlSuffix)}/{slug}/";
 		var title = MarkdownNavigationTitleReader.GetNavigationTitle(context.ReadFileSystem, markdownFile);
 
 		// Create simple navigation item - will be handled by regular documentation system

--- a/src/Elastic.ApiExplorer/OpenApiGenerator.cs
+++ b/src/Elastic.ApiExplorer/OpenApiGenerator.cs
@@ -65,7 +65,7 @@ public class OpenApiGenerator(
 				var title = openApiDocument.Info?.Title
 					?? apiConfig.Product.DisplayName
 					?? prefix;
-				var url = $"{context.UrlPathPrefix}/api/{prefix}/";
+				var url = $"{ApiUrlBuilder.ProductRoot(context.UrlPathPrefix, prefix)}/";
 				catalogEntries.Add(new ApiCatalogEntry(prefix, title, url));
 			}
 			catch (Exception ex) when (ex is not OperationCanceledException)

--- a/src/Elastic.ApiExplorer/OpenApiGenerator.cs
+++ b/src/Elastic.ApiExplorer/OpenApiGenerator.cs
@@ -118,7 +118,7 @@ public class OpenApiGenerator(
 
 	private async Task GenerateApiCatalog(IReadOnlyList<ApiCatalogEntry> entries, Cancel ctx)
 	{
-		var catalogUrl = $"{context.UrlPathPrefix}/api/";
+		var catalogUrl = $"{ApiUrlBuilder.ApiRoot(context.UrlPathPrefix)}/";
 		var navigation = new ApiCatalogNavigationItem(catalogUrl, entries);
 		var navigationRenderer = new IsolatedBuildNavigationHtmlWriter(context, navigation);
 

--- a/src/Elastic.ApiExplorer/Operations/OperationNavigationItem.cs
+++ b/src/Elastic.ApiExplorer/Operations/OperationNavigationItem.cs
@@ -42,7 +42,7 @@ public class OperationNavigationItem : ILeafNavigationItem<ApiOperation>, IEndpo
 		NavigationTitle = apiOperation.ApiName;
 		Parent = parent;
 		var moniker = ApiUrlBuilder.OperationMoniker(apiOperation.Operation.OperationId, apiOperation.Route);
-		Url = $"{urlPathPrefix?.TrimEnd('/')}/api/{apiUrlSuffix}/operation/{moniker}";
+		Url = $"{ApiUrlBuilder.ProductRoot(urlPathPrefix, apiUrlSuffix)}/operation/{moniker}";
 		Id = ShortId.Create(Url);
 	}
 

--- a/src/Elastic.ApiExplorer/Operations/OperationNavigationItem.cs
+++ b/src/Elastic.ApiExplorer/Operations/OperationNavigationItem.cs
@@ -42,7 +42,7 @@ public class OperationNavigationItem : ILeafNavigationItem<ApiOperation>, IEndpo
 		NavigationTitle = apiOperation.ApiName;
 		Parent = parent;
 		var moniker = ApiUrlBuilder.OperationMoniker(apiOperation.Operation.OperationId, apiOperation.Route);
-		Url = $"{urlPathPrefix?.TrimEnd('/')}/api/{apiUrlSuffix}/{moniker}";
+		Url = $"{urlPathPrefix?.TrimEnd('/')}/api/{apiUrlSuffix}/operation/{moniker}";
 		Id = ShortId.Create(Url);
 	}
 

--- a/src/Elastic.ApiExplorer/Types/SchemaNavigationItem.cs
+++ b/src/Elastic.ApiExplorer/Types/SchemaNavigationItem.cs
@@ -43,7 +43,7 @@ public class SchemaNavigationItem : ILeafNavigationItem<ApiSchema>
 		NavigationTitle = apiSchema.DisplayName;
 		Parent = parent;
 		var moniker = ApiUrlBuilder.SchemaMoniker(apiSchema.SchemaId);
-		Url = $"{urlPathPrefix?.TrimEnd('/')}/api/{apiUrlSuffix}/types/{moniker}";
+		Url = $"{ApiUrlBuilder.ProductRoot(urlPathPrefix, apiUrlSuffix)}/types/{moniker}";
 		Id = ShortId.Create(Url);
 	}
 

--- a/tests/Elastic.ApiExplorer.Tests/ApiMarkdownIntraApiLinkTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/ApiMarkdownIntraApiLinkTests.cs
@@ -41,7 +41,7 @@ public class ApiMarkdownIntraApiLinkTests
 		var renderContext = new ApiRenderContext(context, new OpenApiDocument(), new StaticFileContentHashProvider(new EmbeddedOrPhysicalFileProvider(context)))
 		{
 			NavigationHtml = string.Empty,
-			CurrentNavigation = new StubNavigationItem("/api/kibana/operation/operation-foo"),
+			CurrentNavigation = new StubNavigationItem("/api/doc/kibana/operation/operation-foo"),
 			MarkdownRenderer = renderer,
 			ApiExplorerLog = null
 		};
@@ -52,8 +52,8 @@ public class ApiMarkdownIntraApiLinkTests
 
 		_ = ApiMarkdown.Render(renderContext, markdown);
 
-		renderer.LastMarkdown.Should().Contain("(/api/kibana/group/endpoint-data-views)");
-		renderer.LastMarkdown.Should().Contain("(/api/kibana/operation/operation-post-saved-objects-export)");
+		renderer.LastMarkdown.Should().Contain("(/api/doc/kibana/group/endpoint-data-views)");
+		renderer.LastMarkdown.Should().Contain("(/api/doc/kibana/operation/operation-post-saved-objects-export)");
 	}
 
 	private sealed class StubNavigationItem(string url) : INavigationItem

--- a/tests/Elastic.ApiExplorer.Tests/ApiMarkdownIntraApiLinkTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/ApiMarkdownIntraApiLinkTests.cs
@@ -41,7 +41,7 @@ public class ApiMarkdownIntraApiLinkTests
 		var renderContext = new ApiRenderContext(context, new OpenApiDocument(), new StaticFileContentHashProvider(new EmbeddedOrPhysicalFileProvider(context)))
 		{
 			NavigationHtml = string.Empty,
-			CurrentNavigation = new StubNavigationItem("/api/kibana/operation-foo/"),
+			CurrentNavigation = new StubNavigationItem("/api/kibana/operation/operation-foo"),
 			MarkdownRenderer = renderer,
 			ApiExplorerLog = null
 		};
@@ -52,8 +52,8 @@ public class ApiMarkdownIntraApiLinkTests
 
 		_ = ApiMarkdown.Render(renderContext, markdown);
 
-		renderer.LastMarkdown.Should().Contain("(/api/kibana/tags/endpoint-data-views/)");
-		renderer.LastMarkdown.Should().Contain("(/api/kibana/operation-post-saved-objects-export/)");
+		renderer.LastMarkdown.Should().Contain("(/api/kibana/group/endpoint-data-views)");
+		renderer.LastMarkdown.Should().Contain("(/api/kibana/operation/operation-post-saved-objects-export)");
 	}
 
 	private sealed class StubNavigationItem(string url) : INavigationItem

--- a/tests/Elastic.ApiExplorer.Tests/ApiMarkdownIntraApiLinkTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/ApiMarkdownIntraApiLinkTests.cs
@@ -5,12 +5,12 @@
 using System.IO.Abstractions;
 using AwesomeAssertions;
 using Elastic.ApiExplorer.Infrastructure;
+using Elastic.ApiExplorer.Landing;
 using Elastic.ApiExplorer.Model;
 using Elastic.ApiExplorer.Operations;
 using Elastic.Documentation;
 using Elastic.Documentation.Configuration;
 using Elastic.Documentation.Diagnostics;
-using Elastic.Documentation.Navigation;
 using Elastic.Documentation.Site.FileProviders;
 using Microsoft.OpenApi;
 using Nullean.ScopedFileSystem;
@@ -41,7 +41,7 @@ public class ApiMarkdownIntraApiLinkTests
 		var renderContext = new ApiRenderContext(context, new OpenApiDocument(), new StaticFileContentHashProvider(new EmbeddedOrPhysicalFileProvider(context)))
 		{
 			NavigationHtml = string.Empty,
-			CurrentNavigation = new StubNavigationItem("/api/doc/kibana/operation/operation-foo"),
+			CurrentNavigation = new LandingNavigationItem("/api/doc/kibana").Index,
 			MarkdownRenderer = renderer,
 			ApiExplorerLog = null
 		};
@@ -54,15 +54,5 @@ public class ApiMarkdownIntraApiLinkTests
 
 		renderer.LastMarkdown.Should().Contain("(/api/doc/kibana/group/endpoint-data-views)");
 		renderer.LastMarkdown.Should().Contain("(/api/doc/kibana/operation/operation-post-saved-objects-export)");
-	}
-
-	private sealed class StubNavigationItem(string url) : INavigationItem
-	{
-		public string Url { get; } = url;
-		public string NavigationTitle => "stub";
-		public IRootNavigationItem<INavigationModel, INavigationItem> NavigationRoot => throw new NotSupportedException();
-		public INodeNavigationItem<INavigationModel, INavigationItem>? Parent { get; set; }
-		public bool Hidden => false;
-		public int NavigationIndex { get; set; }
 	}
 }

--- a/tests/Elastic.ApiExplorer.Tests/ApiPropertyTreeBuilderTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/ApiPropertyTreeBuilderTests.cs
@@ -18,7 +18,7 @@ public class ApiPropertyTreeBuilderTests(ApiExplorerFixture fixture) : IClassFix
 		var options = new PropertyDisplayOptions
 		{
 			RenderMarkdown = s => new HtmlString($"<p>{s}</p>"),
-			ApiRootUrl = "/api/fixture",
+			ApiRootUrl = "/api/doc/fixture",
 			CollapseMode = collapseMode
 		};
 		return new ApiPropertyTreeBuilder(fixture.Document, options, currentPageType);
@@ -70,7 +70,7 @@ public class ApiPropertyTreeBuilderTests(ApiExplorerFixture fixture) : IClassFix
 		aggs.Children.Kind.Should().Be(ChildKind.None, "the dictionary value type has its own page");
 		aggs.TypeLink.Should().NotBeNull();
 		aggs.TypeLink!.TypeName.Should().Be("AggregationContainer");
-		aggs.TypeLink.Url.Should().Be("/api/fixture/types/_types-aggregations-aggregationcontainer");
+		aggs.TypeLink.Url.Should().Be("/api/doc/fixture/types/_types-aggregations-aggregationcontainer");
 	}
 
 	[Fact]

--- a/tests/Elastic.ApiExplorer.Tests/KibanaApiMarkdownNavigationTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/KibanaApiMarkdownNavigationTests.cs
@@ -89,7 +89,7 @@ public class KibanaApiMarkdownNavigationTests
 	{
 		var (_, introNav) = SetupKibanaNavigation();
 
-		introNav.Url.Should().Be("/api/kibana/kibana-api-overview/");
+		introNav.Url.Should().Be("/api/doc/kibana/kibana-api-overview/");
 	}
 
 	[Fact]
@@ -98,10 +98,12 @@ public class KibanaApiMarkdownNavigationTests
 		var actTypes = () => SimpleMarkdownNavigationItem.ValidateSlugForCollisions("types", "kibana", "/docs/types.md");
 		var actGroup = () => SimpleMarkdownNavigationItem.ValidateSlugForCollisions("group", "kibana", "/docs/group.md");
 		var actOperation = () => SimpleMarkdownNavigationItem.ValidateSlugForCollisions("operation", "kibana", "/docs/operation.md");
+		var actDoc = () => SimpleMarkdownNavigationItem.ValidateSlugForCollisions("doc", "kibana", "/docs/doc.md");
 
 		actTypes.Should().Throw<InvalidOperationException>().WithMessage("*conflicts with reserved API Explorer segment*types*");
 		actGroup.Should().Throw<InvalidOperationException>().WithMessage("*conflicts with reserved API Explorer segment*group*");
 		actOperation.Should().Throw<InvalidOperationException>().WithMessage("*conflicts with reserved API Explorer segment*operation*");
+		actDoc.Should().Throw<InvalidOperationException>().WithMessage("*conflicts with reserved API Explorer segment*doc*");
 	}
 
 	[Fact]

--- a/tests/Elastic.ApiExplorer.Tests/KibanaApiMarkdownNavigationTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/KibanaApiMarkdownNavigationTests.cs
@@ -96,28 +96,26 @@ public class KibanaApiMarkdownNavigationTests
 	public void UrlCollisionValidation_ShouldDetectReservedSegments()
 	{
 		var actTypes = () => SimpleMarkdownNavigationItem.ValidateSlugForCollisions("types", "kibana", "/docs/types.md");
-		var actTags = () => SimpleMarkdownNavigationItem.ValidateSlugForCollisions("tags", "kibana", "/docs/tags.md");
+		var actGroup = () => SimpleMarkdownNavigationItem.ValidateSlugForCollisions("group", "kibana", "/docs/group.md");
+		var actOperation = () => SimpleMarkdownNavigationItem.ValidateSlugForCollisions("operation", "kibana", "/docs/operation.md");
 
 		actTypes.Should().Throw<InvalidOperationException>().WithMessage("*conflicts with reserved API Explorer segment*types*");
-		actTags.Should().Throw<InvalidOperationException>().WithMessage("*conflicts with reserved API Explorer segment*tags*");
+		actGroup.Should().Throw<InvalidOperationException>().WithMessage("*conflicts with reserved API Explorer segment*group*");
+		actOperation.Should().Throw<InvalidOperationException>().WithMessage("*conflicts with reserved API Explorer segment*operation*");
 	}
 
 	[Fact]
-	public void UrlCollisionValidation_ShouldDetectOperationMonikers()
+	public void UrlCollisionValidation_ShouldAllowSlugMatchingOperationId()
 	{
-		var operationMonikers = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "search", "index" };
+		var act = () => SimpleMarkdownNavigationItem.ValidateSlugForCollisions("search", "kibana", "/docs/search.md");
 
-		var act = () => SimpleMarkdownNavigationItem.ValidateSlugForCollisions("search", "kibana", "/docs/search.md", operationMonikers);
-
-		act.Should().Throw<InvalidOperationException>().WithMessage("*conflicts with existing operation moniker*");
+		act.Should().NotThrow();
 	}
 
 	[Fact]
 	public void UrlCollisionValidation_ShouldAllowValidSlugs()
 	{
-		var operationMonikers = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "search", "index" };
-
-		var act = () => SimpleMarkdownNavigationItem.ValidateSlugForCollisions("overview", "kibana", "/docs/overview.md", operationMonikers);
+		var act = () => SimpleMarkdownNavigationItem.ValidateSlugForCollisions("overview", "kibana", "/docs/overview.md");
 
 		act.Should().NotThrow();
 	}

--- a/tests/Elastic.ApiExplorer.Tests/KibanaApiMarkdownNavigationTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/KibanaApiMarkdownNavigationTests.cs
@@ -93,20 +93,6 @@ public class KibanaApiMarkdownNavigationTests
 	}
 
 	[Fact]
-	public void UrlCollisionValidation_ShouldDetectReservedSegments()
-	{
-		var actTypes = () => SimpleMarkdownNavigationItem.ValidateSlugForCollisions("types", "kibana", "/docs/types.md");
-		var actGroup = () => SimpleMarkdownNavigationItem.ValidateSlugForCollisions("group", "kibana", "/docs/group.md");
-		var actOperation = () => SimpleMarkdownNavigationItem.ValidateSlugForCollisions("operation", "kibana", "/docs/operation.md");
-		var actDoc = () => SimpleMarkdownNavigationItem.ValidateSlugForCollisions("doc", "kibana", "/docs/doc.md");
-
-		actTypes.Should().Throw<InvalidOperationException>().WithMessage("*conflicts with reserved API Explorer segment*types*");
-		actGroup.Should().Throw<InvalidOperationException>().WithMessage("*conflicts with reserved API Explorer segment*group*");
-		actOperation.Should().Throw<InvalidOperationException>().WithMessage("*conflicts with reserved API Explorer segment*operation*");
-		actDoc.Should().Throw<InvalidOperationException>().WithMessage("*conflicts with reserved API Explorer segment*doc*");
-	}
-
-	[Fact]
 	public void UrlCollisionValidation_ShouldAllowSlugMatchingOperationId()
 	{
 		var act = () => SimpleMarkdownNavigationItem.ValidateSlugForCollisions("search", "kibana", "/docs/search.md");

--- a/tests/Elastic.ApiExplorer.Tests/SimpleMarkdownNavigationItemTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/SimpleMarkdownNavigationItemTests.cs
@@ -32,7 +32,6 @@ public class SimpleMarkdownNavigationItemTests
 	[InlineData("types", "types")]
 	[InlineData("group", "group")]
 	[InlineData("operation", "operation")]
-	[InlineData("doc", "doc")]
 	public void ValidateSlugForCollisions_ThrowsForReservedSegments(string slug, string reservedSegment)
 	{
 		var act = () => SimpleMarkdownNavigationItem.ValidateSlugForCollisions(

--- a/tests/Elastic.ApiExplorer.Tests/SimpleMarkdownNavigationItemTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/SimpleMarkdownNavigationItemTests.cs
@@ -32,6 +32,7 @@ public class SimpleMarkdownNavigationItemTests
 	[InlineData("types", "types")]
 	[InlineData("group", "group")]
 	[InlineData("operation", "operation")]
+	[InlineData("doc", "doc")]
 	public void ValidateSlugForCollisions_ThrowsForReservedSegments(string slug, string reservedSegment)
 	{
 		var act = () => SimpleMarkdownNavigationItem.ValidateSlugForCollisions(

--- a/tests/Elastic.ApiExplorer.Tests/SimpleMarkdownNavigationItemTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/SimpleMarkdownNavigationItemTests.cs
@@ -30,7 +30,8 @@ public class SimpleMarkdownNavigationItemTests
 
 	[Theory]
 	[InlineData("types", "types")]
-	[InlineData("tags", "tags")]
+	[InlineData("group", "group")]
+	[InlineData("operation", "operation")]
 	public void ValidateSlugForCollisions_ThrowsForReservedSegments(string slug, string reservedSegment)
 	{
 		var act = () => SimpleMarkdownNavigationItem.ValidateSlugForCollisions(
@@ -41,37 +42,20 @@ public class SimpleMarkdownNavigationItemTests
 	}
 
 	[Fact]
-	public void ValidateSlugForCollisions_ThrowsForOperationMoniker()
+	public void ValidateSlugForCollisions_AllowsSlugThatMatchesOperationId()
 	{
-		var operationMonikers = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "search", "index", "get" };
-
 		var act = () => SimpleMarkdownNavigationItem.ValidateSlugForCollisions(
-			"search", "elasticsearch", "/docs/search.md", operationMonikers);
-
-		act.Should().Throw<InvalidOperationException>()
-			.WithMessage("*conflicts with existing operation moniker*");
-	}
-
-	[Fact]
-	public void ValidateSlugForCollisions_AllowsValidSlug()
-	{
-		var operationMonikers = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "search", "index", "get" };
-
-		var act = () => SimpleMarkdownNavigationItem.ValidateSlugForCollisions(
-			"overview", "elasticsearch", "/docs/overview.md", operationMonikers);
+			"search", "elasticsearch", "/docs/search.md");
 
 		act.Should().NotThrow();
 	}
 
 	[Fact]
-	public void ValidateSlugForCollisions_IsCaseInsensitive()
+	public void ValidateSlugForCollisions_AllowsValidSlug()
 	{
-		var operationMonikers = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "search", "index", "get" };
-
 		var act = () => SimpleMarkdownNavigationItem.ValidateSlugForCollisions(
-			"SEARCH", "elasticsearch", "/docs/search.md", operationMonikers);
+			"overview", "elasticsearch", "/docs/overview.md");
 
-		act.Should().Throw<InvalidOperationException>()
-			.WithMessage("*conflicts with existing operation moniker*");
+		act.Should().NotThrow();
 	}
 }

--- a/tests/Elastic.ApiExplorer.Tests/TagMetadataTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/TagMetadataTests.cs
@@ -857,6 +857,8 @@ public class TagMetadataTests
 	[Theory]
 	[InlineData("cat", "endpoint-cat")]
 	[InlineData("health_report", "endpoint-health_report")]
+	[InlineData("APM agent configuration", "endpoint-apm-agent-configuration")]
+	[InlineData("Elastic Package Manager (EPM)", "endpoint-elastic-package-manager-epm")]
 	public void TagMoniker_MatchesBumpShScheme(string tagName, string expected)
 	{
 		ApiUrlBuilder.TagMoniker(tagName).Should().Be(expected);

--- a/tests/Elastic.ApiExplorer.Tests/TagMetadataTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/TagMetadataTests.cs
@@ -649,7 +649,7 @@ public class TagMetadataTests
 
 		var firstTag = informationGroup.NavigationItems.OfType<TagNavigationItem>().First();
 		informationGroup.Url.Should().NotBe(firstTag.Url);
-		firstTag.Url.Should().Contain("/tags/");
+		firstTag.Url.Should().Contain("/group/");
 	}
 
 	[Fact]
@@ -835,18 +835,35 @@ public class TagMetadataTests
 		items.Should().HaveCount(1);
 		var tag = items[0].Index.Model.Should().BeOfType<ApiTag>().Subject;
 		tag.Name.Should().Be("only");
-		tag.TagUrlSegment.Should().Be("only");
+		tag.TagUrlSegment.Should().Be("endpoint-only");
 		tag.Description.Should().Be("Solo tag group.");
 	}
 
 	[Fact]
 	public void GenerateTagMoniker_DataStream_Uses_Hyphen()
 	{
-		ApiUrlBuilder.TagMoniker("data stream").Should().Be("data-stream");
+		ApiUrlBuilder.TagMoniker("data stream").Should().Be("endpoint-data-stream");
+	}
+
+	[Theory]
+	[InlineData("bulk", "/_bulk", "operation-bulk")]
+	[InlineData("cat-aliases", "/_cat/aliases", "operation-cat-aliases")]
+	[InlineData(null, "/indices/{index}/_search", "operation-indices-index-_search")]
+	public void OperationMoniker_MatchesBumpShScheme(string? operationId, string route, string expected)
+	{
+		ApiUrlBuilder.OperationMoniker(operationId, route).Should().Be(expected);
+	}
+
+	[Theory]
+	[InlineData("cat", "endpoint-cat")]
+	[InlineData("health_report", "endpoint-health_report")]
+	public void TagMoniker_MatchesBumpShScheme(string tagName, string expected)
+	{
+		ApiUrlBuilder.TagMoniker(tagName).Should().Be(expected);
 	}
 
 	[Fact]
-	public async Task Tag_Url_Uses_Tags_Segment()
+	public async Task Tag_Url_Uses_Group_Segment()
 	{
 		var openApiJson = /*lang=json,strict*/ """
 		{
@@ -865,9 +882,42 @@ public class TagMetadataTests
 
 		var alpha = FindTagNavigationItem(navigation, "alpha");
 		alpha.Should().NotBeNull();
-		alpha.Url.Should().EndWith("/api/es/tags/alpha/");
+		alpha.Url.Should().EndWith("/api/es/group/endpoint-alpha");
 
-		alpha.Index.Model.Should().BeOfType<ApiTag>().Which.TagUrlSegment.Should().Be("alpha");
+		alpha.Index.Model.Should().BeOfType<ApiTag>().Which.TagUrlSegment.Should().Be("endpoint-alpha");
+	}
+
+	[Fact]
+	public async Task Operation_Url_Uses_Operation_Segment()
+	{
+		var openApiJson = /*lang=json,strict*/ """
+		{
+		  "openapi": "3.0.3",
+		  "info": { "title": "T", "version": "1.0" },
+		  "paths": {
+		    "/search": {
+		      "get": {
+		        "operationId": "search-op",
+		        "tags": ["search"],
+		        "responses": { "200": { "description": "ok" } }
+		      }
+		    }
+		  },
+		  "tags": [ { "name": "search" } ]
+		}
+		""";
+
+		var (generator, openApiDocument) = await CreateGeneratorWithSpec(openApiJson);
+		var navigation = generator.CreateNavigation("elasticsearch", openApiDocument);
+
+		var operation = navigation.NavigationItems
+			.OfType<TagNavigationItem>()
+			.Single()
+			.NavigationItems
+			.OfType<OperationNavigationItem>()
+			.Single();
+
+		operation.Url.Should().Be("/api/elasticsearch/operation/operation-search-op");
 	}
 
 	[Fact]

--- a/tests/Elastic.ApiExplorer.Tests/TagMetadataTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/TagMetadataTests.cs
@@ -884,7 +884,7 @@ public class TagMetadataTests
 
 		var alpha = FindTagNavigationItem(navigation, "alpha");
 		alpha.Should().NotBeNull();
-		alpha.Url.Should().EndWith("/api/es/group/endpoint-alpha");
+		alpha.Url.Should().EndWith("/api/doc/es/group/endpoint-alpha");
 
 		alpha.Index.Model.Should().BeOfType<ApiTag>().Which.TagUrlSegment.Should().Be("endpoint-alpha");
 	}
@@ -919,7 +919,7 @@ public class TagMetadataTests
 			.OfType<OperationNavigationItem>()
 			.Single();
 
-		operation.Url.Should().Be("/api/elasticsearch/operation/operation-search-op");
+		operation.Url.Should().Be("/api/doc/elasticsearch/operation/operation-search-op");
 	}
 
 	[Fact]


### PR DESCRIPTION
## Why

- ApiExplorer page URLs must match the inner path segments on live bump.sh API docs so CloudFront cutover needs only the `doc/` drop (#725)
- Closes elastic/docs-eng-team#720

## What

- Change operation URLs to `/api/{key}/operation/operation-{id}` and group URLs to `/api/{key}/group/endpoint-{slug}`
- Update ApiMarkdown intra-API link rewrites and navigation tests for the new paths

## Notes

- Stacks on #3805 (`issue-719-version-index-client`)
- Landing and schema type URLs are unchanged


Made with [Cursor](https://cursor.com)