### PR TITLE
Allow .artifacts for changelog CI I/O

### DIFF
--- a/src/Elastic.Documentation.Tooling/FileSystems/ChangelogFileSystem.cs
+++ b/src/Elastic.Documentation.Tooling/FileSystems/ChangelogFileSystem.cs
@@ -10,13 +10,14 @@ namespace Elastic.Documentation.FileSystems;
 
 /// <summary>
 /// Scope for changelog commands: the git root of the target repository.
-/// Allows reading <c>.git</c> metadata (remote URL, branch); does not include
-/// AppData or build artifacts — changelog operates only within the repo working tree.
+/// Allows reading <c>.git</c> metadata (remote URL, branch) and writing under
+/// the conventional <c>.artifacts</c> CI staging directory. Does not include
+/// AppData — changelog operates only within the repo working tree.
 /// </summary>
 public class ChangelogFileSystem(IDirectoryInfo root, IFileSystem? inner = null)
 	: ScopedFileSystem(inner ?? Physical, new ScopedFileSystemOptions([root.FullName])
 	{
-		AllowedHiddenFolderNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".git" },
+		AllowedHiddenFolderNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".git", ".artifacts" },
 		AllowedHiddenFileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".git" }
 	}),
 	IChangelogFileSystem

--- a/tests/Elastic.Changelog.Tests/Evaluation/ChangelogCiFileSystemTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/ChangelogCiFileSystemTests.cs
@@ -1,0 +1,70 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions.TestingHelpers;
+using AwesomeAssertions;
+using Elastic.Documentation.Configuration;
+using Elastic.Documentation.FileSystems;
+using Nullean.ScopedFileSystem;
+
+namespace Elastic.Changelog.Tests.Evaluation;
+
+/// <summary>
+/// Regression: changelog CI staging uses <c>.artifacts/changelog-*</c> under the checkout.
+/// ScopedFileSystem rejects hidden path segments unless they are allowlisted.
+/// </summary>
+public class ChangelogCiFileSystemTests
+{
+	private static readonly string Root = Paths.WorkingDirectoryRoot.FullName;
+
+	[Fact]
+	public void ChangelogFileSystem_AllowsArtifactsStagingAndArtifactDirs()
+	{
+		var mock = new MockFileSystem(new MockFileSystemOptions { CurrentDirectory = Root });
+		var fs = ChangelogFileSystem.FromWorkingDirectory(mock);
+
+		var staging = Path.Join(Root, ".artifacts", "changelog-staging");
+		var artifact = Path.Join(Root, ".artifacts", "changelog-artifact");
+		var stagingFile = Path.Join(staging, "42.yaml");
+		var artifactFile = Path.Join(artifact, "metadata.json");
+
+		var create = () =>
+		{
+			fs.Directory.CreateDirectory(staging);
+			fs.Directory.CreateDirectory(artifact);
+			fs.File.WriteAllText(stagingFile, "title: test");
+			fs.File.WriteAllText(artifactFile, "{}");
+		};
+
+		create.Should().NotThrow();
+		fs.File.Exists(stagingFile).Should().BeTrue();
+		fs.File.Exists(artifactFile).Should().BeTrue();
+	}
+
+	[Fact]
+	public void ChangelogFileSystem_BlocksOtherHiddenDirectories()
+	{
+		var mock = new MockFileSystem(new MockFileSystemOptions { CurrentDirectory = Root });
+		var fs = ChangelogFileSystem.FromWorkingDirectory(mock);
+		var hidden = Path.Join(Root, ".hidden", "nested");
+
+		var create = () => fs.Directory.CreateDirectory(hidden);
+
+		create.Should().Throw<ScopedFileSystemException>()
+			.WithMessage("*hidden*");
+	}
+
+	[Fact]
+	public void RunnerTempFileSystem_BlocksOtherHiddenDirectories()
+	{
+		var mock = new MockFileSystem(new MockFileSystemOptions { CurrentDirectory = Root });
+		var fs = new RunnerTempFileSystem(mock.DirectoryInfo.New(Root), inner: mock);
+		var hidden = Path.Join(Root, ".hidden", "nested");
+
+		var create = () => fs.Directory.CreateDirectory(hidden);
+
+		create.Should().Throw<ScopedFileSystemException>()
+			.WithMessage("*hidden*");
+	}
+}


### PR DESCRIPTION
## Why

`changelog add --output .artifacts/changelog-staging` (used by docs-actions changelog-submit) still fails when generation runs: `ChangelogFileSystem` rejects hidden `.artifacts` path segments. [#3917](https://github.com/elastic/docs-builder/pull/3917) already fixed the overlapping `prepare-artifact` / `RunnerTempFileSystem` path.

Also requires [elastic/docs-actions#308](https://github.com/elastic/docs-actions/pull/308) so `upload-artifact` includes files under `.artifacts/changelog-artifact`.

## Test plan

* [ ] `dotnet test tests/Elastic.Changelog.Tests/`
* [ ] After edge publish: confirm a `changelog-submit` run that *does* generate still succeeds end-to-end

## What

* Allowlist `.artifacts` on `ChangelogFileSystem` (aligned with other scopes that already allow it).
* Add focused filesystem regression tests: allow `.artifacts`, block other hidden dirs.