### PR TITLE
fix: allow .artifacts in RunnerTempFileSystem for prepare-artifact

### DIFF
--- a/src/Elastic.Documentation.Tooling/FileSystems/RunnerTempFileSystem.cs
+++ b/src/Elastic.Documentation.Tooling/FileSystems/RunnerTempFileSystem.cs
@@ -16,6 +16,10 @@ namespace Elastic.Documentation.FileSystems;
 /// Used by <c>evaluate-pr</c>, <c>evaluate-artifact</c>, and <c>prepare-artifact</c> —
 /// all three operate on paths vended by the CI environment, not a fixed docset or checkout.
 /// Permits <c>.git</c> so changelog configuration can be located by the config loader.
+/// Permits <c>.artifacts</c> so <c>prepare-artifact</c> can write the staging dirs that
+/// <c>elastic/docs-actions</c> passes (<c>.artifacts/changelog-staging</c> /
+/// <c>.artifacts/changelog-artifact</c>). Those paths are descendants of the working root,
+/// so they are not added as extra roots and must be allowlisted as hidden folders.
 /// </para>
 /// </summary>
 public class RunnerTempFileSystem(
@@ -49,7 +53,7 @@ public class RunnerTempFileSystem(
 
 		return new ScopedFileSystemOptions([.. roots])
 		{
-			AllowedHiddenFolderNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".git" },
+			AllowedHiddenFolderNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".git", ".artifacts" },
 			AllowedHiddenFileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".git" }
 		};
 	}

--- a/tests/Elastic.Changelog.Tests/Evaluation/ChangelogPrepareArtifactServiceTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/ChangelogPrepareArtifactServiceTests.cs
@@ -104,6 +104,39 @@ public class ChangelogPrepareArtifactServiceTests(ITestOutputHelper output) : Ch
 		A.CallTo(() => _mockCore.SetOutputAsync("status", "success")).MustHaveHappened();
 	}
 
+	// Regression: docs-actions stages under `.artifacts/...` inside the checkout.
+	// Those paths are descendants of the working root (not added as extra roots), so
+	// RunnerTempFileSystem must allow the `.artifacts` hidden folder or prepare-artifact
+	// fails with "path must not traverse hidden directories" (elastic/cloud changelog-submit).
+	[Fact]
+	public async Task PrepareArtifact_DotArtifactsPaths_CopiesYamlAndWritesMetadata()
+	{
+		var artifactsStaging = Path.Join(Root, ".artifacts", "changelog-staging");
+		var artifactsOutput = Path.Join(Root, ".artifacts", "changelog-artifact");
+
+		RunnerTempFileSystem.Directory.CreateDirectory(artifactsStaging);
+		await RunnerTempFileSystem.File.WriteAllTextAsync(
+			Path.Join(artifactsStaging, "42.yaml"),
+			"title: test changelog");
+		await SetupConfig();
+
+		var service = CreateService();
+		var args = DefaultArgs() with
+		{
+			StagingDir = artifactsStaging,
+			OutputDir = artifactsOutput
+		};
+
+		var result = await service.PrepareArtifact(Collector, args, CancellationToken.None);
+
+		result.Should().BeTrue();
+		RunnerTempFileSystem.File.Exists(Path.Join(artifactsOutput, "42.yaml")).Should().BeTrue();
+		var json = RunnerTempFileSystem.File.ReadAllText(Path.Join(artifactsOutput, "metadata.json"));
+		var metadata = JsonSerializer.Deserialize(json, ChangelogArtifactMetadataJsonContext.Default.ChangelogArtifactMetadata)!;
+		metadata.Status.Should().Be("success");
+		metadata.ChangelogFilename.Should().Be("42.yaml");
+	}
+
 	[Fact]
 	public async Task PrepareArtifact_ForkFields_PersistedInMetadata()
 	{

--- a/tests/Elastic.Changelog.Tests/Evaluation/ChangelogPrepareArtifactServiceTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/ChangelogPrepareArtifactServiceTests.cs
@@ -114,10 +114,12 @@ public class ChangelogPrepareArtifactServiceTests(ITestOutputHelper output) : Ch
 		var artifactsStaging = Path.Join(Root, ".artifacts", "changelog-staging");
 		var artifactsOutput = Path.Join(Root, ".artifacts", "changelog-artifact");
 
+		var ct = TestContext.Current.CancellationToken;
 		RunnerTempFileSystem.Directory.CreateDirectory(artifactsStaging);
 		await RunnerTempFileSystem.File.WriteAllTextAsync(
 			Path.Join(artifactsStaging, "42.yaml"),
-			"title: test changelog");
+			"title: test changelog",
+			ct);
 		await SetupConfig();
 
 		var service = CreateService();
@@ -127,7 +129,7 @@ public class ChangelogPrepareArtifactServiceTests(ITestOutputHelper output) : Ch
 			OutputDir = artifactsOutput
 		};
 
-		var result = await service.PrepareArtifact(Collector, args, CancellationToken.None);
+		var result = await service.PrepareArtifact(Collector, args, ct);
 
 		result.Should().BeTrue();
 		RunnerTempFileSystem.File.Exists(Path.Join(artifactsOutput, "42.yaml")).Should().BeTrue();


### PR DESCRIPTION
## Why

`elastic/cloud` (and any repo using `docs-actions` changelog submit) is failing `changelog-submit` with:

```
Access denied: path must not traverse hidden directories.
```

in `ChangelogPrepareArtifactService` / `prepare-artifact`.

`elastic/docs-actions` always passes:

- `--staging-dir .artifacts/changelog-staging`
- `--output-dir .artifacts/changelog-artifact`

`RunnerTempFileSystem.ForPrepareArtifact` tries to register those as extra CI roots, but they are **descendants of the working directory**, so they are dropped (disjoint-roots rule). Create/write then hits the hidden-folder guard, which only allowed `.git`.

This fails even when evaluate-pr correctly skips generation (`all products blocked by label rules`), because prepare-artifact still runs to write `metadata.json`.

Example: https://github.com/elastic/cloud/actions/runs/32744185650

## What

- Allow `.artifacts` in `RunnerTempFileSystem.AllowedHiddenFolderNames` (same as `DocumentationFileSystem` / `CheckoutsFileSystem` / `GitResolveFileSystem`).
- Add a regression test that prepares an artifact under `.artifacts/...`.

## Test plan

- [x] Unit test `PrepareArtifact_DotArtifactsPaths_CopiesYamlAndWritesMetadata` (run in CI; local `dotnet` not available on this machine)
- [ ] After edge publish: confirm a cloud `changelog-submit` that previously failed now succeeds

Created with Cursor using Grok 4.5

Made with [Cursor](https://cursor.com)