### PR TITLE
Retry git clone/fetch on timeout + per-repo clone_timeout in assembler.yml

### DIFF
--- a/config/assembler.yml
+++ b/config/assembler.yml
@@ -84,8 +84,6 @@ shared_configuration:
 ###
 narrative:
   checkout_strategy: full
-  # docs-content is large; give each fetch attempt extra headroom before retrying.
-  clone_timeout: 45s
 
 ###
 # 'references' defines a map of `elastic/<repository_name> * <repository_config>

--- a/config/assembler.yml
+++ b/config/assembler.yml
@@ -84,6 +84,8 @@ shared_configuration:
 ###
 narrative:
   checkout_strategy: full
+  # docs-content is large; give each fetch attempt extra headroom before retrying.
+  clone_timeout: 15m
 
 ###
 # 'references' defines a map of `elastic/<repository_name> * <repository_config>
@@ -94,6 +96,10 @@ narrative:
 #             # 'partial' --cone sparse-checkout of only the 'docs' folder with --filter=blob:none
 #   current: <git_ref>
 #   next: <git_ref>
+#   clone_timeout: <duration>
+#             # Per-attempt timeout for network git operations (fetch, pull) in CI.
+#             # Accepts a positive integer followed by 's' (seconds) or 'm' (minutes), e.g. '30s' or '15m'.
+#             # When omitted the global default of 10m applies in CI (unbounded locally).
 ###
 references:
 

--- a/config/assembler.yml
+++ b/config/assembler.yml
@@ -85,7 +85,7 @@ shared_configuration:
 narrative:
   checkout_strategy: full
   # docs-content is large; give each fetch attempt extra headroom before retrying.
-  clone_timeout: 15m
+  clone_timeout: 45s
 
 ###
 # 'references' defines a map of `elastic/<repository_name> * <repository_config>

