### PR TITLE
Add commit-range bundling to changelog bundle (--start-git-ref/--end-git-ref)

### DIFF
--- a/docs/cli-schema.json
+++ b/docs/cli-schema.json
@@ -3229,6 +3229,28 @@
             },
             {
               "role": "flag",
+              "name": "start-git-ref",
+              "type": "string",
+              "required": false,
+              "summary": "Start ref (exclusive) of a git commit range to bundle, for example the previously published endpoint ref. Must be provided together with --end-git-ref; the start ref is never inferred. The PR list is derived from the range itself (GitHub compare API \u002B GraphQL associatedPullRequests), each PR\u0027s entry is sourced pool-first with PR-metadata fallback, and requires GITHUB_TOKEN. Supported in profile-based commands (for example, \u0027bundle serverless-release 2026-08-13 --start-git-ref abc123 --end-git-ref def456\u0027); mutually exclusive with all other filter options."
+            },
+            {
+              "role": "flag",
+              "name": "end-git-ref",
+              "type": "string",
+              "required": false,
+              "summary": "End ref (inclusive) of the git commit range to bundle \u2014 the currently published endpoint ref. Must be provided together with --start-git-ref. Recorded in the bundle output as the git_ref metadata field."
+            },
+            {
+              "role": "flag",
+              "name": "dry-run",
+              "type": "boolean",
+              "required": false,
+              "summary": "Resolve the commit range and print the run report (resolved PR list with per-PR entry source: pool, inferred, or missing) as Markdown without writing a bundle. Only valid together with --start-git-ref/--end-git-ref. Supported in profile-based commands.",
+              "defaultValue": "false"
+            },
+            {
+              "role": "flag",
               "name": "log-level",
               "shortName": "l",
               "type": "enum",

--- a/docs/cli/changelog/cmd-bundle.md
+++ b/docs/cli/changelog/cmd-bundle.md
@@ -50,6 +50,7 @@ Exactly one of the following filter flags is required:
 - `--release-version` — fetch PR references from a GitHub release tag (e.g. `v9.2.0` or `latest`)
 - `--report` — filter by PRs referenced in a promotion report (URL or local file)
 - `--files` — include specific changelog YAML paths, or a newline-delimited path list file
+- `--start-git-ref` + `--end-git-ref` — derive the PR list from a git commit range (see [Commit-range mode](#git-ref-mode))
 
 `--force-local` is not a filter. It forces local entry sourcing for the run (equivalent to `bundle.use_local_changelogs: true` without editing config) and is allowed in both option-based and profile-based modes.
 
@@ -73,6 +74,43 @@ docs-builder changelog bundle \
   --files "./docs/changelog/a.yaml,./docs/changelog/b.yaml" \
   --output docs/releases/serverless/2026-07-07.yaml \
   --output-products "cloud-serverless 2026-07-07"
+```
+
+## Commit-range mode [git-ref-mode]
+
+`--start-git-ref` and `--end-git-ref` cut a bundle from a **git commit range** instead of an externally supplied PR list. This is the mode date-promotion automation (serverless, Cloud ECH/ECE) uses: the promotion system hands off two commit hashes from a protected branch, and the command derives everything else itself.
+
+```sh
+docs-builder changelog bundle serverless-release 2026-08-13 \
+  --start-git-ref <previous-published-ref> \
+  --end-git-ref <current-published-ref>
+```
+
+Both refs are always required together — the start ref is never inferred from previous bundles. The command:
+
+1. Enumerates the commits in `start..end` via the GitHub compare API (paginated).
+2. Resolves each commit to its merged pull request via GraphQL `associatedPullRequests`. Works for squash and merge commits on protected integration branches; commits with no associated PR are reported, never silently dropped. When a commit is associated with multiple merged PRs, the command warns and picks deterministically (merge-commit match first, then lowest PR number).
+3. Sources each PR's changelog entry with a fixed precedence:
+   - **A checked-in entry from the entry pool wins.** Pool entries are matched by file-name-derived PR numbers (file names survive scrubbing, so this works for private repos whose `prs` references were removed from public copies) or by the entry's `prs` references.
+   - **Otherwise the entry is synthesized from PR metadata** — the same extraction path `changelog add` uses: release-note text from the PR body becomes the description, and labels map to type/areas/products/feature-id via the `pivot.*` configuration. `rules.create` label rules decide inclusion.
+   - **PRs whose metadata cannot be fetched are reported as missing** with a warning.
+4. Records the end ref in the bundle output as the `git_ref` metadata field.
+
+Commit-range mode works in both profile-based and option-based commands and is mutually exclusive with every other filter. In profile-based commands the profile contributes output metadata only (`output_products`, `repo`, `owner`, `rules`, and so on) — it must not set a `products` pattern or `source: github_release`. When the profile has no explicit `output` pattern, the bundle name follows the `{product}-{version}.yaml` convention.
+
+Re-running the same range produces the same bundle content; bundling never overwrites changelog entries.
+
+:::{note}
+Commit-range mode requires a `GITHUB_TOKEN` environment variable: the GraphQL API used for commit→PR association does not accept anonymous requests.
+:::
+
+### Dry run
+
+Pass `--dry-run` to resolve the range and print the run report — the resolved PR list with each PR's entry source (`pool`, `inferred (PR body)`, `inferred (title)`, `excluded (rules)`, or `missing`) plus any commits without an associated PR — as Markdown, without writing a bundle. The report is suitable for a release PR body or a CI job summary.
+
+```sh
+docs-builder changelog bundle serverless-release 2026-08-13 \
+  --start-git-ref abc123 --end-git-ref def456 --dry-run
 ```
 
 ## Bundles are self-contained

--- a/docs/data/release-notes/bundle.md
+++ b/docs/data/release-notes/bundle.md
@@ -112,6 +112,33 @@ bundle:
 1. This profile fetches the PR list from the GitHub release notes for the version tag specified in the command.
 2. For `source: github_release` profiles, the `{lifecycle}` placeholder in `output` and `output_products` is inferred from full release tag name. For example, if the release tag is `v1.34.1-preview.1` the lifecycle is `preview`. Refer to [](/cli/changelog/bundle.md#lifecycle-inference) for more details.
 
+### Bundle by git commit range [profile-git-range]
+
+If the source of truth for what was shipped in each release is a **git commit range** — for example, a date-promotion deployment that hands off the previously and currently published commit hashes — pass `--start-git-ref` and `--end-git-ref` alongside the profile. The command derives the PR list from the range itself (GitHub compare API + GraphQL `associatedPullRequests`), so no PR list file or promotion report is needed.
+
+Your profile must **not** contain a `products` pattern or `source: github_release`; it contributes output metadata only. For example:
+
+```yaml
+bundle:
+  repo: my-service <1>
+  owner: elastic
+  output_directory: docs/releases
+  profiles:
+    serverless-release:
+      output_products: "cloud-serverless {version}" <2>
+```
+
+1. The authoring repository whose commit range is resolved and whose entry pool is consulted.
+2. Also applied to entries synthesized from PR metadata when the PR's labels map to no product. When the profile has no `output` pattern, the bundle is named `{product}-{version}.yaml` by convention.
+
+```sh
+docs-builder changelog bundle serverless-release 2026-08-13 \
+  --start-git-ref <previous-published-ref> \
+  --end-git-ref <current-published-ref>
+```
+
+For each PR in the range, a checked-in changelog entry (already uploaded to the entry pool) wins; otherwise an entry is synthesized from the PR's title, labels, and release-note text using the same extraction path as `changelog add`. The bundle records the end ref in a `git_ref` metadata field. Refer to [Commit-range mode](/cli/changelog/bundle.md#git-ref-mode) for the full behavior, including the `--dry-run` run report.
+
 ### Bundle by folder or changelog product
 
 If the source of truth for what was shipped in each release is:

--- a/src/services/Elastic.Changelog/Bundling/ChangelogBundlingService.cs
+++ b/src/services/Elastic.Changelog/Bundling/ChangelogBundlingService.cs
@@ -122,6 +122,24 @@ public record BundleChangelogsArguments
 	/// When non-null (including empty), PR/issue links are filtered to this <c>owner/repo</c> allowlist (from changelog.yml <c>bundle.link_allow_repos</c>).
 	/// </summary>
 	public IReadOnlyList<string>? LinkAllowRepos { get; init; }
+
+	/// <summary>
+	/// Start ref (exclusive) of a git commit range to bundle (<c>--start-git-ref</c>).
+	/// Must be provided together with <see cref="EndGitRef"/>.
+	/// </summary>
+	public string? StartGitRef { get; init; }
+
+	/// <summary>
+	/// End ref (inclusive) of a git commit range to bundle (<c>--end-git-ref</c>); stored as the
+	/// bundle's <c>git_ref</c> metadata. Must be provided together with <see cref="StartGitRef"/>.
+	/// </summary>
+	public string? EndGitRef { get; init; }
+
+	/// <summary>
+	/// When true, resolve the commit range and print the run report (resolved PR list with per-PR
+	/// entry source) without writing a bundle. Only valid together with a git ref range.
+	/// </summary>
+	public bool DryRun { get; init; }
 }
 
 /// <summary>
@@ -150,13 +168,17 @@ public partial class ChangelogBundlingService(
 	IConfigurationContext? configurationContext = null,
 	ScopedFileSystem? fileSystem = null,
 	IGitHubReleaseService? releaseService = null,
-	CdnChangelogEntryFetcher? entryFetcher = null)
+	CdnChangelogEntryFetcher? entryFetcher = null,
+	IGitHubPrService? prService = null,
+	IGitHubCommitRangeService? commitRangeService = null)
 	: IService
 {
 	private readonly ILogger _logger = logFactory.CreateLogger<ChangelogBundlingService>();
 	private readonly ScopedFileSystem _fileSystem = fileSystem ?? FileSystemFactory.RealRead;
 	private readonly IGitHubReleaseService _releaseService = releaseService ?? new GitHubReleaseService(logFactory);
 	private readonly CdnChangelogEntryFetcher _entryFetcher = entryFetcher ?? new CdnChangelogEntryFetcher(logFactory);
+	private readonly IGitHubPrService _prService = prService ?? new GitHubPrService(logFactory);
+	private readonly IGitHubCommitRangeService _commitRangeService = commitRangeService ?? new GitHubCommitRangeService(logFactory);
 	private readonly ChangelogConfigurationLoader? _configLoader = configurationContext != null
 		? new ChangelogConfigurationLoader(logFactory, configurationContext, fileSystem ?? FileSystemFactory.RealRead)
 		: null;
@@ -183,6 +205,9 @@ public partial class ChangelogBundlingService(
 	{
 		try
 		{
+			if (!ValidateGitRefArguments(collector, input))
+				return false;
+
 			// Capture whether the caller explicitly pointed at a local folder before config defaults
 			// fill it in. An explicit --directory always forces local sourcing.
 			var explicitDirectory = !string.IsNullOrWhiteSpace(input.Directory);
@@ -244,6 +269,20 @@ public partial class ChangelogBundlingService(
 			var authoringOwner = ChangelogRepoOwnerResolver.ResolveOwner(input.Owner, input.Repo, DefaultOwner);
 			var authoringBranch = string.IsNullOrWhiteSpace(input.Branch) ? DefaultBranch : input.Branch;
 			var useCdn = ShouldSourceFromCdn(authoringRepo, useLocalChangelogs: useLocalChangelogs, explicitDirectory: explicitDirectory);
+
+			// Commit-range mode replaces the filter pipeline: the PR list is derived from git and
+			// each PR's entry is sourced pool-first with PR-metadata fallback.
+			if (!string.IsNullOrWhiteSpace(input.StartGitRef))
+			{
+				var sourcing = new GitRangeSourcingContext
+				{
+					UseCdn = useCdn,
+					Owner = authoringOwner,
+					Repo = authoringRepo,
+					Branch = authoringBranch
+				};
+				return await BundleFromGitRange(collector, input, config, sourcing, ctx);
+			}
 
 			// Validate input. In CDN mode the local input directory is not read, so its existence
 			// is not required.
@@ -363,137 +402,7 @@ public partial class ChangelogBundlingService(
 				return false;
 			}
 
-			// Apply rules.bundle secondary filter (three modes: none, global content, per-product context).
-			// Input stage (--input-products, --prs, etc.) and bundle filtering stage are conceptually separate.
-			var filteredEntries = matchResult.Entries;
-			if (config?.Rules?.Bundle != null)
-			{
-				var outputProductIds = input.OutputProducts
-					?.Select(p => p.Product)
-					.Where(p => !string.IsNullOrWhiteSpace(p))
-					.Select(p => p!)
-					.ToList();
-				var mode = config.Rules.Bundle.DetermineFilterMode();
-				filteredEntries = mode switch
-				{
-					BundleFilterMode.NoFiltering => filteredEntries,
-					BundleFilterMode.GlobalContent => ApplyGlobalContentBundleFilter(collector, filteredEntries, config.Rules.Bundle),
-					BundleFilterMode.PerProductContext => ApplyPerProductContextBundleFilter(
-						collector,
-						filteredEntries,
-						config.Rules.Bundle,
-						outputProductIds),
-					_ => filteredEntries
-				};
-			}
-
-			if (filteredEntries.Count == 0)
-			{
-				collector.EmitError(string.Empty, "No changelog entries remained after applying rules.bundle filter");
-				return false;
-			}
-
-			// Load feature IDs to hide
-			var featureHidingLoader = new FeatureHidingLoader(_fileSystem);
-			var featureHidingResult = await featureHidingLoader.LoadFeatureIdsAsync(collector, input.HideFeatures, ctx);
-			if (!featureHidingResult.IsValid)
-				return false;
-
-			// Build bundle
-			var bundleBuilder = new BundleBuilder();
-			var buildResult = bundleBuilder.BuildBundle(
-				collector,
-				filteredEntries,
-				input.OutputProducts,
-				input.Repo,
-				input.Owner,
-				featureHidingResult.FeatureIdsToHide
-			);
-
-			if (!buildResult.IsValid || buildResult.Data == null)
-				return false;
-
-			var bundleData = buildResult.Data;
-			if (input.LinkAllowRepos != null)
-			{
-				if (!LinkAllowlistSanitizer.TryApplyBundle(
-					collector,
-					bundleData,
-					input.LinkAllowRepos,
-					input.Owner ?? "elastic",
-					input.Repo,
-					out var sanitizedBundle,
-					out _))
-					return false;
-				bundleData = sanitizedBundle;
-
-				if (configurationContext != null && input.LinkAllowRepos.Count > 0)
-				{
-					try
-					{
-						var assemblyYaml = configurationContext.ConfigurationFileProvider.AssemblerFile.ReadToEnd();
-						var assembly = AssemblyConfiguration.Deserialize(assemblyYaml, skipPrivateRepositories: false);
-						LinkAllowlistSanitizer.EmitAssemblerDiagnostics(collector, input.LinkAllowRepos, assembly);
-					}
-					catch (Exception ex) when (ex is not (OutOfMemoryException or StackOverflowException))
-					{
-						collector.EmitWarning(
-							string.Empty,
-							$"Could not load assembler.yml for bundle.link_allow_repos diagnostics: {ex.Message}");
-					}
-				}
-			}
-
-			// Apply description with placeholder substitution
-			if (!string.IsNullOrEmpty(input.Description))
-			{
-				var version = (input.OutputProducts?.Count > 0 ? input.OutputProducts[0].Target : null)
-							  ?? (bundleData.Products.Count > 0 ? bundleData.Products[0].Target : null);
-				var lifecycle = (input.OutputProducts?.Count > 0 ? input.OutputProducts[0].Lifecycle : null)
-								?? (bundleData.Products.Count > 0 ? bundleData.Products[0].Lifecycle?.ToStringFast(true) : null);
-				var owner = input.Owner ?? "elastic";
-				var repo = input.Repo ?? (bundleData.Products.Count > 0 ? bundleData.Products[0].ProductId : null) ?? "unknown";
-
-				try
-				{
-					var substitutedDescription = BundleDescriptionSubstitution.SubstitutePlaceholders(
-						input.Description, version, lifecycle, owner, repo, validateResolvable: true);
-					bundleData = bundleData with { Description = substitutedDescription };
-				}
-				catch (InvalidOperationException ex)
-				{
-					collector.EmitError(string.Empty, $"Description placeholder substitution failed: {ex.Message}");
-					return false;
-				}
-			}
-
-			// Apply release date: CLI override → existing bundle date → auto-populate (unless suppressed)
-			var finalReleaseDate = bundleData.ReleaseDate; // Preserve existing date if present
-			if (!string.IsNullOrEmpty(input.ReleaseDate))
-			{
-				// Explicit CLI override
-				if (DateOnly.TryParseExact(input.ReleaseDate, "yyyy-MM-dd", out var parsedDate))
-				{
-					finalReleaseDate = parsedDate;
-				}
-				else
-				{
-					collector.EmitError(string.Empty, $"Invalid release date format '{input.ReleaseDate}'. Expected YYYY-MM-DD format.");
-					return false;
-				}
-			}
-			else if (finalReleaseDate == null && !input.SuppressReleaseDate)
-			{
-				// Auto-populate with today's date (UTC) if no existing date
-				finalReleaseDate = DateOnly.FromDateTime(DateTime.UtcNow);
-			}
-
-			bundleData = bundleData with { ReleaseDate = finalReleaseDate };
-
-			// Write bundle file
-			await WriteBundleFileAsync(bundleData, outputPath, ctx);
-
-			return true;
+			return await BuildAndWriteBundle(collector, input, config, matchResult.Entries, outputPath, ctx);
 		}
 		catch (IOException ioEx)
 		{
@@ -507,19 +416,172 @@ public partial class ChangelogBundlingService(
 		}
 	}
 
+	/// <summary>
+	/// Shared bundle tail: applies the <c>rules.bundle</c> secondary filter, builds the bundle,
+	/// applies link allowlist/description/release-date/git-ref metadata, and writes the output file.
+	/// </summary>
+	private async Task<bool> BuildAndWriteBundle(
+		IDiagnosticsCollector collector,
+		BundleChangelogsArguments input,
+		ChangelogConfiguration? config,
+		IReadOnlyList<MatchedChangelogFile> entries,
+		string outputPath,
+		Cancel ctx)
+	{
+		// Apply rules.bundle secondary filter (three modes: none, global content, per-product context).
+		// Input stage (--input-products, --prs, etc.) and bundle filtering stage are conceptually separate.
+		var filteredEntries = entries;
+		if (config?.Rules?.Bundle != null)
+		{
+			var outputProductIds = input.OutputProducts
+				?.Select(p => p.Product)
+				.Where(p => !string.IsNullOrWhiteSpace(p))
+				.Select(p => p!)
+				.ToList();
+			var mode = config.Rules.Bundle.DetermineFilterMode();
+			filteredEntries = mode switch
+			{
+				BundleFilterMode.NoFiltering => filteredEntries,
+				BundleFilterMode.GlobalContent => ApplyGlobalContentBundleFilter(collector, filteredEntries, config.Rules.Bundle),
+				BundleFilterMode.PerProductContext => ApplyPerProductContextBundleFilter(
+					collector,
+					filteredEntries,
+					config.Rules.Bundle,
+					outputProductIds),
+				_ => filteredEntries
+			};
+		}
+
+		if (filteredEntries.Count == 0)
+		{
+			collector.EmitError(string.Empty, "No changelog entries remained after applying rules.bundle filter");
+			return false;
+		}
+
+		// Load feature IDs to hide
+		var featureHidingLoader = new FeatureHidingLoader(_fileSystem);
+		var featureHidingResult = await featureHidingLoader.LoadFeatureIdsAsync(collector, input.HideFeatures, ctx);
+		if (!featureHidingResult.IsValid)
+			return false;
+
+		// Build bundle
+		var bundleBuilder = new BundleBuilder();
+		var buildResult = bundleBuilder.BuildBundle(
+			collector,
+			filteredEntries,
+			input.OutputProducts,
+			input.Repo,
+			input.Owner,
+			featureHidingResult.FeatureIdsToHide
+		);
+
+		if (!buildResult.IsValid || buildResult.Data == null)
+			return false;
+
+		var bundleData = buildResult.Data;
+		if (input.LinkAllowRepos != null)
+		{
+			if (!LinkAllowlistSanitizer.TryApplyBundle(
+				collector,
+				bundleData,
+				input.LinkAllowRepos,
+				input.Owner ?? "elastic",
+				input.Repo,
+				out var sanitizedBundle,
+				out _))
+				return false;
+			bundleData = sanitizedBundle;
+
+			if (configurationContext != null && input.LinkAllowRepos.Count > 0)
+			{
+				try
+				{
+					var assemblyYaml = configurationContext.ConfigurationFileProvider.AssemblerFile.ReadToEnd();
+					var assembly = AssemblyConfiguration.Deserialize(assemblyYaml, skipPrivateRepositories: false);
+					LinkAllowlistSanitizer.EmitAssemblerDiagnostics(collector, input.LinkAllowRepos, assembly);
+				}
+				catch (Exception ex) when (ex is not (OutOfMemoryException or StackOverflowException))
+				{
+					collector.EmitWarning(
+						string.Empty,
+						$"Could not load assembler.yml for bundle.link_allow_repos diagnostics: {ex.Message}");
+				}
+			}
+		}
+
+		// Apply description with placeholder substitution
+		if (!string.IsNullOrEmpty(input.Description))
+		{
+			var version = (input.OutputProducts?.Count > 0 ? input.OutputProducts[0].Target : null)
+						  ?? (bundleData.Products.Count > 0 ? bundleData.Products[0].Target : null);
+			var lifecycle = (input.OutputProducts?.Count > 0 ? input.OutputProducts[0].Lifecycle : null)
+							?? (bundleData.Products.Count > 0 ? bundleData.Products[0].Lifecycle?.ToStringFast(true) : null);
+			var owner = input.Owner ?? "elastic";
+			var repo = input.Repo ?? (bundleData.Products.Count > 0 ? bundleData.Products[0].ProductId : null) ?? "unknown";
+
+			try
+			{
+				var substitutedDescription = BundleDescriptionSubstitution.SubstitutePlaceholders(
+					input.Description, version, lifecycle, owner, repo, validateResolvable: true);
+				bundleData = bundleData with { Description = substitutedDescription };
+			}
+			catch (InvalidOperationException ex)
+			{
+				collector.EmitError(string.Empty, $"Description placeholder substitution failed: {ex.Message}");
+				return false;
+			}
+		}
+
+		// Apply release date: CLI override → existing bundle date → auto-populate (unless suppressed)
+		var finalReleaseDate = bundleData.ReleaseDate; // Preserve existing date if present
+		if (!string.IsNullOrEmpty(input.ReleaseDate))
+		{
+			// Explicit CLI override
+			if (DateOnly.TryParseExact(input.ReleaseDate, "yyyy-MM-dd", out var parsedDate))
+			{
+				finalReleaseDate = parsedDate;
+			}
+			else
+			{
+				collector.EmitError(string.Empty, $"Invalid release date format '{input.ReleaseDate}'. Expected YYYY-MM-DD format.");
+				return false;
+			}
+		}
+		else if (finalReleaseDate == null && !input.SuppressReleaseDate)
+		{
+			// Auto-populate with today's date (UTC) if no existing date
+			finalReleaseDate = DateOnly.FromDateTime(DateTime.UtcNow);
+		}
+
+		bundleData = bundleData with { ReleaseDate = finalReleaseDate };
+
+		// Commit-range bundles record the published endpoint ref (--end-git-ref) as metadata.
+		if (!string.IsNullOrWhiteSpace(input.EndGitRef))
+			bundleData = bundleData with { GitRef = input.EndGitRef };
+
+		// Write bundle file
+		await WriteBundleFileAsync(bundleData, outputPath, ctx);
+
+		return true;
+	}
+
 	private async Task<BundleChangelogsArguments?> ProcessProfile(IDiagnosticsCollector collector, BundleChangelogsArguments input, ChangelogConfiguration? config, Cancel ctx)
 	{
-		var filterResult = await ProfileFilterResolver.ResolveAsync(
-			collector,
-			input.Profile!,
-			input.ProfileArgument,
-			config,
-			_fileSystem,
-			_logger,
-			ctx,
-			input.ProfileReport,
-			_releaseService
-		);
+		// Commit-range mode derives its PR list from git; the profile only contributes output
+		// metadata (output/output_products/repo/owner/branch/description), not a filter source.
+		var filterResult = !string.IsNullOrWhiteSpace(input.StartGitRef)
+			? ResolveGitRangeProfileFilter(collector, input, config)
+			: await ProfileFilterResolver.ResolveAsync(
+				collector,
+				input.Profile!,
+				input.ProfileArgument,
+				config,
+				_fileSystem,
+				_logger,
+				ctx,
+				input.ProfileReport,
+				_releaseService
+			);
 
 		if (filterResult == null)
 			return null;
@@ -552,6 +614,21 @@ public partial class ChangelogBundlingService(
 					?? config.Bundle.Directory
 					?? _fileSystem.Directory.GetCurrentDirectory();
 				outputPath = _fileSystem.Path.Join(outputDir, outputPattern).OptionalWindowsReplace();
+			}
+			else if (!string.IsNullOrWhiteSpace(input.StartGitRef))
+			{
+				// Commit-range bundles follow the standardized {product}-{version}.yaml naming
+				// convention when the profile sets no explicit output pattern (explicit output:
+				// patterns are being phased out — see elastic/docs-builder#3774).
+				var primaryProduct = ResolvePrimaryProduct(profile, input);
+				if (!string.IsNullOrWhiteSpace(primaryProduct))
+				{
+					var outputDir = config.Bundle.OutputDirectory
+						?? input.OutputDirectory
+						?? config.Bundle.Directory
+						?? _fileSystem.Directory.GetCurrentDirectory();
+					outputPath = _fileSystem.Path.Join(outputDir, $"{primaryProduct}-{filterResult.Version}.yaml").OptionalWindowsReplace();
+				}
 			}
 
 			// Parse output_products pattern with version/lifecycle substitution
@@ -627,6 +704,210 @@ public partial class ChangelogBundlingService(
 		};
 	}
 
+	/// <summary>
+	/// Validates the commit-range arguments: both refs together (the start ref is never inferred —
+	/// an explicit RFC-review decision), no other filter source, and <c>--dry-run</c> only in range mode.
+	/// </summary>
+	private static bool ValidateGitRefArguments(IDiagnosticsCollector collector, BundleChangelogsArguments input)
+	{
+		var hasStart = !string.IsNullOrWhiteSpace(input.StartGitRef);
+		var hasEnd = !string.IsNullOrWhiteSpace(input.EndGitRef);
+
+		if (!hasStart && !hasEnd)
+		{
+			if (input.DryRun)
+			{
+				collector.EmitError(string.Empty, "--dry-run is only supported when bundling a git commit range (--start-git-ref/--end-git-ref).");
+				return false;
+			}
+
+			return true;
+		}
+
+		if (hasStart != hasEnd)
+		{
+			collector.EmitError(string.Empty,
+				"--start-git-ref and --end-git-ref must be provided together; the start ref is never inferred from previous bundles.");
+			return false;
+		}
+
+		var conflicting = new List<string>();
+		if (input.All)
+			conflicting.Add("--all");
+		if (input.InputProducts is { Count: > 0 })
+			conflicting.Add("--input-products");
+		if (input.Prs is { Length: > 0 })
+			conflicting.Add("--prs");
+		if (input.Issues is { Length: > 0 })
+			conflicting.Add("--issues");
+		if (input.Files is { Length: > 0 })
+			conflicting.Add("--files");
+		if (!string.IsNullOrWhiteSpace(input.Report))
+			conflicting.Add("--report");
+		if (!string.IsNullOrWhiteSpace(input.ProfileReport))
+			conflicting.Add("a report/list positional argument");
+
+		if (conflicting.Count > 0)
+		{
+			collector.EmitError(string.Empty,
+				$"--start-git-ref/--end-git-ref cannot be combined with other filter sources: {string.Join(", ", conflicting)}. " +
+				"The PR list is derived from the commit range itself.");
+			return false;
+		}
+
+		return true;
+	}
+
+	/// <summary>
+	/// Profile resolution for commit-range mode: the profile contributes output metadata only, so
+	/// filter-producing profile shapes (<c>source: github_release</c>, a <c>products</c> pattern)
+	/// are rejected and the version argument is carried through for placeholder substitution.
+	/// </summary>
+	private static ProfileFilterResult? ResolveGitRangeProfileFilter(
+		IDiagnosticsCollector collector,
+		BundleChangelogsArguments input,
+		ChangelogConfiguration? config)
+	{
+		if (config?.Bundle?.Profiles == null || !config.Bundle.Profiles.TryGetValue(input.Profile!, out var profile))
+		{
+			collector.EmitError(string.Empty, $"Profile '{input.Profile}' not found in bundle.profiles configuration");
+			return null;
+		}
+
+		if (string.IsNullOrWhiteSpace(input.ProfileArgument))
+		{
+			collector.EmitError(string.Empty,
+				$"Profile '{input.Profile}' requires a version as the second argument when bundling a git commit range");
+			return null;
+		}
+
+		if (string.Equals(profile.Source, "github_release", StringComparison.OrdinalIgnoreCase))
+		{
+			collector.EmitError(string.Empty,
+				$"Profile '{input.Profile}': 'source: github_release' cannot be combined with --start-git-ref/--end-git-ref. " +
+				"The PR list is derived from the commit range itself.");
+			return null;
+		}
+
+		if (!string.IsNullOrWhiteSpace(profile.Products))
+		{
+			collector.EmitError(string.Empty,
+				$"Profile '{input.Profile}' has a 'products' pattern configured. " +
+				"A git commit range cannot be combined with a products pattern filter; use 'output_products' and 'rules' to shape the bundle.");
+			return null;
+		}
+
+		return new ProfileFilterResult { Version = input.ProfileArgument };
+	}
+
+	/// <summary>How commit-range entries are sourced: the resolved authoring pool and the CDN/local gate.</summary>
+	private sealed record GitRangeSourcingContext
+	{
+		public required bool UseCdn { get; init; }
+		public required string? Owner { get; init; }
+		public required string? Repo { get; init; }
+		public required string? Branch { get; init; }
+	}
+
+	/// <summary>
+	/// Bundles a git commit range: resolves the range to a PR list (compare API +
+	/// <c>associatedPullRequests</c>), sources each PR's entry with the pool-first /
+	/// inferred-from-PR-metadata precedence, and reports PRs and commits that produced no entry.
+	/// In dry-run mode prints the run report instead of writing the bundle.
+	/// </summary>
+	private async Task<bool> BundleFromGitRange(
+		IDiagnosticsCollector collector,
+		BundleChangelogsArguments input,
+		ChangelogConfiguration? config,
+		GitRangeSourcingContext sourcing,
+		Cancel ctx)
+	{
+		if (string.IsNullOrWhiteSpace(sourcing.Repo))
+		{
+			collector.EmitError(string.Empty,
+				"Bundling a git commit range requires a resolvable authoring repository. " +
+				"Set bundle.repo in changelog.yml (or pass --repo).");
+			return false;
+		}
+
+		var owner = string.IsNullOrWhiteSpace(sourcing.Owner) ? DefaultOwner : sourcing.Owner;
+		var resolution = await _commitRangeService.ResolvePullRequestsAsync(collector, new CommitRangeArguments
+		{
+			Owner = owner,
+			Repo = sourcing.Repo,
+			StartRef = input.StartGitRef!,
+			EndRef = input.EndGitRef!
+		}, ctx);
+		if (resolution == null)
+			return false;
+
+		var directory = input.Directory!;
+		var outputPath = input.Output ?? _fileSystem.Path.Join(directory, "changelog-bundle.yaml");
+
+		var candidates = sourcing.UseCdn
+			? await FetchCdnEntriesAsync(collector, owner, sourcing.Repo, sourcing.Branch, ctx)
+			: await ReadLocalEntriesAsync(collector, directory, outputPath, ctx);
+		if (candidates == null)
+			return false;
+
+		var resolver = new GitRangeEntryResolver(_prService, _logger);
+		var result = await resolver.ResolveAsync(collector, resolution, candidates, config, new GitRangeEntryResolutionOptions
+		{
+			Owner = owner,
+			Repo = sourcing.Repo,
+			StartRef = input.StartGitRef!,
+			EndRef = input.EndGitRef!,
+			FallbackProducts = input.OutputProducts
+		}, ctx);
+
+		var report = result.Report.ToMarkdown();
+		_logger.LogInformation("Commit-range bundle report:\n{Report}", report);
+
+		if (input.DryRun)
+		{
+			// The report is the dry run's product: print it verbatim for release-PR bodies / job summaries.
+			await Console.Out.WriteLineAsync(report);
+			return result.Success && collector.Errors == 0;
+		}
+
+		if (!result.Success || collector.Errors > 0)
+			return false;
+
+		if (result.Entries.Count == 0)
+		{
+			collector.EmitError(string.Empty,
+				$"No changelog entries could be resolved for commit range {input.StartGitRef}..{input.EndGitRef} of {owner}/{sourcing.Repo}.");
+			return false;
+		}
+
+		return await BuildAndWriteBundle(collector, input, config, result.Entries, outputPath, ctx);
+	}
+
+	/// <summary>Reads the local changelog directory into (file name, content) pairs for range matching.</summary>
+	private async Task<IReadOnlyList<(string FileName, string Content)>?> ReadLocalEntriesAsync(
+		IDiagnosticsCollector collector,
+		string directory,
+		string outputPath,
+		Cancel ctx)
+	{
+		if (!_fileSystem.Directory.Exists(directory))
+		{
+			collector.EmitError(directory, "Directory does not exist");
+			return null;
+		}
+
+		var fileDiscovery = new ChangelogFileDiscovery(_fileSystem, _logger);
+		var yamlFiles = await fileDiscovery.DiscoverChangelogFilesAsync(directory, outputPath, ctx);
+		var entries = new List<(string FileName, string Content)>(yamlFiles.Count);
+		foreach (var filePath in yamlFiles)
+		{
+			var content = await _fileSystem.File.ReadAllTextAsync(filePath, ctx);
+			entries.Add((_fileSystem.Path.GetFileName(filePath), content));
+		}
+
+		return entries;
+	}
+
 	private BundleChangelogsArguments ApplyConfigDefaults(BundleChangelogsArguments input, ChangelogConfiguration? config)
 	{
 		// Apply directory: CLI takes precedence. Only use config when --directory not specified.
@@ -680,6 +961,13 @@ public partial class ChangelogBundlingService(
 	{
 		var needsNetwork = hasReleaseVersion;
 		var needsGithubToken = hasReleaseVersion;
+
+		// Commit-range bundling always needs the GitHub API (compare + GraphQL + PR metadata fallback).
+		if (!string.IsNullOrWhiteSpace(input.StartGitRef) || !string.IsNullOrWhiteSpace(input.EndGitRef))
+		{
+			needsNetwork = true;
+			needsGithubToken = true;
+		}
 
 		ChangelogConfiguration? config = null;
 		if (!string.IsNullOrWhiteSpace(input.Profile))

--- a/src/services/Elastic.Changelog/Bundling/ChangelogBundlingService.cs
+++ b/src/services/Elastic.Changelog/Bundling/ChangelogBundlingService.cs
@@ -1021,6 +1021,19 @@ public partial class ChangelogBundlingService(
 				?? _fileSystem.Directory.GetCurrentDirectory();
 			outputPath = _fileSystem.Path.Join(outputDir, outputPattern).OptionalWindowsReplace();
 		}
+		else if (string.IsNullOrWhiteSpace(outputPath) &&
+			!string.IsNullOrWhiteSpace(input.StartGitRef) &&
+			profileDef != null &&
+			!string.IsNullOrWhiteSpace(input.ProfileArgument) &&
+			ResolvePrimaryProduct(profileDef, input) is { } primaryProduct)
+		{
+			// Mirror ProcessProfile's commit-range convention: {product}-{version}.yaml when the
+			// profile sets no explicit output pattern.
+			var outputDir = config?.Bundle?.OutputDirectory
+				?? config?.Bundle?.Directory
+				?? _fileSystem.Directory.GetCurrentDirectory();
+			outputPath = _fileSystem.Path.Join(outputDir, $"{primaryProduct}-{input.ProfileArgument}.yaml").OptionalWindowsReplace();
+		}
 		else if (string.IsNullOrWhiteSpace(outputPath) && config?.Bundle?.OutputDirectory != null)
 			outputPath = _fileSystem.Path.Join(config.Bundle.OutputDirectory, "changelog-bundle.yaml").OptionalWindowsReplace();
 

--- a/src/services/Elastic.Changelog/Bundling/GitRangeEntryResolver.cs
+++ b/src/services/Elastic.Changelog/Bundling/GitRangeEntryResolver.cs
@@ -1,0 +1,416 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Globalization;
+using System.Text;
+using Elastic.Changelog.Creation;
+using Elastic.Changelog.GitHub;
+using Elastic.Documentation;
+using Elastic.Documentation.Configuration.Changelog;
+using Elastic.Documentation.Configuration.ReleaseNotes;
+using Elastic.Documentation.Diagnostics;
+using Elastic.Documentation.ReleaseNotes;
+using Microsoft.Extensions.Logging;
+using YamlDotNet.Core;
+
+namespace Elastic.Changelog.Bundling;
+
+/// <summary>
+/// Options for resolving the changelog entries of a commit-range bundle.
+/// </summary>
+public record GitRangeEntryResolutionOptions
+{
+	/// <summary>Authoring GitHub owner (org) the range was resolved against.</summary>
+	public required string Owner { get; init; }
+
+	/// <summary>Authoring GitHub repository the range was resolved against.</summary>
+	public required string Repo { get; init; }
+
+	/// <summary>Start ref of the range (report provenance).</summary>
+	public required string StartRef { get; init; }
+
+	/// <summary>End ref of the range (report provenance).</summary>
+	public required string EndRef { get; init; }
+
+	/// <summary>
+	/// Products applied to entries synthesized from PR metadata when the PR's labels do not map
+	/// to any product (typically the profile's <c>output_products</c>). Wildcards are ignored.
+	/// </summary>
+	public IReadOnlyList<ProductArgument>? FallbackProducts { get; init; }
+}
+
+/// <summary>How a pull request's changelog entry was sourced for a commit-range bundle.</summary>
+public enum GitRangePrSourceKind
+{
+	/// <summary>A checked-in entry existed in the entry pool (CDN or local directory).</summary>
+	Pool,
+
+	/// <summary>Synthesized from PR metadata, including release-note text extracted from the PR body.</summary>
+	InferredPrBody,
+
+	/// <summary>Synthesized from PR metadata using the PR title only (no release-note text found).</summary>
+	InferredTitle,
+
+	/// <summary>Excluded by <c>rules.create</c> label rules.</summary>
+	Excluded,
+
+	/// <summary>The PR's metadata could not be fetched; no entry could be produced.</summary>
+	Missing
+}
+
+/// <summary>Per-PR row of the commit-range bundle run report.</summary>
+public record GitRangePrReportRow
+{
+	public required int Number { get; init; }
+	public required string Url { get; init; }
+	public required GitRangePrSourceKind Source { get; init; }
+
+	/// <summary>Entry file name(s) backing this PR (pool file names or the synthesized name).</summary>
+	public IReadOnlyList<string> EntryFileNames { get; init; } = [];
+}
+
+/// <summary>
+/// Run report for a commit-range bundle: the resolved PR list with per-PR entry source, plus the
+/// commits that could not be attributed to a PR. Rendered as Markdown suitable for a release PR body.
+/// </summary>
+public record GitRangeBundleReport
+{
+	public required string StartRef { get; init; }
+	public required string EndRef { get; init; }
+	public required int TotalCommits { get; init; }
+	public required IReadOnlyList<GitRangePrReportRow> Rows { get; init; }
+	public required IReadOnlyList<string> CommitsWithoutPullRequest { get; init; }
+
+	/// <summary>Renders the report as Markdown, suitable for a release PR body or job summary.</summary>
+	public string ToMarkdown()
+	{
+		var sb = new StringBuilder();
+		_ = sb.AppendLine(CultureInfo.InvariantCulture, $"### Changelog bundle for `{StartRef}..{EndRef}`")
+			.AppendLine()
+			.AppendLine(CultureInfo.InvariantCulture, $"{TotalCommits} commit(s), {Rows.Count} pull request(s).")
+			.AppendLine()
+			.AppendLine("| PR | Source | Entry |")
+			.AppendLine("|---|---|---|");
+
+		foreach (var row in Rows)
+		{
+			var source = row.Source switch
+			{
+				GitRangePrSourceKind.Pool => "pool",
+				GitRangePrSourceKind.InferredPrBody => "inferred (PR body)",
+				GitRangePrSourceKind.InferredTitle => "inferred (title)",
+				GitRangePrSourceKind.Excluded => "excluded (rules)",
+				_ => "missing"
+			};
+			var entry = row.EntryFileNames.Count > 0 ? string.Join(", ", row.EntryFileNames.Select(f => $"`{f}`")) : "—";
+			_ = sb.AppendLine(CultureInfo.InvariantCulture, $"| [#{row.Number}]({row.Url}) | {source} | {entry} |");
+		}
+
+		if (CommitsWithoutPullRequest.Count > 0)
+		{
+			_ = sb.AppendLine()
+				.AppendLine("Commits without an associated pull request:")
+				.AppendLine();
+			foreach (var sha in CommitsWithoutPullRequest)
+				_ = sb.AppendLine(CultureInfo.InvariantCulture, $"- `{sha}`");
+		}
+
+		return sb.ToString();
+	}
+}
+
+/// <summary>Result of resolving commit-range entries.</summary>
+public record GitRangeEntryResolutionResult
+{
+	public required bool Success { get; init; }
+	public required IReadOnlyList<MatchedChangelogFile> Entries { get; init; }
+	public required GitRangeBundleReport Report { get; init; }
+}
+
+/// <summary>
+/// Resolves the changelog entries for the pull requests of a commit range, applying the RFC's
+/// sourcing precedence per PR: a checked-in entry from the pool (matched by file-name-derived PR
+/// numbers — file names survive scrubbing — or by the entry's <c>prs</c> references) wins over an
+/// entry synthesized from PR metadata via the same extraction path <c>changelog add</c> uses
+/// (release-note text from the PR body, label-mapped type/areas/products); PRs whose metadata
+/// cannot be fetched are reported as missing rather than silently dropped.
+/// </summary>
+public class GitRangeEntryResolver(IGitHubPrService prService, ILogger logger)
+{
+	/// <summary>
+	/// Resolves entries for every PR in <paramref name="resolution"/> against the candidate pool
+	/// <paramref name="candidates"/>. Never throws for per-PR failures; the report captures them.
+	/// </summary>
+	public async Task<GitRangeEntryResolutionResult> ResolveAsync(
+		IDiagnosticsCollector collector,
+		CommitRangeResolution resolution,
+		IReadOnlyList<(string FileName, string Content)> candidates,
+		ChangelogConfiguration? config,
+		GitRangeEntryResolutionOptions options,
+		Cancel ctx)
+	{
+		var parsedCandidates = candidates.Select(c => ParseCandidate(c.FileName, c.Content)).ToList();
+
+		var rows = new List<GitRangePrReportRow>();
+		var entries = new List<MatchedChangelogFile>();
+		var includedFileNames = new HashSet<string>(StringComparer.Ordinal);
+		var success = true;
+
+		foreach (var pr in resolution.PullRequests)
+		{
+			var matches = parsedCandidates.Where(c => MatchesPr(c, pr.Number, options)).ToList();
+			if (matches.Count > 0)
+			{
+				var fileNames = new List<string>();
+				foreach (var match in matches)
+				{
+					fileNames.Add(match.FileName);
+					if (!includedFileNames.Add(match.FileName))
+						continue;
+					if (match.Entry == null)
+					{
+						collector.EmitError(match.FileName,
+							$"Changelog entry '{match.FileName}' matches PR #{pr.Number} but could not be parsed: {match.ParseError}");
+						success = false;
+						continue;
+					}
+
+					entries.Add(match.Entry);
+				}
+
+				rows.Add(new GitRangePrReportRow
+				{
+					Number = pr.Number,
+					Url = pr.Url,
+					Source = GitRangePrSourceKind.Pool,
+					EntryFileNames = fileNames
+				});
+				continue;
+			}
+
+			var (row, synthesized, failed) = await SynthesizeFromPrMetadata(collector, pr, config, options, ctx);
+			rows.Add(row);
+			if (synthesized != null)
+				entries.Add(synthesized);
+			if (failed)
+				success = false;
+		}
+
+		var report = new GitRangeBundleReport
+		{
+			StartRef = options.StartRef,
+			EndRef = options.EndRef,
+			TotalCommits = resolution.TotalCommits,
+			Rows = rows,
+			CommitsWithoutPullRequest = resolution.CommitsWithoutPullRequest
+		};
+
+		return new GitRangeEntryResolutionResult
+		{
+			Success = success,
+			Entries = entries,
+			Report = report
+		};
+	}
+
+	private sealed record ParsedCandidate(string FileName, IReadOnlyList<int> FileNameNumbers, MatchedChangelogFile? Entry, string? ParseError, IReadOnlyList<string> NormalizedPrs);
+
+	private static ParsedCandidate ParseCandidate(string fileName, string content)
+	{
+		var numbers = ParseLeadingPrNumbers(fileName);
+		try
+		{
+			var checksum = ChangelogBundlingService.ComputeSha1(content);
+			var normalized = ReleaseNotesSerialization.NormalizeYaml(content);
+			var dto = ReleaseNotesSerialization.GetEntryDeserializer().Deserialize<ChangelogEntryDto>(normalized);
+			var entry = new MatchedChangelogFile
+			{
+				Data = ReleaseNotesSerialization.ConvertEntry(dto),
+				FilePath = fileName,
+				FileName = fileName,
+				Checksum = checksum
+			};
+			var prs = dto.Prs ?? (dto.Pr != null ? [dto.Pr] : new List<string>());
+			return new ParsedCandidate(fileName, numbers, entry, null, prs);
+		}
+		catch (YamlException ex)
+		{
+			return new ParsedCandidate(fileName, numbers, null, ex.Message, []);
+		}
+	}
+
+	/// <summary>
+	/// Parses PR numbers from the leading dash-separated numeric segments of an entry file name,
+	/// covering the PR-number naming schemes (<c>123.yaml</c>, <c>123-456.yaml</c>,
+	/// <c>123-bug-fix-slug.yaml</c>). File names survive scrubbing, so this match works for
+	/// private pools whose <c>prs</c> references were removed from the public copies.
+	/// </summary>
+	internal static IReadOnlyList<int> ParseLeadingPrNumbers(string fileName)
+	{
+		var stem = fileName;
+		var extensionIndex = stem.LastIndexOf('.');
+		if (extensionIndex > 0)
+			stem = stem[..extensionIndex];
+
+		var numbers = new List<int>();
+		foreach (var segment in stem.Split('-'))
+		{
+			if (segment.Length > 0 && segment.All(char.IsAsciiDigit) && int.TryParse(segment, out var number))
+				numbers.Add(number);
+			else
+				break;
+		}
+
+		return numbers;
+	}
+
+	private static bool MatchesPr(ParsedCandidate candidate, int prNumber, GitRangeEntryResolutionOptions options)
+	{
+		if (candidate.FileNameNumbers.Contains(prNumber))
+			return true;
+
+		var expected = $"{options.Owner}/{options.Repo}#{prNumber}".ToLowerInvariant();
+		return candidate.NormalizedPrs.Any(pr =>
+			ChangelogBundlingService.NormalizePrForComparison(pr, options.Owner, options.Repo) == expected);
+	}
+
+	/// <summary>
+	/// Synthesizes an in-memory changelog entry from PR metadata — the same extraction path
+	/// <c>changelog add</c> uses: release-note text from the PR body as the description, labels
+	/// mapped to type/areas/products/feature-id/highlight via the config pivots, and
+	/// <c>rules.create</c> label rules deciding inclusion.
+	/// </summary>
+	private async Task<(GitRangePrReportRow Row, MatchedChangelogFile? Entry, bool Failed)> SynthesizeFromPrMetadata(
+		IDiagnosticsCollector collector,
+		CommitRangePullRequest pr,
+		ChangelogConfiguration? config,
+		GitRangeEntryResolutionOptions options,
+		Cancel ctx)
+	{
+		var prInfo = await prService.FetchPrInfoAsync(pr.Url, options.Owner, options.Repo, ctx);
+		if (prInfo == null || string.IsNullOrWhiteSpace(prInfo.Title))
+		{
+			collector.EmitWarning(string.Empty,
+				$"No checked-in changelog entry was found for PR {pr.Url} and its metadata could not be fetched from GitHub. " +
+				"The bundle will not include an entry for this PR.");
+			return (Row(pr, GitRangePrSourceKind.Missing), null, false);
+		}
+
+		var labels = prInfo.Labels.ToArray();
+		var labelProducts = config?.LabelToProducts != null
+			? PrInfoProcessor.MapLabelsToProducts(labels, config.LabelToProducts)
+			: [];
+
+		if (config != null)
+		{
+			var effectiveProducts = labelProducts.Count > 0 ? labelProducts : (options.FallbackProducts ?? []).ToList();
+			if (PrInfoProcessor.ShouldSkipPrDueToLabelBlockers(labels, effectiveProducts, config, collector, pr.Url))
+				return (Row(pr, GitRangePrSourceKind.Excluded), null, false);
+		}
+
+		var title = prInfo.Title;
+		if (config?.Extract.StripTitlePrefix == true)
+			title = ChangelogTextUtilities.StripSquareBracketPrefix(title);
+
+		var typeString = config?.LabelToType != null
+			? PrInfoProcessor.MapLabelsToType(labels, config.LabelToType)
+			: null;
+		if (typeString == null)
+		{
+			collector.EmitWarning(pr.Url,
+				$"Could not derive a changelog type from the labels of PR #{pr.Number}; defaulting to 'other'. " +
+				"Configure pivot.types in changelog.yml to map labels to types.");
+		}
+
+		var type = ChangelogEntryTypeExtensions.TryParse(typeString ?? "other", out var parsedType, ignoreCase: true, allowMatchingMetadataAttribute: true)
+			? parsedType
+			: ChangelogEntryType.Other;
+
+		var products = ResolveProducts(collector, pr, labelProducts, options);
+		if (products == null)
+			return (Row(pr, GitRangePrSourceKind.Missing), null, true);
+
+		var description = config?.Extract.ReleaseNotes != false
+			? ReleaseNotesExtractor.FindReleaseNote(prInfo.Body)
+			: null;
+
+		var areas = config?.LabelToAreas != null
+			? PrInfoProcessor.MapLabelsToAreas(labels, config.LabelToAreas)
+			: [];
+
+		var featureId = config?.LabelToFeatures != null
+			? PrInfoProcessor.MapLabelsToFeatureId(labels, config.LabelToFeatures, collector)
+			: null;
+
+		var highlight = config?.HighlightLabels is { Count: > 0 } highlightLabels &&
+			labels.Any(label => highlightLabels.Contains(label, StringComparer.OrdinalIgnoreCase))
+			? true
+			: (bool?)null;
+
+		var issues = config?.Extract.Issues != false && prInfo.LinkedIssues.Count > 0
+			? prInfo.LinkedIssues.ToList()
+			: null;
+
+		var entryData = new ChangelogEntry
+		{
+			Title = title,
+			Type = type,
+			Description = description,
+			Products = products,
+			Areas = areas.Count > 0 ? areas : null,
+			FeatureId = featureId,
+			Highlight = highlight,
+			Prs = [pr.Url],
+			Issues = issues
+		};
+
+		var yaml = ReleaseNotesSerialization.SerializeEntry(entryData);
+		var fileName = $"{pr.Number}.yaml";
+		var entry = new MatchedChangelogFile
+		{
+			Data = entryData,
+			FilePath = fileName,
+			FileName = fileName,
+			Checksum = ChangelogBundlingService.ComputeSha1(yaml)
+		};
+
+		var kind = description != null ? GitRangePrSourceKind.InferredPrBody : GitRangePrSourceKind.InferredTitle;
+		logger.LogInformation("Synthesized changelog entry for PR #{Number} from PR metadata ({Kind})", pr.Number, kind);
+		return (Row(pr, kind, fileName), entry, false);
+	}
+
+	/// <summary>
+	/// Products for a synthesized entry: label-derived products win; otherwise the concrete
+	/// (non-wildcard) fallback products from the profile/CLI. Returns null after emitting an
+	/// error when neither yields a product — a bundle entry without products is invalid.
+	/// </summary>
+	private static List<ProductReference>? ResolveProducts(
+		IDiagnosticsCollector collector,
+		CommitRangePullRequest pr,
+		IReadOnlyList<ProductArgument> labelProducts,
+		GitRangeEntryResolutionOptions options)
+	{
+		var source = labelProducts.Count > 0
+			? labelProducts
+			: (options.FallbackProducts ?? []).Where(p => !string.IsNullOrWhiteSpace(p.Product) && p.Product != "*").ToList();
+
+		if (source.Count == 0)
+		{
+			collector.EmitError(string.Empty,
+				$"Cannot determine products for the entry synthesized from PR {pr.Url}: its labels map to no product and no output products are configured. " +
+				"Configure pivot.products label mappings or set output_products on the bundle profile.");
+			return null;
+		}
+
+		return source.Select(p => p.ToProductReference()).ToList();
+	}
+
+	private static GitRangePrReportRow Row(CommitRangePullRequest pr, GitRangePrSourceKind source, string? fileName = null) => new()
+	{
+		Number = pr.Number,
+		Url = pr.Url,
+		Source = source,
+		EntryFileNames = fileName != null ? [fileName] : []
+	};
+}

--- a/src/tooling/docs-builder/Commands/ChangelogCommand.cs
+++ b/src/tooling/docs-builder/Commands/ChangelogCommand.cs
@@ -571,6 +571,9 @@ internal sealed partial class ChangelogCommands(
 	/// <param name="branch">Branch whose CDN changelog entry pool (<c>changelog/{org}/{repo}/{branch}/...</c>) is sourced from. Falls back to <c>bundle.branch</c> or "main". This option is not supported in profile-based commands. The equivalent configuration options are <c>bundle.branch</c> or <c>bundle.profiles.&lt;name&gt;.branch</c>.</param>
 	/// <param name="prs">Filter by pull request URLs (comma-separated), or a path to a newline-delimited file containing fully-qualified GitHub PR URLs. Can be specified multiple times. This option is not supported in profile-based commands. Pass a promotion report as the second or third positional argument instead, or set <c>source: github_release</c> on the profile.</param>
 	/// <param name="files">Filter by changelog YAML paths (comma-separated), or a path to a newline-delimited file containing changelog paths. Can be specified multiple times. When entries are sourced from the CDN, paths are matched to pool entries by file name and do not need to exist locally; with local sourcing (--force-local, --directory, or bundle.use_local_changelogs) the paths must exist on disk. This option is not supported in profile-based commands; pass a path list file as the second or third positional argument instead.</param>
+	/// <param name="startGitRef">Start ref (exclusive) of a git commit range to bundle, for example the previously published endpoint ref. Must be provided together with --end-git-ref; the start ref is never inferred. The PR list is derived from the range itself (GitHub compare API + GraphQL associatedPullRequests), each PR's entry is sourced pool-first with PR-metadata fallback, and requires GITHUB_TOKEN. Supported in profile-based commands (for example, 'bundle serverless-release 2026-08-13 --start-git-ref abc123 --end-git-ref def456'); mutually exclusive with all other filter options.</param>
+	/// <param name="endGitRef">End ref (inclusive) of the git commit range to bundle — the currently published endpoint ref. Must be provided together with --start-git-ref. Recorded in the bundle output as the <c>git_ref</c> metadata field.</param>
+	/// <param name="dryRun">Resolve the commit range and print the run report (resolved PR list with per-PR entry source: pool, inferred, or missing) as Markdown without writing a bundle. Only valid together with --start-git-ref/--end-git-ref. Supported in profile-based commands.</param>
 	/// <param name="forceLocal">Force local entry sourcing for this run (equivalent to <c>bundle.use_local_changelogs: true</c> without editing config). Allowed in profile-based commands.</param>
 	/// <param name="repo">GitHub repository name for PR/issue numbers or --release-version. Falls back to <c>bundle.repo</c> or the product ID. This option is not supported in profile-based commands. The equivalent configuration options are <c>bundle.repo</c> or <c>bundle.profiles.&lt;name&gt;.repo</c>.</param>
 	/// <param name="report">URL or file path to a promotion report; extracts PR URLs as the filter. This option is not supported in profile-based commands. Pass the report as the second or third positional argument instead.</param>
@@ -602,6 +605,9 @@ internal sealed partial class ChangelogCommands(
 		string? releaseVersion = null,
 		string? repo = null,
 		string? report = null,
+		string? startGitRef = null,
+		string? endGitRef = null,
+		bool dryRun = false,
 		CancellationToken ct = default
 	)
 	{
@@ -611,6 +617,26 @@ internal sealed partial class ChangelogCommands(
 		var service = new ChangelogBundlingService(logFactory, configurationContext);
 
 		var isProfileMode = !string.IsNullOrWhiteSpace(profile);
+		var isGitRefMode = !string.IsNullOrWhiteSpace(startGitRef) || !string.IsNullOrWhiteSpace(endGitRef);
+
+		if (isGitRefMode && (string.IsNullOrWhiteSpace(startGitRef) || string.IsNullOrWhiteSpace(endGitRef)))
+		{
+			collector.EmitError(string.Empty,
+				"--start-git-ref and --end-git-ref must be provided together; the start ref is never inferred from previous bundles.");
+			return 1;
+		}
+
+		if (dryRun && !isGitRefMode)
+		{
+			collector.EmitError(string.Empty, "--dry-run is only supported when bundling a git commit range (--start-git-ref/--end-git-ref).");
+			return 1;
+		}
+
+		if (isGitRefMode && releaseVersion != null)
+		{
+			collector.EmitError(string.Empty, "--start-git-ref/--end-git-ref and --release-version are mutually exclusive.");
+			return 1;
+		}
 
 		// --release-version mode: resolve the release into a PR list and proceed as if --prs was specified
 		if (releaseVersion != null)
@@ -739,10 +765,12 @@ internal sealed partial class ChangelogCommands(
 				specifiedFilters.Add("--files");
 			if (!string.IsNullOrWhiteSpace(report))
 				specifiedFilters.Add("--report");
+			if (isGitRefMode)
+				specifiedFilters.Add("--start-git-ref/--end-git-ref");
 
 			if (specifiedFilters.Count == 0)
 			{
-				collector.EmitError(string.Empty, "At least one filter option must be specified: --all, --input-products, --prs, --issues, --report, --files, or use a profile (e.g., 'bundle elasticsearch-release 9.2.0')");
+				collector.EmitError(string.Empty, "At least one filter option must be specified: --all, --input-products, --prs, --issues, --report, --files, --start-git-ref/--end-git-ref, or use a profile (e.g., 'bundle elasticsearch-release 9.2.0')");
 				_ = collector.StartAsync(ctx);
 				await collector.WaitForDrain();
 				await collector.StopAsync(ctx);
@@ -751,7 +779,7 @@ internal sealed partial class ChangelogCommands(
 
 			if (specifiedFilters.Count > 1)
 			{
-				collector.EmitError(string.Empty, $"Multiple filter options cannot be specified together. You specified: {string.Join(", ", specifiedFilters)}. Please use only one filter option: --all, --input-products, --prs, --issues, --report, or --files");
+				collector.EmitError(string.Empty, $"Multiple filter options cannot be specified together. You specified: {string.Join(", ", specifiedFilters)}. Please use only one filter option: --all, --input-products, --prs, --issues, --report, --files, or --start-git-ref/--end-git-ref");
 				_ = collector.StartAsync(ctx);
 				await collector.WaitForDrain();
 				await collector.StopAsync(ctx);
@@ -854,7 +882,9 @@ internal sealed partial class ChangelogCommands(
 				Directory = directory?.FullName,
 				Repo = repo,
 				Config = config?.FullName,
-				Description = description
+				Description = description,
+				StartGitRef = startGitRef,
+				EndGitRef = endGitRef
 			};
 			var planResult = await service.PlanBundleAsync(collector, planInput, releaseVersion != null, ctx);
 			if (planResult == null)
@@ -922,7 +952,10 @@ internal sealed partial class ChangelogCommands(
 			HideFeatures = allFeatureIdsForBundle.Count > 0 ? allFeatureIdsForBundle.ToArray() : null,
 			Description = description,
 			ReleaseDate = releaseDate,
-			SuppressReleaseDate = noReleaseDate
+			SuppressReleaseDate = noReleaseDate,
+			StartGitRef = startGitRef,
+			EndGitRef = endGitRef,
+			DryRun = dryRun
 		};
 
 		serviceInvoker.AddCommand(service, input,

--- a/tests/Elastic.Changelog.Tests/Changelogs/BundleGitRefTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/BundleGitRefTests.cs
@@ -327,6 +327,35 @@ public class BundleGitRefTests(ITestOutputHelper output) : ChangelogTestBase(out
 	}
 
 	[Fact]
+	public async Task Plan_GitRefProfileWithoutOutputPattern_ResolvesConventionalPathAndNetworkNeeds()
+	{
+		// The bundle-create CI action relies on --plan's output_path to locate the generated file,
+		// so the plan must mirror the {product}-{version}.yaml convention of the real run.
+		var outputDir = FileSystem.Path.Join(Paths.WorkingDirectoryRoot.FullName, Guid.NewGuid().ToString());
+		FileSystem.Directory.CreateDirectory(outputDir);
+		var configPath = await WriteProfileConfig(outputDir);
+
+		var service = Service(PoolHandler(), RangeService());
+
+		var input = new BundleChangelogsArguments
+		{
+			Profile = "promotion",
+			ProfileArgument = "2026-08-13",
+			Config = configPath,
+			StartGitRef = StartRef,
+			EndGitRef = EndRef
+		};
+
+		var plan = await service.PlanBundleAsync(Collector, input, hasReleaseVersion: false, TestContext.Current.CancellationToken);
+
+		plan.Should().NotBeNull();
+		plan!.NeedsNetwork.Should().BeTrue();
+		plan.NeedsGithubToken.Should().BeTrue();
+		plan.OutputPath.Should().NotBeNull();
+		FileSystem.Path.GetFileName(plan.OutputPath!).Should().Be("cloud-hosted-2026-08-13.yaml");
+	}
+
+	[Fact]
 	public void GitRangeReport_ToMarkdown_ListsPrSourcesAndOrphanCommits()
 	{
 		var report = new GitRangeBundleReport

--- a/tests/Elastic.Changelog.Tests/Changelogs/BundleGitRefTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/BundleGitRefTests.cs
@@ -349,10 +349,10 @@ public class BundleGitRefTests(ITestOutputHelper output) : ChangelogTestBase(out
 		var plan = await service.PlanBundleAsync(Collector, input, hasReleaseVersion: false, TestContext.Current.CancellationToken);
 
 		plan.Should().NotBeNull();
-		plan!.NeedsNetwork.Should().BeTrue();
+		plan.NeedsNetwork.Should().BeTrue();
 		plan.NeedsGithubToken.Should().BeTrue();
 		plan.OutputPath.Should().NotBeNull();
-		FileSystem.Path.GetFileName(plan.OutputPath!).Should().Be("cloud-hosted-2026-08-13.yaml");
+		FileSystem.Path.GetFileName(plan.OutputPath).Should().Be("cloud-hosted-2026-08-13.yaml");
 	}
 
 	[Fact]

--- a/tests/Elastic.Changelog.Tests/Changelogs/BundleGitRefTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/BundleGitRefTests.cs
@@ -1,0 +1,383 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Net;
+using AwesomeAssertions;
+using Elastic.Changelog.Bundling;
+using Elastic.Changelog.GitHub;
+using Elastic.Documentation.Configuration;
+using Elastic.Documentation.Configuration.ReleaseNotes;
+using Elastic.Documentation.Diagnostics;
+using FakeItEasy;
+
+namespace Elastic.Changelog.Tests.Changelogs;
+
+/// <summary>
+/// Tests for commit-range bundling (<c>changelog bundle --start-git-ref --end-git-ref</c>):
+/// the PR list is derived from the range, each PR's entry follows the pool-first /
+/// inferred-from-PR-metadata precedence, the bundle records <c>git_ref</c>, and dry-run
+/// reports without writing.
+/// </summary>
+public class BundleGitRefTests(ITestOutputHelper output) : ChangelogTestBase(output)
+{
+	private const string StartRef = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1";
+	private const string EndRef = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2";
+
+	// Pool entry named by PR number (the CI naming scheme for private repos): matches PR 100 by file name.
+	// language=yaml
+	private const string PoolEntryByName = """
+		title: Faster hosted search
+		type: feature
+		products:
+		  - product: cloud-hosted
+		    target: 2026-08-13
+		    lifecycle: ga
+		""";
+
+	// Pool entry with a non-numeric name: matches PR 200 only via its prs reference.
+	// language=yaml
+	private const string PoolEntryByPrs = """
+		title: Sturdier snapshots
+		type: bug-fix
+		products:
+		  - product: cloud-hosted
+		    target: 2026-08-13
+		    lifecycle: ga
+		prs:
+		  - https://github.com/elastic/widget/pull/200
+		""";
+
+	// language=json
+	private const string RegistryJson =
+		"""{ "schema_version": 1, "product": "widget", "bundles": [ { "file": "100.yaml" }, { "file": "sturdier-snapshots.yaml" } ] }""";
+
+	private StubHandler PoolHandler() => new(req =>
+	{
+		var path = req.RequestUri!.AbsolutePath;
+		if (path.EndsWith("/registry.json", StringComparison.Ordinal))
+			return Json(RegistryJson);
+		if (path.EndsWith("100.yaml", StringComparison.Ordinal))
+			return Yaml(PoolEntryByName);
+		if (path.EndsWith("sturdier-snapshots.yaml", StringComparison.Ordinal))
+			return Yaml(PoolEntryByPrs);
+		return new HttpResponseMessage(HttpStatusCode.NotFound);
+	});
+
+	private CdnChangelogEntryFetcher Fetcher(StubHandler handler) =>
+		new(new TestLoggerFactory(Output), handler, sleep: (_, _) => Task.CompletedTask);
+
+	private static CommitRangePullRequest RangePr(int number) => new()
+	{
+		Number = number,
+		Url = $"https://github.com/elastic/widget/pull/{number}",
+		CommitShas = [$"sha-{number}"]
+	};
+
+	private static IGitHubCommitRangeService RangeService(params int[] prNumbers)
+	{
+		var service = A.Fake<IGitHubCommitRangeService>();
+		_ = A.CallTo(() => service.ResolvePullRequestsAsync(A<IDiagnosticsCollector>._, A<CommitRangeArguments>._, A<Cancel>._))
+			.Returns(new CommitRangeResolution
+			{
+				TotalCommits = prNumbers.Length,
+				PullRequests = prNumbers.Select(RangePr).ToList(),
+				CommitsWithoutPullRequest = []
+			});
+		return service;
+	}
+
+	private async Task<string> WriteProfileConfig(string outputDir)
+	{
+		// language=yaml
+		var configContent =
+			"""
+			pivot:
+			  types:
+			    feature: ">feature"
+			    bug-fix: ">bug"
+			    breaking-change: ">breaking"
+			bundle:
+			  output_directory: PLACEHOLDER
+			  repo: widget
+			  owner: elastic
+			  profiles:
+			    promotion:
+			      output_products: "cloud-hosted {version}"
+			""".Replace("PLACEHOLDER", outputDir);
+
+		var configPath = FileSystem.Path.Join(Paths.WorkingDirectoryRoot.FullName, Guid.NewGuid().ToString(), "changelog.yml");
+		FileSystem.Directory.CreateDirectory(FileSystem.Path.GetDirectoryName(configPath)!);
+		await FileSystem.File.WriteAllTextAsync(configPath, configContent, TestContext.Current.CancellationToken);
+		return configPath;
+	}
+
+	private ChangelogBundlingService Service(
+		StubHandler handler,
+		IGitHubCommitRangeService rangeService,
+		IGitHubPrService? prService = null) =>
+		new(LoggerFactory, ConfigurationContext, FileSystem, null, Fetcher(handler),
+			prService ?? A.Fake<IGitHubPrService>(), rangeService);
+
+	[Fact]
+	public async Task ProfileMode_PoolFirstWithInferredFallback_WritesBundleWithGitRef()
+	{
+		var outputDir = FileSystem.Path.Join(Paths.WorkingDirectoryRoot.FullName, Guid.NewGuid().ToString());
+		FileSystem.Directory.CreateDirectory(outputDir);
+		var configPath = await WriteProfileConfig(outputDir);
+
+		// PR 100: pool hit by file name. PR 200: pool hit by prs reference. PR 300: no pool entry —
+		// synthesized from PR metadata (release-note text + label-derived type). PR 400: metadata
+		// unavailable — reported missing, bundle still ships.
+		var prService = A.Fake<IGitHubPrService>();
+		_ = A.CallTo(() => prService.FetchPrInfoAsync("https://github.com/elastic/widget/pull/300", A<string?>._, A<string?>._, A<Cancel>._))
+			.Returns(new GitHubPrInfo
+			{
+				Title = "Sharper autocomplete",
+				Body = "Some context.\n\n## Release Note\nAutocomplete now ranks recent indices first.\n\nInternal details.",
+				Labels = [">feature"],
+				LinkedIssues = []
+			});
+		_ = A.CallTo(() => prService.FetchPrInfoAsync("https://github.com/elastic/widget/pull/400", A<string?>._, A<string?>._, A<Cancel>._))
+			.Returns((GitHubPrInfo?)null);
+
+		var service = Service(PoolHandler(), RangeService(100, 200, 300, 400), prService);
+
+		var input = new BundleChangelogsArguments
+		{
+			Profile = "promotion",
+			ProfileArgument = "2026-08-13",
+			Config = configPath,
+			StartGitRef = StartRef,
+			EndGitRef = EndRef
+		};
+
+		var result = await service.BundleChangelogs(Collector, input, TestContext.Current.CancellationToken);
+
+		result.Should().BeTrue($"Errors: {string.Join("; ", Collector.Diagnostics.Where(d => d.Severity == Severity.Error).Select(d => d.Message))}");
+		Collector.Errors.Should().Be(0);
+
+		// No profile output pattern → the standardized {product}-{version}.yaml convention applies.
+		var outputFiles = FileSystem.Directory.GetFiles(outputDir, "*.yaml");
+		outputFiles.Should().ContainSingle();
+		FileSystem.Path.GetFileName(outputFiles[0]).Should().Be("cloud-hosted-2026-08-13.yaml");
+
+		var bundle = await FileSystem.File.ReadAllTextAsync(outputFiles[0], TestContext.Current.CancellationToken);
+
+		// Pool entries win over inference.
+		bundle.Should().Contain("Faster hosted search");
+		bundle.Should().Contain("Sturdier snapshots");
+
+		// The synthesized entry carries PR-body release-note text, the label-derived type, and the
+		// profile's output products.
+		bundle.Should().Contain("Sharper autocomplete");
+		bundle.Should().Contain("Autocomplete now ranks recent indices first.");
+		bundle.Should().Contain("name: 300.yaml");
+
+		// The published endpoint ref is recorded as bundle metadata.
+		bundle.Should().Contain($"git_ref: {EndRef}");
+
+		// PR 400 is reported, not silently dropped.
+		Collector.Diagnostics.Should().Contain(d =>
+			d.Severity == Severity.Warning && d.Message.Contains("pull/400") && d.Message.Contains("could not be fetched"));
+	}
+
+	[Fact]
+	public async Task ProfileMode_DryRun_ResolvesButWritesNothing()
+	{
+		var outputDir = FileSystem.Path.Join(Paths.WorkingDirectoryRoot.FullName, Guid.NewGuid().ToString());
+		FileSystem.Directory.CreateDirectory(outputDir);
+		var configPath = await WriteProfileConfig(outputDir);
+
+		var service = Service(PoolHandler(), RangeService(100, 200));
+
+		var input = new BundleChangelogsArguments
+		{
+			Profile = "promotion",
+			ProfileArgument = "2026-08-13",
+			Config = configPath,
+			StartGitRef = StartRef,
+			EndGitRef = EndRef,
+			DryRun = true
+		};
+
+		var result = await service.BundleChangelogs(Collector, input, TestContext.Current.CancellationToken);
+
+		result.Should().BeTrue();
+		Collector.Errors.Should().Be(0);
+		FileSystem.Directory.GetFiles(outputDir, "*.yaml").Should().BeEmpty("dry-run must not write a bundle");
+	}
+
+	[Fact]
+	public async Task StartRefWithoutEndRef_Errors()
+	{
+		var service = Service(PoolHandler(), RangeService());
+
+		var input = new BundleChangelogsArguments
+		{
+			Repo = "widget",
+			StartGitRef = StartRef
+		};
+
+		var result = await service.BundleChangelogs(Collector, input, TestContext.Current.CancellationToken);
+
+		result.Should().BeFalse();
+		Collector.Diagnostics.Should().Contain(d =>
+			d.Severity == Severity.Error && d.Message.Contains("must be provided together"));
+	}
+
+	[Fact]
+	public async Task GitRefCombinedWithOtherFilter_Errors()
+	{
+		var service = Service(PoolHandler(), RangeService());
+
+		var input = new BundleChangelogsArguments
+		{
+			Repo = "widget",
+			StartGitRef = StartRef,
+			EndGitRef = EndRef,
+			Prs = ["https://github.com/elastic/widget/pull/1"]
+		};
+
+		var result = await service.BundleChangelogs(Collector, input, TestContext.Current.CancellationToken);
+
+		result.Should().BeFalse();
+		Collector.Diagnostics.Should().Contain(d =>
+			d.Severity == Severity.Error && d.Message.Contains("cannot be combined with other filter sources"));
+	}
+
+	[Fact]
+	public async Task ProfileWithProductsPattern_Errors()
+	{
+		var outputDir = FileSystem.Path.Join(Paths.WorkingDirectoryRoot.FullName, Guid.NewGuid().ToString());
+		FileSystem.Directory.CreateDirectory(outputDir);
+
+		// language=yaml
+		var configContent =
+			"""
+			bundle:
+			  output_directory: PLACEHOLDER
+			  repo: widget
+			  owner: elastic
+			  profiles:
+			    filtered:
+			      products: "cloud-hosted {version} *"
+			""".Replace("PLACEHOLDER", outputDir);
+		var configPath = FileSystem.Path.Join(Paths.WorkingDirectoryRoot.FullName, Guid.NewGuid().ToString(), "changelog.yml");
+		FileSystem.Directory.CreateDirectory(FileSystem.Path.GetDirectoryName(configPath)!);
+		await FileSystem.File.WriteAllTextAsync(configPath, configContent, TestContext.Current.CancellationToken);
+
+		var service = Service(PoolHandler(), RangeService());
+
+		var input = new BundleChangelogsArguments
+		{
+			Profile = "filtered",
+			ProfileArgument = "2026-08-13",
+			Config = configPath,
+			StartGitRef = StartRef,
+			EndGitRef = EndRef
+		};
+
+		var result = await service.BundleChangelogs(Collector, input, TestContext.Current.CancellationToken);
+
+		result.Should().BeFalse();
+		Collector.Diagnostics.Should().Contain(d =>
+			d.Severity == Severity.Error && d.Message.Contains("products pattern"));
+	}
+
+	[Fact]
+	public async Task InferredEntry_NoTypeLabel_DefaultsToOtherWithWarning()
+	{
+		var outputDir = FileSystem.Path.Join(Paths.WorkingDirectoryRoot.FullName, Guid.NewGuid().ToString());
+		FileSystem.Directory.CreateDirectory(outputDir);
+		var configPath = await WriteProfileConfig(outputDir);
+
+		var prService = A.Fake<IGitHubPrService>();
+		_ = A.CallTo(() => prService.FetchPrInfoAsync(A<string>._, A<string?>._, A<string?>._, A<Cancel>._))
+			.Returns(new GitHubPrInfo
+			{
+				Title = "Unlabeled change",
+				Body = "No release note block here.",
+				Labels = ["unmapped-label"],
+				LinkedIssues = []
+			});
+
+		var service = Service(PoolHandler(), RangeService(999), prService);
+
+		var input = new BundleChangelogsArguments
+		{
+			Profile = "promotion",
+			ProfileArgument = "2026-08-13",
+			Config = configPath,
+			StartGitRef = StartRef,
+			EndGitRef = EndRef
+		};
+
+		var result = await service.BundleChangelogs(Collector, input, TestContext.Current.CancellationToken);
+
+		result.Should().BeTrue($"Errors: {string.Join("; ", Collector.Diagnostics.Where(d => d.Severity == Severity.Error).Select(d => d.Message))}");
+
+		var outputFiles = FileSystem.Directory.GetFiles(outputDir, "*.yaml");
+		outputFiles.Should().ContainSingle();
+		var bundle = await FileSystem.File.ReadAllTextAsync(outputFiles[0], TestContext.Current.CancellationToken);
+		bundle.Should().Contain("Unlabeled change");
+		bundle.Should().Contain("type: other");
+		Collector.Diagnostics.Should().Contain(d =>
+			d.Severity == Severity.Warning && d.Message.Contains("defaulting to 'other'"));
+	}
+
+	[Fact]
+	public void GitRangeReport_ToMarkdown_ListsPrSourcesAndOrphanCommits()
+	{
+		var report = new GitRangeBundleReport
+		{
+			StartRef = StartRef,
+			EndRef = EndRef,
+			TotalCommits = 3,
+			Rows =
+			[
+				new GitRangePrReportRow { Number = 100, Url = "https://github.com/elastic/widget/pull/100", Source = GitRangePrSourceKind.Pool, EntryFileNames = ["100.yaml"] },
+				new GitRangePrReportRow { Number = 300, Url = "https://github.com/elastic/widget/pull/300", Source = GitRangePrSourceKind.InferredPrBody, EntryFileNames = ["300.yaml"] },
+				new GitRangePrReportRow { Number = 400, Url = "https://github.com/elastic/widget/pull/400", Source = GitRangePrSourceKind.Missing }
+			],
+			CommitsWithoutPullRequest = ["deadbeef"]
+		};
+
+		var markdown = report.ToMarkdown();
+
+		markdown.Should().Contain($"`{StartRef}..{EndRef}`");
+		markdown.Should().Contain("| [#100](https://github.com/elastic/widget/pull/100) | pool | `100.yaml` |");
+		markdown.Should().Contain("| [#300](https://github.com/elastic/widget/pull/300) | inferred (PR body) | `300.yaml` |");
+		markdown.Should().Contain("| [#400](https://github.com/elastic/widget/pull/400) | missing | — |");
+		markdown.Should().Contain("- `deadbeef`");
+	}
+
+	[Theory]
+	[InlineData("100.yaml", new[] { 100 })]
+	[InlineData("100-200.yaml", new[] { 100, 200 })]
+	[InlineData("123-bug-fix-some-slug.yaml", new[] { 123 })]
+	[InlineData("sturdier-snapshots.yaml", new int[0])]
+	[InlineData("1755000000-my-title.yaml", new[] { 1755000000 })]
+	public void ParseLeadingPrNumbers_CoversNamingSchemes(string fileName, int[] expected) =>
+		GitRangeEntryResolver.ParseLeadingPrNumbers(fileName).Should().Equal(expected);
+
+	private static HttpResponseMessage Json(string body) =>
+		new(HttpStatusCode.OK) { Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json") };
+
+	private static HttpResponseMessage Yaml(string body) =>
+		new(HttpStatusCode.OK) { Content = new StringContent(body, System.Text.Encoding.UTF8, "text/yaml") };
+
+	private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
+	{
+		public List<string> RequestedPaths { get; } = [];
+
+		protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
+		{
+			RequestedPaths.Add(request.RequestUri!.AbsolutePath);
+			return responder(request);
+		}
+
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+			Task.FromResult(Send(request, cancellationToken));
+	}
+}


### PR DESCRIPTION
## Why

Converts elastic/cloud-style date promotions from "unblocked manually" (#3783) to "automated": the promotion event hands off two commit hashes from a protected branch, and `changelog bundle` derives the PR list itself instead of consuming an externally staged list (rejected in [docs-actions#235](https://github.com/elastic/docs-actions/pull/235)). This is the git-ref bundling core from the release-notes onboarding RFC ([docs-eng-team#698](https://github.com/elastic/docs-eng-team/pull/698)) and the docs-builder half of the `changelog-promotion-bundle` workflow contract ([docs-actions#266](https://github.com/elastic/docs-actions/pull/266)).

## What

`changelog bundle <profile> <version> --start-git-ref A --end-git-ref B` (both refs always required together — the start ref is never inferred, per the RFC review):

- The PR list comes from the range via `GitHubCommitRangeService` (previous PR in this stack).
- Per-PR entry sourcing follows the RFC precedence: a checked-in entry from the pool wins — matched by file-name-derived PR numbers (file names survive scrubbing, so this works for private repos whose `prs` references are scrubbed from public copies, sidestepping docs-eng-team#734 for discovery) or by `prs` references — otherwise the entry is synthesized from PR metadata through the same extraction path as `changelog add` (release-note text from the PR body, `pivot.*` label mappings, `rules.create`). PRs whose metadata cannot be fetched are reported as missing, never silently dropped.
- The bundle records `--end-git-ref` as its `git_ref` metadata.
- `--dry-run` prints the run report (resolved PR list with per-PR source: pool / inferred / missing, plus commits without a PR) as Markdown suitable for a release PR body; `--plan` reports `needs_network`/`needs_github_token`.
- In profile mode the profile contributes output metadata only (`output_products`, repo/owner, rules); filter-producing shapes (`products` pattern, `source: github_release`) are rejected. Without an explicit `output:` pattern the bundle is named `{product}-{version}.yaml` by convention — deliberately not building on `output:`, which #3774 (B2) is phasing out.
- Re-running the same range produces the same bundle; bundling never overwrites changelog entries.

**Stack:** 2/3 — based on the commit-range resolution service PR; followed by a GitHub HTTP transport refactor.