### PR TITLE
ApiExplorer: parse heading semantics in supplemental files

### DIFF
--- a/src/Elastic.ApiExplorer/Supplemental/ApiSupplementalDoc.cs
+++ b/src/Elastic.ApiExplorer/Supplemental/ApiSupplementalDoc.cs
@@ -35,8 +35,8 @@ internal sealed partial record ApiSupplementalDoc(
 
 		var sections = SplitSections(trimmed);
 		string? description = null;
-		var parameterOverrides = EmptyOverrides();
-		var requestBodyOverrides = EmptyOverrides();
+		var parameterOverrides = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+		var requestBodyOverrides = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 		var postSections = new List<ApiSupplementalSection>();
 
 		foreach (var (heading, body) in sections)
@@ -70,10 +70,7 @@ internal sealed partial record ApiSupplementalDoc(
 	}
 
 	private static ApiSupplementalDoc Empty(string? frontMatter, string? description) =>
-		new(frontMatter, description, EmptyOverrides(), EmptyOverrides(), []);
-
-	private static Dictionary<string, string> EmptyOverrides() =>
-		new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+		new(frontMatter, description, [], [], []);
 
 	private static bool IsParametersHeading(string heading) =>
 		heading.Equals("Parameters", StringComparison.OrdinalIgnoreCase)

--- a/src/Elastic.ApiExplorer/Supplemental/ApiSupplementalDoc.cs
+++ b/src/Elastic.ApiExplorer/Supplemental/ApiSupplementalDoc.cs
@@ -73,7 +73,7 @@ internal sealed partial record ApiSupplementalDoc(
 		new(frontMatter, description, EmptyOverrides(), EmptyOverrides(), []);
 
 	private static Dictionary<string, string> EmptyOverrides() =>
-		new(StringComparer.OrdinalIgnoreCase);
+		new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
 	private static bool IsParametersHeading(string heading) =>
 		heading.Equals("Parameters", StringComparison.OrdinalIgnoreCase)

--- a/src/Elastic.ApiExplorer/Supplemental/ApiSupplementalDoc.cs
+++ b/src/Elastic.ApiExplorer/Supplemental/ApiSupplementalDoc.cs
@@ -1,0 +1,154 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text.RegularExpressions;
+
+namespace Elastic.ApiExplorer.Supplemental;
+
+internal sealed record ApiSupplementalSection(string Heading, string Body);
+
+internal sealed partial record ApiSupplementalDoc(
+	string? FrontMatter,
+	string? Description,
+	Dictionary<string, string> ParameterOverrides,
+	Dictionary<string, string> RequestBodyOverrides,
+	IReadOnlyList<ApiSupplementalSection> PostSections
+)
+{
+	public static ApiSupplementalDoc? Parse(string? raw)
+	{
+		if (raw is null)
+			return null;
+
+		var (frontMatter, rawContent) = ExtractFrontMatter(raw);
+		var trimmed = rawContent.Trim();
+		if (string.IsNullOrWhiteSpace(trimmed))
+		{
+			return string.IsNullOrWhiteSpace(frontMatter)
+				? null
+				: Empty(frontMatter, description: null);
+		}
+
+		if (!trimmed.Contains("\n## ") && !trimmed.StartsWith("## ", StringComparison.Ordinal))
+			return Empty(frontMatter, trimmed);
+
+		var sections = SplitSections(trimmed);
+		string? description = null;
+		var parameterOverrides = EmptyOverrides();
+		var requestBodyOverrides = EmptyOverrides();
+		var postSections = new List<ApiSupplementalSection>();
+
+		foreach (var (heading, body) in sections)
+		{
+			if (heading is null)
+			{
+				var preamble = body.Trim();
+				if (!string.IsNullOrEmpty(preamble))
+					description = description is null ? preamble : description + "\n\n" + preamble;
+			}
+			else if (heading.Equals("Description", StringComparison.OrdinalIgnoreCase))
+			{
+				var content = body.Trim();
+				if (!string.IsNullOrEmpty(content))
+					description = content;
+			}
+			else if (IsParametersHeading(heading))
+				ParseFieldOverrides(body, parameterOverrides);
+			else if (heading.Equals("Request body", StringComparison.OrdinalIgnoreCase))
+				ParseFieldOverrides(body, requestBodyOverrides);
+			else
+				postSections.Add(new ApiSupplementalSection(heading, body.Trim()));
+		}
+
+		return new ApiSupplementalDoc(
+			frontMatter,
+			description,
+			parameterOverrides,
+			requestBodyOverrides,
+			postSections);
+	}
+
+	private static ApiSupplementalDoc Empty(string? frontMatter, string? description) =>
+		new(frontMatter, description, EmptyOverrides(), EmptyOverrides(), []);
+
+	private static Dictionary<string, string> EmptyOverrides() =>
+		new(StringComparer.OrdinalIgnoreCase);
+
+	private static bool IsParametersHeading(string heading) =>
+		heading.Equals("Parameters", StringComparison.OrdinalIgnoreCase)
+		|| heading.Equals("Query parameters", StringComparison.OrdinalIgnoreCase)
+		|| heading.Equals("Path parameters", StringComparison.OrdinalIgnoreCase);
+
+	private static (string? FrontMatter, string Content) ExtractFrontMatter(string raw)
+	{
+		var match = FrontMatterRegex().Match(raw);
+		if (!match.Success)
+			return (null, raw);
+
+		return (match.Value.Trim(), raw[match.Length..]);
+	}
+
+	private static List<(string? heading, string body)> SplitSections(string text)
+	{
+		var result = new List<(string?, string)>();
+		var lines = text.Split('\n');
+		string? currentHeading = null;
+		var bodyLines = new List<string>();
+
+		foreach (var line in lines)
+		{
+			if (line.StartsWith("## ", StringComparison.Ordinal))
+			{
+				if (bodyLines.Count > 0 || currentHeading is not null)
+					result.Add((currentHeading, string.Join("\n", bodyLines)));
+				currentHeading = line[3..].Trim();
+				bodyLines = [];
+			}
+			else
+				bodyLines.Add(line);
+		}
+
+		result.Add((currentHeading, string.Join("\n", bodyLines)));
+		return result;
+	}
+
+	private static void ParseFieldOverrides(string body, Dictionary<string, string> overrides)
+	{
+		var lines = body.Split('\n');
+		string? currentKey = null;
+		var descLines = new List<string>();
+
+		foreach (var rawLine in lines)
+		{
+			var termMatch = TermLineRegex().Match(rawLine);
+			if (termMatch.Success)
+			{
+				if (currentKey is not null)
+					overrides[currentKey] = string.Join("\n", descLines).Trim();
+				currentKey = NormalizeKey(termMatch.Groups[1].Value);
+				descLines = [];
+			}
+			else if (currentKey is not null)
+				descLines.Add(rawLine);
+		}
+
+		if (currentKey is not null)
+			overrides[currentKey] = string.Join("\n", descLines).Trim();
+	}
+
+	private static string NormalizeKey(string raw)
+	{
+		var s = raw.Trim().Trim('`').Trim();
+		var spaceIdx = s.IndexOf(' ');
+		if (spaceIdx > 0)
+			s = s[..spaceIdx];
+		return s.Trim();
+	}
+
+	[GeneratedRegex(@"^:\s+(`[^`]+`|[A-Za-z0-9_.-]+)")]
+	private static partial Regex TermLineRegex();
+
+	[GeneratedRegex(@"\A---\r?\n[\s\S]*?\r?\n---[ \t]*(?:\r?\n|$)")]
+	private static partial Regex FrontMatterRegex();
+}

--- a/src/Elastic.ApiExplorer/Supplemental/ApiSupplementalDoc.cs
+++ b/src/Elastic.ApiExplorer/Supplemental/ApiSupplementalDoc.cs
@@ -21,6 +21,7 @@ internal sealed partial record ApiSupplementalDoc(
 		if (raw is null)
 			return null;
 
+		raw = raw.ReplaceLineEndings("\n");
 		var (frontMatter, rawContent) = ExtractFrontMatter(raw);
 		var trimmed = rawContent.Trim();
 		if (string.IsNullOrWhiteSpace(trimmed))

--- a/tests/Elastic.ApiExplorer.Tests/Supplemental/ApiSupplementalDocTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/Supplemental/ApiSupplementalDocTests.cs
@@ -1,0 +1,254 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using AwesomeAssertions;
+using Elastic.ApiExplorer.Supplemental;
+
+namespace Elastic.ApiExplorer.Tests.Supplemental;
+
+public class ApiSupplementalDocTests
+{
+	[Fact]
+	public void Parse_Null_ReturnsNull()
+	{
+		ApiSupplementalDoc.Parse(null).Should().BeNull();
+	}
+
+	[Fact]
+	public void Parse_FrontMatterOnly_PreservesFrontMatterWithNullDescription()
+	{
+		const string raw = """
+			---
+			applies_to:
+			  stack: preview
+			---
+			""";
+
+		var doc = ApiSupplementalDoc.Parse(raw);
+
+		doc.Should().NotBeNull();
+		doc.FrontMatter.Should().Contain("applies_to:");
+		doc.FrontMatter.Should().Contain("stack: preview");
+		doc.Description.Should().BeNull();
+		doc.ParameterOverrides.Should().BeEmpty();
+		doc.RequestBodyOverrides.Should().BeEmpty();
+		doc.PostSections.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void Parse_NoHeadings_EntireBodyIsDescription()
+	{
+		const string raw = """
+			The search API returns hits that match the query.
+
+			It supports aggregations.
+			""";
+
+		var doc = ApiSupplementalDoc.Parse(raw);
+
+		doc.Should().NotBeNull();
+		doc.FrontMatter.Should().BeNull();
+		doc.Description.Should().Be("The search API returns hits that match the query.\n\nIt supports aggregations.");
+		doc.PostSections.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void Parse_NoHeadingsWithFrontMatter_StripsFrontMatterFromDescription()
+	{
+		const string raw = """
+			---
+			description: Metadata description.
+			---
+
+			User-facing supplemental description.
+			""";
+
+		var doc = ApiSupplementalDoc.Parse(raw);
+
+		doc.Should().NotBeNull();
+		doc.FrontMatter.Should().Contain("description: Metadata description.");
+		doc.Description.Should().Be("User-facing supplemental description.");
+		doc.Description.Should().NotContain("Metadata description.");
+	}
+
+	[Fact]
+	public void Parse_DescriptionHeading_IsolatesDescriptionFromOtherSections()
+	{
+		const string raw = """
+			## Description
+
+			The search API returns hits that match the query.
+
+			## Usage examples
+
+			Use `search_after` for deep pagination.
+			""";
+
+		var doc = ApiSupplementalDoc.Parse(raw);
+
+		doc.Should().NotBeNull();
+		doc.Description.Should().Be("The search API returns hits that match the query.");
+		doc.PostSections.Should().ContainSingle()
+			.Which.Should().Be(new ApiSupplementalSection("Usage examples", "Use `search_after` for deep pagination."));
+	}
+
+	[Fact]
+	public void Parse_ParametersHeading_MapsDefinitionList()
+	{
+		const string raw = """
+			## Parameters
+
+			: `allow_no_indices`
+			  If `false`, missing indices return an error.
+
+			: `expand_wildcards`
+			  Type of index that wildcard patterns can match.
+			""";
+
+		var doc = ApiSupplementalDoc.Parse(raw);
+
+		doc.Should().NotBeNull();
+		doc.Description.Should().BeNull();
+		doc.ParameterOverrides.Should().HaveCount(2);
+		doc.ParameterOverrides["allow_no_indices"].Should().Be("If `false`, missing indices return an error.");
+		doc.ParameterOverrides["expand_wildcards"].Should().Be("Type of index that wildcard patterns can match.");
+	}
+
+	[Fact]
+	public void Parse_QueryAndPathParameterHeadings_ShareOneMap()
+	{
+		const string raw = """
+			## Query parameters
+
+			: `q`
+			  Query string.
+
+			## Path parameters
+
+			: `index`
+			  Comma-separated list of data streams.
+			""";
+
+		var doc = ApiSupplementalDoc.Parse(raw);
+
+		doc.Should().NotBeNull();
+		doc.ParameterOverrides.Should().HaveCount(2);
+		doc.ParameterOverrides["q"].Should().Be("Query string.");
+		doc.ParameterOverrides["index"].Should().Be("Comma-separated list of data streams.");
+	}
+
+	[Fact]
+	public void Parse_RequestBodyHeading_MapsDefinitionList()
+	{
+		const string raw = """
+			## Request body
+
+			: `query`
+			  Defines the search query using Query DSL.
+
+			: `aggs`
+			  Aggregations to compute over the result set.
+			""";
+
+		var doc = ApiSupplementalDoc.Parse(raw);
+
+		doc.Should().NotBeNull();
+		doc.RequestBodyOverrides.Should().HaveCount(2);
+		doc.RequestBodyOverrides["query"].Should().Be("Defines the search query using Query DSL.");
+		doc.RequestBodyOverrides["aggs"].Should().Be("Aggregations to compute over the result set.");
+		doc.ParameterOverrides.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void Parse_BacktickAndBareName_ProduceSameKey()
+	{
+		const string raw = """
+			## Parameters
+
+			: `allow_no_indices`
+			  Backtick form.
+
+			: allow_no_indices
+			  Bare form.
+			""";
+
+		var doc = ApiSupplementalDoc.Parse(raw);
+
+		doc.Should().NotBeNull();
+		doc.ParameterOverrides.Should().ContainSingle()
+			.Which.Key.Should().Be("allow_no_indices");
+		doc.ParameterOverrides["allow_no_indices"].Should().Be("Bare form.");
+	}
+
+	[Fact]
+	public void Parse_UnrecognizedHeadings_CollectInDocumentOrder()
+	{
+		const string raw = """
+			## Description
+
+			Operation description.
+
+			## Best practices
+
+			Avoid deep pagination.
+
+			## Common patterns
+
+			Use filters with aggregations.
+			""";
+
+		var doc = ApiSupplementalDoc.Parse(raw);
+
+		doc.Should().NotBeNull();
+		doc.Description.Should().Be("Operation description.");
+		doc.PostSections.Should().Equal(
+			new ApiSupplementalSection("Best practices", "Avoid deep pagination."),
+			new ApiSupplementalSection("Common patterns", "Use filters with aggregations."));
+	}
+
+	[Fact]
+	public void Parse_TagStyleFile_LeavesOverrideMapsEmpty()
+	{
+		const string raw = """
+			## Description
+
+			Machine learning anomaly detection APIs.
+
+			## Getting started
+
+			Create a job, then open it.
+			""";
+
+		var doc = ApiSupplementalDoc.Parse(raw);
+
+		doc.Should().NotBeNull();
+		doc.Description.Should().Be("Machine learning anomaly detection APIs.");
+		doc.ParameterOverrides.Should().BeEmpty();
+		doc.RequestBodyOverrides.Should().BeEmpty();
+		doc.PostSections.Should().ContainSingle()
+			.Which.Should().Be(new ApiSupplementalSection("Getting started", "Create a job, then open it."));
+	}
+
+	[Fact]
+	public void Parse_NestedH3_DoesNotStartNewSection()
+	{
+		const string raw = """
+			## Usage examples
+
+			Intro.
+
+			### Full-text search
+
+			Details stay in this section.
+			""";
+
+		var doc = ApiSupplementalDoc.Parse(raw);
+
+		doc.Should().NotBeNull();
+		doc.PostSections.Should().ContainSingle();
+		doc.PostSections[0].Heading.Should().Be("Usage examples");
+		doc.PostSections[0].Body.Should().Contain("### Full-text search");
+		doc.PostSections[0].Body.Should().Contain("Details stay in this section.");
+	}
+}

--- a/tests/Elastic.ApiExplorer.Tests/Supplemental/ApiSupplementalDocTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/Supplemental/ApiSupplementalDocTests.cs
@@ -54,6 +54,17 @@ public class ApiSupplementalDocTests
 	}
 
 	[Fact]
+	public void Parse_CrlfInput_NormalizesToLf()
+	{
+		const string raw = "The search API returns hits that match the query.\r\n\r\nIt supports aggregations.";
+
+		var doc = ApiSupplementalDoc.Parse(raw);
+
+		doc.Should().NotBeNull();
+		doc.Description.Should().Be("The search API returns hits that match the query.\n\nIt supports aggregations.");
+	}
+
+	[Fact]
 	public void Parse_NoHeadingsWithFrontMatter_StripsFrontMatterFromDescription()
 	{
 		const string raw = """


### PR DESCRIPTION
## Why

- API Explorer needs CLI-parity heading rules so later merge work can apply description, parameter, and request-body overrides from `op-*.md` and `tag-*.md` ([elastic/docs-eng-team#727](https://github.com/elastic/docs-eng-team/issues/727)).
- Without a parser, #728 would have to split supplemental Markdown ad hoc at render time.

## What

- Add `ApiSupplementalDoc.Parse` next to supplemental discovery.
- Cover front matter, no-heading descriptions, named override sections, and ordered post-content in unit tests.

## Notes

- Parse is not wired into rendering. Discovery still returns file paths. That merge is #728.
- `tasks/` is local planning only and is not in this PR.


Made with [Cursor](https://cursor.com)