### PR TITLE
Docs: API Explorer enrichment author guide

### DIFF
--- a/docs/_docset.yml
+++ b/docs/_docset.yml
@@ -205,6 +205,7 @@ toc:
         children:
           - file: index.md
           - file: api-explorer.md
+          - file: supplemental.md
       - folder: cli-schema
         children:
           - file: index.md

--- a/docs/api/docs-builder-elasticsearch/op-async-search-get.md
+++ b/docs/api/docs-builder-elasticsearch/op-async-search-get.md
@@ -1,7 +1,3 @@
----
-description: Retrieve results of a previously submitted async search.
----
-
 ## Description
 
 Retrieve the results of a previously submitted asynchronous search request.

--- a/docs/api/docs-builder-elasticsearch/op-async-search-get.md
+++ b/docs/api/docs-builder-elasticsearch/op-async-search-get.md
@@ -1,5 +1,27 @@
-# Async search get supplemental fixture
+---
+description: Retrieve results of a previously submitted async search.
+---
 
-This file is a local fixture for docs-builder development.
+## Description
 
-Discovery should associate it with the `async-search-get` operation.
+Retrieve the results of a previously submitted asynchronous search request.
+If Elasticsearch security features are enabled, Elasticsearch restricts access to the user or API key that submitted the request.
+
+This file is the local fixture for docs-builder development. The file name matches the `async-search-get` operation.
+
+## Parameters
+
+: `keep_alive`
+  How long Elasticsearch keeps this search and its saved results.
+  If you omit it, Elasticsearch uses the value from the matching submit request.
+  If you extend it, Elasticsearch also extends the validity of the saved results.
+  If the period expires while the search still runs, Elasticsearch cancels the search.
+  If the search is complete, Elasticsearch deletes the saved results.
+
+: id
+  The async search id returned by the submit request.
+
+## When to poll
+
+Retry `GET /_async_search/{id}` until `is_running` is `false`.
+If you need to wait on the server, set `wait_for_completion_timeout`. Do not poll from the client in that case.

--- a/docs/api/docs-builder-elasticsearch/op-async-search-get.md
+++ b/docs/api/docs-builder-elasticsearch/op-async-search-get.md
@@ -1,3 +1,5 @@
+# Async search get
+
 ## Description
 
 Retrieve the results of a previously submitted asynchronous search request.

--- a/docs/data/openapi/api-explorer.md
+++ b/docs/data/openapi/api-explorer.md
@@ -4,12 +4,12 @@ navigation_title: API Explorer
 
 # API Explorer
 
-The API Explorer renders OpenAPI specifications as API documentation. If you configure it in your content set, `docs-builder` generates pages from the spec. The generated pages include:
+The API Explorer turns an OpenAPI spec into HTML pages. If you add an `api:` entry in `docset.yml`, {{dbuild}} generates:
 
-- API operations
-- request and response schemas
-- shared type definitions
-- inline examples
+- a product landing page
+- one tag landing page per tag
+- one operation page per operation
+- schema type pages for shared types
 
 :::{warning}
 This feature is still under development and the functionality described on this page might change.
@@ -17,97 +17,86 @@ This feature is still under development and the functionality described on this 
 
 ## Get started
 
-This repository includes a working example. Follow the steps with that example. To use your own product, replace the key and spec in the steps.
+This repository includes a working example. Follow these steps against that example.
 
 :::::{stepper}
 
-::::{step} Add an `api:` entry to `docset.yml`
+::::{step} Read the `api:` entry in `_docset.yml`
 
-The `api` key is only valid in `docset.yml`. Do not use it in `toc.yml`. Each product key takes a sequence with exactly one entry. That entry has:
+The `api` key is valid in `docset.yml` only. Do not put it in `toc.yml`.
 
-- required `spec:`
-- required `product:`
-- optional `repository:`
-- optional `children:`
+This repository uses `_docset.yml`. The live entry is:
 
 ```yaml
 api:
-  elasticsearch:
-    - spec: elasticsearch-openapi.json
+  docs-builder-elasticsearch:
+    - spec: elasticsearch.json
       product: elasticsearch
-      repository: elastic/elasticsearch-specification   # optional; see Reference
-      children:                                         # optional
-        - file: getting-started.md
+      repository: elastic/elasticsearch-specification
 ```
 
-This repository uses the key `docs-builder-elasticsearch`. Assembler preview then does not collide with docs-content. See `docs/_docset.yml`.
+The map key is the URL suffix. This key produces `/api/doc/docs-builder-elasticsearch/`.
 
