### PR TITLE
Fix stale git lock files and silent fetch failures in clone path

### DIFF
--- a/src/Elastic.Codex/Sourcing/CodexGitRepository.cs
+++ b/src/Elastic.Codex/Sourcing/CodexGitRepository.cs
@@ -31,6 +31,10 @@ public class CodexGitRepository(ILoggerFactory logFactory, IDiagnosticsCollector
 		BaseDelay: TimeSpan.FromSeconds(5),
 		AttemptTimeout: GitTimeouts.CiDefault);
 
+	protected override void OnBeforeRetry() =>
+		GitLocks.ClearStale(WorkingDirectory.FileSystem, WorkingDirectory.FullName,
+			f => Logger.LogWarning("Removed stale git lock file {LockFile}", f));
+
 	public string GetCurrentCommit() => Capture("git", "rev-parse", "HEAD");
 
 	public bool HasHead() => !string.IsNullOrEmpty(CaptureQuiet("git", "rev-parse", "--verify", "HEAD"));

--- a/src/Elastic.Documentation.LinkIndex/GitLinkIndexReader.cs
+++ b/src/Elastic.Documentation.LinkIndex/GitLinkIndexReader.cs
@@ -151,13 +151,18 @@ public class GitLinkIndexReader : ILinkIndexReader, IDisposable
 	/// <summary>
 	/// Runs a git command with a retry policy. Throws <see cref="InvalidOperationException"/> on exhaustion.
 	/// </summary>
-	private static void RunGitWithRetry(string workingDirectory, RetryPolicy policy, params string[] args)
+	private void RunGitWithRetry(string workingDirectory, RetryPolicy policy, params string[] args)
 	{
 		var failure = CommandRetry.Invoke(
 			policy,
 			invoke: () => ExecGit(workingDirectory, args, policy.AttemptTimeout),
 			delay: d => Thread.Sleep(d),
-			onRetry: f => Console.Error.WriteLine($"[git {string.Join(" ", args)}] {f}; retrying…")
+			onRetry: f =>
+			{
+				GitLocks.ClearStale(_fileSystem, workingDirectory,
+					l => Console.Error.WriteLine($"[git {string.Join(" ", args)}] Removed stale lock file {l}"));
+				Console.Error.WriteLine($"[git {string.Join(" ", args)}] {f}; retrying…");
+			}
 		);
 
 		if (failure is not null)

--- a/src/Elastic.Documentation.Tooling/ExternalCommands/CommandRetry.cs
+++ b/src/Elastic.Documentation.Tooling/ExternalCommands/CommandRetry.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.IO.Abstractions;
 using ProcNet;
 
 namespace Elastic.Documentation.ExternalCommands;
@@ -94,4 +95,31 @@ public static class GitTimeouts
 		string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CI"))
 			? null
 			: TimeSpan.FromMinutes(10);
+}
+
+/// <summary>
+/// Cleans up orphaned git lock files left behind when a git process is killed by a per-attempt timeout.
+/// Safe to call only from a retry path — never before the first attempt.
+/// </summary>
+public static class GitLocks
+{
+	public static void ClearStale(IFileSystem fileSystem, string workingDirectory, Action<string> onCleared)
+	{
+		var gitDir = fileSystem.Path.Join(workingDirectory, ".git");
+		if (!fileSystem.Directory.Exists(gitDir))
+			return;
+
+		foreach (var lockFile in fileSystem.Directory.EnumerateFiles(gitDir, "*.lock", SearchOption.AllDirectories))
+		{
+			try
+			{
+				fileSystem.File.Delete(lockFile);
+				onCleared(lockFile);
+			}
+			catch
+			{
+				// Another process may hold it; leave it and let git report the error.
+			}
+		}
+	}
 }

