### PR TITLE
Enable antialiased font smoothing on body

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/styles.css
+++ b/src/Elastic.Documentation.Site/Assets/styles.css
@@ -48,6 +48,8 @@ html {
 body {
 	/* This is still needed because of some usages of ch units and to maintain the previous behavior */
 	font-size: 16px;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
 }
 
 :root {


### PR DESCRIPTION
## Why

Subpixel smoothing made Inter look heavier and less crisp than the type in Figma and the rest of elastic.co.

## What

Sets `-webkit-font-smoothing: antialiased` and `-moz-osx-font-smoothing: grayscale` on `body` so docs type matches the intended weight.