### PR TITLE
Exclude default items from RazorSlice glob in Elastic.Documentation.Site

### DIFF
--- a/src/Elastic.Documentation.Site/Elastic.Documentation.Site.csproj
+++ b/src/Elastic.Documentation.Site/Elastic.Documentation.Site.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <RazorSlice Include="**/*.cshtml" Exclude="**/_ViewImports.cshtml" />
+    <RazorSlice Include="**/*.cshtml" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);**/_ViewImports.cshtml" />
   </ItemGroup>
 
   <!-- source https://www.meziantou.net/running-npm-tasks-when-building-a-dotnet-project.htm -->


### PR DESCRIPTION
## Why

The `RazorSlice` item glob (`**/*.cshtml`) has no `DefaultItemExcludes`, so it recursively walks `bin/`, `obj/`, and `node_modules/` on every MSBuild evaluation. `node_modules` is populated automatically by this project's own `NpmInstall` target as part of a normal build, so this isn't a hypothetical edge case — it happens on every clean build/CI run.

## What

Adds `$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)` to the glob's `Exclude`, matching what every other default item type (`Compile`, `None`, etc.) already gets for free from the SDK.

Measured on this repo (54 projects) using MSBuild's `-profileevaluation`, with `node_modules` populated via `npm ci` (57k files / 8.3k dirs):

| | Before | After |
|---|---|---|
| This glob's evaluation cost | 5.25s | ~0.01–0.025s (99.5%+ reduction) |
| Total solution evaluation time | 26.4s | 19.8s (-25%) |

No functional change — the same `.cshtml` files are discovered either way, since none live under `bin/`, `obj/`, or `node_modules/`.

Made with [Cursor](https://cursor.com)