### PR TITLE
perf: skip PreprocessLinkSubstitutions when no {{ }} present

### DIFF
--- a/src/Elastic.Markdown/Myst/MarkdownParser.cs
+++ b/src/Elastic.Markdown/Myst/MarkdownParser.cs
@@ -220,6 +220,11 @@ public partial class MarkdownParser(BuildContext build, IParserResolvers resolve
 	/// </summary>
 	private static string PreprocessLinkSubstitutions(string markdown, ParserContext context)
 	{
+		// The callback only rewrites links whose URL contains {{ }}. If the document
+		// has no {{ at all, both GetCodeBlockRanges and the Regex.Replace are pure overhead.
+		if (!markdown.Contains("{{", StringComparison.Ordinal))
+			return markdown;
+
 		// Find all code block boundaries to avoid processing links inside subs=false blocks
 		var codeBlockRanges = GetCodeBlockRanges(markdown);
 


### PR DESCRIPTION
## Summary

`PreprocessLinkSubstitutions` unconditionally runs `GetCodeBlockRanges` (a full span scan) and `Regex.Replace` (allocates a new string + a `Match`+`Group` object per link) on every markdown file. The callback only rewrites links whose URL contains `{{`; on a corpus where the vast majority of files have no attribute substitutions at all, both operations are pure overhead.

Adding an early-return guard eliminates both allocations for every file that does not contain `{{`.

## Test plan

- [ ] `dotnet test tests/Elastic.Markdown.Tests/ --filter SubstitutionTest|MutationOperatorsInLinksTest` — 7 tests pass (covers the link-substitution path)
- [ ] `dotnet test tests/Elastic.Markdown.Tests/` — full 1951-test suite passes
- [ ] `dotnet run --project src/tooling/docs-migrate -- bench` — record `ResolveDirectoryTree` time

🤖 Generated with [Claude Code](https://claude.com/claude-code)