### PR TITLE
ApiExplorer: fail the build on invalid supplemental files

### DIFF
--- a/src/Elastic.ApiExplorer/OpenApiGenerator.cs
+++ b/src/Elastic.ApiExplorer/OpenApiGenerator.cs
@@ -241,8 +241,11 @@ public class OpenApiGenerator(
 		Cancel ctx)
 	{
 		var discovery = DiscoverSupplemental(openApiDocument, apiConfig);
-		ApiSupplementalValidator.Validate(
-			discovery, openApiDocument, context.Collector, moniker, emitUnmatchedBaseFiles: emitUnmatchedBaseFiles);
+		ApiSupplementalValidator.Validate(discovery, new(
+			openApiDocument,
+			context.Collector,
+			moniker,
+			EmitUnmatchedBaseFiles: emitUnmatchedBaseFiles));
 		var navigation = CreateNavigation(prefix, openApiDocument, apiConfig);
 		_logger.LogInformation("Generating OpenApiDocument {Title}", openApiDocument.Info?.Title ?? "<no title>");
 

--- a/src/Elastic.ApiExplorer/OpenApiGenerator.cs
+++ b/src/Elastic.ApiExplorer/OpenApiGenerator.cs
@@ -113,7 +113,8 @@ public class OpenApiGenerator(
 					apiConfig,
 					switcherItems,
 					versioned.Version.Moniker,
-					emitUnmatchedBaseFiles: !hasMain && versioned.Version.Moniker == monikers[0],
+					emitUnmatchedBaseFiles: versioned.Version.Moniker == "main"
+						|| (!hasMain && versioned.Version.Moniker == monikers[0]),
 					ctx)
 				.ConfigureAwait(false);
 		}

--- a/src/Elastic.ApiExplorer/OpenApiGenerator.cs
+++ b/src/Elastic.ApiExplorer/OpenApiGenerator.cs
@@ -106,7 +106,7 @@ public class OpenApiGenerator(
 			var switcherItems = ApiVersionSwitcher.Build(
 				context.UrlPathPrefix, prefix, monikers, versioned.Version.Moniker);
 			var apiUrlSuffix = ApiUrlBuilder.ProductSuffix(prefix, versioned.Version.Moniker);
-			await GenerateApiProduct(apiUrlSuffix, versioned.Document, apiConfig, switcherItems, ctx)
+			await GenerateApiProduct(apiUrlSuffix, versioned.Document, apiConfig, switcherItems, versioned.Version.Moniker, ctx)
 				.ConfigureAwait(false);
 		}
 
