### PR TITLE
Resolve git ref from packed-refs when loose ref file is missing

### DIFF
--- a/src/Elastic.Documentation.Tooling/GitCheckoutInformationFactory.cs
+++ b/src/Elastic.Documentation.Tooling/GitCheckoutInformationFactory.cs
@@ -89,9 +89,12 @@ public static partial class GitCheckoutInformationFactory
 			var refPath = headText["ref:".Length..].Trim();
 			branch = refPath.Replace("refs/heads/", string.Empty);
 			var refFilePath = fileSystem.Path.Join(gitDir.FullName, refPath.Replace('/', fileSystem.Path.DirectorySeparatorChar));
-			gitRef = fileSystem.File.Exists(refFilePath)
-				? fileSystem.File.ReadAllText(refFilePath).Trim()
-				: headText; // symbolic ref not yet written (new empty repo) — use the ref name itself
+			if (fileSystem.File.Exists(refFilePath))
+				gitRef = fileSystem.File.ReadAllText(refFilePath).Trim();
+			else if (TryResolvePackedRef(fileSystem, gitDir, refPath, out var packedSha))
+				gitRef = packedSha; // loose ref file absent — ref lives in packed-refs instead
+			else
+				gitRef = headText; // symbolic ref not yet written (new empty repo) — use the ref name itself
 		}
 		else
 		{
@@ -168,6 +171,39 @@ public static partial class GitCheckoutInformationFactory
 		var gitDirWithoutConfig = fileSystem.Directory.Exists(gitPath)
 			&& !fileSystem.File.Exists(fileSystem.Path.Join(gitPath, "config"));
 		return noGitEntry || gitDirWithoutConfig;
+	}
+
+	/// <summary>
+	/// Resolves a symbolic ref (e.g. <c>refs/heads/main</c>) to a SHA via <c>.git/packed-refs</c>.
+	/// Git packs loose refs into this file (e.g. after <c>git gc</c>, or on checkouts made by
+	/// <c>actions/checkout</c>), so the ref may not exist as a standalone file under <c>refs/</c>
+	/// even though HEAD still points at it.
+	/// </summary>
+	private static bool TryResolvePackedRef(IFileSystem fileSystem, IDirectoryInfo gitDir, string refPath, out string sha)
+	{
+		sha = string.Empty;
+		var packedRefsPath = fileSystem.Path.Join(gitDir.FullName, "packed-refs");
+		if (!fileSystem.File.Exists(packedRefsPath))
+			return false;
+
+		foreach (var line in fileSystem.File.ReadAllLines(packedRefsPath))
+		{
+			// Comment lines start with '#'; peeled-tag annotations start with '^'. Both are skipped.
+			if (line.Length == 0 || line[0] == '#' || line[0] == '^')
+				continue;
+
+			var spaceIndex = line.IndexOf(' ');
+			if (spaceIndex < 0)
+				continue;
+
+			var lineRef = line[(spaceIndex + 1)..].Trim();
+			if (!lineRef.Equals(refPath, StringComparison.Ordinal))
+				continue;
+
+			sha = line[..spaceIndex].Trim();
+			return !string.IsNullOrEmpty(sha);
+		}
+		return false;
 	}
 
 	private static string BranchTrackingRemote(string branch, IniFile config)

--- a/tests/Elastic.Documentation.Configuration.Tests/GitCheckoutResolutionTests.cs
+++ b/tests/Elastic.Documentation.Configuration.Tests/GitCheckoutResolutionTests.cs
@@ -217,6 +217,40 @@ public class GitCheckoutResolutionTests
 	}
 
 	[Fact]
+	public void RegularRepo_PackedRefWithoutLooseRefFile_ResolvesShaFromPackedRefs()
+	{
+		// actions/checkout (and `git gc`) can leave HEAD pointing at a symbolic ref with no
+		// corresponding loose file under refs/heads — the SHA only lives in packed-refs.
+		var fs = new MockFileSystem();
+		fs.AddDirectory("/repo/.git");
+		fs.AddFile("/repo/.git/HEAD", new MockFileData("ref: refs/heads/main\n"));
+		fs.AddFile("/repo/.git/packed-refs", new MockFileData("""
+			# pack-refs with: peeled fully-peeled sorted
+			deadbeef1234567890deadbeef1234567890dead refs/heads/main
+			cafebabe0000000000cafebabe0000000000cafe refs/remotes/origin/main
+			"""));
+		fs.AddFile("/repo/.git/config", new MockFileData("""
+			[core]
+				repositoryformatversion = 0
+			[remote "origin"]
+				url = https://github.com/elastic/test-repo.git
+			[branch "main"]
+				remote = origin
+				merge = refs/heads/main
+			"""));
+
+		var checkout = fs.DirectoryInfo.New("/repo");
+		var scoped = new CheckoutsFileSystem(fs.DirectoryInfo.New("/repo"), inner: fs);
+
+		var result = GitCheckoutInformationFactory.Create(checkout, scoped);
+
+		result.IsAvailable.Should().BeTrue();
+		result.Branch.Should().Be("main");
+		result.Ref.Should().Be("deadbeef1234567890deadbeef1234567890dead",
+			"the SHA must be resolved from packed-refs, never the literal HEAD contents like 'ref: refs/heads/main'");
+	}
+
+	[Fact]
 	public void MockWithNoGitLayout_ReturnsCannedTestData()
 	{
 		// Back-compat: tests that seed no .git at all must continue to receive the canned


### PR DESCRIPTION
## Why

When a checkout has refs packed into `.git/packed-refs` (e.g. `actions/checkout`, or any repo after `git gc`) with no corresponding loose file under `.git/refs/heads/`, `GitCheckoutInformationFactory` fell back to using the raw `HEAD` contents (e.g. `"ref: refs/heads/main"`) as the resolved git ref. That string then got truncated to 7 characters for display, surfacing as a garbled commit value like `ref: re` in the docs site's "Deployment info" header panel.

## What

`GitCheckoutInformationFactory.TryCreate` now falls back to parsing `.git/packed-refs` to resolve the SHA for a symbolic ref before giving up and using the literal `HEAD` text (which remains a last-resort fallback for genuinely new/empty repos with no ref written anywhere). Added a regression test reproducing the packed-refs-only layout and asserting the resolved `Ref` is the actual SHA.

Made with [Cursor](https://cursor.com)