### PR TITLE
Add commit-range PR resolution service and bundle git_ref metadata

### DIFF
--- a/src/Elastic.Documentation.Configuration/ReleaseNotes/Bundle.cs
+++ b/src/Elastic.Documentation.Configuration/ReleaseNotes/Bundle.cs
@@ -24,6 +24,12 @@ public sealed record BundleDto
 	[YamlMember(Alias = "release-date", ApplyNamingConventions = false)]
 	public string? ReleaseDate { get; set; }
 	/// <summary>
+	/// Optional git ref of the published endpoint this bundle was cut for.
+	/// Written by commit-range bundling (<c>--end-git-ref</c>); serialized as <c>git_ref</c>.
+	/// </summary>
+	[YamlMember(Alias = "git_ref", ApplyNamingConventions = false)]
+	public string? GitRef { get; set; }
+	/// <summary>
 	/// Feature IDs that should be hidden when rendering this bundle.
 	/// Entries with matching feature-id values will be commented out in the output.
 	/// </summary>

--- a/src/Elastic.Documentation.Configuration/ReleaseNotes/ReleaseNotesSerialization.cs
+++ b/src/Elastic.Documentation.Configuration/ReleaseNotes/ReleaseNotesSerialization.cs
@@ -196,6 +196,7 @@ public static partial class ReleaseNotesSerialization
 		Products = dto.Products?.Select(ToBundledProduct).ToList() ?? [],
 		Description = dto.Description,
 		ReleaseDate = ParseReleaseDate(dto.ReleaseDate),
+		GitRef = dto.GitRef,
 		HideFeatures = dto.HideFeatures ?? [],
 		Entries = dto.Entries?.Select(ToBundledEntry).ToList() ?? [],
 		ExcludeEntries = dto.ExcludeEntries?.Select(ToBundledEntry).ToList() ?? []
@@ -308,6 +309,7 @@ public static partial class ReleaseNotesSerialization
 		Products = bundle.Products.Select(ToDto).ToList(),
 		Description = bundle.Description,
 		ReleaseDate = bundle.ReleaseDate?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+		GitRef = bundle.GitRef,
 		HideFeatures = bundle.HideFeatures.Count > 0 ? bundle.HideFeatures.ToList() : null,
 		Entries = bundle.Entries.Count > 0 ? bundle.Entries.Select(ToDto).ToList() : null,
 		ExcludeEntries = bundle.ExcludeEntries.Count > 0 ? bundle.ExcludeEntries.Select(ToDto).ToList() : null

--- a/src/Elastic.Documentation/ReleaseNotes/Bundle.cs
+++ b/src/Elastic.Documentation/ReleaseNotes/Bundle.cs
@@ -28,6 +28,12 @@ public record Bundle
 	public DateOnly? ReleaseDate { get; init; }
 
 	/// <summary>
+	/// Optional git ref of the published endpoint this bundle was cut for.
+	/// Set by commit-range bundling (<c>--end-git-ref</c>); not rendered to end-users.
+	/// </summary>
+	public string? GitRef { get; init; }
+
+	/// <summary>
 	/// Feature IDs that should be hidden when rendering this bundle.
 	/// Entries with matching feature-id values will be commented out in the output.
 	/// </summary>

