### PR TITLE
feat(changelog): canonical upload keys and scrubber marker writing (Step 8)

### DIFF
--- a/src/Elastic.Documentation/ReleaseNotes/ChangelogTextUtilities.cs
+++ b/src/Elastic.Documentation/ReleaseNotes/ChangelogTextUtilities.cs
@@ -171,13 +171,20 @@ public static partial class ChangelogTextUtilities
 		if (prUrl.StartsWith("https://github.com/", StringComparison.OrdinalIgnoreCase) ||
 			prUrl.StartsWith("http://github.com/", StringComparison.OrdinalIgnoreCase))
 		{
-			var uri = new Uri(prUrl);
-			var segments = uri.Segments;
-			// segments[0] is "/", segments[1] is "owner/", segments[2] is "repo/", segments[3] is "pull/", segments[4] is "123"
-			if (segments.Length >= 5 &&
-				segments[3].Equals("pull/", StringComparison.OrdinalIgnoreCase) &&
-				int.TryParse(segments[4].TrimEnd('/'), out var prNum))
-				return prNum;
+			try
+			{
+				var uri = new Uri(prUrl);
+				var segments = uri.Segments;
+				// segments[0] is "/", segments[1] is "owner/", segments[2] is "repo/", segments[3] is "pull/", segments[4] is "123"
+				if (segments.Length >= 5 &&
+					segments[3].Equals("pull/", StringComparison.OrdinalIgnoreCase) &&
+					int.TryParse(segments[4].TrimEnd('/'), out var prNum))
+					return prNum;
+			}
+			catch (UriFormatException)
+			{
+				// Malformed URL; fall through to return null.
+			}
 		}
 
 		// Handle short format: owner/repo#123

--- a/src/services/Elastic.Changelog/Scrubbing/ChangelogContentScrubber.cs
+++ b/src/services/Elastic.Changelog/Scrubbing/ChangelogContentScrubber.cs
@@ -110,9 +110,6 @@ public sealed class ChangelogContentScrubber(ILoggerFactory logFactory, IReadOnl
 			return new ScrubResult { Content = content };
 		}
 
-		// Derive canonical key and markers from the pre-scrub entry while prs: URLs are still intact.
-		var (canonicalKey, markers) = BuildCanonicalKeyAndMarkers(key, entry);
-
 		var bundledEntry = new BundledEntry
 		{
 			Type = entry.Type,
@@ -133,6 +130,11 @@ public sealed class ChangelogContentScrubber(ILoggerFactory logFactory, IReadOnl
 			collector, bundledEntry, allowRepos, "elastic", null,
 			out var sanitized, out var changed))
 			throw new InvalidOperationException($"Failed to apply allowlist to changelog entry; errors: {collector.Errors}");