--- a/src/Elastic.Documentation.Tooling/ExternalCommands/ExternalCommandExecutor.cs
+++ b/src/Elastic.Documentation.Tooling/ExternalCommands/ExternalCommandExecutor.cs
@@ -49,6 +49,7 @@ public abstract class ExternalCommandExecutor(IDiagnosticsCollector collector, I
 			delay: DelayBeforeRetry,
 			onRetry: f =>
 			{
+				OnBeforeRetry();
 				// Deliberately not routed through Log: a silent multi-second stall is worse than extra local output.
 				Logger.LogWarning("[{Command}] {Failure}. Retrying in {WorkingDirectory}", command, f, workingDirectory.FullName);
 			});
@@ -62,6 +63,8 @@ public abstract class ExternalCommandExecutor(IDiagnosticsCollector collector, I
 		collector.EmitError("", detail);
 		return false;
 	}
+
+	protected virtual void OnBeforeRetry() { }
 
 	protected virtual void DelayBeforeRetry(TimeSpan delay)
 	{

--- a/src/services/Elastic.Documentation.Assembler/Sourcing/GitFacade.cs
+++ b/src/services/Elastic.Documentation.Assembler/Sourcing/GitFacade.cs
@@ -15,8 +15,8 @@ public interface IGitRepository
 	string GetCurrentCommit();
 	void GitAddOrigin(string origin);
 	bool IsInitialized();
-	void Pull(string branch);
-	void Fetch(string reference);
+	bool Pull(string branch);
+	bool Fetch(string reference);
 	void EnableSparseCheckout(string[] folders);
 	void DisableSparseCheckout();
 	void Checkout(string reference);
@@ -48,12 +48,16 @@ public class SingleCommitOptimizedGitRepository(ILoggerFactory logFactory, IDiag
 	/// <inheritdoc />
 	protected override ILogger Logger { get; } = logFactory.CreateLogger<SingleCommitOptimizedGitRepository>();
 
+	protected override void OnBeforeRetry() =>
+		GitLocks.ClearStale(WorkingDirectory.FileSystem, WorkingDirectory.FullName,
+			f => Logger.LogWarning("{RepositoryName}: Removed stale git lock file {LockFile}", WorkingDirectory.Name, f));
+
 	public string GetCurrentCommit() => Capture("git", "rev-parse", "HEAD");
 
 	public void Init() => ExecIn(EnvironmentVars, "git", "init");
 	public bool IsInitialized() => Directory.Exists(Path.Join(WorkingDirectory.FullName, ".git"));
-	public void Pull(string branch) => _ = ExecInWithRetry(EnvironmentVars, _networkRetry, "git", "pull", "--depth", "1", "--allow-unrelated-histories", "--no-ff", "origin", branch);
-	public void Fetch(string reference) => _ = ExecInWithRetry(EnvironmentVars, _networkRetry, "git", "fetch", "--no-tags", "--prune", "--no-recurse-submodules", "--depth", "1", "origin", reference);
+	public bool Pull(string branch) => ExecInWithRetry(EnvironmentVars, _networkRetry, "git", "pull", "--depth", "1", "--allow-unrelated-histories", "--no-ff", "origin", branch);
+	public bool Fetch(string reference) => ExecInWithRetry(EnvironmentVars, _networkRetry, "git", "fetch", "--no-tags", "--prune", "--no-recurse-submodules", "--depth", "1", "origin", reference);
 	public void EnableSparseCheckout(string[] folders) => ExecIn(EnvironmentVars, "git", ["sparse-checkout", "set", "--no-cone", .. folders]);
 
 	public void DisableSparseCheckout() => ExecIn(EnvironmentVars, "git", "sparse-checkout", "disable");

--- a/src/services/Elastic.Documentation.Assembler/Sourcing/RepositorySourcesFetcher.cs
+++ b/src/services/Elastic.Documentation.Assembler/Sourcing/RepositorySourcesFetcher.cs
@@ -202,7 +202,13 @@ public class RepositorySourcer(ILoggerFactory logFactory, IDirectoryInfo checkou
 			_logger.LogInformation("{RepositoryName}: HEAD already at {GitRef}", repository.Name, gitRef);
 		else
 		{
-			FetchAndCheckout(git, repository, gitRef);
+			if (!FetchAndCheckout(git, repository, gitRef))
+			{
+				_logger.LogError("{RepositoryName}: Fetch failed for {GitRef}, falling back to recreating from scratch", repository.Name, gitRef);
+				checkoutFolder.Delete(true);
+				checkoutFolder.Refresh();
+				return CloneRef(repository, gitRef, pull, attempt + 1, appendRepositoryName, assumeCloned);
+			}
 			if (!pull)
 			{
 				return new Checkout
@@ -212,13 +218,9 @@ public class RepositorySourcer(ILoggerFactory logFactory, IDirectoryInfo checkou
 					Repository = repository,
 				};
 			}
-			try
+			if (!git.Pull(gitRef))
 			{
-				git.Pull(gitRef);
-			}
-			catch (Exception e)
-			{
-				_logger.LogError(e, "{RepositoryName}: Failed to update {GitRef} from {Path}, falling back to recreating from scratch",
+				_logger.LogError("{RepositoryName}: Pull failed for {GitRef} from {Path}, falling back to recreating from scratch",
 					repository.Name, gitRef, checkoutFolder.FullName);
 				checkoutFolder.Delete(true);
 				checkoutFolder.Refresh();
@@ -248,9 +250,10 @@ public class RepositorySourcer(ILoggerFactory logFactory, IDirectoryInfo checkou
 		return false;
 	}
 
-	private static void FetchAndCheckout(IGitRepository git, Repository repository, string gitRef)
+	private static bool FetchAndCheckout(IGitRepository git, Repository repository, string gitRef)
 	{
-		git.Fetch(gitRef);
+		if (!git.Fetch(gitRef))
+			return false;
 		switch (repository.CheckoutStrategy)
 		{
 			case CheckoutStrategy.Full:
@@ -263,6 +266,7 @@ public class RepositorySourcer(ILoggerFactory logFactory, IDirectoryInfo checkou
 				throw new ArgumentOutOfRangeException(nameof(repository), repository.CheckoutStrategy, null);
 		}
 		git.Checkout(gitRef);
+		return true;
 	}
 }
 

--- a/tests/Elastic.Documentation.Build.Tests/ExternalCommandExecutorRetryTests.cs
+++ b/tests/Elastic.Documentation.Build.Tests/ExternalCommandExecutorRetryTests.cs
@@ -113,6 +113,27 @@ public class ExternalCommandExecutorRetryTests
 		executor.Diagnostics.Errors.Should().Be(1);
 	}
 
+	[Fact]
+	public void ExecInWithRetry_OnRetry_CallsOnBeforeRetryOncePerRetryNotBeforeFirstAttempt()
+	{
+		var executor = CreateExecutor(ExitCode(1), ExitCode(1), ExitCode(0));
+
+		var succeeded = executor.Retry(FiveAttempts);
+
+		succeeded.Should().BeTrue();
+		executor.OnBeforeRetryCallCount.Should().Be(2);
+	}
+
+	[Fact]
+	public void ExecInWithRetry_OnFirstAttemptSuccess_OnBeforeRetryNeverCalled()
+	{
+		var executor = CreateExecutor(ExitCode(0));
+
+		executor.Retry(FiveAttempts);
+
+		executor.OnBeforeRetryCallCount.Should().Be(0);
+	}
+
 	// ── Helpers ──────────────────────────────────────────────────────────────────
 
 	/// <summary>Scripts a normal process exit.</summary>
@@ -134,6 +155,8 @@ public class ExternalCommandExecutorRetryTests
 	{
 		public int CallCount { get; private set; }
 
+		public int OnBeforeRetryCallCount { get; private set; }
+
 		public List<TimeSpan> RecordedDelays { get; } = [];
 
 		public IDiagnosticsCollector Diagnostics => Collector;
@@ -146,6 +169,8 @@ public class ExternalCommandExecutorRetryTests
 				throw new InvalidOperationException($"Unexpected invocation {CallCount + 1}, only {steps.Length} steps were scripted");
 			return steps[CallCount++]();   // may throw ProcExecException
 		}
+
+		protected override void OnBeforeRetry() => OnBeforeRetryCallCount++;
 
 		protected override void DelayBeforeRetry(TimeSpan delay) => RecordedDelays.Add(delay);
 

--- a/tests/Elastic.Documentation.Build.Tests/GitLocksTests.cs
+++ b/tests/Elastic.Documentation.Build.Tests/GitLocksTests.cs
@@ -1,0 +1,55 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions.TestingHelpers;
+using AwesomeAssertions;
+using Elastic.Documentation.ExternalCommands;
+
+namespace Elastic.Documentation.Build.Tests;
+
+public class GitLocksTests
+{
+	[Fact]
+	public void ClearStale_RemovesAllLockFilesUnderGitDir()
+	{
+		var fs = new MockFileSystem();
+		fs.AddFile("/repo/.git/shallow.lock", new MockFileData(""));
+		fs.AddFile("/repo/.git/refs/heads/main.lock", new MockFileData(""));
+		fs.AddFile("/repo/.git/index.lock", new MockFileData(""));
+		var cleared = new List<string>();
+
+		GitLocks.ClearStale(fs, "/repo", cleared.Add);
+
+		cleared.Should().HaveCount(3);
+		fs.File.Exists("/repo/.git/shallow.lock").Should().BeFalse();
+		fs.File.Exists("/repo/.git/refs/heads/main.lock").Should().BeFalse();
+		fs.File.Exists("/repo/.git/index.lock").Should().BeFalse();
+	}
+
+	[Fact]
+	public void ClearStale_DoesNotDeleteNonLockFiles()
+	{
+		var fs = new MockFileSystem();
+		fs.AddFile("/repo/.git/shallow.lock", new MockFileData(""));
+		fs.AddFile("/repo/.git/config", new MockFileData("[core]"));
+		var cleared = new List<string>();
+
+		GitLocks.ClearStale(fs, "/repo", cleared.Add);
+
+		cleared.Should().HaveCount(1);
+		fs.File.Exists("/repo/.git/config").Should().BeTrue();
+	}
+
+	[Fact]
+	public void ClearStale_WhenNoGitDir_DoesNothing()
+	{
+		var fs = new MockFileSystem();
+		var cleared = new List<string>();
+
+		var act = () => GitLocks.ClearStale(fs, "/repo", cleared.Add);
+
+		act.Should().NotThrow();
+		cleared.Should().BeEmpty();
+	}
+}


### PR DESCRIPTION
## Why

When a `git fetch` is killed by the per-attempt CI timeout, git leaves `*.lock` files behind in `.git/`. The next retry dies instantly with exit 128 ("File exists") — a retry slot burned on a condition that can never self-recover without clearing the lock first.

Compounding this, `IGitRepository.Fetch` was `void` and swallowed its failure return value, so when all retries were exhausted, `FetchAndCheckout` still proceeded to `git checkout` against a tree with no matching ref. The wipe-and-reclone fallback in `CloneRef` never fired for fetch failures — only for exceptions from `GetCurrentCommit` and `Pull`.

## What

- `GitLocks.ClearStale(IFileSystem, ...)` sweeps `*.lock` files under `.git/` before each retry. Called only from the retry path — never before attempt 1, where a lock could belong to a concurrent process.
- `OnBeforeRetry()` virtual hook added to `ExternalCommandExecutor`; git executor subclasses override it to call `GitLocks.ClearStale`.
- `IGitRepository.Fetch` and `Pull` now return `bool`. `FetchAndCheckout` short-circuits on a failed fetch. `CloneRef` triggers wipe-and-reclone on fetch or pull failure, using the same pattern already in place for `GetCurrentCommit` exceptions.
- The dead `try/catch` around `git.Pull` (which could never fire since `ExecInWithRetry` doesn't throw) is replaced with a bool-check reclone path.