### PR TITLE
feat: dropdown: section flavor for navigation_preview.yml top nav

### DIFF
--- a/config/navigation_preview.yml
+++ b/config/navigation_preview.yml
@@ -49,6 +49,20 @@ toc:
   - section: APIs
     external: https://www.elastic.co/docs/api/
 
+  ###########
+  # PRODUCTS #
+  ###########
+  - section: Products
+    dropdown:
+      - title: Elasticsearch
+        url: solutions/search/elasticsearch
+      - title: Observability
+        url: solutions/observability
+      - title: Security
+        url: solutions/security
+      - title: Elastic Cloud
+        url: deploy-manage/deploy/elastic-cloud
+
   #############
   # REFERENCE #
   #############

--- a/src/Elastic.Documentation.Configuration/Toc/SiteNavigationFile.cs
+++ b/src/Elastic.Documentation.Configuration/Toc/SiteNavigationFile.cs
@@ -23,13 +23,19 @@ public interface ISiteNavigationEntry
 	IReadOnlyCollection<SiteTableOfContentsRef> Children { get; }
 }
 
+/// <summary>A link entry within a <c>dropdown:</c> section.</summary>
+public record SiteDropdownLinkRef(string Title, string Url);
+
 public record SiteSectionRef(
 	string Title,
 	string? ExternalUrl,
-	IReadOnlyCollection<SiteTableOfContentsRef> Children
+	IReadOnlyCollection<SiteTableOfContentsRef> Children,
+	IReadOnlyCollection<SiteDropdownLinkRef> DropdownLinks
 ) : ISiteNavigationEntry
 {
 	public bool IsExternal => ExternalUrl is not null;
+	/// <summary>True when the section carries a dropdown list instead of tree children.</summary>
+	public bool IsDropdown => DropdownLinks.Count > 0;
 }
 
 [YamlSerializable]
@@ -207,6 +213,35 @@ public class SiteTableOfContentsCollectionYamlConverter : IYamlTypeConverter
 					}
 					value = childrenList;
 				}
+				else if (key.Value is "dropdown")
+				{
+					var dropdownList = new List<SiteDropdownLinkRef>();
+					_ = parser.Consume<SequenceStart>();
+					while (!parser.TryConsume<SequenceEnd>(out _))
+					{
+						if (!parser.TryConsume<MappingStart>(out _))
+							continue;
+						string? itemTitle = null;
+						string? itemUrl = null;
+						while (!parser.TryConsume<MappingEnd>(out _))
+						{
+							var itemKey = parser.Consume<Scalar>();
+							if (parser.Accept<Scalar>(out var itemValue))
+							{
+								_ = parser.MoveNext();
+								if (itemKey.Value is "title")
+									itemTitle = itemValue.Value;
+								else if (itemKey.Value is "url")
+									itemUrl = itemValue.Value;
+							}
+							else
+								parser.SkipThisAndNestedEvents();
+						}
+						if (itemTitle is not null && itemUrl is not null)
+							dropdownList.Add(new SiteDropdownLinkRef(itemTitle, itemUrl));
+					}
+					value = dropdownList;
+				}
 				else
 					parser.SkipThisAndNestedEvents();
 			}
@@ -222,7 +257,10 @@ public class SiteTableOfContentsCollectionYamlConverter : IYamlTypeConverter
 			IReadOnlyCollection<SiteTableOfContentsRef> children = dictionary.TryGetValue("children", out var childrenObj) && childrenObj is List<SiteTableOfContentsRef> refs
 				? refs
 				: [];
-			return new SiteSectionRef(sectionTitle, externalUrl, children);
+			IReadOnlyCollection<SiteDropdownLinkRef> dropdownLinks = dictionary.TryGetValue("dropdown", out var dropdownObj) && dropdownObj is List<SiteDropdownLinkRef> dLinks
+				? dLinks
+				: [];
+			return new SiteSectionRef(sectionTitle, externalUrl, children, dropdownLinks);
 		}
 
 		if (dictionary.TryGetValue("toc", out var tocPath) && tocPath is string sourceString)