-The product key is the URL suffix. `elasticsearch` produces pages under `/api/doc/elasticsearch/`.
+Each key takes a sequence with exactly one entry. That entry requires `spec:` and `product:`. `repository:` and `children:` are optional. See [Reference](#reference).
 
 ::::
 
 ::::{step} Preview the generated pages
 
-If `--watch` is on, {{dbuild}} skips API generation. Run {{dbuild}} without `--watch`:
+If you pass `--watch`, {{dbuild}} does not generate API pages. Run serve without `--watch`:
 
 ```bash
 docs-builder serve
 ```
 
-Open [http://localhost:3000/api/doc/docs-builder-elasticsearch/](http://localhost:3000/api/doc/docs-builder-elasticsearch/). That landing page comes from `docs/elasticsearch.json`.
+Open [http://localhost:3000/api/doc/docs-builder-elasticsearch/](http://localhost:3000/api/doc/docs-builder-elasticsearch/). {{dbuild}} generates API pages on the first `/api/` request. After that, it rebuilds them when the spec file or files under `api/<key>/` change.
 
-If you only edit Markdown outside the API tree, use `--skip-api` with `docs-builder build`.
+If you only edit Markdown outside the API tree, pass `--skip-api` to `docs-builder build`.
 
 ::::
 
-::::{step} Enrich an operation
+::::{step} Open the supplemental fixture
 
-Put a Markdown file named after the spec `operationId` into `api/<key>/`. Do not add a toc entry. The build finds the file automatically.
+Put operation files in `api/<key>/`. The file name is `op-` plus the spec `operationId`. Do not add a toc entry.
 
-This repository includes `docs/api/docs-builder-elasticsearch/op-async-search-get.md`. After you run `serve`, open this page:
+This repository includes `docs/api/docs-builder-elasticsearch/op-async-search-get.md`. After serve, open:
 
 [http://localhost:3000/api/doc/docs-builder-elasticsearch/operation/operation-async-search-get/](http://localhost:3000/api/doc/docs-builder-elasticsearch/operation/operation-async-search-get/)
 
-The file does this:
+That file:
 
-- It replaces the spec description.
-- It overrides the `keep_alive` parameter text.
-- It appends a **When to poll** section after the generated reference.
+- replaces the spec description
+- overrides the `keep_alive` and `id` parameter text
+- appends a **When to poll** section after the generated reference
 
-See [Writing supplemental content](./supplemental.md) for file naming, heading rules, tag files, and `children:` pages.
+Heading rules, tag files, and `children:` pages are in [Writing supplemental content](./supplemental.md).
 
 ::::
 
 ::::{step} Override one major version
 
-If a description or parameter must differ for one major, add a version-suffixed file next to the base file:
+If one major needs different text, add a `.vN.md` file next to the base file. This repository does not ship a `.vN.md` file. The pattern is:
 
 ```text
 api/elasticsearch/
-  op-search.md        # every version that has this operation
-  op-search.v8.md     # merged on top of the base file for 8.x only
+  op-search.md
+  op-search.v8.md
 ```
 
-The unversioned `/api/doc/<key>/` tree uses the overlay of the current major. Then that tree matches `/vN/` for that major. Full merge rules are in [Writing supplemental content](./supplemental.md#version-specific-files).
+The unversioned `/api/doc/<key>/` tree uses the overlay of the highest numeric major that this product renders. Merge rules are in [Writing supplemental content](./supplemental.md#version-specific-files).
 
 ::::
 
 ::::{step} Read the build error, then fix the file
 
-Validation is strict. The build fails if any of these occur:
-
-- a misspelled `operationId`
-- an unknown parameter key
-- a reserved child slug
-
-Typical messages:
+If the file name does not match an `operationId`, the build fails. If a parameter key is not in the spec, the build also fails.
 
 ```text
 API supplemental file 'op-nope.md' does not match any operationId in the latest spec
 API supplemental: Parameter 'typo' not found in operation 'async-search-get' in the latest spec
 ```
 
-Fix the file. Then rebuild. The full list is in [Writing supplemental content](./supplemental.md#validation-errors).
+Fix the file. Then rebuild. More messages are in [Writing supplemental content](./supplemental.md#validation-errors).
 
 ::::
 
@@ -117,278 +106,118 @@ Fix the file. Then rebuild. The full list is in [Writing supplemental content](.
 
 | `docset.yml` key | Required | Description |
 |---|---|---|
-| `spec:` | yes | Path to an OpenAPI file, relative to `docset.yml`. If the file exists, {{dbuild}} renders it. The basename always looks up the remote version index. |
-| `product:` | yes | A product id from `products.yml`. Binds the API to that product's versioning system and display name. |
-| `repository:` | no | `org/repo` used to look up the version index instead of this checkout's GitHub remote. Set this when the spec is published from a different repository. |
-| `children:` | no | Hand-written Markdown pages under `api/<key>/`, in declared order. See [children:](./supplemental.md#children-pages). |
+| `spec:` | yes | Path to an OpenAPI file, relative to `docset.yml`. If the file exists, {{dbuild}} renders it for `main`. The basename is always used to look up the remote version index. |
+| `product:` | yes | A product id from `products.yml`. This binds the API to that product's versioning system. |
+| `repository:` | no | `org/repo` used to look up the version index. Set this when the spec is published from a different GitHub repository than the docset. |
+| `children:` | no | Extra Markdown pages under `api/<key>/`, in declared order. See [children:](./supplemental.md#children-pages). |
 
-Each product key must have exactly one sequence entry. That entry must have exactly one `spec:`. If the sequence is empty, the build fails. If the sequence has more than one entry, the build also fails.
+Each product key must have exactly one sequence entry. That entry must have exactly one `spec:`. An empty sequence fails the build. A sequence with more than one entry also fails the build.
 
 ### `spec:`
 
-- If a file exists at that path, {{dbuild}} renders it. This is the usual setup when a docset includes its own spec.
-- The basename (for example `elasticsearch-openapi.json`) always looks up this API in the remote version index. This is true if the file exists locally. It is also true if the file is missing. See [Remote spec resolution](#remote-spec-resolution).
+If the file exists on disk, {{dbuild}} uses it for the `main` moniker. Older majors still come from the version index.
+
+The basename always looks up the version index. That is true when the file exists. It is also true when the file is missing. See [Remote spec resolution](#remote-spec-resolution).
 
 ### `product:`
 
-If `product:` does not match a known product id, the build fails. The error includes a suggestion.
+If `product:` is not a known product id, the build fails. The error includes a suggestion.
 
 ### `repository:`
 
-If the spec is published from a different repository than the docset, set `repository:`:
+This repository sets `repository: elastic/elasticsearch-specification` because the spec is published from that repository, not from `elastic/docs-builder`.
 
-```yaml
-api:
-  elasticsearch:
-    - spec: elasticsearch-openapi.json
-      product: elasticsearch
-      repository: elastic/elasticsearch-specification
-```
-
-Most docsets omit `repository:`. If you omit it, {{dbuild}} uses the GitHub remote of the current checkout.
+If you omit `repository:`, {{dbuild}} uses the GitHub remote of the current checkout.
 
 ### `children:`
 
-`children:` is the only way to add a full Markdown page to an API reference section. {{dbuild}} excludes child files from normal HTML generation. Do not add them to `exclude:`.
+`children:` adds full Markdown pages under the product root. Supplemental `op-*.md` and `tag-*.md` files are not `children:` pages. They merge into generated operation and tag pages.
 
-A `*.vN.md` suffix limits that child to major `N` only. Naming, reserved slugs, and collisions are in [Writing supplemental content](./supplemental.md#children-pages).
+{{dbuild}} does not emit child files as normal docset HTML. Do not add them to `exclude:`.
 
 ## Page URLs
 
-{{dbuild}} uses the bump.sh URL scheme. `{key}` is the `api:` map key. It is not the `product:` id.
+`{key}` is the `api:` map key. It is not the `product:` id.
 
 | Page | Path |
 |---|---|
 | Product root (`main`) | `/api/doc/{key}/` |
-| Released major | `/api/doc/{key}/v9/`, `/api/doc/{key}/v8/`, … |
+| Released major | `/api/doc/{key}/v9/`, `/api/doc/{key}/v8/` |
 | Operation | `/api/doc/{key}/operation/operation-{operationId}/` |
 | Tag landing | `/api/doc/{key}/group/endpoint-{tagSlug}/` |
 | Schema type | `/api/doc/{key}/types/{schemaMoniker}/` |
 | Child Markdown | `/api/doc/{key}/{slug}/` |
 
-{{dbuild}} lowercases operation ids in the URL. For tag slugs, it replaces spaces with hyphens. It also lowercases the tag name. Underscores stay.
+{{dbuild}} lowercases the `operationId` in the URL. For tag slugs, it replaces spaces with hyphens and lowercases the name. Underscores stay.
+
+The `api:` key creates this URL tree. Do not list generated operation pages in `toc.yml`. From Markdown inside an API page, you can link with paths such as `../group/endpoint-search` and `../operation/operation-search`. {{dbuild}} rewrites those links against the current product base.
 
 ## Multi-version behavior
 
-For versioned products, {{dbuild}} renders every resolved version from the index:
+For a versioned product, {{dbuild}} renders every resolved version:
 
 | Index moniker | URL path | Role |
 |---|---|---|
-| `main` | `/api/doc/{key}/` | Canonical current-major tree |
-| `9`, `8`, … | `/api/doc/{key}/v9/`, `/v8/`, … | Released major snapshots |
+| `main` | `/api/doc/{key}/` | Current-major tree |
+| `9`, `8` | `/api/doc/{key}/v9/`, `/v8/` | Frozen major snapshots |
 
-The numeric `9` entry is a frozen v9 snapshot. It is distinct from the moving `main` entry. The unversioned tree uses the overlay of the current major. Then `/api/doc/{key}/` matches `/vN/` for that major.
+The numeric `9` entry is a frozen snapshot. It is not the same as `main`. The unversioned tree uses the overlay of the highest numeric major that this product renders.
 
-If a local spec file exists, it overrides only the `main` moniker. Older majors still resolve from the index.
+If a local spec file exists, it overrides `main` only.
 
-Versionless products (`versioning: serverless` and similar) render only `/api/doc/{key}/`. This is true even if the index lists older monikers. If more than one version is rendered, API pages show a version dropdown at the top of the left navigation rail.
+A versionless product (`versioning: serverless` and similar) renders only `/api/doc/{key}/`. If more than one version is rendered, the left navigation shows a version dropdown.
 
 ## Remote spec resolution
 
-If `spec:` does not resolve to a file on disk, {{dbuild}} resolves the current (`main`) version of that spec from a remote version index. The index is on CloudFront. Every Elastic repository that publishes OpenAPI specs shares this index.
+If `spec:` does not resolve to a file on disk, {{dbuild}} fetches `main` from a CloudFront version index. Repositories that publish OpenAPI specs share this index.
 
-### How specs are published
-
-Each repository publishes its OpenAPI spec under a stable object key in a shared bucket:
+Object keys in the bucket look like this:
 
 ```
 <org>/<repo>/<branch>/<spec-name>.<ext>
 ```
 
-Elasticsearch publishes its spec from a separate specification repository. Example keys are `elastic/elasticsearch-specification/main/elasticsearch.json` and `elastic/elasticsearch-specification/8.19/elasticsearch.json`.
+Example: `elastic/elasticsearch-specification/main/elasticsearch.json`.
 
-### The version index
+The root manifest is `https://d29hkgsdo66d1n.cloudfront.net/index.json`. It is keyed by `org/repo`, then spec basename, then moniker (`main`, `9`, `8`). {{dbuild}} fetches that manifest once per build. It looks up `repository:` first. If `repository:` is missing, it uses the GitHub remote of the current checkout. Spec objects are fetched at `{base}/{org}/{repo}/{version}/{spec-basename}`.
 
-A single root `index.json` manifest maps every published spec to its highest-minor branch per major. The keys are:
-
-1. `org/repo`
-2. spec basename (the basename of `spec:`)
-3. version moniker (`main`, `9`, `8`, ...)
-
-```json
-{
-  "elastic/elasticsearch-specification": {
-    "elasticsearch.json": {
-      "main": { "version": "main" },
-      "9": { "version": "9.5" },
-      "8": { "version": "8.19" }
-    }
-  }
-}
-```
-
-{{dbuild}} fetches this manifest once per build from `https://d29hkgsdo66d1n.cloudfront.net/index.json`. It looks up the `org/repo` from `repository:`. If `repository:` is missing, it uses the GitHub remote of the current checkout. It then looks up the basename of `spec:` to find the versions of this API. Spec objects are fetched at `{base}/{org}/{repo}/{version}/{spec-basename}`.
-
-If the API has no local spec file, and the `org/repo` or spec basename is missing from the index, the build fails. The error names the API and what was missing. If a local spec file is also configured, that error becomes a warning. Then the build renders the local file.
-
-## Place your spec files
-
-If you carry a spec locally, put the OpenAPI file in the same folder as `docset.yml`. You can also put it in a subfolder. {{dbuild}} resolves the `spec:` path from the `docset.yml` location.
-
-Example layout:
-
-```
-docs/
-  docset.yml
-  elasticsearch-openapi.json
-  kibana-openapi.json
-  index.md
-  ...
-```
-
-Your `docset.yml` references the specs as follows:
-
-```yaml
-api:
-  elasticsearch:
-    - spec: elasticsearch-openapi.json
-      product: elasticsearch
-  kibana:
-    - spec: kibana-openapi.json
-      product: kibana
-```
+If there is no local spec and the index has no matching entry, the build fails. If a local spec exists, that miss is a warning. Then {{dbuild}} renders the local file.
 
 ## When the API Explorer runs
 
-- **`docs-builder build`.** {{dbuild}} generates API docs as part of the standard build. Use `--skip-api` to skip generation when you edit other content.
-- **`docs-builder serve`.** {{dbuild}} generates API docs on startup. It regenerates them when spec files change.
-- **Assembler builds.** {{dbuild}} generates API docs when the `ASSEMBLER_API_EXPLORER` feature flag is on. That flag is on for the `staging` and `preview` environments. Production stays off until cutover.
-
-:::{note}
-If you run `docs-builder serve --watch`, {{dbuild}} skips API generation. This is a performance optimization for `dotnet watch` workflows. Run `serve` without `--watch` to include API docs in your local preview.
-:::
-
-This repository declares a local `docs-builder-elasticsearch` API in `_docset.yml`. That entry reads `elasticsearch.json`. It sets `repository: elastic/elasticsearch-specification`. Use that entry to preview ApiExplorer and supplemental files during isolated `docs-builder serve`. Open `/api/doc/docs-builder-elasticsearch/`.
-
-## Link to API pages in navigation
-
-Reference API pages in `toc.yml` or `docset.yml` with cross-link syntax:
-
-```yaml
-toc:
-  - file: index.md
-  - title: Elasticsearch API Reference
-    crosslink: elasticsearch://api/doc/elasticsearch/
-```
-
-## What the API Explorer renders
-
-The API Explorer generates these page types from your OpenAPI spec:
-
-- **Landing page.** An overview of the API grouped by tag.
-- **Tag landing pages.** One page per tag that lists operations in that tag. The page includes the tag display name, an optional OpenAPI `description` (CommonMark), and an optional `externalDocs` link.
-- **Operation pages.** One page per API operation. The page includes the HTTP method, path, parameters, request body, response schemas, and examples.
-- **Schema type pages.** Dedicated pages for complex shared types such as `QueryContainer` and `AggregationContainer`.
+- **`docs-builder build`.** {{dbuild}} generates API pages unless you pass `--skip-api`.
+- **`docs-builder serve`.** {{dbuild}} generates API pages on the first `/api/` request. It rebuilds them when the spec or `api/<key>/` Markdown files change. `--watch` skips API generation.
+- **Assembler builds.** {{dbuild}} generates API pages when the `assembler-api-explorer` feature flag is on. `staging` and `preview` set `ASSEMBLER_API_EXPLORER`. Production does not.
 
 ## OpenAPI extensions
 
-The API Explorer supports some OpenAPI specification extensions. These extensions improve navigation and display:
+These spec extensions change how pages render. They live in the OpenAPI file, not in supplemental Markdown.
 
-- [x-codeSamples](#x-codesamples)
-- [x-displayName](#x-displayname)
-- [x-req-auth](#x-req-auth)
-- [x-tagGroups](#x-taggroups)
+### `x-codeSamples`
 
-For background on OpenAPI vendor extensions, refer to [OpenAPI Specification](https://spec.openapis.org/oas/latest.html#specification-extensions).
-
-### Multi-language code examples [x-codesamples]
-
-If an OpenAPI operation includes the `x-codeSamples` extension, the API Explorer renders the samples with a language selector tab. Users can switch among Console, cURL, Python, JavaScript, Ruby, PHP, and Java.
-
-The `x-codeSamples` extension is a JSON array of objects. Each object has a `lang` field and a `source` field:
+If an operation has `x-codeSamples`, the operation page shows a **Code Examples** section. Each array item needs `lang` and `source`. Console is sorted first when present. The tab list is the `lang` values in the spec. Tabs use the `api-language` sync group, so the selected language stays across pages.
 
 ```json
 "x-codeSamples": [
   { "lang": "Console", "source": "GET /_search" },
-  { "lang": "curl", "source": "curl -X GET ..." },
-  { "lang": "Python", "source": "resp = client.search()" }
+  { "lang": "curl", "source": "curl -X GET ..." }
 ]
 ```
 
-The code samples appear in a standalone "Code Examples" section on every operation page that has the extension. This is true for every HTTP method. GET, DELETE, and other operations without a request body also show language tabs when `x-codeSamples` is present. If multiple languages are available, they appear as tabs. The selected language persists across operations and page navigations. If only one language is available, the example renders without a tab selector.
+### `x-req-auth`
 
-Console is the default language. If Console is present, it appears first in the tab order.
-
-### Prerequisites [x-req-auth]
-
-Add the operation-level `x-req-auth` extension to list authentication or privilege requirements. Users must satisfy these requirements before they call the API.
-The API Explorer renders these lines in a **Prerequisites** section on the operation page.
-
-`x-req-auth` is a JSON array of strings.
-Each non-empty string becomes one item in the prerequisites list. {{dbuild}} trims leading and trailing whitespace.
+If an operation has `x-req-auth` as a JSON array of strings, the operation page shows a **Prerequisites** section after **Paths**. Empty strings are dropped. If the value is not an array, the section is omitted and the build may log a warning.
 
 ```json
-{
-  "get": {
-    "operationId": "get-snapshot",
-    "responses": { "200": { "description": "ok" } },
-    "x-req-auth": [
-      "Cluster privilege: `cluster:admin/snapshot`"
-    ]
-  }
-}
+"x-req-auth": [
+  "Cluster privilege: `cluster:admin/snapshot`"
+]
 ```
 
-If prerequisites are present, **Prerequisites** also appears in the on-page table of contents (after **Paths**).
-If the extension is missing, empty, or not a JSON array, the API Explorer omits the section.
-{{dbuild}} skips malformed values. The build may log a warning.
+### `x-displayName`
 
-### Tag labels [x-displayname]
+If a tag object has `x-displayName`, navigation and tag headings use that string. URLs still use the canonical tag `name`. If two tag names slug to the same URL segment, the build fails.
 
-Use the `x-displayName` extension (from [Redocly](https://redocly.com/docs-legacy/api-reference-docs/specification-extensions/x-display-name)) on tag objects. This sets a display name for navigation and landing pages. URLs stay based on the canonical tag name.
+### `x-tagGroups`
 
-```json
-{
-  "tags": [
-    {
-      "name": "tasks",
-      "description": "The task management APIs enable you to get information about tasks currently running.",
-      "x-displayName": "Task management"
-    },
-    {
-      "name": "ml_anomaly",
-      "description": "Machine learning anomaly detection APIs.",
-      "x-displayName": "Machine Learning Anomaly Detection"
-    }
-  ]
-}
-```
-
-**Behavior:**
-
-- If `x-displayName` is present, the API Explorer uses it for navigation titles, tag landing page titles, and section headings on the main API overview.
-- If `x-displayName` is absent, the API Explorer uses the canonical tag `name`.
-- Tag landing page URLs and tag URL segments come from the canonical tag `name`.
-
-:::{note}
-If two different canonical tag names normalize to the same tag landing page URL, the build fails. The error names both tags and the colliding segment so you can fix the spec.
-:::
-
-### Tag groups [x-taggroups]
-
-Use the document-level `x-tagGroups` extension (from [Redocly](https://redocly.com/docs-legacy/api-reference-docs/specification-extensions/x-tag-groups)) to group tags in the API Explorer sidebar. Each group has a display `name` and a list of tag `name` values. Group order in the array is the order of top-level sections in the navigation.
-
-```json
-{
-  "openapi": "3.0.3",
-  "info": { "title": "Example", "version": "1.0.0" },
-  "paths": {},
-  "x-tagGroups": [
-    {
-      "name": "Search & Document APIs",
-      "tags": ["search", "document", "eql", "esql", "sql"]
-    },
-    {
-      "name": "Cluster Management",
-      "tags": ["indices", "cluster", "snapshot"]
-    }
-  ]
-}
-```
-
-**Behavior:**
-
-- If `x-tagGroups` is present and valid, the API Explorer uses it as an extra grouping level in the sidebar.
-- In the navigation tree, a group's section title links to the **main API overview** for that product. It is not a separate page. It does not point at the first tag in the group. Tag landings stay under `.../group/...`.
-- If `x-tagGroups` is absent, the API Explorer lists tags directly under the API root in a single flat layer.
-- If an operation tag is not listed under any group, it still appears. The API Explorer shows it under a fallback section named `unknown`. The build logs a warning so you can fix the spec.
+If the document has `x-tagGroups`, the sidebar groups tags by those lists. Group order follows the array. A group title links to the product landing page. It is not its own URL. Tags that are missing from every group appear under `unknown`. The build logs a warning.

--- a/docs/data/openapi/api-explorer.md
+++ b/docs/data/openapi/api-explorer.md
@@ -4,54 +4,138 @@ navigation_title: API Explorer
 
 # API Explorer
 
-The API Explorer renders OpenAPI specifications as interactive API documentation. When you configure it in your content set, `docs-builder` automatically generates pages for each API operation, request and response schemas, shared type definitions, and inline examples.
+The API Explorer renders OpenAPI specifications as API documentation. If you configure it in your content set, `docs-builder` generates pages from the spec. The generated pages include:
+
+- API operations
+- request and response schemas
+- shared type definitions
+- inline examples
 
 :::{warning}
 This feature is still under development and the functionality described on this page might change.
 :::
 
-## Configure the API Explorer
+## Get started
 
-Add the `api` key to your `docset.yml` file to enable the API Explorer. Each product key takes a
-single-entry sequence with a required `spec:` and `product:`, and optional `repository:` and
-`children:`:
+This repository includes a working example. Follow the steps with that example. To use your own product, replace the key and spec in the steps.
+
+:::::{stepper}
+
+::::{step} Add an `api:` entry to `docset.yml`
+
+The `api` key is only valid in `docset.yml`. Do not use it in `toc.yml`. Each product key takes a sequence with exactly one entry. That entry has:
+
+- required `spec:`
+- required `product:`
+- optional `repository:`
+- optional `children:`
 
 ```yaml
 api:
   elasticsearch:
     - spec: elasticsearch-openapi.json
       product: elasticsearch
-  kibana:
-    - spec: kibana-openapi.json
-      product: kibana
+      repository: elastic/elasticsearch-specification   # optional; see Reference
+      children:                                         # optional
+        - file: getting-started.md
 ```
 
-Each product key produces its own section of API documentation. For example, `elasticsearch` generates pages under `/api/elasticsearch/` and `kibana` generates pages under `/api/kibana/`.
+This repository uses the key `docs-builder-elasticsearch`. Assembler preview then does not collide with docs-content. See `docs/_docset.yml`.
 
-The `api` key is only valid in `docset.yml`. You can't use it in `toc.yml` files.
+The product key is the URL suffix. `elasticsearch` produces pages under `/api/doc/elasticsearch/`.
 
-### `spec:` (required)
+::::
 
-A path to an OpenAPI spec file, relative to the folder that contains `docset.yml`. `spec:` serves
-two purposes at once:
+::::{step} Preview the generated pages
 
-- If a file exists at that path, {{dbuild}} renders it directly. This is the common setup for a
-  docset that carries its own spec file.
-- Its basename (for example `elasticsearch-openapi.json`) is always used to look up this API's
-  entry in the remote version index, whether or not the file exists locally. See
-  [Remote spec resolution](#remote-spec-resolution).
+If `--watch` is on, {{dbuild}} skips API generation. Run {{dbuild}} without `--watch`:
 
-### `product:` (required)
+```bash
+docs-builder serve
+```
 
-A product id defined in `products.yml`. This binds the API to that product's versioning system
-and display name. The build fails with a suggestion if `product:` doesn't match a known product id.
+Open [http://localhost:3000/api/doc/docs-builder-elasticsearch/](http://localhost:3000/api/doc/docs-builder-elasticsearch/). That landing page comes from `docs/elasticsearch.json`.
 
-### `repository:` (optional)
+If you only edit Markdown outside the API tree, use `--skip-api` with `docs-builder build`.
 
-An `org/repo` override (for example `elastic/elasticsearch-specification`) used to look up this
-API in the remote version index, instead of the current checkout's own GitHub remote. Set this
-whenever the repository that publishes the OpenAPI spec differs from the repository the docset
-itself builds from:
+::::
+
+::::{step} Enrich an operation
+
+Put a Markdown file named after the spec `operationId` into `api/<key>/`. Do not add a toc entry. The build finds the file automatically.
+
+This repository includes `docs/api/docs-builder-elasticsearch/op-async-search-get.md`. After you run `serve`, open this page:
+
+[http://localhost:3000/api/doc/docs-builder-elasticsearch/operation/operation-async-search-get/](http://localhost:3000/api/doc/docs-builder-elasticsearch/operation/operation-async-search-get/)
+
+The file does this:
+
+- It replaces the spec description.
+- It overrides the `keep_alive` parameter text.
+- It appends a **When to poll** section after the generated reference.
+
+See [Writing supplemental content](./supplemental.md) for file naming, heading rules, tag files, and `children:` pages.
+
+::::
+
+::::{step} Override one major version
+
+If a description or parameter must differ for one major, add a version-suffixed file next to the base file:
+
+```text
+api/elasticsearch/
+  op-search.md        # every version that has this operation
+  op-search.v8.md     # merged on top of the base file for 8.x only
+```
+
+The unversioned `/api/doc/<key>/` tree uses the overlay of the current major. Then that tree matches `/vN/` for that major. Full merge rules are in [Writing supplemental content](./supplemental.md#version-specific-files).
+
+::::
+
+::::{step} Read the build error, then fix the file
+
+Validation is strict. The build fails if any of these occur:
+
+- a misspelled `operationId`
+- an unknown parameter key
+- a reserved child slug
+
+Typical messages:
+
+```text
+API supplemental file 'op-nope.md' does not match any operationId in the latest spec
+API supplemental: Parameter 'typo' not found in operation 'async-search-get' in the latest spec
+```
+
+Fix the file. Then rebuild. The full list is in [Writing supplemental content](./supplemental.md#validation-errors).
+
+::::
+
+:::::
+
+## Reference
+
+| `docset.yml` key | Required | Description |
+|---|---|---|
+| `spec:` | yes | Path to an OpenAPI file, relative to `docset.yml`. If the file exists, {{dbuild}} renders it. The basename always looks up the remote version index. |
+| `product:` | yes | A product id from `products.yml`. Binds the API to that product's versioning system and display name. |
+| `repository:` | no | `org/repo` used to look up the version index instead of this checkout's GitHub remote. Set this when the spec is published from a different repository. |
+| `children:` | no | Hand-written Markdown pages under `api/<key>/`, in declared order. See [children:](./supplemental.md#children-pages). |
+
+Each product key must have exactly one sequence entry. That entry must have exactly one `spec:`. If the sequence is empty, the build fails. If the sequence has more than one entry, the build also fails.
+
+### `spec:`
+
+- If a file exists at that path, {{dbuild}} renders it. This is the usual setup when a docset includes its own spec.
+- The basename (for example `elasticsearch-openapi.json`) always looks up this API in the remote version index. This is true if the file exists locally. It is also true if the file is missing. See [Remote spec resolution](#remote-spec-resolution).
+
+### `product:`
+
+If `product:` does not match a known product id, the build fails. The error includes a suggestion.
+
+### `repository:`
+
+If the spec is published from a different repository than the docset, set `repository:`:
 
 ```yaml
 api:
@@ -61,89 +145,47 @@ api:
       repository: elastic/elasticsearch-specification
 ```
 
-Most docsets omit `repository:` — it's only needed for this cross-repo case. When omitted,
-{{dbuild}} derives the repository from the current checkout's GitHub remote.
+Most docsets omit `repository:`. If you omit it, {{dbuild}} uses the GitHub remote of the current checkout.
 
-### `children:` (optional)
+### `children:`
 
-Explicit hand-written pages rendered under `api/<key>/`, in the declared order:
+`children:` is the only way to add a full Markdown page to an API reference section. {{dbuild}} excludes child files from normal HTML generation. Do not add them to `exclude:`.
 
-```yaml
-api:
-  kibana:
-    - spec: kibana-openapi.json
-      product: kibana
-      children:
-        - file: kibana-api-overview.md
-```
+A `*.vN.md` suffix limits that child to major `N` only. Naming, reserved slugs, and collisions are in [Writing supplemental content](./supplemental.md#children-pages).
 
-`children:` is the only way to inject hand-written content into an API reference section:
+## Page URLs
 
-- Child pages are fully rendered Markdown with access to all MyST directives, substitutions, and cross-links.
-- Child files are automatically excluded from normal HTML generation — you do not need to add them to the `exclude:` list.
-- A `*.vN.md` suffix limits that child to major `N` only. `getting-started.md` appears in every version. `knn-guide.v9.md` appears only in 9.x (including the unversioned `main` tree when 9 is the current major).
+{{dbuild}} uses the bump.sh URL scheme. `{key}` is the `api:` map key. It is not the `product:` id.
 
-Per-operation and per-tag Markdown files in `api/<key>/` (`op-*.md`, `tag-*.md`) work like CLI supplemental files: drop a file named after the operation or tag, and the build picks it up. Heading rules:
-
-- No `##` headings: the whole body replaces the spec description.
-- `## Description`: replaces the spec description. Other sections in the same file still apply.
-- `## Parameters` (or `## Query parameters` / `## Path parameters`) and `## Request body`: definition-list entries replace those field descriptions. Unlisted fields keep the spec text.
-- Any other `##` heading is appended after the generated reference content.
-
-YAML frontmatter is metadata only (`description`, `applies_to`, `navigation_title`). It is not page body text. Schema type pages still take descriptions from the OpenAPI spec only.
-
-#### Version-specific supplemental files
-
-API Explorer is multi-version. CLI reference is not. When a description or parameter must differ for one major, add a version-suffixed file next to the base file:
-
-```text
-api/elasticsearch/
-  op-search.md        # every version that has this operation
-  op-search.v8.md     # merged on top of the base file for 8.x only
-  tag-ml-anomaly.md
-  tag-ml-anomaly.v9.md
-```
-
-The version file uses the same heading rules as the base file, with one extra rule because two files are merging:
-
-- `## Description` or bare text replaces the base description for that version.
-- Listed parameter and request-body keys replace or add to the base overrides. Unlisted keys stay.
-- Extra `##` sections with a new heading are added alongside the base file. If both files use the same extra heading, the version file replaces the base section.
-- Sections you omit keep the base file.
-
-A version with no matching `.vN.md` uses the base file unchanged. Tag files use this same merge. The unversioned `main` tree uses the current major's overlay, so `/api/doc/<key>/` matches `/vN/` for that major.
-
-#### Child file naming and validation
-
-A file's URL slug is derived from its filename: lowercase, with spaces and underscores replaced by
-hyphens, and the `.md` extension removed. A `.vN` version suffix is not part of the slug.
-For example, `Getting-Started.md` becomes `getting-started`, and `knn-guide.v9.md` becomes `knn-guide`.
-
-The following slugs are reserved and cannot be used as child file names:
-
-| Reserved slug | Reason |
+| Page | Path |
 |---|---|
-| `types` | API Explorer uses this path for schema type pages |
-| `tags` | API Explorer uses this path for tag landing pages |
+| Product root (`main`) | `/api/doc/{key}/` |
+| Released major | `/api/doc/{key}/v9/`, `/api/doc/{key}/v8/`, … |
+| Operation | `/api/doc/{key}/operation/operation-{operationId}/` |
+| Tag landing | `/api/doc/{key}/group/endpoint-{tagSlug}/` |
+| Schema type | `/api/doc/{key}/types/{schemaMoniker}/` |
+| Child Markdown | `/api/doc/{key}/{slug}/` |
 
-Additionally, the slug must not match any operation moniker already generated by the spec. The
-build fails with a descriptive error if either collision occurs, naming the conflicting file and
-the reserved or operation segment.
+{{dbuild}} lowercases operation ids in the URL. For tag slugs, it replaces spaces with hyphens. It also lowercases the tag name. Underscores stay.
 
-If the same slug is produced by two different child files in the same product, the build
-also fails with a duplicate-slug error.
+## Multi-version behavior
 
-### One spec per product
+For versioned products, {{dbuild}} renders every resolved version from the index:
 
-Each product key in the `api:` block must have **exactly one** entry, with **exactly one**
-`spec:`. The build fails if a product sequence is empty or has more than one entry. Multiple
-specs per product are not currently supported.
+| Index moniker | URL path | Role |
+|---|---|---|
+| `main` | `/api/doc/{key}/` | Canonical current-major tree |
+| `9`, `8`, … | `/api/doc/{key}/v9/`, `/v8/`, … | Released major snapshots |
+
+The numeric `9` entry is a frozen v9 snapshot. It is distinct from the moving `main` entry. The unversioned tree uses the overlay of the current major. Then `/api/doc/{key}/` matches `/vN/` for that major.
+
+If a local spec file exists, it overrides only the `main` moniker. Older majors still resolve from the index.
+
+Versionless products (`versioning: serverless` and similar) render only `/api/doc/{key}/`. This is true even if the index lists older monikers. If more than one version is rendered, API pages show a version dropdown at the top of the left navigation rail.
 
 ## Remote spec resolution
 
-When `spec:` does not resolve to a file on disk, {{dbuild}} resolves the current (`main`) version
-of that spec remotely through a CloudFront-backed version index shared by every Elastic repository
-that publishes OpenAPI specs.
+If `spec:` does not resolve to a file on disk, {{dbuild}} resolves the current (`main`) version of that spec from a remote version index. The index is on CloudFront. Every Elastic repository that publishes OpenAPI specs shares this index.
 
 ### How specs are published
 
@@ -153,15 +195,15 @@ Each repository publishes its OpenAPI spec under a stable object key in a shared
 <org>/<repo>/<branch>/<spec-name>.<ext>
 ```
 
-For example, Elasticsearch's spec is published from a separate specification repository, at keys
-like `elastic/elasticsearch-specification/main/elasticsearch.json` and
-`elastic/elasticsearch-specification/8.19/elasticsearch.json`.
+Elasticsearch publishes its spec from a separate specification repository. Example keys are `elastic/elasticsearch-specification/main/elasticsearch.json` and `elastic/elasticsearch-specification/8.19/elasticsearch.json`.
 
 ### The version index
 
-A single root `index.json` manifest maps every published spec to its highest-minor branch per
-major. It is keyed by `org/repo`, then by spec basename (matching `spec:`'s basename), then by
-version moniker (`main`, `9`, `8`, ...):
+A single root `index.json` manifest maps every published spec to its highest-minor branch per major. The keys are:
+
+1. `org/repo`
+2. spec basename (the basename of `spec:`)
+3. version moniker (`main`, `9`, `8`, ...)
 
 ```json
 {
@@ -175,57 +217,15 @@ version moniker (`main`, `9`, `8`, ...):
 }
 ```
 
-{{dbuild}} fetches this manifest once per build from
-`https://d29hkgsdo66d1n.cloudfront.net/index.json`, then looks up the `org/repo` (from
-`repository:`, falling back to the current checkout's GitHub remote) and the `spec:` basename to
-find this API's versions. Spec objects are fetched at
-`{base}/{org}/{repo}/{version}/{spec-basename}`.
+{{dbuild}} fetches this manifest once per build from `https://d29hkgsdo66d1n.cloudfront.net/index.json`. It looks up the `org/repo` from `repository:`. If `repository:` is missing, it uses the GitHub remote of the current checkout. It then looks up the basename of `spec:` to find the versions of this API. Spec objects are fetched at `{base}/{org}/{repo}/{version}/{spec-basename}`.
 
-If the API has no local spec file and the `org/repo` or spec basename does not have a matching
-entry in the index, the build fails with an error naming the API and what was missing. If a local
-spec file is also configured, that error becomes a warning instead, and the build falls back to
-rendering the local file.
-
-For versioned products, {{dbuild}} renders every resolved version from the index:
-
-| Index moniker | URL path | Role |
-|---|---|---|
-| `main` | `/api/doc/<key>/` | Canonical current-major tree |
-| `9`, `8`, … | `/api/doc/<key>/v9/`, `/api/doc/<key>/v8/`, … | Released major snapshots |
-
-The numeric `9` entry is a frozen v9 snapshot. It is distinct from the moving `main` entry.
-When a local spec file exists, it overrides only the `main` moniker. Older majors still resolve
-remotely through the index.
-
-Versionless products (`versioning: serverless` and similar) render only the unversioned
-`/api/doc/<key>/` path even when the index lists historical monikers. When more than one
-version is rendered, API pages show a simple version dropdown at the top of the left navigation
-rail. The dropdown links to each version's landing page.
-
-### Smoke-test every CloudFront spec locally
-
-The docs-builder dev docset ships six API keys that mirror every spec currently listed
-in the live version index. They have no local spec files, so `docs-builder serve` fetches each one
-from CloudFront:
-
-| URL path | Index entry |
-|---|---|
-| `/api/elasticsearch/` | `elastic/elasticsearch-specification` → `elasticsearch.json` |
-| `/api/elasticsearch-serverless/` | `elastic/elasticsearch-specification` → `elasticsearch-serverless.json` |
-| `/api/kibana/` | `elastic/kibana` → `kibana.yaml` |
-| `/api/kibana-serverless/` | `elastic/kibana` → `kibana-serverless.yaml` |
-| `/api/cloud-connect/` | `elastic/cloud-connected-api` → `cloud-connect.yml` |
-| `/api/cloud-serverless/` | `elastic/serverless-api-specification` → `elastic-cloud-serverless.yml` |
-
-Run `docs-builder serve` (without `--watch`) and open any path above.
+If the API has no local spec file, and the `org/repo` or spec basename is missing from the index, the build fails. The error names the API and what was missing. If a local spec file is also configured, that error becomes a warning. Then the build renders the local file.
 
 ## Place your spec files
 
-To carry a spec locally, place the OpenAPI specification file in the same folder as your
-`docset.yml` (or in a subfolder of it). The path you specify in `spec:` is resolved relative to
-the `docset.yml` location.
+If you carry a spec locally, put the OpenAPI file in the same folder as `docset.yml`. You can also put it in a subfolder. {{dbuild}} resolves the `spec:` path from the `docset.yml` location.
 
-For example, if your content set is structured like this:
+Example layout:
 
 ```
 docs/
@@ -250,41 +250,39 @@ api:
 
 ## When the API Explorer runs
 
-The API Explorer generates documentation in these scenarios:
-
-- **`docs-builder build`**: API docs are generated as part of the standard build. Use `--skip-api` to skip generation for faster iteration on content.
-- **`docs-builder serve`**: API docs are generated on startup and regenerated automatically when spec files change.
-- **Assembler builds**: API docs are generated when the `ASSEMBLER_API_EXPLORER` feature flag is on. That flag is on for the `staging` and `preview` environments. Production stays off until cutover.
+- **`docs-builder build`.** {{dbuild}} generates API docs as part of the standard build. Use `--skip-api` to skip generation when you edit other content.
+- **`docs-builder serve`.** {{dbuild}} generates API docs on startup. It regenerates them when spec files change.
+- **Assembler builds.** {{dbuild}} generates API docs when the `ASSEMBLER_API_EXPLORER` feature flag is on. That flag is on for the `staging` and `preview` environments. Production stays off until cutover.
 
 :::{note}
-API generation is skipped when running `docs-builder serve --watch`. This is a performance optimization for `dotnet watch` workflows. Run `serve` without `--watch` to include API docs in your local preview.
+If you run `docs-builder serve --watch`, {{dbuild}} skips API generation. This is a performance optimization for `dotnet watch` workflows. Run `serve` without `--watch` to include API docs in your local preview.
 :::
 
-This repository's own `_docset.yml` declares a local `docs-builder-elasticsearch` API that reads `elasticsearch.json` and sets `repository: elastic/elasticsearch-specification`. Use that entry to preview ApiExplorer and supplemental files during isolated `docs-builder serve` (open `/api/doc/docs-builder-elasticsearch/`). The key is not `elasticsearch`, so assembler preview does not collide with docs-content.
+This repository declares a local `docs-builder-elasticsearch` API in `_docset.yml`. That entry reads `elasticsearch.json`. It sets `repository: elastic/elasticsearch-specification`. Use that entry to preview ApiExplorer and supplemental files during isolated `docs-builder serve`. Open `/api/doc/docs-builder-elasticsearch/`.
 
 ## Link to API pages in navigation
 
-You can reference API pages in your `toc.yml` or `docset.yml` navigation using cross-link syntax:
+Reference API pages in `toc.yml` or `docset.yml` with cross-link syntax:
 
 ```yaml
 toc:
   - file: index.md
   - title: Elasticsearch API Reference
-    crosslink: elasticsearch://api/elasticsearch/
+    crosslink: elasticsearch://api/doc/elasticsearch/
 ```
 
 ## What the API Explorer renders
 
-The API Explorer generates the following types of pages from your OpenAPI spec:
+The API Explorer generates these page types from your OpenAPI spec:
 
-- **Landing page**: An overview of the API grouped by tag
-- **Tag landing pages**: One page per tag that lists operations in that tag, with the tag's display name, optional OpenAPI `description` (CommonMark), and optional `externalDocs` link
-- **Operation pages**: One page per API operation, with the HTTP method, path, parameters, request body, response schemas, and examples
-- **Schema type pages**: Dedicated pages for complex shared types such as `QueryContainer` and `AggregationContainer`
+- **Landing page.** An overview of the API grouped by tag.
+- **Tag landing pages.** One page per tag that lists operations in that tag. The page includes the tag display name, an optional OpenAPI `description` (CommonMark), and an optional `externalDocs` link.
+- **Operation pages.** One page per API operation. The page includes the HTTP method, path, parameters, request body, response schemas, and examples.
+- **Schema type pages.** Dedicated pages for complex shared types such as `QueryContainer` and `AggregationContainer`.
 
 ## OpenAPI extensions
 
-The API Explorer supports some OpenAPI specification extensions to enhance navigation and display:
+The API Explorer supports some OpenAPI specification extensions. These extensions improve navigation and display:
 
 - [x-codeSamples](#x-codesamples)
 - [x-displayName](#x-displayname)
@@ -295,9 +293,9 @@ For background on OpenAPI vendor extensions, refer to [OpenAPI Specification](ht
 
 ### Multi-language code examples [x-codesamples]
 
-When an OpenAPI operation includes the `x-codeSamples` extension, the API Explorer renders the code samples with a language selector tab. This lets users switch between available languages such as Console, cURL, Python, JavaScript, Ruby, PHP, and Java.
+If an OpenAPI operation includes the `x-codeSamples` extension, the API Explorer renders the samples with a language selector tab. Users can switch among Console, cURL, Python, JavaScript, Ruby, PHP, and Java.
 
-The `x-codeSamples` extension is a JSON array of objects, each with a `lang` and `source` field:
+The `x-codeSamples` extension is a JSON array of objects. Each object has a `lang` field and a `source` field:
 
 ```json
 "x-codeSamples": [
@@ -307,17 +305,17 @@ The `x-codeSamples` extension is a JSON array of objects, each with a `lang` and
 ]
 ```
 
-The code samples appear in a standalone "Code Examples" section on every operation page that has the extension, regardless of HTTP method. This means GET, DELETE, and other operations without a request body also display language tabs when `x-codeSamples` are present. When multiple languages are available, they appear as tabs. The selected language persists across operations and page navigations. When only one language is available, the example renders without a tab selector.
+The code samples appear in a standalone "Code Examples" section on every operation page that has the extension. This is true for every HTTP method. GET, DELETE, and other operations without a request body also show language tabs when `x-codeSamples` is present. If multiple languages are available, they appear as tabs. The selected language persists across operations and page navigations. If only one language is available, the example renders without a tab selector.
 
-Console is treated as the default language and appears first in the tab order when present.
+Console is the default language. If Console is present, it appears first in the tab order.
 
 ### Prerequisites [x-req-auth]
 
-Add the operation-level `x-req-auth` extension to list authentication or privilege requirements that users must satisfy before calling the API.
+Add the operation-level `x-req-auth` extension to list authentication or privilege requirements. Users must satisfy these requirements before they call the API.
 The API Explorer renders these lines in a **Prerequisites** section on the operation page.
 
 `x-req-auth` is a JSON array of strings.
-Each non-empty string becomes one item in the prerequisites list (leading and trailing whitespace is trimmed).
+Each non-empty string becomes one item in the prerequisites list. {{dbuild}} trims leading and trailing whitespace.
 
 ```json
 {
@@ -331,15 +329,13 @@ Each non-empty string becomes one item in the prerequisites list (leading and tr
 }
 ```
 
-
-
-When prerequisites are present, **Prerequisites** also appears in the on-page table of contents (after **Paths**).
-When the extension is missing, empty, or not a JSON array, the section is omitted.
-Malformed values are skipped and the build may log a warning.
+If prerequisites are present, **Prerequisites** also appears in the on-page table of contents (after **Paths**).
+If the extension is missing, empty, or not a JSON array, the API Explorer omits the section.
+{{dbuild}} skips malformed values. The build may log a warning.
 
 ### Tag labels [x-displayname]
 
-Use the `x-displayName` extension (from [Redocly](https://redocly.com/docs-legacy/api-reference-docs/specification-extensions/x-display-name)) on tag objects to provide user-friendly display names in navigation and landing pages while maintaining stable URLs based on the canonical tag name.
+Use the `x-displayName` extension (from [Redocly](https://redocly.com/docs-legacy/api-reference-docs/specification-extensions/x-display-name)) on tag objects. This sets a display name for navigation and landing pages. URLs stay based on the canonical tag name.
 
 ```json
 {
@@ -350,7 +346,7 @@ Use the `x-displayName` extension (from [Redocly](https://redocly.com/docs-legac
       "x-displayName": "Task management"
     },
     {
-      "name": "ml_anomaly", 
+      "name": "ml_anomaly",
       "description": "Machine learning anomaly detection APIs.",
       "x-displayName": "Machine Learning Anomaly Detection"
     }
@@ -360,17 +356,17 @@ Use the `x-displayName` extension (from [Redocly](https://redocly.com/docs-legac
 
 **Behavior:**
 
-- When `x-displayName` is present, it's used for navigation titles, tag landing page titles, and section headings on the main API overview
-- When `x-displayName` is absent, the canonical tag `name` is used as a fallback
-- Tag landing page URLs and tag URL segments are derived from the canonical tag `name`
+- If `x-displayName` is present, the API Explorer uses it for navigation titles, tag landing page titles, and section headings on the main API overview.
+- If `x-displayName` is absent, the API Explorer uses the canonical tag `name`.
+- Tag landing page URLs and tag URL segments come from the canonical tag `name`.
 
 :::{note}
-If two different canonical tag names normalize to the same tag landing page URL, the build fails with an error that names both tags and the colliding segment so the spec can be fixed.
+If two different canonical tag names normalize to the same tag landing page URL, the build fails. The error names both tags and the colliding segment so you can fix the spec.
 :::
 
 ### Tag groups [x-taggroups]
 
-Use the document-level `x-tagGroups` extension (from [Redocly](https://redocly.com/docs-legacy/api-reference-docs/specification-extensions/x-tag-groups)) to define how tags are grouped in the API Explorer sidebar. Each group has a display `name` and a list of tag `name` values that belong to it. Group order in the array is the order of top-level sections in the navigation.
+Use the document-level `x-tagGroups` extension (from [Redocly](https://redocly.com/docs-legacy/api-reference-docs/specification-extensions/x-tag-groups)) to group tags in the API Explorer sidebar. Each group has a display `name` and a list of tag `name` values. Group order in the array is the order of top-level sections in the navigation.
 
 ```json
 {
@@ -392,7 +388,7 @@ Use the document-level `x-tagGroups` extension (from [Redocly](https://redocly.c
 
 **Behavior:**
 
-- When `x-tagGroups` is present and valid, the API Explorer uses it as an additional level of grouping in the sidebar.
-- In the navigation tree, a group's section title links to the **main API overview** for that product (it is not a separate page and does not point at the first tag in the group; tag landings stay under `.../tags/...` only for tags).
-- When `x-tagGroups` is absent, tags are listed directly under the API root in a single flat layer.
-- Any operation tag that is not listed under any group is still included: it appears under a fallback section named `unknown`, and the build logs a warning so you can fix the spec.
+- If `x-tagGroups` is present and valid, the API Explorer uses it as an extra grouping level in the sidebar.
+- In the navigation tree, a group's section title links to the **main API overview** for that product. It is not a separate page. It does not point at the first tag in the group. Tag landings stay under `.../group/...`.
+- If `x-tagGroups` is absent, the API Explorer lists tags directly under the API root in a single flat layer.
+- If an operation tag is not listed under any group, it still appears. The API Explorer shows it under a fallback section named `unknown`. The build logs a warning so you can fix the spec.

--- a/docs/data/openapi/index.md
+++ b/docs/data/openapi/index.md
@@ -4,11 +4,13 @@ navigation_title: OpenAPI
 
 # OpenAPI Support
 
-{{dbuild}} can generate documentation from OpenAPI specifications. The API Explorer renders specs as interactive, navigable reference documentation directly within your documentation site.
+{{dbuild}} can generate documentation from OpenAPI specifications. The API Explorer renders the spec as API reference pages on your documentation site.
 
 ## API Explorer
 
-The [API Explorer](./api-explorer.md) generates pages for every operation, tag, and shared schema type from an OpenAPI JSON specification. Configure it in your `docset.yml`:
+Configure a spec in `docset.yml`. Then preview the generated pages. See [API Explorer](./api-explorer.md) for setup, page URLs, multi-version trees, and OpenAPI extensions.
+
+To override a description or a parameter, add an `op-*.md` or `tag-*.md` file next to the spec. To add extra sections, use the same files. See [Writing supplemental content](./supplemental.md).
 
 ```yaml
 api:
@@ -20,4 +22,4 @@ api:
       product: kibana
 ```
 
-Each product key produces its own section of API documentation with tag grouping, code samples, and schema type pages.
+Each product key produces its own API documentation section under `/api/doc/<key>/`. The section includes tag grouping, code samples, and schema type pages.

--- a/docs/data/openapi/index.md
+++ b/docs/data/openapi/index.md
@@ -4,22 +4,19 @@ navigation_title: OpenAPI
 
 # OpenAPI Support
 
-{{dbuild}} can generate documentation from OpenAPI specifications. The API Explorer renders the spec as API reference pages on your documentation site.
+{{dbuild}} can generate API reference pages from an OpenAPI spec.
 
 ## API Explorer
 
-Configure a spec in `docset.yml`. Then preview the generated pages. See [API Explorer](./api-explorer.md) for setup, page URLs, multi-version trees, and OpenAPI extensions.
+Add an `api:` entry in `docset.yml`. Then preview the pages. See [API Explorer](./api-explorer.md) for configuration, URL paths, and OpenAPI extensions.
 
-To override a description or a parameter, add an `op-*.md` or `tag-*.md` file next to the spec. To add extra sections, use the same files. See [Writing supplemental content](./supplemental.md).
+To change an operation or tag page, put an `op-*.md` or `tag-*.md` file in `api/<key>/`. See [Writing supplemental content](./supplemental.md).
 
 ```yaml
 api:
   elasticsearch:
     - spec: elasticsearch-openapi.json
       product: elasticsearch
-  kibana:
-    - spec: kibana-openapi.json
-      product: kibana
 ```
 
-Each product key produces its own API documentation section under `/api/doc/<key>/`. The section includes tag grouping, code samples, and schema type pages.
+The map key is the URL suffix. `elasticsearch` produces pages under `/api/doc/elasticsearch/`.

--- a/docs/data/openapi/supplemental.md
+++ b/docs/data/openapi/supplemental.md
@@ -34,6 +34,8 @@ api/docs-builder-elasticsearch/
 
 A top-level `.md` file that is not `op-*.md` or `tag-*.md` is not a supplemental file. If you want that file as its own page, list it under `children:`.
 
+If the file lives under the documentation source directory, give it a `#` title so the docset scanner has a page title. That heading is not the operation description. Use `## Description` for the generated API page.
+
 ## Heading rules
 
 Headings control how {{dbuild}} merges the file into the generated page.

--- a/docs/data/openapi/supplemental.md
+++ b/docs/data/openapi/supplemental.md
@@ -1,0 +1,214 @@
+---
+navigation_title: Supplemental content
+---
+
+# Writing supplemental content
+
+Supplemental files add context to generated API Explorer pages. They also add usage examples and richer parameter descriptions. You do not edit the OpenAPI spec.
+
+**Files are discovered automatically.** Drop a file into `api/<key>/` that follows the naming convention. The next build finds the file. Do not add it to `toc.yml` or `children:`.
+
+**Validation is strict.** If a file name does not match an `operationId` or tag in the spec, the build fails. If a parameter key or request-body key is unknown, the build also fails. If you rename or remove an operation, an old file fails the build.
+
+**Frontmatter is metadata only.** YAML frontmatter can set `description`, `applies_to`, and `navigation_title`. {{dbuild}} copies that metadata to the generated page. It does not render frontmatter as the page body.
+
+Schema type pages use descriptions from the OpenAPI spec only. There is no `schema-*.md` convention.
+
+For a step-by-step example, see [API Explorer](./api-explorer.md).
+
+## File naming
+
+{{dbuild}} discovers only top-level `*.md` files in `api/<key>/`. It ignores nested folders.
+
+| File pattern | Matches |
+|---|---|
+| `op-<operationId>.md` | Operation whose spec `operationId` equals `<operationId>` with no rewriting |
+| `tag-<tagSlug>.md` | Tag whose URL slug equals `<tagSlug>` |
+| `op-<operationId>.vN.md` | Same operation, merged on major `N` only |
+| `tag-<tagSlug>.vN.md` | Same tag, merged on major `N` only |
+
+The `op-` stem is the spec `operationId` with no change. Do not slugify it.
+
+The `tag-` stem is the tag URL slug. {{dbuild}} replaces spaces with hyphens. It lowercases the name. Underscores stay. `search` matches `tag-search.md`. `ML Anomaly` matches `tag-ml-anomaly.md`. `ml_anomaly` matches `tag-ml_anomaly.md`.
+
+```text
+api/elasticsearch/
+  op-async-search-get.md
+  op-search.md
+  op-search.v8.md
+  tag-search.md
+  getting-started.md          # not auto-discovered; list it under children:
+```
+
+{{dbuild}} ignores any other top-level `.md` file during supplemental discovery. If you want that file as a page, list it under `children:`.
+
+## Heading rules
+
+The heading structure of a supplemental file controls what the file adds to the generated page.
+
+### Frontmatter
+
+```markdown
+---
+description: Retrieve results of a previously submitted async search.
+applies_to:
+  stack: ga
+---
+
+## Description
+
+Poll `GET /_async_search/{id}` until `is_running` is `false`.
+```
+
+{{dbuild}} keeps frontmatter as metadata. It uses the `## Description` section as the page description. If the file has only frontmatter, it uses the spec description.
+
+### No headings
+
+A file with no `##` headings replaces the spec description:
+
+```markdown
+Retrieve the results of a previously submitted asynchronous search request.
+```
+
+### Description
+
+A `## Description` section replaces the spec description. Other sections in the same file still apply:
+
+```markdown
+## Description
+
+Retrieve results of a previously submitted async search.
+Elasticsearch restricts access to the user or API key that submitted the request.
+
+## When to poll
+
+Retry until `is_running` is `false`.
+```
+
+### Parameters and request body
+
+These headings replace descriptions of the fields you list:
+
+- `## Parameters`
+- `## Query parameters`
+- `## Path parameters`
+- `## Request body`
+
+Unlisted fields keep the spec text.
+
+Each entry starts with `: field_name` or `: \`field_name\``:
+
+```markdown
+## Parameters
+
+: `keep_alive`
+  How long Elasticsearch keeps this search. Extending it also extends the
+  validity of the saved results.
+
+: id
+  The async search id returned by the submit request.
+```
+
+If a key is unknown, the build fails.
+
+### Additional sections
+
+Any other `##` heading is appended after the generated reference content. Headings stay in document order. Use these sections for examples or background that belong after the parameter tables.
+
+## Version-specific files
+
+If a description or parameter must differ for one major, add a `.vN.md` file next to the base file:
+
+```text
+api/elasticsearch/
+  op-search.md        # every version that has this operation
+  op-search.v8.md     # merged on top of the base file for 8.x only
+  tag-ml-anomaly.md
+  tag-ml-anomaly.v9.md
+```
+
+The version file uses the same heading rules as the base file. Two files merge, so one extra rule applies:
+
+- `## Description` or bare text replaces the base description for that version.
+- Listed parameter and request-body keys replace or add to the base overrides. Unlisted keys stay.
+- Extra `##` sections with a new heading are added alongside the base file. If both files use the same extra heading, the version file replaces the base section.
+- Sections you omit keep the base file.
+
+If a version has no matching `.vN.md`, that version uses the base file with no change. Tag files use this same merge.
+
+The unversioned `main` tree uses the overlay of the current major. Then `/api/doc/{key}/` matches `/vN/` for that major. Versionless products (serverless and similar) get no overlay.
+
+{{dbuild}} validates a version-suffixed file against that major's spec. `op-search.v8.md` must match an `operationId` in the v8 spec. A match in `main` only is not enough.
+
+## `children:` pages
+
+`children:` pages are full Markdown pages under the product root. You declare them in `docset.yml`. {{dbuild}} does not discover them by name:
+
+```yaml
+api:
+  kibana:
+    - spec: kibana-openapi.json
+      product: kibana
+      children:
+        - file: kibana-api-overview.md
+```
+
+Paths are relative to `api/<key>/`. Child pages can use all MyST directives, substitutions, and cross-links.
+
+A `*.vN.md` suffix limits that child to major `N` only. `getting-started.md` appears in every version. `knn-guide.v9.md` appears only in 9.x. If 9 is the current major, it also appears in the unversioned `main` tree.
+
+### Child slugs
+
+{{dbuild}} builds the URL slug from the filename:
+
+- It lowercases the name.
+- It replaces spaces and underscores with hyphens.
+- It removes the `.md` extension.
+- It does not include a `.vN` suffix in the slug.
+
+`Getting-Started.md` becomes `getting-started`. `knn-guide.v9.md` becomes `knn-guide`.
+
+These slugs are reserved. Do not use them as child file names:
+
+| Reserved slug | Reason |
+|---|---|
+| `types` | Schema type pages live under `/types/` |
+| `group` | Tag landing pages live under `/group/` |
+| `operation` | Operation pages live under `/operation/` |
+
+Do not list `op-*.md` or `tag-*.md` under `children:`. {{dbuild}} discovers those files automatically.
+
+## Validation errors
+
+Authors see these messages at build time.
+
+**Supplemental files**
+
+```text
+API supplemental file 'op-nope.md' does not match any operationId in the latest spec
+API supplemental file 'tag-nope.md' does not match any tag in the latest spec
+API supplemental file 'op-search.v8.md' does not match any operationId in version 8
+API supplemental: Parameter 'typo' not found in operation 'async-search-get' in the latest spec
+API supplemental: Request body field 'typo' not found in operation 'search' in the latest spec
+```
+
+Unmatched base files (`op-*.md` without `.vN`) are reported against `the latest spec`. Version-suffixed files are reported against `version {N}`.
+
+**`children:` and slugs**
+
+```text
+Child page 'op-search.md' for API 'elasticsearch' uses a supplemental file name (op-*.md / tag-*.md). Those files are auto-discovered and cannot be listed under children:.
+Child page 'missing.md' for API 'elasticsearch' does not exist under 'api/elasticsearch/'.
+Markdown file slug 'types' (from 'types.md') conflicts with reserved API Explorer segment in product 'elasticsearch'. Reserved segments: types, group, operation
+Duplicate markdown slug 'getting-started' found in API product 'elasticsearch'.
+```
+
+**`api:` config**
+
+```text
+API configuration for 'elasticsearch' must have exactly one entry, found 2.
+API 'elasticsearch' is missing required 'product:'. It must match a product id defined in products.yml.
+Unknown 'product: widgets' for API 'elasticsearch'. It must be a product id defined in products.yml.
+API 'elasticsearch' is missing required 'spec:'. Its basename is required to resolve the remote version index, even when the file is not present locally.
+'repository: elasticsearch-specification' for API 'elasticsearch' must be in 'org/repo' form, e.g. 'elastic/elasticsearch-specification'.
+```

--- a/docs/data/openapi/supplemental.md
+++ b/docs/data/openapi/supplemental.md
@@ -4,63 +4,47 @@ navigation_title: Supplemental content
 
 # Writing supplemental content
 
-Supplemental files add context to generated API Explorer pages. They also add usage examples and richer parameter descriptions. You do not edit the OpenAPI spec.
+Supplemental files change generated operation pages and tag landing pages. Put the files in `api/<key>/`. Do not put them next to the spec file. Do not list them in `toc.yml`.
 
-**Files are discovered automatically.** Drop a file into `api/<key>/` that follows the naming convention. The next build finds the file. Do not add it to `toc.yml` or `children:`.
+{{dbuild}} reads only top-level `*.md` files in that folder. Nested folders are ignored.
 
-**Validation is strict.** If a file name does not match an `operationId` or tag in the spec, the build fails. If a parameter key or request-body key is unknown, the build also fails. If you rename or remove an operation, an old file fails the build.
+If an `op-*.md` or `tag-*.md` name does not match the spec, the build fails. If an operation file lists a parameter or request-body field that the spec does not have, the build also fails.
 
-**Frontmatter is metadata only.** YAML frontmatter can set `description`, `applies_to`, and `navigation_title`. {{dbuild}} copies that metadata to the generated page. It does not render frontmatter as the page body.
+Schema type pages do not use supplemental files.
 
-Schema type pages use descriptions from the OpenAPI spec only. There is no `schema-*.md` convention.
-
-For a step-by-step example, see [API Explorer](./api-explorer.md).
+For a walkthrough that uses this repository, see [API Explorer](./api-explorer.md).
 
 ## File naming
 
-{{dbuild}} discovers only top-level `*.md` files in `api/<key>/`. It ignores nested folders.
-
 | File pattern | Matches |
 |---|---|
-| `op-<operationId>.md` | Operation whose spec `operationId` equals `<operationId>` with no rewriting |
+| `op-<operationId>.md` | Operation whose spec `operationId` equals `<operationId>` |
 | `tag-<tagSlug>.md` | Tag whose URL slug equals `<tagSlug>` |
-| `op-<operationId>.vN.md` | Same operation, merged on major `N` only |
-| `tag-<tagSlug>.vN.md` | Same tag, merged on major `N` only |
+| `op-<operationId>.vN.md` | Same operation, merged for major `N` only |
+| `tag-<tagSlug>.vN.md` | Same tag, merged for major `N` only |
 
 The `op-` stem is the spec `operationId` with no change. Do not slugify it.
 
 The `tag-` stem is the tag URL slug. {{dbuild}} replaces spaces with hyphens. It lowercases the name. Underscores stay. `search` matches `tag-search.md`. `ML Anomaly` matches `tag-ml-anomaly.md`. `ml_anomaly` matches `tag-ml_anomaly.md`.
 
 ```text
-api/elasticsearch/
+api/docs-builder-elasticsearch/
   op-async-search-get.md
-  op-search.md
-  op-search.v8.md
-  tag-search.md
-  getting-started.md          # not auto-discovered; list it under children:
 ```
 
-{{dbuild}} ignores any other top-level `.md` file during supplemental discovery. If you want that file as a page, list it under `children:`.
+A top-level `.md` file that is not `op-*.md` or `tag-*.md` is not a supplemental file. If you want that file as its own page, list it under `children:`.
 
 ## Heading rules
 
-The heading structure of a supplemental file controls what the file adds to the generated page.
+Headings control how {{dbuild}} merges the file into the generated page.
 
 ### Frontmatter
 
-```markdown
----
-description: Retrieve results of a previously submitted async search.
-applies_to:
-  stack: ga
----
+{{dbuild}} strips YAML frontmatter so it is not the page body.
 
-## Description
+For `op-*.md` and `tag-*.md`, frontmatter is not applied to the generated page. `applies_to` and `navigation_title` in those files have no effect. Operation titles come from the spec summary. Availability badges come from the spec, not from supplemental YAML.
 
-Poll `GET /_async_search/{id}` until `is_running` is `false`.
-```
-
-{{dbuild}} keeps frontmatter as metadata. It uses the `## Description` section as the page description. If the file has only frontmatter, it uses the spec description.
+For `children:` pages, `navigation_title` in frontmatter sets the navigation label. Those pages run through the normal Markdown pipeline.
 
 ### No headings
 
@@ -72,77 +56,61 @@ Retrieve the results of a previously submitted asynchronous search request.
 
 ### Description
 
-A `## Description` section replaces the spec description. Other sections in the same file still apply:
-
-```markdown
-## Description
-
-Retrieve results of a previously submitted async search.
-Elasticsearch restricts access to the user or API key that submitted the request.
-
-## When to poll
-
-Retry until `is_running` is `false`.
-```
+A `## Description` section replaces the spec description. Other sections in the same file still apply.
 
 ### Parameters and request body
 
-These headings replace descriptions of the fields you list:
+These headings work on **operation** files only:
 
 - `## Parameters`
 - `## Query parameters`
 - `## Path parameters`
 - `## Request body`
 
-Unlisted fields keep the spec text.
+Each listed field starts with `: field_name` or `: \`field_name\``. Unlisted fields keep the spec text. An unknown key fails the build.
 
-Each entry starts with `: field_name` or `: \`field_name\``:
+On a **tag** file, those headings are not shown. Tag files use the description and extra `##` sections only.
 
 ```markdown
 ## Parameters
 
 : `keep_alive`
-  How long Elasticsearch keeps this search. Extending it also extends the
-  validity of the saved results.
+  How long Elasticsearch keeps this search and its saved results.
 
 : id
   The async search id returned by the submit request.
 ```
 
-If a key is unknown, the build fails.
-
 ### Additional sections
 
-Any other `##` heading is appended after the generated reference content. Headings stay in document order. Use these sections for examples or background that belong after the parameter tables.
+Any other `##` heading is appended after the generated reference content. Headings stay in document order.
 
 ## Version-specific files
 
-If a description or parameter must differ for one major, add a `.vN.md` file next to the base file:
+If one major needs different text, add a `.vN.md` file next to the base file:
 
 ```text
 api/elasticsearch/
-  op-search.md        # every version that has this operation
-  op-search.v8.md     # merged on top of the base file for 8.x only
-  tag-ml-anomaly.md
-  tag-ml-anomaly.v9.md
+  op-search.md
+  op-search.v8.md
 ```
 
-The version file uses the same heading rules as the base file. Two files merge, so one extra rule applies:
+The version file uses the same heading rules as the base file. The two files merge as follows:
 
 - `## Description` or bare text replaces the base description for that version.
 - Listed parameter and request-body keys replace or add to the base overrides. Unlisted keys stay.
-- Extra `##` sections with a new heading are added alongside the base file. If both files use the same extra heading, the version file replaces the base section.
-- Sections you omit keep the base file.
+- A new extra `##` heading is added. If both files use the same extra heading, the version file replaces that section.
+- Omitted sections keep the base file.
 
-If a version has no matching `.vN.md`, that version uses the base file with no change. Tag files use this same merge.
+If a version has no `.vN.md` file, that version uses the base file only.
 
-The unversioned `main` tree uses the overlay of the current major. Then `/api/doc/{key}/` matches `/vN/` for that major. Versionless products (serverless and similar) get no overlay.
+The unversioned `/api/doc/{key}/` tree uses the overlay of the highest numeric major that this product renders. Versionless products render only `main`. They have no numeric major, so they get no overlay.
 
-{{dbuild}} validates a version-suffixed file against that major's spec. `op-search.v8.md` must match an `operationId` in the v8 spec. A match in `main` only is not enough.
+{{dbuild}} checks a version-suffixed file against that major's spec. `op-search.v8.md` must match an `operationId` in the v8 spec.
 
 ## `children:` pages
 
-`children:` pages are full Markdown pages under the product root. You declare them in `docset.yml`. {{dbuild}} does not discover them by name:
+`children:` pages are separate Markdown pages under the product root. You declare them in `docset.yml`. {{dbuild}} does not pick them up by file name.
 
 ```yaml
 api:
@@ -153,9 +121,9 @@ api:
         - file: kibana-api-overview.md
 ```
 
-Paths are relative to `api/<key>/`. Child pages can use all MyST directives, substitutions, and cross-links.
+Paths are relative to `api/<key>/`. These pages can use MyST directives, substitutions, and cross-links.
 
-A `*.vN.md` suffix limits that child to major `N` only. `getting-started.md` appears in every version. `knn-guide.v9.md` appears only in 9.x. If 9 is the current major, it also appears in the unversioned `main` tree.
+A `*.vN.md` suffix limits that child to major `N`. `getting-started.md` appears in every version. `knn-guide.v9.md` appears in 9.x. If 9 is the highest numeric major, it also appears on the unversioned `main` tree.
 
 ### Child slugs
 
@@ -164,19 +132,19 @@ A `*.vN.md` suffix limits that child to major `N` only. `getting-started.md` app
 - It lowercases the name.
 - It replaces spaces and underscores with hyphens.
 - It removes the `.md` extension.
-- It does not include a `.vN` suffix in the slug.
+- It drops a `.vN` suffix from the slug.
 
 `Getting-Started.md` becomes `getting-started`. `knn-guide.v9.md` becomes `knn-guide`.
 
-These slugs are reserved. Do not use them as child file names:
+These slugs are reserved:
 
 | Reserved slug | Reason |
 |---|---|
-| `types` | Schema type pages live under `/types/` |
-| `group` | Tag landing pages live under `/group/` |
-| `operation` | Operation pages live under `/operation/` |
+| `types` | Schema type pages use `/types/` |
+| `group` | Tag landing pages use `/group/` |
+| `operation` | Operation pages use `/operation/` |
 
-Do not list `op-*.md` or `tag-*.md` under `children:`. {{dbuild}} discovers those files automatically.
+Do not list `op-*.md` or `tag-*.md` under `children:`.
 
 ## Validation errors
 
@@ -192,7 +160,7 @@ API supplemental: Parameter 'typo' not found in operation 'async-search-get' in 
 API supplemental: Request body field 'typo' not found in operation 'search' in the latest spec
 ```
 
-Unmatched base files (`op-*.md` without `.vN`) are reported against `the latest spec`. Version-suffixed files are reported against `version {N}`.
+Unmatched base files are reported against `the latest spec`. Version-suffixed files are reported against `version {N}`.
 
 **`children:` and slugs**
 


### PR DESCRIPTION
## Why

- Authors need a tutorial and a reference for the shipped `api:` config, bump.sh URLs, supplemental files, and validation errors
- https://github.com/elastic/docs-eng-team/issues/731

## What

- Add a hands-on API Explorer walkthrough and a supplemental-content reference page
- Fix stale `/api/{key}/` paths, reserved slugs, and tag landing URLs so they match the code

## Notes

- This PR stacks on `cursor/0fe010e1` (https://github.com/elastic/docs-builder/pull/3944)
- The optional `docs-builder api scaffold` command is not included


Made with [Cursor](https://cursor.com)