### PR TITLE
Pin vulnerable transitive NuGet dependencies to safe versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -118,6 +118,15 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
   </ItemGroup>
+  <!-- Transitive pins: force vulnerable indirect dependencies to safe versions -->
+  <ItemGroup>
+    <!-- SSH.NET 2024.2.0 has GHSA-q939-rpr3-3284 (high); pin to 2026.0.0 -->
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
+    <!-- Scriban.Signed 5.5.0 has multiple CVEs (GHSA-5wr9-m6jw-xx44 critical, etc.); pin to 7.2.6 -->
+    <PackageVersion Include="Scriban.Signed" Version="7.2.6" />
+    <!-- System.Linq.Dynamic.Core 1.3.12 has GHSA-4cv2-4hjh-77rx (high); pin to 1.7.3 -->
+    <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.7.3" />
+  </ItemGroup>
   <!-- Test packages -->
   <ItemGroup>
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.4.3" />

--- a/tests/Elastic.Markdown.Tests/CliReference/CliSupplementalDocTests.cs
+++ b/tests/Elastic.Markdown.Tests/CliReference/CliSupplementalDocTests.cs
@@ -67,7 +67,7 @@ public class CliSupplementalDocTests
 
 		var supplemental = CliSupplementalDoc.Parse(raw);
 		var body = CliMarkdownGenerator.RootPage(schema, supplemental).ReplaceLineEndings("\n");
-		var combined = $"{supplemental!.FrontMatter.ReplaceLineEndings("\n")}\n\n{body}";
+		var combined = $"{supplemental!.FrontMatter?.ReplaceLineEndings("\n")}\n\n{body}";
 
 		combined.Should().StartWith("---\n");
 		combined.Should().Contain("---\n\n# elastic");


### PR DESCRIPTION
## Why

Three transitive NuGet packages pulled in by `WireMock.Net` and `Testcontainers.Elasticsearch` have known vulnerabilities that surface as NU1902/NU1903/NU1904 build warnings (and errors when treated as errors in CI):

- `SSH.NET` 2024.2.0 — GHSA-q939-rpr3-3284 (high)
- `Scriban.Signed` 5.5.0 — GHSA-5wr9-m6jw-xx44 (critical) + 10 additional CVEs
- `System.Linq.Dynamic.Core` 1.3.12 — GHSA-4cv2-4hjh-77rx (high)

## What

Adds explicit `PackageVersion` pins in `Directory.Packages.props` for all three packages at safe versions (SSH.NET → 2026.0.0, Scriban.Signed → 7.2.6, System.Linq.Dynamic.Core → 1.7.3). `CentralPackageTransitivePinningEnabled` is already enabled, so these pins override what the direct dependencies pull in without requiring upgrades to `WireMock.Net` or `Testcontainers.Elasticsearch` themselves.