### PR TITLE
feat(changelog): Lambda notes reconciler — per-target notes-{target}.json indexes

### DIFF
--- a/src/Elastic.Documentation.Configuration/ReleaseNotes/ChangelogKeys.cs
+++ b/src/Elastic.Documentation.Configuration/ReleaseNotes/ChangelogKeys.cs
@@ -99,6 +99,80 @@ public static class ChangelogKeys
 		$"{ChangelogPrefix}{poolGroup}/{RegistryFileName}";
 
 	/// <summary>
+	/// The notes-index key for one target within a repo: <c>changelog/{org}/{repo}/notes-{target}.json</c>.
+	/// Repo-level and branch-agnostic — all notes for a target, regardless of which branch they were authored on.
+	/// </summary>
+	public static string NotesIndexKey(string org, string repo, string target) =>
+		$"{ChangelogPrefix}{org}/{repo}/notes-{target}.json";
+
+	/// <summary>
+	/// The S3 prefix that covers all branches and notes indexes of one repo: <c>changelog/{org}/{repo}/</c>.
+	/// Used by the notes reconciler to list the full repo tree.
+	/// </summary>
+	public static string RepoPrefix(string org, string repo) =>
+		$"{ChangelogPrefix}{org}/{repo}/";
+
+	/// <summary>
+	/// Returns true when <paramref name="key"/> is a notes-index key of the form
+	/// <c>changelog/{org}/{repo}/notes-{target}.json</c> (exactly two group segments, then
+	/// a <c>notes-</c>-prefixed JSON file with a non-empty target slug).
+	/// </summary>
+	public static bool IsNotesIndex(string key)
+	{
+		if (!key.StartsWith(ChangelogPrefix, StringComparison.Ordinal))
+			return false;
+		if (!key.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+			return false;
+
+		var rest = key.AsSpan(ChangelogPrefix.Length);
+
+		// Expect exactly {org}/{repo}/notes-{target}.json
+		var firstSlash = rest.IndexOf('/');
+		if (firstSlash <= 0)
+			return false;
+		var org = rest[..firstSlash];
+
+		var afterOrg = rest[(firstSlash + 1)..];
+		var secondSlash = afterOrg.IndexOf('/');
+		if (secondSlash <= 0)
+			return false;
+		var repo = afterOrg[..secondSlash];
+
+		var file = afterOrg[(secondSlash + 1)..];
+
+		// No further slashes — this must be a direct child of {org}/{repo}/
+		if (file.IndexOf('/') >= 0)
+			return false;
+
+		// Validate org/repo segments and require the notes- prefix with a non-empty target slug
+		if (!IsValidSegment(org, SegmentKind.Org) || !IsValidSegment(repo, SegmentKind.RepoOrBranch))
+			return false;
+
+		const string notesPrefix = "notes-";
+		if (!file.StartsWith(notesPrefix, StringComparison.Ordinal))
+			return false;
+
+		var targetSlug = file[notesPrefix.Length..^".json".Length];
+		return targetSlug.Length > 0 && IsValidSegment(targetSlug, SegmentKind.RepoOrBranch);
+	}
+
+	/// <summary>
+	/// Extracts the <c>{org}/{repo}</c> group from a <c>changelog/{org}/{repo}/notes-{target}.json</c> key.
+	/// Returns null when the key is not a valid notes-index key.
+	/// </summary>
+	public static string? ExtractNotesRepo(string key)
+	{
+		if (!IsNotesIndex(key))
+			return null;
+
+		var rest = key.AsSpan(ChangelogPrefix.Length);
+		var firstSlash = rest.IndexOf('/');
+		var afterOrg = rest[(firstSlash + 1)..];
+		var secondSlash = afterOrg.IndexOf('/');
+		return $"{rest[..firstSlash]}/{afterOrg[..secondSlash]}";
+	}
+
+	/// <summary>
 	/// Extracts the product group from a <c>bundle/{product}/{file}</c> key, or null when
 	/// <paramref name="s3Key"/> is not a bundle key with a valid product segment ahead of the file name.
 	/// The segment is validated on extraction so an out-of-class group can never be re-composed into a

--- a/src/infra/docs-lambda-changelog-scrubber/Program.cs
+++ b/src/infra/docs-lambda-changelog-scrubber/Program.cs
@@ -56,7 +56,8 @@ async Task<SQSBatchResponse> Handler(SQSEvent ev, ILambdaContext context)
 	var scrubber = new ChangelogContentScrubber(logFactory, allowRepos);
 	var reconciler = new BundleRegistryReconciler(logFactory, s3Client, publicBucketName, metrics: metrics);
 	var shallowReconciler = new ShallowRegistryReconciler(logFactory, s3Client, publicBucketName, metrics: metrics);
-	var processor = new ScrubberProcessor(logFactory, s3Client, publicBucketName, scrubber, reconciler, shallowReconciler, metrics);
+	var notesReconciler = new NotesIndexReconciler(logFactory, s3Client, publicBucketName, metrics: metrics);
+	var processor = new ScrubberProcessor(logFactory, s3Client, publicBucketName, scrubber, reconciler, shallowReconciler, notesReconciler, metrics);
 
 	var messages = ev.Records.Select(r => new ScrubberQueueMessage(r.MessageId, r.Body)).ToList();
 	var failedIds = await processor.ProcessAsync(messages, CancellationToken.None);

--- a/src/services/Elastic.Changelog/Reconciliation/ChangelogScope.cs
+++ b/src/services/Elastic.Changelog/Reconciliation/ChangelogScope.cs
@@ -8,7 +8,7 @@ using Elastic.Documentation.Configuration.ReleaseNotes;
 
 namespace Elastic.Changelog.Reconciliation;
 
-/// <summary>The two registry scope families in the changelog bucket key layout.</summary>
+/// <summary>The registry scope families in the changelog bucket key layout.</summary>
 [JsonConverter(typeof(JsonStringEnumConverter<ChangelogScopeKind>))]
 public enum ChangelogScopeKind
 {
@@ -16,15 +16,19 @@ public enum ChangelogScopeKind
 	Bundle,
 
 	/// <summary>An authoring-pool scope: <c>changelog/{org}/{repo}/{branch}/…</c>.</summary>
-	Changelog
+	Changelog,
+
+	/// <summary>A repo-level notes scope: <c>changelog/{org}/{repo}/</c> (branch-agnostic).</summary>
+	Notes
 }
 
 /// <summary>
 /// Identifies one registry scope in the changelog bundles bucket — a product bundle pool
-/// (<c>bundle/{product}/</c>) or an authoring changelog pool
-/// (<c>changelog/{org}/{repo}/{branch}/</c>) — and derives the scope's key prefix and
-/// <c>registry.json</c> key. Segments are validated on construction via
-/// <see cref="ChangelogKeys"/>, so a scope instance can always be composed into safe S3 keys.
+/// (<c>bundle/{product}/</c>), an authoring changelog pool
+/// (<c>changelog/{org}/{repo}/{branch}/</c>), or a repo-level notes scope
+/// (<c>changelog/{org}/{repo}/</c>) — and derives the scope's key prefix. Segments are
+/// validated on construction via <see cref="ChangelogKeys"/>, so a scope instance can
+/// always be composed into safe S3 keys.
 /// </summary>
 public sealed record ChangelogScope
 {
@@ -39,16 +43,20 @@ public sealed record ChangelogScope
 
 	/// <summary>
 	/// The grouping segment(s): the product for a bundle scope, the
-	/// <c>{org}/{repo}/{branch}</c> prefix for a changelog scope.
+	/// <c>{org}/{repo}/{branch}</c> prefix for a changelog scope, or
+	/// <c>{org}/{repo}</c> for a notes scope.
 	/// </summary>
 	public string Group { get; }
 
 	/// <summary>The S3 key prefix of every object in this scope, ending in <c>/</c>.</summary>
-	public string Prefix => Kind == ChangelogScopeKind.Bundle
-		? $"{ChangelogKeys.BundlePrefix}{Group}/"
-		: $"{ChangelogKeys.ChangelogPrefix}{Group}/";
+	public string Prefix => Kind switch
+	{
+		ChangelogScopeKind.Bundle => $"{ChangelogKeys.BundlePrefix}{Group}/",
+		ChangelogScopeKind.Notes => $"{ChangelogKeys.ChangelogPrefix}{Group}/",
+		_ => $"{ChangelogKeys.ChangelogPrefix}{Group}/"
+	};
 
-	/// <summary>The S3 key of this scope's <c>registry.json</c> manifest.</summary>
+	/// <summary>The S3 key of this scope's <c>registry.json</c> manifest (bundle and changelog scopes only).</summary>
 	public string RegistryKey => Kind == ChangelogScopeKind.Bundle
 		? ChangelogKeys.BundleRegistryKey(Group)
 		: ChangelogKeys.ChangelogRegistryKey(Group);
@@ -71,17 +79,27 @@ public sealed record ChangelogScope
 		return scope is not null;
 	}
 
+	/// <summary>Creates a notes scope for <paramref name="org"/>/<paramref name="repo"/>; false when any segment is invalid.</summary>
+	public static bool TryCreateNotes(string? org, string? repo, [NotNullWhen(true)] out ChangelogScope? scope)
+	{
+		scope = ChangelogKeys.IsValidOrg(org) && ChangelogKeys.IsValidRepo(repo)
+			? new ChangelogScope(ChangelogScopeKind.Notes, $"{org}/{repo}")
+			: null;
+		return scope is not null;
+	}
+
 	/// <summary>
-	/// Derives the scope an object key belongs to — <c>bundle/{product}/{file}</c> or
-	/// <c>changelog/{org}/{repo}/{branch}/{file}</c>, including the scope's own
-	/// <c>registry.json</c> key. False when the key sits outside both layouts or a segment
-	/// fails validation.
+	/// Derives the scope an object key belongs to — <c>bundle/{product}/{file}</c>,
+	/// <c>changelog/{org}/{repo}/{branch}/{file}</c>, or <c>changelog/{org}/{repo}/notes-*.json</c>.
+	/// False when the key sits outside all layouts or a segment fails validation.
 	/// </summary>
 	public static bool TryFromKey(string key, [NotNullWhen(true)] out ChangelogScope? scope)
 	{
 		scope = null;
 		if (ChangelogKeys.ExtractBundleGroup(key) is { } product)
 			scope = new ChangelogScope(ChangelogScopeKind.Bundle, product);
+		else if (ChangelogKeys.ExtractNotesRepo(key) is { } repo)
+			scope = new ChangelogScope(ChangelogScopeKind.Notes, repo);
 		else if (ChangelogKeys.ExtractChangelogGroup(key) is { } pool)
 			scope = new ChangelogScope(ChangelogScopeKind.Changelog, pool);
 		return scope is not null;

--- a/src/services/Elastic.Changelog/Reconciliation/NotesIndex.cs
+++ b/src/services/Elastic.Changelog/Reconciliation/NotesIndex.cs
@@ -1,0 +1,31 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text.Json.Serialization;
+
+namespace Elastic.Changelog.Reconciliation;
+
+/// <summary>
+/// Notes index published at <c>changelog/{org}/{repo}/notes-{target}.json</c>.
+/// Lists pool-relative paths of all <c>note-*.yml</c> fragments for one target,
+/// across every branch of the repo.
+/// </summary>
+/// <remarks>
+/// Contents are paths, not bodies — the note files remain the single source of truth.
+/// A stale index can only omit or over-list, never serve stale prose. Bundling a target
+/// is therefore 1 GET for the index + one GET per listed note.
+/// </remarks>
+public sealed record NotesIndex
+{
+	/// <summary>Pool-relative paths of notes for this target, e.g. <c>["main/note-slow-rollover.yml"]</c>.</summary>
+	public required IReadOnlyList<string> Notes { get; init; }
+}
+
+[JsonSourceGenerationOptions(
+	WriteIndented = true,
+	PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+	DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+)]
+[JsonSerializable(typeof(NotesIndex))]
+public sealed partial class NotesIndexJsonContext : JsonSerializerContext;

--- a/src/services/Elastic.Changelog/Reconciliation/NotesIndexReconciler.cs
+++ b/src/services/Elastic.Changelog/Reconciliation/NotesIndexReconciler.cs
@@ -1,0 +1,203 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Net;
+using System.Text.Json;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Elastic.Documentation.Configuration.ReleaseNotes;
+using Microsoft.Extensions.Logging;
+
+namespace Elastic.Changelog.Reconciliation;
+
+/// <summary>
+/// Rebuilds the per-target <c>notes-{target}.json</c> indexes for one repository by listing
+/// all <c>note-*.yml</c> objects under <c>changelog/{org}/{repo}/</c>, reading each to extract
+/// its <c>target:</c> values, and writing the affected indexes atomically.
+/// </summary>
+/// <remarks>
+/// A note may list products at multiple targets, so one note can appear in several indexes.
+/// The index stores pool-relative paths (<c>{branch}/note-{name}.yml</c>) so the same file
+/// name on two branches yields two distinct entries in the same index.
+/// </remarks>
+public sealed class NotesIndexReconciler(
+	ILoggerFactory logFactory,
+	IAmazonS3 s3Client,
+	string publicBucketName,
+	string? sourceBucketName = null,
+	TimeSpan? retryBaseDelay = null,
+	ReconcileMetrics? metrics = null
+)
+{
+	private const int MaxWriteAttempts = 5;
+	private const int MaxParallelReads = 8;
+
+	private readonly ILogger _logger = logFactory.CreateLogger<NotesIndexReconciler>();
+	private readonly TimeSpan _retryBaseDelay = retryBaseDelay ?? TimeSpan.FromMilliseconds(200);
+	private readonly ReconcileMetrics _metrics = metrics ?? new ReconcileMetrics();
+	private readonly string _sourceBucketName = sourceBucketName ?? publicBucketName;
+
+	/// <summary>
+	/// Rebuilds all <c>notes-{target}.json</c> indexes for the given repository scope.
+	/// All currently published <c>note-*.yml</c> files across every branch are listed and
+	/// read to derive the target grouping; every affected index is then (re)written.
+	/// </summary>
+	public async Task ReconcileRepoAsync(ChangelogScope notesScope, Cancel ctx)
+	{
+		if (notesScope.Kind != ChangelogScopeKind.Notes)
+			throw new ArgumentException($"Notes reconcile requires a Notes scope; got '{notesScope}'.", nameof(notesScope));
+
+		_logger.LogInformation("Reconciling notes indexes for repo {Repo}", notesScope.Group);
+
+		// List every note-*.yml under changelog/{org}/{repo}/ (all branches).
+		var noteObjects = await ListNoteFiles(notesScope, ctx);
+		_logger.LogDebug("Found {Count} note file(s) for {Repo}", noteObjects.Count, notesScope.Group);
+
+		// Read each note to extract its targets.
+		// Using List<string> per target; duplicates are removed at write time via Distinct().
+		var byTarget = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+		foreach (var obj in noteObjects)
+		{
+			ctx.ThrowIfCancellationRequested();
+			var poolRelativePath = obj.Key[notesScope.Prefix.Length..];
+			var targets = await ExtractTargetsAsync(obj.Key, ctx);
+			foreach (var target in targets)
+			{
+				if (!byTarget.TryGetValue(target, out var paths))
+					byTarget[target] = paths = [];
+				paths.Add(poolRelativePath);
+			}
+		}
+
+		if (byTarget.Count == 0)
+		{
+			_logger.LogDebug("No targets found for repo {Repo}; no indexes written", notesScope.Group);
+			return;
+		}
+
+		// Write one index per target.
+		await Parallel.ForEachAsync(
+			byTarget,
+			new ParallelOptions { MaxDegreeOfParallelism = MaxParallelReads, CancellationToken = ctx },
+			async (kvp, ct) =>
+			{
+				var (target, paths) = kvp;
+				var indexKey = ChangelogKeys.NotesIndexKey(
+					notesScope.Group.Split('/')[0],
+					notesScope.Group.Split('/')[1],
+					target);
+				await WriteIndexAsync(indexKey, [.. paths.Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal)], ct);
+			});
+	}
+
+	private async Task<IReadOnlyList<S3Object>> ListNoteFiles(ChangelogScope notesScope, Cancel ctx)
+	{
+		var request = new ListObjectsV2Request
+		{
+			BucketName = publicBucketName,
+			Prefix = notesScope.Prefix
+			// No delimiter: list all branches recursively.
+		};
+
+		var files = new List<S3Object>();
+		ListObjectsV2Response response;
+		do
+		{
+			response = await s3Client.ListObjectsV2Async(request, ctx);
+			foreach (var obj in response.S3Objects ?? [])
+			{
+				var relativePath = obj.Key[notesScope.Prefix.Length..];
+				// Accept only pool-relative paths: {branch}/note-{name}.yml (no further nesting)
+				var slash = relativePath.IndexOf('/');
+				if (slash <= 0)
+					continue;
+				var fileName = relativePath[(slash + 1)..];
+				if (!IsNoteFileName(fileName))
+					continue;
+				files.Add(obj);
+				_metrics.IncrementObjectsListed();
+			}
+			request.ContinuationToken = response.NextContinuationToken;
+		} while (response.IsTruncated == true);
+
+		return files;
+	}
+
+	private static bool IsNoteFileName(string fileName) =>
+		fileName.StartsWith("note-", StringComparison.OrdinalIgnoreCase)
+		&& (fileName.EndsWith(".yml", StringComparison.OrdinalIgnoreCase) || fileName.EndsWith(".yaml", StringComparison.OrdinalIgnoreCase))
+		&& !fileName.Contains('/', StringComparison.Ordinal);
+
+	private async Task<IReadOnlyList<string>> ExtractTargetsAsync(string key, Cancel ctx)
+	{
+		try
+		{
+			using var response = await s3Client.GetObjectAsync(new GetObjectRequest
+			{
+				BucketName = _sourceBucketName,
+				Key = key
+			}, ctx);
+
+			await using var stream = response.ResponseStream;
+			using var reader = new StreamReader(stream);
+			var yaml = await reader.ReadToEndAsync(ctx);
+
+			var normalized = ReleaseNotesSerialization.NormalizeYaml(yaml);
+			var dto = ReleaseNotesSerialization.GetEntryDeserializer().Deserialize<ChangelogEntryDto>(normalized);
+
+			if (dto.Products is not { Count: > 0 })
+				return [];
+
+			return dto.Products
+				.Select(p => p.Target)
+				.Where(t => !string.IsNullOrWhiteSpace(t))
+				.Distinct(StringComparer.Ordinal)
+				.ToList()!;
+		}
+		catch (AmazonS3Exception ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+		{
+			// Note was deleted between the list and the read; skip it.
+			return [];
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			_logger.LogWarning(ex, "Could not read targets from note {Key}; skipping", key);
+			return [];
+		}
+	}
+
+	private async Task WriteIndexAsync(string key, IReadOnlyList<string> paths, Cancel ctx)
+	{
+		var index = new NotesIndex { Notes = paths };
+		var json = JsonSerializer.Serialize(index, NotesIndexJsonContext.Default.NotesIndex);
+
+		for (var attempt = 1; attempt <= MaxWriteAttempts; attempt++)
+		{
+			ctx.ThrowIfCancellationRequested();
+			try
+			{
+				_ = await s3Client.PutObjectAsync(new PutObjectRequest
+				{
+					BucketName = publicBucketName,
+					Key = key,
+					ContentBody = json,
+					ContentType = "application/json"
+				}, ctx);
+
+				_metrics.IncrementRegistryWrites();
+				_logger.LogInformation("Wrote notes index {Key} with {Count} path(s)", key, paths.Count);
+				return;
+			}
+			catch (Exception ex) when (ex is not OperationCanceledException)
+			{
+				if (attempt >= MaxWriteAttempts)
+					throw;
+
+				var delay = _retryBaseDelay * attempt;
+				_logger.LogDebug(ex, "Notes index write {Key} failed (attempt {A}/{Max}); retrying in {Delay}", key, attempt, MaxWriteAttempts, delay);
+				await Task.Delay(delay, ctx);
+			}
+		}
+	}
+}

--- a/src/services/Elastic.Changelog/Reconciliation/NotesIndexReconciler.cs
+++ b/src/services/Elastic.Changelog/Reconciliation/NotesIndexReconciler.cs
@@ -70,9 +70,16 @@ public sealed class NotesIndexReconciler(
 			}
 		}
 
+		var groupParts = notesScope.Group.Split('/');
+		var (org, repo) = (groupParts[0], groupParts[1]);
+
+		// List existing notes-*.json indexes so we can remove obsolete ones.
+		var existingIndexKeys = await ListExistingNotesIndexes(notesScope, ctx);
+
 		if (byTarget.Count == 0)
 		{
-			_logger.LogDebug("No targets found for repo {Repo}; no indexes written", notesScope.Group);
+			_logger.LogDebug("No targets found for repo {Repo}; removing any stale indexes", notesScope.Group);
+			await DeleteStaleIndexes(existingIndexKeys, [], org, repo, ctx);
 			return;
 		}
 
@@ -83,12 +90,71 @@ public sealed class NotesIndexReconciler(
 			async (kvp, ct) =>
 			{
 				var (target, paths) = kvp;
-				var indexKey = ChangelogKeys.NotesIndexKey(
-					notesScope.Group.Split('/')[0],
-					notesScope.Group.Split('/')[1],
-					target);
+				var indexKey = ChangelogKeys.NotesIndexKey(org, repo, target);
 				await WriteIndexAsync(indexKey, [.. paths.Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal)], ct);
 			});