--- a/src/services/Elastic.Changelog/GitHub/GitHubCommitRangeService.cs
+++ b/src/services/Elastic.Changelog/GitHub/GitHubCommitRangeService.cs
@@ -1,0 +1,483 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using Elastic.Documentation.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Elastic.Changelog.GitHub;
+
+/// <summary>
+/// Resolves the merged pull requests contained in a commit range using the GitHub compare REST API
+/// (commit enumeration, paginated) and the GraphQL <c>associatedPullRequests</c> connection
+/// (commit → PR association). Works for squash and merge commits on protected integration branches;
+/// commits with no associated merged PR are reported, not silently dropped.
+/// </summary>
+public sealed partial class GitHubCommitRangeService : IGitHubCommitRangeService, IDisposable
+{
+	private const int ComparePageSize = 100;
+	private const int GraphQlBatchSize = 50;
+	private const int MaxAssociatedPullRequests = 10;
+
+	private static readonly TimeSpan FetchTimeout = TimeSpan.FromSeconds(60);
+
+	/// <summary>
+	/// Process-wide client shared by every service built for the production (no injected handler)
+	/// path. Intentionally never disposed — it lives for the lifetime of the process.
+	/// </summary>
+	private static readonly HttpClient SharedHttpClient = CreateClient(null);
+
+	private readonly ILogger _logger;
+	private readonly HttpClient _httpClient;
+	private readonly HttpClient? _ownedHttpClient;
+	private readonly string? _githubToken;
+
+	[GeneratedRegex("^[0-9a-fA-F]{7,40}$")]
+	private static partial Regex CommitShaRegex();
+
+	[GeneratedRegex("^[A-Za-z0-9_.-]+$")]
+	private static partial Regex SafeGraphQlIdentifierRegex();
+
+	/// <param name="logFactory">Logger factory.</param>
+	/// <param name="handler">Optional HTTP handler override (tests). Owned by the caller.</param>
+	/// <param name="githubToken">Optional token override; defaults to the <c>GITHUB_TOKEN</c> environment variable.</param>
+	public GitHubCommitRangeService(ILoggerFactory logFactory, HttpMessageHandler? handler = null, string? githubToken = null)
+	{
+		_logger = logFactory.CreateLogger<GitHubCommitRangeService>();
+		_githubToken = githubToken;
+		if (handler is null)
+			_httpClient = SharedHttpClient;
+		else
+		{
+			// disposeHandler: false — the injected handler is owned by the caller (tests), not by us.
+			_ownedHttpClient = CreateClient(handler);
+			_httpClient = _ownedHttpClient;
+		}
+	}
+
+	private static HttpClient CreateClient(HttpMessageHandler? handler)
+	{
+		var client = handler is null
+			? new HttpClient(new SocketsHttpHandler { PooledConnectionLifetime = TimeSpan.FromMinutes(5) })
+			: new HttpClient(handler, disposeHandler: false);
+		client.Timeout = FetchTimeout;
+		client.DefaultRequestHeaders.Add("User-Agent", "docs-builder");
+		return client;
+	}
+
+	/// <inheritdoc />
+	public async Task<CommitRangeResolution?> ResolvePullRequestsAsync(
+		IDiagnosticsCollector collector,
+		CommitRangeArguments args,
+		Cancel ctx)
+	{
+		var token = _githubToken ?? Environment.GetEnvironmentVariable("GITHUB_TOKEN");
+		if (string.IsNullOrWhiteSpace(token))
+		{
+			collector.EmitError(string.Empty,
+				"Resolving pull requests from a commit range requires GitHub credentials. " +
+				"Set the GITHUB_TOKEN environment variable (the GraphQL API used for commit→PR association does not accept anonymous requests).");
+			return null;
+		}
+
+		if (!SafeGraphQlIdentifierRegex().IsMatch(args.Owner) || !SafeGraphQlIdentifierRegex().IsMatch(args.Repo))
+		{
+			collector.EmitError(string.Empty,
+				$"Invalid repository '{args.Owner}/{args.Repo}': owner and repo must contain only letters, digits, '.', '_' or '-'.");
+			return null;
+		}
+
+		var commits = await FetchCompareCommitsAsync(collector, args, token, ctx).ConfigureAwait(false);
+		if (commits == null)
+			return null;
+
+		if (commits.Count == 0)
+		{
+			collector.EmitWarning(string.Empty,
+				$"Commit range {args.StartRef}..{args.EndRef} for {args.Owner}/{args.Repo} contains no commits.");
+			return new CommitRangeResolution { TotalCommits = 0, PullRequests = [], CommitsWithoutPullRequest = [] };
+		}
+
+		return await AssociatePullRequestsAsync(collector, args, commits, token, ctx).ConfigureAwait(false);
+	}
+
+	/// <summary>
+	/// Enumerates the commit shas in <c>start...end</c> via the compare REST API, following
+	/// pagination until <c>total_commits</c> commits have been collected.
+	/// </summary>
+	private async Task<IReadOnlyList<string>?> FetchCompareCommitsAsync(
+		IDiagnosticsCollector collector,
+		CommitRangeArguments args,
+		string token,
+		Cancel ctx)
+	{
+		var basehead = $"{Uri.EscapeDataString(args.StartRef)}...{Uri.EscapeDataString(args.EndRef)}";
+		var commits = new List<string>();
+		var totalCommits = 0;
+		var page = 1;
+
+		while (true)
+		{
+			var url = $"https://api.github.com/repos/{args.Owner}/{args.Repo}/compare/{basehead}?per_page={ComparePageSize}&page={page}";
+			_logger.LogDebug("Fetching compare page {Page}: {Url}", page, url);
+
+			using var request = CreateRestRequest(url, token);
+			using var response = await _httpClient.SendAsync(request, ctx).ConfigureAwait(false);
+			if (response.StatusCode == HttpStatusCode.NotFound)
+			{
+				collector.EmitError(string.Empty,
+					$"GitHub could not compare {args.StartRef}...{args.EndRef} in {args.Owner}/{args.Repo} (404). " +
+					"Ensure both refs exist in the repository and the token can read it.");
+				return null;
+			}
+
+			if (!response.IsSuccessStatusCode)
+			{
+				collector.EmitError(string.Empty,
+					$"GitHub compare request for {args.Owner}/{args.Repo} {args.StartRef}...{args.EndRef} failed: {(int)response.StatusCode} {response.ReasonPhrase}.");
+				return null;
+			}
+
+			var json = await response.Content.ReadAsStringAsync(ctx).ConfigureAwait(false);
+			var compare = JsonSerializer.Deserialize(json, CommitRangeJsonContext.Default.GitHubCompareResponse);
+			if (compare == null)
+			{
+				collector.EmitError(string.Empty, "Failed to deserialize GitHub compare response.");
+				return null;
+			}
+
+			if (page == 1)
+			{
+				totalCommits = compare.TotalCommits;
+				if (string.Equals(compare.Status, "behind", StringComparison.OrdinalIgnoreCase) ||
+					string.Equals(compare.Status, "identical", StringComparison.OrdinalIgnoreCase))
+				{
+					collector.EmitWarning(string.Empty,
+						$"Commit range {args.StartRef}...{args.EndRef} for {args.Owner}/{args.Repo} is '{compare.Status}' — the end ref adds no commits over the start ref.");
+					return [];
+				}
+
+				if (string.Equals(compare.Status, "diverged", StringComparison.OrdinalIgnoreCase))
+				{
+					collector.EmitWarning(string.Empty,
+						$"Refs {args.StartRef} and {args.EndRef} for {args.Owner}/{args.Repo} have diverged; only commits reachable from {args.EndRef} but not {args.StartRef} are considered.");
+				}
+			}
+
+			var pageCommits = compare.Commits ?? [];
+			foreach (var commit in pageCommits)
+			{
+				if (!string.IsNullOrWhiteSpace(commit.Sha))
+					commits.Add(commit.Sha);
+			}
+
+			if (commits.Count >= totalCommits || pageCommits.Count == 0)
+				break;
+			page++;
+		}
+
+		_logger.LogInformation("Compare {Start}...{End} for {Owner}/{Repo}: {Count} commit(s)",
+			args.StartRef, args.EndRef, args.Owner, args.Repo, commits.Count);
+
+		if (commits.Count < totalCommits)
+		{
+			collector.EmitError(string.Empty,
+				$"GitHub compare pagination for {args.Owner}/{args.Repo} returned {commits.Count} of {totalCommits} commits; refusing to resolve a partial range.");
+			return null;
+		}
+
+		return commits;
+	}
+
+	/// <summary>
+	/// Resolves each commit to its merged pull request via GraphQL <c>associatedPullRequests</c>,
+	/// batching commits per query and caching nothing across runs (each run is self-contained).
+	/// </summary>
+	private async Task<CommitRangeResolution?> AssociatePullRequestsAsync(
+		IDiagnosticsCollector collector,
+		CommitRangeArguments args,
+		IReadOnlyList<string> commits,
+		string token,
+		Cancel ctx)
+	{
+		var invalidShas = commits.Where(sha => !CommitShaRegex().IsMatch(sha)).ToList();
+		if (invalidShas.Count > 0)
+		{
+			collector.EmitError(string.Empty,
+				$"GitHub compare returned malformed commit sha(s): {string.Join(", ", invalidShas)}.");
+			return null;
+		}
+
+		var prsByNumber = new Dictionary<int, (string Url, List<string> Shas)>();
+		var orderedPrNumbers = new List<int>();
+		var commitsWithoutPr = new List<string>();
+		var repoFullName = $"{args.Owner}/{args.Repo}";
+
+		for (var offset = 0; offset < commits.Count; offset += GraphQlBatchSize)
+		{
+			var batch = commits.Skip(offset).Take(GraphQlBatchSize).ToList();
+			var byAlias = await FetchAssociatedPullRequestsBatchAsync(collector, args, batch, token, ctx).ConfigureAwait(false);
+			if (byAlias == null)
+				return null;
+
+			for (var i = 0; i < batch.Count; i++)
+			{
+				var sha = batch[i];
+				_ = byAlias.TryGetValue($"c{i}", out var commitNode);
+				var selected = SelectPullRequest(collector, sha, commitNode, repoFullName);
+				if (selected == null)
+				{
+					commitsWithoutPr.Add(sha);
+					continue;
+				}
+
+				if (prsByNumber.TryGetValue(selected.Number, out var existing))
+					existing.Shas.Add(sha);
+				else
+				{
+					prsByNumber[selected.Number] = (selected.Url ?? $"https://github.com/{repoFullName}/pull/{selected.Number}", [sha]);
+					orderedPrNumbers.Add(selected.Number);
+				}
+			}
+		}
+
+		var pullRequests = orderedPrNumbers
+			.Select(number => new CommitRangePullRequest
+			{
+				Number = number,
+				Url = prsByNumber[number].Url,
+				CommitShas = prsByNumber[number].Shas
+			})
+			.ToList();
+
+		_logger.LogInformation(
+			"Resolved {PrCount} pull request(s) from {CommitCount} commit(s) in {Owner}/{Repo} {Start}...{End} ({NoPrCount} commit(s) without an associated PR)",
+			pullRequests.Count, commits.Count, args.Owner, args.Repo, args.StartRef, args.EndRef, commitsWithoutPr.Count);
+
+		return new CommitRangeResolution
+		{
+			TotalCommits = commits.Count,
+			PullRequests = pullRequests,
+			CommitsWithoutPullRequest = commitsWithoutPr
+		};
+	}
+
+	/// <summary>
+	/// Picks the merged, same-repository pull request for a commit. Prefers the PR whose merge
+	/// commit is the commit itself (squash/merge on the integration branch); warns on ambiguity
+	/// and resolves it deterministically by lowest PR number (RFC review: don't overdesign before
+	/// the first real deploy).
+	/// </summary>
+	private static GraphQlPullRequest? SelectPullRequest(
+		IDiagnosticsCollector collector,
+		string sha,
+		GraphQlCommit? commitNode,
+		string repoFullName)
+	{
+		var candidates = commitNode?.AssociatedPullRequests?.Nodes?
+			.OfType<GraphQlPullRequest>()
+			.Where(pr => pr.Merged &&
+				string.Equals(pr.BaseRepository?.NameWithOwner, repoFullName, StringComparison.OrdinalIgnoreCase))
+			.ToList() ?? [];
+
+		if (candidates.Count == 0)
+			return null;
+
+		var mergeCommitMatches = candidates
+			.Where(pr => string.Equals(pr.MergeCommit?.Oid, sha, StringComparison.OrdinalIgnoreCase))
+			.OrderBy(pr => pr.Number)
+			.ToList();
+
+		if (mergeCommitMatches.Count == 1)
+			return mergeCommitMatches[0];
+
+		if (candidates.Count > 1)
+		{
+			var pool = mergeCommitMatches.Count > 0 ? mergeCommitMatches : candidates;
+			var chosen = pool.OrderBy(pr => pr.Number).First();
+			var numbers = string.Join(", ", candidates.Select(pr => pr.Number).Order().Select(n => $"#{n}"));
+			collector.EmitWarning(string.Empty,
+				$"Commit {sha} is associated with multiple merged pull requests ({numbers}); using #{chosen.Number}.");
+			return chosen;
+		}
+
+		return candidates[0];
+	}
+
+	private async Task<Dictionary<string, GraphQlCommit?>?> FetchAssociatedPullRequestsBatchAsync(
+		IDiagnosticsCollector collector,
+		CommitRangeArguments args,
+		IReadOnlyList<string> shas,
+		string token,
+		Cancel ctx)
+	{
+		var query = BuildBatchQuery(args.Owner, args.Repo, shas);
+		var body = JsonSerializer.Serialize(new GraphQlRequest { Query = query }, CommitRangeJsonContext.Default.GraphQlRequest);
+
+		using var request = new HttpRequestMessage(HttpMethod.Post, "https://api.github.com/graphql");
+		request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+		request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+
+		using var response = await _httpClient.SendAsync(request, ctx).ConfigureAwait(false);
+		if (!response.IsSuccessStatusCode)
+		{
+			collector.EmitError(string.Empty,
+				$"GitHub GraphQL request for {args.Owner}/{args.Repo} failed: {(int)response.StatusCode} {response.ReasonPhrase}.");
+			return null;
+		}
+
+		var json = await response.Content.ReadAsStringAsync(ctx).ConfigureAwait(false);
+		var parsed = JsonSerializer.Deserialize(json, CommitRangeJsonContext.Default.GraphQlResponse);
+
+		if (parsed?.Errors is { Count: > 0 })
+		{
+			var messages = string.Join("; ", parsed.Errors.Select(e => e.Message).Where(m => !string.IsNullOrWhiteSpace(m)));
+			collector.EmitError(string.Empty, $"GitHub GraphQL query for {args.Owner}/{args.Repo} returned errors: {messages}.");
+			return null;
+		}
+
+		if (parsed?.Data?.Repository == null)
+		{
+			collector.EmitError(string.Empty,
+				$"GitHub GraphQL query could not resolve repository {args.Owner}/{args.Repo}. Ensure the token can read it.");
+			return null;
+		}
+
+		return parsed.Data.Repository;
+	}
+
+	/// <summary>
+	/// Builds one aliased GraphQL query resolving <c>associatedPullRequests</c> for every sha in
+	/// the batch. Shas are validated hex and owner/repo validated identifiers before interpolation.
+	/// </summary>
+	private static string BuildBatchQuery(string owner, string repo, IReadOnlyList<string> shas)
+	{
+		var sb = new StringBuilder();
+		_ = sb.Append("query { repository(owner: \"").Append(owner).Append("\", name: \"").Append(repo).Append("\") {");
+		for (var i = 0; i < shas.Count; i++)
+		{
+			_ = sb.Append(" c").Append(i).Append(": object(oid: \"").Append(shas[i]).Append("\") { ... on Commit {")
+				.Append(" oid associatedPullRequests(first: ").Append(MaxAssociatedPullRequests).Append(") { nodes {")
+				.Append(" number url merged mergeCommit { oid } baseRepository { nameWithOwner }")
+				.Append(" } } } }");
+		}
+
+		_ = sb.Append(" } }");
+		return sb.ToString();
+	}
+
+	private static HttpRequestMessage CreateRestRequest(string url, string token)
+	{
+		var request = new HttpRequestMessage(HttpMethod.Get, url);
+		request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+		request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+		return request;
+	}
+
+	/// <summary>
+	/// Disposes the per-instance client created for an injected handler; the shared production
+	/// client is process-lived and intentionally not disposed.
+	/// </summary>
+	public void Dispose() => _ownedHttpClient?.Dispose();
+
+	private sealed class GitHubCompareResponse
+	{
+		[JsonPropertyName("status")]
+		public string? Status { get; set; }
+
+		[JsonPropertyName("total_commits")]
+		public int TotalCommits { get; set; }
+
+		[JsonPropertyName("commits")]
+		public List<GitHubCompareCommit>? Commits { get; set; }
+	}
+
+	private sealed class GitHubCompareCommit
+	{
+		[JsonPropertyName("sha")]
+		public string? Sha { get; set; }
+	}
+
+	private sealed class GraphQlRequest
+	{
+		[JsonPropertyName("query")]
+		public string Query { get; set; } = string.Empty;
+	}
+
+	private sealed class GraphQlResponse
+	{
+		[JsonPropertyName("data")]
+		public GraphQlData? Data { get; set; }
+
+		[JsonPropertyName("errors")]
+		public List<GraphQlError>? Errors { get; set; }
+	}
+
+	private sealed class GraphQlError
+	{
+		[JsonPropertyName("message")]
+		public string? Message { get; set; }
+	}
+
+	private sealed class GraphQlData
+	{
+		[JsonPropertyName("repository")]
+		public Dictionary<string, GraphQlCommit?>? Repository { get; set; }
+	}
+
+	private sealed class GraphQlCommit
+	{
+		[JsonPropertyName("oid")]
+		public string? Oid { get; set; }
+
+		[JsonPropertyName("associatedPullRequests")]
+		public GraphQlPullRequestConnection? AssociatedPullRequests { get; set; }
+	}
+
+	private sealed class GraphQlPullRequestConnection
+	{
+		[JsonPropertyName("nodes")]
+		public List<GraphQlPullRequest?>? Nodes { get; set; }
+	}
+
+	private sealed class GraphQlPullRequest
+	{
+		[JsonPropertyName("number")]
+		public int Number { get; set; }
+
+		[JsonPropertyName("url")]
+		public string? Url { get; set; }
+
+		[JsonPropertyName("merged")]
+		public bool Merged { get; set; }
+
+		[JsonPropertyName("mergeCommit")]
+		public GraphQlCommitRef? MergeCommit { get; set; }
+
+		[JsonPropertyName("baseRepository")]
+		public GraphQlRepositoryRef? BaseRepository { get; set; }
+	}
+
+	private sealed class GraphQlCommitRef
+	{
+		[JsonPropertyName("oid")]
+		public string? Oid { get; set; }
+	}
+
+	private sealed class GraphQlRepositoryRef
+	{
+		[JsonPropertyName("nameWithOwner")]
+		public string? NameWithOwner { get; set; }
+	}
+
+	[JsonSerializable(typeof(GitHubCompareResponse))]
+	[JsonSerializable(typeof(GraphQlRequest))]
+	[JsonSerializable(typeof(GraphQlResponse))]
+	private sealed partial class CommitRangeJsonContext : JsonSerializerContext;
+}