@@ -227,9 +227,11 @@ public class OpenApiGenerator(
 		OpenApiDocument openApiDocument,
 		ResolvedApiConfiguration? apiConfig,
 		IReadOnlyList<ApiVersionSwitcherItem> versionSwitcherItems,
+		string moniker,
 		Cancel ctx)
 	{
 		var discovery = DiscoverSupplemental(openApiDocument, apiConfig);
+		ApiSupplementalValidator.Validate(discovery, openApiDocument, context.Collector, moniker);
 		var navigation = CreateNavigation(prefix, openApiDocument, apiConfig);
 		_logger.LogInformation("Generating OpenApiDocument {Title}", openApiDocument.Info?.Title ?? "<no title>");
 

--- a/src/Elastic.ApiExplorer/OpenApiGenerator.cs
+++ b/src/Elastic.ApiExplorer/OpenApiGenerator.cs
@@ -24,6 +24,10 @@ namespace Elastic.ApiExplorer;
 
 internal sealed record VersionedOpenApiDocument(ResolvedApiVersion Version, OpenApiDocument Document);
 
+internal sealed record ResolvedProductDocuments(
+	IReadOnlyList<VersionedOpenApiDocument> Documents,
+	string? UnmatchedBaseFilesMoniker);
+
 internal sealed record ApiProductGeneration(
 	string Prefix,
 	OpenApiDocument Document,
@@ -104,12 +108,12 @@ public class OpenApiGenerator(
 		ResolvedApiConfiguration apiConfig,
 		Cancel ctx)
 	{
-		var versionedDocuments = await ResolveDocumentsForProduct(prefix, apiConfig, ctx).ConfigureAwait(false);
-		if (versionedDocuments.Count == 0)
+		var resolved = await ResolveDocumentsForProduct(prefix, apiConfig, ctx).ConfigureAwait(false);
+		if (resolved.Documents.Count == 0)
 			return null;
 
+		var versionedDocuments = resolved.Documents;
 		var monikers = versionedDocuments.Select(v => v.Version.Moniker).ToArray();
-		var hasMain = monikers.Contains("main");
 		foreach (var versioned in versionedDocuments)
 		{
 			var switcherItems = ApiVersionSwitcher.Build(
@@ -122,8 +126,7 @@ public class OpenApiGenerator(
 						apiConfig,
 						switcherItems,
 						versioned.Version.Moniker,
-						EmitUnmatchedBaseFiles: versioned.Version.Moniker == "main"
-							|| (!hasMain && versioned.Version.Moniker == monikers[0])),
+						EmitUnmatchedBaseFiles: versioned.Version.Moniker == resolved.UnmatchedBaseFilesMoniker),
 					ctx)
 				.ConfigureAwait(false);
 		}
@@ -139,9 +142,11 @@ public class OpenApiGenerator(
 
 	/// <summary>
 	/// Resolves every OpenAPI document to render for one API key, including canonical <c>main</c>
-	/// and released numeric majors. Returns an empty list when nothing could be resolved.
+	/// and released numeric majors. Returns empty documents when nothing could be resolved.
+	/// <see cref="ResolvedProductDocuments.UnmatchedBaseFilesMoniker"/> is the declared latest
+	/// version only when that document actually resolved.
 	/// </summary>
-	internal async Task<IReadOnlyList<VersionedOpenApiDocument>> ResolveDocumentsForProduct(
+	internal async Task<ResolvedProductDocuments> ResolveDocumentsForProduct(
 		string apiKey,
 		ResolvedApiConfiguration apiConfig,
 		Cancel ctx)
@@ -158,13 +163,17 @@ public class OpenApiGenerator(
 			: [.. versions];
 
 		if (versionsToRender.Length == 0)
-			return [];
+			return new([], null);
 
 		if (!versionless && versionsToRender.All(v => v.Moniker != "main") && versions.Count > 0)
 		{
 			context.Collector.EmitGlobalWarning(
 				$"Version index for API '{apiKey}' has no 'main' entry; the unversioned path will not be rendered.");
 		}
+
+		var latestDeclared = versionsToRender.Any(v => v.Moniker == "main")
+			? "main"
+			: versionsToRender[0].Moniker;
 
 		var results = new List<VersionedOpenApiDocument>(versionsToRender.Length);
 		foreach (var version in versionsToRender)
@@ -176,18 +185,18 @@ public class OpenApiGenerator(
 			results.Add(new VersionedOpenApiDocument(version, document));
 		}
 
-		return results;
+		return ToResolvedProductDocuments(results, latestDeclared);
 	}
 
-	private async Task<IReadOnlyList<VersionedOpenApiDocument>> ResolveLocalMainOnly(IFileInfo localFile)
+	private async Task<ResolvedProductDocuments> ResolveLocalMainOnly(IFileInfo localFile)
 	{
 		var document = await _openApiReader.ReadAsync(localFile).ConfigureAwait(false);
 		if (document is null)
-			return [];
+			return new([], null);
 
-		return
+		VersionedOpenApiDocument[] documents =
 		[
-			new VersionedOpenApiDocument(
+			new(
 				new ResolvedApiVersion
 				{
 					Moniker = "main",
@@ -197,7 +206,15 @@ public class OpenApiGenerator(
 				},
 				document)
 		];
+		return ToResolvedProductDocuments(documents, "main");
 	}
+
+	private static ResolvedProductDocuments ToResolvedProductDocuments(
+		IReadOnlyList<VersionedOpenApiDocument> documents,
+		string latestDeclared) =>
+		new(
+			documents,
+			documents.Any(d => d.Version.Moniker == latestDeclared) ? latestDeclared : null);
 
 	private static bool IsVersionlessProduct(Product product) =>
 		product.VersioningSystem?.IsVersionless == true;

--- a/src/Elastic.ApiExplorer/OpenApiGenerator.cs
+++ b/src/Elastic.ApiExplorer/OpenApiGenerator.cs
@@ -101,12 +101,20 @@ public class OpenApiGenerator(
 			return null;
 
 		var monikers = versionedDocuments.Select(v => v.Version.Moniker).ToArray();
+		var hasMain = monikers.Contains("main");
 		foreach (var versioned in versionedDocuments)
 		{
 			var switcherItems = ApiVersionSwitcher.Build(
 				context.UrlPathPrefix, prefix, monikers, versioned.Version.Moniker);
 			var apiUrlSuffix = ApiUrlBuilder.ProductSuffix(prefix, versioned.Version.Moniker);
-			await GenerateApiProduct(apiUrlSuffix, versioned.Document, apiConfig, switcherItems, versioned.Version.Moniker, ctx)
+			await GenerateApiProduct(
+					apiUrlSuffix,
+					versioned.Document,
+					apiConfig,
+					switcherItems,
+					versioned.Version.Moniker,
+					emitUnmatchedBaseFiles: !hasMain && versioned.Version.Moniker == monikers[0],
+					ctx)
 				.ConfigureAwait(false);
 		}
 
@@ -228,10 +236,12 @@ public class OpenApiGenerator(
 		ResolvedApiConfiguration? apiConfig,
 		IReadOnlyList<ApiVersionSwitcherItem> versionSwitcherItems,
 		string moniker,
+		bool emitUnmatchedBaseFiles,
 		Cancel ctx)
 	{
 		var discovery = DiscoverSupplemental(openApiDocument, apiConfig);
-		ApiSupplementalValidator.Validate(discovery, openApiDocument, context.Collector, moniker);
+		ApiSupplementalValidator.Validate(
+			discovery, openApiDocument, context.Collector, moniker, emitUnmatchedBaseFiles: emitUnmatchedBaseFiles);
 		var navigation = CreateNavigation(prefix, openApiDocument, apiConfig);
 		_logger.LogInformation("Generating OpenApiDocument {Title}", openApiDocument.Info?.Title ?? "<no title>");
 

--- a/src/Elastic.ApiExplorer/OpenApiGenerator.cs
+++ b/src/Elastic.ApiExplorer/OpenApiGenerator.cs
@@ -24,6 +24,14 @@ namespace Elastic.ApiExplorer;
 
 internal sealed record VersionedOpenApiDocument(ResolvedApiVersion Version, OpenApiDocument Document);
 
+internal sealed record ApiProductGeneration(
+	string Prefix,
+	OpenApiDocument Document,
+	ResolvedApiConfiguration? ApiConfig,
+	IReadOnlyList<ApiVersionSwitcherItem> VersionSwitcherItems,
+	string Moniker,
+	bool EmitUnmatchedBaseFiles);
+
 /// <summary>
 /// Renders API explorer pages for every configured OpenAPI specification: builds the navigation
 /// tree via <see cref="ApiNavigationBuilder"/> and writes each page to the output directory.
@@ -108,13 +116,14 @@ public class OpenApiGenerator(
 				context.UrlPathPrefix, prefix, monikers, versioned.Version.Moniker);
 			var apiUrlSuffix = ApiUrlBuilder.ProductSuffix(prefix, versioned.Version.Moniker);
 			await GenerateApiProduct(
-					apiUrlSuffix,
-					versioned.Document,
-					apiConfig,
-					switcherItems,
-					versioned.Version.Moniker,
-					emitUnmatchedBaseFiles: versioned.Version.Moniker == "main"
-						|| (!hasMain && versioned.Version.Moniker == monikers[0]),
+					new(
+						apiUrlSuffix,
+						versioned.Document,
+						apiConfig,
+						switcherItems,
+						versioned.Version.Moniker,
+						EmitUnmatchedBaseFiles: versioned.Version.Moniker == "main"
+							|| (!hasMain && versioned.Version.Moniker == monikers[0])),
 					ctx)
 				.ConfigureAwait(false);
 		}
@@ -231,33 +240,26 @@ public class OpenApiGenerator(
 		_ = await Render(navigation.Index, navigation.Index.Model, renderContext, navigationRenderer, ctx).ConfigureAwait(false);
 	}
 
-	private async Task GenerateApiProduct(
-		string prefix,
-		OpenApiDocument openApiDocument,
-		ResolvedApiConfiguration? apiConfig,
-		IReadOnlyList<ApiVersionSwitcherItem> versionSwitcherItems,
-		string moniker,
-		bool emitUnmatchedBaseFiles,
-		Cancel ctx)
+	private async Task GenerateApiProduct(ApiProductGeneration generation, Cancel ctx)
 	{
-		var discovery = DiscoverSupplemental(openApiDocument, apiConfig);
+		var discovery = DiscoverSupplemental(generation.Document, generation.ApiConfig);
 		ApiSupplementalValidator.Validate(discovery, new(
-			openApiDocument,
+			generation.Document,
 			context.Collector,
-			moniker,
-			EmitUnmatchedBaseFiles: emitUnmatchedBaseFiles));
-		var navigation = CreateNavigation(prefix, openApiDocument, apiConfig);
-		_logger.LogInformation("Generating OpenApiDocument {Title}", openApiDocument.Info?.Title ?? "<no title>");
+			generation.Moniker,
+			EmitUnmatchedBaseFiles: generation.EmitUnmatchedBaseFiles));
+		var navigation = CreateNavigation(generation.Prefix, generation.Document, generation.ApiConfig);
+		_logger.LogInformation("Generating OpenApiDocument {Title}", generation.Document.Info?.Title ?? "<no title>");
 
 		var navigationRenderer = new IsolatedBuildNavigationHtmlWriter(context, navigation);
 
-		var renderContext = new ApiRenderContext(context, openApiDocument, _contentHashProvider)
+		var renderContext = new ApiRenderContext(context, generation.Document, _contentHashProvider)
 		{
 			NavigationHtml = string.Empty,
 			CurrentNavigation = navigation,
 			MarkdownRenderer = markdownStringRenderer,
 			ApiExplorerLog = _logger,
-			VersionSwitcherItems = versionSwitcherItems,
+			VersionSwitcherItems = generation.VersionSwitcherItems,
 			OperationSupplemental = ApiSupplementalDoc.Load(discovery.Operations),
 			TagSupplemental = ApiSupplementalDoc.Load(discovery.Tags)
 		};

--- a/src/Elastic.ApiExplorer/Supplemental/ApiSupplementalDiscovery.cs
+++ b/src/Elastic.ApiExplorer/Supplemental/ApiSupplementalDiscovery.cs
@@ -141,7 +141,7 @@ public static class ApiSupplementalDiscovery
 	private static string? OperationTagName(OpenApiTagReference tagRef) =>
 		!string.IsNullOrEmpty(tagRef.Name) ? tagRef.Name : tagRef.Reference?.Id;
 
-	private static (Dictionary<string, string> UniqueBySlug, IReadOnlyList<TagSlugCollision> Collisions) IndexTags(
+	internal static (Dictionary<string, string> UniqueBySlug, IReadOnlyList<TagSlugCollision> Collisions) IndexTags(
 		IReadOnlyCollection<string> tagNames)
 	{
 		var bySlug = new Dictionary<string, List<string>>(StringComparer.Ordinal);

--- a/src/Elastic.ApiExplorer/Supplemental/ApiSupplementalDiscovery.cs
+++ b/src/Elastic.ApiExplorer/Supplemental/ApiSupplementalDiscovery.cs
@@ -39,9 +39,9 @@ public static class ApiSupplementalDiscovery
 
 	public static ApiSupplementalDiscoveryResult Discover(IDirectoryInfo? folder, OpenApiDocument document)
 	{
-		var (operationIds, tagNames) = CollectEntities(document);
+		var (operationsById, tagNames) = CollectEntities(document);
 		var (tagBySlug, collisions) = IndexTags(tagNames);
-		return MatchFiles(folder, operationIds, tagBySlug, collisions);
+		return MatchFiles(folder, operationsById.Keys.ToHashSet(StringComparer.Ordinal), tagBySlug, collisions);
 	}
 
 	private static ApiSupplementalDiscoveryResult MatchFiles(
@@ -98,9 +98,10 @@ public static class ApiSupplementalDiscovery
 		};
 	}
 
-	private static (HashSet<string> OperationIds, HashSet<string> TagNames) CollectEntities(OpenApiDocument document)
+	internal static (Dictionary<string, OpenApiOperation> OperationsById, HashSet<string> TagNames) CollectEntities(
+		OpenApiDocument document)
 	{
-		var operations = new HashSet<string>(StringComparer.Ordinal);
+		var operations = new Dictionary<string, OpenApiOperation>(StringComparer.Ordinal);
 		var tags = new HashSet<string>(StringComparer.Ordinal);
 
 		if (document.Tags is not null)
@@ -120,7 +121,7 @@ public static class ApiSupplementalDiscovery
 			foreach (var operation in path.Value.Operations.Values)
 			{
 				if (!string.IsNullOrWhiteSpace(operation.OperationId))
-					_ = operations.Add(operation.OperationId);
+					operations[operation.OperationId] = operation;
 
 				if (operation.Tags is null)
 					continue;

--- a/src/Elastic.ApiExplorer/Supplemental/ApiSupplementalValidator.cs
+++ b/src/Elastic.ApiExplorer/Supplemental/ApiSupplementalValidator.cs
@@ -16,18 +16,22 @@ internal static class ApiSupplementalValidator
 		ApiSupplementalDiscoveryResult discovery,
 		OpenApiDocument document,
 		IDiagnosticsCollector collector,
-		string moniker)
+		string moniker,
+		bool emitUnmatchedBaseFiles = false)
 	{
 		var (operationsById, tagNames) = ApiSupplementalDiscovery.CollectEntities(document);
-		if (moniker == "main")
+		var isNumeric = int.TryParse(moniker, out var major);
+		if (moniker != "main" && !isNumeric)
+			return;
+
+		if (moniker == "main" || emitUnmatchedBaseFiles)
 			EmitUnmatched(discovery.Unmatched, collector, "the latest spec");
-		else if (int.TryParse(moniker, out var major))
+
+		if (isNumeric)
 		{
 			var tagSlugs = new HashSet<string>(tagNames.Select(ApiUrlBuilder.TagSlug), StringComparer.Ordinal);
 			ValidateVersionSuffixed(discovery.VersionSuffixed, major, operationsById, tagSlugs, document, collector);
 		}
-		else
-			return;
 
 		ValidateOperationOverrides(discovery.Operations, operationsById, document, collector);
 	}

--- a/src/Elastic.ApiExplorer/Supplemental/ApiSupplementalValidator.cs
+++ b/src/Elastic.ApiExplorer/Supplemental/ApiSupplementalValidator.cs
@@ -10,26 +10,30 @@ using Microsoft.OpenApi;
 
 namespace Elastic.ApiExplorer.Supplemental;
 
+internal sealed record ApiSupplementalValidationRequest(
+	OpenApiDocument Document,
+	IDiagnosticsCollector Collector,
+	string Moniker,
+	bool EmitUnmatchedBaseFiles);
+
 internal static class ApiSupplementalValidator
 {
 	public static void Validate(
 		ApiSupplementalDiscoveryResult discovery,
-		OpenApiDocument document,
-		IDiagnosticsCollector collector,
-		string moniker,
-		bool emitUnmatchedBaseFiles)
+		ApiSupplementalValidationRequest request)
 	{
-		if (emitUnmatchedBaseFiles)
-			EmitUnmatched(discovery.Unmatched, collector, "the latest spec");
+		if (request.EmitUnmatchedBaseFiles)
+			EmitUnmatched(discovery.Unmatched, request.Collector, "the latest spec");
 
-		var (operationsById, tagNames) = ApiSupplementalDiscovery.CollectEntities(document);
-		if (int.TryParse(moniker, out var major))
+		var (operationsById, tagNames) = ApiSupplementalDiscovery.CollectEntities(request.Document);
+		if (int.TryParse(request.Moniker, out var major))
 		{
 			var tagSlugs = new HashSet<string>(tagNames.Select(ApiUrlBuilder.TagSlug), StringComparer.Ordinal);
-			ValidateVersionSuffixed(discovery.VersionSuffixed, major, operationsById, tagSlugs, document, collector);
+			ValidateVersionSuffixed(
+				discovery.VersionSuffixed, major, operationsById, tagSlugs, request.Document, request.Collector);
 		}
 
-		ValidateOperationOverrides(discovery.Operations, operationsById, document, collector);
+		ValidateOperationOverrides(discovery.Operations, operationsById, request.Document, request.Collector);
 	}
 
 	private static void EmitUnmatched(

--- a/src/Elastic.ApiExplorer/Supplemental/ApiSupplementalValidator.cs
+++ b/src/Elastic.ApiExplorer/Supplemental/ApiSupplementalValidator.cs
@@ -153,8 +153,41 @@ internal static class ApiSupplementalValidator
 
 	private static HashSet<string> RequestBodyFieldNames(SchemaAnalyzer analyzer, OpenApiOperation operation)
 	{
+		var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 		var schema = operation.RequestBody?.Content?.FirstOrDefault().Value?.Schema;
-		var properties = analyzer.GetSchemaProperties(schema);
-		return new HashSet<string>(properties?.Keys ?? [], StringComparer.OrdinalIgnoreCase);
+		CollectFieldNames(analyzer, schema, names, []);
+		return names;
+	}
+
+	private static void CollectFieldNames(
+		SchemaAnalyzer analyzer,
+		IOpenApiSchema? schema,
+		HashSet<string> names,
+		HashSet<object> visited)
+	{
+		var resolved = analyzer.ResolveSchema(schema);
+		if (resolved is null || !visited.Add(resolved))
+			return;
+
+		var properties = analyzer.GetSchemaProperties(resolved);
+		if (properties is not null)
+		{
+			foreach (var (name, child) in properties)
+			{
+				_ = names.Add(name);
+				CollectFieldNames(analyzer, child, names, visited);
+			}
+		}
+
+		if (resolved.Items is not null)
+			CollectFieldNames(analyzer, resolved.Items, names, visited);
+
+		if (resolved.AdditionalProperties is IOpenApiSchema additional)
+			CollectFieldNames(analyzer, additional, names, visited);
+
+		foreach (var option in resolved.OneOf ?? [])
+			CollectFieldNames(analyzer, option, names, visited);
+		foreach (var option in resolved.AnyOf ?? [])
+			CollectFieldNames(analyzer, option, names, visited);
 	}
 }

--- a/src/Elastic.ApiExplorer/Supplemental/ApiSupplementalValidator.cs
+++ b/src/Elastic.ApiExplorer/Supplemental/ApiSupplementalValidator.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information
 
 using System.IO.Abstractions;
-using Elastic.ApiExplorer.Infrastructure;
 using Elastic.ApiExplorer.Model;
 using Elastic.Documentation.Diagnostics;
 using Microsoft.OpenApi;
@@ -28,7 +27,8 @@ internal static class ApiSupplementalValidator
 		var (operationsById, tagNames) = ApiSupplementalDiscovery.CollectEntities(request.Document);
 		if (int.TryParse(request.Moniker, out var major))
 		{
-			var tagSlugs = new HashSet<string>(tagNames.Select(ApiUrlBuilder.TagSlug), StringComparer.Ordinal);
+			var (uniqueBySlug, _) = ApiSupplementalDiscovery.IndexTags(tagNames);
+			var tagSlugs = new HashSet<string>(uniqueBySlug.Keys, StringComparer.Ordinal);
 			ValidateVersionSuffixed(
 				discovery.VersionSuffixed, major, operationsById, tagSlugs, request.Document, request.Collector);
 		}

--- a/src/Elastic.ApiExplorer/Supplemental/ApiSupplementalValidator.cs
+++ b/src/Elastic.ApiExplorer/Supplemental/ApiSupplementalValidator.cs
@@ -17,17 +17,13 @@ internal static class ApiSupplementalValidator
 		OpenApiDocument document,
 		IDiagnosticsCollector collector,
 		string moniker,
-		bool emitUnmatchedBaseFiles = false)
+		bool emitUnmatchedBaseFiles)
 	{
-		if (moniker == "main" || emitUnmatchedBaseFiles)
+		if (emitUnmatchedBaseFiles)
 			EmitUnmatched(discovery.Unmatched, collector, "the latest spec");
 
-		var isNumeric = int.TryParse(moniker, out var major);
-		if (moniker != "main" && !isNumeric)
-			return;
-
 		var (operationsById, tagNames) = ApiSupplementalDiscovery.CollectEntities(document);
-		if (isNumeric)
+		if (int.TryParse(moniker, out var major))
 		{
 			var tagSlugs = new HashSet<string>(tagNames.Select(ApiUrlBuilder.TagSlug), StringComparer.Ordinal);
 			ValidateVersionSuffixed(discovery.VersionSuffixed, major, operationsById, tagSlugs, document, collector);

--- a/src/Elastic.ApiExplorer/Supplemental/ApiSupplementalValidator.cs
+++ b/src/Elastic.ApiExplorer/Supplemental/ApiSupplementalValidator.cs
@@ -1,0 +1,161 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions;
+using Elastic.ApiExplorer.Infrastructure;
+using Elastic.ApiExplorer.Model;
+using Elastic.Documentation.Diagnostics;
+using Microsoft.OpenApi;
+
+namespace Elastic.ApiExplorer.Supplemental;
+
+internal static class ApiSupplementalValidator
+{
+	public static void Validate(
+		ApiSupplementalDiscoveryResult discovery,
+		OpenApiDocument document,
+		IDiagnosticsCollector collector,
+		string moniker)
+	{
+		var (operationsById, tagNames) = ApiSupplementalDiscovery.CollectEntities(document);
+		if (moniker == "main")
+		{
+			EmitUnmatched(discovery.Unmatched, collector, "the latest spec");
+			ValidateOperationOverrides(discovery.Operations, operationsById, document, collector);
+			return;
+		}
+
+		if (!int.TryParse(moniker, out var major))
+			return;
+
+		var tagSlugs = new HashSet<string>(tagNames.Select(ApiUrlBuilder.TagSlug), StringComparer.Ordinal);
+		ValidateVersionSuffixed(discovery.VersionSuffixed, major, operationsById, tagSlugs, document, collector);
+	}
+
+	private static void EmitUnmatched(
+		IReadOnlyList<IFileInfo> unmatched,
+		IDiagnosticsCollector collector,
+		string specLabel)
+	{
+		foreach (var file in unmatched)
+			EmitUnmatchedFile(file, collector, specLabel);
+	}
+
+	private static void EmitUnmatchedFile(IFileInfo file, IDiagnosticsCollector collector, string specLabel)
+	{
+		var kind = file.Name.StartsWith("op-", StringComparison.OrdinalIgnoreCase)
+			? "operationId"
+			: "tag";
+		collector.EmitError(file, $"API supplemental file '{file.Name}' does not match any {kind} in {specLabel}");
+	}
+
+	private static void ValidateVersionSuffixed(
+		IReadOnlyList<ApiSupplementalVersionedFile> versionSuffixed,
+		int major,
+		IReadOnlyDictionary<string, OpenApiOperation> operationsById,
+		IReadOnlySet<string> tagSlugs,
+		OpenApiDocument document,
+		IDiagnosticsCollector collector)
+	{
+		var analyzer = new SchemaAnalyzer(document);
+		var specLabel = $"version {major}";
+		foreach (var versioned in versionSuffixed)
+		{
+			if (versioned.Name.VersionMajor != major)
+				continue;
+
+			if (versioned.Name.Kind == ApiSupplementalKind.Operation)
+			{
+				if (!operationsById.TryGetValue(versioned.Name.Stem, out var operation))
+				{
+					EmitUnmatchedFile(versioned.File, collector, specLabel);
+					continue;
+				}
+
+				ValidateFileOverrides(versioned.File, operation, analyzer, collector);
+				continue;
+			}
+
+			if (!tagSlugs.Contains(versioned.Name.Stem))
+				EmitUnmatchedFile(versioned.File, collector, specLabel);
+		}
+	}
+
+	private static void ValidateOperationOverrides(
+		IReadOnlyDictionary<string, IFileInfo> operationFiles,
+		IReadOnlyDictionary<string, OpenApiOperation> operationsById,
+		OpenApiDocument document,
+		IDiagnosticsCollector collector)
+	{
+		var analyzer = new SchemaAnalyzer(document);
+		foreach (var (operationId, file) in operationFiles)
+		{
+			if (!operationsById.TryGetValue(operationId, out var operation))
+				continue;
+
+			ValidateFileOverrides(file, operation, analyzer, collector);
+		}
+	}
+
+	private static void ValidateFileOverrides(
+		IFileInfo file,
+		OpenApiOperation operation,
+		SchemaAnalyzer analyzer,
+		IDiagnosticsCollector collector)
+	{
+		var doc = ApiSupplementalDoc.Parse(file.FileSystem.File.ReadAllText(file.FullName));
+		if (doc is null)
+			return;
+
+		ValidateOverrideKeys(file, operation, analyzer, collector, doc);
+	}
+
+	private static void ValidateOverrideKeys(
+		IFileInfo file,
+		OpenApiOperation operation,
+		SchemaAnalyzer analyzer,
+		IDiagnosticsCollector collector,
+		ApiSupplementalDoc doc)
+	{
+		var operationId = operation.OperationId ?? "";
+		if (doc.ParameterOverrides.Count > 0)
+		{
+			var parameterNames = ParameterNames(operation);
+			foreach (var key in doc.ParameterOverrides.Keys)
+			{
+				if (!parameterNames.Contains(key))
+					collector.EmitError(file, $"API supplemental: Parameter '{key}' not found in operation '{operationId}'");
+			}
+		}
+
+		if (doc.RequestBodyOverrides.Count > 0)
+		{
+			var bodyNames = RequestBodyFieldNames(analyzer, operation);
+			foreach (var key in doc.RequestBodyOverrides.Keys)
+			{
+				if (!bodyNames.Contains(key))
+					collector.EmitError(file, $"API supplemental: Request body field '{key}' not found in operation '{operationId}'");
+			}
+		}
+	}
+
+	private static HashSet<string> ParameterNames(OpenApiOperation operation)
+	{
+		var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+		foreach (var parameter in operation.Parameters ?? [])
+		{
+			if (!string.IsNullOrEmpty(parameter.Name))
+				_ = names.Add(parameter.Name);
+		}
+
+		return names;
+	}
+
+	private static HashSet<string> RequestBodyFieldNames(SchemaAnalyzer analyzer, OpenApiOperation operation)
+	{
+		var schema = operation.RequestBody?.Content?.FirstOrDefault().Value?.Schema;
+		var properties = analyzer.GetSchemaProperties(schema);
+		return new HashSet<string>(properties?.Keys ?? [], StringComparer.OrdinalIgnoreCase);
+	}
+}

--- a/src/Elastic.ApiExplorer/Supplemental/ApiSupplementalValidator.cs
+++ b/src/Elastic.ApiExplorer/Supplemental/ApiSupplementalValidator.cs
@@ -19,14 +19,14 @@ internal static class ApiSupplementalValidator
 		string moniker,
 		bool emitUnmatchedBaseFiles = false)
 	{
-		var (operationsById, tagNames) = ApiSupplementalDiscovery.CollectEntities(document);
+		if (moniker == "main" || emitUnmatchedBaseFiles)
+			EmitUnmatched(discovery.Unmatched, collector, "the latest spec");
+
 		var isNumeric = int.TryParse(moniker, out var major);
 		if (moniker != "main" && !isNumeric)
 			return;
 
-		if (moniker == "main" || emitUnmatchedBaseFiles)
-			EmitUnmatched(discovery.Unmatched, collector, "the latest spec");
-
+		var (operationsById, tagNames) = ApiSupplementalDiscovery.CollectEntities(document);
 		if (isNumeric)
 		{
 			var tagSlugs = new HashSet<string>(tagNames.Select(ApiUrlBuilder.TagSlug), StringComparer.Ordinal);

--- a/src/Elastic.ApiExplorer/Supplemental/ApiSupplementalValidator.cs
+++ b/src/Elastic.ApiExplorer/Supplemental/ApiSupplementalValidator.cs
@@ -33,7 +33,7 @@ internal static class ApiSupplementalValidator
 				discovery.VersionSuffixed, major, operationsById, tagSlugs, request.Document, request.Collector);
 		}
 
-		ValidateOperationOverrides(discovery.Operations, operationsById, request.Document, request.Collector);
+		ValidateOperationOverrides(discovery.Operations, operationsById, request);
 	}
 
 	private static void EmitUnmatched(
@@ -76,7 +76,7 @@ internal static class ApiSupplementalValidator
 					continue;
 				}
 
-				ValidateFileOverrides(versioned.File, operation, analyzer, collector);
+				ValidateFileOverrides(versioned.File, operation, analyzer, collector, specLabel);
 				continue;
 			}
 
@@ -88,30 +88,34 @@ internal static class ApiSupplementalValidator
 	private static void ValidateOperationOverrides(
 		IReadOnlyDictionary<string, IFileInfo> operationFiles,
 		IReadOnlyDictionary<string, OpenApiOperation> operationsById,
-		OpenApiDocument document,
-		IDiagnosticsCollector collector)
+		ApiSupplementalValidationRequest request)
 	{
-		var analyzer = new SchemaAnalyzer(document);
+		var analyzer = new SchemaAnalyzer(request.Document);
+		var specLabel = SpecLabel(request.Moniker);
 		foreach (var (operationId, file) in operationFiles)
 		{
 			if (!operationsById.TryGetValue(operationId, out var operation))
 				continue;
 
-			ValidateFileOverrides(file, operation, analyzer, collector);
+			ValidateFileOverrides(file, operation, analyzer, request.Collector, specLabel);
 		}
 	}
+
+	private static string SpecLabel(string moniker) =>
+		int.TryParse(moniker, out var major) ? $"version {major}" : "the latest spec";
 
 	private static void ValidateFileOverrides(
 		IFileInfo file,
 		OpenApiOperation operation,
 		SchemaAnalyzer analyzer,
-		IDiagnosticsCollector collector)
+		IDiagnosticsCollector collector,
+		string specLabel)
 	{
 		var doc = ApiSupplementalDoc.Parse(file.FileSystem.File.ReadAllText(file.FullName));
 		if (doc is null)
 			return;
 
-		ValidateOverrideKeys(file, operation, analyzer, collector, doc);
+		ValidateOverrideKeys(file, operation, analyzer, collector, doc, specLabel);
 	}
 
 	private static void ValidateOverrideKeys(
@@ -119,7 +123,8 @@ internal static class ApiSupplementalValidator
 		OpenApiOperation operation,
 		SchemaAnalyzer analyzer,
 		IDiagnosticsCollector collector,
-		ApiSupplementalDoc doc)
+		ApiSupplementalDoc doc,
+		string specLabel)
 	{
 		var operationId = operation.OperationId ?? "";
 		if (doc.ParameterOverrides.Count > 0)
@@ -128,7 +133,7 @@ internal static class ApiSupplementalValidator
 			foreach (var key in doc.ParameterOverrides.Keys)
 			{
 				if (!parameterNames.Contains(key))
-					collector.EmitError(file, $"API supplemental: Parameter '{key}' not found in operation '{operationId}'");
+					collector.EmitError(file, $"API supplemental: Parameter '{key}' not found in operation '{operationId}' in {specLabel}");
 			}
 		}
 
@@ -138,7 +143,7 @@ internal static class ApiSupplementalValidator
 			foreach (var key in doc.RequestBodyOverrides.Keys)
 			{
 				if (!bodyNames.Contains(key))
-					collector.EmitError(file, $"API supplemental: Request body field '{key}' not found in operation '{operationId}'");
+					collector.EmitError(file, $"API supplemental: Request body field '{key}' not found in operation '{operationId}' in {specLabel}");
 			}
 		}
 	}

