### PR TITLE
Gate dotnet CI jobs on lint to avoid wasted CURB0001 failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ env:
 
 jobs:
   validate-assembler:
+    needs: [lint]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7.0.1
@@ -35,12 +36,15 @@ jobs:
         run: dotnet run --project src/tooling/docs-builder -c release -- assembler content-source validate
 
   build-link-index-updater-lambda:
+    needs: [lint]
     uses: ./.github/workflows/build-link-index-updater-lambda.yml
 
   build-openapi-index-lambda:
+    needs: [lint]
     uses: ./.github/workflows/build-openapi-index-lambda.yml
 
   synthetics:
+    needs: [lint]
     runs-on: ubuntu-latest
     env:
       MSBuildNoWarn: IDE0032
@@ -133,6 +137,7 @@ jobs:
           path: .
 
   build:
+    needs: [lint]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Why

Since the lint job was moved to the curb GitHub Action (#3953), any formatting violation causes CURB0001 — but all the dotnet jobs also invoke MSBuild (which runs curb), so they fail with the same error anyway. Without this change, a single lint failure spins up and wastes runners for `build` (3× matrix), `validate-assembler`, `synthetics`, and the two lambda builds before they all fail on the same root cause.

## What

Added `needs: [lint]` to all jobs that invoke dotnet: `validate-assembler`, `build-link-index-updater-lambda`, `build-openapi-index-lambda`, `synthetics`, and `build`. The `npm` job is TypeScript-only and continues to run independently.