--- a/src/services/Elastic.Changelog/GitHub/IGitHubCommitRangeService.cs
+++ b/src/services/Elastic.Changelog/GitHub/IGitHubCommitRangeService.cs
@@ -1,0 +1,76 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Documentation.Diagnostics;
+
+namespace Elastic.Changelog.GitHub;
+
+/// <summary>
+/// Arguments for resolving the pull requests contained in a git commit range.
+/// </summary>
+public record CommitRangeArguments
+{
+	/// <summary>GitHub repository owner (org).</summary>
+	public required string Owner { get; init; }
+
+	/// <summary>GitHub repository name.</summary>
+	public required string Repo { get; init; }
+
+	/// <summary>Start ref (exclusive) of the range, e.g. the previously published endpoint ref.</summary>
+	public required string StartRef { get; init; }
+
+	/// <summary>End ref (inclusive) of the range, e.g. the currently published endpoint ref.</summary>
+	public required string EndRef { get; init; }
+}
+
+/// <summary>
+/// A pull request resolved from a commit range, with the range commits that led to it.
+/// </summary>
+public record CommitRangePullRequest
+{
+	/// <summary>Pull request number in the repository the range was resolved against.</summary>
+	public required int Number { get; init; }
+
+	/// <summary>Canonical https://github.com/{owner}/{repo}/pull/{number} URL.</summary>
+	public required string Url { get; init; }
+
+	/// <summary>Shas of the range commits associated with this pull request (provenance).</summary>
+	public required IReadOnlyList<string> CommitShas { get; init; }
+}
+
+/// <summary>
+/// The pull requests contained in a commit range, plus the commits that could not be
+/// attributed to any merged pull request (reported, never silently dropped).
+/// </summary>
+public record CommitRangeResolution
+{
+	/// <summary>Total commits reported by the compare API for the range.</summary>
+	public required int TotalCommits { get; init; }
+
+	/// <summary>
+	/// Merged pull requests in the range, de-duplicated, ordered by first appearance
+	/// in the commit range (oldest commit first).
+	/// </summary>
+	public required IReadOnlyList<CommitRangePullRequest> PullRequests { get; init; }
+
+	/// <summary>Shas of range commits with no associated merged pull request.</summary>
+	public required IReadOnlyList<string> CommitsWithoutPullRequest { get; init; }
+}
+
+/// <summary>
+/// Resolves the merged pull requests contained in a git commit range
+/// (<c>start..end</c>) of a GitHub repository.
+/// </summary>
+public interface IGitHubCommitRangeService
+{
+	/// <summary>
+	/// Enumerates the commits in <c>start..end</c> and resolves each to its merged pull request.
+	/// Returns <c>null</c> after emitting an error when the range cannot be resolved
+	/// (unknown refs, missing credentials, API failures).
+	/// </summary>
+	Task<CommitRangeResolution?> ResolvePullRequestsAsync(
+		IDiagnosticsCollector collector,
+		CommitRangeArguments args,
+		Cancel ctx);
+}

