### PR TITLE
fix: add otel-collector phantom to navigation_preview.yml

### DIFF
--- a/config/navigation_preview.yml
+++ b/config/navigation_preview.yml
@@ -13,6 +13,9 @@ phantoms:
   - toc: docs-content://release-notes/apm-agents
   - toc: docs-content://
   - toc: cloud://release-notes
+  # Temporary: elastic-agent renames reference/edot-collector → reference/otel-collector (elastic/elastic-agent#16022).
+  # Remove this phantom and update the nav entry below once that PR merges.
+  - toc: elastic-agent://reference/otel-collector
 
 toc:
   ##########


### PR DESCRIPTION
## Summary

- The `validate-path-prefixes-local` CI check uses the `dev` environment, which has `NAVIGATION_PREVIEW: true` in `config/assembler.yml`
- This causes `AssembleContext` to call `ConfigurationFileProvider.UseNavigationPreview()`, loading `navigation_preview.yml` instead of `navigation.yml`
- The temporary phantom for the elastic-agent slug rename (`edot-collector → otel-collector`) was added to `navigation.yml` (#3795) but **not** to `navigation_preview.yml`
- Result: elastic/elastic-agent#16022 CI fails with "Can not validate 'elastic-agent://reference/otel-collector/...' it's not declared in any link reference nor is it a phantom"

This PR mirrors the phantom from `navigation.yml` into `navigation_preview.yml`.

**Remove this phantom from both files** when elastic/elastic-agent#16022 merges and #3799 swaps the nav entries.

## Test plan

- [ ] elastic/elastic-agent#16022 CI `validate-path-prefixes-local` step passes after this merges and the image rebuilds

🤖 Generated with [Claude Code](https://claude.com/claude-code)