+
+		// Remove indexes whose targets are no longer present.
+		await DeleteStaleIndexes(existingIndexKeys, byTarget.Keys.ToHashSet(StringComparer.Ordinal), org, repo, ctx);
+	}
+
+	private async Task<IReadOnlyList<string>> ListExistingNotesIndexes(ChangelogScope notesScope, Cancel ctx)
+	{
+		var request = new ListObjectsV2Request
+		{
+			BucketName = publicBucketName,
+			Prefix = notesScope.Prefix
+		};
+
+		var keys = new List<string>();
+		ListObjectsV2Response response;
+		do
+		{
+			response = await s3Client.ListObjectsV2Async(request, ctx);
+			foreach (var obj in response.S3Objects ?? [])
+			{
+				if (ChangelogKeys.IsNotesIndex(obj.Key))
+					keys.Add(obj.Key);
+			}
+			request.ContinuationToken = response.NextContinuationToken;
+		} while (response.IsTruncated == true);
+
+		return keys;
+	}
+
+	private async Task DeleteStaleIndexes(
+		IReadOnlyList<string> existingKeys,
+		HashSet<string> currentTargets,
+		string org,
+		string repo,
+		Cancel ctx)
+	{
+		// "changelog/{org}/{repo}/notes-" — the stable prefix shared by all notes-*.json keys for this repo.
+		var notesKeyPrefix = $"{ChangelogKeys.ChangelogPrefix}{org}/{repo}/notes-";
+
+		foreach (var key in existingKeys)
+		{
+			// Extract the target slug from the key to check if it's still needed.
+			if (!key.StartsWith(notesKeyPrefix, StringComparison.Ordinal))
+				continue;
+			var targetSlug = key[notesKeyPrefix.Length..^".json".Length];
+			if (currentTargets.Contains(targetSlug))
+				continue;
+
+			try
+			{
+				_ = await s3Client.DeleteObjectAsync(new DeleteObjectRequest
+				{
+					BucketName = publicBucketName,
+					Key = key
+				}, ctx);
+				_logger.LogInformation("Removed stale notes index {Key}", key);
+			}
+			catch (Exception ex) when (ex is not OperationCanceledException)
+			{
+				_logger.LogWarning(ex, "Failed to delete stale notes index {Key}", key);
+			}
+		}
 	}
 
 	private async Task<IReadOnlyList<S3Object>> ListNoteFiles(ChangelogScope notesScope, Cancel ctx)