--- a/src/Elastic.ApiExplorer/Supplemental/ApiSupplementalValidator.cs
+++ b/src/Elastic.ApiExplorer/Supplemental/ApiSupplementalValidator.cs
@@ -20,17 +20,16 @@ internal static class ApiSupplementalValidator
 	{
 		var (operationsById, tagNames) = ApiSupplementalDiscovery.CollectEntities(document);
 		if (moniker == "main")
-		{
 			EmitUnmatched(discovery.Unmatched, collector, "the latest spec");
-			ValidateOperationOverrides(discovery.Operations, operationsById, document, collector);
-			return;
+		else if (int.TryParse(moniker, out var major))
+		{
+			var tagSlugs = new HashSet<string>(tagNames.Select(ApiUrlBuilder.TagSlug), StringComparer.Ordinal);
+			ValidateVersionSuffixed(discovery.VersionSuffixed, major, operationsById, tagSlugs, document, collector);
 		}
-
-		if (!int.TryParse(moniker, out var major))
+		else
 			return;
 
-		var tagSlugs = new HashSet<string>(tagNames.Select(ApiUrlBuilder.TagSlug), StringComparer.Ordinal);
-		ValidateVersionSuffixed(discovery.VersionSuffixed, major, operationsById, tagSlugs, document, collector);
+		ValidateOperationOverrides(discovery.Operations, operationsById, document, collector);
 	}
 
 	private static void EmitUnmatched(

--- a/tests/Elastic.ApiExplorer.Tests/OpenApiGeneratorCurrentSpecResolutionTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/OpenApiGeneratorCurrentSpecResolutionTests.cs
@@ -71,8 +71,8 @@ public class OpenApiGeneratorCurrentSpecResolutionTests
 			versionIndexClient,
 			reader);
 
-		var documents = await generator.ResolveDocumentsForProduct(
-			"cloud-serverless", ApiConfig(product, localFile), TestContext.Current.CancellationToken);
+		var documents = (await generator.ResolveDocumentsForProduct(
+			"cloud-serverless", ApiConfig(product, localFile), TestContext.Current.CancellationToken)).Documents;
 
 		documents.Should().ContainSingle().Which.Document.Should().BeSameAs(expectedDocument);
 		handler.CallCount.Should().Be(0, "a versionless local spec must short-circuit remote version resolution");
@@ -112,8 +112,8 @@ public class OpenApiGeneratorCurrentSpecResolutionTests
 
 		var errorsBeforeResolution = collector.Errors;
 
-		var documents = await generator.ResolveDocumentsForProduct(
-			"elasticsearch", ApiConfig(product), TestContext.Current.CancellationToken);
+		var documents = (await generator.ResolveDocumentsForProduct(
+			"elasticsearch", ApiConfig(product), TestContext.Current.CancellationToken)).Documents;
 
 		documents.Should().ContainSingle().Which.Document.Should().BeSameAs(expectedDocument);
 		handler.RequestedPaths.Should().BeEquivalentTo(
@@ -145,8 +145,8 @@ public class OpenApiGeneratorCurrentSpecResolutionTests
 			reader);
 		var errorsBeforeResolution = collector.Errors;
 
-		var documents = await generator.ResolveDocumentsForProduct(
-			"elasticsearch", ApiConfig(product), TestContext.Current.CancellationToken);
+		var documents = (await generator.ResolveDocumentsForProduct(
+			"elasticsearch", ApiConfig(product), TestContext.Current.CancellationToken)).Documents;
 
 		documents.Should().BeEmpty();
 		collector.Errors.Should().BeGreaterThan(errorsBeforeResolution);

--- a/tests/Elastic.ApiExplorer.Tests/OpenApiGeneratorMultiVersionTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/OpenApiGeneratorMultiVersionTests.cs
@@ -96,7 +96,7 @@ public class OpenApiGeneratorMultiVersionTests
 			SpecDocument("Elasticsearch 8"));
 		var generator = CreateGenerator(context, versionIndexClient, reader);
 
