### PR TITLE
Move CI lint job to the curb GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,12 +126,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Bootstrap Action Workspace
-        id: bootstrap
-        uses: ./.github/actions/bootstrap
-
       - name: Lint
-        run: ./build.sh lint
+        uses: nullean/curb@c399bcd201b5ca466cfbcf5776825a629abf4f4b # 0.7.1
+        with:
+          command: check
+          path: .
 
   build:
     runs-on: ${{ matrix.os }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,17 +74,15 @@ See the [release-drafter configuration](./.github/release-drafter.yml) for more 
 
 ## Git Hooks with Husky.Net
 
-This repository uses [Husky.Net](https://alirezanet.github.io/Husky.Net/) to automatically format and validate code before commits and pushes.
+This repository uses [Husky.Net](https://alirezanet.github.io/Husky.Net/) to automatically format and validate code before commits.
 
 ### What Gets Checked
 
 **Pre-commit hooks** (run on staged files):
+- **dotnet-lint** - Checks C# formatting with [curb](https://curb.nullean.net) (`dotnet curb check .`)
 - **prettier** - Formats TypeScript, JavaScript, CSS, and JSON files in `src/Elastic.Documentation.Site/`
 - **typescript-check** - Type checks TypeScript files with `tsc --noEmit` (only if TS files are staged)
 - **eslint** - Lints and fixes JavaScript/TypeScript files
-
-**Pre-push hooks** (run on files being pushed):
-- **dotnet-lint** - Lints C# and F# files using `./build.sh lint` (runs `dotnet format --verify-no-changes`)
 
 ### Installation
 
@@ -100,16 +98,15 @@ Then install the git hooks:
 dotnet husky install
 ```
 
-That's it! The hooks will now run automatically on every commit and push.
+That's it! The hooks will now run automatically on every commit.
 
 ### Usage
 
-Once installed, hooks run automatically when you commit or push:
+Once installed, hooks run automatically when you commit:
 
 ```bash
 git add .
 git commit -m "your message"  # Pre-commit hooks run here
-git push                       # Pre-push hooks run here
 ```
 
 **Note:** If hooks modify files (prettier, eslint), the commit will fail so you can review the changes. Simply stage the changes and commit again:
@@ -119,24 +116,21 @@ git add -u
 git commit -m "your message"
 ```
 
-If the **dotnet-lint** hook fails during push, you need to fix the linting errors and commit the fixes before pushing again.
+If the **dotnet-lint** hook fails, run `dotnet curb format .` to fix the formatting and commit the fixes.
 
 ### Manual Execution
 
-You can test hooks without committing or pushing:
+You can test hooks without committing:
 
 ```bash
 # Run all pre-commit tasks
 dotnet husky run --group pre-commit
 
-# Run all pre-push tasks
-dotnet husky run --group pre-push
-
 # Test individual tasks
+dotnet husky run --name dotnet-lint
 dotnet husky run --name prettier
 dotnet husky run --name typescript-check
 dotnet husky run --name eslint
-dotnet husky run --name dotnet-lint
 ```
 
 ### Configuration


### PR DESCRIPTION
## Why

Now that #3904 migrated the formatting toolchain from `dotnet format` to [curb](https://curb.nullean.net), the `lint` CI job no longer needs a full .NET SDK bootstrap (tool restore, Node setup, etc.) just to run a formatting check — curb ships as a pre-built container image via its own GitHub Action.

## What

- `lint` job in `.github/workflows/ci.yml` now uses `nullean/curb` (pinned to the `0.7.1` commit SHA, per this repo's zizmor policy for non-`actions/*`/`elastic/*` actions) instead of checking out the repo, bootstrapping .NET/Node, and running `./build.sh lint`.
- Updated `CONTRIBUTING.md`'s Husky.Net section, which still described `dotnet-lint` as a pre-push hook running `dotnet format --verify-no-changes` — #3904 had already moved it to a pre-commit hook running `dotnet curb check`, but the docs weren't updated to match.

Made with [Cursor](https://cursor.com)