--- a/docs/documentation/assembler/configure/index.md
+++ b/docs/documentation/assembler/configure/index.md
@@ -98,3 +98,31 @@ references:
     next: main
     current: 9.0
 ```
+
+## Per-repository settings reference
+
+The following settings can be specified on any entry under `narrative` or `references`:
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `current` | string | `main` | Git ref (branch, tag, or commit) used for the `current` content source. |
+| `next` | string | `main` | Git ref used for the `next` content source. |
+| `edge` | string | `main` | Git ref used for the `edge` content source. |
+| `checkout_strategy` | `full` \| `partial` | `partial` | `full` clones the entire repository; `partial` uses a sparse checkout of `docs/` only. |
+| `sparse_paths` | list of strings | `["docs"]` | Directories to include when `checkout_strategy: partial`. |
+| `skip` | bool | `false` | Exclude this repository from the build. |
+| `private` | bool | `false` | Mark repository as private; excluded from public builds when `--skip-private` is set. |
+| `path` | string | — | Override the local filesystem path to use instead of cloning. Respected locally only (ignored in CI). |
+| `clone_timeout` | duration | `10m` in CI | Per-attempt timeout for network git operations (fetch, pull) in CI. Accepts a positive integer followed by `s` (seconds) or `m` (minutes), e.g. `30s` or `15m`. Unbounded when not in CI. When omitted, the global default of 10 minutes applies. |
+
+### `clone_timeout` example
+
+```yaml
+narrative:
+  checkout_strategy: full
+  clone_timeout: 15m   # large repo — give each fetch attempt extra headroom
+
+references:
+  my-fast-repo:
+    clone_timeout: 30s   # small repo — fail quickly and retry
+```

--- a/src/Elastic.Codex/Sourcing/CodexGitRepository.cs
+++ b/src/Elastic.Codex/Sourcing/CodexGitRepository.cs
@@ -13,7 +13,7 @@ namespace Elastic.Codex.Sourcing;
 /// Git repository operations optimized for shallow clones.
 /// </summary>
 public class CodexGitRepository(ILoggerFactory logFactory, IDiagnosticsCollector collector, IDirectoryInfo workingDirectory)
-	: ExternalCommandExecutor(collector, workingDirectory, Environment.GetEnvironmentVariable("CI") is null or "" ? null : TimeSpan.FromMinutes(10))
+	: ExternalCommandExecutor(collector, workingDirectory)
 {
 	/// <inheritdoc />
 	protected override ILogger Logger { get; } = logFactory.CreateLogger<CodexGitRepository>();
@@ -24,6 +24,13 @@ public class CodexGitRepository(ILoggerFactory logFactory, IDiagnosticsCollector
 		{ "GIT_EDITOR", "true" }
 	};
 
+	// Network-bound fetch operations retry up to 3 times with exponential back-off.
+	// The default CI timeout is shared with the assembler path (10 min per attempt).
+	private static readonly RetryPolicy NetworkRetry = new(
+		MaxAttempts: 3,
+		BaseDelay: TimeSpan.FromSeconds(5),
+		AttemptTimeout: GitTimeouts.CiDefault);
+
 	public string GetCurrentCommit() => Capture("git", "rev-parse", "HEAD");
 
 	public bool HasHead() => !string.IsNullOrEmpty(CaptureQuiet("git", "rev-parse", "--verify", "HEAD"));
@@ -33,7 +40,7 @@ public class CodexGitRepository(ILoggerFactory logFactory, IDiagnosticsCollector
 	public bool IsInitialized() => Directory.Exists(Path.Join(WorkingDirectory.FullName, ".git"));
 
 	public void Fetch(string reference) =>
-		ExecIn(EnvironmentVars, "git", "fetch", "--no-tags", "--prune", "--no-recurse-submodules", "--depth", "1", "origin", reference);
+		_ = ExecInWithRetry(EnvironmentVars, NetworkRetry, "git", "fetch", "--no-tags", "--prune", "--no-recurse-submodules", "--depth", "1", "origin", reference);
 
 	public void EnableSparseCheckout(string[] folders) =>
 		ExecIn(EnvironmentVars, "git", ["sparse-checkout", "set", "--no-cone", .. folders]);

--- a/src/Elastic.Documentation.Configuration/Assembler/Repository.cs
+++ b/src/Elastic.Documentation.Configuration/Assembler/Repository.cs
@@ -54,6 +54,14 @@ public record Repository
 	[YamlMember(Alias = "private")]
 	public bool Private { get; set; }
 
+	/// <summary>
+	/// Per-attempt timeout for network git operations (fetch, pull) in CI.
+	/// Accepts duration strings such as <c>30s</c> or <c>15m</c>.
+	/// When omitted the global default applies (10 minutes in CI, unbounded locally).
+	/// </summary>
+	[YamlMember(Alias = "clone_timeout")]
+	public TimeSpan? CloneTimeout { get; set; }
+
 	public string GetBranch(ContentSource contentSource) => contentSource switch
 	{
 		ContentSource.Current => GitReferenceCurrent,

--- a/src/Elastic.Documentation.Configuration/ConfigurationFileProvider.cs
+++ b/src/Elastic.Documentation.Configuration/ConfigurationFileProvider.cs
@@ -26,6 +26,7 @@ public partial class ConfigurationFileProvider
 	public static IDeserializer Deserializer { get; } = new StaticDeserializerBuilder(new YamlStaticContext())
 		.WithNamingConvention(UnderscoredNamingConvention.Instance)
 		.WithTypeConverter(new HintTypeSetConverter())
+		.WithTypeConverter(new DurationYamlConverter())
 		.WithTypeConverter(new ApplicableToYamlConverter([]))
 		.WithTypeConverter(new TocItemCollectionYamlConverter())
 		.WithTypeConverter(new TocItemYamlConverter())

--- a/src/Elastic.Documentation.Configuration/Converters/DurationYamlConverter.cs
+++ b/src/Elastic.Documentation.Configuration/Converters/DurationYamlConverter.cs
@@ -1,0 +1,61 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization;
+
+namespace Elastic.Documentation.Configuration.Converters;
+
+/// <summary>
+/// YAML type converter for nullable <see cref="TimeSpan"/>.
+/// Accepts duration strings of the form <c>&lt;integer&gt;s</c> (seconds) or <c>&lt;integer&gt;m</c> (minutes).
+/// No other units are supported; values such as <c>1h</c>, <c>90</c>, or <c>0m</c> are rejected with a
+/// descriptive <see cref="YamlException"/>. A null / absent mapping value deserializes as <c>null</c>.
+/// </summary>
+/// <remarks>
+/// This converter is intentionally restrictive: minutes is the largest unit to keep operator intent
+/// clear and to prevent accidentally setting very long timeouts.
+/// </remarks>
+public class DurationYamlConverter : IYamlTypeConverter
+{
+	public bool Accepts(Type type) => type == typeof(TimeSpan?) || type == typeof(TimeSpan);
+
+	public object? ReadYaml(IParser parser, Type type, ObjectDeserializer rootDeserializer)
+	{
+		if (parser.Current is not Scalar scalar)
+		{
+			_ = parser.MoveNext();
+			return null;
+		}
+
+		var value = scalar.Value;
+		_ = parser.MoveNext();
+
+		if (string.IsNullOrWhiteSpace(value))
+			return null;
+
+		if (value.EndsWith('m') && int.TryParse(value.AsSpan(0, value.Length - 1), out var minutes) && minutes > 0)
+			return TimeSpan.FromMinutes(minutes);
+
+		if (value.EndsWith('s') && int.TryParse(value.AsSpan(0, value.Length - 1), out var seconds) && seconds > 0)
+			return TimeSpan.FromSeconds(seconds);
+
+		throw new YamlException(scalar.Start, scalar.End,
+			$"Invalid duration '{value}'. Expected a positive integer followed by 's' (seconds) or 'm' (minutes), e.g. '30s' or '15m'.");
+	}
+
+	public void WriteYaml(IEmitter emitter, object? value, Type type, ObjectSerializer serializer)
+	{
+		if (value is TimeSpan ts)
+		{
+			var text = ts.TotalMinutes >= 1 && ts.TotalMinutes % 1 == 0
+				? $"{(int)ts.TotalMinutes}m"
+				: $"{(int)ts.TotalSeconds}s";
+			emitter.Emit(new Scalar(text));
+		}
+		else
+			emitter.Emit(new Scalar(""));
+	}
+}

--- a/src/Elastic.Documentation.LinkIndex/Elastic.Documentation.LinkIndex.csproj
+++ b/src/Elastic.Documentation.LinkIndex/Elastic.Documentation.LinkIndex.csproj
@@ -15,6 +15,7 @@
     <ItemGroup>
       <ProjectReference Include="..\Elastic.Documentation\Elastic.Documentation.csproj" />
       <ProjectReference Include="..\Elastic.Documentation.Configuration\Elastic.Documentation.Configuration.csproj" />
+      <ProjectReference Include="..\Elastic.Documentation.Tooling\Elastic.Documentation.Tooling.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/Elastic.Documentation.LinkIndex/GitLinkIndexReader.cs
+++ b/src/Elastic.Documentation.LinkIndex/GitLinkIndexReader.cs
@@ -2,12 +2,13 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-using System.Diagnostics;
 using System.IO.Abstractions;
 using Elastic.Documentation.Configuration;
+using Elastic.Documentation.ExternalCommands;
 using Elastic.Documentation.FileSystems;
 using Elastic.Documentation.Links;
 using Nullean.ScopedFileSystem;
+using ProcNet;
 
 namespace Elastic.Documentation.LinkIndex;
 
@@ -21,6 +22,17 @@ public class GitLinkIndexReader : ILinkIndexReader, IDisposable
 	private static readonly string CloneDirectory = Path.Join(
 		Paths.ApplicationData.FullName,
 		"codex-link-index");
+
+	private static readonly Dictionary<string, string> GitEnvironmentVars = new()
+	{
+		{ "GIT_EDITOR", "true" }
+	};
+
+	// Fetch retries up to 3 times with exponential back-off, each bounded by the CI default timeout.
+	private static readonly RetryPolicy FetchRetry = new(
+		MaxAttempts: 3,
+		BaseDelay: TimeSpan.FromSeconds(5),
+		AttemptTimeout: GitTimeouts.CiDefault);
 
 	private readonly string _environment;
 	private readonly IFileSystem _fileSystem;
@@ -112,7 +124,7 @@ public class GitLinkIndexReader : ILinkIndexReader, IDisposable
 				RunGit(CloneDirectory, "remote", "add", "origin", gitUrl);
 			}
 
-			RunGit(CloneDirectory, "fetch", "--no-tags", "--prune", "--depth", "1", "origin", "HEAD");
+			RunGitWithRetry(CloneDirectory, FetchRetry, "fetch", "--no-tags", "--prune", "--depth", "1", "origin", "HEAD");
 			RunGit(CloneDirectory, "checkout", "--force", "FETCH_HEAD");
 
 			_ensuredClone = true;
@@ -136,28 +148,40 @@ public class GitLinkIndexReader : ILinkIndexReader, IDisposable
 		return $"git@github.com:{LinkIndexOrigin}.git";
 	}
 
+	/// <summary>
+	/// Runs a git command with a retry policy. Throws <see cref="InvalidOperationException"/> on exhaustion.
+	/// </summary>
+	private static void RunGitWithRetry(string workingDirectory, RetryPolicy policy, params string[] args)
+	{
+		var failure = CommandRetry.Invoke(
+			policy,
+			invoke: () => ExecGit(workingDirectory, args, policy.AttemptTimeout),
+			delay: d => Thread.Sleep(d),
+			onRetry: f => Console.Error.WriteLine($"[git {string.Join(" ", args)}] {f}; retrying…")
+		);
+
+		if (failure is not null)
+			throw new InvalidOperationException($"Git command failed after {policy.MaxAttempts} attempts (last: {failure.Value}).");
+	}
+
+	/// <summary>
+	/// Runs a single git command with no retry. Throws <see cref="InvalidOperationException"/> on failure.
+	/// </summary>
 	private static void RunGit(string workingDirectory, params string[] args)
 	{
-		var startInfo = new ProcessStartInfo
+		var exitCode = ExecGit(workingDirectory, args, timeout: null);
+		if (exitCode != 0)
+			throw new InvalidOperationException($"Git command failed (exit {exitCode}): git {string.Join(" ", args)}");
+	}
+
+	private static int ExecGit(string workingDirectory, string[] args, TimeSpan? timeout)
+	{
+		var arguments = new ExecArguments("git", args)
 		{
-			FileName = "git",
 			WorkingDirectory = workingDirectory,
-			UseShellExecute = false,
-			RedirectStandardOutput = true,
-			RedirectStandardError = true,
-			CreateNoWindow = true
+			Environment = GitEnvironmentVars,
+			Timeout = timeout
 		};
-		foreach (var arg in args)
-			startInfo.ArgumentList.Add(arg);
-		startInfo.Environment["GIT_EDITOR"] = "true";
-
-		using var process = Process.Start(startInfo) ?? throw new InvalidOperationException("Failed to start git process.");
-
-		var stderr = process.StandardError.ReadToEnd();
-		_ = process.StandardOutput.ReadToEnd();
-		process.WaitForExit();
-
-		if (process.ExitCode != 0)
-			throw new InvalidOperationException($"Git command failed (exit {process.ExitCode}): {stderr.Trim()}");
+		return Proc.Exec(arguments);
 	}
 }

--- a/src/Elastic.Documentation.Tooling/ExternalCommands/CommandRetry.cs
+++ b/src/Elastic.Documentation.Tooling/ExternalCommands/CommandRetry.cs
@@ -1,0 +1,97 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using ProcNet;
+
+namespace Elastic.Documentation.ExternalCommands;
+
+/// <param name="MaxAttempts">Total attempts, including the first.</param>
+/// <param name="BaseDelay">Delay before the second attempt. Each later attempt doubles it.</param>
+/// <param name="AttemptTimeout">Per-attempt timeout. Overrides the executor-level timeout when set.</param>
+public readonly record struct RetryPolicy(int MaxAttempts, TimeSpan BaseDelay, TimeSpan? AttemptTimeout = null)
+{
+	public static RetryPolicy None { get; } = new(1, TimeSpan.Zero);
+
+	public TimeSpan DelayBeforeAttempt(int attempt) =>
+		attempt <= 1 ? TimeSpan.Zero : BaseDelay * Math.Pow(2, attempt - 2);
+}
+
+/// <summary>Outcome of a single command attempt.</summary>
+/// <param name="ExitCode">The process exit code, or -1 when the attempt threw (e.g. ProcNet timeout).</param>
+/// <param name="Exception">The exception that ended the attempt, or null when it exited cleanly.</param>
+public readonly record struct CommandFailure(int ExitCode, Exception? Exception)
+{
+	public override string ToString() =>
+		Exception is not null
+			? $"exit {ExitCode}: {Exception.Message}"
+			: $"exit {ExitCode}";
+}
+
+/// <summary>
+/// Low-level retry primitive used by <see cref="ExternalCommandExecutor"/>.
+/// Treats a <see cref="ProcExecException"/> (per-attempt ProcNet timeout) as a retryable failure
+/// rather than an unhandled exception, so the retry loop always engages on transient network stalls.
+/// </summary>
+public static class CommandRetry
+{
+	/// <summary>
+	/// Runs <paramref name="invoke"/> up to <see cref="RetryPolicy.MaxAttempts"/> times.
+	/// Returns <c>null</c> on success (exit code 0); returns the last <see cref="CommandFailure"/> when
+	/// all attempts are exhausted.
+	/// </summary>
+	/// <param name="policy">Retry configuration.</param>
+	/// <param name="invoke">Factory that runs the command and returns its exit code.</param>
+	/// <param name="delay">Called with the computed back-off interval before each retry (not called before attempt 1).</param>
+	/// <param name="onRetry">Called after each failed attempt that has a retry remaining.</param>
+	public static CommandFailure? Invoke(
+		RetryPolicy policy,
+		Func<int> invoke,
+		Action<TimeSpan> delay,
+		Action<CommandFailure> onRetry)
+	{
+		CommandFailure last = default;
+		for (var attempt = 1; attempt <= policy.MaxAttempts; attempt++)
+		{
+			if (attempt > 1)
+				delay(policy.DelayBeforeAttempt(attempt));
+
+			int exitCode;
+			Exception? caught = null;
+			try
+			{
+				exitCode = invoke();
+			}
+			catch (ProcExecException ex)
+			{
+				// ProcNet throws on per-attempt timeout instead of returning a non-zero exit code.
+				// We catch it here so the retry loop always sees a failure as a failure, not as
+				// an unhandled escape that bypasses the retry budget.
+				exitCode = -1;
+				caught = ex;
+			}
+
+			if (exitCode == 0)
+				return null;
+
+			last = new CommandFailure(exitCode, caught);
+			if (attempt < policy.MaxAttempts)
+				onRetry(last);
+		}
+
+		return last;
+	}
+}
+
+/// <summary>Shared git timeout constants.</summary>
+public static class GitTimeouts
+{
+	/// <summary>
+	/// Default per-attempt timeout applied to network git operations in CI.
+	/// Returns <c>null</c> (no timeout) outside CI so local first-clones are not killed.
+	/// </summary>
+	public static TimeSpan? CiDefault =>
+		string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CI"))
+			? null
+			: TimeSpan.FromMinutes(10);
+}

--- a/src/Elastic.Documentation.Tooling/ExternalCommands/ExternalCommandExecutor.cs
+++ b/src/Elastic.Documentation.Tooling/ExternalCommands/ExternalCommandExecutor.cs
@@ -10,16 +10,6 @@ using ProcNet.Std;
 
 namespace Elastic.Documentation.ExternalCommands;
 
-/// <param name="MaxAttempts">Total attempts, including the first.</param>
-/// <param name="BaseDelay">Delay before the second attempt. Each later attempt doubles it.</param>
-public readonly record struct RetryPolicy(int MaxAttempts, TimeSpan BaseDelay)
-{
-	public static RetryPolicy None { get; } = new(1, TimeSpan.Zero);
-
-	public TimeSpan DelayBeforeAttempt(int attempt) =>
-		attempt <= 1 ? TimeSpan.Zero : BaseDelay * Math.Pow(2, attempt - 2);
-}
-
 public abstract class ExternalCommandExecutor(IDiagnosticsCollector collector, IDirectoryInfo workingDirectory, TimeSpan? timeout = null)
 {
 	protected abstract ILogger Logger { get; }
@@ -34,13 +24,13 @@ public abstract class ExternalCommandExecutor(IDiagnosticsCollector collector, I
 	protected IDirectoryInfo WorkingDirectory => workingDirectory;
 	protected IDiagnosticsCollector Collector => collector;
 
-	protected virtual int ExecInCore(Dictionary<string, string> environmentVars, string binary, params string[] args)
+	protected virtual int ExecInCore(Dictionary<string, string> environmentVars, TimeSpan? attemptTimeout, string binary, params string[] args)
 	{
 		var arguments = new ExecArguments(binary, args)
 		{
 			WorkingDirectory = workingDirectory.FullName,
 			Environment = environmentVars,
-			Timeout = timeout
+			Timeout = attemptTimeout
 		};
 		return Proc.Exec(arguments);
 	}
@@ -51,25 +41,25 @@ public abstract class ExternalCommandExecutor(IDiagnosticsCollector collector, I
 	protected bool ExecInWithRetry(Dictionary<string, string> environmentVars, RetryPolicy retry, string binary, params string[] args)
 	{
 		var command = $"{binary} {string.Join(" ", args)}";
-		var exitCode = 0;
-		for (var attempt = 1; attempt <= retry.MaxAttempts; attempt++)
-		{
-			if (attempt > 1)
-				DelayBeforeRetry(retry.DelayBeforeAttempt(attempt));
+		var attemptTimeout = retry.AttemptTimeout ?? timeout;
 
-			exitCode = ExecInCore(environmentVars, binary, args);
-			if (exitCode == 0)
-				return true;
-
-			// Deliberately not routed through Log: a silent multi second stall is worse than extra local output.
-			if (attempt < retry.MaxAttempts)
+		var failure = CommandRetry.Invoke(
+			retry,
+			invoke: () => ExecInCore(environmentVars, attemptTimeout, binary, args),
+			delay: DelayBeforeRetry,
+			onRetry: f =>
 			{
-				Logger.LogWarning("[{Command}] Exit code {ExitCode}. Retrying ({Attempt}/{MaxAttempts}) in {WorkingDirectory}",
-					command, exitCode, attempt, retry.MaxAttempts, workingDirectory.FullName);
-			}
-		}
+				// Deliberately not routed through Log: a silent multi-second stall is worse than extra local output.
+				Logger.LogWarning("[{Command}] {Failure}. Retrying in {WorkingDirectory}", command, f, workingDirectory.FullName);
+			});
 
-		collector.EmitError("", $"Exit code: {exitCode} while executing {command} in {workingDirectory}");
+		if (failure is null)
+			return true;
+
+		var detail = failure.Value.Exception is not null
+			? $"{command}: {failure.Value.Exception.Message}"
+			: $"Exit code: {failure.Value.ExitCode} while executing {command} in {workingDirectory}";
+		collector.EmitError("", detail);
 		return false;
 	}
 

--- a/src/services/Elastic.Documentation.Assembler/Sourcing/GitFacade.cs
+++ b/src/services/Elastic.Documentation.Assembler/Sourcing/GitFacade.cs
@@ -24,8 +24,8 @@ public interface IGitRepository
 
 // This git repository implementation is optimized for pull and fetching single commits.
 // It uses `git pull --depth 1` and `git fetch --depth 1` to minimize the amount of data transferred.
-public class SingleCommitOptimizedGitRepository(ILoggerFactory logFactory, IDiagnosticsCollector collector, IDirectoryInfo workingDirectory)
-	: ExternalCommandExecutor(collector, workingDirectory, Environment.GetEnvironmentVariable("CI") is null or "" ? null : TimeSpan.FromMinutes(10))
+public class SingleCommitOptimizedGitRepository(ILoggerFactory logFactory, IDiagnosticsCollector collector, IDirectoryInfo workingDirectory, TimeSpan? cloneTimeout = null)
+	: ExternalCommandExecutor(collector, workingDirectory)
 		, IGitRepository
 {
 	private static readonly Dictionary<string, string> EnvironmentVars = new()
@@ -36,9 +36,14 @@ public class SingleCommitOptimizedGitRepository(ILoggerFactory logFactory, IDiag
 		{ "GIT_EDITOR", "true" }
 	};
 
-	// Only the network bound commands retry. CloneRef wraps this with up to 3 wipe-and-reclone passes,
-	// so the effective worst case is 3 x 5 invocations.
-	private static readonly RetryPolicy NetworkRetry = new(MaxAttempts: 5, BaseDelay: TimeSpan.FromSeconds(1));
+	// Network-bound operations retry up to 3 times with exponential back-off.
+	// Each attempt is bounded by the per-repo clone_timeout (default: CI ? 10min : unbounded).
+	// CloneRef wraps Fetch with up to 3 wipe-and-reclone passes, so the realistic worst case is
+	// 3 × 3 = 9 fetch invocations, each bounded by the per-attempt timeout.
+	private readonly RetryPolicy _networkRetry = new(
+		MaxAttempts: 3,
+		BaseDelay: TimeSpan.FromSeconds(5),
+		AttemptTimeout: cloneTimeout ?? GitTimeouts.CiDefault);
 
 	/// <inheritdoc />
 	protected override ILogger Logger { get; } = logFactory.CreateLogger<SingleCommitOptimizedGitRepository>();
@@ -47,8 +52,8 @@ public class SingleCommitOptimizedGitRepository(ILoggerFactory logFactory, IDiag
 
 	public void Init() => ExecIn(EnvironmentVars, "git", "init");
 	public bool IsInitialized() => Directory.Exists(Path.Join(WorkingDirectory.FullName, ".git"));
-	public void Pull(string branch) => _ = ExecInWithRetry(EnvironmentVars, NetworkRetry, "git", "pull", "--depth", "1", "--allow-unrelated-histories", "--no-ff", "origin", branch);
-	public void Fetch(string reference) => _ = ExecInWithRetry(EnvironmentVars, NetworkRetry, "git", "fetch", "--no-tags", "--prune", "--no-recurse-submodules", "--depth", "1", "origin", reference);
+	public void Pull(string branch) => _ = ExecInWithRetry(EnvironmentVars, _networkRetry, "git", "pull", "--depth", "1", "--allow-unrelated-histories", "--no-ff", "origin", branch);
+	public void Fetch(string reference) => _ = ExecInWithRetry(EnvironmentVars, _networkRetry, "git", "fetch", "--no-tags", "--prune", "--no-recurse-submodules", "--depth", "1", "origin", reference);
 	public void EnableSparseCheckout(string[] folders) => ExecIn(EnvironmentVars, "git", ["sparse-checkout", "set", "--no-cone", .. folders]);
 
 	public void DisableSparseCheckout() => ExecIn(EnvironmentVars, "git", "sparse-checkout", "disable");

--- a/src/services/Elastic.Documentation.Assembler/Sourcing/RepositorySourcesFetcher.cs
+++ b/src/services/Elastic.Documentation.Assembler/Sourcing/RepositorySourcesFetcher.cs
@@ -44,7 +44,7 @@ public class AssemblerRepositorySourcer(ILoggerFactory logFactory, AssembleConte
 				_logger.LogInformation("{RepositoryName}: Using local override path for {RepositoryName} at {Path}", repo.Name, repo.Name, repo.Path);
 				checkoutFolder = fs.DirectoryInfo.New(repo.Path);
 			}
-			IGitRepository gitFacade = new SingleCommitOptimizedGitRepository(logFactory, context.Collector, checkoutFolder);
+			IGitRepository gitFacade = new SingleCommitOptimizedGitRepository(logFactory, context.Collector, checkoutFolder, repo.CloneTimeout);
 			if (!checkoutFolder.Exists)
 			{
 				context.Collector.EmitError(checkoutFolder.FullName, $"'{repo.Name}' does not exist in link index checkout directory");
@@ -160,7 +160,7 @@ public class RepositorySourcer(ILoggerFactory logFactory, IDirectoryInfo checkou
 			_logger.LogInformation("{RepositoryName}: Using override path for {RepositoryName}@{Commit} at {CheckoutFolder}", repository.Name, repository.Name, gitRef, checkoutFolder.FullName);
 		}
 
-		IGitRepository git = new SingleCommitOptimizedGitRepository(logFactory, collector, checkoutFolder);
+		IGitRepository git = new SingleCommitOptimizedGitRepository(logFactory, collector, checkoutFolder, repository.CloneTimeout);
 
 		if (assumeCloned && checkoutFolder.Exists)
 		{

--- a/tests/Elastic.Documentation.Build.Tests/ExternalCommandExecutorRetryTests.cs
+++ b/tests/Elastic.Documentation.Build.Tests/ExternalCommandExecutorRetryTests.cs
@@ -9,6 +9,7 @@ using Elastic.Documentation.Diagnostics;
 using Elastic.Documentation.ExternalCommands;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using ProcNet;
 
 namespace Elastic.Documentation.Build.Tests;
 
@@ -19,7 +20,7 @@ public class ExternalCommandExecutorRetryTests
 	[Fact]
 	public void ExecInWithRetry_SucceedsOnFirstAttempt_EmitsNoErrors()
 	{
-		var executor = CreateExecutor(0);
+		var executor = CreateExecutor(ExitCode(0));
 
 		var succeeded = executor.Retry(FiveAttempts);
 
@@ -32,7 +33,7 @@ public class ExternalCommandExecutorRetryTests
 	[Fact]
 	public void ExecInWithRetry_SucceedsAfterTransientFailures_EmitsNoErrors()
 	{
-		var executor = CreateExecutor(1, 1, 0);
+		var executor = CreateExecutor(ExitCode(1), ExitCode(1), ExitCode(0));
 
 		var succeeded = executor.Retry(FiveAttempts);
 
@@ -45,7 +46,7 @@ public class ExternalCommandExecutorRetryTests
 	[Fact]
 	public void ExecInWithRetry_ExhaustsAllAttempts_EmitsExactlyOneError()
 	{
-		var executor = CreateExecutor(1, 1, 1, 1, 1);
+		var executor = CreateExecutor(ExitCode(1), ExitCode(1), ExitCode(1), ExitCode(1), ExitCode(1));
 
 		var succeeded = executor.Retry(FiveAttempts);
 
@@ -62,7 +63,7 @@ public class ExternalCommandExecutorRetryTests
 	[Fact]
 	public void ExecInWithRetry_WithCustomPolicy_HonoursAttemptsAndBaseDelay()
 	{
-		var executor = CreateExecutor(1, 1, 1);
+		var executor = CreateExecutor(ExitCode(1), ExitCode(1), ExitCode(1));
 
 		var succeeded = executor.Retry(new RetryPolicy(MaxAttempts: 3, BaseDelay: TimeSpan.FromSeconds(2)));
 
@@ -75,7 +76,7 @@ public class ExternalCommandExecutorRetryTests
 	[Fact]
 	public void ExecIn_WhenCommandFails_EmitsOneErrorWithoutRetrying()
 	{
-		var executor = CreateExecutor(1);
+		var executor = CreateExecutor(ExitCode(1));
 
 		executor.ExecOnce();
 
@@ -84,15 +85,51 @@ public class ExternalCommandExecutorRetryTests
 		executor.RecordedDelays.Should().BeEmpty();
 	}
 
-	private static RetryTestCommandExecutor CreateExecutor(params int[] exitCodes)
+	[Fact]
+	public void ExecInWithRetry_WhenAttemptTimesOut_RetriesAndSucceeds()
+	{
+		// First attempt simulates a ProcNet per-attempt timeout; second succeeds.
+		var executor = CreateExecutor(Timeout("10 minutes"), ExitCode(0));
+
+		var succeeded = executor.Retry(FiveAttempts);
+
+		succeeded.Should().BeTrue();
+		executor.CallCount.Should().Be(2);
+		executor.Diagnostics.Errors.Should().Be(0);
+		// One delay recorded between the timed-out attempt and the successful retry.
+		executor.RecordedDelays.Should().HaveCount(1);
+	}
+
+	[Fact]
+	public void ExecInWithRetry_WhenEveryAttemptTimesOut_EmitsExactlyOneError()
+	{
+		var policy = new RetryPolicy(MaxAttempts: 3, BaseDelay: TimeSpan.FromSeconds(1));
+		var executor = CreateExecutor(Timeout("10 minutes"), Timeout("10 minutes"), Timeout("10 minutes"));
+
+		var succeeded = executor.Retry(policy);
+
+		succeeded.Should().BeFalse();
+		executor.CallCount.Should().Be(3);
+		executor.Diagnostics.Errors.Should().Be(1);
+	}
+
+	// ── Helpers ──────────────────────────────────────────────────────────────────
+
+	/// <summary>Scripts a normal process exit.</summary>
+	private static Func<int> ExitCode(int code) => () => code;
+
+	/// <summary>Scripts a ProcNet per-attempt timeout (throws rather than returning an exit code).</summary>
+	private static Func<int> Timeout(string message) => () => throw new ProcExecException($"Timeout {message}");
+
+	private static RetryTestCommandExecutor CreateExecutor(params Func<int>[] steps)
 	{
 		var fileSystem = new MockFileSystem();
 		var workingDirectory = fileSystem.DirectoryInfo.New("/workspace/repo");
 		workingDirectory.Create();
-		return new RetryTestCommandExecutor(new DiagnosticsCollector([]), workingDirectory, exitCodes);
+		return new RetryTestCommandExecutor(new DiagnosticsCollector([]), workingDirectory, steps);
 	}
 
-	private sealed class RetryTestCommandExecutor(IDiagnosticsCollector collector, IDirectoryInfo workingDirectory, int[] exitCodes)
+	private sealed class RetryTestCommandExecutor(IDiagnosticsCollector collector, IDirectoryInfo workingDirectory, Func<int>[] steps)
 		: ExternalCommandExecutor(collector, workingDirectory)
 	{
 		public int CallCount { get; private set; }
@@ -103,11 +140,11 @@ public class ExternalCommandExecutorRetryTests
 
 		protected override ILogger Logger { get; } = NullLogger.Instance;
 
-		protected override int ExecInCore(Dictionary<string, string> environmentVars, string binary, params string[] args)
+		protected override int ExecInCore(Dictionary<string, string> environmentVars, TimeSpan? attemptTimeout, string binary, params string[] args)
 		{
-			if (CallCount >= exitCodes.Length)
-				throw new InvalidOperationException($"Unexpected invocation {CallCount + 1}, only {exitCodes.Length} exit codes were scripted");
-			return exitCodes[CallCount++];
+			if (CallCount >= steps.Length)
+				throw new InvalidOperationException($"Unexpected invocation {CallCount + 1}, only {steps.Length} steps were scripted");
+			return steps[CallCount++]();   // may throw ProcExecException
 		}
 
 		protected override void DelayBeforeRetry(TimeSpan delay) => RecordedDelays.Add(delay);

--- a/tests/Elastic.Documentation.Configuration.Tests/CloneTimeoutTests.cs
+++ b/tests/Elastic.Documentation.Configuration.Tests/CloneTimeoutTests.cs
@@ -1,0 +1,57 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using AwesomeAssertions;
+using Elastic.Documentation.Configuration.Assembler;
+using YamlDotNet.Core;
+
+namespace Elastic.Documentation.Configuration.Tests;
+
+public class CloneTimeoutTests
+{
+	private static AssemblyConfiguration Deserialize(string refsYaml) =>
+		AssemblyConfiguration.Deserialize($"narrative:\nreferences:\n{refsYaml}");
+
+	[Theory]
+	[InlineData("30s", 30)]
+	[InlineData("2m", 120)]
+	[InlineData("15m", 900)]
+	[InlineData("1s", 1)]
+	public void CloneTimeout_ValidDuration_Deserializes(string input, int expectedSeconds)
+	{
+		var config = Deserialize($"  my-repo:\n    clone_timeout: {input}");
+
+		var timeout = config.ReferenceRepositories["my-repo"].CloneTimeout;
+		timeout.Should().NotBeNull();
+		timeout.Value.TotalSeconds.Should().Be(expectedSeconds);
+	}
+
+	[Fact]
+	public void CloneTimeout_Absent_IsNull()
+	{
+		var config = Deserialize("  my-repo:");
+
+		config.ReferenceRepositories["my-repo"].CloneTimeout.Should().BeNull();
+	}
+
+	[Fact]
+	public void CloneTimeout_OnNarrative_Deserializes()
+	{
+		var config = AssemblyConfiguration.Deserialize("narrative:\n  clone_timeout: 15m\nreferences:\n  some-repo:");
+
+		config.Narrative.CloneTimeout.Should().Be(TimeSpan.FromMinutes(15));
+	}
+
+	[Theory]
+	[InlineData("1h")]
+	[InlineData("90")]
+	[InlineData("0m")]
+	[InlineData("0s")]
+	[InlineData("-5m")]
+	public void CloneTimeout_InvalidDuration_ThrowsYamlException(string input)
+	{
+		var act = () => Deserialize($"  my-repo:\n    clone_timeout: {input}");
+		act.Should().Throw<YamlException>();
+	}
+}


### PR DESCRIPTION
## Why

`assembler clone` and `codex clone` have been failing the entire CI job when a single git fetch stalls — most recently `docs-content` hitting a 10-minute wall twice in the same day (runs 32874373436 and 32888557297). The existing retry loop added in #3759 never engaged: `ProcNet.Proc.Exec` *throws* `ProcExecException` on a per-attempt timeout instead of returning a non-zero exit code, so the exception bypassed the loop entirely. `CodexGitRepository.Fetch` had no retry at all, and `GitLinkIndexReader` used a raw `Process` with unbounded `WaitForExit()` and no retry.

## What

Introduces `CommandRetry.Invoke` — a small static loop that catches `ProcExecException` (ProcNet timeout) alongside non-zero exits and treats both as retryable failures. This is the actual fix for the CI failures.

`RetryPolicy` gains an `AttemptTimeout` field so the per-attempt ProcNet timeout and the retry count travel together. `ExternalCommandExecutor.ExecInWithRetry` delegates to the new loop; the error message now includes the exception text when the last failure was a timeout. `NetworkRetry` drops from 5 to 3 attempts to keep worst-case wall-clock inside job budgets.

The retry is wired into every network git call: assembler `SingleCommitOptimizedGitRepository` (fetch + pull), `CodexGitRepository.Fetch` (previously unretried), and `GitLinkIndexReader` (previously raw `Process`, now uses `Proc.Exec` + `CommandRetry`).

Adds a `clone_timeout` per-repository setting to `assembler.yml` — a duration string (`30s`, `15m`) that overrides the 10-minute CI default on a per-repo basis. `docs-content` is set to `15m` immediately. A `DurationYamlConverter` enforces seconds-or-minutes only; hours and bare integers are rejected at config-load time.

## How

`CommandRetry.Invoke` is the canonical retry primitive going forward. It lives in `Elastic.Documentation.Tooling` alongside `ExternalCommandExecutor` and is the only place `ProcExecException` is caught. `GitTimeouts.CiDefault` is the single authoritative expression for the CI-only timeout default, replacing two verbatim duplicates.