-		var documents = await generator.ResolveDocumentsForProduct("elasticsearch", ApiConfig(product), TestContext.Current.CancellationToken);
+		var documents = (await generator.ResolveDocumentsForProduct("elasticsearch", ApiConfig(product), TestContext.Current.CancellationToken)).Documents;
 
 		documents.Should().HaveCount(3);
 		documents.Select(d => d.Version.Moniker).Should().BeEquivalentTo(["main", "9", "8"]);
@@ -123,7 +123,7 @@ public class OpenApiGeneratorMultiVersionTests
 		var generator = CreateGenerator(context, versionIndexClient, reader);
 		var apiConfig = ApiConfig(product, specFileName: "elastic-cloud-serverless.yml", repository: "elastic/serverless-api-specification");
 
-		var documents = await generator.ResolveDocumentsForProduct("cloud-serverless", apiConfig, TestContext.Current.CancellationToken);
+		var documents = (await generator.ResolveDocumentsForProduct("cloud-serverless", apiConfig, TestContext.Current.CancellationToken)).Documents;
 
 		documents.Should().ContainSingle();
 		documents[0].Version.Moniker.Should().Be("main");
@@ -146,7 +146,7 @@ public class OpenApiGeneratorMultiVersionTests
 			.ReturnsLazily((Stream _, string _) => SpecDocument("Elasticsearch remote"));
 		var generator = CreateGenerator(context, versionIndexClient, reader);
 
