### PR TITLE
ApiExplorer: generate multi-version API page trees

### DIFF
--- a/docs/data/openapi/api-explorer.md
+++ b/docs/data/openapi/api-explorer.md
@@ -162,8 +162,20 @@ entry in the index, the build fails with an error naming the API and what was mi
 spec file is also configured, that error becomes a warning instead, and the build falls back to
 rendering the local file.
 
-Today only the `main` moniker is rendered — there is no version-prefixed output or version
-switcher yet.
+For versioned products, {{dbuild}} renders every resolved version from the index:
+
+| Index moniker | URL path | Role |
+|---|---|---|
+| `main` | `/api/doc/<key>/` | Canonical current-major tree |
+| `9`, `8`, … | `/api/doc/<key>/v9/`, `/api/doc/<key>/v8/`, … | Released major snapshots |
+
+The numeric `9` entry is a frozen v9 snapshot. It is distinct from the moving `main` entry.
+When a local spec file exists, it overrides only the `main` moniker. Older majors still resolve
+remotely through the index.
+
+Versionless products (`versioning: serverless` and similar) render only the unversioned
+`/api/doc/<key>/` path even when the index lists historical monikers. The version switcher UI is
+tracked separately.
 
 ### Smoke-test every CloudFront spec locally
 

--- a/docs/data/openapi/api-explorer.md
+++ b/docs/data/openapi/api-explorer.md
@@ -174,8 +174,9 @@ When a local spec file exists, it overrides only the `main` moniker. Older major
 remotely through the index.
 
 Versionless products (`versioning: serverless` and similar) render only the unversioned
-`/api/doc/<key>/` path even when the index lists historical monikers. The version switcher UI is
-tracked separately.
+`/api/doc/<key>/` path even when the index lists historical monikers. When more than one
+version is rendered, API pages show a simple version dropdown at the top of the left navigation
+rail. The dropdown links to each version's landing page.
 
 ### Smoke-test every CloudFront spec locally
 

--- a/src/Elastic.ApiExplorer/Infrastructure/ApiRenderContext.cs
+++ b/src/Elastic.ApiExplorer/Infrastructure/ApiRenderContext.cs
@@ -14,6 +14,9 @@ using Microsoft.OpenApi;
 
 namespace Elastic.ApiExplorer.Infrastructure;
 
