### PR TITLE
ci: add stale issue and PR cleanup

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,34 @@
+name: Close stale issues and PRs
+
+on:
+  schedule:
+    - cron: "0 9 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v11
+        with:
+          days-before-stale: 90
+          days-before-close: 14
+          stale-issue-label: stale
+          stale-pr-label: stale
+          close-issue-label: closed-stale
+          close-pr-label: closed-stale
+          exempt-issue-labels: "never-stale,good first issue"
+          exempt-pr-labels: "never-stale"
+          exempt-draft-pr: false
+          stale-issue-message: >
+            This issue is stale because it has been open 90 days with no activity.
+            Remove the `stale` label, or leave a comment, or this will be closed in 14 days.
+          stale-pr-message: >
+            This pull request is stale because it has been open 90 days with no activity.
+            Remove the `stale` label, or leave a comment, or this will be closed in 14 days.


### PR DESCRIPTION
## Why

- Inactive issues and PRs stay open indefinitely, which makes the tracker harder to work with.
- This repo had no stale cleanup, so abandoned items never got a close path.

## What

- Add a daily `actions/stale` workflow that marks issues and PRs stale after 90 days of inactivity and closes them 14 days later.
- Draft PRs are included. `never-stale` and `good first issue` are exempt.

## Notes

- The job runs at 09:00 UTC (10:00 CET). GitHub cron is UTC only, so this is 11:00 during CEST.
- Workflow permissions are empty at the top level. The job requests `actions`, `issues`, and `pull-requests` write.
- First runs process at most 30 items, so the initial sweep is gradual.


Made with [Cursor](https://cursor.com)