-		var documents = await generator.ResolveDocumentsForProduct("elasticsearch", ApiConfig(product, localFile), TestContext.Current.CancellationToken);
+		var documents = (await generator.ResolveDocumentsForProduct("elasticsearch", ApiConfig(product, localFile), TestContext.Current.CancellationToken)).Documents;
 
 		documents.Should().HaveCount(3);
 		documents.Should().ContainSingle(d => d.Version.Moniker == "main" && d.Document == localDocument);
@@ -154,6 +154,44 @@ public class OpenApiGeneratorMultiVersionTests
 		documents.Should().ContainSingle(d => d.Version.Moniker == "8");
 		A.CallTo(() => reader.ReadAsync(localFile)).MustHaveHappenedOnceExactly();
 		A.CallTo(() => reader.ReadAsync(A<Stream>._, "elasticsearch-openapi.json")).MustHaveHappened(2, Times.Exactly);
+	}
+
+	[Fact]
+	public async Task ResolveDocumentsForProduct_MainFetchFails_DoesNotMarkOlderSpecForUnmatchedBaseFiles()
+	{
+		var collector = new DiagnosticsCollector([]);
+		var stack = TestHelpers.CreateStackVersionsConfiguration(currentMajor: 9);
+		var product = TestHelpers.CreateProduct("elasticsearch", stack.GetVersioningSystem(VersioningSystemId.Stack));
+		var context = CreateContext(collector, stack, ProductsFor(product), GitForElasticsearch());
+		var handler = new StubHandler(request =>
+		{
+			var path = request.RequestUri!.AbsolutePath;
+			if (path.EndsWith("index.json", StringComparison.Ordinal))
+				return IndexResponse(/*lang=json,strict*/ """
+					{
+						"elastic/elasticsearch": {
+							"elasticsearch-openapi.json": {
+								"main": { "version": "main" },
+								"9": { "version": "9.4" },
+								"8": { "version": "8.19" }
+							}
+						}
+					}
+					""");
+			if (path.Contains("/main/", StringComparison.Ordinal))
+				return new HttpResponseMessage(HttpStatusCode.NotFound);
+			return SpecResponse();
+		});
+		using var versionIndexClient = new VersionIndexClient(BaseUri, handler, maxAttempts: 1, sleep: (_, _) => Task.CompletedTask);
+		var reader = CreateSequentialReader(
+			SpecDocument("Elasticsearch 9"),
+			SpecDocument("Elasticsearch 8"));
+		var generator = CreateGenerator(context, versionIndexClient, reader);
+
+		var resolved = await generator.ResolveDocumentsForProduct("elasticsearch", ApiConfig(product), TestContext.Current.CancellationToken);
+
+		resolved.Documents.Select(d => d.Version.Moniker).Should().BeEquivalentTo(["9", "8"]);
+		resolved.UnmatchedBaseFilesMoniker.Should().BeNull();
 	}
 
 	[Fact]