@@ -108,8 +174,8 @@ public sealed class NotesIndexReconciler(
 			foreach (var obj in response.S3Objects ?? [])
 			{
 				var relativePath = obj.Key[notesScope.Prefix.Length..];
-				// Accept only pool-relative paths: {branch}/note-{name}.yml (no further nesting)
-				var slash = relativePath.IndexOf('/');
+				// Use LastIndexOf so branch names containing '/' (e.g. feature/foo) are handled correctly.
+				var slash = relativePath.LastIndexOf('/');
 				if (slash <= 0)
 					continue;
 				var fileName = relativePath[(slash + 1)..];

--- a/src/services/Elastic.Changelog/Reconciliation/NotesIndexReconciler.cs
+++ b/src/services/Elastic.Changelog/Reconciliation/NotesIndexReconciler.cs
@@ -83,19 +83,26 @@ public sealed class NotesIndexReconciler(
 			return;
 		}
 
-		// Write one index per target.
-		await Parallel.ForEachAsync(
-			byTarget,
-			new ParallelOptions { MaxDegreeOfParallelism = MaxParallelReads, CancellationToken = ctx },
-			async (kvp, ct) =>
-			{
-				var (target, paths) = kvp;
-				var indexKey = ChangelogKeys.NotesIndexKey(org, repo, target);
-				await WriteIndexAsync(indexKey, [.. paths.Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal)], ct);
-			});
-
-		// Remove indexes whose targets are no longer present.
-		await DeleteStaleIndexes(existingIndexKeys, byTarget.Keys.ToHashSet(StringComparer.Ordinal), org, repo, ctx);
+		// Write one index per target. DeleteStaleIndexes runs even if some writes fail — stale
+		// deletion is safe because we only remove targets absent from byTarget.Keys, which is
+		// independent of whether the new writes succeeded.
+		try
+		{
+			await Parallel.ForEachAsync(
+				byTarget,
+				new ParallelOptions { MaxDegreeOfParallelism = MaxParallelReads, CancellationToken = ctx },
+				async (kvp, ct) =>
+				{
+					var (target, paths) = kvp;
+					var indexKey = ChangelogKeys.NotesIndexKey(org, repo, target);
+					await WriteIndexAsync(indexKey, [.. paths.Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal)], ct);
+				});
+		}
+		finally
+		{
+			// Remove indexes whose targets are no longer present.
+			await DeleteStaleIndexes(existingIndexKeys, byTarget.Keys.ToHashSet(StringComparer.Ordinal), org, repo, ctx);
+		}
 	}
 
 	private async Task<IReadOnlyList<string>> ListExistingNotesIndexes(ChangelogScope notesScope, Cancel ctx)