+
+		// Derive canonical key and markers AFTER allowlist filtering so private-only PRs that are
+		// stripped from public output don't become the primary anchor or generate stale markers.
+		var publicEntry = changed ? entry with { Prs = sanitized.Prs } : entry;
+		var (canonicalKey, markers) = BuildCanonicalKeyAndMarkers(key, publicEntry);
 
 		if (!changed)
 		{

--- a/src/services/Elastic.Changelog/Scrubbing/ChangelogContentScrubber.cs
+++ b/src/services/Elastic.Changelog/Scrubbing/ChangelogContentScrubber.cs
@@ -97,17 +97,16 @@ public sealed class ChangelogContentScrubber(ILoggerFactory logFactory, IReadOnl
 		var normalized = ReleaseNotesSerialization.NormalizeYaml(content);
 		var entry = ReleaseNotesSerialization.DeserializeEntry(normalized);
 
-		// Marker: link: <pr_number> with no other content. Return unchanged — there is no URL to scrub.
+		// Pure marker: link: <pr_number> with no other content. Return unchanged — there is no URL to scrub.
 		if (entry.Link != null)
 		{
 			var hasContent = !string.IsNullOrEmpty(entry.Title)
 				|| entry.Type != ChangelogEntryType.Invalid
 				|| entry.Products is { Count: > 0 }
 				|| entry.Prs is { Count: > 0 };
-			if (hasContent)
-				throw new InvalidOperationException(
-					"Changelog entry has both 'link:' and content fields. A marker must contain only 'link: <pr_number>'.");
-			return new ScrubResult { Content = content };
+			if (!hasContent)
+				return new ScrubResult { Content = content };
+			// Has link: alongside other fields — fall through to normal scrubbing (link is preserved below).
 		}
 
 		// Derive canonical key and markers from the pre-scrub entry while prs: URLs are still intact.

--- a/src/services/Elastic.Changelog/Scrubbing/ChangelogContentScrubber.cs
+++ b/src/services/Elastic.Changelog/Scrubbing/ChangelogContentScrubber.cs
@@ -190,7 +190,7 @@ public sealed class ChangelogContentScrubber(ILoggerFactory logFactory, IReadOnl
 		if (prNumbers.Count == 1)
 			return (canonicalKey, []);
 
-		var markerContent = ReleaseNotesSerialization.SerializeEntry(new ChangelogEntry { Link = primaryPr.ToString() });
+		var markerContent = ReleaseNotesSerialization.SerializeEntry(new ChangelogEntry { Link = primaryPr.ToString(System.Globalization.CultureInfo.InvariantCulture) });
 		var markers = prNumbers
 			.Skip(1)
 			.Select(pr => (keyPrefix + $"{pr}.yaml", markerContent))

--- a/src/services/Elastic.Changelog/Scrubbing/ChangelogContentScrubber.cs
+++ b/src/services/Elastic.Changelog/Scrubbing/ChangelogContentScrubber.cs
@@ -97,16 +97,17 @@ public sealed class ChangelogContentScrubber(ILoggerFactory logFactory, IReadOnl
 		var normalized = ReleaseNotesSerialization.NormalizeYaml(content);
 		var entry = ReleaseNotesSerialization.DeserializeEntry(normalized);
 
-		// Pure marker: link: <pr_number> with no other content. Return unchanged — there is no URL to scrub.
+		// Marker: link: <pr_number> with no other content. Return unchanged — there is no URL to scrub.
 		if (entry.Link != null)
 		{
 			var hasContent = !string.IsNullOrEmpty(entry.Title)
 				|| entry.Type != ChangelogEntryType.Invalid
 				|| entry.Products is { Count: > 0 }
 				|| entry.Prs is { Count: > 0 };
-			if (!hasContent)
-				return new ScrubResult { Content = content };
-			// Has link: alongside other fields — fall through to normal scrubbing (link is preserved below).
+			if (hasContent)
+				throw new InvalidOperationException(
+					"Changelog entry has both 'link:' and content fields. A marker must contain only 'link: <pr_number>'.");
+			return new ScrubResult { Content = content };
 		}
 
 		// Derive canonical key and markers from the pre-scrub entry while prs: URLs are still intact.

--- a/src/services/Elastic.Changelog/Scrubbing/ChangelogContentScrubber.cs
+++ b/src/services/Elastic.Changelog/Scrubbing/ChangelogContentScrubber.cs
@@ -10,6 +10,29 @@ using Microsoft.Extensions.Logging;
 
 namespace Elastic.Changelog.Scrubbing;
 
+/// <summary>
+/// The result of scrubbing a changelog artifact for public publication.
+/// </summary>
+public record ScrubResult
+{
+	/// <summary>The scrubbed YAML content to write to the public bucket.</summary>
+	public required string Content { get; init; }
+
+	/// <summary>
+	/// Canonical public key for this object. Null when the source key is already canonical
+	/// and no rename is needed; non-null when the source was named non-canonically
+	/// (e.g. <c>12345-fix.yaml</c>) and must be written at <c>12345.yaml</c> instead.
+	/// </summary>
+	public string? CanonicalKey { get; init; }
+
+	/// <summary>
+	/// Additional marker objects to write to the public bucket for non-primary PRs
+	/// in a multi-PR entry. Each marker's entire content is <c>link: {parentPr}</c>.
+	/// Empty for single-PR entries and bundles.
+	/// </summary>
+	public IReadOnlyList<(string Key, string Content)> Markers { get; init; } = [];
+}
+
 /// <summary>Rewrites private-bucket changelog YAML into its public, allowlist-scrubbed form.</summary>
 public interface IChangelogContentScrubber
 {
@@ -18,7 +41,7 @@ public interface IChangelogContentScrubber
 	/// shape: <c>bundle/{product}/…</c> is a bundle, everything else a changelog entry. Throws
 	/// when the content cannot be proven free of private references.
 	/// </summary>
-	Task<string> ScrubAsync(string key, string content, Cancel ctx);
+	Task<ScrubResult> ScrubAsync(string key, string content, Cancel ctx);
 }
 
 /// <summary>
@@ -31,7 +54,7 @@ public sealed class ChangelogContentScrubber(ILoggerFactory logFactory, IReadOnl
 	private readonly ILogger _logger = logFactory.CreateLogger<ChangelogContentScrubber>();
 
 	/// <inheritdoc />
-	public async Task<string> ScrubAsync(string key, string content, Cancel ctx)
+	public async Task<ScrubResult> ScrubAsync(string key, string content, Cancel ctx)
 	{
 		// Artifact-root layout: bundles live under "bundle/{product}/…", entries under
 		// "changelog/{org}/{repo}/{branch}/…". Match the bundle prefix (not a "/bundle/" substring,
@@ -40,10 +63,10 @@ public sealed class ChangelogContentScrubber(ILoggerFactory logFactory, IReadOnl
 
 		return isBundlePath
 			? await ScrubBundle(content, ctx)
-			: await ScrubChangelog(content, ctx);
+			: await ScrubChangelog(key, content, ctx);
 	}
 
-	private async Task<string> ScrubBundle(string content, Cancel ctx)
+	private async Task<ScrubResult> ScrubBundle(string content, Cancel ctx)
 	{
 		ctx.ThrowIfCancellationRequested();
 
@@ -59,15 +82,15 @@ public sealed class ChangelogContentScrubber(ILoggerFactory logFactory, IReadOnl
 		{
 			_logger.LogInformation("Bundle had no private references, writing unchanged");
 			LinkAllowlistSanitizer.ValidateNoPrivateReferences(content, allowRepos);
-			return content;
+			return new ScrubResult { Content = content };
 		}
 
 		var result = ReleaseNotesSerialization.SerializeBundle(sanitized);
 		LinkAllowlistSanitizer.ValidateNoPrivateReferences(result, allowRepos);
-		return result;
+		return new ScrubResult { Content = result };
 	}
 
-	private async Task<string> ScrubChangelog(string content, Cancel ctx)
+	private async Task<ScrubResult> ScrubChangelog(string key, string content, Cancel ctx)
 	{
 		ctx.ThrowIfCancellationRequested();
 
@@ -84,8 +107,11 @@ public sealed class ChangelogContentScrubber(ILoggerFactory logFactory, IReadOnl
 			if (hasContent)
 				throw new InvalidOperationException(
 					"Changelog entry has both 'link:' and content fields. A marker must contain only 'link: <pr_number>'.");
-			return content;
+			return new ScrubResult { Content = content };
 		}
+
+		// Derive canonical key and markers from the pre-scrub entry while prs: URLs are still intact.
+		var (canonicalKey, markers) = BuildCanonicalKeyAndMarkers(key, entry);
 
 		var bundledEntry = new BundledEntry
 		{
@@ -112,7 +138,7 @@ public sealed class ChangelogContentScrubber(ILoggerFactory logFactory, IReadOnl
 		{
 			_logger.LogInformation("Changelog entry had no private references, writing unchanged");
 			LinkAllowlistSanitizer.ValidateNoPrivateReferences(content, allowRepos);
-			return content;
+			return new ScrubResult { Content = content, CanonicalKey = canonicalKey, Markers = markers };
 		}
 
 		var scrubEntry = entry with
@@ -127,6 +153,49 @@ public sealed class ChangelogContentScrubber(ILoggerFactory logFactory, IReadOnl
 
 		var result = ReleaseNotesSerialization.SerializeEntry(scrubEntry);
 		LinkAllowlistSanitizer.ValidateNoPrivateReferences(result, allowRepos);
-		return result;
+		return new ScrubResult { Content = result, CanonicalKey = canonicalKey, Markers = markers };
+	}
+
+	private static (string? CanonicalKey, IReadOnlyList<(string Key, string Content)> Markers)
+		BuildCanonicalKeyAndMarkers(string sourceKey, ChangelogEntry entry)
+	{
+		// note-* files are their own anchor; markers have link: already set as their identity.
+		var lastSlash = sourceKey.LastIndexOf('/');
+		if (lastSlash < 0)
+			return (null, []);
+
+		var fileName = sourceKey[(lastSlash + 1)..];
+		var keyPrefix = sourceKey[..(lastSlash + 1)];
+
+		if (fileName.StartsWith("note-", StringComparison.OrdinalIgnoreCase) || entry.IsMarker)
+			return (null, []);
+
+		var prNumbers = entry.Prs?
+			.Select(pr => ChangelogTextUtilities.ExtractPrNumber(pr))
+			.Where(n => n.HasValue)
+			.Select(n => n!.Value)
+			.Distinct()
+			.OrderBy(n => n)
+			.ToList();
+
+		if (prNumbers is null or { Count: 0 })
+			return (null, []);
+
+		var primaryPr = prNumbers[0];
+		var canonicalFileName = $"{primaryPr}.yaml";
+		var canonicalKey = string.Equals(fileName, canonicalFileName, StringComparison.OrdinalIgnoreCase)
+			? null
+			: keyPrefix + canonicalFileName;
+
+		if (prNumbers.Count == 1)
+			return (canonicalKey, []);
+
+		var markerContent = ReleaseNotesSerialization.SerializeEntry(new ChangelogEntry { Link = primaryPr.ToString() });
+		var markers = prNumbers
+			.Skip(1)
+			.Select(pr => (keyPrefix + $"{pr}.yaml", markerContent))
+			.ToList<(string, string)>();
+
+		return (canonicalKey, markers);
 	}
 }

--- a/src/services/Elastic.Changelog/Scrubbing/ScrubberProcessor.cs
+++ b/src/services/Elastic.Changelog/Scrubbing/ScrubberProcessor.cs
@@ -8,6 +8,7 @@ using Amazon.S3.Model;
 using Amazon.S3.Util;
 using Elastic.Changelog.Reconciliation;
 using Elastic.Documentation.Configuration.ReleaseNotes;
+using Elastic.Documentation.ReleaseNotes;
 using Microsoft.Extensions.Logging;
 
 namespace Elastic.Changelog.Scrubbing;
@@ -315,6 +316,11 @@ public sealed class ScrubberProcessor(
 				{
 					var scrubResult = await scrubber.ScrubAsync(key, source.Content, ctx);
 					var publicKey = scrubResult.CanonicalKey ?? key;
+
+					// Read the current public entry before overwriting so we can derive which
+					// marker objects it previously produced and delete any that are no longer needed.
+					var oldPublicContent = await TryGetPublicObject(publicKey, ctx);
+
 					await PutPublicObject(publicKey, scrubResult.Content, "application/yaml", ctx);
 					if (scrubResult.CanonicalKey is not null)
 						_logger.LogInformation("Scrubbed {Key} → canonical public key {CanonicalKey}", key, scrubResult.CanonicalKey);
@@ -326,6 +332,10 @@ public sealed class ScrubberProcessor(
 						await PutPublicObject(markerKey, markerContent, "application/yaml", ctx);
 						_logger.LogInformation("Wrote marker {MarkerKey} → {PrimaryKey}", markerKey, publicKey);
 					}
+
+					// Remove marker objects that existed in the previous scrub result but are no
+					// longer produced (e.g. an entry shrank from 3 PRs to 1).
+					await DeleteStaleMarkersAsync(publicKey, oldPublicContent, scrubResult.Markers, ctx);
 				}
 			}
 			else
@@ -392,6 +402,88 @@ public sealed class ScrubberProcessor(
 		{
 			return null;
 		}
+	}
+
+	private async Task<string?> TryGetPublicObject(string key, Cancel ctx)
+	{
+		try
+		{
+			using var response = await s3Client.GetObjectAsync(new GetObjectRequest
+			{
+				BucketName = publicBucketName,
+				Key = key
+			}, ctx);
+			await using var stream = response.ResponseStream;
+			using var reader = new StreamReader(stream);
+			return await reader.ReadToEndAsync(ctx);
+		}
+		catch (AmazonS3Exception ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+		{
+			return null;
+		}
+	}
+
+	private async Task DeleteStaleMarkersAsync(
+		string publicKey,
+		string? oldPublicContent,
+		IReadOnlyList<(string Key, string Content)> newMarkers,
+		Cancel ctx)
+	{
+		if (oldPublicContent is null)
+			return;
+
+		IReadOnlyList<string> oldMarkerKeys;
+		try
+		{
+			oldMarkerKeys = DeriveMarkerKeys(publicKey, oldPublicContent);
+		}
+		catch
+		{
+			// If the old content can't be parsed, we can't derive old markers — skip cleanup.
+			return;
+		}
+
+		if (oldMarkerKeys.Count == 0)
+			return;
+
+		var newMarkerKeySet = newMarkers.Select(m => m.Key).ToHashSet(StringComparer.Ordinal);
+		foreach (var staleKey in oldMarkerKeys)
+		{
+			if (newMarkerKeySet.Contains(staleKey))
+				continue;
+			await DeletePublicObject(staleKey, ctx);
+			_logger.LogInformation("Deleted stale marker {StaleKey} (no longer referenced by {PrimaryKey})", staleKey, publicKey);
+		}
+	}
+
+	private static IReadOnlyList<string> DeriveMarkerKeys(string publicKey, string content)
+	{
+		var entry = ReleaseNotesSerialization.DeserializeEntry(content);
+		if (entry.IsMarker || entry.Prs is not { Count: > 0 })
+			return [];
+
+		var lastSlash = publicKey.LastIndexOf('/');
+		if (lastSlash < 0)
+			return [];
+		var keyPrefix = publicKey[..(lastSlash + 1)];
+
+		var prNumbers = entry.Prs
+			.Select(pr => ChangelogTextUtilities.ExtractPrNumber(pr))
+			.Where(n => n.HasValue)
+			.Select(n => n!.Value)
+			.Distinct()
+			.OrderBy(n => n)
+			.ToList();
+
+		if (prNumbers.Count <= 1)
+			return [];
+
+		var primaryPr = prNumbers[0];
+		return prNumbers
+			.Skip(1)
+			.Select(pr => $"{keyPrefix}{pr}.yaml")
+			.Where(k => !string.Equals(k, $"{keyPrefix}{primaryPr}.yaml", StringComparison.OrdinalIgnoreCase))
+			.ToList();
 	}
 
 	private async Task PutPublicObject(string key, string content, string contentType, Cancel ctx) =>

--- a/src/services/Elastic.Changelog/Scrubbing/ScrubberProcessor.cs
+++ b/src/services/Elastic.Changelog/Scrubbing/ScrubberProcessor.cs
@@ -313,9 +313,19 @@ public sealed class ScrubberProcessor(
 				}
 				else
 				{
-					var scrubbed = await scrubber.ScrubAsync(key, source.Content, ctx);
-					await PutPublicObject(key, scrubbed, "application/yaml", ctx);
-					_logger.LogInformation("Scrubbed and wrote {Key} to public bucket", key);
+					var scrubResult = await scrubber.ScrubAsync(key, source.Content, ctx);
+					var publicKey = scrubResult.CanonicalKey ?? key;
+					await PutPublicObject(publicKey, scrubResult.Content, "application/yaml", ctx);
+					if (scrubResult.CanonicalKey is not null)
+						_logger.LogInformation("Scrubbed {Key} → canonical public key {CanonicalKey}", key, scrubResult.CanonicalKey);
+					else
+						_logger.LogInformation("Scrubbed and wrote {Key} to public bucket", key);
+
+					foreach (var (markerKey, markerContent) in scrubResult.Markers)
+					{
+						await PutPublicObject(markerKey, markerContent, "application/yaml", ctx);
+						_logger.LogInformation("Wrote marker {MarkerKey} → {PrimaryKey}", markerKey, publicKey);
+					}
 				}
 			}
 			else

--- a/src/services/Elastic.Changelog/Uploading/ChangelogUploadService.cs
+++ b/src/services/Elastic.Changelog/Uploading/ChangelogUploadService.cs
@@ -233,7 +233,7 @@ public class ChangelogUploadService(
 		if (prNumbers.Count == 1)
 			return (canonicalFileName, []);
 
-		var markerContent = ReleaseNotesSerialization.SerializeEntry(new ChangelogEntry { Link = primaryPr.ToString() });
+		var markerContent = ReleaseNotesSerialization.SerializeEntry(new ChangelogEntry { Link = primaryPr.ToString(System.Globalization.CultureInfo.InvariantCulture) });
 		var markers = prNumbers
 			.Skip(1)
 			.Select(pr => ($"{pr}.yaml", markerContent))

--- a/src/services/Elastic.Changelog/Uploading/ChangelogUploadService.cs
+++ b/src/services/Elastic.Changelog/Uploading/ChangelogUploadService.cs
@@ -11,6 +11,7 @@ using Elastic.Documentation.Configuration.ReleaseNotes;
 using Elastic.Documentation.Diagnostics;
 using Elastic.Documentation.FileSystems;
 using Elastic.Documentation.Integrations.S3;
+using Elastic.Documentation.ReleaseNotes;
 using Elastic.Documentation.Services;
 using Microsoft.Extensions.Logging;
 
@@ -174,11 +175,71 @@ public class ChangelogUploadService(
 			}
 
 			var fileName = _fileSystem.Path.GetFileName(filePath);
-			var s3Key = ChangelogKeys.ChangelogFileKey(org, repo, branch, fileName);
-			targets.Add(new UploadTarget(filePath, s3Key));
+
+			if (fileName.StartsWith("note-", StringComparison.OrdinalIgnoreCase))
+			{
+				targets.Add(new UploadTarget(filePath, ChangelogKeys.ChangelogFileKey(org, repo, branch, fileName)));
+				continue;
+			}
+
+			ChangelogEntry? entry = null;
+			try
+			{
+				var content = _fileSystem.File.ReadAllText(filePath);
+				entry = ReleaseNotesSerialization.DeserializeEntry(content);
+			}
+			catch (Exception ex)
+			{
+				_logger.LogWarning(ex, "Could not read entry from {File}; using filename for key", filePath);
+			}
+
+			var (canonicalFileName, markerEntries) = DeriveCanonicalFileNameAndMarkers(fileName, entry, _logger);
+			var primaryKey = ChangelogKeys.ChangelogFileKey(org, repo, branch, canonicalFileName);
+			targets.Add(new UploadTarget(filePath, primaryKey));
+
+			foreach (var (markerFileName, markerContent) in markerEntries)
+			{
+				var markerKey = ChangelogKeys.ChangelogFileKey(org, repo, branch, markerFileName);
+				targets.Add(new UploadTarget(string.Empty, markerKey, markerContent));
+			}
 		}
 
 		return targets;
+	}
+
+	internal static (string CanonicalFileName, IReadOnlyList<(string FileName, string Content)> Markers)
+		DeriveCanonicalFileNameAndMarkers(string fileName, ChangelogEntry? entry, ILogger? logger = null)
+	{
+		if (entry is null)
+			return (fileName, []);
+
+		var prNumbers = entry.Prs?
+			.Select(pr => ChangelogTextUtilities.ExtractPrNumber(pr))
+			.Where(n => n.HasValue)
+			.Select(n => n!.Value)
+			.Distinct()
+			.OrderBy(n => n)
+			.ToList();
+
+		if (prNumbers is null or { Count: 0 })
+		{
+			logger?.LogWarning("Entry {File} has no PR references; using filename as-is for key", fileName);
+			return (fileName, []);
+		}
+
+		var primaryPr = prNumbers[0]; // already sorted ascending, min is first
+		var canonicalFileName = $"{primaryPr}.yaml";
+
+		if (prNumbers.Count == 1)
+			return (canonicalFileName, []);
+
+		var markerContent = ReleaseNotesSerialization.SerializeEntry(new ChangelogEntry { Link = primaryPr.ToString() });
+		var markers = prNumbers
+			.Skip(1)
+			.Select(pr => ($"{pr}.yaml", markerContent))
+			.ToList();
+
+		return (canonicalFileName, markers);
 	}
 
 	internal IReadOnlyList<UploadTarget> DiscoverBundleUploadTargets(IDiagnosticsCollector collector, string bundleDir)

--- a/src/services/Elastic.Documentation.Integrations/S3/S3IncrementalUploader.cs
+++ b/src/services/Elastic.Documentation.Integrations/S3/S3IncrementalUploader.cs
@@ -10,7 +10,12 @@ using Microsoft.Extensions.Logging;
 namespace Elastic.Documentation.Integrations.S3;
 
 /// <summary>Describes a file to upload: its local path and intended S3 key.</summary>
-public record UploadTarget(string LocalPath, string S3Key);
+/// <remarks>
+/// When <see cref="InlineContent"/> is non-null the object is uploaded from that string
+/// directly (skipping ETag comparison) and <see cref="LocalPath"/> is ignored. Used for
+/// machine-generated marker objects that have no on-disk counterpart.
+/// </remarks>
+public record UploadTarget(string LocalPath, string S3Key, string? InlineContent = null);
 
 /// <summary>Result of an incremental upload run.</summary>
 public record UploadResult(int Uploaded, int Skipped, int Failed);
@@ -41,6 +46,14 @@ public class S3IncrementalUploader(
 
 			try
 			{
+				if (target.InlineContent is { } inlineContent)
+				{
+					_logger.LogInformation("Uploading inline marker → s3://{Bucket}/{S3Key}", bucketName, target.S3Key);
+					await PutInlineObject(target.S3Key, inlineContent, ctx);
+					uploaded++;
+					continue;
+				}
+
 				if (!skipEtagCheck)
 				{
 					var remoteEtag = await GetRemoteEtag(target.S3Key, ctx);
@@ -98,6 +111,18 @@ public class S3IncrementalUploader(
 			Key = target.S3Key,
 			InputStream = stream,
 			ChecksumAlgorithm = ChecksumAlgorithm.SHA256
+		};
+		_ = await s3Client.PutObjectAsync(request, ctx);
+	}
+
+	private async Task PutInlineObject(string key, string content, Cancel ctx)
+	{
+		var request = new PutObjectRequest
+		{
+			BucketName = bucketName,
+			Key = key,
+			ContentBody = content,
+			ContentType = "application/yaml"
 		};
 		_ = await s3Client.PutObjectAsync(request, ctx);
 	}

--- a/tests/Elastic.Changelog.Tests/Changelogs/MarkerScrubTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/MarkerScrubTests.cs
@@ -27,7 +27,7 @@ public class MarkerScrubTests
 
 		var result = await _scrubber.ScrubAsync(key, content, Ctx);
 
-		result.Should().Be(content);
+		result.Content.Should().Be(content);
 	}
 
 	[Fact]
@@ -38,7 +38,7 @@ public class MarkerScrubTests
 
 		var result = await _scrubber.ScrubAsync(key, content, Ctx);
 
-		result.Should().Be(content);
+		result.Content.Should().Be(content);
 	}
 
 	[Fact]

--- a/tests/Elastic.Changelog.Tests/Scrubbing/ChangelogContentScrubberTests.cs
+++ b/tests/Elastic.Changelog.Tests/Scrubbing/ChangelogContentScrubberTests.cs
@@ -25,9 +25,11 @@ public class ChangelogContentScrubberTests
 
 		var result = await scrubber.ScrubAsync("changelog/elastic/elasticsearch/main/12346.yaml", yaml, CancellationToken.None);
 
-		var entry = ReleaseNotesSerialization.DeserializeEntry(result);
+		var entry = ReleaseNotesSerialization.DeserializeEntry(result.Content);
 		entry.Link.Should().Be("12345", "link: must survive the scrub round-trip");
 		entry.IsMarker.Should().BeTrue();
+		result.CanonicalKey.Should().BeNull("markers are already canonical");
+		result.Markers.Should().BeEmpty();
 	}
 
 	[Fact]
@@ -42,8 +44,88 @@ public class ChangelogContentScrubberTests
 
 		var result = await scrubber.ScrubAsync("changelog/elastic/elasticsearch/main/12345.yaml", yaml, CancellationToken.None);
 
-		var entry = ReleaseNotesSerialization.DeserializeEntry(result);
+		var entry = ReleaseNotesSerialization.DeserializeEntry(result.Content);
 		entry.Link.Should().BeNull();
 		entry.IsMarker.Should().BeFalse();
+	}
+
+	[Fact]
+	public async Task ScrubAsync_NonCanonicalKey_ReturnsCanonicalKey()
+	{
+		var yaml =
+			"title: Fix search performance\n" +
+			"type: bug-fix\n" +
+			"prs:\n" +
+			"  - https://github.com/elastic/elasticsearch/pull/12345\n";
+		var scrubber = Scrubber(["elastic/elasticsearch"]);
+
+		var result = await scrubber.ScrubAsync(
+			"changelog/elastic/elasticsearch/main/12345-fix.yaml", yaml, CancellationToken.None);
+
+		result.CanonicalKey.Should().Be("changelog/elastic/elasticsearch/main/12345.yaml");
+		result.Markers.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task ScrubAsync_AlreadyCanonicalKey_CanonicalKeyIsNull()
+	{
+		var yaml =
+			"title: Fix search performance\n" +
+			"type: bug-fix\n" +
+			"prs:\n" +
+			"  - https://github.com/elastic/elasticsearch/pull/12345\n";
+		var scrubber = Scrubber(["elastic/elasticsearch"]);
+
+		var result = await scrubber.ScrubAsync(
+			"changelog/elastic/elasticsearch/main/12345.yaml", yaml, CancellationToken.None);
+
+		result.CanonicalKey.Should().BeNull("source key is already canonical");
+	}
+
+	[Fact]
+	public async Task ScrubAsync_MultiPrEntry_WritesMarkersForNonPrimaryPrs()
+	{
+		// prs [100, 200, 300] → primary is 100 (min), markers for 200 and 300
+		var yaml =
+			"title: Multi-PR feature\n" +
+			"type: feature\n" +
+			"prs:\n" +
+			"  - https://github.com/elastic/elasticsearch/pull/300\n" +
+			"  - https://github.com/elastic/elasticsearch/pull/100\n" +
+			"  - https://github.com/elastic/elasticsearch/pull/200\n";
+		var scrubber = Scrubber(["elastic/elasticsearch"]);
+
+		var result = await scrubber.ScrubAsync(
+			"changelog/elastic/elasticsearch/main/100.yaml", yaml, CancellationToken.None);
+
+		result.CanonicalKey.Should().BeNull("source key already matches the min PR");
+		result.Markers.Should().HaveCount(2);
+		result.Markers.Should().Contain(m => m.Key == "changelog/elastic/elasticsearch/main/200.yaml");
+		result.Markers.Should().Contain(m => m.Key == "changelog/elastic/elasticsearch/main/300.yaml");
+
+		foreach (var (_, markerContent) in result.Markers)
+		{
+			var markerEntry = ReleaseNotesSerialization.DeserializeEntry(markerContent);
+			markerEntry.Link.Should().Be("100");
+			markerEntry.IsMarker.Should().BeTrue();
+		}
+	}
+
+	[Fact]
+	public async Task ScrubAsync_NoteFile_PassesThroughWithNoCanonicalKey()
+	{
+		var yaml =
+			"title: Known issue with rollover\n" +
+			"type: known-issue\n" +
+			"products:\n" +
+			"  - product: elasticsearch\n" +
+			"    target: 9.2.0\n";
+		var scrubber = Scrubber(["elastic/elasticsearch"]);
+
+		var result = await scrubber.ScrubAsync(
+			"changelog/elastic/elasticsearch/main/note-slow-rollover.yaml", yaml, CancellationToken.None);
+
+		result.CanonicalKey.Should().BeNull("note-* files are already canonical and need no rename");
+		result.Markers.Should().BeEmpty();
 	}
 }

--- a/tests/Elastic.Changelog.Tests/Scrubbing/ScrubberProcessorTests.cs
+++ b/tests/Elastic.Changelog.Tests/Scrubbing/ScrubberProcessorTests.cs
@@ -28,7 +28,8 @@ public class ScrubberProcessorTests
 		// The real scrub pass has its own tests; here it just marks content so assertions can
 		// tell a scrubbed write from a raw copy.
 		_ = A.CallTo(() => _scrubber.ScrubAsync(A<string>._, A<string>._, A<Cancel>._))
-			.ReturnsLazily((string _, string content, Cancel _) => Task.FromResult("scrubbed: " + content));
+			.ReturnsLazily((string _, string content, Cancel _) =>
+				Task.FromResult(new ScrubResult { Content = "scrubbed: " + content }));
 
 		var reconciler = new BundleRegistryReconciler(
 			NullLoggerFactory.Instance, _s3.Client, PublicBucket, retryBaseDelay: TimeSpan.Zero, metrics: _metrics);
@@ -271,6 +272,54 @@ public class ScrubberProcessorTests
 		failed.Should().BeEmpty();
 		_s3.ContentOf(PublicBucket, "bundle/elasticsearch/es-9.1.0.yaml").Should().Be("scrubbed: v2");
 		_metrics.ObjectReconcileRetries.Should().Be(1);
+	}
+
+	[Fact]
+	public async Task Process_CanonicalKeyEntry_WritesToCanonicalPublicKey()
+	{
+		// Scrubber says the private key 12345-fix.yaml should be written to public as 12345.yaml.
+		const string privateKey = "changelog/elastic/elasticsearch/main/12345-fix.yaml";
+		const string canonicalKey = "changelog/elastic/elasticsearch/main/12345.yaml";
+		_ = _s3.Seed(PrivateBucket, privateKey, "entry-content");
+		_ = A.CallTo(() => _scrubber.ScrubAsync(privateKey, A<string>._, A<Cancel>._))
+			.ReturnsLazily((string _, string content, Cancel _) =>
+				Task.FromResult(new ScrubResult { Content = "scrubbed: " + content, CanonicalKey = canonicalKey }));
+
+		var failed = await _processor.ProcessAsync([Message("ObjectCreated:Put", privateKey)], Ctx);
+
+		failed.Should().BeEmpty();
+		_s3.ContentOf(PublicBucket, canonicalKey).Should().Be("scrubbed: entry-content",
+			"canonical key must receive the scrubbed content");
+		_s3.Exists(PublicBucket, privateKey).Should().BeFalse(
+			"private (non-canonical) key must not appear in the public bucket");
+	}
+
+	[Fact]
+	public async Task Process_MultiPrEntry_WritesMarkersForNonPrimaryPrs()
+	{
+		// Scrubber returns markers for PRs 200 and 300 pointing to the primary PR 100.
+		const string privateKey = "changelog/elastic/elasticsearch/main/100.yaml";
+		_ = _s3.Seed(PrivateBucket, privateKey, "multi-pr-content");
+		_ = A.CallTo(() => _scrubber.ScrubAsync(privateKey, A<string>._, A<Cancel>._))
+			.ReturnsLazily((string _, string content, Cancel _) =>
+				Task.FromResult(new ScrubResult
+				{
+					Content = "scrubbed: " + content,
+					Markers =
+					[
+						("changelog/elastic/elasticsearch/main/200.yaml", "link: \"100\"\n"),
+						("changelog/elastic/elasticsearch/main/300.yaml", "link: \"100\"\n")
+					]
+				}));
+
+		var failed = await _processor.ProcessAsync([Message("ObjectCreated:Put", privateKey)], Ctx);
+
+		failed.Should().BeEmpty();
+		_s3.ContentOf(PublicBucket, privateKey).Should().Be("scrubbed: multi-pr-content");
+		_s3.ContentOf(PublicBucket, "changelog/elastic/elasticsearch/main/200.yaml").Should().Be("link: \"100\"\n",
+			"marker for PR 200 must be written to public bucket");
+		_s3.ContentOf(PublicBucket, "changelog/elastic/elasticsearch/main/300.yaml").Should().Be("link: \"100\"\n",
+			"marker for PR 300 must be written to public bucket");
 	}
 
 	[Fact]

--- a/tests/Elastic.Changelog.Tests/Uploading/ChangelogUploadServiceTests.cs
+++ b/tests/Elastic.Changelog.Tests/Uploading/ChangelogUploadServiceTests.cs
@@ -11,7 +11,9 @@ using AwesomeAssertions;
 using Elastic.Changelog.Tests.Changelogs;
 using Elastic.Changelog.Uploading;
 using Elastic.Documentation.Configuration;
+using Elastic.Documentation.Configuration.ReleaseNotes;
 using Elastic.Documentation.FileSystems;
+using Elastic.Documentation.ReleaseNotes;
 using FakeItEasy;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -806,5 +808,121 @@ public class ChangelogUploadServiceTests
 			A<PutObjectRequest>.That.Matches(r => r.Key.EndsWith("registry.json", StringComparison.Ordinal)),
 			A<CancellationToken>._
 		)).MustNotHaveHappened();
+	}
+
+	// --- Canonical key derivation tests
+
+	[Fact]
+	public void DeriveCanonicalFileNameAndMarkers_FullPrUrl_UsesMinPrAsCanonicalKey()
+	{
+		var entry = new ChangelogEntry
+		{
+			Prs = ["https://github.com/elastic/elasticsearch/pull/12345"]
+		};
+
+		var (canonicalFileName, markers) = ChangelogUploadService.DeriveCanonicalFileNameAndMarkers("12345-fix.yaml", entry);
+
+		canonicalFileName.Should().Be("12345.yaml");
+		markers.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void DeriveCanonicalFileNameAndMarkers_MultiPrEntry_ReturnsMinAndMarkersForRest()
+	{
+		var entry = new ChangelogEntry
+		{
+			Prs =
+			[
+				"https://github.com/elastic/elasticsearch/pull/300",
+				"https://github.com/elastic/elasticsearch/pull/100",
+				"https://github.com/elastic/elasticsearch/pull/200"
+			]
+		};
+
+		var (canonicalFileName, markers) = ChangelogUploadService.DeriveCanonicalFileNameAndMarkers("100.yaml", entry);
+
+		canonicalFileName.Should().Be("100.yaml", "min PR is 100");
+		markers.Should().HaveCount(2);
+		markers.Should().Contain(m => m.FileName == "200.yaml");
+		markers.Should().Contain(m => m.FileName == "300.yaml");
+
+		foreach (var (_, markerContent) in markers)
+		{
+			var markerEntry = ReleaseNotesSerialization.DeserializeEntry(markerContent);
+			markerEntry.Link.Should().Be("100");
+		}
+	}
+
+	[Fact]
+	public void DeriveCanonicalFileNameAndMarkers_NoPrs_FallsBackToFileName()
+	{
+		var entry = new ChangelogEntry { Title = "No PRs" };
+
+		var (canonicalFileName, markers) = ChangelogUploadService.DeriveCanonicalFileNameAndMarkers("some-note.yaml", entry);
+
+		canonicalFileName.Should().Be("some-note.yaml");
+		markers.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void DiscoverUploadTargets_EntryWithFullPrUrl_UsesCanonicalKey()
+	{
+		// language=yaml
+		AddChangelog("12345-fix.yaml", """
+			title: Fix search performance
+			type: bug-fix
+			prs:
+			  - https://github.com/elastic/elasticsearch/pull/12345
+			""");
+
+		var targets = _service.DiscoverUploadTargets(_collector, _changelogDir, "elastic", "elasticsearch", "main");
+
+		targets.Should().ContainSingle();
+		targets[0].S3Key.Should().Be("changelog/elastic/elasticsearch/main/12345.yaml",
+			"canonical key is derived from PR number, not the authored filename");
+		_collector.Warnings.Should().Be(0);
+	}
+
+	[Fact]
+	public void DiscoverUploadTargets_NoteFile_PassesThroughVerbatim()
+	{
+		// language=yaml
+		AddChangelog("note-slow-rollover.yaml", """
+			title: Known issue with rollover
+			type: known-issue
+			products:
+			  - product: elasticsearch
+			    target: 9.2.0
+			""");
+
+		var targets = _service.DiscoverUploadTargets(_collector, _changelogDir, "elastic", "elasticsearch", "main");
+
+		targets.Should().ContainSingle();
+		targets[0].S3Key.Should().Be("changelog/elastic/elasticsearch/main/note-slow-rollover.yaml",
+			"note-* files are their own anchor and use verbatim filenames");
+	}
+
+	[Fact]
+	public void DiscoverUploadTargets_MultiPrEntry_AddsMarkerTargets()
+	{
+		// language=yaml
+		AddChangelog("100.yaml", """
+			title: Multi-PR feature
+			type: feature
+			prs:
+			  - https://github.com/elastic/elasticsearch/pull/100
+			  - https://github.com/elastic/elasticsearch/pull/200
+			""");
+
+		var targets = _service.DiscoverUploadTargets(_collector, _changelogDir, "elastic", "elasticsearch", "main");
+
+		targets.Should().HaveCount(2, "one primary + one marker");
+		targets.Should().Contain(t => t.S3Key == "changelog/elastic/elasticsearch/main/100.yaml" && t.InlineContent == null,
+			"primary entry has a local file");
+		var marker = targets.SingleOrDefault(t => t.S3Key == "changelog/elastic/elasticsearch/main/200.yaml");
+		marker.Should().NotBeNull();
+		marker!.InlineContent.Should().NotBeNullOrEmpty("marker has inline content, no local file");
+		var markerEntry = ReleaseNotesSerialization.DeserializeEntry(marker.InlineContent!);
+		markerEntry.Link.Should().Be("100");
 	}
 }

--- a/tests/Elastic.Changelog.Tests/Uploading/ChangelogUploadServiceTests.cs
+++ b/tests/Elastic.Changelog.Tests/Uploading/ChangelogUploadServiceTests.cs
@@ -921,8 +921,8 @@ public class ChangelogUploadServiceTests
 			"primary entry has a local file");
 		var marker = targets.SingleOrDefault(t => t.S3Key == "changelog/elastic/elasticsearch/main/200.yaml");
 		marker.Should().NotBeNull();
-		marker!.InlineContent.Should().NotBeNullOrEmpty("marker has inline content, no local file");
-		var markerEntry = ReleaseNotesSerialization.DeserializeEntry(marker.InlineContent!);
+		marker.InlineContent.Should().NotBeNullOrEmpty("marker has inline content, no local file");
+		var markerEntry = ReleaseNotesSerialization.DeserializeEntry(marker.InlineContent);
 		markerEntry.Link.Should().Be("100");
 	}
 }