--- a/tests/Elastic.ApiExplorer.Tests/Supplemental/ApiSupplementalValidationTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/Supplemental/ApiSupplementalValidationTests.cs
@@ -61,7 +61,7 @@ public class ApiSupplementalValidationTests(ApiExplorerFixture fixture) : IClass
 			""")), fixture.Document, "main");
 
 		collector.ErrorMessages.Should().ContainSingle(m =>
-			m.Contains("Parameter 'nope'") && m.Contains("operation 'search'"));
+			m.Contains("Parameter 'nope'") && m.Contains("operation 'search'") && m.Contains("the latest spec"));
 	}
 
 	[Fact]
@@ -81,7 +81,8 @@ public class ApiSupplementalValidationTests(ApiExplorerFixture fixture) : IClass
 			""")), fixture.Document, "main");
 
 		collector.ErrorMessages.Should().ContainSingle()
-			.Which.Should().Contain("Request body field 'nope_field'").And.Contain("operation 'search'");
+			.Which.Should().Contain("Request body field 'nope_field'").And.Contain("operation 'search'")
+			.And.Contain("the latest spec");
 	}
 
 	[Fact]
@@ -155,7 +156,7 @@ public class ApiSupplementalValidationTests(ApiExplorerFixture fixture) : IClass
 			""")), fixture.Document, "next");
 
 		collector.ErrorMessages.Should().ContainSingle(m =>
-			m.Contains("Parameter 'nope'") && m.Contains("operation 'search'"));
+			m.Contains("Parameter 'nope'") && m.Contains("operation 'search'") && m.Contains("the latest spec"));
 	}
 
 	[Fact]
@@ -169,7 +170,7 @@ public class ApiSupplementalValidationTests(ApiExplorerFixture fixture) : IClass
 			""")), SpecWith("search", "q"), "8");
 
 		collector.ErrorMessages.Should().ContainSingle(m =>
-			m.Contains("Parameter 'pretty'") && m.Contains("operation 'search'"));
+			m.Contains("Parameter 'pretty'") && m.Contains("operation 'search'") && m.Contains("version 8"));
 	}
 
 	[Fact]
@@ -225,7 +226,7 @@ public class ApiSupplementalValidationTests(ApiExplorerFixture fixture) : IClass
 			""")), fixture.Document, "8");
 
 		collector.ErrorMessages.Should().ContainSingle(m =>
-			m.Contains("Parameter 'nope'") && m.Contains("operation 'search'"));
+			m.Contains("Parameter 'nope'") && m.Contains("operation 'search'") && m.Contains("version 8"));
 	}
 
 	private static CapturingDiagnosticsCollector Validate(

--- a/tests/Elastic.ApiExplorer.Tests/Supplemental/ApiSupplementalValidationTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/Supplemental/ApiSupplementalValidationTests.cs
@@ -199,6 +199,22 @@ public class ApiSupplementalValidationTests(ApiExplorerFixture fixture) : IClass
 	}
 
 	[Fact]
+	public void Validate_VersionSuffixedTagSlugCollision_EmitsError()
+	{
+		var spec = SpecWith("ping");
+		spec.Tags = new HashSet<OpenApiTag>
+		{
+			new() { Name = "foo bar" },
+			new() { Name = "foo-bar" }
+		};
+
+		var collector = Validate(FolderWith(("tag-foo-bar.v8.md", "# supplemental")), spec, "8");
+
+		collector.ErrorMessages.Should().ContainSingle(m =>
+			m.Contains("tag-foo-bar.v8.md") && m.Contains("does not match any tag in version 8"));
+	}
+
+	[Fact]
 	public void Validate_VersionSuffixedUnknownParameter_EmitsError()
 	{
 		var collector = Validate(FolderWith(("op-search.v8.md", """

--- a/tests/Elastic.ApiExplorer.Tests/Supplemental/ApiSupplementalValidationTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/Supplemental/ApiSupplementalValidationTests.cs
@@ -119,6 +119,19 @@ public class ApiSupplementalValidationTests(ApiExplorerFixture fixture) : IClass
 	}
 
 	[Fact]
