### PR TITLE
Infer listing group from parent directory when frontmatter is absent

### DIFF
--- a/src/Elastic.Documentation.Configuration/Toc/DocumentationSetFile.cs
+++ b/src/Elastic.Documentation.Configuration/Toc/DocumentationSetFile.cs
@@ -860,6 +860,16 @@ public class DocumentationSetFile : TableOfContentsFile
 		foreach (var file in contentFiles)
 		{
 			var group = fileGroups[file];
+
+			// If listing: frontmatter is absent, infer the group from the parent directory
+			// when that directory is a known group folder (has a group index file).
+			if (string.IsNullOrEmpty(group) && file.Directory is not null)
+			{
+				var parentRel = Path.GetRelativePath(listingDirAbsolute, file.Directory.FullName).Replace('\\', '/');
+				if (groupIndexFiles.ContainsKey(parentRel))
+					group = parentRel;
+			}
+
 			if (!string.IsNullOrEmpty(group))
 			{
 				if (!groupedFiles.ContainsKey(group))


### PR DESCRIPTION
## Why

The `listing:` directive groups files via explicit `listing: <group>` frontmatter. Content that's already organized into per-group subdirectories (e.g. `reference/indentation/foo.md`) shouldn't have to repeat that grouping in every file's frontmatter — it's redundant with the directory structure and easy to forget, silently dropping pages into the "ungrouped" bucket.

## What

When a content file has no `listing:` frontmatter, `ResolveListingRef` now falls back to inferring the group from the file's parent directory, but only when that directory is a recognized group folder (i.e. it has a group index file). Explicit `listing:` frontmatter still takes precedence when present.

Made with [Cursor](https://cursor.com)