### PR TITLE
Update CODEOWNERS for documentation ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
 * @elastic/docs-engineering
-/docs/ @elastic/docs @elastic/docs-engineering
-/config/ @elastic/docs-tech-leads @elastic/docs-engineering


### PR DESCRIPTION
Docs is getting pinged on a lot of eng PRs now and they're going faster than we can review. I propose that we remove ownership until we can find a valid reason to keep it. Eng can tag specific writers when relevant (e.g. when a writer submitted an issue that is being addressed)

also: tech leads DNE

edit: I think it's nice for writers to be able to update guidance pages, but I don't think docs eng having to ✅ that smaller number of contributions is a bad thing