+	public void Validate_UnmatchedBaseFileWhenLatestMonikerIsNonNumeric_EmitsError()
+	{
+		var collector = Validate(
+			FolderWith(("op-does-not-exist.md", "# supplemental")),
+			SpecWith("ping"),
+			"next",
+			emitUnmatchedBaseFiles: true);
+
+		collector.ErrorMessages.Should().ContainSingle(m =>
+			m.Contains("op-does-not-exist.md") && m.Contains("does not match any operationId in the latest spec"));
+	}
+
+	[Fact]
 	public void Validate_UnknownParameterOnOlderVersionMatchedBaseFile_EmitsError()
 	{
 		var collector = Validate(FolderWith(("op-search.md", """

--- a/tests/Elastic.ApiExplorer.Tests/Supplemental/ApiSupplementalValidationTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/Supplemental/ApiSupplementalValidationTests.cs
@@ -215,8 +215,14 @@ public class ApiSupplementalValidationTests(ApiExplorerFixture fixture) : IClass
 	private static CapturingDiagnosticsCollector Validate(
 		IDirectoryInfo folder,
 		OpenApiDocument document,
+		string moniker) =>
+		Validate(folder, document, moniker, emitUnmatchedBaseFiles: moniker == "main");
+
+	private static CapturingDiagnosticsCollector Validate(
+		IDirectoryInfo folder,
+		OpenApiDocument document,
 		string moniker,
-		bool? emitUnmatchedBaseFiles = null)
+		bool emitUnmatchedBaseFiles)
 	{
 		var discovery = ApiSupplementalDiscovery.Discover(folder, document);
 		var collector = new CapturingDiagnosticsCollector();
@@ -224,7 +230,7 @@ public class ApiSupplementalValidationTests(ApiExplorerFixture fixture) : IClass
 			document,
 			collector,
 			moniker,
-			EmitUnmatchedBaseFiles: emitUnmatchedBaseFiles ?? (moniker == "main")));
+			EmitUnmatchedBaseFiles: emitUnmatchedBaseFiles));
 		return collector;
 	}
 

--- a/tests/Elastic.ApiExplorer.Tests/Supplemental/ApiSupplementalValidationTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/Supplemental/ApiSupplementalValidationTests.cs
@@ -106,6 +106,20 @@ public class ApiSupplementalValidationTests(ApiExplorerFixture fixture) : IClass
 	}
 
 	[Fact]
+	public void Validate_UnknownParameterOnOlderVersionMatchedBaseFile_EmitsError()
+	{
+		var collector = Validate(FolderWith(("op-search.md", """
+			## Parameters
+
+			: `pretty`
+			  Removed in this version.
+			""")), SpecWith("search", "q"), "8");
+
+		collector.ErrorMessages.Should().ContainSingle(m =>
+			m.Contains("Parameter 'pretty'") && m.Contains("operation 'search'"));
+	}
+
+	[Fact]
 	public void Validate_VersionSuffixedUnknownOperation_EmitsErrorNamingVersion()
 	{
 		var collector = Validate(FolderWith(("op-nope.v8.md", "# supplemental")), SpecWith("ping"), "8");
@@ -162,7 +176,7 @@ public class ApiSupplementalValidationTests(ApiExplorerFixture fixture) : IClass
 		return new MockFileSystem(data).DirectoryInfo.New(Folder);
 	}
 
-	private static OpenApiDocument SpecWith(string operationId) => new()
+	private static OpenApiDocument SpecWith(string operationId, params string[] parameterNames) => new()
 	{
 		Info = new OpenApiInfo { Title = "t", Version = "1" },
 		Paths = new OpenApiPaths
@@ -175,6 +189,9 @@ public class ApiSupplementalValidationTests(ApiExplorerFixture fixture) : IClass
 					{
 						OperationId = operationId,
 						Tags = new HashSet<OpenApiTagReference> { new("core") },
+						Parameters = parameterNames
+							.Select(name => (IOpenApiParameter)new OpenApiParameter { Name = name, In = ParameterLocation.Query })
+							.ToList(),
 						Responses = new OpenApiResponses { ["200"] = new OpenApiResponse { Description = "ok" } }
 					}
 				}

--- a/tests/Elastic.ApiExplorer.Tests/Supplemental/ApiSupplementalValidationTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/Supplemental/ApiSupplementalValidationTests.cs
@@ -220,12 +220,11 @@ public class ApiSupplementalValidationTests(ApiExplorerFixture fixture) : IClass
 	{
 		var discovery = ApiSupplementalDiscovery.Discover(folder, document);
 		var collector = new CapturingDiagnosticsCollector();
-		ApiSupplementalValidator.Validate(
-			discovery,
+		ApiSupplementalValidator.Validate(discovery, new(
 			document,
 			collector,
 			moniker,
-			emitUnmatchedBaseFiles: emitUnmatchedBaseFiles ?? (moniker == "main"));
+			EmitUnmatchedBaseFiles: emitUnmatchedBaseFiles ?? (moniker == "main")));
 		return collector;
 	}
 

--- a/tests/Elastic.ApiExplorer.Tests/Supplemental/ApiSupplementalValidationTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/Supplemental/ApiSupplementalValidationTests.cs
@@ -1,0 +1,201 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
+using AwesomeAssertions;
+using Elastic.ApiExplorer.Supplemental;
+using Elastic.Documentation;
+using Elastic.Documentation.Diagnostics;
+using Microsoft.OpenApi;
+
+namespace Elastic.ApiExplorer.Tests.Supplemental;
+
+public class ApiSupplementalValidationTests(ApiExplorerFixture fixture) : IClassFixture<ApiExplorerFixture>
+{
+	private const string Folder = "/docs/api/fixture";
+
+	[Fact]
+	public void Validate_UnmatchedOperationFileOnLatest_EmitsErrorNamingFile()
+	{
+		var collector = Validate(FolderWith(("op-does-not-exist.md", "# supplemental")), fixture.Document, "main");
+
+		collector.ErrorMessages.Should().ContainSingle(m =>
+			m.Contains("op-does-not-exist.md") && m.Contains("does not match any operationId in the latest spec"));
+	}
+
+	[Fact]
+	public void Validate_UnmatchedTagFileOnLatest_EmitsError()
+	{
+		var collector = Validate(FolderWith(("tag-does-not-exist.md", "# supplemental")), fixture.Document, "main");
+
+		collector.ErrorMessages.Should().ContainSingle(m =>
+			m.Contains("tag-does-not-exist.md") && m.Contains("does not match any tag in the latest spec"));
+	}
+
+	[Fact]
+	public void Validate_IgnoredFileOnLatest_EmitsNoError()
+	{
+		var collector = Validate(FolderWith(("random-notes.md", "# notes")), fixture.Document, "main");
+
+		collector.Errors.Should().Be(0);
+	}
+
+	[Fact]
+	public void Validate_KnownOperationWithNoUnknownKeys_EmitsNoError()
+	{
+		var collector = Validate(FolderWith(("op-search.md", "Returns hits that match the query.")), fixture.Document, "main");
+
+		collector.Errors.Should().Be(0);
+	}
+
+	[Fact]
+	public void Validate_UnknownParameterOnLatest_EmitsErrorNamingOperationAndParameter()
+	{
+		var collector = Validate(FolderWith(("op-search.md", """
+			## Parameters
+
+			: `nope`
+			  Not a search parameter.
+			""")), fixture.Document, "main");
+
+		collector.ErrorMessages.Should().ContainSingle(m =>
+			m.Contains("Parameter 'nope'") && m.Contains("operation 'search'"));
+	}
+
+	[Fact]
+	public void Validate_UnknownRequestBodyFieldOnLatest_EmitsError()
+	{
+		var collector = Validate(FolderWith(("op-search.md", """
+			## Request body
+
+			: `query`
+			  Known field.
+
+			: `fields`
+			  Also a known field.
+
+			: `nope_field`
+			  Not a request body field.
+			""")), fixture.Document, "main");
+
+		collector.ErrorMessages.Should().ContainSingle()
+			.Which.Should().Contain("Request body field 'nope_field'").And.Contain("operation 'search'");
+	}
+
+	[Fact]
+	public void Validate_ListedRealParameter_EmitsNoError()
+	{
+		var collector = Validate(FolderWith(("op-search.md", """
+			## Parameters
+
+			: `q`
+			  A query in the Lucene query string syntax.
+			""")), fixture.Document, "main");
+
+		collector.Errors.Should().Be(0);
+	}
+
+	[Fact]
+	public void Validate_UnmatchedBaseFileOnOlderVersion_EmitsNoError()
+	{
+		var collector = Validate(FolderWith(("op-search.md", "# supplemental")), SpecWith("ping"), "8");
+
+		collector.Errors.Should().Be(0);
+	}
+
+	[Fact]
+	public void Validate_VersionSuffixedUnknownOperation_EmitsErrorNamingVersion()
+	{
+		var collector = Validate(FolderWith(("op-nope.v8.md", "# supplemental")), SpecWith("ping"), "8");
+
+		collector.ErrorMessages.Should().ContainSingle(m =>
+			m.Contains("op-nope.v8.md") && m.Contains("does not match any operationId in version 8"));
+	}
+
+	[Fact]
+	public void Validate_VersionSuffixedMatchingOperation_EmitsNoUnmatchedError()
+	{
+		var collector = Validate(FolderWith(("op-search.v8.md", "Returns hits that match the query.")), fixture.Document, "8");
+
+		collector.Errors.Should().Be(0);
+	}
+
+	[Fact]
+	public void Validate_VersionSuffixedUnknownTag_EmitsErrorNamingVersion()
+	{
+		var collector = Validate(FolderWith(("tag-nope.v8.md", "# supplemental")), SpecWith("ping"), "8");
+
+		collector.ErrorMessages.Should().ContainSingle(m =>
+			m.Contains("tag-nope.v8.md") && m.Contains("does not match any tag in version 8"));
+	}
+
+	[Fact]
+	public void Validate_VersionSuffixedUnknownParameter_EmitsError()
+	{
+		var collector = Validate(FolderWith(("op-search.v8.md", """
+			## Parameters
+
+			: `nope`
+			  Not a search parameter.
+			""")), fixture.Document, "8");
+
+		collector.ErrorMessages.Should().ContainSingle(m =>
+			m.Contains("Parameter 'nope'") && m.Contains("operation 'search'"));
+	}
+
+	private static CapturingDiagnosticsCollector Validate(
+		IDirectoryInfo folder,
+		OpenApiDocument document,
+		string moniker)
+	{
+		var discovery = ApiSupplementalDiscovery.Discover(folder, document);
+		var collector = new CapturingDiagnosticsCollector();
+		ApiSupplementalValidator.Validate(discovery, document, collector, moniker);
+		return collector;
+	}
+
+	private static IDirectoryInfo FolderWith(params (string Name, string Body)[] files)
+	{
+		var data = files.ToDictionary(f => $"{Folder}/{f.Name}", f => new MockFileData(f.Body));
+		return new MockFileSystem(data).DirectoryInfo.New(Folder);
+	}
+
+	private static OpenApiDocument SpecWith(string operationId) => new()
+	{
+		Info = new OpenApiInfo { Title = "t", Version = "1" },
+		Paths = new OpenApiPaths
+		{
+			["/x"] = new OpenApiPathItem
+			{
+				Operations = new Dictionary<HttpMethod, OpenApiOperation>
+				{
+					[HttpMethod.Get] = new()
+					{
+						OperationId = operationId,
+						Tags = new HashSet<OpenApiTagReference> { new("core") },
+						Responses = new OpenApiResponses { ["200"] = new OpenApiResponse { Description = "ok" } }
+					}
+				}
+			}
+		}
+	};
+
+	private sealed class CapturingDiagnosticsCollector() : DiagnosticsCollector([])
+	{
+		private readonly List<Diagnostic> _captured = [];
+
+		public IEnumerable<string> ErrorMessages =>
+			_captured.Where(d => d.Severity == Severity.Error).Select(d => d.Message);
+
+		public override void Write(Diagnostic diagnostic)
+		{
+			IncrementSeverityCount(diagnostic);
+			_captured.Add(diagnostic);
+		}
+
+		public override DiagnosticsCollector StartAsync(Cancel ctx) => this;
+		public override Task StopAsync(Cancel cancellationToken) => Task.CompletedTask;
+	}
+}

--- a/tests/Elastic.ApiExplorer.Tests/Supplemental/ApiSupplementalValidationTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/Supplemental/ApiSupplementalValidationTests.cs
@@ -212,7 +212,7 @@ public class ApiSupplementalValidationTests(ApiExplorerFixture fixture) : IClass
 			document,
 			collector,
 			moniker,
-			emitUnmatchedBaseFiles: emitUnmatchedBaseFiles ?? moniker == "main");
+			emitUnmatchedBaseFiles: emitUnmatchedBaseFiles ?? (moniker == "main"));
 		return collector;
 	}
 

--- a/tests/Elastic.ApiExplorer.Tests/Supplemental/ApiSupplementalValidationTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/Supplemental/ApiSupplementalValidationTests.cs
@@ -132,6 +132,20 @@ public class ApiSupplementalValidationTests(ApiExplorerFixture fixture) : IClass
 	}
 
 	[Fact]
+	public void Validate_UnknownParameterOnNonNumericLatest_EmitsError()
+	{
+		var collector = Validate(FolderWith(("op-search.md", """
+			## Parameters
+
+			: `nope`
+			  Not a search parameter.
+			""")), fixture.Document, "next");
+
+		collector.ErrorMessages.Should().ContainSingle(m =>
+			m.Contains("Parameter 'nope'") && m.Contains("operation 'search'"));
+	}
+
+	[Fact]
 	public void Validate_UnknownParameterOnOlderVersionMatchedBaseFile_EmitsError()
 	{
 		var collector = Validate(FolderWith(("op-search.md", """
@@ -189,12 +203,16 @@ public class ApiSupplementalValidationTests(ApiExplorerFixture fixture) : IClass
 		IDirectoryInfo folder,
 		OpenApiDocument document,
 		string moniker,
-		bool emitUnmatchedBaseFiles = false)
+		bool? emitUnmatchedBaseFiles = null)
 	{
 		var discovery = ApiSupplementalDiscovery.Discover(folder, document);
 		var collector = new CapturingDiagnosticsCollector();
 		ApiSupplementalValidator.Validate(
-			discovery, document, collector, moniker, emitUnmatchedBaseFiles: emitUnmatchedBaseFiles);
+			discovery,
+			document,
+			collector,
+			moniker,
+			emitUnmatchedBaseFiles: emitUnmatchedBaseFiles ?? moniker == "main");
 		return collector;
 	}
 

--- a/tests/Elastic.ApiExplorer.Tests/Supplemental/ApiSupplementalValidationTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/Supplemental/ApiSupplementalValidationTests.cs
@@ -85,6 +85,19 @@ public class ApiSupplementalValidationTests(ApiExplorerFixture fixture) : IClass
 	}
 
 	[Fact]
