### PR TITLE
Update changelog docs and CLI text

### DIFF
--- a/docs/cli-schema.json
+++ b/docs/cli-schema.json
@@ -2802,7 +2802,7 @@
               "name": "products",
               "type": "string",
               "required": false,
-              "summary": "Optional: Products affected in format \u0022product target lifecycle, ...\u0022 (e.g., \u0022elasticsearch 9.2.0 ga, cloud-serverless 2025-08-05\u0022). If not specified, will be inferred from repository or config defaults."
+              "summary": "Optional: Products affected in format \u0022product [lifecycle], ...\u0022 (e.g., \u0022cloud-serverless, kibana\u0022 or \u0022elasticsearch ga\u0022). Do not include a version or date; that is an error. Use \u0027changelog note\u0027 for version-listed items. If not specified, products are inferred from the repository or config defaults."
             },
             {
               "role": "flag",
@@ -3239,7 +3239,7 @@
               "name": "input-products",
               "type": "string",
               "required": false,
-              "summary": "Filter by products in format \u0022product target lifecycle, ...\u0022 (for example, \u0022cloud-serverless 2025-12-02 ga, cloud-serverless 2025-12-06 beta\u0022). All three parts are required but can be wildcards (*). This option is not supported in profile-based commands. The equivalent configuration option is bundle.profiles.\u003Cname\u003E.products."
+              "summary": "Filter by products in format \u0022product target lifecycle, ...\u0022 (for example, \u0022cloud-serverless 2025-12-02 ga, cloud-serverless 2025-12-06 beta\u0022). All three parts are required but can be wildcards (*). A non-wildcard target matches products[].versions (changelog note) or a legacy target; not supported when sourcing from the CDN. This option is not supported in profile-based commands. The equivalent configuration option is bundle.profiles.\u003Cname\u003E.products."
             },
             {
               "role": "flag",
@@ -3278,7 +3278,7 @@
               "name": "force-local",
               "type": "boolean",
               "required": false,
-              "summary": "Force local entry sourcing for this run (equivalent to bundle.use_local_changelogs: true without editing config). Allowed in profile-based commands.",
+              "summary": "Force local entry sourcing for this run (equivalent to bundle.use_local_changelogs: true without editing config). Allowed in profile-based commands. Skips automatic inclusion of CDN changelog notes that match output_products.",
               "defaultValue": "false"
             },
             {
@@ -3949,7 +3949,7 @@
           ],
           "name": "note",
           "summary": "Create a note-*.yml changelog fragment for items that have no associated PR.",