+/// <summary>One option in the API left-nav version switcher.</summary>
+public sealed record ApiVersionSwitcherItem(string Label, string Url, bool Selected);
+
 public record ApiRenderContext(
 	BuildContext BuildContext,
 	OpenApiDocument Model,
@@ -27,4 +30,7 @@ public record ApiRenderContext(
 
 	/// <summary>Logger for API Explorer rendering (e.g. OpenAPI extension parsing); optional when the host does not provide one.</summary>
 	public ILogger? ApiExplorerLog { get; init; }
+
+	/// <summary>Version options for the left-nav switcher. Empty when the product has only one tree.</summary>
+	public IReadOnlyList<ApiVersionSwitcherItem> VersionSwitcherItems { get; init; } = [];
 }

--- a/src/Elastic.ApiExplorer/Infrastructure/ApiRenderContext.cs
+++ b/src/Elastic.ApiExplorer/Infrastructure/ApiRenderContext.cs
@@ -14,7 +14,6 @@ using Microsoft.OpenApi;
 
 namespace Elastic.ApiExplorer.Infrastructure;
 
-/// <summary>One option in the API left-nav version switcher.</summary>
 public sealed record ApiVersionSwitcherItem(string Label, string Url, bool Selected);
 
 public record ApiRenderContext(
@@ -31,6 +30,5 @@ public record ApiRenderContext(
 	/// <summary>Logger for API Explorer rendering (e.g. OpenAPI extension parsing); optional when the host does not provide one.</summary>
 	public ILogger? ApiExplorerLog { get; init; }
 
-	/// <summary>Version options for the left-nav switcher. Empty when the product has only one tree.</summary>
 	public IReadOnlyList<ApiVersionSwitcherItem> VersionSwitcherItems { get; init; } = [];
 }

--- a/src/Elastic.ApiExplorer/Infrastructure/ApiUrlBuilder.cs
+++ b/src/Elastic.ApiExplorer/Infrastructure/ApiUrlBuilder.cs
@@ -19,6 +19,13 @@ public static partial class ApiUrlBuilder
 		$"{ApiRoot(urlPathPrefix)}/doc/{apiUrlSuffix}";
 
 	/// <summary>
+	/// URL path suffix for one API product version: <c>{key}</c> for <c>main</c>,
+	/// <c>{key}/v{N}</c> for released numeric majors from the version index.
+	/// </summary>
+	public static string ProductSuffix(string apiKey, string versionMoniker) =>
+		versionMoniker == "main" ? apiKey : $"{apiKey}/v{versionMoniker}";
+
+	/// <summary>
 	/// Deterministic URL leaf for an operation page under <c>.../operation/</c>: lowercase
 	/// <c>operation-{id}</c> when an operation id is present, otherwise derived from the route.
 	/// </summary>

--- a/src/Elastic.ApiExplorer/Infrastructure/ApiVersionSwitcher.cs
+++ b/src/Elastic.ApiExplorer/Infrastructure/ApiVersionSwitcher.cs
@@ -1,0 +1,29 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic.ApiExplorer.Infrastructure;
+
+/// <summary>Builds left-nav version switcher options from resolved API version monikers.</summary>
+public static class ApiVersionSwitcher
+{
+	public static IReadOnlyList<ApiVersionSwitcherItem> Build(
+		string? urlPathPrefix,
+		IReadOnlyList<(string Moniker, string ApiUrlSuffix)> versions,
+		string currentMoniker)
+	{
+		if (versions.Count <= 1)
+			return [];
+
+		return versions
+			.OrderByDescending(v => v.Moniker == "main" ? int.MaxValue : ParseMajor(v.Moniker))
+			.Select(v => new ApiVersionSwitcherItem(
+				Label: v.Moniker == "main" ? "Latest" : $"{v.Moniker}.x",
+				Url: $"{ApiUrlBuilder.ProductRoot(urlPathPrefix, v.ApiUrlSuffix)}/",
+				Selected: v.Moniker == currentMoniker))
+			.ToArray();
+	}
+
+	private static int ParseMajor(string moniker) =>
+		int.TryParse(moniker, out var major) ? major : 0;
+}

--- a/src/Elastic.ApiExplorer/Infrastructure/ApiVersionSwitcher.cs
+++ b/src/Elastic.ApiExplorer/Infrastructure/ApiVersionSwitcher.cs
@@ -4,23 +4,23 @@
 
 namespace Elastic.ApiExplorer.Infrastructure;
 
-/// <summary>Builds left-nav version switcher options from resolved API version monikers.</summary>
 public static class ApiVersionSwitcher
 {
 	public static IReadOnlyList<ApiVersionSwitcherItem> Build(
 		string? urlPathPrefix,
-		IReadOnlyList<(string Moniker, string ApiUrlSuffix)> versions,
+		string apiKey,
+		IReadOnlyList<string> monikers,
 		string currentMoniker)
 	{
-		if (versions.Count <= 1)
+		if (monikers.Count <= 1)
 			return [];
 
-		return versions
-			.OrderByDescending(v => v.Moniker == "main" ? int.MaxValue : ParseMajor(v.Moniker))
-			.Select(v => new ApiVersionSwitcherItem(
-				Label: v.Moniker == "main" ? "Latest" : $"{v.Moniker}.x",
-				Url: $"{ApiUrlBuilder.ProductRoot(urlPathPrefix, v.ApiUrlSuffix)}/",
-				Selected: v.Moniker == currentMoniker))
+		return monikers
+			.OrderByDescending(m => m == "main" ? int.MaxValue : ParseMajor(m))
+			.Select(m => new ApiVersionSwitcherItem(
+				Label: m == "main" ? "Latest" : $"{m}.x",
+				Url: $"{ApiUrlBuilder.ProductRoot(urlPathPrefix, ApiUrlBuilder.ProductSuffix(apiKey, m))}/",
+				Selected: m == currentMoniker))
 			.ToArray();
 	}
 

--- a/src/Elastic.ApiExplorer/Infrastructure/ApiViewModel.cs
+++ b/src/Elastic.ApiExplorer/Infrastructure/ApiViewModel.cs
@@ -22,6 +22,9 @@ public record ApiTocItem(string Heading, string Slug, int Level = 2);
 public record ApiLayoutViewModel : GlobalLayoutViewModel
 {
 	public required IReadOnlyList<ApiTocItem> TocItems { get; init; }
+
+	/// <summary>Version options for the left-nav switcher. Empty when the product has only one tree.</summary>
+	public IReadOnlyList<ApiVersionSwitcherItem> VersionSwitcherItems { get; init; } = [];
 }
 
 public abstract class ApiViewModel(ApiRenderContext context)
@@ -80,6 +83,7 @@ public abstract class ApiViewModel(ApiRenderContext context)
 			StaticFileContentHashProvider = StaticFileContentHashProvider,
 			BuildType = BuildContext.BuildType,
 			TocItems = GetTocItems(),
+			VersionSwitcherItems = RenderContext.VersionSwitcherItems,
 			// Header properties for isolated mode
 			HeaderTitle = docTitle,
 			HeaderVersion = Document.Info?.Version ?? "1.0",

--- a/src/Elastic.ApiExplorer/Infrastructure/ApiViewModel.cs
+++ b/src/Elastic.ApiExplorer/Infrastructure/ApiViewModel.cs
@@ -22,8 +22,6 @@ public record ApiTocItem(string Heading, string Slug, int Level = 2);
 public record ApiLayoutViewModel : GlobalLayoutViewModel
 {
 	public required IReadOnlyList<ApiTocItem> TocItems { get; init; }
-
-	/// <summary>Version options for the left-nav switcher. Empty when the product has only one tree.</summary>
 	public IReadOnlyList<ApiVersionSwitcherItem> VersionSwitcherItems { get; init; } = [];
 }
 

--- a/src/Elastic.ApiExplorer/OpenApiGenerator.cs
+++ b/src/Elastic.ApiExplorer/OpenApiGenerator.cs
@@ -21,13 +21,7 @@ using Microsoft.OpenApi;
 
 namespace Elastic.ApiExplorer;
 
-/// <summary>
-/// One resolved OpenAPI document for a version-index moniker, with the URL suffix used for navigation and output.
-/// </summary>
-internal sealed record VersionedOpenApiDocument(
-	ResolvedApiVersion Version,
-	OpenApiDocument Document,
-	string ApiUrlSuffix);
+internal sealed record VersionedOpenApiDocument(ResolvedApiVersion Version, OpenApiDocument Document);
 
 /// <summary>
 /// Renders API explorer pages for every configured OpenAPI specification: builds the navigation
@@ -69,10 +63,13 @@ public class OpenApiGenerator(
 				if (versionedDocuments.Count == 0)
 					continue;
 
+				var monikers = versionedDocuments.Select(v => v.Version.Moniker).ToArray();
 				foreach (var versioned in versionedDocuments)
 				{
-					var switcherItems = BuildVersionSwitcherItems(versionedDocuments, versioned.Version.Moniker);
-					await GenerateApiProduct(versioned.ApiUrlSuffix, versioned.Document, apiConfig, switcherItems, ctx)
+					var switcherItems = ApiVersionSwitcher.Build(
+						context.UrlPathPrefix, prefix, monikers, versioned.Version.Moniker);
+					var apiUrlSuffix = ApiUrlBuilder.ProductSuffix(prefix, versioned.Version.Moniker);
+					await GenerateApiProduct(apiUrlSuffix, versioned.Document, apiConfig, switcherItems, ctx)
 						.ConfigureAwait(false);
 				}
 
@@ -104,22 +101,21 @@ public class OpenApiGenerator(
 		ResolvedApiConfiguration apiConfig,
 		Cancel ctx)
 	{
-		if (apiConfig.LocalSpecFile is { } localFile && IsVersionlessProduct(apiConfig.Product))
-			return await ResolveLocalMainOnly(apiKey, localFile).ConfigureAwait(false);
+		var versionless = IsVersionlessProduct(apiConfig.Product);
+		if (apiConfig.LocalSpecFile is { } localFile && versionless)
+			return await ResolveLocalMainOnly(localFile).ConfigureAwait(false);
 
 		var versions = await _versionIndexClient.ResolveVersionsAsync(
 			context.Git, apiKey, apiConfig, context.Collector, ctx).ConfigureAwait(false);
 
-		var versionsToRender = IsVersionlessProduct(apiConfig.Product)
+		var versionsToRender = versionless
 			? versions.Where(v => v.Moniker == "main").ToArray()
 			: [.. versions];
 
 		if (versionsToRender.Length == 0)
 			return [];
 
-		if (!IsVersionlessProduct(apiConfig.Product)
-			&& versionsToRender.All(v => v.Moniker != "main")
-			&& versions.Count > 0)
+		if (!versionless && versionsToRender.All(v => v.Moniker != "main") && versions.Count > 0)
 		{
 			context.Collector.EmitGlobalWarning(
 				$"Version index for API '{apiKey}' has no 'main' entry; the unversioned path will not be rendered.");
@@ -132,41 +128,13 @@ public class OpenApiGenerator(
 			if (document is null)
 				continue;
 
-			results.Add(new VersionedOpenApiDocument(
-				version,
-				document,
-				ApiUrlBuilder.ProductSuffix(apiKey, version.Moniker)));
+			results.Add(new VersionedOpenApiDocument(version, document));
 		}
 
 		return results;
 	}
 
-	/// <summary>
-	/// Resolves the document to render for the current tree: the local override file when present,
-	/// otherwise the <c>main</c> moniker fetched remotely through the version index. Returns null when
-	/// nothing could be resolved; <see cref="VersionIndexClient"/> has already emitted the diagnostic.
-	/// </summary>
-	internal async Task<OpenApiDocument?> ResolveCurrentDocument(string apiKey, ResolvedApiConfiguration apiConfig, Cancel ctx)
-	{
-		if (apiConfig.LocalSpecFile is { } localFile)
-			return await _openApiReader.ReadAsync(localFile);
-
-		var versions = await _versionIndexClient.ResolveVersionsAsync(context.Git, apiKey, apiConfig, context.Collector, ctx).ConfigureAwait(false);
-		var current = versions.FirstOrDefault(v => v.Moniker == "main");
-		if (current is null)
-		{
-			if (versions.Count > 0)
-			{
-				context.Collector.EmitGlobalWarning(
-					$"Version index for API '{apiKey}' has no 'main' entry; this API will not be rendered.");
-			}
-			return null;
-		}
-
-		return await ResolveDocumentForVersion(apiKey, apiConfig, current, ctx).ConfigureAwait(false);
-	}
-
-	private async Task<IReadOnlyList<VersionedOpenApiDocument>> ResolveLocalMainOnly(string apiKey, IFileInfo localFile)
+	private async Task<IReadOnlyList<VersionedOpenApiDocument>> ResolveLocalMainOnly(IFileInfo localFile)
 	{
 		var document = await _openApiReader.ReadAsync(localFile).ConfigureAwait(false);
 		if (document is null)
@@ -182,8 +150,7 @@ public class OpenApiGenerator(
 					IsLocal = true,
 					LocalFile = localFile
 				},
-				document,
-				ApiUrlBuilder.ProductSuffix(apiKey, "main"))
+				document)
 		];
 	}
 
@@ -227,14 +194,6 @@ public class OpenApiGenerator(
 
 		_ = await Render(navigation.Index, navigation.Index.Model, renderContext, navigationRenderer, ctx).ConfigureAwait(false);
 	}
-
-	private IReadOnlyList<ApiVersionSwitcherItem> BuildVersionSwitcherItems(
-		IReadOnlyList<VersionedOpenApiDocument> versions,
-		string currentMoniker) =>
-		ApiVersionSwitcher.Build(
-			context.UrlPathPrefix,
-			versions.Select(v => (v.Version.Moniker, v.ApiUrlSuffix)).ToArray(),
-			currentMoniker);
 
 	private async Task GenerateApiProduct(
 		string prefix,

--- a/src/Elastic.ApiExplorer/OpenApiGenerator.cs
+++ b/src/Elastic.ApiExplorer/OpenApiGenerator.cs
@@ -11,6 +11,7 @@ using Elastic.ApiExplorer.Navigation;
 using Elastic.ApiExplorer.Operations;
 using Elastic.Documentation;
 using Elastic.Documentation.Configuration;
+using Elastic.Documentation.Configuration.Products;
 using Elastic.Documentation.Configuration.Toc;
 using Elastic.Documentation.Navigation;
 using Elastic.Documentation.Site.FileProviders;
@@ -21,13 +22,21 @@ using Microsoft.OpenApi;
 namespace Elastic.ApiExplorer;
 
 /// <summary>
+/// One resolved OpenAPI document for a version-index moniker, with the URL suffix used for navigation and output.
+/// </summary>
+internal sealed record VersionedOpenApiDocument(
+	ResolvedApiVersion Version,
+	OpenApiDocument Document,
+	string ApiUrlSuffix);
+
+/// <summary>
 /// Renders API explorer pages for every configured OpenAPI specification: builds the navigation
 /// tree via <see cref="ApiNavigationBuilder"/> and writes each page to the output directory.
 /// </summary>
 /// <remarks>
-/// Only renders the current tree for each API: a local override file when the docset carries one,
-/// otherwise the <c>main</c> moniker resolved remotely through <see cref="VersionIndexClient"/>. There
-/// is no version-prefixed output or switcher yet — see issue #721 for multi-version generation.
+/// For versioned products, renders the canonical <c>main</c> tree at the unversioned path plus one
+/// full tree per released numeric major at <c>/vN/</c>. Versionless products render only
+/// <c>main</c>. The version switcher UI is tracked separately in issue #723.
 /// </remarks>
 public class OpenApiGenerator(
 	ILoggerFactory logFactory,
@@ -56,13 +65,16 @@ public class OpenApiGenerator(
 		{
 			try
 			{
-				var openApiDocument = await ResolveCurrentDocument(prefix, apiConfig, ctx).ConfigureAwait(false);
-				if (openApiDocument is null)
+				var versionedDocuments = await ResolveDocumentsForProduct(prefix, apiConfig, ctx).ConfigureAwait(false);
+				if (versionedDocuments.Count == 0)
 					continue;
 
-				await GenerateApiProduct(prefix, openApiDocument, apiConfig, ctx);
+				foreach (var versioned in versionedDocuments)
+					await GenerateApiProduct(versioned.ApiUrlSuffix, versioned.Document, apiConfig, ctx).ConfigureAwait(false);
 
-				var title = openApiDocument.Info?.Title
+				var canonical = versionedDocuments.FirstOrDefault(v => v.Version.Moniker == "main")
+					?? versionedDocuments[0];
+				var title = canonical.Document.Info?.Title
 					?? apiConfig.Product.DisplayName
 					?? prefix;
 				var url = $"{ApiUrlBuilder.ProductRoot(context.UrlPathPrefix, prefix)}/";
@@ -77,6 +89,52 @@ public class OpenApiGenerator(
 
 		if (catalogEntries.Count > 0)
 			await GenerateApiCatalog(catalogEntries, ctx).ConfigureAwait(false);
+	}
+
+	/// <summary>
+	/// Resolves every OpenAPI document to render for one API key, including canonical <c>main</c>
+	/// and released numeric majors. Returns an empty list when nothing could be resolved.
+	/// </summary>
+	internal async Task<IReadOnlyList<VersionedOpenApiDocument>> ResolveDocumentsForProduct(
+		string apiKey,
+		ResolvedApiConfiguration apiConfig,
+		Cancel ctx)
+	{
+		if (apiConfig.LocalSpecFile is { } localFile && IsVersionlessProduct(apiConfig.Product))
+			return await ResolveLocalMainOnly(apiKey, localFile).ConfigureAwait(false);
+
+		var versions = await _versionIndexClient.ResolveVersionsAsync(
+			context.Git, apiKey, apiConfig, context.Collector, ctx).ConfigureAwait(false);
+
+		var versionsToRender = IsVersionlessProduct(apiConfig.Product)
+			? versions.Where(v => v.Moniker == "main").ToArray()
+			: [.. versions];
+
+		if (versionsToRender.Length == 0)
+			return [];
+
+		if (!IsVersionlessProduct(apiConfig.Product)
+			&& versionsToRender.All(v => v.Moniker != "main")
+			&& versions.Count > 0)
+		{
+			context.Collector.EmitGlobalWarning(
+				$"Version index for API '{apiKey}' has no 'main' entry; the unversioned path will not be rendered.");
+		}
+
+		var results = new List<VersionedOpenApiDocument>(versionsToRender.Length);
+		foreach (var version in versionsToRender)
+		{
+			var document = await ResolveDocumentForVersion(apiKey, apiConfig, version, ctx).ConfigureAwait(false);
+			if (document is null)
+				continue;
+
+			results.Add(new VersionedOpenApiDocument(
+				version,
+				document,
+				ApiUrlBuilder.ProductSuffix(apiKey, version.Moniker)));
+		}
+
+		return results;
 	}
 
 	/// <summary>
@@ -101,10 +159,43 @@ public class OpenApiGenerator(
 			return null;
 		}
 
-		if (current.IsLocal)
-			return await _openApiReader.ReadAsync(current.LocalFile!);
+		return await ResolveDocumentForVersion(apiKey, apiConfig, current, ctx).ConfigureAwait(false);
+	}
 
-		var stream = await _versionIndexClient.FetchSpecStreamAsync(apiKey, current, context.Collector, ctx).ConfigureAwait(false);
+	private async Task<IReadOnlyList<VersionedOpenApiDocument>> ResolveLocalMainOnly(string apiKey, IFileInfo localFile)
+	{
+		var document = await _openApiReader.ReadAsync(localFile).ConfigureAwait(false);
+		if (document is null)
+			return [];
+
+		return
+		[
+			new VersionedOpenApiDocument(
+				new ResolvedApiVersion
+				{
+					Moniker = "main",
+					Version = "main",
+					IsLocal = true,
+					LocalFile = localFile
+				},
+				document,
+				ApiUrlBuilder.ProductSuffix(apiKey, "main"))
+		];
+	}
+
+	private static bool IsVersionlessProduct(Product product) =>
+		product.VersioningSystem?.IsVersionless == true;
+
+	private async Task<OpenApiDocument?> ResolveDocumentForVersion(
+		string apiKey,
+		ResolvedApiConfiguration apiConfig,
+		ResolvedApiVersion version,
+		Cancel ctx)
+	{
+		if (version.IsLocal)
+			return await _openApiReader.ReadAsync(version.LocalFile!).ConfigureAwait(false);
+
+		var stream = await _versionIndexClient.FetchSpecStreamAsync(apiKey, version, context.Collector, ctx).ConfigureAwait(false);
 		if (stream is null)
 			return null;
 
@@ -148,7 +239,7 @@ public class OpenApiGenerator(
 			ApiExplorerLog = _logger
 		};
 
-		await RenderNavigationItems(renderContext, navigationRenderer, navigation, ctx);
+		await RenderNavigationItems(renderContext, navigationRenderer, navigation, ctx).ConfigureAwait(false);
 	}
 
 	private async Task RenderNavigationItems(

--- a/src/Elastic.ApiExplorer/OpenApiGenerator.cs
+++ b/src/Elastic.ApiExplorer/OpenApiGenerator.cs
@@ -36,7 +36,7 @@ internal sealed record VersionedOpenApiDocument(
 /// <remarks>
 /// For versioned products, renders the canonical <c>main</c> tree at the unversioned path plus one
 /// full tree per released numeric major at <c>/vN/</c>. Versionless products render only
-/// <c>main</c>. The version switcher UI is tracked separately in issue #723.
+/// <c>main</c>. When more than one version is rendered, pages include a left-nav version switcher.
 /// </remarks>
 public class OpenApiGenerator(
 	ILoggerFactory logFactory,
@@ -70,7 +70,11 @@ public class OpenApiGenerator(
 					continue;
 
 				foreach (var versioned in versionedDocuments)
-					await GenerateApiProduct(versioned.ApiUrlSuffix, versioned.Document, apiConfig, ctx).ConfigureAwait(false);
+				{
+					var switcherItems = BuildVersionSwitcherItems(versionedDocuments, versioned.Version.Moniker);
+					await GenerateApiProduct(versioned.ApiUrlSuffix, versioned.Document, apiConfig, switcherItems, ctx)
+						.ConfigureAwait(false);
+				}
 
 				var canonical = versionedDocuments.FirstOrDefault(v => v.Version.Moniker == "main")
 					?? versionedDocuments[0];
@@ -224,7 +228,20 @@ public class OpenApiGenerator(
 		_ = await Render(navigation.Index, navigation.Index.Model, renderContext, navigationRenderer, ctx).ConfigureAwait(false);
 	}
 
-	private async Task GenerateApiProduct(string prefix, OpenApiDocument openApiDocument, ResolvedApiConfiguration? apiConfig, Cancel ctx)
+	private IReadOnlyList<ApiVersionSwitcherItem> BuildVersionSwitcherItems(
+		IReadOnlyList<VersionedOpenApiDocument> versions,
+		string currentMoniker) =>
+		ApiVersionSwitcher.Build(
+			context.UrlPathPrefix,
+			versions.Select(v => (v.Version.Moniker, v.ApiUrlSuffix)).ToArray(),
+			currentMoniker);
+
+	private async Task GenerateApiProduct(
+		string prefix,
+		OpenApiDocument openApiDocument,
+		ResolvedApiConfiguration? apiConfig,
+		IReadOnlyList<ApiVersionSwitcherItem> versionSwitcherItems,
+		Cancel ctx)
 	{
 		var navigation = CreateNavigation(prefix, openApiDocument, apiConfig);
 		_logger.LogInformation("Generating OpenApiDocument {Title}", openApiDocument.Info?.Title ?? "<no title>");
@@ -236,7 +253,8 @@ public class OpenApiGenerator(
 			NavigationHtml = string.Empty,
 			CurrentNavigation = navigation,
 			MarkdownRenderer = markdownStringRenderer,
-			ApiExplorerLog = _logger
+			ApiExplorerLog = _logger,
+			VersionSwitcherItems = versionSwitcherItems
 		};
 
 		await RenderNavigationItems(renderContext, navigationRenderer, navigation, ctx).ConfigureAwait(false);

--- a/src/Elastic.ApiExplorer/_Layout.cshtml
+++ b/src/Elastic.ApiExplorer/_Layout.cshtml
@@ -27,7 +27,7 @@ else
 			</div>
 			@await RenderPartialAsync(_ApiToc.Create(Model.TocItems.ToArray()))
 		</div>
-		@await RenderPartialAsync(_PagesNav.Create(Model))
+		@await RenderPartialAsync(_ApiPagesNav.Create(Model))
 	</div>
 </div>
 @if (Model.BuildType == BuildType.Assembler)

--- a/src/Elastic.ApiExplorer/_Partials/Layout/_ApiPagesNav.cshtml
+++ b/src/Elastic.ApiExplorer/_Partials/Layout/_ApiPagesNav.cshtml
@@ -13,14 +13,7 @@
 					onchange="window.location.href = this.value">
 					@foreach (var item in Model.VersionSwitcherItems)
 					{
-						if (item.Selected)
-						{
-							<option value="@item.Url" selected>@item.Label</option>
-						}
-						else
-						{
-							<option value="@item.Url">@item.Label</option>
-						}
+						<option value="@item.Url" selected="@item.Selected">@item.Label</option>
 					}
 				</select>
 			</div>

--- a/src/Elastic.ApiExplorer/_Partials/Layout/_ApiPagesNav.cshtml
+++ b/src/Elastic.ApiExplorer/_Partials/Layout/_ApiPagesNav.cshtml
@@ -1,0 +1,40 @@
+@inherits RazorSlice<Elastic.ApiExplorer.Infrastructure.ApiLayoutViewModel>
+<aside class="sidebar font-sans bg-white fixed md:sticky shadow-2xl md:shadow-none left-full group-has-[#pages-nav-hamburger:checked]/body:left-0 bottom-0 md:left-auto top-[calc(var(--offset-top)+1px)] w-[80%] md:w-auto shrink-0 border-r border-r-grey-20 z-[10000] md:z-auto transition-[top,max-height] duration-300 md:col-start-1 md:row-start-1">
+	<nav
+		id="pages-nav"
+		class="sidebar-nav h-full simple-scrollbar">
+		@if (Model.VersionSwitcherItems.Count > 1)
+		{
+			<div class="sticky top-0 z-10 bg-white px-4 pt-4 pb-2">
+				<label for="api-version-switcher" class="sr-only">API version</label>
+				<select
+					id="api-version-switcher"
+					class="w-full border border-grey-20 rounded-sm font-sans font-semibold text-sm pl-3 pr-8 py-2 bg-white hover:border-grey-40 focus:outline-none focus:ring-2 focus:ring-blue-elastic-50 cursor-pointer"
+					onchange="window.location.href = this.value">
+					@foreach (var item in Model.VersionSwitcherItems)
+					{
+						if (item.Selected)
+						{
+							<option value="@item.Url" selected>@item.Label</option>
+						}
+						else
+						{
+							<option value="@item.Url">@item.Label</option>
+						}
+					}
+				</select>
+			</div>
+		}
+		@(new HtmlString(Model.NavigationHtml))
+	</nav>
+	@* ReSharper disable once Html.IdNotResolved *@
+	<label role="button" for="pages-nav-hamburger" class="absolute md:hidden top-7 -right-12 bg-white p-1 rounded-full border-1 border-grey-20 cursor-pointer z-99">
+		<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+			<path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+		</svg>
+	</label>
+</aside>
+@* ReSharper disable once Html.IdNotResolved *@
+<label for="pages-nav-hamburger" aria-hidden="true" class="hidden group-has-[#pages-nav-hamburger:checked]/body:block md:hidden! fixed top-0 left-0 right-0 bottom-0 bg-black/50 z-[9999] ">
+
+</label>

--- a/tests/Elastic.ApiExplorer.Tests/ApiUrlBuilderTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/ApiUrlBuilderTests.cs
@@ -1,0 +1,29 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using AwesomeAssertions;
+using Elastic.ApiExplorer.Infrastructure;
+
+namespace Elastic.ApiExplorer.Tests;
+
+public class ApiUrlBuilderTests
+{
+	[Theory]
+	[InlineData("elasticsearch", "main", "elasticsearch")]
+	[InlineData("elasticsearch", "9", "elasticsearch/v9")]
+	[InlineData("elasticsearch", "8", "elasticsearch/v8")]
+	[InlineData("kibana", "10", "kibana/v10")]
+	public void ProductSuffix_MapsVersionMonikersToPathSuffixes(string apiKey, string versionMoniker, string expected)
+	{
+		ApiUrlBuilder.ProductSuffix(apiKey, versionMoniker).Should().Be(expected);
+	}
+
+	[Theory]
+	[InlineData("", "elasticsearch", "/api/doc/elasticsearch")]
+	[InlineData("", "elasticsearch/v9", "/api/doc/elasticsearch/v9")]
+	public void ProductRoot_UsesVersionAwareSuffix(string urlPathPrefix, string apiUrlSuffix, string expected)
+	{
+		ApiUrlBuilder.ProductRoot(urlPathPrefix, apiUrlSuffix).Should().Be(expected);
+	}
+}

--- a/tests/Elastic.ApiExplorer.Tests/ApiVersionSwitcherTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/ApiVersionSwitcherTests.cs
@@ -1,0 +1,40 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using AwesomeAssertions;
+using Elastic.ApiExplorer.Infrastructure;
+
+namespace Elastic.ApiExplorer.Tests;
+
+public class ApiVersionSwitcherTests
+{
+	[Fact]
+	public void Build_SingleVersion_ReturnsEmpty()
+	{
+		var items = ApiVersionSwitcher.Build("", [("main", "elasticsearch")], "main");
+
+		items.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void Build_MultipleVersions_OrdersLatestFirstAndMarksCurrent()
+	{
+		var items = ApiVersionSwitcher.Build(
+			"",
+			[
+				("main", "elasticsearch"),
+				("9", "elasticsearch/v9"),
+				("8", "elasticsearch/v8")
+			],
+			"8");
+
+		items.Should().HaveCount(3);
+		items.Select(i => i.Label).Should().Equal("Latest", "9.x", "8.x");
+		items.Select(i => i.Url).Should().Equal(
+			"/api/doc/elasticsearch/",
+			"/api/doc/elasticsearch/v9/",
+			"/api/doc/elasticsearch/v8/");
+		items.Single(i => i.Selected).Label.Should().Be("8.x");
+	}
+}

--- a/tests/Elastic.ApiExplorer.Tests/ApiVersionSwitcherTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/ApiVersionSwitcherTests.cs
@@ -12,7 +12,7 @@ public class ApiVersionSwitcherTests
 	[Fact]
 	public void Build_SingleVersion_ReturnsEmpty()
 	{
-		var items = ApiVersionSwitcher.Build("", [("main", "elasticsearch")], "main");
+		var items = ApiVersionSwitcher.Build("", "elasticsearch", ["main"], "main");
 
 		items.Should().BeEmpty();
 	}
@@ -22,11 +22,8 @@ public class ApiVersionSwitcherTests
 	{
 		var items = ApiVersionSwitcher.Build(
 			"",
-			[
-				("main", "elasticsearch"),
-				("9", "elasticsearch/v9"),
-				("8", "elasticsearch/v8")
-			],
+			"elasticsearch",
+			["main", "9", "8"],
 			"8");
 
 		items.Should().HaveCount(3);

--- a/tests/Elastic.ApiExplorer.Tests/OpenApiGeneratorCurrentSpecResolutionTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/OpenApiGeneratorCurrentSpecResolutionTests.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Collections.Frozen;
 using System.IO.Abstractions;
 using System.Net;
 using AwesomeAssertions;
@@ -10,6 +11,7 @@ using Elastic.Documentation;
 using Elastic.Documentation.Configuration;
 using Elastic.Documentation.Configuration.Products;
 using Elastic.Documentation.Configuration.Toc;
+using Elastic.Documentation.Configuration.Versions;
 using Elastic.Documentation.Diagnostics;
 using FakeItEasy;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -22,26 +24,39 @@ public class OpenApiGeneratorCurrentSpecResolutionTests
 {
 	private static readonly Uri BaseUri = new("https://cdn.example/");
 
-	private static BuildContext CreateContext(DiagnosticsCollector collector, GitCheckoutInformation? git = null)
+	private static BuildContext CreateContext(
+		DiagnosticsCollector collector,
+		VersionsConfiguration? versionsConfiguration = null,
+		ProductsConfiguration? productsConfiguration = null,
+		GitCheckoutInformation? git = null)
 	{
 		var fs = FileSystemFactory.RealGitRootForPath(null);
-		return new BuildContext(collector, fs, fs, TestHelpers.CreateConfigurationContext(new FileSystem()),
+		return new BuildContext(collector, fs, fs,
+			TestHelpers.CreateConfigurationContext(new FileSystem(), versionsConfiguration, productsConfiguration),
 			ExportOptions.Default, null, null, gitCheckoutInformation: git);
 	}
 
-	private static ResolvedApiConfiguration ApiConfig(IFileInfo? localSpecFile) => new()
+	private static ResolvedApiConfiguration ApiConfig(Product product, IFileInfo? localSpecFile = null) => new()
 	{
-		ProductKey = "elasticsearch",
-		Product = new Product { Id = "elasticsearch", DisplayName = "Elasticsearch" },
+		ProductKey = product.Id,
+		Product = product,
 		SpecFileName = "elasticsearch-openapi.json",
 		LocalSpecFile = localSpecFile
 	};
 
 	[Fact]
-	public async Task ResolveCurrentDocument_LocalSpecPresent_RendersLocalFileWithoutAnyNetworkCall()
+	public async Task ResolveDocumentsForProduct_VersionlessLocalSpec_RendersLocalFileWithoutNetwork()
 	{
 		var collector = new DiagnosticsCollector([]);
-		var context = CreateContext(collector);
+		var versionless = TestHelpers.CreateVersionlessConfiguration();
+		var product = TestHelpers.CreateProduct("cloud-serverless", versionless.GetVersioningSystem(VersioningSystemId.Serverless));
+		var products = new ProductsConfiguration
+		{
+			Products = new Dictionary<string, Product> { [product.Id] = product }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase),
+			PublicReferenceProducts = new Dictionary<string, Product> { [product.Id] = product }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase),
+			ProductDisplayNames = new Dictionary<string, string> { [product.Id] = product.DisplayName }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase)
+		};
+		var context = CreateContext(collector, versionless, products);
 		var localFile = new FileSystem().FileInfo.New(
 			Path.Combine(Paths.WorkingDirectoryRoot.FullName, "docs", "elasticsearch-openapi-docs.json"));
 		var expectedDocument = SpecDocument();
@@ -57,19 +72,22 @@ public class OpenApiGeneratorCurrentSpecResolutionTests
 			versionIndexClient,
 			reader);
 
-		var document = await generator.ResolveCurrentDocument("elasticsearch", ApiConfig(localFile), TestContext.Current.CancellationToken);
+		var documents = await generator.ResolveDocumentsForProduct(
+			"cloud-serverless", ApiConfig(product, localFile), TestContext.Current.CancellationToken);
 
-		document.Should().BeSameAs(expectedDocument);
-		handler.CallCount.Should().Be(0, "a local spec file must short-circuit remote version resolution entirely");
+		documents.Should().ContainSingle().Which.Document.Should().BeSameAs(expectedDocument);
+		handler.CallCount.Should().Be(0, "a versionless local spec must short-circuit remote version resolution");
 		A.CallTo(() => reader.ReadAsync(localFile)).MustHaveHappenedOnceExactly();
 	}
 
 	[Fact]
-	public async Task ResolveCurrentDocument_NoLocalSpec_ResolvesRemoteMainThroughVersionIndex()
+	public async Task ResolveDocumentsForProduct_NoLocalSpec_ResolvesRemoteMainThroughVersionIndex()
 	{
 		var collector = new CapturingDiagnosticsCollector();
+		var stack = TestHelpers.CreateStackVersionsConfiguration(currentMajor: 9);
+		var product = TestHelpers.CreateProduct("elasticsearch", stack.GetVersioningSystem(VersioningSystemId.Stack));
 		var git = new GitCheckoutInformation { Branch = "main", Remote = "https://github.com/elastic/elasticsearch.git", Ref = "refs/heads/main" };
-		var context = CreateContext(collector, git);
+		var context = CreateContext(collector, stack, git: git);
 
 		var handler = new StubHandler(request => request.RequestUri!.AbsolutePath.EndsWith("index.json", StringComparison.Ordinal)
 			? IndexResponse(/*lang=json,strict*/ """
@@ -93,13 +111,12 @@ public class OpenApiGeneratorCurrentSpecResolutionTests
 			versionIndexClient,
 			reader);
 
-		// The sample docset's own kibana/dashboard entries fail product validation against this
-		// test's minimal products config; only care about diagnostics from resolving 'elasticsearch'.
 		var errorsBeforeResolution = collector.Errors;
 
-		var document = await generator.ResolveCurrentDocument("elasticsearch", ApiConfig(null), TestContext.Current.CancellationToken);
+		var documents = await generator.ResolveDocumentsForProduct(
+			"elasticsearch", ApiConfig(product), TestContext.Current.CancellationToken);
 
-		document.Should().BeSameAs(expectedDocument);
+		documents.Should().ContainSingle().Which.Document.Should().BeSameAs(expectedDocument);
 		handler.RequestedPaths.Should().BeEquivalentTo(
 		[
 			"/index.json",
@@ -110,11 +127,13 @@ public class OpenApiGeneratorCurrentSpecResolutionTests
 	}
 
 	[Fact]
-	public async Task ResolveCurrentDocument_NoLocalSpecAndIndexUnreachable_ReturnsNullAndEmitsError()
+	public async Task ResolveDocumentsForProduct_NoLocalSpecAndIndexUnreachable_ReturnsEmptyAndEmitsError()
 	{
 		var collector = new DiagnosticsCollector([]);
+		var stack = TestHelpers.CreateStackVersionsConfiguration(currentMajor: 9);
+		var product = TestHelpers.CreateProduct("elasticsearch", stack.GetVersioningSystem(VersioningSystemId.Stack));
 		var git = new GitCheckoutInformation { Branch = "main", Remote = "https://github.com/elastic/elasticsearch.git", Ref = "refs/heads/main" };
-		var context = CreateContext(collector, git);
+		var context = CreateContext(collector, stack, git: git);
 
 		var handler = new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.NotFound));
 		using var versionIndexClient = new VersionIndexClient(BaseUri, handler, maxAttempts: 1, sleep: (_, _) => Task.CompletedTask);
@@ -127,9 +146,10 @@ public class OpenApiGeneratorCurrentSpecResolutionTests
 			reader);
 		var errorsBeforeResolution = collector.Errors;
 
-		var document = await generator.ResolveCurrentDocument("elasticsearch", ApiConfig(null), TestContext.Current.CancellationToken);
+		var documents = await generator.ResolveDocumentsForProduct(
+			"elasticsearch", ApiConfig(product), TestContext.Current.CancellationToken);
 
-		document.Should().BeNull();
+		documents.Should().BeEmpty();
 		collector.Errors.Should().BeGreaterThan(errorsBeforeResolution);
 		A.CallTo(() => reader.ReadAsync(A<IFileInfo>._)).MustNotHaveHappened();
 		A.CallTo(() => reader.ReadAsync(A<Stream>._, A<string>._)).MustNotHaveHappened();

--- a/tests/Elastic.ApiExplorer.Tests/OpenApiGeneratorMultiVersionTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/OpenApiGeneratorMultiVersionTests.cs
@@ -1,0 +1,307 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Collections.Frozen;
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
+using System.Net;
+using AwesomeAssertions;
+using Elastic.ApiExplorer.Infrastructure;
+using Elastic.ApiExplorer.Landing;
+using Elastic.ApiExplorer.Model;
+using Elastic.ApiExplorer.Operations;
+using Elastic.Documentation;
+using Elastic.Documentation.Configuration;
+using Elastic.Documentation.Configuration.Products;
+using Elastic.Documentation.Configuration.Toc;
+using Elastic.Documentation.Configuration.Versions;
+using Elastic.Documentation.Diagnostics;
+using FakeItEasy;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.OpenApi;
+using Nullean.ScopedFileSystem;
+
+namespace Elastic.ApiExplorer.Tests;
+
+public class OpenApiGeneratorMultiVersionTests
+{
+	private static readonly Uri BaseUri = new("https://cdn.example/");
+
+	private static BuildContext CreateContext(
+		DiagnosticsCollector collector,
+		VersionsConfiguration? versionsConfiguration = null,
+		ProductsConfiguration? productsConfiguration = null,
+		GitCheckoutInformation? git = null)
+	{
+		var fs = FileSystemFactory.RealGitRootForPath(null);
+		return new BuildContext(collector, fs, fs, TestHelpers.CreateConfigurationContext(new FileSystem(), versionsConfiguration, productsConfiguration),
+			ExportOptions.Default, null, null, gitCheckoutInformation: git);
+	}
+
+	private static ResolvedApiConfiguration ApiConfig(
+		Product product,
+		IFileInfo? localSpecFile = null,
+		string specFileName = "elasticsearch-openapi.json",
+		string? repository = null) => new()
+	{
+		ProductKey = product.Id,
+		Product = product,
+		SpecFileName = specFileName,
+		LocalSpecFile = localSpecFile,
+		Repository = repository
+	};
+
+	private static ProductsConfiguration ProductsFor(params Product[] products) =>
+		new()
+		{
+			Products = products.ToFrozenDictionary(p => p.Id, StringComparer.OrdinalIgnoreCase),
+			PublicReferenceProducts = products.ToFrozenDictionary(p => p.Id, StringComparer.OrdinalIgnoreCase),
+			ProductDisplayNames = products.ToDictionary(p => p.Id, p => p.DisplayName, StringComparer.OrdinalIgnoreCase).ToFrozenDictionary(StringComparer.OrdinalIgnoreCase)
+		};
+
+	private static OpenApiDocument SpecDocument(string title) => new()
+	{
+		Info = new OpenApiInfo { Title = title, Version = "1.0" },
+		Paths = new OpenApiPaths
+		{
+			["/ping"] = new OpenApiPathItem
+			{
+				Operations = new Dictionary<HttpMethod, OpenApiOperation>
+				{
+					[HttpMethod.Get] = new()
+					{
+						OperationId = "ping",
+						Tags = new HashSet<OpenApiTagReference> { new("core") },
+						Responses = new OpenApiResponses { ["200"] = new OpenApiResponse { Description = "ok" } }
+					}
+				}
+			}
+		},
+		Tags = new HashSet<OpenApiTag> { new() { Name = "core" } }
+	};
+
+	[Fact]
+	public async Task ResolveDocumentsForProduct_MultiMajorIndex_ResolvesMainAndNumericVersions()
+	{
+		var collector = new CapturingDiagnosticsCollector();
+		var stack = TestHelpers.CreateStackVersionsConfiguration(currentMajor: 9);
+		var product = TestHelpers.CreateProduct("elasticsearch", stack.GetVersioningSystem(VersioningSystemId.Stack));
+		var context = CreateContext(collector, stack, ProductsFor(product), GitForElasticsearch());
+		var handler = MultiVersionHandler();
+		using var versionIndexClient = new VersionIndexClient(BaseUri, handler, sleep: (_, _) => Task.CompletedTask);
+		var reader = CreateSequentialReader(
+			SpecDocument("Elasticsearch main"),
+			SpecDocument("Elasticsearch 9"),
+			SpecDocument("Elasticsearch 8"));
+		var generator = CreateGenerator(context, versionIndexClient, reader);
+
+		var documents = await generator.ResolveDocumentsForProduct("elasticsearch", ApiConfig(product), TestContext.Current.CancellationToken);
+
+		documents.Should().HaveCount(3);
+		documents.Select(d => d.Version.Moniker).Should().BeEquivalentTo(["main", "9", "8"]);
+		documents.Should().ContainSingle(d => d.ApiUrlSuffix == "elasticsearch" && d.Document.Info!.Title == "Elasticsearch main");
+		documents.Should().ContainSingle(d => d.ApiUrlSuffix == "elasticsearch/v9" && d.Document.Info!.Title == "Elasticsearch 9");
+		documents.Should().ContainSingle(d => d.ApiUrlSuffix == "elasticsearch/v8" && d.Document.Info!.Title == "Elasticsearch 8");
+	}
+
+	[Fact]
+	public async Task ResolveDocumentsForProduct_CurrentMajorNine_StillRendersNumericNineTree()
+	{
+		var collector = new CapturingDiagnosticsCollector();
+		var stack = TestHelpers.CreateStackVersionsConfiguration(currentMajor: 9);
+		var product = TestHelpers.CreateProduct("elasticsearch", stack.GetVersioningSystem(VersioningSystemId.Stack));
+		var context = CreateContext(collector, stack, ProductsFor(product), GitForElasticsearch());
+		using var versionIndexClient = new VersionIndexClient(BaseUri, MultiVersionHandler(), sleep: (_, _) => Task.CompletedTask);
+		var reader = CreateSequentialReader(
+			SpecDocument("Elasticsearch main"),
+			SpecDocument("Elasticsearch 9"),
+			SpecDocument("Elasticsearch 8"));
+		var generator = CreateGenerator(context, versionIndexClient, reader);
+
+		var documents = await generator.ResolveDocumentsForProduct("elasticsearch", ApiConfig(product), TestContext.Current.CancellationToken);
+
+		documents.Should().Contain(d => d.Version.Moniker == "9" && d.ApiUrlSuffix == "elasticsearch/v9");
+	}
+
+	[Fact]
+	public async Task ResolveDocumentsForProduct_VersionlessProduct_RendersMainOnly()
+	{
+		var collector = new CapturingDiagnosticsCollector();
+		var versionless = TestHelpers.CreateVersionlessConfiguration();
+		var product = TestHelpers.CreateProduct("cloud-serverless", versionless.GetVersioningSystem(VersioningSystemId.Serverless));
+		var context = CreateContext(collector, versionless, ProductsFor(product), GitForElasticsearch());
+		using var versionIndexClient = new VersionIndexClient(BaseUri, MultiVersionHandler(repository: "elastic/serverless-api-specification"), sleep: (_, _) => Task.CompletedTask);
+		var reader = CreateSequentialReader(SpecDocument("Serverless main"));
+		var generator = CreateGenerator(context, versionIndexClient, reader);
+		var apiConfig = ApiConfig(product, specFileName: "elastic-cloud-serverless.yml", repository: "elastic/serverless-api-specification");
+
+		var documents = await generator.ResolveDocumentsForProduct("cloud-serverless", apiConfig, TestContext.Current.CancellationToken);
+
+		documents.Should().ContainSingle();
+		documents[0].Version.Moniker.Should().Be("main");
+		documents[0].ApiUrlSuffix.Should().Be("cloud-serverless");
+	}
+
+	[Fact]
+	public async Task ResolveDocumentsForProduct_LocalMainAndRemoteHistoricalVersions_ResolvesAllTrees()
+	{
+		var collector = new CapturingDiagnosticsCollector();
+		var stack = TestHelpers.CreateStackVersionsConfiguration(currentMajor: 9);
+		var product = TestHelpers.CreateProduct("elasticsearch", stack.GetVersioningSystem(VersioningSystemId.Stack));
+		var context = CreateContext(collector, stack, ProductsFor(product), GitForElasticsearch());
+		var localFile = new FileSystem().FileInfo.New(Path.Combine(Paths.WorkingDirectoryRoot.FullName, "docs", "elasticsearch-openapi-docs.json"));
+		var localDocument = SpecDocument("Elasticsearch local main");
+		using var versionIndexClient = new VersionIndexClient(BaseUri, MultiVersionHandler(), sleep: (_, _) => Task.CompletedTask);
+		var reader = A.Fake<IOpenApiSpecificationReader>();
+		A.CallTo(() => reader.ReadAsync(localFile)).Returns(localDocument);
+		A.CallTo(() => reader.ReadAsync(A<Stream>._, "elasticsearch-openapi.json"))
+			.ReturnsLazily((Stream _, string _) => SpecDocument("Elasticsearch remote"));
+		var generator = CreateGenerator(context, versionIndexClient, reader);
+
+		var documents = await generator.ResolveDocumentsForProduct("elasticsearch", ApiConfig(product, localFile), TestContext.Current.CancellationToken);
+
+		documents.Should().HaveCount(3);
+		documents.Should().ContainSingle(d => d.Version.Moniker == "main" && d.Document == localDocument);
+		documents.Should().ContainSingle(d => d.Version.Moniker == "9");
+		documents.Should().ContainSingle(d => d.Version.Moniker == "8");
+		A.CallTo(() => reader.ReadAsync(localFile)).MustHaveHappenedOnceExactly();
+		A.CallTo(() => reader.ReadAsync(A<Stream>._, "elasticsearch-openapi.json")).MustHaveHappened(2, Times.Exactly);
+	}
+
+	[Fact]
+	public void CreateNavigation_VersionedSuffix_UsesVersionPrefixedUrls()
+	{
+		var collector = new DiagnosticsCollector([]);
+		var stack = TestHelpers.CreateStackVersionsConfiguration(currentMajor: 9);
+		var product = TestHelpers.CreateProduct("elasticsearch", stack.GetVersioningSystem(VersioningSystemId.Stack));
+		var context = CreateContext(collector, stack, ProductsFor(product));
+		var generator = new OpenApiGenerator(NullLoggerFactory.Instance, context, NoopMarkdownStringRenderer.Instance);
+		var navigation = generator.CreateNavigation("elasticsearch/v8", SpecDocument("Elasticsearch 8"));
+
+		navigation.Url.Should().Be("/api/doc/elasticsearch/v8");
+		var operation = navigation.NavigationItems
+			.OfType<TagNavigationItem>()
+			.Single()
+			.NavigationItems
+			.OfType<OperationNavigationItem>()
+			.Single();
+		operation.Url.Should().Be("/api/doc/elasticsearch/v8/operation/operation-ping");
+	}
+
+	[Fact]
+	public async Task Generate_WritesDistinctOutputTreesForMainAndReleasedMajors()
+	{
+		var collector = new CapturingDiagnosticsCollector();
+		var stack = TestHelpers.CreateStackVersionsConfiguration(currentMajor: 9);
+		var product = TestHelpers.CreateProduct("elasticsearch", stack.GetVersioningSystem(VersioningSystemId.Stack));
+		var outputRoot = Path.Join(Paths.WorkingDirectoryRoot.FullName, $"api-explorer-output-{Guid.NewGuid():N}");
+		var context = CreateGenerateContext(collector, stack, ProductsFor(product), outputRoot, GitForElasticsearch());
+		using var versionIndexClient = new VersionIndexClient(BaseUri, MultiVersionHandler(), sleep: (_, _) => Task.CompletedTask);
+		var reader = CreateSequentialReader(
+			SpecDocument("Elasticsearch main"),
+			SpecDocument("Elasticsearch 9"),
+			SpecDocument("Elasticsearch 8"));
+		var generator = CreateGenerator(context, versionIndexClient, reader);
+
+		await generator.Generate(TestContext.Current.CancellationToken);
+
+		context.WriteFileSystem.File.Exists(Path.Join(outputRoot, "api", "doc", "elasticsearch", "index.html")).Should().BeTrue();
+		context.WriteFileSystem.File.Exists(Path.Join(outputRoot, "api", "doc", "elasticsearch", "v9", "index.html")).Should().BeTrue();
+		context.WriteFileSystem.File.Exists(Path.Join(outputRoot, "api", "doc", "elasticsearch", "v8", "index.html")).Should().BeTrue();
+		context.WriteFileSystem.File.Exists(Path.Join(outputRoot, "api", "doc", "elasticsearch", "v8", "operation", "operation-ping", "index.html")).Should().BeTrue();
+	}
+
+	private static BuildContext CreateGenerateContext(
+		DiagnosticsCollector collector,
+		VersionsConfiguration versionsConfiguration,
+		ProductsConfiguration productsConfiguration,
+		string outputRoot,
+		GitCheckoutInformation git)
+	{
+		var repoRoot = Path.Join(Paths.WorkingDirectoryRoot.FullName, $"api-multi-version-test-{Guid.NewGuid():N}");
+		var configPath = Path.Join(repoRoot, "docs", "docset.yml");
+		var docsetYaml = """
+			api:
+			  elasticsearch:
+			    - spec: elasticsearch-openapi.json
+			      product: elasticsearch
+			""";
+		var fs = new MockFileSystem(new MockFileSystemOptions { CurrentDirectory = Paths.WorkingDirectoryRoot.FullName });
+		fs.AddDirectory(Path.Join(repoRoot, ".git"));
+		fs.AddFile(configPath, new MockFileData(docsetYaml));
+		var readFs = FileSystemFactory.ScopeCurrentWorkingDirectory(fs);
+		var writeFs = FileSystemFactory.ScopeCurrentWorkingDirectoryForWrite(fs);
+		var configurationContext = TestHelpers.CreateConfigurationContext(fs, versionsConfiguration, productsConfiguration);
+
+		return new BuildContext(collector, readFs, writeFs, configurationContext,
+			ExportOptions.Default, source: repoRoot, output: outputRoot, gitCheckoutInformation: git,
+			configurationFile: readFs.FileInfo.New(configPath));
+	}
+
+	private static OpenApiGenerator CreateGenerator(BuildContext context, VersionIndexClient versionIndexClient, IOpenApiSpecificationReader reader) =>
+		new(NullLoggerFactory.Instance, context, NoopMarkdownStringRenderer.Instance, versionIndexClient, reader);
+
+	private static IOpenApiSpecificationReader CreateSequentialReader(params OpenApiDocument[] documents)
+	{
+		var queue = new Queue<OpenApiDocument>(documents);
+		var reader = A.Fake<IOpenApiSpecificationReader>();
+		A.CallTo(() => reader.ReadAsync(A<Stream>._, A<string>._))
+			.ReturnsLazily(_ => Task.FromResult<OpenApiDocument?>(queue.Dequeue()));
+		return reader;
+	}
+
+	private static HttpMessageHandler MultiVersionHandler(string repository = "elastic/elasticsearch") =>
+		new StubHandler(request =>
+		{
+			if (request.RequestUri!.AbsolutePath.EndsWith("index.json", StringComparison.Ordinal))
+			{
+				return IndexResponse(/*lang=json,strict*/ $$"""
+					{
+						"{{repository}}": {
+							"elasticsearch-openapi.json": {
+								"main": { "version": "main" },
+								"9": { "version": "9.4" },
+								"8": { "version": "8.19" }
+							},
+							"elastic-cloud-serverless.yml": {
+								"main": { "version": "main" },
+								"8": { "version": "8.19" }
+							}
+						}
+					}
+					""");
+			}
+
+			return SpecResponse();
+		});
+
+	private static GitCheckoutInformation GitForElasticsearch() => new()
+	{
+		Branch = "main",
+		Remote = "https://github.com/elastic/elasticsearch.git",
+		Ref = "refs/heads/main"
+	};
+
+	private static HttpResponseMessage IndexResponse(string body) =>
+		new(HttpStatusCode.OK) { Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json") };
+
+	private static HttpResponseMessage SpecResponse() => new(HttpStatusCode.OK)
+	{
+		Content = new StringContent(
+			/*lang=json,strict*/ """{"openapi":"3.1.0","info":{"title":"Spec","version":"1.0"},"paths":{}}""",
+			System.Text.Encoding.UTF8, "application/json")
+	};
+
+	private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
+	{
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+			Task.FromResult(responder(request));
+	}
+
+	private sealed class CapturingDiagnosticsCollector() : DiagnosticsCollector([])
+	{
+		public override DiagnosticsCollector StartAsync(Cancel ctx) => this;
+		public override Task StopAsync(Cancel cancellationToken) => Task.CompletedTask;
+	}
+}

--- a/tests/Elastic.ApiExplorer.Tests/OpenApiGeneratorMultiVersionTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/OpenApiGeneratorMultiVersionTests.cs
@@ -84,7 +84,7 @@ public class OpenApiGeneratorMultiVersionTests
 	[Fact]
 	public async Task ResolveDocumentsForProduct_MultiMajorIndex_ResolvesMainAndNumericVersions()
 	{
-		var collector = new CapturingDiagnosticsCollector();
+		var collector = new DiagnosticsCollector([]);
 		var stack = TestHelpers.CreateStackVersionsConfiguration(currentMajor: 9);
 		var product = TestHelpers.CreateProduct("elasticsearch", stack.GetVersioningSystem(VersioningSystemId.Stack));
 		var context = CreateContext(collector, stack, ProductsFor(product), GitForElasticsearch());
@@ -100,34 +100,21 @@ public class OpenApiGeneratorMultiVersionTests
 
 		documents.Should().HaveCount(3);
 		documents.Select(d => d.Version.Moniker).Should().BeEquivalentTo(["main", "9", "8"]);
-		documents.Should().ContainSingle(d => d.ApiUrlSuffix == "elasticsearch" && d.Document.Info.Title == "Elasticsearch main");
-		documents.Should().ContainSingle(d => d.ApiUrlSuffix == "elasticsearch/v9" && d.Document.Info.Title == "Elasticsearch 9");
-		documents.Should().ContainSingle(d => d.ApiUrlSuffix == "elasticsearch/v8" && d.Document.Info.Title == "Elasticsearch 8");
-	}
-
-	[Fact]
-	public async Task ResolveDocumentsForProduct_CurrentMajorNine_StillRendersNumericNineTree()
-	{
-		var collector = new CapturingDiagnosticsCollector();
-		var stack = TestHelpers.CreateStackVersionsConfiguration(currentMajor: 9);
-		var product = TestHelpers.CreateProduct("elasticsearch", stack.GetVersioningSystem(VersioningSystemId.Stack));
-		var context = CreateContext(collector, stack, ProductsFor(product), GitForElasticsearch());
-		using var versionIndexClient = new VersionIndexClient(BaseUri, MultiVersionHandler(), sleep: (_, _) => Task.CompletedTask);
-		var reader = CreateSequentialReader(
-			SpecDocument("Elasticsearch main"),
-			SpecDocument("Elasticsearch 9"),
-			SpecDocument("Elasticsearch 8"));
-		var generator = CreateGenerator(context, versionIndexClient, reader);
-
-		var documents = await generator.ResolveDocumentsForProduct("elasticsearch", ApiConfig(product), TestContext.Current.CancellationToken);
-
-		documents.Should().Contain(d => d.Version.Moniker == "9" && d.ApiUrlSuffix == "elasticsearch/v9");
+		documents.Should().ContainSingle(d =>
+			ApiUrlBuilder.ProductSuffix("elasticsearch", d.Version.Moniker) == "elasticsearch"
+			&& d.Document.Info.Title == "Elasticsearch main");
+		documents.Should().ContainSingle(d =>
+			ApiUrlBuilder.ProductSuffix("elasticsearch", d.Version.Moniker) == "elasticsearch/v9"
+			&& d.Document.Info.Title == "Elasticsearch 9");
+		documents.Should().ContainSingle(d =>
+			ApiUrlBuilder.ProductSuffix("elasticsearch", d.Version.Moniker) == "elasticsearch/v8"
+			&& d.Document.Info.Title == "Elasticsearch 8");
 	}
 
 	[Fact]
 	public async Task ResolveDocumentsForProduct_VersionlessProduct_RendersMainOnly()
 	{
-		var collector = new CapturingDiagnosticsCollector();
+		var collector = new DiagnosticsCollector([]);
 		var versionless = TestHelpers.CreateVersionlessConfiguration();
 		var product = TestHelpers.CreateProduct("cloud-serverless", versionless.GetVersioningSystem(VersioningSystemId.Serverless));
 		var context = CreateContext(collector, versionless, ProductsFor(product), GitForElasticsearch());
@@ -140,13 +127,13 @@ public class OpenApiGeneratorMultiVersionTests
 
 		documents.Should().ContainSingle();
 		documents[0].Version.Moniker.Should().Be("main");
-		documents[0].ApiUrlSuffix.Should().Be("cloud-serverless");
+		ApiUrlBuilder.ProductSuffix("cloud-serverless", documents[0].Version.Moniker).Should().Be("cloud-serverless");
 	}
 
 	[Fact]
 	public async Task ResolveDocumentsForProduct_LocalMainAndRemoteHistoricalVersions_ResolvesAllTrees()
 	{
-		var collector = new CapturingDiagnosticsCollector();
+		var collector = new DiagnosticsCollector([]);
 		var stack = TestHelpers.CreateStackVersionsConfiguration(currentMajor: 9);
 		var product = TestHelpers.CreateProduct("elasticsearch", stack.GetVersioningSystem(VersioningSystemId.Stack));
 		var context = CreateContext(collector, stack, ProductsFor(product), GitForElasticsearch());
@@ -192,7 +179,7 @@ public class OpenApiGeneratorMultiVersionTests
 	[Fact]
 	public async Task Generate_WritesDistinctOutputTreesForMainAndReleasedMajors()
 	{
-		var collector = new CapturingDiagnosticsCollector();
+		var collector = new DiagnosticsCollector([]);
 		var stack = TestHelpers.CreateStackVersionsConfiguration(currentMajor: 9);
 		var product = TestHelpers.CreateProduct("elasticsearch", stack.GetVersioningSystem(VersioningSystemId.Stack));
 		var outputRoot = Path.Join(Paths.WorkingDirectoryRoot.FullName, $"api-explorer-output-{Guid.NewGuid():N}");
@@ -297,11 +284,5 @@ public class OpenApiGeneratorMultiVersionTests
 	{
 		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
 			Task.FromResult(responder(request));
-	}
-
-	private sealed class CapturingDiagnosticsCollector() : DiagnosticsCollector([])
-	{
-		public override DiagnosticsCollector StartAsync(Cancel ctx) => this;
-		public override Task StopAsync(Cancel cancellationToken) => Task.CompletedTask;
 	}
 }

--- a/tests/Elastic.ApiExplorer.Tests/OpenApiGeneratorMultiVersionTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/OpenApiGeneratorMultiVersionTests.cs
@@ -44,13 +44,13 @@ public class OpenApiGeneratorMultiVersionTests
 		IFileInfo? localSpecFile = null,
 		string specFileName = "elasticsearch-openapi.json",
 		string? repository = null) => new()
-	{
-		ProductKey = product.Id,
-		Product = product,
-		SpecFileName = specFileName,
-		LocalSpecFile = localSpecFile,
-		Repository = repository
-	};
+		{
+			ProductKey = product.Id,
+			Product = product,
+			SpecFileName = specFileName,
+			LocalSpecFile = localSpecFile,
+			Repository = repository
+		};
 
 	private static ProductsConfiguration ProductsFor(params Product[] products) =>
 		new()
@@ -100,9 +100,9 @@ public class OpenApiGeneratorMultiVersionTests
 
 		documents.Should().HaveCount(3);
 		documents.Select(d => d.Version.Moniker).Should().BeEquivalentTo(["main", "9", "8"]);
-		documents.Should().ContainSingle(d => d.ApiUrlSuffix == "elasticsearch" && d.Document.Info!.Title == "Elasticsearch main");
-		documents.Should().ContainSingle(d => d.ApiUrlSuffix == "elasticsearch/v9" && d.Document.Info!.Title == "Elasticsearch 9");
-		documents.Should().ContainSingle(d => d.ApiUrlSuffix == "elasticsearch/v8" && d.Document.Info!.Title == "Elasticsearch 8");
+		documents.Should().ContainSingle(d => d.ApiUrlSuffix == "elasticsearch" && d.Document.Info.Title == "Elasticsearch main");
+		documents.Should().ContainSingle(d => d.ApiUrlSuffix == "elasticsearch/v9" && d.Document.Info.Title == "Elasticsearch 9");
+		documents.Should().ContainSingle(d => d.ApiUrlSuffix == "elasticsearch/v8" && d.Document.Info.Title == "Elasticsearch 8");
 	}
 
 	[Fact]

--- a/tests/Elastic.ApiExplorer.Tests/TestHelpers.cs
+++ b/tests/Elastic.ApiExplorer.Tests/TestHelpers.cs
@@ -23,20 +23,7 @@ public static class TestHelpers
 {
 	public static IConfigurationContext CreateConfigurationContext(IFileSystem fileSystem, VersionsConfiguration? versionsConfiguration = null, ProductsConfiguration? productsConfiguration = null)
 	{
-		versionsConfiguration ??= new VersionsConfiguration
-		{
-			VersioningSystems = new Dictionary<VersioningSystemId, VersioningSystem>
-			{
-				{
-					VersioningSystemId.Stack, new VersioningSystem
-					{
-						Id = VersioningSystemId.Stack,
-						Current = new SemVersion(8, 0, 0),
-						Base = new SemVersion(8, 0, 0)
-					}
-				}
-			},
-		};
+		versionsConfiguration ??= CreateStackVersionsConfiguration(currentMajor: 9, currentMinor: 0);
 		if (productsConfiguration is null)
 		{
 			var products = new Dictionary<string, Product>
@@ -71,4 +58,44 @@ public static class TestHelpers
 			SearchConfiguration = search
 		};
 	}
+
+	public static VersionsConfiguration CreateStackVersionsConfiguration(int currentMajor, int currentMinor = 0, int patch = 0) =>
+		new()
+		{
+			VersioningSystems = new Dictionary<VersioningSystemId, VersioningSystem>
+			{
+				{
+					VersioningSystemId.Stack, new VersioningSystem
+					{
+						Id = VersioningSystemId.Stack,
+						Current = new SemVersion(currentMajor, currentMinor, patch),
+						Base = new SemVersion(currentMajor, 0, 0)
+					}
+				}
+			},
+		};
+
+	public static VersionsConfiguration CreateVersionlessConfiguration() =>
+		new()
+		{
+			VersioningSystems = new Dictionary<VersioningSystemId, VersioningSystem>
+			{
+				{
+					VersioningSystemId.Serverless, new VersioningSystem
+					{
+						Id = VersioningSystemId.Serverless,
+						Current = new SemVersion(VersioningSystem.VersionlessSentinel, 0, 0),
+						Base = new SemVersion(VersioningSystem.VersionlessSentinel, 0, 0)
+					}
+				}
+			},
+		};
+
+	public static Product CreateProduct(string id, VersioningSystem versioningSystem, string? displayName = null) =>
+		new()
+		{
+			Id = id,
+			DisplayName = displayName ?? id,
+			VersioningSystem = versioningSystem
+		};
 }


### PR DESCRIPTION
## Why

- All build modes must render every available OpenAPI major from the version index, not only `main`
- Closes elastic/docs-eng-team#721

## What

- Generate a full page tree for `main` at `/api/doc/{key}/` and for each released major at `/api/doc/{key}/vN/`
- Keep numeric released majors even when they match the current stack major; versionless products still render only `main`
- Add a simple left-nav version dropdown that links to each version landing page

## Notes

- Stacks on #3817 (`issue-720-api-url-scheme`); retarget to `main` after that stack merges
- Cross-version operation linking and search-export versioning stay out of scope


Made with [Cursor](https://cursor.com)