+	public void Validate_NestedRequestBodyField_EmitsNoError()
+	{
+		var collector = Validate(FolderWith(("op-search.md", """
+			## Request body
+
+			: `bool`
+			  Nested under query; the renderer matches by leaf name.
+			""")), SpecWithNestedRequestBody("search", "query", "bool"), "main");
+
+		collector.Errors.Should().Be(0);
+	}
+
+	[Fact]
 	public void Validate_ListedRealParameter_EmitsNoError()
 	{
 		var collector = Validate(FolderWith(("op-search.md", """
@@ -244,6 +257,34 @@ public class ApiSupplementalValidationTests(ApiExplorerFixture fixture) : IClass
 			}
 		}
 	};
+
+	private static OpenApiDocument SpecWithNestedRequestBody(string operationId, string parent, string nested)
+	{
+		var document = SpecWith(operationId);
+		document.Paths["/x"].Operations![HttpMethod.Get].RequestBody = new OpenApiRequestBody
+		{
+			Content = new Dictionary<string, IOpenApiMediaType>
+			{
+				["application/json"] = new OpenApiMediaType
+				{
+					Schema = new OpenApiSchema
+					{
+						Properties = new Dictionary<string, IOpenApiSchema>
+						{
+							[parent] = new OpenApiSchema
+							{
+								Properties = new Dictionary<string, IOpenApiSchema>
+								{
+									[nested] = new OpenApiSchema { Type = JsonSchemaType.Object }
+								}
+							}
+						}
+					}
+				}
+			}
+		};
+		return document;
+	}
 
 	private sealed class CapturingDiagnosticsCollector() : DiagnosticsCollector([])
 	{

--- a/tests/Elastic.ApiExplorer.Tests/Supplemental/ApiSupplementalValidationTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/Supplemental/ApiSupplementalValidationTests.cs
@@ -106,6 +106,19 @@ public class ApiSupplementalValidationTests(ApiExplorerFixture fixture) : IClass
 	}
 
 	[Fact]
+	public void Validate_UnmatchedBaseFileWhenLatestIsNumeric_EmitsError()
+	{
+		var collector = Validate(
+			FolderWith(("op-does-not-exist.md", "# supplemental")),
+			SpecWith("ping"),
+			"8",
+			emitUnmatchedBaseFiles: true);
+
+		collector.ErrorMessages.Should().ContainSingle(m =>
+			m.Contains("op-does-not-exist.md") && m.Contains("does not match any operationId in the latest spec"));
+	}
+
+	[Fact]
 	public void Validate_UnknownParameterOnOlderVersionMatchedBaseFile_EmitsError()
 	{
 		var collector = Validate(FolderWith(("op-search.md", """
@@ -162,11 +175,13 @@ public class ApiSupplementalValidationTests(ApiExplorerFixture fixture) : IClass
 	private static CapturingDiagnosticsCollector Validate(
 		IDirectoryInfo folder,
 		OpenApiDocument document,
-		string moniker)
+		string moniker,
+		bool emitUnmatchedBaseFiles = false)
 	{
 		var discovery = ApiSupplementalDiscovery.Discover(folder, document);
 		var collector = new CapturingDiagnosticsCollector();
-		ApiSupplementalValidator.Validate(discovery, document, collector, moniker);
+		ApiSupplementalValidator.Validate(
+			discovery, document, collector, moniker, emitUnmatchedBaseFiles: emitUnmatchedBaseFiles);
 		return collector;
 	}
 


### PR DESCRIPTION
## Why

- An `op-*.md` or `tag-*.md` file can name a missing operation, tag, parameter, or request-body field, and the build still succeeds.
- The OpenAPI content enrichment RFC requires those cases to fail at generate time. See [docs-eng-team#729](https://github.com/elastic/docs-eng-team/issues/729).

## What

- The generate step now fails unmatched `op-*.md` and `tag-*.md` files against the latest spec.
- Unknown parameter and request-body keys in matched files are build errors.
- Version-suffixed files are checked against that major. A base file for an operation that exists only in latest does not fail older-version generates.

## Notes

- Version-suffix merge remains [#730](https://github.com/elastic/docs-eng-team/issues/730).
- Closest-match suggestions are not included.


Made with [Cursor](https://cursor.com)