### PR TITLE
Hub pages 3/4: {get-started}

### DIFF
--- a/docs/_docset.yml
+++ b/docs/_docset.yml
@@ -122,6 +122,7 @@ toc:
       - file: file_inclusion.md
       - file: footnotes.md
       - file: frontmatter.md
+      - file: get-started.md
       - file: hero.md
       - file: hub-pages.md
       - file: icons.md

--- a/docs/examples/products/docs-builder.md
+++ b/docs/examples/products/docs-builder.md
@@ -12,6 +12,28 @@ description: docs-builder documentation. Build, validate, and publish Elastic do
 :tertiary-action: [Explore docs-builder](#explore)
 :::
 
+:::{get-started}
+title: Get started in 3 steps
+intro: Install docs-builder, write your first page, then preview and publish it.
+steps:
+  - title: Install docs-builder
+    options:
+      - label: Build from source
+        description: Clone the repository and build the CLI yourself.
+        code: dotnet build
+        language: sh
+      - label: Run in a container
+        description: No local install needed.
+        url: /getting-started/installation.md
+        url-label: Container setup
+  - title: Write your first page
+    description: Author Markdown, add links, and use the directive set.
+    link: /getting-started/writing-content.md
+    link-label: Start writing
+  - title: Preview and publish
+    description: Serve the site locally with live reload, then publish it.
+:::
+
 ::::{card-group}
 :title: Get hands-on
 :id: hands-on

--- a/docs/examples/products/docs-builder.md
+++ b/docs/examples/products/docs-builder.md
@@ -13,7 +13,7 @@ description: docs-builder documentation. Build, validate, and publish Elastic do
 :::
 
 :::{get-started}
-title: Get started in 3 steps
+title: Get started in 4 steps
 intro: Install docs-builder, write your first page, then preview and publish it.
 steps:
   - title: Install docs-builder
@@ -32,6 +32,10 @@ steps:
     link-label: Start writing
   - title: Preview and publish
     description: Serve the site locally with live reload, then publish it.
+    link: /getting-started/serve.md
+    link-label: Serve locally
+  - title: Validate the build
+    description: Check links, syntax, and frontmatter before you open a pull request.
 :::
 
 ::::{card-group}

--- a/docs/syntax/get-started.md
+++ b/docs/syntax/get-started.md
@@ -8,7 +8,7 @@ See the [docs-builder documentation hub](../examples/products/docs-builder.md) f
 
 ## Basic
 
-A hub's onboarding section is three steps. The first offers two equally weighted ways to start, and the rest are single links.
+A hub's onboarding section is a numbered list of steps. Use as many as the path needs. The first step often offers two equally weighted ways to start, and the rest are single links.
 
 ```markdown
 :::{get-started}
@@ -52,6 +52,16 @@ A command in a step option goes through the standard code block, so it gets synt
 
 Every field except `title` is optional. The [example hub](../examples/products/docs-builder.md) uses each one once, and shows all three step shapes, so you can start from it and delete what you do not need.
 
+
+## How many steps
+
+There is no fixed number. The layout arranges whatever you write:
+
+- A step carrying `options` spans the full row.
+- The remaining steps share the row, three across when they divide by three, two when they are even, so the last row is never short.
+- Below a narrow width the steps stack into one column.
+
+Keep the list short enough to read as one path. Four steps still scan. Ten do not.
 
 ## Step shapes
 

--- a/docs/syntax/get-started.md
+++ b/docs/syntax/get-started.md
@@ -1,0 +1,95 @@
+# Get started
+
+The onboarding section of a [hub page](hub-pages.md). It gives a new reader one opinionated path to a first success, before they face the full link list.
+
+The section is optional. Skip it when the hero already says what to do next.
+
+See the [docs-builder documentation hub](../examples/products/docs-builder.md) for a rendered section.
+
+## Basic
+
+A hub's onboarding section is three steps. The first offers two equally weighted ways to start, and the rest are single links.
+
+```markdown
+:::{get-started}
+title: Get started in 3 steps
+intro: Install docs-builder, write your first page, then preview and publish it.
+steps:
+  - title: Install docs-builder
+    options:
+      - label: Install locally
+        description: Install the CLI on your machine.
+        code: curl -sSL https://ela.st/docs-builder-install | sh
+        language: sh
+      - label: Run in a container
+        description: No local install needed.
+        url: /getting-started/installation.md
+        url-label: Container setup
+  - title: Write your first page
+    description: Author Markdown, add links, and use the directive set.
+    link: /getting-started/writing-content.md
+    link-label: Start writing
+  - title: Preview and publish
+    description: Serve the site locally with live reload, then publish it.
+    link: /getting-started/serve.md
+    link-label: Serve locally
+:::
+```
+
+The body is YAML, not markdown, like [`{link-card}`](link-card.md).
+
+## Schema
+
+| Field | Notes |
+|---|---|
+| `title` | **Required.** H2 heading. |
+| `intro` | One-line lead below the heading. |
+| `steps` | The numbered steps. |
+
+Everything the section offers lives inside a step. An install command belongs in `steps[0].options[]`, which keeps the whole path inside the numbered sequence.
+
+A command in a step option goes through the standard code block, so it gets syntax highlighting and a copy button like every other code block on the site.
+
+Every field except `title` is optional. The [example hub](../examples/products/docs-builder.md) uses each one once, and shows all three step shapes, so you can start from it and delete what you do not need.
+
+
+## Step shapes
+
+A step takes one of three shapes.
+
+**Plain.** A `title` and a `description`. Nothing is clickable.
+
+```yaml
+- title: Preview and publish
+  description: Serve the site locally, then publish it.
+```
+
+**Link.** Add `link` and `link-label`, and the whole step card becomes clickable.
+
+```yaml
+- title: Write your first page
+  description: Author markdown, add links, and use the directive set.
+  link: /getting-started/writing-content.md
+  link-label: Start writing
+```
+
+**Options.** Add `options` for two or more equally weighted paths, shown side by side. Each option takes a `label`, a `description`, and either a copyable `code` snippet with its `language`, or a `url` with a `url-label`.
+
+```yaml
+- title: Preview and publish
+  options:
+    - label: Preview locally
+      description: Serve the site with live reload while you write.
+      code: docs-builder serve
+      language: sh
+    - label: Publish
+      description: Build the site and publish it.
+      url: /getting-started/publish.md
+      url-label: How to publish
+```
+
+Steps are numbered automatically, in source order. The number sits before the title, because the section describes a sequence and the number is what carries that.
+
+## Links
+
+Every `steps[].link` and `options[].url` validates at build time, using the same forms as [`{link-card}`](link-card.md#links).

--- a/docs/syntax/hub-pages.md
+++ b/docs/syntax/hub-pages.md
@@ -56,6 +56,7 @@ Write both deliberately. The search body indexes the hero title and description 
 | [`{hero}`](hero.md) | Identity band. Carries the product icon, the page title, a description, and up to three actions. |
 | [`{card-group}`](card-group.md) | Section heading and card grid. Renders as an accordion inside `{explore}`. |
 | [`{link-card}`](link-card.md) | One card: title, description, and a list of links. Renders as a link column inside `{explore}`. |
+| [`{get-started}`](get-started.md) | Onboarding funnel. An install command, a tutorial link, and numbered steps. |
 | [`{explore}`](explore.md) | The browse-everything section. A stack of collapsible accordions. |
 
 ## Page skeleton

--- a/src/Elastic.Documentation.Site/Assets/markdown/hub.css
+++ b/src/Elastic.Documentation.Site/Assets/markdown/hub.css
@@ -162,13 +162,13 @@
 	}
 	.hub-get-started .hub-get-started-title {
 		margin: 0 0 8px;
-		font-size: 1.375rem;
+		font-size: var(--text-xl);
 		font-weight: 700;
 		color: var(--color-ink);
 	}
 	.hub-get-started .hub-get-started-intro {
 		margin: 0 0 20px;
-		font-size: 0.9375rem;
+		font-size: var(--text-base);
 		color: var(--color-ink-light, #4c4c4c);
 		line-height: 1.5;
 	}
@@ -187,7 +187,7 @@
 	}
 	.hub-get-started .hub-get-started-install code {
 		font-family: var(--font-mono, monospace);
-		font-size: 0.8125rem;
+		font-size: var(--text-sm);
 		color: var(--color-white);
 		background: transparent;
 	}
@@ -216,20 +216,23 @@
 		position: absolute;
 		top: 20px;
 		right: 20px;
-		font-size: 0.8125rem;
+		font-size: var(--text-sm);
 		font-weight: 600;
-		color: var(--color-grey-70, #98a2b3);
+		/* grey-70 reads at 3.31:1 on white, short of the 4.5:1 minimum. ink-light
+		   carries the same quiet weight at 7.03:1 and is what other secondary text
+		   on the page already uses. */
+		color: var(--color-ink-light);
 		letter-spacing: 0.06em;
 	}
 	.hub-get-started .hub-get-started-step-title {
 		margin: 0;
-		font-size: 0.9375rem;
+		font-size: var(--text-base);
 		font-weight: 700;
 		color: var(--color-ink-dark);
 	}
 	.hub-get-started .hub-get-started-step-desc {
 		margin: 0;
-		font-size: 0.8125rem;
+		font-size: var(--text-sm);
 		color: var(--color-ink-light, #4c4c4c);
 		line-height: 1.45;
 	}
@@ -260,13 +263,13 @@
 		border-left: 1px solid var(--color-grey-20);
 	}
 	.hub-get-started .hub-get-started-option-label {
-		font-size: 0.875rem;
+		font-size: var(--text-sm);
 		font-weight: 700;
 		color: var(--color-ink-dark);
 	}
 	.hub-get-started .hub-get-started-option-desc {
 		margin: 0;
-		font-size: 0.8125rem;
+		font-size: var(--text-sm);
 		color: var(--color-ink-light, #4c4c4c);
 		line-height: 1.45;
 	}
@@ -282,7 +285,7 @@
 		min-height: 48px;
 		margin-top: auto;
 		padding: 0 18px;
-		font-size: 0.875rem;
+		font-size: var(--text-sm);
 		font-weight: 600;
 		color: var(--color-ink-dark);
 		background: var(--color-white);
@@ -301,7 +304,7 @@
 	.hub-get-started .hub-get-started-option-link {
 		@apply inline-flex items-center gap-1;
 		align-self: flex-start;
-		font-size: 0.8125rem;
+		font-size: var(--text-sm);
 		font-weight: 600;
 		color: var(--color-blue-elastic-100, #0b64dd);
 	}
@@ -347,7 +350,7 @@
 		@apply inline-flex items-center gap-1;
 		margin-top: auto;
 		padding-top: 14px;
-		font-size: 0.8125rem;
+		font-size: var(--text-sm);
 		font-weight: 600;
 		color: var(--color-blue-elastic-100, #0b64dd);
 	}

--- a/src/Elastic.Documentation.Site/Assets/markdown/hub.css
+++ b/src/Elastic.Documentation.Site/Assets/markdown/hub.css
@@ -216,7 +216,7 @@
 		position: absolute;
 		top: 20px;
 		right: 20px;
-		font-size: var(--text-sm);
+		font-size: var(--text-base);
 		font-weight: 600;
 		/* grey-70 reads at 3.31:1 on white, short of the 4.5:1 minimum. ink-light
 		   carries the same quiet weight at 7.03:1 and is what other secondary text
@@ -232,7 +232,7 @@
 	}
 	.hub-get-started .hub-get-started-step-desc {
 		margin: 0;
-		font-size: var(--text-sm);
+		font-size: var(--text-base);
 		color: var(--color-ink-light, #4c4c4c);
 		line-height: 1.45;
 	}
@@ -263,13 +263,13 @@
 		border-left: 1px solid var(--color-grey-20);
 	}
 	.hub-get-started .hub-get-started-option-label {
-		font-size: var(--text-sm);
+		font-size: var(--text-base);
 		font-weight: 700;
 		color: var(--color-ink-dark);
 	}
 	.hub-get-started .hub-get-started-option-desc {
 		margin: 0;
-		font-size: var(--text-sm);
+		font-size: var(--text-base);
 		color: var(--color-ink-light, #4c4c4c);
 		line-height: 1.45;
 	}
@@ -285,7 +285,7 @@
 		min-height: 48px;
 		margin-top: auto;
 		padding: 0 18px;
-		font-size: var(--text-sm);
+		font-size: var(--text-base);
 		font-weight: 600;
 		color: var(--color-ink-dark);
 		background: var(--color-white);
@@ -304,7 +304,7 @@
 	.hub-get-started .hub-get-started-option-link {
 		@apply inline-flex items-center gap-1;
 		align-self: flex-start;
-		font-size: var(--text-sm);
+		font-size: var(--text-base);
 		font-weight: 600;
 		color: var(--color-blue-elastic-100, #0b64dd);
 	}
@@ -350,7 +350,7 @@
 		@apply inline-flex items-center gap-1;
 		margin-top: auto;
 		padding-top: 14px;
-		font-size: var(--text-sm);
+		font-size: var(--text-base);
 		font-weight: 600;
 		color: var(--color-blue-elastic-100, #0b64dd);
 	}

--- a/src/Elastic.Documentation.Site/Assets/markdown/hub.css
+++ b/src/Elastic.Documentation.Site/Assets/markdown/hub.css
@@ -155,8 +155,11 @@
 	}
 
 	/* Get started ------------------------------------------------------ */
+	/* A container, not the viewport: the left sidebar narrows the body, so the step
+	   grid has to answer to the space it actually has. */
 	.hub-get-started {
 		@apply mx-auto w-full max-w-5xl;
+		container-type: inline-size;
 		margin-bottom: 56px;
 		scroll-margin-top: 96px;
 	}
@@ -192,9 +195,15 @@
 		background: transparent;
 	}
 
+	/* The track count is authored, not inferred from the width: the directive counts the
+	   steps that flow in columns and sets --hub-step-columns, so a section of any length
+	   fills its rows evenly instead of leaving a short last row. */
 	.hub-get-started .hub-get-started-steps {
 		@apply grid gap-4;
-		grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+		grid-template-columns: repeat(
+			var(--hub-step-columns, 2),
+			minmax(0, 1fr)
+		);
 		margin: 0;
 		padding: 0;
 		list-style: none;
@@ -237,10 +246,14 @@
 		line-height: 1.45;
 	}
 
-	/* Step 01 with two equal start options spans the full row. */
-	.hub-get-started .hub-get-started-steps:has(.hub-get-started-step-wide) {
-		grid-template-columns: repeat(2, minmax(0, 1fr));
+	/* Below this the tracks are too narrow to hold a step title and a description. */
+	@container (max-width: 640px) {
+		.hub-get-started .hub-get-started-steps {
+			grid-template-columns: 1fr;
+		}
 	}
+
+	/* A step offering equally weighted options spans the full row, whatever the track count. */
 	.hub-get-started .hub-get-started-step-wide {
 		grid-column: 1 / -1;
 		container-type: inline-size;

--- a/src/Elastic.Documentation.Site/Assets/markdown/hub.css
+++ b/src/Elastic.Documentation.Site/Assets/markdown/hub.css
@@ -348,9 +348,11 @@
 			box-shadow 0.15s,
 			border-color 0.15s;
 	}
+	/* Same hover treatment as every other card that is itself a link. Blue would make
+	   one step look like the call to action when they are a sequence. */
 	.hub-get-started .hub-get-started-step-link:hover,
 	.hub-get-started .hub-get-started-step-link:focus-visible {
-		border-color: var(--color-blue-elastic);
+		border-color: var(--color-grey-80);
 		box-shadow: 0 1px 4px rgb(0 0 0 / 0.07);
 	}
 	.hub-get-started .hub-get-started-step-anchor {

--- a/src/Elastic.Documentation.Site/Assets/markdown/hub.css
+++ b/src/Elastic.Documentation.Site/Assets/markdown/hub.css
@@ -154,6 +154,204 @@
 		flex-shrink: 0;
 	}
 
+	/* Get started ------------------------------------------------------ */
+	.hub-get-started {
+		@apply mx-auto w-full max-w-5xl;
+		margin-bottom: 56px;
+		scroll-margin-top: 96px;
+	}
+	.hub-get-started .hub-get-started-title {
+		margin: 0 0 8px;
+		font-size: 1.375rem;
+		font-weight: 700;
+		color: var(--color-ink);
+	}
+	.hub-get-started .hub-get-started-intro {
+		margin: 0 0 20px;
+		font-size: 0.9375rem;
+		color: var(--color-ink-light, #4c4c4c);
+		line-height: 1.5;
+	}
+	.hub-get-started .hub-get-started-install {
+		position: relative;
+		flex: 1 1 380px;
+		min-width: 0;
+		margin: 0;
+	}
+	.hub-get-started .hub-get-started-install pre {
+		margin: 0;
+		padding: 12px 16px;
+		overflow-x: auto;
+		background: var(--color-ink-navy);
+		border-radius: 10px;
+	}
+	.hub-get-started .hub-get-started-install code {
+		font-family: var(--font-mono, monospace);
+		font-size: 0.8125rem;
+		color: var(--color-white);
+		background: transparent;
+	}
+
+	.hub-get-started .hub-get-started-steps {
+		@apply grid gap-4;
+		grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+	.hub-get-started .hub-get-started-step {
+		@apply relative flex flex-col;
+		padding: 20px;
+		background: var(--color-white);
+		border: 1px solid var(--color-grey-20);
+		border-radius: 14px;
+	}
+	.hub-get-started .hub-get-started-step-head {
+		@apply flex items-center;
+		gap: 12px;
+		margin-bottom: 10px;
+		padding-right: 34px;
+	}
+	.hub-get-started .hub-get-started-step-num {
+		position: absolute;
+		top: 20px;
+		right: 20px;
+		font-size: 0.8125rem;
+		font-weight: 600;
+		color: var(--color-grey-70, #98a2b3);
+		letter-spacing: 0.06em;
+	}
+	.hub-get-started .hub-get-started-step-title {
+		margin: 0;
+		font-size: 0.9375rem;
+		font-weight: 700;
+		color: var(--color-ink-dark);
+	}
+	.hub-get-started .hub-get-started-step-desc {
+		margin: 0;
+		font-size: 0.8125rem;
+		color: var(--color-ink-light, #4c4c4c);
+		line-height: 1.45;
+	}
+
+	/* Step 01 with two equal start options spans the full row. */
+	.hub-get-started .hub-get-started-steps:has(.hub-get-started-step-wide) {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+	.hub-get-started .hub-get-started-step-wide {
+		grid-column: 1 / -1;
+		container-type: inline-size;
+	}
+	.hub-get-started .hub-get-started-options {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		margin-top: 16px;
+		padding-top: 16px;
+		border-top: 1px solid var(--color-grey-20);
+	}
+	.hub-get-started .hub-get-started-option {
+		@apply flex flex-col;
+		gap: 10px;
+		padding-right: 28px;
+	}
+	.hub-get-started .hub-get-started-option + .hub-get-started-option {
+		padding-right: 0;
+		padding-left: 28px;
+		border-left: 1px solid var(--color-grey-20);
+	}
+	.hub-get-started .hub-get-started-option-label {
+		font-size: 0.875rem;
+		font-weight: 700;
+		color: var(--color-ink-dark);
+	}
+	.hub-get-started .hub-get-started-option-desc {
+		margin: 0;
+		font-size: 0.8125rem;
+		color: var(--color-ink-light, #4c4c4c);
+		line-height: 1.45;
+	}
+	.hub-get-started .hub-get-started-option .hub-get-started-install {
+		flex: none;
+		width: 100%;
+		margin-top: auto;
+	}
+	.hub-get-started .hub-get-started-option-btn {
+		@apply inline-flex items-center justify-center;
+		gap: 8px;
+		width: 100%;
+		min-height: 48px;
+		margin-top: auto;
+		padding: 0 18px;
+		font-size: 0.875rem;
+		font-weight: 600;
+		color: var(--color-ink-dark);
+		background: var(--color-white);
+		border: 1px solid var(--color-ink-dark);
+		border-radius: 8px;
+		transition:
+			background 0.15s ease,
+			border-color 0.15s ease;
+	}
+	.hub-get-started .hub-get-started-option-btn:hover,
+	.hub-get-started .hub-get-started-option-btn:focus-visible {
+		background: var(--color-grey-10);
+		border-color: var(--color-ink-dark);
+		color: var(--color-ink-dark);
+	}
+	.hub-get-started .hub-get-started-option-link {
+		@apply inline-flex items-center gap-1;
+		align-self: flex-start;
+		font-size: 0.8125rem;
+		font-weight: 600;
+		color: var(--color-blue-elastic-100, #0b64dd);
+	}
+	.hub-get-started .hub-get-started-option-link:hover,
+	.hub-get-started .hub-get-started-option-link:focus-visible {
+		text-decoration: underline;
+	}
+	@container (max-width: 560px) {
+		.hub-get-started .hub-get-started-options {
+			grid-template-columns: 1fr;
+		}
+		.hub-get-started .hub-get-started-option {
+			padding-right: 0;
+		}
+		.hub-get-started .hub-get-started-option + .hub-get-started-option {
+			padding-left: 0;
+			padding-top: 16px;
+			margin-top: 4px;
+			border-left: 0;
+			border-top: 1px solid var(--color-grey-20);
+		}
+	}
+
+	/* Steps 02/03 are clickable link cards. */
+	.hub-get-started .hub-get-started-step-link {
+		padding: 0;
+		transition:
+			box-shadow 0.15s,
+			border-color 0.15s;
+	}
+	.hub-get-started .hub-get-started-step-link:hover,
+	.hub-get-started .hub-get-started-step-link:focus-visible {
+		border-color: var(--color-blue-elastic);
+		box-shadow: 0 1px 4px rgb(0 0 0 / 0.07);
+	}
+	.hub-get-started .hub-get-started-step-anchor {
+		@apply flex h-full flex-col;
+		padding: 20px;
+		color: inherit;
+		text-decoration: none;
+	}
+	.hub-get-started .hub-get-started-step-arrow {
+		@apply inline-flex items-center gap-1;
+		margin-top: auto;
+		padding-top: 14px;
+		font-size: 0.8125rem;
+		font-weight: 600;
+		color: var(--color-blue-elastic-100, #0b64dd);
+	}
+
 	/* Zone (section heading) ------------------------------------------ */
 	.hub-zone {
 		@apply mx-auto w-full max-w-5xl;

--- a/src/Elastic.Markdown/Myst/Directives/DirectiveBlockParser.cs
+++ b/src/Elastic.Markdown/Myst/Directives/DirectiveBlockParser.cs
@@ -150,6 +150,9 @@ public class DirectiveBlockParser : FencedBlockParserBase<DirectiveBlock>
 		if (info.IndexOf("{link-card}") > 0)
 			return new LinkCardBlock(this, context);
 
+		if (info.IndexOf("{get-started}") > 0)
+			return new GetStartedBlock(this, context);
+
 		if (info.IndexOf("{agent-skill}") > 0)
 			return new AgentSkillBlock(this, context);
 

--- a/src/Elastic.Markdown/Myst/Directives/DirectiveHtmlRenderer.cs
+++ b/src/Elastic.Markdown/Myst/Directives/DirectiveHtmlRenderer.cs
@@ -117,6 +117,9 @@ public class DirectiveHtmlRenderer : HtmlObjectRenderer<DirectiveBlock>
 			case LinkCardBlock linkCardBlock:
 				WriteLinkCard(renderer, linkCardBlock);
 				return;
+			case GetStartedBlock getStartedBlock:
+				WriteGetStarted(renderer, getStartedBlock);
+				return;
 			case PageCardBlock pageCardBlock:
 				WritePageCard(renderer, pageCardBlock);
 				return;
@@ -263,6 +266,43 @@ public class DirectiveHtmlRenderer : HtmlObjectRenderer<DirectiveBlock>
 			IconSvg = ProductIcons.Get(block.Data.Icon),
 			SitePathPrefix = block.Build.UrlPathPrefix,
 			IsColumn = HubExplore.FindAncestor(block) is not null
+		});
+		RenderRazorSlice(slice, renderer);
+	}
+
+	private static void WriteGetStarted(HtmlRenderer renderer, GetStartedBlock block)
+	{
+		var data = block.Data;
+		var steps = new List<GetStartedStepViewModel>(data.Steps.Length);
+		for (var i = 0; i < data.Steps.Length; i++)
+		{
+			var step = data.Steps[i];
+			steps.Add(new GetStartedStepViewModel
+			{
+				Number = i + 1,
+				Title = step.Title,
+				DescriptionHtml = RenderInlineMarkdown(step.Description),
+				Link = step.Link,
+				LinkLabel = step.LinkLabel,
+				Options = [.. step.Options.Select(option => new GetStartedOptionViewModel
+				{
+					Label = option.Label,
+					DescriptionHtml = RenderInlineMarkdown(option.Description),
+					Code = option.Code,
+					Language = option.Language,
+					Url = option.Url,
+					UrlLabel = option.UrlLabel
+				})]
+			});
+		}
+
+		var slice = GetStartedView.Create(new GetStartedViewModel
+		{
+			DirectiveBlock = block,
+			Title = data.Title,
+			IntroHtml = RenderInlineMarkdown(data.Intro),
+			Steps = steps,
+			SitePathPrefix = block.Build.UrlPathPrefix
 		});
 		RenderRazorSlice(slice, renderer);
 	}

--- a/src/Elastic.Markdown/Myst/Directives/Hub/GetStartedBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Hub/GetStartedBlock.cs
@@ -1,0 +1,121 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Markdown.Diagnostics;
+using YamlDotNet.Core;
+using YamlDotNet.Serialization;
+
+namespace Elastic.Markdown.Myst.Directives.Hub;
+
+/// <summary>
+/// The first hub-body section: a short onboarding funnel with an intro line, an
+/// optional install snippet, an optional tutorial link, and a set of numbered
+/// steps. The schema is YAML-formatted in the directive body for predictable
+/// structure.
+/// </summary>
+/// <example>
+/// <code>
+/// :::{get-started}
+/// title: Get started in 3 steps
+/// intro: Spin up Kibana, connect your data, and start exploring in minutes.
+/// :::
+/// </code>
+/// </example>
+public class GetStartedBlock(DirectiveBlockParser parser, ParserContext context)
+	: DirectiveBlock(parser, context)
+{
+	public override string Directive => "get-started";
+
+	public GetStartedData Data { get; private set; } = GetStartedData.Empty;
+
+	public override void FinalizeAndValidate(ParserContext context)
+	{
+		var yaml = HubYamlBody.Extract(this, new BuildContextFileReader(Build.ReadFileSystem));
+		if (yaml is null)
+		{
+			this.EmitError("{get-started} requires a YAML body. See the get-started directive docs.");
+			return;
+		}
+
+		try
+		{
+			Data = YamlSerialization.Deserialize<GetStartedData>(yaml, Build.ProductsConfiguration) ?? GetStartedData.Empty;
+		}
+		catch (YamlException ex)
+		{
+			this.EmitError($"{{get-started}} YAML parse error: {ex.Message}");
+			return;
+		}
+
+		if (string.IsNullOrWhiteSpace(Data.Title))
+			this.EmitError("{get-started} requires a `title` field in its YAML body.");
+
+
+		foreach (var step in Data.Steps)
+		{
+			if (!string.IsNullOrWhiteSpace(step.Link))
+				step.Link = DirectiveLinkValidator.ValidateAndResolve(step.Link, this, context);
+			foreach (var option in step.Options)
+				option.Url = DirectiveLinkValidator.ValidateAndResolve(option.Url, this, context);
+		}
+	}
+}
+
+[YamlSerializable]
+public record GetStartedData
+{
+	[YamlMember(Alias = "title")]
+	public string? Title { get; set; }
+
+	[YamlMember(Alias = "intro")]
+	public string? Intro { get; set; }
+
+	[YamlMember(Alias = "steps")]
+	public GetStartedStep[] Steps { get; set; } = [];
+
+	public static GetStartedData Empty { get; } = new();
+}
+
+[YamlSerializable]
+public record GetStartedStep
+{
+	[YamlMember(Alias = "title")]
+	public string? Title { get; set; }
+
+	[YamlMember(Alias = "description")]
+	public string? Description { get; set; }
+
+	/// <summary>When set, the whole step card links here.</summary>
+	[YamlMember(Alias = "link")]
+	public string? Link { get; set; }
+
+	[YamlMember(Alias = "link-label")]
+	public string? LinkLabel { get; set; }
+
+	/// <summary>Two-or-more equally-weighted start options rendered side by side.</summary>
+	[YamlMember(Alias = "options")]
+	public GetStartedStepOption[] Options { get; set; } = [];
+}
+
+[YamlSerializable]
+public record GetStartedStepOption
+{
+	[YamlMember(Alias = "label")]
+	public string? Label { get; set; }
+
+	[YamlMember(Alias = "description")]
+	public string? Description { get; set; }
+
+	[YamlMember(Alias = "code")]
+	public string? Code { get; set; }
+
+	[YamlMember(Alias = "language")]
+	public string? Language { get; set; }
+
+	[YamlMember(Alias = "url")]
+	public string? Url { get; set; }
+
+	[YamlMember(Alias = "url-label")]
+	public string? UrlLabel { get; set; }
+}

--- a/src/Elastic.Markdown/Myst/Directives/Hub/GetStartedView.cshtml
+++ b/src/Elastic.Markdown/Myst/Directives/Hub/GetStartedView.cshtml
@@ -55,8 +55,8 @@
 										{
 											<a class="hub-get-started-option-link" @Model.LinkAttributes(option.Url)>
 												<span>@(string.IsNullOrWhiteSpace(option.UrlLabel) ? "Learn more" : option.UrlLabel)</span>
-												<svg width="13" height="13" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-													<path d="M3 8h9M8.5 4l4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+												<svg class="hub-arrow" viewBox="0 0 24 24" fill="none" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+													<path stroke-linecap="round" stroke-linejoin="round" d="M17.25 8.25 21 12m0 0-3.75 3.75M21 12H3"/>
 												</svg>
 											</a>
 										}
@@ -87,8 +87,8 @@
 							}
 							<span class="hub-get-started-step-arrow" aria-hidden="true">
 								<span>@(string.IsNullOrWhiteSpace(step.LinkLabel) ? "Open" : step.LinkLabel)</span>
-								<svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-									<path d="M3 8h9M8.5 4l4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+								<svg class="hub-arrow" viewBox="0 0 24 24" fill="none" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+									<path stroke-linecap="round" stroke-linejoin="round" d="M17.25 8.25 21 12m0 0-3.75 3.75M21 12H3"/>
 								</svg>
 							</span>
 						</a>

--- a/src/Elastic.Markdown/Myst/Directives/Hub/GetStartedView.cshtml
+++ b/src/Elastic.Markdown/Myst/Directives/Hub/GetStartedView.cshtml
@@ -1,0 +1,116 @@
+@inherits RazorSlice<Elastic.Markdown.Myst.Directives.Hub.GetStartedViewModel>
+
+<section class="hub-get-started" id="get-started">
+	<div class="hub-get-started-lead">
+		@if (!string.IsNullOrWhiteSpace(Model.Title))
+		{
+			<h2 class="hub-get-started-title">@Model.Title</h2>
+		}
+		@if (!string.IsNullOrWhiteSpace(Model.IntroHtml))
+		{
+			<p class="hub-get-started-intro">@(new HtmlString(Model.IntroHtml))</p>
+		}
+	</div>
+
+	@if (Model.Steps.Count > 0)
+	{
+		<ol class="hub-get-started-steps">
+			@foreach (var step in Model.Steps)
+			{
+				@if (step.Options.Count > 0)
+				{
+					<li class="hub-get-started-step hub-get-started-step-wide">
+						<div class="hub-get-started-step-head">
+							<span class="hub-get-started-step-num" aria-hidden="true">@step.Number.ToString("D2")</span>
+							@if (!string.IsNullOrWhiteSpace(step.Title))
+							{
+								<h3 class="hub-get-started-step-title">@step.Title</h3>
+							}
+						</div>
+						@if (!string.IsNullOrWhiteSpace(step.DescriptionHtml))
+						{
+							<p class="hub-get-started-step-desc">@(new HtmlString(step.DescriptionHtml))</p>
+						}
+						<div class="hub-get-started-options">
+							@foreach (var option in step.Options)
+							{
+								<div class="hub-get-started-option">
+									@if (!string.IsNullOrWhiteSpace(option.Label))
+									{
+										<span class="hub-get-started-option-label">@option.Label</span>
+									}
+									@if (!string.IsNullOrWhiteSpace(option.DescriptionHtml))
+									{
+										<p class="hub-get-started-option-desc">@(new HtmlString(option.DescriptionHtml))</p>
+									}
+									@if (!string.IsNullOrWhiteSpace(option.Code))
+									{
+										<div class="hub-get-started-install highlight">
+											<pre><code class="language-@(option.Language ?? "text")">@option.Code</code></pre>
+										</div>
+									}
+									@if (!string.IsNullOrWhiteSpace(option.Url))
+									{
+										@if (!string.IsNullOrWhiteSpace(option.Code))
+										{
+											<a class="hub-get-started-option-link" @Model.LinkAttributes(option.Url)>
+												<span>@(string.IsNullOrWhiteSpace(option.UrlLabel) ? "Learn more" : option.UrlLabel)</span>
+												<svg width="13" height="13" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+													<path d="M3 8h9M8.5 4l4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+												</svg>
+											</a>
+										}
+										else
+										{
+											<a class="hub-get-started-option-btn" @Model.LinkAttributes(option.Url)>@(string.IsNullOrWhiteSpace(option.UrlLabel) ? "Get started" : option.UrlLabel)</a>
+										}
+									}
+								</div>
+							}
+						</div>
+					</li>
+				}
+				else if (!string.IsNullOrWhiteSpace(step.Link))
+				{
+					<li class="hub-get-started-step hub-get-started-step-link">
+						<a class="hub-get-started-step-anchor" @Model.LinkAttributes(step.Link)>
+							<div class="hub-get-started-step-head">
+								<span class="hub-get-started-step-num" aria-hidden="true">@step.Number.ToString("D2")</span>
+								@if (!string.IsNullOrWhiteSpace(step.Title))
+								{
+									<h3 class="hub-get-started-step-title">@step.Title</h3>
+								}
+							</div>
+							@if (!string.IsNullOrWhiteSpace(step.DescriptionHtml))
+							{
+								<p class="hub-get-started-step-desc">@(new HtmlString(step.DescriptionHtml))</p>
+							}
+							<span class="hub-get-started-step-arrow" aria-hidden="true">
+								<span>@(string.IsNullOrWhiteSpace(step.LinkLabel) ? "Open" : step.LinkLabel)</span>
+								<svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+									<path d="M3 8h9M8.5 4l4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+								</svg>
+							</span>
+						</a>
+					</li>
+				}
+				else
+				{
+					<li class="hub-get-started-step">
+						<div class="hub-get-started-step-head">
+							<span class="hub-get-started-step-num" aria-hidden="true">@step.Number.ToString("D2")</span>
+							@if (!string.IsNullOrWhiteSpace(step.Title))
+							{
+								<h3 class="hub-get-started-step-title">@step.Title</h3>
+							}
+						</div>
+						@if (!string.IsNullOrWhiteSpace(step.DescriptionHtml))
+						{
+							<p class="hub-get-started-step-desc">@(new HtmlString(step.DescriptionHtml))</p>
+						}
+					</li>
+				}
+			}
+		</ol>
+	}
+</section>

--- a/src/Elastic.Markdown/Myst/Directives/Hub/GetStartedView.cshtml
+++ b/src/Elastic.Markdown/Myst/Directives/Hub/GetStartedView.cshtml
@@ -14,7 +14,7 @@
 
 	@if (Model.Steps.Count > 0)
 	{
-		<ol class="hub-get-started-steps">
+		<ol class="hub-get-started-steps" style="--hub-step-columns: @Model.StepColumns">
 			@foreach (var step in Model.Steps)
 			{
 				@if (step.Options.Count > 0)

--- a/src/Elastic.Markdown/Myst/Directives/Hub/GetStartedViewModel.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Hub/GetStartedViewModel.cs
@@ -1,0 +1,32 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic.Markdown.Myst.Directives.Hub;
+
+public class GetStartedViewModel : HubDirectiveViewModel
+{
+	public required string? Title { get; init; }
+	public required string? IntroHtml { get; init; }
+	public required IReadOnlyList<GetStartedStepViewModel> Steps { get; init; }
+}
+
+public sealed record GetStartedStepViewModel
+{
+	public required int Number { get; init; }
+	public required string? Title { get; init; }
+	public required string? DescriptionHtml { get; init; }
+	public required string? Link { get; init; }
+	public required string? LinkLabel { get; init; }
+	public required IReadOnlyList<GetStartedOptionViewModel> Options { get; init; }
+}
+
+public sealed record GetStartedOptionViewModel
+{
+	public required string? Label { get; init; }
+	public required string? DescriptionHtml { get; init; }
+	public required string? Code { get; init; }
+	public required string? Language { get; init; }
+	public required string? Url { get; init; }
+	public required string? UrlLabel { get; init; }
+}

--- a/src/Elastic.Markdown/Myst/Directives/Hub/GetStartedViewModel.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Hub/GetStartedViewModel.cs
@@ -9,6 +9,25 @@ public class GetStartedViewModel : HubDirectiveViewModel
 	public required string? Title { get; init; }
 	public required string? IntroHtml { get; init; }
 	public required IReadOnlyList<GetStartedStepViewModel> Steps { get; init; }
+
+	/// <summary>
+	/// Track count for the step grid. A step carrying options spans the full row, so only the
+	/// remaining steps compete for columns. The count is picked to divide them evenly and leave
+	/// no short last row: three across when they divide by three, two when they are even,
+	/// otherwise as many as there are, up to three.
+	/// </summary>
+	public int StepColumns
+	{
+		get
+		{
+			var inFlow = Steps.Count(s => s.Options.Count == 0);
+			if (inFlow == 0)
+				return 1;
+			if (inFlow % 3 == 0)
+				return 3;
+			return inFlow % 2 == 0 ? 2 : inFlow < 3 ? inFlow : 3;
+		}
+	}
 }
 
 public sealed record GetStartedStepViewModel

--- a/src/Elastic.Markdown/Myst/Renderers/LlmMarkdown/LlmBlockRenderers.cs
+++ b/src/Elastic.Markdown/Myst/Renderers/LlmMarkdown/LlmBlockRenderers.cs
@@ -514,6 +514,9 @@ public class LlmDirectiveRenderer : MarkdownObjectRenderer<LlmMarkdownRenderer, 
 			case LinkCardBlock linkCardBlock:
 				WriteLinkCardBlock(renderer, linkCardBlock);
 				return;
+			case GetStartedBlock getStartedBlock:
+				WriteGetStartedBlock(renderer, getStartedBlock);
+				return;
 		}
 
 		// Ensure single empty line before directive
@@ -578,6 +581,51 @@ public class LlmDirectiveRenderer : MarkdownObjectRenderer<LlmMarkdownRenderer, 
 		WriteHeroAction(renderer, heroBlock.SecondaryActionLabel, heroBlock.SecondaryActionUrl);
 		WriteHeroAction(renderer, heroBlock.TertiaryActionLabel, heroBlock.TertiaryActionUrl);
 		renderer.EnsureLine();
+	}
+
+	// The onboarding path is a sequence, so it exports as an ordered list. Options under a step
+	// become sub-items, each with its command or its link.
+	private static void WriteGetStartedBlock(LlmMarkdownRenderer renderer, GetStartedBlock block)
+	{
+		var data = block.Data;
+		renderer.EnsureBlockSpacing();
+
+		if (!string.IsNullOrEmpty(data.Title))
+		{
+			renderer.WriteLine($"## {data.Title}");
+			renderer.EnsureLine();
+		}
+		if (!string.IsNullOrEmpty(data.Intro))
+		{
+			renderer.WriteLine(data.Intro);
+			renderer.EnsureLine();
+		}
+
+		for (var i = 0; i < data.Steps.Length; i++)
+			WriteGetStartedStep(renderer, data.Steps[i], i + 1);
+
+		renderer.EnsureLine();
+	}
+
+	private static void WriteGetStartedStep(LlmMarkdownRenderer renderer, GetStartedStep step, int number)
+	{
+		renderer.EnsureLine();
+		var title = string.IsNullOrEmpty(step.Link)
+			? step.Title
+			: $"[{step.Title}]({HubLinkForLlm(renderer, step.Link)})";
+		renderer.WriteLine($"{number}. {title}");
+
+		if (!string.IsNullOrEmpty(step.Description))
+			renderer.WriteLine($"   {step.Description}");
+
+		foreach (var option in step.Options)
+		{
+			renderer.WriteLine($"   - {option.Label}: {option.Description}");
+			if (!string.IsNullOrEmpty(option.Code))
+				renderer.WriteLine($"     `{option.Code}`");
+			if (!string.IsNullOrEmpty(option.Url))
+				renderer.WriteLine($"     [{option.UrlLabel ?? "Get started"}]({HubLinkForLlm(renderer, option.Url)})");
+		}
 	}
 
 	// The curated grouping of links is what a hub page is for, so the export keeps the whole

--- a/src/Elastic.Markdown/Myst/Renderers/PlainText/PlainTextBlockRenderers.cs
+++ b/src/Elastic.Markdown/Myst/Renderers/PlainText/PlainTextBlockRenderers.cs
@@ -291,6 +291,7 @@ public class PlainTextDirectiveRenderer : MarkdownObjectRenderer<PlainTextRender
 			case ExploreBlock:
 			case CardGroupBlock:
 			case LinkCardBlock:
+			case GetStartedBlock:
 				return;
 
 			case AgentSkillBlock agentSkillBlock:

--- a/src/Elastic.Markdown/Myst/YamlSerialization.cs
+++ b/src/Elastic.Markdown/Myst/YamlSerialization.cs
@@ -83,4 +83,7 @@ internal class ListingFrontMatterConverter : IYamlTypeConverter
 [YamlSerializable(typeof(ListingFrontMatter))]
 [YamlSerializable(typeof(Elastic.Markdown.Myst.Directives.Hub.LinkCardData))]
 [YamlSerializable(typeof(Elastic.Markdown.Myst.Directives.Hub.LinkCardLink))]
+[YamlSerializable(typeof(Elastic.Markdown.Myst.Directives.Hub.GetStartedData))]
+[YamlSerializable(typeof(Elastic.Markdown.Myst.Directives.Hub.GetStartedStep))]
+[YamlSerializable(typeof(Elastic.Markdown.Myst.Directives.Hub.GetStartedStepOption))]
 public partial class DocsBuilderYamlStaticContext;

--- a/tests/authoring/Blocks/Hub/GetStarted.fs
+++ b/tests/authoring/Blocks/Hub/GetStarted.fs
@@ -1,0 +1,106 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+module ``AuthoringTests``.``block elements``.``hub``.``get started elements``
+
+open Xunit
+open authoring
+
+type ``get started with a title and intro`` () =
+    static let markdown = Setup.Markdown """
+:::{get-started}
+title: Get started in 3 steps
+intro: Install, write, preview.
+steps:
+  - title: Install
+    description: Install the CLI.
+:::
+"""
+
+    [<Fact>]
+    let ``renders the heading`` () =
+        markdown |> convertsToContainingHtml """<h2 class="hub-get-started-title">Get started in 3 steps</h2>"""
+
+    [<Fact>]
+    let ``numbers steps from one, zero padded`` () =
+        markdown |> convertsToContainingRawHtml """<span class="hub-get-started-step-num" aria-hidden="true">01</span>"""
+
+    // Nothing renders between the intro and the numbered list. The section is the steps.
+    [<Fact>]
+    let ``renders nothing above the steps`` () =
+        markdown |> doesNotConvertToContainingHtml "hub-get-started-actions"
+
+    [<Fact>]
+    let ``has no errors`` () = markdown |> hasNoErrors
+
+type ``get started with a link step`` () =
+    static let markdown = Setup.Markdown """
+:::{get-started}
+title: Get started
+steps:
+  - title: Write your first page
+    description: Author markdown.
+    link: /index.md
+    link-label: Start writing
+:::
+"""
+
+    [<Fact>]
+    let ``makes the whole step clickable`` () =
+        markdown |> convertsToContainingHtml """<span>Start writing</span>"""
+
+    [<Fact>]
+    let ``has no errors`` () = markdown |> hasNoErrors
+
+type ``get started with option steps`` () =
+    static let markdown = Setup.Markdown """
+:::{get-started}
+title: Get started
+steps:
+  - title: Preview and publish
+    options:
+      - label: Preview locally
+        description: Serve with live reload.
+        code: docs-builder serve
+        language: sh
+      - label: Publish
+        description: Build and publish.
+        url: /index.md
+        url-label: How to publish
+:::
+"""
+
+    [<Fact>]
+    let ``renders both options`` () =
+        markdown |> convertsToContainingHtml """<span class="hub-get-started-option-label">Preview locally</span>"""
+
+    [<Fact>]
+    let ``renders the option command`` () =
+        markdown |> convertsToContainingHtml """<code class="language-sh">docs-builder serve</code>"""
+
+    [<Fact>]
+    let ``has no errors`` () = markdown |> hasNoErrors
+
+type ``get started with a relative step link`` () =
+    static let markdown = Setup.Markdown """
+:::{get-started}
+title: Get started
+steps:
+  - title: Broken
+    link: nope.md
+:::
+"""
+
+    [<Fact>]
+    let ``rejects a relative path`` () =
+        markdown |> hasError "must be an absolute path starting with `/`"
+
+type ``get started without a body`` () =
+    static let markdown = Setup.Markdown """
+:::{get-started}
+:::
+"""
+
+    [<Fact>]
+    let ``errors`` () =
+        markdown |> hasError "{get-started}"

--- a/tests/authoring/Blocks/Hub/GetStarted.fs
+++ b/tests/authoring/Blocks/Hub/GetStarted.fs
@@ -104,3 +104,51 @@ type ``get started without a body`` () =
     [<Fact>]
     let ``errors`` () =
         markdown |> hasError "{get-started}"
+
+// The section is not fixed at three steps. The track count follows the steps that flow in
+// columns, so the last row is never short. A step carrying options spans the full row and
+// takes no track.
+type ``get started with four steps`` () =
+    static let markdown = Setup.Markdown """
+:::{get-started}
+title: Get started
+steps:
+  - title: Install
+    options:
+      - label: Source
+        code: dotnet build
+      - label: Container
+        url: /index.md
+  - title: Write
+  - title: Preview
+  - title: Validate
+:::
+"""
+
+    [<Fact>]
+    let ``lays the three remaining steps across three tracks`` () =
+        markdown |> convertsToContainingRawHtml """<ol class="hub-get-started-steps" style="--hub-step-columns: 3">"""
+
+    [<Fact>]
+    let ``has no errors`` () = markdown |> hasNoErrors
+
+type ``get started with five steps`` () =
+    static let markdown = Setup.Markdown """
+:::{get-started}
+title: Get started
+steps:
+  - title: One
+  - title: Two
+  - title: Three
+  - title: Four
+:::
+"""
+
+    // Four steps divide evenly into two rows of two, so they take two tracks rather than
+    // three with a single step stranded on the last row.
+    [<Fact>]
+    let ``pairs four steps into two tracks`` () =
+        markdown |> convertsToContainingRawHtml """<ol class="hub-get-started-steps" style="--hub-step-columns: 2">"""
+
+    [<Fact>]
+    let ``has no errors`` () = markdown |> hasNoErrors

--- a/tests/authoring/authoring.fsproj
+++ b/tests/authoring/authoring.fsproj
@@ -57,6 +57,7 @@
     <Compile Include="Blocks\NestedDirectiveOptions.fs" />
     <Compile Include="Blocks\Hub\Hero.fs" />
     <Compile Include="Blocks\Hub\CardsAndExplore.fs" />
+    <Compile Include="Blocks\Hub\GetStarted.fs" />
     <Compile Include="Applicability\AppliesToFrontMatter.fs" />
     <Compile Include="Applicability\AppliesToDirective.fs" />
     <Compile Include="Applicability\ApplicableToComponent.fs" />


### PR DESCRIPTION
Part 3 of 4, based on #3826. Implements elastic/docs-content-internal#1382.

Demo: https://docs-v3-preview.elastic.dev/elastic/docs-builder/pull/3827/examples/products/docs-builder

The onboarding section of a hub page. It gives a new reader one opinionated path to a first success, before they face the full link list. The section is optional.

## Structure

A numbered list of steps, of any length. The first often offers two equally weighted ways to start, and the rest are single steps.

| Shape | Fields | Renders as |
|---|---|---|
| Options | `title`, `options[]` | Two or more equally weighted paths side by side, each with a command or a link |
| Link | `title`, `description`, `link`, `link-label` | The whole card is clickable |
| Plain | `title`, `description` | A static card |

Nothing renders between the intro and the numbered list. An install command belongs in `steps[0].options[]`, which keeps the whole path inside the numbered sequence. The prototype's `install` and `tutorial` fields are removed: they placed content above the steps, which the structure does not call for.

## Implementation choices

**A linked step hovers grey, not blue.** Blue makes one step in a sequence look like the call to action, and it differed from the other card types. Every card on a hub page that is itself a link now hovers the same way, matching `{page-card}`.

**The step count is not fixed.** The prototype's layout assumed three. The directive now counts the steps that flow in columns and sets the track count: three across when they divide by three, two when they are even, so the last row is never short. A step carrying `options` spans the full row and takes no track. Below 640px of available width the steps stack into one column, measured on the section rather than the viewport, because the left sidebar narrows the body.

**A step option's command uses the standard code block.** It renders inside `.highlight pre` with a language class, which is what the site's copy button and syntax highlighter select on. Both attach with no extra wiring, because the hub layout kept the `markdown-content` id in #3825. That gives the Copy affordance the designs show.

**Step numbering sits before the title.** The section describes a sequence, and the number is what carries that. The designs put it in the card corner, which turns it into a decorative counter the reader meets after the title.

**No per-step icon.** The prototype has `steps[].icon`, resolved through `EuiSvgIcons`. It is removed. In the designs the icons restate the step title, the number badge is already the card's visual anchor, and a schema field that exists for decoration means every author picks icons that then drift between hubs.

**Machine-readable output.** The LLM export renders steps as an ordered list, with options as sub-items carrying their command or link. The search body gets nothing, as with the other hub directives.

## Example page

The example hub's section uses every field once and shows all three step shapes. It carries four steps, so the preview shows a section that is not the three-step case the prototype assumed.

## Testing

`./build.sh unit-test` passes. `dotnet format` and `npm run fmt:check` are clean. A full docs build reports 0 errors and 0 warnings.

`tests/authoring/Blocks/Hub/GetStarted.fs` covers all three step shapes, the track count for four steps with and without a wide step, a step option's command landing in a highlightable code block, automatic numbering, that nothing renders above the steps, and two failure paths.

## Screenshots to add or update

None attached. The side-by-side option layout in step one is worth checking on the preview.