### PR DESCRIPTION
## Summary

Step 8 of the two-anchor changelog plan (stacks on #3928 — `link:` read side).

- **Canonical upload keys**: `ChangelogUploadService.DiscoverUploadTargets` now derives the S3 key from the entry's min PR number instead of the authored filename. `12345-fix.yaml` with `prs: [https://…/pull/12345]` uploads as `12345.yaml`. `note-*` files pass through verbatim.
- **Marker objects on upload**: multi-PR entries upload a full-body primary at `{min-pr}.yaml` plus an inline `link: {min-pr}` marker for each non-primary PR. `S3IncrementalUploader.UploadTarget` gains `InlineContent` so markers need no on-disk file.
- **Scrubber writes to canonical public key**: `ScrubAsync` now returns `ScrubResult { Content, CanonicalKey?, Markers }`. When the private-bucket key is non-canonical (e.g. `12345-fix.yaml`), `CanonicalKey` is set and `ScrubberProcessor` writes the scrubbed content at the canonical public key. Handles the 5 measured legacy non-canonical objects without a code-path change — they'll be written to canonical on their next scrub event.
- **Multi-PR markers in public bucket**: `ScrubberProcessor` writes each `result.Markers` entry to the public bucket alongside the primary.

## Test plan

- [x] 949 `Elastic.Changelog.Tests` pass (includes 12 new tests)
- [x] 676 `Elastic.Documentation.Configuration.Tests` pass
- [x] Lambda builds clean (`docs-lambda-changelog-scrubber`)
- [x] `DeriveCanonicalFileNameAndMarkers` unit tests for single-PR, multi-PR, no-PR cases
- [x] `DiscoverUploadTargets` tests for full PR URL → canonical key, `note-*` verbatim, multi-PR marker targets
- [x] `ScrubAsync` tests for non-canonical key, already-canonical key, multi-PR markers, note files
- [x] `ScrubberProcessor` tests for canonical-key routing and marker writing

🤖 Generated with [Claude Code](https://claude.com/claude-code)