--- a/src/Elastic.Documentation.Navigation/Assembler/SectionTopNavBuilder.cs
+++ b/src/Elastic.Documentation.Navigation/Assembler/SectionTopNavBuilder.cs
@@ -9,12 +9,14 @@ namespace Elastic.Documentation.Navigation.Assembler;
 /// <summary>
 /// Builds a <see cref="TopNavRenderModel"/> from the top-level navigation entries in
 /// <c>navigation_preview.yml</c> when the <c>navigation-preview</c> feature flag is on.
-/// Supports two entry shapes:
+/// Supports three <c>section:</c> shapes:
 /// <list type="bullet">
-/// <item><c>toc:</c> — a single navigation root, becomes one tab.</item>
-/// <item><c>section:</c> — a named group of toc: refs, becomes one tab whose active state
-///   matches the section's navigation root. External sections become external-link tabs.</item>
+/// <item><c>external:</c> — external-link tab, never active.</item>
+/// <item><c>dropdown:</c> — a panel of links, never active (no tree membership).</item>
+/// <item><c>children:</c> — maps to a <see cref="SectionNavigation"/> tree node; active when the
+///   current page's NavigationRoot.Id equals the section's Id.</item>
 /// </list>
+/// Plain <c>toc:</c> entries also produce one tab, active when NavigationRoot.Id == item.Id.
 /// Active state is determined by comparing the current page's NavigationRoot.Id to each
 /// tab's stored <see cref="TopNavLinkItem.SectionId"/>.
 /// </summary>
@@ -47,6 +49,15 @@ public static class SectionTopNavBuilder
 				if (section.IsExternal)
 				{
 					items.Add(new TopNavLinkItem(section.Title, section.ExternalUrl!, IsExternal: true));
+				}
+				else if (section.IsDropdown)
+				{
+					// Resolve each link URL against the site prefix so hrefs in the template are site-absolute.
+					var sitePrefix = navigation.Url.TrimEnd('/');
+					var links = section.DropdownLinks
+						.Select(l => new TopNavLinkItem(l.Title, sitePrefix + "/" + l.Url.TrimStart('/'), IsExternal: false))
+						.ToArray();
+					items.Add(new TopNavDropdownItem(section.Title, [new TopNavGroup(null, links)]));
 				}
 				else if (sectionsByTitle.TryGetValue(section.Title, out var sectionNav))
 				{

--- a/src/Elastic.Documentation.Site/Assets/secondary-nav.css
+++ b/src/Elastic.Documentation.Site/Assets/secondary-nav.css
@@ -16,7 +16,9 @@
 	}
 
 	.secondary-nav-mobile-menu[open] > summary .secondary-nav-mobile-chevron,
-	.secondary-nav-mobile-submenu[open] > summary .secondary-nav-mobile-chevron {
+	.secondary-nav-mobile-submenu[open]
+		> summary
+		.secondary-nav-mobile-chevron {
 		transform: rotate(180deg);
 	}
 }

