### PR TITLE
Hooks: restore local tools before curb in pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-dotnet husky run --group pre-commit
+dotnet tool restore --verbosity quiet
+dotnet tool run husky -- run --group pre-commit

--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -15,7 +15,7 @@
       "name": "dotnet-lint",
       "group": "pre-commit",
       "command": "dotnet",
-      "args": ["curb", "check", ".", "--cache", ".artifacts/curb.cache"],
+      "args": ["tool", "run", "curb", "--", "check", ".", "--cache", ".artifacts/curb.cache"],
       "include": ["**/*.cs"]
     },
     {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,8 @@ dotnet husky install
 
 That's it! The hooks will now run automatically on every commit.
 
+The pre-commit hook runs `dotnet tool restore` before curb, so a new worktree does not need a manual restore before the first commit. You still need `dotnet husky install` in that worktree so `.husky/_/husky.sh` exists.
+
 ### Usage
 
 Once installed, hooks run automatically when you commit:


### PR DESCRIPTION
## Why

- After the curb migration, pre-commit runs `dotnet curb`, which is a local tool. A new worktree, or a clone that restored tools before curb-cli was added, fails the hook with "dotnet curb is not available" and Git rejects the commit.

## What

- Restore local tools in the pre-commit hook, then run curb with `dotnet tool run`.
- Document that a new worktree still needs `dotnet husky install`.

## Notes

- `dotnet husky install` is still required in each worktree so `.husky/_/husky.sh` exists.


Made with [Cursor](https://cursor.com)