### PR TITLE
Fix scoped-filesystem access-denied errors in codex builds

### DIFF
--- a/src/Elastic.Codex/Building/CodexBuildService.cs
+++ b/src/Elastic.Codex/Building/CodexBuildService.cs
@@ -15,7 +15,6 @@ using Elastic.Documentation.Configuration.Codex;
 using Elastic.Documentation.Configuration.ReleaseNotes;
 using Elastic.Documentation.Diagnostics;
 using Elastic.Documentation.FileSystems;
-using Elastic.Documentation.Isolated;
 using Elastic.Documentation.LinkIndex;
 using Elastic.Documentation.Links;
 using Elastic.Documentation.Links.CrossLinks;
@@ -25,6 +24,7 @@ using Elastic.Documentation.Serialization;
 using Elastic.Documentation.Services;
 using Elastic.Documentation.Site;
 using Elastic.Documentation.Site.Navigation;
+using Elastic.Markdown;
 using Elastic.Markdown.Exporters;
 using Elastic.Markdown.IO;
 using Microsoft.Extensions.Logging;
@@ -37,8 +37,7 @@ namespace Elastic.Codex.Building;
 /// </summary>
 public class CodexBuildService(
 	ILoggerFactory logFactory,
-	IConfigurationContext configurationContext,
-	IsolatedBuildService isolatedBuildService) : IService
+	IConfigurationContext configurationContext) : IService
 {
 	private readonly ILogger _logger = logFactory.CreateLogger<CodexBuildService>();
 
@@ -97,9 +96,8 @@ public class CodexBuildService(
 		if (exporters is not null && buildContexts.Count > 0)
 		{
 			var firstContext = buildContexts[0].BuildContext;
-			firstContext.Endpoints.BuildType = "codex";
 			firstContext.Endpoints.Environment = environment; // from codex.yml; ensures the correct index (e.g. internal)
-			sharedExporters = exporters.CreateMarkdownExporters(logFactory, firstContext).ToArray();
+			sharedExporters = CreateExporters(context, firstContext, exporters);
 			var startTasks = sharedExporters.Select(async e => await e.StartAsync(ctx));
 			await Task.WhenAll(startTasks);
 		}
@@ -253,16 +251,37 @@ public class CodexBuildService(
 
 		try
 		{
+			var docContext = buildContext.BuildContext;
+			var documentationSet = buildContext.DocumentationSet;
 			var codexBreadcrumbs = ResolveCodexBreadcrumbs(context, buildContext);
+			var manageLifecycle = sharedExporters is null;
+			var allExporters = sharedExporters ?? CreateExporters(context, docContext, ExportOptions.Default);
 
-			return await isolatedBuildService.BuildDocumentationSet(
-				buildContext.DocumentationSet,
-				null, // Use doc set's navigation for traversal
-				null, // Use default navigation HTML writer (doc set's navigation)
-				ExportOptions.Default,
-				sharedExporters,
-				pageViewFactory: new CodexPageViewFactory(context.Configuration.Title, codexBreadcrumbs),
-				ctx);
+			if (manageLifecycle)
+			{
+				var startTasks = allExporters.Select(async e => await e.StartAsync(ctx));
+				await Task.WhenAll(startTasks);
+			}
+
+			var generator = new DocumentationGenerator(
+				documentationSet,
+				logFactory,
+				documentationSet,
+				markdownExporters: allExporters,
+				pageViewFactory: new CodexPageViewFactory(context.Configuration.Title, codexBreadcrumbs));
+
+			var result = await generator.GenerateAll(ctx);
+
+			if (manageLifecycle)
+			{
+				var finishTasks = allExporters.Select(async e => await e.FinishExportAsync(docContext.OutputDirectory, ctx));
+				_ = await Task.WhenAll(finishTasks);
+
+				var stopTasks = allExporters.Select(async e => await e.StopAsync(ctx));
+				await Task.WhenAll(stopTasks);
+			}
+
+			return new BuildDocumentationSetResult(docContext.Collector.Errors == 0, result.Redirects);
 		}
 		catch (Exception ex)
 		{
@@ -271,6 +290,25 @@ public class CodexBuildService(
 			_logger.LogError(ex, "Failed to build documentation set {Name}", buildContext.Checkout.Reference.Name);
 			return new BuildDocumentationSetResult(false, new Dictionary<string, LinkRedirect>());
 		}
+	}
+
+	/// <summary>
+	/// Composes markdown exporters for a codex documentation set build. The LLM exporter is special-cased
+	/// because it writes sibling <c>{folder}.md</c> files one level above a docset's own output directory —
+	/// out of scope for a per-docset write filesystem — so it needs the codex-wide write filesystem instead.
+	/// </summary>
+	private IMarkdownExporter[] CreateExporters(CodexContext context, BuildContext docContext, IReadOnlySet<Exporter> exporters)
+	{
+		docContext.Endpoints.BuildType = "codex";
+		if (!exporters.Contains(Exporter.LLMText))
+			return exporters.CreateMarkdownExporters(logFactory, docContext).ToArray();
+
+		// ExportOptions.Default is a shared static HashSet -- copy before mutating, never touch it in place.
+		var withoutLlm = new HashSet<Exporter>(exporters);
+		_ = withoutLlm.Remove(Exporter.LLMText);
+		return withoutLlm.CreateMarkdownExporters(logFactory, docContext)
+			.Append(new LlmMarkdownExporter(writeFileSystem: context.WriteFileSystem))
+			.ToArray();
 	}
 
 	private static void CollectRedirects(
@@ -391,6 +429,13 @@ public record CodexBuildResult(
 	CodexNavigation Navigation,
 	IReadOnlyList<DocumentationSet> DocumentationSets,
 	CodexGenerator? CodexGenerator = null);
+
+/// <summary>
+/// Result of building a documentation set, including redirects for aggregation in the codex build.
+/// </summary>
+/// <param name="Success">Whether the build completed without errors.</param>
+/// <param name="Redirects">Redirect mappings from the documentation set, if available.</param>
+public record BuildDocumentationSetResult(bool Success, IReadOnlyDictionary<string, LinkRedirect> Redirects);
 
 /// <summary>
 /// Build context for a single documentation set within the codex.

--- a/src/Elastic.Codex/CodexGenerator.cs
+++ b/src/Elastic.Codex/CodexGenerator.cs
@@ -38,7 +38,7 @@ public interface ICodexPageRenderer
 public class CodexGenerator(ILoggerFactory logFactory, BuildContext context, IDirectoryInfo outputDirectory)
 {
 	private readonly ILogger _logger = logFactory.CreateLogger<CodexGenerator>();
-	private readonly IFileSystem _writeFileSystem = context.WriteFileSystem;
+	private readonly IFileSystem _writeFileSystem = outputDirectory.FileSystem;
 	private readonly StaticFileContentHashProvider _contentHashProvider = new(new EmbeddedOrPhysicalFileProvider(context));
 	private readonly IDirectoryInfo _outputDirectory = outputDirectory;
 

--- a/src/Elastic.Codex/Indexing/CodexIndexService.cs
+++ b/src/Elastic.Codex/Indexing/CodexIndexService.cs
@@ -7,7 +7,6 @@ using Elastic.Codex.Building;
 using Elastic.Codex.Sourcing;
 using Elastic.Documentation;
 using Elastic.Documentation.Configuration;
-using Elastic.Documentation.Isolated;
 using Elastic.Documentation.Services;
 using Microsoft.Extensions.Logging;
 using Nullean.ScopedFileSystem;
@@ -21,8 +20,7 @@ namespace Elastic.Codex.Indexing;
 /// </summary>
 public class CodexIndexService(
 	ILoggerFactory logFactory,
-	IConfigurationContext configurationContext,
-	IsolatedBuildService isolatedBuildService
+	IConfigurationContext configurationContext
 ) : IService
 {
 	/// <summary>
@@ -39,7 +37,7 @@ public class CodexIndexService(
 		await ElasticsearchEndpointConfigurator.ApplyAsync(cfg, esOptions, codexContext.Collector, fileSystem, ctx);
 
 		var exporters = new HashSet<Exporter> { Exporter.Elasticsearch };
-		var buildService = new CodexBuildService(logFactory, configurationContext, isolatedBuildService);
+		var buildService = new CodexBuildService(logFactory, configurationContext);
 		var result = await buildService.BuildAll(codexContext, cloneResult, fileSystem, ctx, exporters);
 		return result.DocumentationSets.Count > 0;
 	}

--- a/src/Elastic.Documentation.Tooling/FileSystems/CheckoutsFileSystem.cs
+++ b/src/Elastic.Documentation.Tooling/FileSystems/CheckoutsFileSystem.cs
@@ -48,23 +48,17 @@ public class CheckoutsFileSystem : ScopedFileSystem, ICheckoutsFileSystem
 		var rootPath = root.FullName;
 		var roots = new List<string> { rootPath };
 
-		// AppData is disjointness-filtered too: on CI the checkouts directory lives inside AppData
-		// (/home/runner/.local/share/elastic/docs-builder/checkouts/...), so AppData would subsume
-		// root and the ScopedFileSystem constructor would throw.
-		var appData = Paths.ApplicationData.FullName;
-		if (!IsSubPath(appData, rootPath, fs) && !IsSubPath(rootPath, appData, fs))
-			roots.Add(appData);
+		// On CI (and for codex checkouts) the checkouts directory lives inside AppData
+		// (e.g. /home/runner/.local/share/elastic/docs-builder/checkouts/..., or
+		// AppData/codex/clone/<repo>). AddDisjointRoot keeps whichever of the two is the outer
+		// path rather than dropping AppData outright, so sibling AppData directories (e.g.
+		// config-runtime) stay in scope even when root itself is nested inside AppData.
+		roots.AddDisjointRoot(Paths.ApplicationData.FullName, fs);
 
 		if (extraRoots is not null)
 		{
 			foreach (var extra in extraRoots)
-			{
-				if (string.IsNullOrEmpty(extra))
-					continue;
-				// Drop descendants of root (already covered) and ancestors (would subsume root, causing overlap).
-				if (!IsSubPath(extra, rootPath, fs) && !IsSubPath(rootPath, extra, fs) && !roots.Contains(extra, StringComparer.OrdinalIgnoreCase))
-					roots.Add(extra);
-			}
+				roots.AddDisjointRoot(extra, fs);
 		}
 
 		return new ScopedFileSystemOptions([.. roots])

--- a/src/Elastic.Documentation.Tooling/FileSystems/DocumentationFileSystem.cs
+++ b/src/Elastic.Documentation.Tooling/FileSystems/DocumentationFileSystem.cs
@@ -84,31 +84,18 @@ public class DocumentationFileSystem : ScopedFileSystem, IDocumentationFileSyste
 		var checkoutPath = paths.CheckoutDirectory.FullName;
 		var roots = new List<string> { checkoutPath };
 
-		// AppData is disjointness-filtered: on CI each individual docset checkout lives inside AppData
-		// (/home/runner/.local/share/elastic/docs-builder/checkouts/current/<repo>), so AppData would
-		// subsume checkoutPath and trigger ValidateRootsAreDisjoint.
-		var appData = Configuration.Paths.ApplicationData.FullName;
-		if (!IDirectoryInfoExtensions.IsSubPath(appData, checkoutPath, fs)
-			&& !IDirectoryInfoExtensions.IsSubPath(checkoutPath, appData, fs))
-		{
-			roots.Add(appData);
-		}
+		// On CI (and for codex checkouts) the docset checkout lives inside AppData
+		// (e.g. /home/runner/.local/share/elastic/docs-builder/checkouts/current/<repo>, or
+		// AppData/codex/clone/<repo>). AddDisjointRoot keeps whichever of the two is the outer
+		// path rather than dropping AppData outright, so sibling AppData directories (e.g.
+		// config-runtime) stay in scope even when the checkout itself is nested inside AppData.
+		roots.AddDisjointRoot(Configuration.Paths.ApplicationData.FullName, fs);
 
 		foreach (var gitDir in paths.GitDirectories)
-		{
-			if (!IDirectoryInfoExtensions.IsSubPath(gitDir, checkoutPath, fs))
-				roots.Add(gitDir);
-		}
+			roots.AddDisjointRoot(gitDir, fs);
 
 		foreach (var extra in paths.ExtraRoots)
-		{
-			if (!string.IsNullOrEmpty(extra)
-				&& !IDirectoryInfoExtensions.IsSubPath(extra, checkoutPath, fs)
-				&& !roots.Contains(extra, StringComparer.OrdinalIgnoreCase))
-			{
-				roots.Add(extra);
-			}
-		}
+			roots.AddDisjointRoot(extra, fs);
 
 		return new ScopedFileSystemOptions([.. roots])
 		{

--- a/src/Elastic.Documentation/Extensions/IFileInfoExtensions.cs
+++ b/src/Elastic.Documentation/Extensions/IFileInfoExtensions.cs
@@ -121,6 +121,38 @@ public static class IDirectoryInfoExtensions
 	public static bool IsSubPath(string path, string parent, IFileSystem fs) =>
 		fs.DirectoryInfo.New(path).IsSubPathOf(fs.DirectoryInfo.New(parent));
 
+	/// <summary>
+	/// Adds <paramref name="candidate"/> to <paramref name="roots"/> for a <c>ScopedFileSystemOptions</c>
+	/// root list, collapsing overlaps instead of just skipping them.
+	/// <para>
+	/// A naive "only add if disjoint" filter (skip <paramref name="candidate"/> whenever it nests with
+	/// an existing root either way) silently narrows the scope to whichever root was added first. That
+	/// is wrong when the existing root is the narrower one — e.g. a docset checkout cloned under AppData
+	/// (<c>AppData/checkouts/&lt;repo&gt;</c>): keeping only the checkout path would hide sibling AppData
+	/// directories like <c>config-runtime</c> that legitimate reads/writes still need. This instead keeps
+	/// whichever of the two is the outer (containing) path.
+	/// </para>
+	/// </summary>
+	public static void AddDisjointRoot(this List<string> roots, string candidate, IFileSystem fs)
+	{
+		if (string.IsNullOrEmpty(candidate))
+			return;
+
+		for (var i = 0; i < roots.Count; i++)
+		{
+			if (IsSubPath(candidate, roots[i], fs)) // candidate already covered by an existing (wider) root
+				return;
+			if (IsSubPath(roots[i], candidate, fs)) // candidate is wider; it supersedes the existing root
+			{
+				roots[i] = candidate;
+				return;
+			}
+		}
+
+		if (!roots.Contains(candidate, StringComparer.OrdinalIgnoreCase))
+			roots.Add(candidate);
+	}
+
 	/// Checks if <paramref name="directory"/> has parent directory <paramref name="parentName"/>, defaults to OrdinalIgnoreCase comparison
 	public static bool HasParent(this IDirectoryInfo directory, string parentName, StringComparison comparison = OrdinalIgnoreCase)
 	{

--- a/src/Elastic.Documentation/FileSystems/AssemblyWriteFileSystem.cs
+++ b/src/Elastic.Documentation/FileSystems/AssemblyWriteFileSystem.cs
@@ -57,18 +57,14 @@ public class AssemblyWriteFileSystem(
 		var checkoutPath = checkout.FullName;
 		var roots = new List<string> { checkoutPath };
 
-		// AppData is disjointness-filtered: on CI the checkouts directory lives inside AppData
-		// (/home/runner/.local/share/elastic/docs-builder/checkouts/...), so AppData would subsume
-		// checkoutPath and trigger ValidateRootsAreDisjoint.
-		var appData = ApplicationDataPath;
-		if (!IDirectoryInfoExtensions.IsSubPath(appData, checkoutPath, fs)
-			&& !IDirectoryInfoExtensions.IsSubPath(checkoutPath, appData, fs))
-		{
-			roots.Add(appData);
-		}
+		// On CI the checkouts directory lives inside AppData
+		// (/home/runner/.local/share/elastic/docs-builder/checkouts/...). AddDisjointRoot keeps
+		// whichever of the two is the outer path rather than dropping AppData outright, so sibling
+		// AppData directories stay in scope even when the checkout itself is nested inside AppData.
+		roots.AddDisjointRoot(ApplicationDataPath, fs);
 
-		if (output is not null && !IDirectoryInfoExtensions.IsSubPath(output.FullName, checkoutPath, fs))
-			roots.Add(output.FullName);
+		if (output is not null)
+			roots.AddDisjointRoot(output.FullName, fs);
 
 		// MockFileSystem hardcodes its temp path ("C:\temp" on Windows, unix-ified to "/temp/"
 		// elsewhere) instead of calling System.IO.Path.GetTempPath(). AllowedSpecialFolder.Temp uses

--- a/src/Elastic.Documentation/FileSystems/DocumentationWriteFileSystem.cs
+++ b/src/Elastic.Documentation/FileSystems/DocumentationWriteFileSystem.cs
@@ -63,18 +63,15 @@ public class DocumentationWriteFileSystem(
 		var checkoutPath = checkout.FullName;
 		var roots = new List<string> { checkoutPath };
 
-		// AppData is disjointness-filtered: on CI each docset checkout lives inside AppData
-		// (/home/runner/.local/share/elastic/docs-builder/checkouts/current/<repo>), so AppData would
-		// subsume checkoutPath and trigger ValidateRootsAreDisjoint.
-		var appData = ApplicationDataPath;
-		if (!IDirectoryInfoExtensions.IsSubPath(appData, checkoutPath, fs)
-			&& !IDirectoryInfoExtensions.IsSubPath(checkoutPath, appData, fs))
-		{
-			roots.Add(appData);
-		}
+		// On CI (and for codex checkouts) the docset checkout lives inside AppData
+		// (e.g. /home/runner/.local/share/elastic/docs-builder/checkouts/current/<repo>, or
+		// AppData/codex/clone/<repo>). AddDisjointRoot keeps whichever of the two is the outer
+		// path rather than dropping AppData outright, so sibling AppData directories (e.g.
+		// config-runtime) stay in scope even when the checkout itself is nested inside AppData.
+		roots.AddDisjointRoot(ApplicationDataPath, fs);
 
-		if (output is not null && !IDirectoryInfoExtensions.IsSubPath(output.FullName, checkout.FullName, fs))
-			roots.Add(output.FullName);
+		if (output is not null)
+			roots.AddDisjointRoot(output.FullName, fs);
 
 		// MockFileSystem hardcodes its temp path ("C:\temp" on Windows, unix-ified to "/temp/"
 		// elsewhere) instead of calling System.IO.Path.GetTempPath(). AllowedSpecialFolder.Temp uses

--- a/src/Elastic.Markdown/Exporters/LlmMarkdownExporter.cs
+++ b/src/Elastic.Markdown/Exporters/LlmMarkdownExporter.cs
@@ -10,6 +10,7 @@ using Elastic.Documentation.AppliesTo;
 using Elastic.Documentation.Configuration;
 using Elastic.Documentation.Configuration.Inference;
 using Elastic.Documentation.Configuration.Products;
+using Elastic.Documentation.FileSystems;
 using Elastic.Markdown.Helpers;
 using Elastic.Markdown.Myst.Components;
 using Elastic.Markdown.Myst.Renderers.LlmMarkdown;
@@ -20,7 +21,14 @@ namespace Elastic.Markdown.Exporters;
 /// <summary>
 /// Exports markdown files as LLM-optimized CommonMark using custom renderers
 /// </summary>
-public class LlmMarkdownExporter(bool branded = false) : IMarkdownExporter
+/// <param name="branded">Omits Elastic boilerplate from generated <c>llms.txt</c> content when set.</param>
+/// <param name="writeFileSystem">
+/// Filesystem to write exported files to. When <see langword="null"/>, falls back to the per-file
+/// <see cref="MarkdownExportFileContext.BuildContext"/>'s write filesystem. Codex builds inject the
+/// codex-wide write filesystem here, since this exporter writes sibling <c>{folder}.md</c> files one
+/// level above a docset's own output directory, which is out of scope for a per-docset filesystem.
+/// </param>
+public class LlmMarkdownExporter(bool branded = false, DocumentationWriteFileSystem? writeFileSystem = null) : IMarkdownExporter
 {
 
 	private const string LlmsTxtTemplate = """
@@ -87,7 +95,7 @@ public class LlmMarkdownExporter(bool branded = false) : IMarkdownExporter
 
 	public async ValueTask<bool> ExportAsync(MarkdownExportFileContext fileContext, Cancel ctx)
 	{
-		var fs = fileContext.BuildContext.WriteFileSystem;
+		var fs = writeFileSystem ?? fileContext.BuildContext.WriteFileSystem;
 		var llmMarkdown = ConvertToLlmMarkdown(fileContext.Document, fileContext.BuildContext);
 		var outputFile = GetLlmOutputFile(fs, fileContext);
 		if (outputFile.Directory is { Exists: false })

--- a/src/services/Elastic.Documentation.Isolated/IsolatedBuildService.cs
+++ b/src/services/Elastic.Documentation.Isolated/IsolatedBuildService.cs
@@ -13,15 +13,11 @@ using Elastic.Documentation.Configuration.ReleaseNotes;
 using Elastic.Documentation.Diagnostics;
 using Elastic.Documentation.FileSystems;
 using Elastic.Documentation.LinkIndex;
-using Elastic.Documentation.Links;
 using Elastic.Documentation.Links.CrossLinks;
-using Elastic.Documentation.Navigation;
 using Elastic.Documentation.Services;
-using Elastic.Documentation.Site.Navigation;
 using Elastic.Markdown;
 using Elastic.Markdown.Exporters;
 using Elastic.Markdown.IO;
-using Elastic.Markdown.Page;
 using Microsoft.Extensions.Logging;
 using Nullean.ScopedFileSystem;
 
@@ -191,75 +187,4 @@ public class IsolatedBuildService(
 
 		return strict.Value ? context.Collector.Errors + context.Collector.Warnings == 0 : context.Collector.Errors == 0;
 	}
-
-	/// <summary>
-	/// Builds a pre-configured documentation set with optional injected navigation.
-	/// Used by portal builds where navigation spans multiple documentation sets.
-	/// When <paramref name="externalExporters"/> is provided, those exporters are used instead of
-	/// creating new ones, and their lifecycle (Start/Stop) is not managed by this method.
-	/// </summary>
-	public async Task<BuildDocumentationSetResult> BuildDocumentationSet(
-		DocumentationSet documentationSet,
-		INavigationTraversable? navigation = null,
-		INavigationHtmlWriter? navigationHtmlWriter = null,
-		IReadOnlySet<Exporter>? exporters = null,
-		IMarkdownExporter[]? externalExporters = null,
-		IPageViewFactory? pageViewFactory = null,
-		Cancel ctx = default)
-	{
-		var context = documentationSet.Context;
-		var manageLifecycle = externalExporters is null;
-
-		IMarkdownExporter[] allExporters;
-		if (externalExporters is not null)
-		{
-			allExporters = externalExporters;
-		}
-		else
-		{
-			exporters ??= ExportOptions.Default;
-			context.Endpoints.BuildType = "codex";
-			allExporters = exporters.CreateMarkdownExporters(logFactory, context).ToArray();
-		}
-
-		if (manageLifecycle)
-		{
-			var startTasks = allExporters.Select(async e => await e.StartAsync(ctx));
-			await Task.WhenAll(startTasks);
-		}
-
-		// Use the provided navigation or fall back to the doc set's own navigation
-		var effectiveNavigation = navigation ?? documentationSet;
-
-		var generator = new DocumentationGenerator(
-			documentationSet,
-			logFactory,
-			effectiveNavigation,
-			navigationHtmlWriter,
-			null,
-			allExporters,
-			pageViewFactory: pageViewFactory);
-
-		var result = await generator.GenerateAll(ctx);
-
-		if (manageLifecycle)
-		{
-			var finishTasks = allExporters.Select(async e => await e.FinishExportAsync(context.OutputDirectory, ctx));
-			_ = await Task.WhenAll(finishTasks);
-
-			var stopTasks = allExporters.Select(async e => await e.StopAsync(ctx));
-			await Task.WhenAll(stopTasks);
-		}
-
-		_logger.LogInformation("Finished building documentation set {Name}", documentationSet.Context.Git.RepositoryName);
-
-		return new BuildDocumentationSetResult(context.Collector.Errors == 0, result.Redirects);
-	}
 }
-
-/// <summary>
-/// Result of building a documentation set, including redirects for aggregation in portal builds.
-/// </summary>
-/// <param name="Success">Whether the build completed without errors.</param>
-/// <param name="Redirects">Redirect mappings from the documentation set, if available.</param>
-public record BuildDocumentationSetResult(bool Success, IReadOnlyDictionary<string, LinkRedirect> Redirects);

--- a/src/tooling/docs-builder/Commands/Codex/CodexCommands.cs
+++ b/src/tooling/docs-builder/Commands/Codex/CodexCommands.cs
@@ -4,7 +4,6 @@
 
 using System.ComponentModel.DataAnnotations;
 using System.IO.Abstractions;
-using Actions.Core.Services;
 using Documentation.Builder.Http;
 using Elastic.Codex;
 using Elastic.Codex.Building;
@@ -13,7 +12,6 @@ using Elastic.Documentation;
 using Elastic.Documentation.Configuration;
 using Elastic.Documentation.Diagnostics;
 using Elastic.Documentation.FileSystems;
-using Elastic.Documentation.Isolated;
 using Elastic.Documentation.LinkIndex;
 using Elastic.Documentation.Services;
 using Microsoft.Extensions.Logging;
@@ -33,9 +31,7 @@ namespace Documentation.Builder.Commands.Codex;
 internal sealed class CodexCommands(
 	ILoggerFactory logFactory,
 	IDiagnosticsCollector collector,
-	IConfigurationContext configurationContext,
-	ICoreService githubActionsService,
-	IEnvironmentVariables environmentVariables
+	IConfigurationContext configurationContext
 )
 {
 	/// <summary>Clone all repositories and build the portal in one step.</summary>
@@ -76,8 +72,7 @@ internal sealed class CodexCommands(
 				return cloneResult.Checkouts.Count > 0;
 			});
 
-		var isolatedBuildService = new IsolatedBuildService(logFactory, configurationContext, githubActionsService, environmentVariables);
-		var buildService = new CodexBuildService(logFactory, configurationContext, isolatedBuildService);
+		var buildService = new CodexBuildService(logFactory, configurationContext);
 		serviceInvoker.AddCommand(buildService, (codexContext, cloneResult, fs), strict,
 			async (s, col, state, c) =>
 			{
@@ -159,8 +154,7 @@ internal sealed class CodexCommands(
 			return 1;
 		}
 
-		var isolatedBuildService = new IsolatedBuildService(logFactory, configurationContext, githubActionsService, environmentVariables);
-		var buildService = new CodexBuildService(logFactory, configurationContext, isolatedBuildService);
+		var buildService = new CodexBuildService(logFactory, configurationContext);
 		serviceInvoker.AddCommand(buildService, (codexContext, cloneResult, fs), strict,
 			async (s, col, state, c) =>
 			{

--- a/src/tooling/docs-builder/Commands/Codex/CodexIndexCommand.cs
+++ b/src/tooling/docs-builder/Commands/Codex/CodexIndexCommand.cs
@@ -4,7 +4,6 @@
 
 using System.ComponentModel.DataAnnotations;
 using System.IO.Abstractions;
-using Actions.Core.Services;
 using Elastic.Codex;
 using Elastic.Codex.Indexing;
 using Elastic.Codex.Sourcing;
@@ -12,7 +11,6 @@ using Elastic.Documentation;
 using Elastic.Documentation.Configuration;
 using Elastic.Documentation.Diagnostics;
 using Elastic.Documentation.FileSystems;
-using Elastic.Documentation.Isolated;
 using Elastic.Documentation.Services;
 using Microsoft.Extensions.Logging;
 using Nullean.Argh;
@@ -24,9 +22,7 @@ namespace Documentation.Builder.Commands.Codex;
 internal sealed class CodexIndexCommand(
 	ILoggerFactory logFactory,
 	IDiagnosticsCollector collector,
-	IConfigurationContext configurationContext,
-	ICoreService githubActionsService,
-	IEnvironmentVariables environmentVariables
+	IConfigurationContext configurationContext
 )
 {
 	/// <summary>Index the built portal documentation into Elasticsearch.</summary>
@@ -58,8 +54,7 @@ internal sealed class CodexIndexCommand(
 			return 1;
 		}
 
-		var isolatedBuildService = new IsolatedBuildService(logFactory, configurationContext, githubActionsService, environmentVariables);
-		var service = new CodexIndexService(logFactory, configurationContext, isolatedBuildService);
+		var service = new CodexIndexService(logFactory, configurationContext);
 		serviceInvoker.AddCommand(service, (codexContext, cloneResult, fs, es),
 			static async (s, col, state, c) =>
 				await s.Index(state.codexContext, state.cloneResult, state.fs, state.es, c)


### PR DESCRIPTION
## Why

The `codex build` command failed. It showed `Access denied` errors. It failed even when the file paths were correct. Two separate problems caused this.

## What

### Problem 1: the code threw away the wrong folder

The code builds a list of folders that a build may read or write. Some folders sit inside other folders. Old code kept only one folder in each pair and threw away the other one. The code always kept the inner (smaller) folder.

This was wrong in one case. A codex checkout can sit inside the app's data folder. In this case, the app's data folder is the correct folder to keep. The old code threw it away instead. This removed access to other files inside the app's data folder, like `config-runtime`. Those files were still needed.

The fix adds a new helper, `AddDisjointRoot`. It keeps the outer (bigger) folder, not the inner folder.

### Problem 2: two writers used the wrong file system scope

A codex build makes one output folder per repository. This diagram shows the folder layout:

```
.artifacts/codex/docs/
├── r/
│   └── my-repo/              <- one repo's own folder: r/my-repo/
│       ├── index.html
│       └── config/
├── r/my-repo.md              <- LlmMarkdownExporter writes here, ONE LEVEL UP from my-repo/
├── _static/                  <- CodexGenerator writes here, at the TOP folder
├── index.html                <- CodexGenerator writes the home page here
└── redirects.json
```

Two parts of the code write files outside a single repo's own folder:

- `LlmMarkdownExporter` writes a file next to the repo folder, one level up.
- `CodexGenerator` writes shared files. Examples: the home page and the static assets folder. These files go in the top folder, not in one repo's folder.

Both parts used the file system scope for one repo's folder. This scope was too narrow. It did not cover the folder one level up, or the top folder. This caused the `Access denied` error.

The fix gives both parts the correct, wider file system scope. This scope covers the whole codex output tree. Other build types (isolated builds, assembler builds) do not use this wider scope. They keep their normal, narrower scope.

### Small cleanup

One method, `BuildDocumentationSet`, was only used by codex builds. It lived in a shared file used by other build types too. The fix moves this method into the codex-specific file. This makes the code easier to read. It does not change behavior for other build types.

## Test plan

- Build the project. Result: no errors.
- Run all unit tests. Result: all tests pass.
- Run the code format checker. Result: no problems found.
- Run a real codex build with several repos. Check the output files: sibling `.md` files, the `_static` folder, `redirects.json`, and `index.html`. Result: all files are in the correct place. No `Access denied` errors.