--- a/src/Elastic.Documentation.Site/Assets/secondary-nav.css
+++ b/src/Elastic.Documentation.Site/Assets/secondary-nav.css
@@ -1,9 +1,11 @@
 @layer components {
-	.secondary-nav-mobile-menu summary {
+	.secondary-nav-mobile-menu summary,
+	.secondary-nav-mobile-submenu summary {
 		list-style: none;
 	}
 
-	.secondary-nav-mobile-menu summary::-webkit-details-marker {
+	.secondary-nav-mobile-menu summary::-webkit-details-marker,
+	.secondary-nav-mobile-submenu summary::-webkit-details-marker {
 		display: none;
 	}
 
@@ -13,7 +15,8 @@
 		transition: transform 0.15s ease;
 	}
 
-	.secondary-nav-mobile-menu[open] .secondary-nav-mobile-chevron {
+	.secondary-nav-mobile-menu[open] > summary .secondary-nav-mobile-chevron,
+	.secondary-nav-mobile-submenu[open] > summary .secondary-nav-mobile-chevron {
 		transform: rotate(180deg);
 	}
 }

--- a/tests/Navigation.Tests/Assembler/SectionNavigationTests.cs
+++ b/tests/Navigation.Tests/Assembler/SectionNavigationTests.cs
@@ -266,6 +266,49 @@ public class SectionNavigationTests(ITestOutputHelper output)
 	// ──────────────────────────────────────────────────────────────
 
 	[Fact]
+	public void SectionTopNavBuilder_BuildsDropdownTab_WhenDropdownLinksPresent()
+	{
+		// YAML that has both a children section (to give SiteNavigation a valid index)
+		// and a dropdown section to exercise the new dropdown path.
+		// language=yaml
+		var yaml = """
+		           toc:
+		             - section: Guides
+		               children:
+		                 - toc: observability://
+		                   path_prefix: /observability
+		             - section: Products
+		               dropdown:
+		                 - title: Elasticsearch
+		                   url: solutions/search/elasticsearch
+		                 - title: Observability
+		                   url: solutions/observability
+		           """;
+
+		var (navigation, _, _) = BuildTwoChildSection(output, yaml);
+		var navFile = SiteNavigationFile.Deserialize(yaml);
+
+		var renderModel = SectionTopNavBuilder.Build(navigation, navFile);
+
+		renderModel.Should().NotBeNull();
+		renderModel.Items.Should().HaveCount(2, "one Guides tab + one Products dropdown");
+
+		var dropdown = renderModel.Items[1].Should().BeOfType<TopNavDropdownItem>().Subject;
+		dropdown.Title.Should().Be("Products");
+		dropdown.IsActive(currentSectionId: null).Should().BeFalse("dropdown tabs are never active");
+		dropdown.Groups.Should().HaveCount(1, "flat dropdown: items become one ungrouped group");
+
+		var group = dropdown.Groups[0];
+		group.Label.Should().BeNull("flat dropdown has no group label");
+		group.Links.Should().HaveCount(2);
+		group.Links[0].Title.Should().Be("Elasticsearch");
+		group.Links[0].Url.Should().Be("/docs/solutions/search/elasticsearch",
+			"site prefix is prepended to the configured url");
+		group.Links[1].Title.Should().Be("Observability");
+		group.Links[1].Url.Should().Be("/docs/solutions/observability");
+	}
+
+	[Fact]
 	public void SectionTopNavBuilder_BuildsTab_WithSectionId()
 	{
 		// language=yaml


### PR DESCRIPTION
## Summary

- Adds a `dropdown:` key to the `section:` entry shape in `navigation_preview.yml`
- A dropdown section renders a panel of links in the top nav bar, with no tree membership and no active-tab state
- The rendering template (`_SecondaryNav.cshtml`) and JS (`secondary-nav.ts`) required no changes — `TopNavDropdownItem` was already wired up

Demo: https://docs-v3-preview.elastic.dev/elastic/docs-builder/docs/3873

## What changed

**Config layer** (`SiteNavigationFile.cs`):
- New `SiteDropdownLinkRef(Title, Url)` record
- `SiteSectionRef` gains `DropdownLinks` and `IsDropdown`
- `SiteTableOfContentsCollectionYamlConverter` parses `dropdown:` sequences as `{title, url}` items

**Builder** (`SectionTopNavBuilder.cs`):
- `IsDropdown` sections → `TopNavDropdownItem` with a single flat group; each URL gets the site prefix prepended

**`navigation_preview.yml`**: adds a `Products` dropdown between APIs and Reference, with four solution links as a concrete example

**Test**: `SectionTopNavBuilder_BuildsDropdownTab_WhenDropdownLinksPresent` verifies the new path end-to-end

## Test plan

- [x] `dotnet test tests/Navigation.Tests/` — 225 passed, 0 failed
- [x] `dotnet build` — clean for both `Elastic.Documentation.Configuration` and `Elastic.Documentation.Navigation`
- [ ] Preview build with `NAVIGATION_PREVIEW=true` to confirm the Products dropdown renders in the top nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)