-          "notes": "Use this command for release notes that are not tied to a specific pull request \u2014 for example, a\nknown-issue entry or a cross-cutting change that spans many PRs. Every product listed must have a\nconcrete target (not a wildcard); --prs and --issues are still accepted as\noptional citations but do not affect the output filename.",
+          "notes": "Use this command for version-listed changelogs that are not tied to a specific pull request \u2014 for example, a\nknown issue or a security advisory. Every product listed must include at least one concrete version\n(not a wildcard); --prs and --issues are still accepted as\noptional citations but do not affect the output filename.",
           "usage": "docs-builder changelog note [options]",
           "examples": [],
           "parameters": [
@@ -3965,7 +3965,7 @@
               "name": "products",
               "type": "string",
               "required": false,
-              "summary": "Products in format \u0022product target lifecycle, ...\u0022 (for example, \u0022elasticsearch 9.2.0 ga\u0022). Target is required for all products."
+              "summary": "Products in format \u0022product versions [lifecycle], ...\u0022 (for example, \u0022elasticsearch 9.2.0|9.3.0 ga\u0022). At least one concrete version is required for each product."
             },
             {
               "role": "flag",

--- a/docs/cli/changelog/cmd-add.md
+++ b/docs/cli/changelog/cmd-add.md
@@ -3,6 +3,8 @@
 Create a changelog file that describes a single item in the release documentation.
 For details and examples, go to [](/data/release-notes/create.md).
 
+For changelogs that don't need a PR link (for example, known issues or security advisories), use [`changelog note`](/cli/changelog/note.md) instead.
+
 ## Options
 
 : `--no-extract-release-notes`
@@ -10,7 +12,8 @@ For details and examples, go to [](/data/release-notes/create.md).
   By default, the behavior is determined by the [extract.release_notes](/data/release-notes/configure-ref.md#extract) changelog configuration setting. Release notes are extracted when using `--prs` or `--report` (and from issues when using `--issues`).
 
 : `--products`
-  Products affected in format `"product target lifecycle, ..."` (for example, `"elasticsearch 9.2.0 ga, cloud-serverless 2025-08-05"`).
+  Products affected in format `"product [lifecycle], ..."` (for example, `"cloud-serverless, kibana"` or `"elasticsearch ga"`).
+  Do not include a version or date in the middle slot; that is an error.
   The valid product identifiers are listed in [products.yml](https://github.com/elastic/docs-builder/blob/main/config/products.yml).
   For more information about valid product and lifecycle values, go to [Product format](#product-format-and-resolution).
 
@@ -45,12 +48,12 @@ You can override those settings with the `--use-pr-number` or `--use-issue-numbe
 ```sh
 docs-builder changelog add \
   --prs 1234 \
-  --products "elasticsearch 9.2.3" \
+  --products "elasticsearch ga" \
   --use-pr-number
 
 docs-builder changelog add \
   --issues 4567 \
-  --products "elasticsearch 9.3.0" \
+  --products "elasticsearch" \
   --use-issue-number
 ```
 
@@ -62,23 +65,18 @@ docs-builder changelog add \
 
 ## Product format and resolution
 
-The `--products` option accepts values with the format `"product target lifecycle, ..."` where:
+The `--products` option accepts values with the format `"product [lifecycle], ..."` where:
 
 - `product` is a product ID that exists in [products.yml](https://github.com/elastic/docs-builder/blob/main/config/products.yml) (required)
-- `target` is the target version or date (optional)
 - `lifecycle` exists in [Lifecycle.cs](https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/Lifecycle.cs) (optional)
 
 You can further limit the possible values with the [products](/data/release-notes/configure-ref.md#products) and [lifecycles](/data/release-notes/configure-ref.md#lifecycles) options in the changelog configuration file.
 
 For example:
 
-- `"kibana 9.2.0 ga"`
-- `"cloud-serverless 2025-08-05"`
-- `"cloud-enterprise 4.0.3, cloud-hosted 2025-10-31"`
-
-:::{note}
-Specifying a version in the `--products` spec (the middle slot, for example `"elasticsearch 9.3.0 ga"`) is an error for `changelog add`. Entries derive their release line from their origin branch, not from a contributor-supplied version. To create an item that explicitly targets one or more versions — such as a known issue or a CVE — use [`changelog note`](/cli/changelog/note.md) instead, which accepts `versions` in place of a target.
-:::
+- `"kibana"`
+- `"kibana ga"`
+- `"cloud-serverless, kibana"`
 
 The `changelog add` command resolves product values in the following order:
 

--- a/docs/cli/changelog/cmd-bundle.md
+++ b/docs/cli/changelog/cmd-bundle.md
@@ -32,7 +32,6 @@ bundle:
   output_directory: docs/releases
   profiles:
     elasticsearch-release:
-      products: "elasticsearch {version} {lifecycle}"
       output_products: "elasticsearch {version}"
 ```
 
@@ -45,7 +44,7 @@ Supply filter flags directly when you don't have a profile configured or need a 
 Exactly one of the following filter flags is required:
 
 - `--all` — include every changelog in the directory
-- `--input-products` — match by product, target date, and lifecycle (e.g. `"elasticsearch * *"`)
+- `--input-products` — match by product, version or date, and lifecycle (e.g. `"elasticsearch * *"`). A concrete version or date only matches files with `products[].versions` (or a legacy `target`); use `*` in the middle slot for PR-linked files. Local/directory only — not supported when sourcing from the CDN.
 - `--prs` — filter by PR URLs or a newline-delimited file of PR URLs
 - `--issues` — filter by issue URLs or a newline-delimited file of issue URLs
 - `--release-version` — fetch PR references from a GitHub release tag (e.g. `v9.2.0` or `latest`)
@@ -59,9 +58,9 @@ Exactly one of the following filter flags is required:
 # Bundle all changelogs in docs/changelog/
 docs-builder changelog bundle --all --directory docs/changelog
 
-# Bundle changelogs for a specific product release
+# Bundle local elasticsearch changelogs (including PR-linked files that omit versions)
 docs-builder changelog bundle \
-  --input-products "elasticsearch 9.2.0 ga" \
+  --input-products "elasticsearch * *" \
   --output docs/releases/9.2.0.yaml
 
 # Bundle from a GitHub release
@@ -100,6 +99,7 @@ Both refs are always required together — the start ref is never inferred from 
 Commit-range mode works in both profile-based and option-based commands and is mutually exclusive with every other filter. In profile-based commands the profile contributes output metadata only (`output_products`, `repo`, `owner`, `rules`, and so on) — it must not set a `products` pattern or `source: github_release`. The bundle name follows the `{product}-{version}.yaml` convention.
 
 Re-running the same range produces the same bundle content; bundling never overwrites changelog entries.
+Commit-range mode does not automatically add changelog notes whose `products[].versions` match `output_products`. Use `--files` or a path list if those files must be in the bundle.
 
 :::{note}
 Commit-range mode requires a `GITHUB_TOKEN` environment variable: the GraphQL API used for commit→PR association does not accept anonymous requests.
@@ -117,6 +117,8 @@ docs-builder changelog bundle serverless-release 2026-08-13 \
 ## Bundles are self-contained
 
 Every bundle embeds the full content of each changelog entry (`title`, `type`, `products`, and so on), plus a `file` block recording the source file name and checksum for provenance. Rendering — via the `{changelog}` directive, `changelog render`, or the CDN pipeline — never reads the original changelog files, so you can clean them up with `docs-builder changelog remove` immediately after bundling.
+
+When you bundle from a PR list or GitHub release and the command is sourcing from the CDN, it also adds uploaded changelogs whose `products[].versions` include that version (from `output_products`). Those files are appended to the same `entries` list; `rules.bundle` applies to them too. This automatic add does not apply to git-range bundles or `--force-local`. For more detail, see [Bundle changelogs](/data/release-notes/bundle.md).
 
 ## CI usage
 
@@ -141,6 +143,8 @@ For example:
 - `"cloud-enterprise 4.0.3, cloud-hosted 2025-10-31"`
 
 If you use `"* * *"` in the `--input-products` command option or `bundle.profiles.<name>.products` configuration setting, it's equivalent to the `--all` command option.
+
+For `--input-products` and profile `products`, a concrete version or date in the middle slot only matches files that have `products[].versions` or a legacy `target` (typically files created with `changelog note`). A `*` in that slot still matches every file, including PR-linked changelogs. This filter is local/directory only: when changelog files are sourced from the CDN, `--input-products` and an equivalent versioned profile `products` pattern are not supported. `--output-products` is bundle metadata, not a file filter.
 
 ## Lifecycle inference [lifecycle-inference]
 
@@ -303,6 +307,8 @@ You can use the `--input-products` option to create a bundle of changelogs that 
 When using `--input-products`, you must provide all three parts: product, target, and lifecycle.
 Each part can be a wildcard (`*`) to match any value.
 
+A concrete target (version or date, including a prefix such as `2025-11-*`) only matches files that declare `products[].versions` or a legacy `target`. Use `"elasticsearch * *"` (or `"* * *"`) when you need PR-linked changelogs that omit `versions`. `--input-products` is not supported when sourcing from the CDN; use `--prs`, `--release-version`, a report, `--files`, or a profile without a versioned `products` pattern instead.
+
 :::{tip}
 If you use profile-based bundling, provide this information in the `bundle.profiles.<name>.products` field.
 :::
@@ -312,7 +318,7 @@ docs-builder changelog bundle \
   --input-products "cloud-serverless 2025-12-02 ga, cloud-serverless 2025-12-06 beta" <1>
 ```
 
-1. Include all changelogs that have the `cloud-serverless` product identifier with target dates of either December 2 2025 (lifecycle `ga`) or December 6 2025 (lifecycle `beta`). For more information about product values, refer to [Product format](/cli/changelog/bundle.md#product-format).
+1. Include local changelogs that have the `cloud-serverless` product identifier and `products[].versions` (or a legacy `target`) of either December 2 2025 (lifecycle `ga`) or December 6 2025 (lifecycle `beta`). This does not match PR-linked changelogs that omit `versions`. For more information about product values, refer to [Product format](/cli/changelog/bundle.md#product-format).
 
 You can use wildcards in any of the three parts:
 
@@ -389,6 +395,7 @@ To apply additional filtering by the changelog type, areas, or products, add [ru
 ### Bundle by file paths [changelog-bundle-files]
 
 Use `--files` when you know the exact changelog files to include and they may not have `prs` or `issues` metadata.
+Path-list / `--files` selection is by file name and is not filtered by `products[].versions`, so listed files may declare different versions or dates.
 
 ```sh
 docs-builder changelog bundle \
@@ -422,6 +429,7 @@ docs-builder changelog bundle serverless-release 2026-07-07 ./docs/temp/prs.txt 
 
 `--force-local` is allowed in both option-based and profile-based commands.
 Use it with path-list / `--files` filters when the listed files should be read from disk instead of matched against the CDN pool.
+Because local sourcing skips the CDN note auto-merge, include those files with `--files` or a path list if they belong in the bundle.
 
 ### Hide features [changelog-bundle-hide-features]
 
@@ -429,7 +437,7 @@ You can use the `--hide-features` option to embed feature IDs that should be hid
 
 ```sh
 docs-builder changelog bundle \
-  --input-products "elasticsearch 9.3.0 *" \
+  --input-products "elasticsearch * *" \
   --hide-features "feature:hidden-api,feature:experimental" \ <1>
   --output /path/to/bundles/9.3.0.yaml
 ```

--- a/docs/cli/changelog/cmd-gh-release.md
+++ b/docs/cli/changelog/cmd-gh-release.md
@@ -15,7 +15,7 @@ The command creates two types of output in the directory specified by `--output`
 - One YAML changelog file per pull request found in the release notes.
 - A bundle file at `{output}/bundles/{version}-{product}-bundle.yml` that references all created changelog files.
 
-The product, target version, and lifecycle are inferred automatically from the release tag and the repository name (via [products.yml](https://github.com/elastic/docs-builder/blob/main/config/products.yml)). For example, a tag of `v9.2.0` on `elastic/elasticsearch` creates changelogs with `product: elasticsearch`, `target: 9.2.0`, and `lifecycle: ga`.
+The product ID (and optional lifecycle) are inferred from the release tag and the repository name (via [products.yml](https://github.com/elastic/docs-builder/blob/main/config/products.yml)). For example, a tag of `v9.2.0` on `elastic/elasticsearch` creates PR-linked changelogs with `product: elasticsearch` and `lifecycle: ga`. The files do not include a version field; which product release they belong to is determined by the origin branch.
 
 ## Entry sourcing precedence
 

--- a/docs/cli/changelog/cmd-note.md
+++ b/docs/cli/changelog/cmd-note.md
@@ -1,40 +1,39 @@
 ## Description
 
-Create a changelog note file for an item that applies to one or more specific release versions and has no associated pull request.
-Notes are used for known issues, security advisories, and other items that are not tied to a single PR.
+Create a changelog YAML for content that is not tied to a pull request.
+Typical uses are known issues and security advisories.
 For details and examples, go to [](/data/release-notes/create.md).
 
-Note files are named `note-{slug}.yml` and are uploaded to the changelog pool like any other entry.
-Each note declares `products[].versions` — the release versions it applies to — instead of deriving its release line from a branch.
+Files are named `note-{slug}.yml`. Each product lists `products[].versions` — the release versions the change applies to.
 
 ## Options
 
 : `--products`
-  Products and versions in the format `"product versions lifecycle, ..."` where `versions` is a `|`-separated list of release versions (for example, `"elasticsearch 9.3.0|9.4.0 ga"`).
-  Unlike `changelog add`, the middle slot is interpreted as a `|`-separated version list, not a single target.
+  Products and versions in the format `"product versions [lifecycle], ..."` where `versions` is a `|`-separated list of release versions (for example, `"elasticsearch 9.3.0|9.4.0 ga"`).
+  Unlike `changelog add`, the middle slot is required and is a version list, not omitted.
   The valid product identifiers are listed in [products.yml](https://github.com/elastic/docs-builder/blob/main/config/products.yml).
 
 : `--title`
-  A short, user-facing headline for the note (max 80 characters). Required.
+  A short, user-facing headline (max 80 characters). Required.
 
 : `--type`
   The type of change. For valid values, see [ChangelogEntryType.cs](https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ChangelogEntryType.cs). Required.
 
 : `--description`
-  Additional information about the note (max 600 characters). Optional.
+  Additional information (max 600 characters). Optional.
 
 : `--issues`
-  URLs of related issues. Optional citation field; does not determine note addressability.
+  URLs of related issues. Optional citation field; listing issues does not attach the file to a release.
 
 ## Product and version format
 
-The `--products` option uses the same positional format as `changelog add`, but the middle slot is a version list:
+The `--products` option uses the same positional slots as `changelog add`, but the middle slot is a `|`-separated version list and is required:
 
 - `"elasticsearch 9.3.0 ga"` — one version
 - `"elasticsearch 9.3.0|9.4.0|9.5.0 ga"` — multiple versions
 - `"cloud-serverless 2025-08-05"` — date-based release, one version
 
-A note that spans products can declare each product separately:
+A changelog that spans products can declare each product separately:
 
 ```sh
 docs-builder changelog note \
@@ -46,8 +45,7 @@ docs-builder changelog note \
 
 ## Output
 
-The command writes a `note-{slug}.yml` file to the configured output directory.
-The file contains `products[].versions` instead of `products[].target`:
+The command writes a `note-{slug}.yml` file to the configured output directory:
 
 ```yaml
 title: Known issue with aggregations
@@ -58,17 +56,18 @@ products:
     lifecycle: ga
 ```
 
-## Lifecycle after creation
+## After creation
 
-Notes are uploaded to `changelog/{org}/{repo}/{branch}/note-*.yml` in the private S3 bucket and go through the scrubber exactly like entries.
-A Lambda-maintained index at `changelog/{org}/{repo}/notes-{version}.json` lists every note that applies to a given version.
+Upload is the same as for other changelog YAML files.
+An index at `changelog/{org}/{repo}/notes-{version}.json` lists every changelog "note" file that applies to each version.
 
-If the release bundle for that version has already shipped when a note is uploaded, the scrubber Lambda automatically generates an amend sidecar (`{bundle}.amend-notes.yaml`) so the note reaches CDN consumers without a manual rerun.
+If the release bundle for that product and version or date has already shipped when you upload, the scrubber generates an amend file so the changelog reaches published docs without a manual rerun.
+
+If there is no existing or planned bundle for that product and version or date, you can create a bundle from a path list that contains all the relevant changelogs. Refer to [Bundle by file paths](/cli/changelog/bundle.md#changelog-bundle-files).
 
 ## Configuration checks
 
 The same configuration-file checks that apply to `changelog add` apply here:
 valid `products`, `lifecycles`, and `type` values are validated against `docs/changelog.yml` when it exists.
 
-Specifying a version target in `--products` for `changelog add` is an error; use `changelog note` instead.
-Conversely, `--versions` has no meaning for `changelog add` — it is note-specific.
+A version in `--products` for `changelog add` is an error; use `changelog note` instead.

--- a/docs/cli/changelog/index.md
+++ b/docs/cli/changelog/index.md
@@ -3,7 +3,7 @@ The `changelog` commands manage a file-per-change workflow that produces release
 ## Typical workflow
 
 1. **Configure** — create `docs/changelog.yml` with label mappings and bundle profiles: `docs-builder changelog init`
-2. **Create** — add a changelog YAML for each notable PR: `docs-builder changelog add`
+2. **Create** — add a changelog YAML for each notable PR: `docs-builder changelog add`. For items not tied to a PR (known issues, advisories), use `docs-builder changelog note`.
 3. **Bundle** — aggregate entries for a release: `docs-builder changelog bundle`
 4. **Publish** — render the bundle to a release notes page: `docs-builder changelog render`
 

--- a/docs/data/release-notes/_snippets/changelog-fields.md
+++ b/docs/data/release-notes/_snippets/changelog-fields.md
@@ -12,7 +12,7 @@ type:
 # For the acceptable values, refer to https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ChangelogEntryType.cs
 products:
 
-# A required array of objects that denote the affected products and their target release.
+# A required array of objects that denote the affected products.
 
     - product:
 
@@ -22,9 +22,9 @@ products:
       
       versions:
 
-      # Note files only — a required list of release versions this note applies to.
-      # This field is mandatory only when the changelog is a note (i.e. doesn't have a PR).
-      # Example: [9.3.0, 9.4.0]
+      # Required when the changelog is not tied to a pull request (known issues, advisories).
+      # Omit this field when `prs` attaches the change to a release.
+      # Use a YAML list such as [9.3.0, 9.4.0], not "*" and not a pipe-separated string.
 
       lifecycle:
 

--- a/docs/data/release-notes/bundle.md
+++ b/docs/data/release-notes/bundle.md
@@ -110,7 +110,8 @@ bundle:
 
 ### Bundle by git commit range [profile-git-range]
 
-If the source of truth for what was shipped in each release is a **git commit range** — for example, a date-promotion deployment that hands off the previously and currently published commit hashes — pass `--start-git-ref` and `--end-git-ref` alongside the profile. The command derives the PR list from the range itself (GitHub compare API + GraphQL `associatedPullRequests`), so no PR list file or promotion report is needed.
+If the source of truth for what was shipped in each release is a git commit range, pass `--start-git-ref` and `--end-git-ref` alongside the profile.
+The command derives the PR list from the range itself (GitHub compare API + GraphQL `associatedPullRequests`), so no PR list file or promotion report is needed.
 
 Your profile must **not** contain a `products` pattern or `source: github_release`; it contributes output metadata only. For example:
 
@@ -169,14 +170,16 @@ bundle:
 ```
 
 1. This profile collects all changelogs from the `directory`.
-2. This profile collects any changelogs that have `product: cloud-serverless`, any lifecycle, and the date partially specified in the command.
-3. This profile collects any changelogs that have `product: kibana`, `lifecycle: ga`, and the version specified in the command. No two profiles may target the same primary product — they would collide on the same conventional `{product}-{version}.yaml` bundle name.
-4. In this case, the lifecycle is inferred from the version specified in the command. For example, if the version is `9.2.0-beta.1` the lifecycle is `beta`. ISO date arguments (for example, `2026-07-21`) derive `ga`. Refer to [](/cli/changelog/bundle.md#lifecycle-inference).
+2. This profile collects any changelogs that have `product: cloud-serverless`, any lifecycle, and the date partially specified in the command. The date pattern matches files that declare `products[].versions` (or a legacy `target`), typically files created with `changelog note`. It does not match PR-linked changelogs that omit `versions`.
+3. This profile collects any changelogs that have `product: kibana`, `lifecycle: ga`, and the version specified in the command. Like the date pattern, a concrete version only matches files that declare `products[].versions` (or a legacy `target`). No two profiles may target the same primary product — they would collide on the same conventional `{product}-{version}.yaml` bundle name.
+4. In this case, the lifecycle is inferred from the version specified in the command. For example, if the version is `9.2.0-beta.1` the lifecycle is `beta`. ISO date arguments (for example, `2026-07-21`) derive `ga`. Refer to [](/cli/changelog/bundle.md#lifecycle-inference). A concrete `{version}` in `products` has the same `versions`/`target` matching rule as the previous examples.
 
 For date-based and semver profiles, lifecycle is controlled only in the profile YAML: omit it from the pattern, use `{lifecycle}` to derive it, or hardcode `ga`, `beta`, or `preview`. Non-`ga` date-based releases are exceptional and should hardcode the lifecycle.
 
 :::{note}
 The `products` field determines which changelog files are gathered for consideration. You can still apply [rules](#rules) afterward to further filter changelogs from the bundle. The input stage and bundle filtering stage are conceptually separate.
+
+A concrete version or date in the middle slot of `products` (including `{version}` and `{version}-*`) only matches files that have `products[].versions` or a legacy `target`. A `*` in that slot (for example `products: "* * *"`) still matches every file, including PR-linked changelogs. This filter is local/directory only: when changelog files are sourced from the CDN, `--input-products` and an equivalent versioned profile `products` pattern are not supported.
 :::
 
 ## Create bundles
@@ -272,6 +275,10 @@ For example, if the source of truth for what was shipped in each release is:
 
 By default all changelogs that match the chosen source of truth are included in the bundle.
 Bundles are self-contained: the full content of each changelog is embedded in the bundle, so you can freely move or remove the changelog files afterward.
+
+When you create a release bundle for a product version from a PR list or GitHub release and the command is sourcing from the CDN, it also adds uploaded changelogs whose `products[].versions` include that version (the version comes from `output_products`). Those files are appended to the same `entries` list as the PR-linked changelogs — they are not a separate section. `rules.bundle` applies to them too. This automatic add does not apply to git-range bundles or `--force-local`.
+
+To create a bundle that contains only "note" changelogs (including files that have different `versions` values), use a [path list](/data/release-notes/bundle.md) (profile third argument or `--files`).
 
 To apply additional filtering by the changelog type, areas, or products, add [bundle rules](#rules).
 

--- a/docs/data/release-notes/create.md
+++ b/docs/data/release-notes/create.md
@@ -3,6 +3,9 @@
 You can use `docs-builder changelog` commands to create data files ("changelogs") for each notable change in your GitHub repository.
 These files are ultimately used to generate release documentation.
 
+Every changelog is the same YAML schema.
+However, some fields are required or optional depending on the context.
+
 This page describes how to create these files both from the [command line](#command-line) and from [GitHub actions](#github-actions).
 
 ## Before you begin
@@ -12,41 +15,58 @@ Refer to [](/data/release-notes/configure.md).
 
 ## Create changelog files from command line [command-line]
 
-These steps describe how to use the [changelog add](/cli/changelog/add.md) command.
+These steps describe how to use the [changelog add](/cli/changelog/add.md) and [changelog note](/cli/changelog/note.md) commands to create changelog YAML files.
 If you already have automated release notes for GitHub releases, you can use the [changelog gh-release](/cli/changelog/gh-release.md) command instead.
 
 1. If you're accessing private repositories or creating a large number of changelogs, log into GitHub or set the `GITHUB_TOKEN` (or `GH_TOKEN` ) environment variable with a sufficient personal access token. Refer to [Authorization](/data/release-notes/configure.md#authorization).
 
-1. Run the `changelog add` command in your GitHub repo's root directory.
-   For example:
+1. Run the `changelog add` or `changelog note` command in your GitHub repo's root directory.
 
-    ```sh
-    docs-builder changelog add \
-    --title "Improve SAML error handling by adding metadata" \
-    --type enhancement \
-    --products "elasticsearch 9.2.8, cloud-serverless 2026-02-02"
-    ```
+   - Create a changelog that references a GitHub pull request:
 
-    Title, type, and products are the minimal details required for each changelog file.
+     ```sh
+     docs-builder changelog add \
+     --prs https://github.com/elastic/elasticsearch/pull/137598
+     ```
+
+     The `--prs` value can be a full URL (such as `https://github.com/owner/repo/pull/123`), a short format (such as `owner/repo#123`), just a number, or a path to a file containing newline-delimited PR URLs. Multiple PRs can be provided comma-separated. One changelog is created for each PR.
+
+     When you specify `--prs` or `--issues`, the command tries to fetch information from GitHub.
+     It derives the title from the pull request or issue title, extracts linked references, and derives the areas, products, and type from labels (if mappings are defined in the configuration file).
+     To control what information is extracted, refer to the [extract](/data/release-notes/configure-ref.md#extract) and [pivot](/data/release-notes/configure-ref.md#pivot) sections of the changelog configuration file.
+
+     :::{note}
+     This type of changelog does not contain `products[].versions`.
+     If you specify `--products` with a version or date, the `changelog add` command returns an error.
+
+     Release bundles are created from PR lists or GitHub tags thus `prs` is sufficient to map these changelogs to releases.
+     :::
+
+   - Create a changelog that does **not** reference a GitHub pull request:
+
+     ```sh
+     docs-builder changelog note \
+     --title "Alerts aren't generated for rules with alert flapping off and an alert delay higher than 1" \
+     --type known-issue \
+     --products "cloud-serverless 2025-10-25" \
+     --action 'Set the alert delay value to 1 or turn on "Alert flapping detection".'
+     ```
+
+     :::{note}
+     This type of changelog requires `products[].versions`.
+     If you specify `--products` without a version or date, the `changelog note` command returns an error.
+
+     These files don't have `prs` and thus don't appear in a release's PR list.
+     The `products[].versions` are used to add these files to release bundles automatically.
+     :::
+
+     Title, type, and products (including version or date) are the minimal details required when you are not deriving details from a PR.
 
     :::{tip}
-    Any special characters (such as backquotes) must be preceded with a backslash escape character (`\`).
+    Any command strings that contain special characters (such as backquotes) must be preceded with a backslash escape character (`\`).
     :::
 
-    Alternatively, pull the information from GitHub:
-
-    ```sh
-    docs-builder changelog add \
-    --prs https://github.com/elastic/elasticsearch/pull/137598
-    ```
-
-    The `--prs` value can be a full URL (such as `https://github.com/owner/repo/pull/123`), a short format (such as `owner/repo#123`), just a number, or a path to a file containing newline-delimited PR URLs. Multiple PRs can be provided comma-separated. One changelog is created for each PR.
-
-    When you specify `--prs` or `--issues`, the command tries to fetch information from GitHub.
-    It derives the title from the pull request or issue title, extracts linked references, and derives the areas, products, and type from labels (if mappings are defined in the configuration file).
-    To control what information is extracted, refer to the [extract](/data/release-notes/configure-ref.md#extract) and [pivot](/data/release-notes/configure-ref.md#pivot) sections of the changelog configuration file.
-
-    For the most up-to-date command syntax, use the `-h` option or refer to [](/cli/changelog/add.md).
+    For the most up-to-date command syntax, use the `-h` option or refer to [](/cli/changelog/add.md) and [](/cli/changelog/note.md).
 
 1. [Review the output file](#review).
 
@@ -150,7 +170,7 @@ EOF
 
 # Use the file with --prs
 docs-builder changelog add --prs prs.txt \
-  --products "elasticsearch 9.2.0 ga"
+  --products "elasticsearch ga"
 ```
 
 In this example, the command creates one changelog for each pull request in the list.
@@ -165,8 +185,8 @@ docs-builder changelog add --release-version v1.34.0
 ```
 
 This command creates one changelog file per PR found in the `v1.34.0` GitHub release notes.
-The product, target version, and lifecycle in each changelog are inferred automatically from the release tag and the repository name.
-For example, a tag of `v1.34.0` in the `apm-agent-dotnet` repo creates changelogs with `product: apm-agent-dotnet`, `target: 1.34.0`, and `lifecycle: ga`.
+The product ID and lifecycle in each file can be inferred from the repository name and configuration.
+The files do not include a version field; which product release they belong to is determined by the origin branch.
 
 :::{note}
 `--release-version` requires `--repo` (or `bundle.repo` set in `changelog.yml`) and is mutually exclusive with `--prs` and `--issues`.
@@ -189,7 +209,6 @@ Example changelog for a release highlight:
 type: feature
 products:
 - product: elasticsearch
-  target: 9.4.0
   lifecycle: ga
 title: ES|QL Views support
 description: 'ES|QL now supports Views: virtual indices whose fields are produced by an ES|QL query. A view is referenced inside a FROM clause exactly like a regular index....'

--- a/docs/data/release-notes/overview.md
+++ b/docs/data/release-notes/overview.md
@@ -5,7 +5,7 @@ By adding a file for each notable change in your GitHub repository and grouping 
 To use the `docs-builder changelog` commands in your development workflow:
 
 1. [Configure changelogs](/data/release-notes/configure.md): Create a configuration file, map labels, and define rules for creation and bundling.
-1. [Create changelogs](/data/release-notes/create.md) with the `docs-builder changelog add` command.
+1. [Create changelogs](/data/release-notes/create.md) with `docs-builder changelog add` or `docs-builder changelog note` (depending on whether there's a PR associated with the change).
    - Alternatively, if you already have automated release notes for GitHub releases, you can use the `docs-builder changelog gh-release` command to create changelog files and a bundle from your GitHub release notes. Refer to [](/cli/changelog/gh-release.md).
 1. [Bundle changelogs](/data/release-notes/bundle.md) with the `docs-builder changelog bundle` command. For example, create a bundle for the pull requests that are included in a product release. When changelogs are no longer needed in the repo, [remove changelog files](/data/release-notes/bundle.md#changelog-remove) with `docs-builder changelog remove`.
 1. [Publish release notes](/data/release-notes/publish.md): Use the `{changelog}` directive in docs or `docs-builder changelog render` to produce release documentation.

--- a/src/services/Elastic.Changelog/Creation/ChangelogFileWriter.cs
+++ b/src/services/Elastic.Changelog/Creation/ChangelogFileWriter.cs
@@ -290,9 +290,9 @@ public class ChangelogFileWriter(IFileSystem fileSystem, ILogger logger)
 			#       Valid values are defined in https://github.com/elastic/docs-builder/blob/main/config/products.yml
 			#
 			#     versions:
-			#       Note-only. A list of release versions this note applies to.
+			#       Required when the changelog is not tied to a pull request.
 			#       Example: [9.3.0, 9.4.0] or [2026-05-15]
-			#       For PR-anchored entries, leave this absent — the branch is the address.
+			#       Omit when the file lists prs.
 			#
 			#     lifecycle:
 			#       An optional string for new features or enhancements that have a specific availability.

--- a/src/tooling/docs-builder/Commands/ChangelogCommand.cs
+++ b/src/tooling/docs-builder/Commands/ChangelogCommand.cs
@@ -221,7 +221,7 @@ internal sealed partial class ChangelogCommands(
 	}
 
 	/// <summary>Create a new changelog entry YAML file.</summary>
-	/// <param name="products">Optional: Products affected in format "product target lifecycle, ..." (e.g., "elasticsearch 9.2.0 ga, cloud-serverless 2025-08-05"). If not specified, will be inferred from repository or config defaults.</param>
+	/// <param name="products">Optional: Products affected in format "product [lifecycle], ..." (e.g., "cloud-serverless, kibana" or "elasticsearch ga"). Do not include a version or date; that is an error. Use 'changelog note' for version-listed items. If not specified, products are inferred from the repository or config defaults.</param>
 	/// <param name="action">Optional: What users must do to mitigate</param>
 	/// <param name="areas">Optional: Area(s) affected (comma-separated or specify multiple times)</param>
 	/// <param name="config">Optional: Path to the changelog.yml configuration file. Defaults to 'docs/changelog.yml'</param>
@@ -556,13 +556,13 @@ internal sealed partial class ChangelogCommands(
 
 	/// <summary>Create a <c>note-*.yml</c> changelog fragment for items that have no associated PR.</summary>
 	/// <remarks>
-	/// Use this command for release notes that are not tied to a specific pull request — for example, a
-	/// known-issue entry or a cross-cutting change that spans many PRs. Every product listed must have a
-	/// concrete <c>target</c> (not a wildcard); <c>--prs</c> and <c>--issues</c> are still accepted as
+	/// Use this command for version-listed changelogs that are not tied to a specific pull request — for example, a
+	/// known issue or a security advisory. Every product listed must include at least one concrete version
+	/// (not a wildcard); <c>--prs</c> and <c>--issues</c> are still accepted as
 	/// optional citations but do not affect the output filename.
 	/// </remarks>
 	/// <param name="name">Explicit slug for the note filename. Defaults to a slug derived from the title.</param>
-	/// <param name="products">Products in format "product target lifecycle, ..." (for example, "elasticsearch 9.2.0 ga"). Target is required for all products.</param>
+	/// <param name="products">Products in format "product versions [lifecycle], ..." (for example, "elasticsearch 9.2.0|9.3.0 ga"). At least one concrete version is required for each product.</param>
 	/// <param name="action">Optional action text.</param>
 	/// <param name="areas">Optional area tags.</param>
 	/// <param name="concise">Omit schema reference comments from the generated YAML.</param>
@@ -754,7 +754,7 @@ internal sealed partial class ChangelogCommands(
 	/// <param name="hideFeatures">Feature IDs (comma-separated) or a path to a newline-delimited file. Entries with matching feature-id values are hidden when the bundle is rendered. This option is not supported in profile-based commands. The equivalent configuration option is <c>bundle.profiles.&lt;name&gt;.hide_features</c>.</param>
 	/// <param name="noReleaseDate">Skip auto-population of release date in the bundle. Mutually exclusive with --release-date. This option is not supported in profile-based commands. The equivalent configuration options are <c>bundle.release_dates: false</c> or <c>bundle.profiles.&lt;name&gt;.release_dates: false</c>.</param>
 	/// <param name="releaseDate">Explicit release date for the bundle in YYYY-MM-DD format. Overrides auto-population behaviour. Mutually exclusive with --no-release-date. This option is not supported in profile-based commands; use option-based mode, or set <c>bundle.release_dates</c> in configuration to control auto-population.</param>
-	/// <param name="inputProducts">Filter by products in format "product target lifecycle, ..." (for example, "cloud-serverless 2025-12-02 ga, cloud-serverless 2025-12-06 beta"). All three parts are required but can be wildcards (*). This option is not supported in profile-based commands. The equivalent configuration option is <c>bundle.profiles.&lt;name&gt;.products</c>.</param>
+	/// <param name="inputProducts">Filter by products in format "product target lifecycle, ..." (for example, "cloud-serverless 2025-12-02 ga, cloud-serverless 2025-12-06 beta"). All three parts are required but can be wildcards (*). A non-wildcard target matches products[].versions (changelog note) or a legacy target; not supported when sourcing from the CDN. This option is not supported in profile-based commands. The equivalent configuration option is <c>bundle.profiles.&lt;name&gt;.products</c>.</param>
 	/// <param name="issues">Filter by issue URLs (comma-separated), or a path to a newline-delimited file containing fully-qualified GitHub issue URLs. Can be specified multiple times. This option is not supported in profile-based commands. Pass a promotion report as the second or third positional argument instead, or set <c>source: github_release</c> on the profile.</param>
 	/// <param name="output">Output path for the bundled changelog (directory or .yml/.yaml file). Uses config <c>bundle.output_directory</c> or defaults to 'changelog-bundle.yaml' in the input directory. This option is not supported in profile-based commands, where bundle names are derived by convention as <c>{product}-{version}.yaml</c> from the profile's primary output product.</param>
 	/// <param name="outputProducts">Explicitly set the products array in the output file in format "product target lifecycle, ...". This option is not supported in profile-based commands. The equivalent configuration option is <c>bundle.profiles.&lt;name&gt;.output_products</c>.</param>
@@ -765,7 +765,7 @@ internal sealed partial class ChangelogCommands(
 	/// <param name="startGitRef">Start ref (exclusive) of a git commit range to bundle, for example the previously published endpoint ref. Must be provided together with --end-git-ref; the start ref is never inferred. The PR list is derived from the range itself (GitHub compare API + GraphQL associatedPullRequests), each PR's entry is sourced pool-first with PR-metadata fallback, and requires GITHUB_TOKEN. Supported in profile-based commands (for example, 'bundle serverless-release 2026-08-13 --start-git-ref abc123 --end-git-ref def456'); mutually exclusive with all other filter options.</param>
 	/// <param name="endGitRef">End ref (inclusive) of the git commit range to bundle — the currently published endpoint ref. Must be provided together with --start-git-ref. Recorded in the bundle output as the <c>git_ref</c> metadata field.</param>
 	/// <param name="dryRun">Resolve the commit range and print the run report (resolved PR list with per-PR entry source: pool, inferred, or missing) as Markdown without writing a bundle. Only valid together with --start-git-ref/--end-git-ref. Supported in profile-based commands.</param>
-	/// <param name="forceLocal">Force local entry sourcing for this run (equivalent to <c>bundle.use_local_changelogs: true</c> without editing config). Allowed in profile-based commands.</param>
+	/// <param name="forceLocal">Force local entry sourcing for this run (equivalent to <c>bundle.use_local_changelogs: true</c> without editing config). Allowed in profile-based commands. Skips automatic inclusion of CDN changelog notes that match output_products.</param>
 	/// <param name="repo">GitHub repository name for PR/issue numbers or --release-version. Falls back to <c>bundle.repo</c> or the product ID. This option is not supported in profile-based commands. The equivalent configuration options are <c>bundle.repo</c> or <c>bundle.profiles.&lt;name&gt;.repo</c>.</param>
 	/// <param name="report">URL or file path to a promotion report; extracts PR URLs as the filter. This option is not supported in profile-based commands. Pass the report as the second or third positional argument instead.</param>
 	/// <param name="releaseVersion">GitHub release tag to use as a filter source (for example, "v9.2.0" or "latest"). Fetches PR references from release notes. This option is not supported in profile-based commands. The equivalent configuration option is <c>bundle.profiles.&lt;name&gt;.source: github_release</c>.</param>


### PR DESCRIPTION
Fixes the documentation issues identified in https://github.com/elastic/docs-builder/issues/3956
In particular, it updates the https://docs-v3-preview.elastic.dev/elastic/docs-builder/tree/main/data/release-notes and https://docs-v3-preview.elastic.dev/elastic/docs-builder/tree/main/cli/changelog and command line help to more closely match the many behaviour changes implemented this week.

The most important changes are relate to the removal of the incorrect `version` options from some of the examples.