### PR TITLE
Bump Mermaider to 0.12.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -86,7 +86,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
     <PackageVersion Include="Markdig" Version="1.2.0" />
-    <PackageVersion Include="Mermaider" Version="0.12.1" />
+    <PackageVersion Include="Mermaider" Version="0.12.2" />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.19.1" />
     <PackageVersion Include="ModelContextProtocol" Version="1.4.0" />
     <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.4.0" />

--- a/tests/Elastic.ApiExplorer.Tests/XReqAuthTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/XReqAuthTests.cs
@@ -158,9 +158,10 @@ public class XReqAuthTests
 
 		var opCount = 0;
 		var pathCount = 0;
+		var opLimitReached = false;
 		foreach (var p in doc.Paths)
 		{
-			if (pathCount >= 3)
+			if (opLimitReached || pathCount >= 3)
 				break;
 			pathCount++;
 			if (p.Value.Operations is null)
@@ -168,7 +169,10 @@ public class XReqAuthTests
 			foreach (var httpOp in p.Value.Operations)
 			{
 				if (opCount >= 5)
-					goto done;
+				{
+					opLimitReached = true;
+					break;
+				}
 				var lines = OpenApiXReqAuthParser.TryGetPrerequisiteLines(
 					httpOp.Value,
 					null,
@@ -179,7 +183,6 @@ public class XReqAuthTests
 				opCount++;
 			}
 		}
-	done:
 		opCount.Should().BeGreaterThan(0, "sample should have at least one operation in the first 3 paths");
 	}
 }


### PR DESCRIPTION
## Why

Mermaid flowcharts with side-exit edges rendered with overlapping nodes: sibling nodes that had no relationship to a given edge would visually sit on top of it, making diagrams misleading (see [#3841](https://github.com/elastic/docs-builder/issues/3841) and [#3780](https://github.com/elastic/docs-builder/issues/3780)).

## What

Bumps the `Mermaider` NuGet package from `0.12.1` to `0.12.2`, which includes an [upstream fix](https://github.com/nullean/mermaider/commit/fe25845196bf2952b05837fa466e035d59b5f18c) for side-exit edge routing that caused the overlapping-node layout bug.

Fixes https://github.com/elastic/docs-builder/issues/3841
Fixes https://github.com/elastic/docs-builder/issues/3780

Made with [Cursor](https://cursor.com)