--- a/tests/Elastic.Changelog.Tests/Changelogs/GitHubCommitRangeServiceTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/GitHubCommitRangeServiceTests.cs
@@ -1,0 +1,286 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Globalization;
+using System.Net;
+using System.Text;
+using System.Web;
+using AwesomeAssertions;
+using Elastic.Changelog.GitHub;
+using Elastic.Documentation.Diagnostics;
+
+namespace Elastic.Changelog.Tests.Changelogs;
+
+/// <summary>
+/// Fake-HTTP tests for <see cref="GitHubCommitRangeService"/>: compare-API commit enumeration
+/// (including pagination) and GraphQL <c>associatedPullRequests</c> resolution across the
+/// squash / merge-commit / no-PR / multi-PR shapes.
+/// </summary>
+public class GitHubCommitRangeServiceTests(ITestOutputHelper output) : ChangelogTestBase(output)
+{
+	private const string Owner = "elastic";
+	private const string Repo = "widget";
+
+	private static readonly CommitRangeArguments Args = new()
+	{
+		Owner = Owner,
+		Repo = Repo,
+		StartRef = "startsha",
+		EndRef = "endsha"
+	};
+
+	private static string Sha(int i) => i.ToString(CultureInfo.InvariantCulture).PadLeft(40, '0');
+
+	private static string CompareJson(int totalCommits, IEnumerable<string> shas, string status = "ahead")
+	{
+		var commits = string.Join(",", shas.Select(sha => $$"""{ "sha": "{{sha}}" }"""));
+		return $$"""{ "status": "{{status}}", "total_commits": {{totalCommits}}, "commits": [{{commits}}] }""";
+	}
+
+	/// <summary>One associated PR node for a GraphQL commit object.</summary>
+	private static string PrNode(int number, bool merged = true, string? mergeCommitSha = null, string repoFullName = Owner + "/" + Repo) =>
+		$$"""
+		{ "number": {{number}}, "url": "https://github.com/{{repoFullName}}/pull/{{number}}", "merged": {{(merged ? "true" : "false")}},
+		  "mergeCommit": {{(mergeCommitSha != null ? $$"""{ "oid": "{{mergeCommitSha}}" }""" : "null")}},
+		  "baseRepository": { "nameWithOwner": "{{repoFullName}}" } }
+		""";
+
+	private static string GraphQlJson(IReadOnlyList<(string Sha, string[] PrNodes)> commits)
+	{
+		var sb = new StringBuilder();
+		for (var i = 0; i < commits.Count; i++)
+		{
+			if (i > 0)
+				_ = sb.Append(',');
+			_ = sb.Append(CultureInfo.InvariantCulture, $$""" "c{{i}}": { "oid": "{{commits[i].Sha}}", "associatedPullRequests": { "nodes": [{{string.Join(",", commits[i].PrNodes)}}] } }""");
+		}
+
+		return $$"""{ "data": { "repository": {{{sb}} } } }""";
+	}
+
+	private GitHubCommitRangeService Service(StubHandler handler) =>
+		new(new TestLoggerFactory(Output), handler, githubToken: "test-token");
+
+	private static StubHandler Handler(Func<HttpRequestMessage, string?> compareResponder, Func<HttpRequestMessage, string> graphQlResponder) =>
+		new(req =>
+		{
+			var path = req.RequestUri!.AbsolutePath;
+			if (path == "/graphql")
+				return Json(graphQlResponder(req));
+			if (path.StartsWith($"/repos/{Owner}/{Repo}/compare/", StringComparison.Ordinal))
+			{
+				var body = compareResponder(req);
+				return body == null ? new HttpResponseMessage(HttpStatusCode.NotFound) : Json(body);
+			}
+
+			return new HttpResponseMessage(HttpStatusCode.NotFound);
+		});
+
+	[Fact]
+	public async Task ResolvePullRequests_SquashCommits_ResolvesOnePrPerCommitInRangeOrder()
+	{
+		var (sha1, sha2) = (Sha(1), Sha(2));
+		var handler = Handler(
+			_ => CompareJson(2, [sha1, sha2]),
+			_ => GraphQlJson([(sha1, [PrNode(11, mergeCommitSha: sha1)]), (sha2, [PrNode(12, mergeCommitSha: sha2)])]));
+
+		var result = await Service(handler).ResolvePullRequestsAsync(Collector, Args, TestContext.Current.CancellationToken);
+
+		result.Should().NotBeNull();
+		Collector.Errors.Should().Be(0);
+		result.TotalCommits.Should().Be(2);
+		result.PullRequests.Select(pr => pr.Number).Should().Equal(11, 12);
+		result.PullRequests[0].Url.Should().Be($"https://github.com/{Owner}/{Repo}/pull/11");
+		result.PullRequests[0].CommitShas.Should().Equal(sha1);
+		result.CommitsWithoutPullRequest.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task ResolvePullRequests_MergeCommitPr_DeduplicatesAcrossCommits()
+	{
+		// Two branch commits belong to the same merge-commit PR; its merge commit is a third sha
+		// that is also part of the range.
+		var (sha1, sha2, mergeSha) = (Sha(1), Sha(2), Sha(3));
+		var handler = Handler(
+			_ => CompareJson(3, [sha1, sha2, mergeSha]),
+			_ => GraphQlJson([
+				(sha1, [PrNode(20, mergeCommitSha: mergeSha)]),
+				(sha2, [PrNode(20, mergeCommitSha: mergeSha)]),
+				(mergeSha, [PrNode(20, mergeCommitSha: mergeSha)])
+			]));
+
+		var result = await Service(handler).ResolvePullRequestsAsync(Collector, Args, TestContext.Current.CancellationToken);
+
+		result.Should().NotBeNull();
+		result.PullRequests.Should().ContainSingle();
+		result.PullRequests[0].Number.Should().Be(20);
+		result.PullRequests[0].CommitShas.Should().Equal(sha1, sha2, mergeSha);
+	}
+
+	[Fact]
+	public async Task ResolvePullRequests_CommitWithoutMergedPr_IsReportedNotDropped()
+	{
+		// One commit has no associated PRs at all; another only an unmerged PR; a third only a PR
+		// merged into a different (fork) repository. None may silently disappear.
+		var (sha1, sha2, sha3) = (Sha(1), Sha(2), Sha(3));
+		var handler = Handler(
+			_ => CompareJson(3, [sha1, sha2, sha3]),
+			_ => GraphQlJson([
+				(sha1, []),
+				(sha2, [PrNode(30, merged: false)]),
+				(sha3, [PrNode(31, mergeCommitSha: sha3, repoFullName: "someone/fork")])
+			]));
+
+		var result = await Service(handler).ResolvePullRequestsAsync(Collector, Args, TestContext.Current.CancellationToken);
+
+		result.Should().NotBeNull();
+		result.PullRequests.Should().BeEmpty();
+		result.CommitsWithoutPullRequest.Should().Equal(sha1, sha2, sha3);
+	}
+
+	[Fact]
+	public async Task ResolvePullRequests_MultipleMergedPrs_WarnsAndPicksDeterministically()
+	{
+		var sha1 = Sha(1);
+		var handler = Handler(
+			_ => CompareJson(1, [sha1]),
+			_ => GraphQlJson([(sha1, [PrNode(42), PrNode(7)])]));
+
+		var result = await Service(handler).ResolvePullRequestsAsync(Collector, Args, TestContext.Current.CancellationToken);
+
+		result.Should().NotBeNull();
+		result.PullRequests.Should().ContainSingle();
+		result.PullRequests[0].Number.Should().Be(7, "ambiguity resolves deterministically to the lowest PR number");
+		Collector.Diagnostics.Should().Contain(d =>
+			d.Severity == Severity.Warning && d.Message.Contains("multiple merged pull requests"));
+	}
+
+	[Fact]
+	public async Task ResolvePullRequests_MergeCommitMatchWins_NoAmbiguityWarning()
+	{
+		// A commit associated with two merged PRs, but exactly one of them has this commit as its
+		// merge commit — that one wins without a warning.
+		var sha1 = Sha(1);
+		var handler = Handler(
+			_ => CompareJson(1, [sha1]),
+			_ => GraphQlJson([(sha1, [PrNode(50), PrNode(60, mergeCommitSha: sha1)])]));
+
+		var result = await Service(handler).ResolvePullRequestsAsync(Collector, Args, TestContext.Current.CancellationToken);
+
+		result.Should().NotBeNull();
+		result.PullRequests.Should().ContainSingle();
+		result.PullRequests[0].Number.Should().Be(60);
+		Collector.Diagnostics.Should().NotContain(d => d.Message.Contains("multiple merged pull requests"));
+	}
+
+	[Fact]
+	public async Task ResolvePullRequests_Pagination_FollowsAllComparePages()
+	{
+		// 150 commits: page 1 returns 100, page 2 the remaining 50. GraphQL batches per 50.
+		var shas = Enumerable.Range(1, 150).Select(Sha).ToList();
+		var comparePages = new List<int>();
+		var graphQlBatches = 0;
+
+		var handler = Handler(
+			req =>
+			{
+				var query = HttpUtility.ParseQueryString(req.RequestUri!.Query);
+				var page = int.Parse(query["page"]!, CultureInfo.InvariantCulture);
+				comparePages.Add(page);
+				var pageShas = shas.Skip((page - 1) * 100).Take(100);
+				return CompareJson(150, pageShas);
+			},
+			_ =>
+			{
+				// Batches are issued sequentially in commit order, 50 shas each; every commit
+				// resolves to its own squashed PR (number = index + 1).
+				var batchIndex = graphQlBatches++;
+				var batch = shas.Skip(batchIndex * 50).Take(50).ToList();
+				return GraphQlJson(batch
+					.Select(sha => (sha, new[] { PrNode(shas.IndexOf(sha) + 1, mergeCommitSha: sha) }))
+					.ToList());
+			});
+
+		var result = await Service(handler).ResolvePullRequestsAsync(Collector, Args, TestContext.Current.CancellationToken);
+
+		result.Should().NotBeNull();
+		Collector.Errors.Should().Be(0);
+		comparePages.Should().Equal(1, 2);
+		graphQlBatches.Should().Be(3);
+		result!.TotalCommits.Should().Be(150);
+		result.PullRequests.Should().HaveCount(150);
+		result.PullRequests[0].Number.Should().Be(1);
+		result.PullRequests[^1].Number.Should().Be(150);
+	}
+
+	[Fact]
+	public async Task ResolvePullRequests_EmptyRange_WarnsAndReturnsEmptyResolution()
+	{
+		var handler = Handler(
+			_ => CompareJson(0, [], status: "identical"),
+			_ => throw new InvalidOperationException("GraphQL must not be called for an empty range"));
+
+		var result = await Service(handler).ResolvePullRequestsAsync(Collector, Args, TestContext.Current.CancellationToken);
+
+		result.Should().NotBeNull();
+		result.TotalCommits.Should().Be(0);
+		result.PullRequests.Should().BeEmpty();
+		Collector.Diagnostics.Should().Contain(d => d.Severity == Severity.Warning && d.Message.Contains("identical"));
+	}
+
+	[Fact]
+	public async Task ResolvePullRequests_UnknownRefs_EmitsErrorAndReturnsNull()
+	{
+		var handler = Handler(_ => null, _ => throw new InvalidOperationException("GraphQL must not be called"));
+
+		var result = await Service(handler).ResolvePullRequestsAsync(Collector, Args, TestContext.Current.CancellationToken);
+
+		result.Should().BeNull();
+		Collector.Diagnostics.Should().Contain(d => d.Severity == Severity.Error && d.Message.Contains("404"));
+	}
+
+	[Fact]
+	public async Task ResolvePullRequests_MissingToken_EmitsErrorWithoutAnyRequest()
+	{
+		var handler = Handler(_ => throw new InvalidOperationException("no request expected"), _ => throw new InvalidOperationException("no request expected"));
+		var service = new GitHubCommitRangeService(new TestLoggerFactory(Output), handler, githubToken: "");
+
+		var result = await service.ResolvePullRequestsAsync(Collector, Args, TestContext.Current.CancellationToken);
+
+		result.Should().BeNull();
+		Collector.Diagnostics.Should().Contain(d => d.Severity == Severity.Error && d.Message.Contains("GITHUB_TOKEN"));
+		handler.RequestedPaths.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task ResolvePullRequests_GraphQlErrors_EmitError()
+	{
+		var sha1 = Sha(1);
+		var handler = Handler(
+			_ => CompareJson(1, [sha1]),
+			_ => /*lang=json,strict*/ """{ "data": null, "errors": [ { "message": "boom" } ] }""");
+
+		var result = await Service(handler).ResolvePullRequestsAsync(Collector, Args, TestContext.Current.CancellationToken);
+
+		result.Should().BeNull();
+		Collector.Diagnostics.Should().Contain(d => d.Severity == Severity.Error && d.Message.Contains("boom"));
+	}
+
+	private static HttpResponseMessage Json(string body) =>
+		new(HttpStatusCode.OK) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+
+	private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
+	{
+		public List<string> RequestedPaths { get; } = [];
+
+		protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
+		{
+			RequestedPaths.Add(request.RequestUri!.AbsolutePath);
+			return responder(request);
+		}
+
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+			Task.FromResult(Send(request, cancellationToken));
+	}
+}


### PR DESCRIPTION
## Why

Date-promotion release-notes automation (RFC [docs-eng-team#698](https://github.com/elastic/docs-eng-team/pull/698), companion serverless-deployment RFC) needs `changelog bundle` to cut a bundle from a **git commit range** handed off by the promotion system, instead of an externally staged PR list (rejected in [docs-actions#235](https://github.com/elastic/docs-actions/pull/235) for cache-poisoning and repeatability reasons). This PR lands the two foundations with no behavior change for existing commands; the CLI wiring follows in the next PR of this stack.

## What

- `GitHubCommitRangeService`: resolves the merged PRs contained in `start..end` — commit enumeration via the paginated GitHub compare REST API, commit→PR association via GraphQL `associatedPullRequests` (batched, `GITHUB_TOKEN` required). Works for squash and merge commits on protected integration branches; commits with no associated merged PR are reported, never silently dropped; multi-PR ambiguity warns and resolves deterministically (merge-commit match first, then lowest PR number). Covered by fake-HTTP tests (squash / merge-commit / no-PR / multi-PR / pagination / error shapes).
- `git_ref` on the bundle model (domain + DTO + serialization): the published endpoint ref recorded by commit-range bundling. Landing the field ahead of any emitter gives the scrubber and docs-builder read compatibility first, per the RFC's deployment-order requirement (S6).

**Stack:** 1/3 — followed by the `changelog bundle --start-git-ref/--end-git-ref` wiring and a GitHub HTTP transport refactor.