--- a/src/services/Elastic.Changelog/Reconciliation/NotesIndexReconciler.cs
+++ b/src/services/Elastic.Changelog/Reconciliation/NotesIndexReconciler.cs
@@ -222,11 +222,17 @@ public sealed class NotesIndexReconciler(
 			if (dto.Products is not { Count: > 0 })
 				return [];
 
-			return dto.Products
-				.Select(p => p.Target)
-				.Where(t => !string.IsNullOrWhiteSpace(t))
-				.Distinct(StringComparer.Ordinal)
-				.ToList()!;
+			var valid = new List<string>();
+			foreach (var target in dto.Products.Select(p => p.Target).Where(t => !string.IsNullOrWhiteSpace(t)).Distinct(StringComparer.Ordinal))
+			{
+				if (target!.Contains('/', StringComparison.Ordinal))
+				{
+					_logger.LogWarning("Note {Key} has target '{Target}' containing '/'; skipping — targets must be single path segments", key, target);
+					continue;
+				}
+				valid.Add(target);
+			}
+			return valid;
 		}
 		catch (AmazonS3Exception ex) when (ex.StatusCode == HttpStatusCode.NotFound)
 		{

--- a/src/services/Elastic.Changelog/Scrubbing/ScrubberProcessor.cs
+++ b/src/services/Elastic.Changelog/Scrubbing/ScrubberProcessor.cs
@@ -31,6 +31,7 @@ public sealed class ScrubberProcessor(
 	IChangelogContentScrubber scrubber,
 	BundleRegistryReconciler reconciler,
 	ShallowRegistryReconciler shallowReconciler,
+	NotesIndexReconciler notesReconciler,
 	ReconcileMetrics? metrics = null
 )
 {
@@ -75,6 +76,7 @@ public sealed class ScrubberProcessor(
 	{
 		var objectWork = new Dictionary<string, ObjectWork>(StringComparer.Ordinal);
 		var groupWork = new Dictionary<string, GroupWork>(StringComparer.Ordinal);
+		var notesWork = new Dictionary<string, GroupWork>(StringComparer.Ordinal);
 		var shallowWork = new Dictionary<ChangelogScopeKind, ShallowWork>();
 		var failedIds = new HashSet<string>(StringComparer.Ordinal);
 
@@ -87,7 +89,7 @@ public sealed class ScrubberProcessor(
 				{
 					var key = Uri.UnescapeDataString(record.S3.Object.Key.Replace('+', ' '));
 					_logger.LogInformation("Batch names key={Key} (event={EventName})", key, record.EventName?.Value);
-					Classify(message.MessageId, record.S3.Bucket.Name, key, objectWork, groupWork, shallowWork);
+					Classify(message.MessageId, record.S3.Bucket.Name, key, objectWork, groupWork, notesWork, shallowWork);
 				}
 			}
 			catch (Exception e) when (e is not OperationCanceledException)
@@ -125,6 +127,20 @@ public sealed class ScrubberProcessor(
 			}
 		}
 
+		foreach (var work in notesWork.Values)
+		{
+			ctx.ThrowIfCancellationRequested();
+			try
+			{
+				await notesReconciler.ReconcileRepoAsync(work.Scope, ctx);
+			}
+			catch (Exception e) when (e is not OperationCanceledException)
+			{
+				_logger.LogError(e, "Notes reconcile for {Scope} failed; failing its {Count} contributing message(s)", work.Scope, work.MessageIds.Count);
+				failedIds.UnionWith(work.MessageIds);
+			}
+		}
+
 		foreach (var work in shallowWork.Values)
 		{
 			ctx.ThrowIfCancellationRequested();
@@ -149,6 +165,7 @@ public sealed class ScrubberProcessor(
 		string key,
 		Dictionary<string, ObjectWork> objectWork,
 		Dictionary<string, GroupWork> groupWork,
+		Dictionary<string, GroupWork> notesWork,
 		Dictionary<ChangelogScopeKind, ShallowWork> shallowWork)
 	{
 		var hasScope = ChangelogScope.TryFromKey(key, out var scope);
@@ -167,6 +184,14 @@ public sealed class ScrubberProcessor(
 				AddGroup(groupWork, scope, messageId);
 			else
 				_logger.LogDebug("Ignoring retired pool registry key: {Key}", key);
+			return;
+		}
+
+		// Notes indexes (notes-{target}.json) are reconciler-owned; a client that uploads one is
+		// rejected here — the reconciler writes directly to the public bucket, so no copy is needed.
+		if (ChangelogKeys.IsNotesIndex(key))
+		{
+			_logger.LogWarning("Rejecting client-uploaded notes index {Key}; notes indexes are reconciler-owned", key);
 			return;
 		}
 
@@ -190,8 +215,24 @@ public sealed class ScrubberProcessor(
 
 		if (scope!.Kind == ChangelogScopeKind.Bundle)
 			AddGroup(groupWork, scope, messageId);
+
+		// A note-*.yml upload triggers a notes-index reconcile for the whole repo — all targets
+		// whose index lists this note must be rebuilt. The Changelog scope's group is {org}/{repo}/{branch};
+		// the notes scope is the two-segment {org}/{repo} prefix.
+		if (scope.Kind == ChangelogScopeKind.Changelog)
+		{
+			var fileName = key[scope.Prefix.Length..];
+			if (IsNoteFileName(fileName))
+				AddNotesGroup(notesWork, scope.Group, messageId);
+		}
+
 		AddShallow(shallowWork, scope, messageId);
 	}
+
+	private static bool IsNoteFileName(string fileName) =>
+		fileName.StartsWith("note-", StringComparison.OrdinalIgnoreCase)
+		&& (fileName.EndsWith(".yml", StringComparison.OrdinalIgnoreCase) || fileName.EndsWith(".yaml", StringComparison.OrdinalIgnoreCase))
+		&& !fileName.Contains('/', StringComparison.Ordinal);
 
 	private static void AddObject(
 		Dictionary<string, ObjectWork> objectWork,
@@ -215,6 +256,24 @@ public sealed class ScrubberProcessor(
 		{
 			work = new GroupWork(scope);
 			groupWork[scope.Prefix] = work;
+		}
+		_ = work.MessageIds.Add(messageId);
+	}
+
+	private static void AddNotesGroup(Dictionary<string, GroupWork> notesWork, string changelogGroup, string messageId)
+	{
+		// changelogGroup is {org}/{repo}/{branch...}; extract {org}/{repo} by taking the first two segments.
+		var parts = changelogGroup.Split('/');
+		if (parts.Length < 2)
+			return;
+		var org = parts[0];
+		var repo = parts[1];
+		if (!ChangelogScope.TryCreateNotes(org, repo, out var notesScope))
+			return;
+		if (!notesWork.TryGetValue(notesScope.Prefix, out var work))
+		{
+			work = new GroupWork(notesScope);
+			notesWork[notesScope.Prefix] = work;
 		}
 		_ = work.MessageIds.Add(messageId);
 	}

--- a/tests/Elastic.Changelog.Tests/Reconciliation/NotesIndexReconcilerTests.cs
+++ b/tests/Elastic.Changelog.Tests/Reconciliation/NotesIndexReconcilerTests.cs
@@ -1,0 +1,134 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text.Json;
+using AwesomeAssertions;
+using Elastic.Changelog.Reconciliation;
+using Elastic.Documentation.Configuration.ReleaseNotes;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Elastic.Changelog.Tests.Reconciliation;
+
+public class NotesIndexReconcilerTests
+{
+	private const string PublicBucket = "public-bucket";
+
+	private const string NoteYaml =
+		"title: Slow rollover known issue\n" +
+		"type: known-issue\n" +
+		"products:\n" +
+		"  - product: elasticsearch\n" +
+		"    target: 9.0.0\n";
+
+	private const string NoteYamlTwoTargets =
+		"title: Two-version known issue\n" +
+		"type: known-issue\n" +
+		"products:\n" +
+		"  - product: elasticsearch\n" +
+		"    target: 9.0.0\n" +
+		"  - product: elasticsearch\n" +
+		"    target: 9.1.0\n";
+
+	private readonly FakeS3 _s3 = new(PublicBucket);
+	private readonly NotesIndexReconciler _reconciler;
+
+	public NotesIndexReconcilerTests() =>
+		_reconciler = new NotesIndexReconciler(
+			NullLoggerFactory.Instance, _s3.Client, PublicBucket, retryBaseDelay: TimeSpan.Zero);
+
+	private static ChangelogScope NotesScope(string org = "elastic", string repo = "elasticsearch")
+	{
+		_ = ChangelogScope.TryCreateNotes(org, repo, out var scope);
+		return scope!;
+	}
+
+	private void SeedNote(string branch, string fileName, string yaml) =>
+		_s3.Seed(PublicBucket, $"changelog/elastic/elasticsearch/{branch}/{fileName}", yaml);
+
+	private NotesIndex ReadIndex(string target) =>
+		JsonSerializer.Deserialize(
+			_s3.ContentOf(PublicBucket, ChangelogKeys.NotesIndexKey("elastic", "elasticsearch", target)),
+			NotesIndexJsonContext.Default.NotesIndex)!;
+
+	[Fact]
+	public void DirectYamlParse_NoteYaml_HasProducts()
+	{
+		var dto = ReleaseNotesSerialization.GetEntryDeserializer().Deserialize<ChangelogEntryDto>(NoteYaml);
+		dto.Products.Should().NotBeNullOrEmpty("YAML has products");
+		dto.Products![0].Target.Should().Be("9.0.0");
+	}
+
+	[Fact]
+	public async Task ReconcileRepo_SingleNote_WritesIndex()
+	{
+		SeedNote("main", "note-slow-rollover.yml", NoteYaml);
+
+		await _reconciler.ReconcileRepoAsync(NotesScope(), TestContext.Current.CancellationToken);
+
+		_s3.ListCalls.Should().BeGreaterThan(0, "reconciler should have listed the bucket");
+		_s3.Gets.Count.Should().BeGreaterThan(0, $"reconciler should have fetched the note; ListCalls={_s3.ListCalls} SeedExists={_s3.Exists(PublicBucket, "changelog/elastic/elasticsearch/main/note-slow-rollover.yml")}");
+		_s3.Puts.Count.Should().BeGreaterThan(0, $"reconciler should have written the index; ListCalls={_s3.ListCalls} Gets={_s3.Gets.Count}");
+		var index = ReadIndex("9.0.0");
+		index.Notes.Should().BeEquivalentTo(["main/note-slow-rollover.yml"]);
+	}
+
+	[Fact]
+	public async Task ReconcileRepo_NoteWithTwoTargets_AppearsInBothIndexes()
+	{
+		SeedNote("main", "note-two-targets.yml", NoteYamlTwoTargets);
+
+		await _reconciler.ReconcileRepoAsync(NotesScope(), TestContext.Current.CancellationToken);
+
+		ReadIndex("9.0.0").Notes.Should().BeEquivalentTo(["main/note-two-targets.yml"]);
+		ReadIndex("9.1.0").Notes.Should().BeEquivalentTo(["main/note-two-targets.yml"]);
+	}
+
+	[Fact]
+	public async Task ReconcileRepo_SameNoteNameOnTwoBranches_BothInIndex()
+	{
+		SeedNote("main", "note-slow-rollover.yml", NoteYaml);
+		SeedNote("9.0", "note-slow-rollover.yml", NoteYaml);
+
+		await _reconciler.ReconcileRepoAsync(NotesScope(), TestContext.Current.CancellationToken);
+
+		var index = ReadIndex("9.0.0");
+		index.Notes.Should().BeEquivalentTo([
+			"9.0/note-slow-rollover.yml",
+			"main/note-slow-rollover.yml"
+		]);
+	}
+
+	[Fact]
+	public async Task ReconcileRepo_NoNotes_WritesNoIndexes()
+	{
+		// Seed a regular changelog entry that is not a note-*.yml
+		_s3.Seed(PublicBucket, "changelog/elastic/elasticsearch/main/12345.yaml", "title: PR entry");
+
+		await _reconciler.ReconcileRepoAsync(NotesScope(), TestContext.Current.CancellationToken);
+
+		_s3.Puts.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task ReconcileRepo_NoteWithNoProducts_NotIncludedInAnyIndex()
+	{
+		SeedNote("main", "note-no-products.yml", "title: Note with no products\ntype: known-issue");
+
+		await _reconciler.ReconcileRepoAsync(NotesScope(), TestContext.Current.CancellationToken);
+
+		_s3.Puts.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task ReconcileRepo_IndexPathsAreSorted()
+	{
+		SeedNote("main", "note-b.yml", NoteYaml);
+		SeedNote("9.0", "note-a.yml", NoteYaml);
+
+		await _reconciler.ReconcileRepoAsync(NotesScope(), TestContext.Current.CancellationToken);
+
+		var index = ReadIndex("9.0.0");
+		index.Notes.Should().Equal(["9.0/note-a.yml", "main/note-b.yml"]);
+	}
+}

--- a/tests/Elastic.Changelog.Tests/Reconciliation/NotesIndexReconcilerTests.cs
+++ b/tests/Elastic.Changelog.Tests/Reconciliation/NotesIndexReconcilerTests.cs
@@ -131,4 +131,56 @@ public class NotesIndexReconcilerTests
 		var index = ReadIndex("9.0.0");
 		index.Notes.Should().Equal(["9.0/note-a.yml", "main/note-b.yml"]);
 	}
+
+	[Fact]
+	public async Task ReconcileRepo_BranchWithSlashInName_IsIncludedInIndex()
+	{
+		// Branch name contains '/' — e.g. "feature/my-fix"
+		SeedNote("feature/my-fix", "note-slow-rollover.yml", NoteYaml);
+
+		await _reconciler.ReconcileRepoAsync(NotesScope(), TestContext.Current.CancellationToken);
+
+		var index = ReadIndex("9.0.0");
+		index.Notes.Should().BeEquivalentTo(["feature/my-fix/note-slow-rollover.yml"]);
+	}
+
+	[Fact]
+	public async Task ReconcileRepo_StaleTargetRemoved_OldIndexDeleted()
+	{
+		// Pre-seed a stale notes-8.0.0.json index from a previous reconcile run.
+		_s3.Seed(PublicBucket, ChangelogKeys.NotesIndexKey("elastic", "elasticsearch", "8.0.0"),
+			"""{"notes":["old/note-stale.yml"]}""");
+
+		// Only seed a note for 9.0.0.
+		SeedNote("main", "note-slow-rollover.yml", NoteYaml);
+
+		await _reconciler.ReconcileRepoAsync(NotesScope(), TestContext.Current.CancellationToken);
+
+		// 9.0.0 index should be written.
+		ReadIndex("9.0.0").Notes.Should().BeEquivalentTo(["main/note-slow-rollover.yml"]);
+
+		// 8.0.0 index should have been deleted.
+		_s3.Deletes.Should().ContainSingle()
+			.Which.Key.Should().Be(ChangelogKeys.NotesIndexKey("elastic", "elasticsearch", "8.0.0"));
+	}
+
+	[Fact]
+	public async Task ReconcileRepo_NoNotes_DeletesAllExistingIndexes()
+	{
+		// Pre-seed a stale notes index.
+		_s3.Seed(PublicBucket, ChangelogKeys.NotesIndexKey("elastic", "elasticsearch", "9.0.0"),
+			"""{"notes":["old/note-stale.yml"]}""");
+
+		// No note files — just an unrelated changelog entry.
+		_s3.Seed(PublicBucket, "changelog/elastic/elasticsearch/main/12345.yaml", "title: PR entry");
+
+		await _reconciler.ReconcileRepoAsync(NotesScope(), TestContext.Current.CancellationToken);
+
+		// No new indexes should be written.
+		_s3.Puts.Should().BeEmpty();
+
+		// The stale index should be deleted.
+		_s3.Deletes.Should().ContainSingle()
+			.Which.Key.Should().Be(ChangelogKeys.NotesIndexKey("elastic", "elasticsearch", "9.0.0"));
+	}
 }

--- a/tests/Elastic.Changelog.Tests/Reconciliation/NotesIndexReconcilerTests.cs
+++ b/tests/Elastic.Changelog.Tests/Reconciliation/NotesIndexReconcilerTests.cs
@@ -56,7 +56,7 @@ public class NotesIndexReconcilerTests
 	{
 		var dto = ReleaseNotesSerialization.GetEntryDeserializer().Deserialize<ChangelogEntryDto>(NoteYaml);
 		dto.Products.Should().NotBeNullOrEmpty("YAML has products");
-		dto.Products![0].Target.Should().Be("9.0.0");
+		dto.Products?[0].Target.Should().Be("9.0.0");
 	}
 
 	[Fact]

--- a/tests/Elastic.Changelog.Tests/Reconciliation/NotesIndexReconcilerTests.cs
+++ b/tests/Elastic.Changelog.Tests/Reconciliation/NotesIndexReconcilerTests.cs
@@ -149,7 +149,8 @@ public class NotesIndexReconcilerTests
 	{
 		// Pre-seed a stale notes-8.0.0.json index from a previous reconcile run.
 		_s3.Seed(PublicBucket, ChangelogKeys.NotesIndexKey("elastic", "elasticsearch", "8.0.0"),
-			"""{"notes":["old/note-stale.yml"]}""");
+								 /*lang=json,strict*/
+								 """{"notes":["old/note-stale.yml"]}""");
 
 		// Only seed a note for 9.0.0.
 		SeedNote("main", "note-slow-rollover.yml", NoteYaml);
@@ -169,7 +170,8 @@ public class NotesIndexReconcilerTests
 	{
 		// Pre-seed a stale notes index.
 		_s3.Seed(PublicBucket, ChangelogKeys.NotesIndexKey("elastic", "elasticsearch", "9.0.0"),
-			"""{"notes":["old/note-stale.yml"]}""");
+								 /*lang=json,strict*/
+								 """{"notes":["old/note-stale.yml"]}""");
 
 		// No note files — just an unrelated changelog entry.
 		_s3.Seed(PublicBucket, "changelog/elastic/elasticsearch/main/12345.yaml", "title: PR entry");

--- a/tests/Elastic.Changelog.Tests/Scrubbing/ScrubberProcessorTests.cs
+++ b/tests/Elastic.Changelog.Tests/Scrubbing/ScrubberProcessorTests.cs
@@ -34,8 +34,10 @@ public class ScrubberProcessorTests
 			NullLoggerFactory.Instance, _s3.Client, PublicBucket, retryBaseDelay: TimeSpan.Zero, metrics: _metrics);
 		var shallowReconciler = new ShallowRegistryReconciler(
 			NullLoggerFactory.Instance, _s3.Client, PublicBucket, retryBaseDelay: TimeSpan.Zero, metrics: _metrics);
+		var notesReconciler = new NotesIndexReconciler(
+			NullLoggerFactory.Instance, _s3.Client, PublicBucket, sourceBucketName: PrivateBucket, retryBaseDelay: TimeSpan.Zero, metrics: _metrics);
 		_processor = new ScrubberProcessor(
-			NullLoggerFactory.Instance, _s3.Client, PublicBucket, _scrubber, reconciler, shallowReconciler, _metrics);
+			NullLoggerFactory.Instance, _s3.Client, PublicBucket, _scrubber, reconciler, shallowReconciler, notesReconciler, _metrics);
 	}
 
 	private Cancel Ctx => TestContext.Current.CancellationToken;
@@ -350,6 +352,44 @@ public class ScrubberProcessorTests
 
 		failed.Should().BeEmpty();
 		_metrics.GroupReconciles.Should().Be(1);
+	}
+
+	[Fact]
+	public async Task Process_ClientUploadedNotesIndex_IsRejectedWithNoPublicWrite()
+	{
+		// The notes index is reconciler-owned; a client that uploads notes-*.json must be blocked.
+		_s3.Seed(PrivateBucket, "changelog/elastic/kibana/notes-9.0.0.json", """{"notes":[]}""");
+
+		var failed = await _processor.ProcessAsync([Message("ObjectCreated:Put", "changelog/elastic/kibana/notes-9.0.0.json")], Ctx);
+
+		failed.Should().BeEmpty();
+		_s3.Exists(PublicBucket, "changelog/elastic/kibana/notes-9.0.0.json").Should().BeFalse();
+		// No reconcile triggered — only logging
+		_metrics.GroupReconciles.Should().Be(0);
+	}
+
+	[Fact]
+	public async Task Process_NoteFile_ScrubbedAndNotesReconcileTriggered()
+	{
+		// language=yaml
+		var noteYaml = """
+			title: Known rollover issue
+			type: known-issue
+			products:
+			  - product: elasticsearch
+			    target: 9.0.0
+			""";
+		_s3.Seed(PrivateBucket, "changelog/elastic/elasticsearch/main/note-rollover.yml", noteYaml);
+
+		var failed = await _processor.ProcessAsync(
+			[Message("ObjectCreated:Put", "changelog/elastic/elasticsearch/main/note-rollover.yml")], Ctx);
+
+		failed.Should().BeEmpty();
+		// The note was scrubbed and copied to the public bucket
+		_s3.ContentOf(PublicBucket, "changelog/elastic/elasticsearch/main/note-rollover.yml")
+			.Should().StartWith("scrubbed:");
+		// The notes index was written (reconciler read the note and produced notes-9.0.0.json)
+		_s3.Exists(PublicBucket, "changelog/elastic/elasticsearch/notes-9.0.0.json").Should().BeTrue();
 	}
 
 	// language=yaml

--- a/tests/Elastic.Changelog.Tests/Scrubbing/ScrubberProcessorTests.cs
+++ b/tests/Elastic.Changelog.Tests/Scrubbing/ScrubberProcessorTests.cs
@@ -358,7 +358,7 @@ public class ScrubberProcessorTests
 	public async Task Process_ClientUploadedNotesIndex_IsRejectedWithNoPublicWrite()
 	{
 		// The notes index is reconciler-owned; a client that uploads notes-*.json must be blocked.
-		_s3.Seed(PrivateBucket, "changelog/elastic/kibana/notes-9.0.0.json", """{"notes":[]}""");
+		_s3.Seed(PrivateBucket, "changelog/elastic/kibana/notes-9.0.0.json", /*lang=json,strict*/ """{"notes":[]}""");
 
 		var failed = await _processor.ProcessAsync([Message("ObjectCreated:Put", "changelog/elastic/kibana/notes-9.0.0.json")], Ctx);
 


### PR DESCRIPTION
## Summary

- Adds `NotesIndexReconciler` that lists `changelog/{org}/{repo}/` in the public bucket, reads each `note-*.yml` to extract `target:` values, and writes one `notes-{target}.json` index per target (pool-relative paths, e.g. `main/note-slow-rollover.yml`)
- Adds `ChangelogScopeKind.Notes` and `ChangelogScope.TryCreateNotes` for the repo-level scope (two-segment `changelog/{org}/{repo}/`)
- Adds `NotesIndex` record with AOT-compatible `NotesIndexJsonContext`
- `ScrubberProcessor` rejects client uploads of `notes-*.json` (reconciler-owned) and triggers a notes-index reconcile on `note-*.yml` events
- Lambda `Program.cs` wires up `NotesIndexReconciler` with defaults (reads from public bucket where real scrubber preserves `target:`/`products:`); tests pass `sourceBucketName: PrivateBucket` since the fake scrubber would corrupt YAML

## Test plan

- [ ] `dotnet test tests/Elastic.Changelog.Tests/` — 952 passing
- [ ] `NotesIndexReconcilerTests`: single note, two targets, same name on two branches, no notes, note with no products, sorted paths
- [ ] `ScrubberProcessorTests`: client-uploaded notes index rejected with no public write; note file scrubbed and notes reconcile triggered
- [ ] `dotnet build -c Release` — 0 errors

Part of the two-anchor plan (#3923 step 5). Stacks on `fix/changelog-note-command`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)