### PR TITLE
Promote Vector Database quickstart on docs homepage

### DIFF
--- a/src/Elastic.Markdown/Layout/_LandingPage.cshtml
+++ b/src/Elastic.Markdown/Layout/_LandingPage.cshtml
@@ -39,11 +39,11 @@
 				     style="border: 2px solid transparent; background: linear-gradient(white, white) padding-box, linear-gradient(-65deg, #BFDBFF 17%, #E2D3FE 83%) border-box; background-clip: padding-box, border-box; background-origin: padding-box, border-box;">
 					<span class="euiBadge euiBadge--primary inline-flex items-center font-sans font-bold text-xs uppercase tracking-wide shrink-0 rounded-full px-2 py-0.5 bg-[#8144CC] text-white">NEW</span>
 					<div class="flex flex-col">
-						<p class="font-sans font-bold text-xl">Elastic skills for AI agents</p>
-						<p class="mt-2">Install official skills that teach AI coding agents how to work with Elasticsearch, Kibana, Fleet, and the rest of the Elastic stack.</p>
+						<p class="font-sans font-bold text-xl">Build with Elasticsearch Vector Database</p>
+						<p class="mt-2">Create a project, then use your preferred language to index data and run semantic and hybrid searches in 10 minutes.</p>
 						<div class="grid grid-cols-1 mt-6 gap-2 text-left">
-							<a href="@Model.Link("/explore-analyze/ai-features/agent-skills")" class="link justify-start">
-								Learn more
+							<a href="@Model.Link("/solutions/vector-database/vector-full-text-search")" class="link justify-start">
+								Start tutorial
 								<svg class="link-arrow"
 								     xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
 									<path stroke-linecap="round" stroke-linejoin="round" d="M17.25 8.25 21 12m0 0-3.75 3.75M21 12H3"/>


### PR DESCRIPTION
## Summary
- replace the AI agent skills homepage promotion with the new Vector Database quickstart
- highlight semantic and hybrid search in the reader's preferred language
- link the CTA directly to the tutorial

Depends on [elastic/docs-content#7923](https://github.com/elastic/docs-content/pull/7923).

## Test plan
- [x] Preview the updated homepage locally using the current docs-content source
- [x] Confirm the CTA path matches the Vector Database quickstart URL

Made with [Cursor](https://cursor.com)