### PR TITLE
Improve changelog error message categories

### DIFF
--- a/src/Elastic.Documentation/Diagnostics/FilelessDiagnosticClassifier.cs
+++ b/src/Elastic.Documentation/Diagnostics/FilelessDiagnosticClassifier.cs
@@ -1,0 +1,63 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic.Documentation.Diagnostics;
+
+/// <summary>
+/// Groups file-less diagnostics so console rendering can distinguish unhandled exceptions
+/// from ordinary errors, warnings, and hints.
+/// </summary>
+public readonly record struct FilelessDiagnosticGroups(
+	Diagnostic[] Exceptions,
+	Diagnostic[] Errors,
+	Diagnostic[] Warnings,
+	Diagnostic[] Hints
+)
+{
+	public bool IsEmpty => Exceptions.Length == 0 && Errors.Length == 0 && Warnings.Length == 0 && Hints.Length == 0;
+}
+
+public static class FilelessDiagnosticClassifier
+{
+	/// <summary>
+	/// True when an error message includes an exception dump (e.g. <c>Exception.ToString()</c>
+	/// appended by <see cref="DiagnosticsCollector.EmitError(string, string, Exception?)"/>).
+	/// </summary>
+	public static bool LooksLikeException(Diagnostic diagnostic) =>
+		diagnostic.Severity == Severity.Error && diagnostic.Message.Contains("Exception:", StringComparison.Ordinal);
+
+	public static FilelessDiagnosticGroups Group(IEnumerable<Diagnostic> diagnostics)
+	{
+		var exceptions = new List<Diagnostic>();
+		var errors = new List<Diagnostic>();
+		var warnings = new List<Diagnostic>();
+		var hints = new List<Diagnostic>();
+
+		foreach (var diagnostic in diagnostics)
+		{
+			if (!string.IsNullOrEmpty(diagnostic.File))
+				continue;
+
+			switch (diagnostic.Severity)
+			{
+				case Severity.Error when LooksLikeException(diagnostic):
+					exceptions.Add(diagnostic);
+					break;
+				case Severity.Error:
+					errors.Add(diagnostic);
+					break;
+				case Severity.Warning:
+					warnings.Add(diagnostic);
+					break;
+				case Severity.Hint:
+					hints.Add(diagnostic);
+					break;
+				default:
+					break;
+			}
+		}
+
+		return new FilelessDiagnosticGroups([.. exceptions], [.. errors], [.. warnings], [.. hints]);
+	}
+}

--- a/src/services/Elastic.Changelog/Creation/ChangelogCreationService.cs
+++ b/src/services/Elastic.Changelog/Creation/ChangelogCreationService.cs
@@ -112,6 +112,10 @@ public class ChangelogCreationService(
 				input = input with { Description = null };
 			}
 
+			// CLI-supplied products must not carry versions; fail before any GitHub fetches.
+			if (input.Products.Count > 0 && !_validator.ValidateNoVersionTarget(collector, input))
+				return false;
+
 			// Multiple PRs: one changelog per PR (--use-pr-number uses PR number as each filename)
 			if (input.Prs != null && input.Prs.Length > 1)
 				return await CreateChangelogsForMultiplePrsAsync(collector, input, config, ctx);
@@ -267,7 +271,7 @@ public class ChangelogCreationService(
 
 		var successCount = 0;
 		var skippedCount = 0;
-		var fetchFailedCount = 0;
+		var fetchFailedAndWritten = 0;
 
 		foreach (var prTrimmed in input.Prs.Select(pr => pr.Trim()).Where(prTrimmed => !string.IsNullOrWhiteSpace(prTrimmed)))
 		{
@@ -288,33 +292,38 @@ public class ChangelogCreationService(
 				continue;
 			}
 
-			// A null prInfo here means the GitHub fetch failed: this PR bypasses rules.create
-			// label filtering and is written without a derived title/type. Track it so the failure
-			// is surfaced as a single summary rather than buried among per-PR warnings.
-			if (prInfo == null)
-				fetchFailedCount++;
-
 			// Create a copy of input for this PR
 			var prInput = CreateInputForSinglePr(input, prTrimmed);
 
 			// Process this PR (treat as single PR); the loop owns fetch-failure reporting
 			var result = await CreateSingleChangelogAsync(collector, prInput, config, ctx, reportFetchFailure: false);
-			if (result)
-				successCount++;
+			if (!result)
+				continue;
+
+			successCount++;
+			// A null prInfo here means the GitHub fetch failed: this PR bypasses rules.create
+			// label filtering and is written without a derived title/type. Only count it when a
+			// file was actually written so the summary does not claim creation after a later error.
+			if (prInfo == null)
+				fetchFailedAndWritten++;
 		}
 
-		ReportBulkFetchFailures(collector, fetchFailedCount, input.Prs.Length, input.StrictFetch, "pull request");
+		ReportBulkFetchFailures(collector, fetchFailedAndWritten, input.Prs.Length, input.StrictFetch, "pull request");
 
 		if (successCount == 0 && skippedCount == 0)
 			return false;
 
-		_logger.LogInformation(
-			"Processed {SuccessCount} PR(s) successfully, skipped {SkippedCount} PR(s), {FetchFailedCount} PR(s) could not be fetched",
-			successCount,
-			skippedCount,
-			fetchFailedCount
-		);
-		return successCount > 0;
+		if (successCount > 0)
+		{
+			_logger.LogInformation(
+				"Processed {SuccessCount} PR(s) successfully, skipped {SkippedCount} PR(s), {FetchFailedCount} PR(s) could not be fetched",
+				successCount,
+				skippedCount,
+				fetchFailedAndWritten
+			);
+		}
+
+		return successCount > 0 || skippedCount > 0;
 	}
 
 	private async Task<bool> CreateSingleChangelogAsync(
@@ -401,7 +410,7 @@ public class ChangelogCreationService(
 
 		var successCount = 0;
 		var skippedCount = 0;
-		var fetchFailedCount = 0;
+		var fetchFailedAndWritten = 0;
 
 		foreach (var issueUrl in input.Issues.Select(i => i.Trim()).Where(i => !string.IsNullOrWhiteSpace(i)))
 		{
@@ -421,29 +430,35 @@ public class ChangelogCreationService(
 				continue;
 			}
 
-			// A null issueInfo means the GitHub fetch failed: the entry bypasses rules.create
-			// filtering and is written without a derived title/type. Track it for a summary report.
-			if (issueInfo == null)
-				fetchFailedCount++;
-
 			var issueInput = input with { Issues = [issueUrl] };
 			var result = await CreateSingleChangelogFromIssueAsync(collector, issueInput, config, ctx, reportFetchFailure: false);
-			if (result)
-				successCount++;
+			if (!result)
+				continue;
+
+			successCount++;
+			// A null issueInfo means the GitHub fetch failed: the entry bypasses rules.create
+			// filtering and is written without a derived title/type. Only count it when a file
+			// was actually written so the summary does not claim creation after a later error.
+			if (issueInfo == null)
+				fetchFailedAndWritten++;
 		}
 
-		ReportBulkFetchFailures(collector, fetchFailedCount, input.Issues.Length, input.StrictFetch, "issue");
+		ReportBulkFetchFailures(collector, fetchFailedAndWritten, input.Issues.Length, input.StrictFetch, "issue");
 
 		if (successCount == 0 && skippedCount == 0)
 			return false;
 
-		_logger.LogInformation(
-			"Processed {SuccessCount} issue(s) successfully, skipped {SkippedCount} issue(s), {FetchFailedCount} issue(s) could not be fetched",
-			successCount,
-			skippedCount,
-			fetchFailedCount
-		);
-		return successCount > 0;
+		if (successCount > 0)
+		{
+			_logger.LogInformation(
+				"Processed {SuccessCount} issue(s) successfully, skipped {SkippedCount} issue(s), {FetchFailedCount} issue(s) could not be fetched",
+				successCount,
+				skippedCount,
+				fetchFailedAndWritten
+			);
+		}
+
+		return successCount > 0 || skippedCount > 0;
 	}
 
 	private async Task<bool> CreateSingleChangelogFromIssueAsync(

--- a/src/services/Elastic.Changelog/Creation/CreateChangelogArgumentsValidator.cs
+++ b/src/services/Elastic.Changelog/Creation/CreateChangelogArgumentsValidator.cs
@@ -172,10 +172,8 @@ public class CreateChangelogArgumentsValidator(IConfigurationContext configurati
 			{
 				collector.EmitError(
 					string.Empty,
-					$"Product '{product.Product}' specifies version(s) '{string.Join("|", product.Versions)}', " +
-						"but changelog entries do not carry version applicability — the origin branch is the address. " +
-						"For PR-less items that apply to specific release versions (known issues, security advisories) " +
-						"use 'changelog note' instead."
+					$"Product '{product.Product}' specifies version(s) '{string.Join("|", product.Versions)}'. " +
+						"'changelog add' does not require or allow product versions."
 				);
 				return false;
 			}

--- a/src/services/Elastic.Changelog/Creation/PrInfoProcessor.cs
+++ b/src/services/Elastic.Changelog/Creation/PrInfoProcessor.cs
@@ -297,7 +297,7 @@ public class PrInfoProcessor(IGitHubPrService? githubPrService, ILogger logger)
 
 			if (matchingLabel != null)
 			{
-				collector.EmitWarning(
+				collector.EmitHint(
 					string.Empty,
 					$"{prefix} Skipping changelog creation for PR {prUrl} due to blocking label '{matchingLabel}'{productSuffix} (match: {match.ToString().ToLowerInvariant()})."
 				);
@@ -317,7 +317,7 @@ public class PrInfoProcessor(IGitHubPrService? githubPrService, ILogger logger)
 			if (!hasMatch)
 			{
 				var labelsList = string.Join(", ", rules.Labels);
-				collector.EmitWarning(
+				collector.EmitHint(
 					string.Empty,
 					$"{prefix} Skipping changelog creation for PR {prUrl}, no labels match rules.create.include [{labelsList}]{productSuffix} (match: {match.ToString().ToLowerInvariant()})."
 				);

--- a/src/tooling/docs-builder/Diagnostics/Console/ErrataFileSourceRepository.cs
+++ b/src/tooling/docs-builder/Diagnostics/Console/ErrataFileSourceRepository.cs
@@ -96,15 +96,13 @@ public class ErrataFileSourceRepository : ISourceRepository
 	{
 		// Fileless/global diagnostics (File == "") have no source location and no Errata label.
 		// Errata's Report.Render collapses embedded newlines in the message headline, making
-		// multi-line exception messages and stack traces unreadable. Route them to a dedicated
-		// Panel renderer that preserves line breaks; only file-anchored diagnostics go to Errata.
-		var globalDiagnostics = errors
-			.Where(d => string.IsNullOrEmpty(d.File))
-			.Concat(warnings.Where(d => string.IsNullOrEmpty(d.File)))
-			.ToArray();
+		// multi-line exception messages and stack traces unreadable. Route them by severity;
+		// only file-anchored diagnostics go to Errata.
+		var fileless = FilelessDiagnosticClassifier.Group(errors.Concat(warnings).Concat(hints));
 
 		var fileErrors = errors.Where(d => !string.IsNullOrEmpty(d.File)).ToArray();
 		var fileWarnings = warnings.Where(d => !string.IsNullOrEmpty(d.File)).ToArray();
+		var fileHints = hints.Where(d => !string.IsNullOrEmpty(d.File)).ToList();
 
 		var report = new Report(this);
 		var limited = fileErrors
@@ -122,9 +120,9 @@ public class ErrataFileSourceRepository : ISourceRepository
 			.Take(100)
 			.ToArray();
 
-		// show hints if we don't have plenty of errors/warnings to show
+		// show file-anchored hints if we don't have plenty of errors/warnings to show
 		if (limited.Length < 100)
-			limited = limited.Concat(hints).Take(100).ToArray();
+			limited = limited.Concat(fileHints).Take(100).ToArray();
 
 		foreach (var item in limited)
 		{
@@ -166,41 +164,36 @@ public class ErrataFileSourceRepository : ISourceRepository
 
 		AnsiConsole.WriteLine();
 
-		if (globalDiagnostics.Length > 0)
-			DisplayGlobalDiagnostics(globalDiagnostics);
+		if (!fileless.IsEmpty)
+			DisplayFilelessDiagnostics(fileless);
 
 		if (totalFileCount <= 0)
 		{
-			if (hints.Count > 0)
-				DisplayHintsOnly(report, hints);
+			if (fileHints.Count > 0)
+				DisplayHintsOnly(report, fileHints);
 			return;
 		}
 
 		DisplayErrorAndWarningSummary(report, totalFileCount, limited);
 	}
 
-	private static void DisplayGlobalDiagnostics(Diagnostic[] diagnostics)
+	private static void DisplayFilelessDiagnostics(FilelessDiagnosticGroups groups)
 	{
-		var rows = new List<IRenderable>();
-		var first = true;
-		foreach (var d in diagnostics)
-		{
-			if (!first)
-				rows.Add(new Rule { Style = Style.Parse("grey") });
-			first = false;
+		foreach (var diagnostic in groups.Exceptions)
+			DisplayExceptionPanel(diagnostic);
 
-			// Normalize line endings so \r\n (Windows) and \n both split cleanly.
-			var lines = d.Message.ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries);
-			var headline = lines.Length > 0 ? lines[0] : d.Message;
-			rows.Add(new Markup($"[bold red]{headline.EscapeMarkup()}[/]"));
+		DisplayFilelessLines("Errors", "red", groups.Errors);
+		DisplayFilelessLines("Warnings", "blue", groups.Warnings);
+		DisplayFilelessLines("Hints", "yellow", groups.Hints);
+	}
 
-			if (lines.Length > 1)
-			{
-				// Join remaining lines preserving structure; Markup renders \n as a real newline.
-				var trace = string.Join("\n", lines[1..]);
-				rows.Add(new Markup(trace.EscapeMarkup()));
-			}
-		}
+	private static void DisplayExceptionPanel(Diagnostic diagnostic)
+	{
+		var lines = diagnostic.Message.ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries);
+		var headline = lines.Length > 0 ? lines[0] : diagnostic.Message;
+		var rows = new List<IRenderable> { new Markup($"[bold red]{headline.EscapeMarkup()}[/]") };
+		if (lines.Length > 1)
+			rows.Add(new Markup(string.Join("\n", lines[1..]).EscapeMarkup()));
 
 		var panel = new Panel(new Rows(rows))
 		{
@@ -210,6 +203,29 @@ public class ErrataFileSourceRepository : ISourceRepository
 			Padding = new Padding(2, 1)
 		};
 		AnsiConsole.Write(panel);
+		AnsiConsole.WriteLine();
+	}
+
+	private static void DisplayFilelessLines(string header, string color, Diagnostic[] diagnostics)
+	{
+		if (diagnostics.Length == 0)
+			return;
+
+		AnsiConsole.MarkupLine($"[bold {color}]{header}[/]");
+		foreach (var diagnostic in diagnostics)
+		{
+			var lines = diagnostic.Message.ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries);
+			if (lines.Length == 0)
+			{
+				AnsiConsole.MarkupLine($"  [{color}]{diagnostic.Message.EscapeMarkup()}[/]");
+				continue;
+			}
+
+			AnsiConsole.MarkupLine($"  [{color}]{lines[0].EscapeMarkup()}[/]");
+			foreach (var line in lines.Skip(1))
+				AnsiConsole.MarkupLine($"  {line.EscapeMarkup()}");
+		}
+
 		AnsiConsole.WriteLine();
 	}
 

--- a/tests/Elastic.Changelog.Tests/Changelogs/Create/BlockingLabelTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/Create/BlockingLabelTests.cs
@@ -5,6 +5,7 @@
 using AwesomeAssertions;
 using Elastic.Changelog.Creation;
 using Elastic.Changelog.GitHub;
+using Elastic.Documentation.Diagnostics;
 using FakeItEasy;
 
 namespace Elastic.Changelog.Tests.Changelogs.Create;
@@ -54,11 +55,16 @@ public class BlockingLabelTests(ITestOutputHelper output) : CreateChangelogTestB
 
 		// Assert
 		result.Should().BeTrue(); // Should succeed but skip creating changelog
-		Collector.Warnings.Should().BeGreaterThan(0);
+		Collector.Errors.Should().Be(0);
+		Collector.Hints.Should().BeGreaterThan(0);
 		Collector
 			.Diagnostics
 			.Should()
-			.Contain(d => d.Message.Contains("Skipping changelog creation") && d.Message.Contains("skip:releaseNotes"));
+			.Contain(
+				d => d.Severity == Severity.Hint && d.Message.Contains("Skipping changelog creation") && d.Message.Contains(
+					"skip:releaseNotes"
+				)
+			);
 
 		var outputDir = input.Output ?? FileSystem.Directory.GetCurrentDirectory();
 		if (!FileSystem.Directory.Exists(outputDir))
@@ -103,7 +109,7 @@ public class BlockingLabelTests(ITestOutputHelper output) : CreateChangelogTestB
 			Products =
 			[
 				new ProductArgument { Product = "elasticsearch", Lifecycle = "ga" },
-				new ProductArgument { Product = "cloud-serverless", Target = "2025-08-05" }
+				new ProductArgument { Product = "cloud-serverless", Lifecycle = "ga" }
 			],
 			Config = configPath,
 			Output = CreateOutputDirectory()
@@ -114,8 +120,12 @@ public class BlockingLabelTests(ITestOutputHelper output) : CreateChangelogTestB
 
 		// Assert
 		result.Should().BeTrue(); // Should succeed but skip creating changelog due to cloud-serverless blocker
-		Collector.Warnings.Should().BeGreaterThan(0);
-		Collector.Diagnostics.Should().Contain(d => d.Message.Contains("Skipping changelog creation") && d.Message.Contains("ILM"));
+		Collector.Errors.Should().Be(0);
+		Collector.Hints.Should().BeGreaterThan(0);
+		Collector
+			.Diagnostics
+			.Should()
+			.Contain(d => d.Severity == Severity.Hint && d.Message.Contains("Skipping changelog creation") && d.Message.Contains("ILM"));
 
 		var outputDir = input.Output ?? FileSystem.Directory.GetCurrentDirectory();
 		if (!FileSystem.Directory.Exists(outputDir))
@@ -160,7 +170,7 @@ public class BlockingLabelTests(ITestOutputHelper output) : CreateChangelogTestB
 			Products =
 			[
 				new ProductArgument { Product = "elasticsearch", Lifecycle = "ga" },
-				new ProductArgument { Product = "cloud-serverless", Target = "2025-08-05" }
+				new ProductArgument { Product = "cloud-serverless", Lifecycle = "ga" }
 			],
 			Config = configPath,
 			Output = CreateOutputDirectory()
@@ -171,8 +181,14 @@ public class BlockingLabelTests(ITestOutputHelper output) : CreateChangelogTestB
 
 		// Assert
 		result.Should().BeTrue(); // Should succeed but skip creating changelog due to blocker
-		Collector.Warnings.Should().BeGreaterThan(0);
-		Collector.Diagnostics.Should().Contain(d => d.Message.Contains("Skipping changelog creation") && d.Message.Contains(">non-issue"));
+		Collector.Errors.Should().Be(0);
+		Collector.Hints.Should().BeGreaterThan(0);
+		Collector
+			.Diagnostics
+			.Should()
+			.Contain(
+				d => d.Severity == Severity.Hint && d.Message.Contains("Skipping changelog creation") && d.Message.Contains(">non-issue")
+			);
 
 		var outputDir = input.Output ?? FileSystem.Directory.GetCurrentDirectory();
 		if (!FileSystem.Directory.Exists(outputDir))
@@ -231,15 +247,67 @@ public class BlockingLabelTests(ITestOutputHelper output) : CreateChangelogTestB
 
 		// Assert — product-specific rule should have blocked creation
 		result.Should().BeTrue(); // Succeed but skip
+		Collector.Errors.Should().Be(0);
 		Collector
 			.Diagnostics
 			.Should()
-			.Contain(d => d.Message.Contains("Skipping changelog creation") && d.Message.Contains("skip:releaseNotes"));
+			.Contain(
+				d => d.Severity == Severity.Hint && d.Message.Contains("Skipping changelog creation") && d.Message.Contains(
+					"skip:releaseNotes"
+				)
+			);
 
 		var outputDir = input.Output;
 		if (!FileSystem.Directory.Exists(outputDir))
 			FileSystem.Directory.CreateDirectory(outputDir);
 		var files = FileSystem.Directory.GetFiles(outputDir, "*.yaml");
 		files.Should().HaveCount(0);
+	}
+
+	[Fact]
+	public async Task CreateChangelog_WithAllPrsSkippedByCreateRules_ReturnsSuccessWithoutErrors()
+	{
+		var prInfo = new GitHubPrInfo { Title = "PR with blocking label", Labels = ["type:feature", "skip:releaseNotes"] };
+
+		A.CallTo(() => MockGitHubService.FetchPrInfoAsync(A<string>._, A<string?>._, A<string?>._, A<CancellationToken>._)).Returns(prInfo);
+
+		// language=yaml
+		var configContent =
+			"""
+			pivot:
+			  types:
+			    feature: "type:feature"
+			    bug-fix:
+			    breaking-change:
+			lifecycles:
+			  - ga
+			rules:
+			  create:
+			    products:
+			      elasticsearch:
+			        exclude: "skip:releaseNotes"
+			""";
+		var configPath = await CreateConfigDirectory(configContent);
+		var service = CreateService();
+		var outputDir = CreateOutputDirectory();
+
+		var input = new CreateChangelogArguments
+		{
+			Prs = ["https://github.com/elastic/elasticsearch/pull/111", "https://github.com/elastic/elasticsearch/pull/222"],
+			Products = [new ProductArgument { Product = "elasticsearch", Lifecycle = "ga" }],
+			Config = configPath,
+			Output = outputDir
+		};
+
+		var result = await service.CreateChangelog(Collector, input, TestContext.Current.CancellationToken);
+
+		result.Should().BeTrue();
+		Collector.Errors.Should().Be(0);
+		Collector.Diagnostics.Should().NotContain(d => d.Message.Contains("returned false without emitting errors"));
+		Collector.Diagnostics.Should().OnlyContain(d => d.Severity != Severity.Error);
+		Collector.Diagnostics.Should().Contain(d => d.Severity == Severity.Hint && d.Message.Contains("Skipping changelog creation"));
+		if (!FileSystem.Directory.Exists(outputDir))
+			FileSystem.Directory.CreateDirectory(outputDir);
+		FileSystem.Directory.GetFiles(outputDir, "*.yaml").Should().BeEmpty();
 	}
 }

--- a/tests/Elastic.Changelog.Tests/Changelogs/Create/PrFetchFailureTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/Create/PrFetchFailureTests.cs
@@ -294,7 +294,7 @@ public class PrFetchFailureTests(ITestOutputHelper output) : CreateChangelogTest
 		Collector
 			.Diagnostics
 			.Should()
-			.Contain(d => d.Severity == Severity.Error && d.Message.Contains("do not carry version applicability"));
+			.Contain(d => d.Severity == Severity.Error && d.Message.Contains("does not require or allow product versions"));
 		Collector.Diagnostics.Should().NotContain(d => d.Message.Contains("could not be fetched"));
 		Collector.Diagnostics.Should().NotContain(d => d.Message.Contains("Their changelogs were created"));
 		A.CallTo(

--- a/tests/Elastic.Changelog.Tests/Changelogs/Create/PrFetchFailureTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/Create/PrFetchFailureTests.cs
@@ -231,10 +231,12 @@ public class PrFetchFailureTests(ITestOutputHelper output) : CreateChangelogTest
 
 		// Assert: under --strict-fetch the bulk fetch failure escalates to an error.
 		// No files are written because filename derivation requires a PR number;
-		// the caller must use 'changelog note' for issue-only entries.
+		// the caller must use 'changelog note' for issue-only entries. The aggregate
+		// "changelogs were created" fetch summary is omitted because nothing was written.
 		result.Should().BeFalse();
 		Collector.Errors.Should().BeGreaterThan(0);
-		Collector.Diagnostics.Should().Contain(d => d.Severity == Severity.Error && d.Message.Contains("could not be fetched from GitHub"));
+		Collector.Diagnostics.Should().Contain(d => d.Severity == Severity.Error && d.Message.Contains("changelog note"));
+		Collector.Diagnostics.Should().NotContain(d => d.Message.Contains("Their changelogs were created"));
 	}
 
 	[Fact]
@@ -262,5 +264,43 @@ public class PrFetchFailureTests(ITestOutputHelper output) : CreateChangelogTest
 		result.Should().BeTrue();
 		Collector.Errors.Should().BeGreaterThan(0);
 		Collector.Diagnostics.Should().Contain(d => d.Severity == Severity.Error && d.Message.Contains("--strict-fetch"));
+	}
+
+	[Fact]
+	public async Task CreateChangelog_WithVersionedProductsOnBulkAdd_EmitsErrorWithoutFetchOrFiles()
+	{
+		A.CallTo(() => MockGitHubService.FetchPrInfoAsync(A<string>._, A<string?>._, A<string?>._, A<CancellationToken>._)).Returns(
+			(GitHubPrInfo?)null
+		);
+
+		var service = CreateService();
+		var outputDir = CreateOutputDirectory();
+
+		var input = new CreateChangelogArguments
+		{
+			Prs = ["https://github.com/elastic/elasticsearch/pull/12345", "https://github.com/elastic/elasticsearch/pull/67890"],
+			Products =
+			[
+				new ProductArgument { Product = "cloud-serverless", Target = "2026-08-27" },
+				new ProductArgument { Product = "kibana" }
+			],
+			Output = outputDir
+		};
+
+		var result = await service.CreateChangelog(Collector, input, TestContext.Current.CancellationToken);
+
+		result.Should().BeFalse();
+		Collector.Errors.Should().BeGreaterThan(0);
+		Collector
+			.Diagnostics
+			.Should()
+			.Contain(d => d.Severity == Severity.Error && d.Message.Contains("do not carry version applicability"));
+		Collector.Diagnostics.Should().NotContain(d => d.Message.Contains("could not be fetched"));
+		Collector.Diagnostics.Should().NotContain(d => d.Message.Contains("Their changelogs were created"));
+		A.CallTo(
+			() => MockGitHubService.FetchPrInfoAsync(A<string>._, A<string?>._, A<string?>._, A<CancellationToken>._)
+		).MustNotHaveHappened();
+		if (FileSystem.Directory.Exists(outputDir))
+			FileSystem.Directory.GetFiles(outputDir, "*.yaml").Should().BeEmpty();
 	}
 }

--- a/tests/Elastic.Documentation.Tests/Diagnostics/FilelessDiagnosticClassifierTests.cs
+++ b/tests/Elastic.Documentation.Tests/Diagnostics/FilelessDiagnosticClassifierTests.cs
@@ -1,0 +1,84 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using AwesomeAssertions;
+using Elastic.Documentation.Diagnostics;
+
+namespace Elastic.Documentation.Tests.Diagnostics;
+
+public class FilelessDiagnosticClassifierTests
+{
+	[Fact]
+	public void LooksLikeException_ErrorWithExceptionDump_IsTrue()
+	{
+		var diagnostic = new Diagnostic
+		{
+			Severity = Severity.Error,
+			File = "",
+			Message = "IO error creating changelog: disk full" + Environment.NewLine + "System.IO.IOException: disk full"
+		};
+
+		FilelessDiagnosticClassifier.LooksLikeException(diagnostic).Should().BeTrue();
+	}
+
+	[Fact]
+	public void LooksLikeException_OrdinaryError_IsFalse()
+	{
+		var diagnostic = new Diagnostic
+		{
+			Severity = Severity.Error,
+			File = "",
+			Message = "Product 'cloud-serverless' specifies version(s) '2026-08-27'"
+		};
+
+		FilelessDiagnosticClassifier.LooksLikeException(diagnostic).Should().BeFalse();
+	}
+
+	[Fact]
+	public void LooksLikeException_WarningContainingExceptionWord_IsFalse()
+	{
+		var diagnostic = new Diagnostic
+		{
+			Severity = Severity.Warning,
+			File = "",
+			Message = "No changelog file found for PR: https://github.com/elastic/kibana/pull/279825"
+		};
+
+		FilelessDiagnosticClassifier.LooksLikeException(diagnostic).Should().BeFalse();
+	}
+
+	[Fact]
+	public void Group_SplitsFilelessDiagnosticsBySeverityAndException()
+	{
+		var exception = new Diagnostic
+		{
+			Severity = Severity.Error,
+			File = "",
+			Message = "Unhandled service exception: boom" + Environment.NewLine + "System.InvalidOperationException: boom"
+		};
+		var error = new Diagnostic { Severity = Severity.Error, File = "", Message = "At least one product is required" };
+		var warning = new Diagnostic { Severity = Severity.Warning, File = "", Message = "No changelog file found for PR: 1" };
+		var hint = new Diagnostic { Severity = Severity.Hint, File = "", Message = "[-exclude] Skipping changelog creation" };
+		var fileError = new Diagnostic { Severity = Severity.Error, File = "doc.md", Message = "broken link" };
+
+		var groups = FilelessDiagnosticClassifier.Group([exception, error, warning, hint, fileError]);
+
+		groups.Exceptions.Should().ContainSingle().Which.Message.Should().Contain("InvalidOperationException:");
+		groups.Errors.Should().ContainSingle().Which.Message.Should().Contain("product is required");
+		groups.Warnings.Should().ContainSingle().Which.Message.Should().Contain("No changelog file found");
+		groups.Hints.Should().ContainSingle().Which.Message.Should().Contain("Skipping changelog creation");
+		groups.IsEmpty.Should().BeFalse();
+	}
+
+	[Fact]
+	public void Group_EmptyWhenAllDiagnosticsAreFileAnchored()
+	{
+		var groups = FilelessDiagnosticClassifier.Group([
+			new Diagnostic { Severity = Severity.Error, File = "a.md", Message = "err" },
+			new Diagnostic { Severity = Severity.Warning, File = "b.md", Message = "warn" }
+		]);
+
+		groups.IsEmpty.Should().BeTrue();
+	}
+}


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/docs-builder/issues/3726
Also addresses the poor error situation mentioned in https://github.com/elastic/docs-builder/issues/3956

## Details

- Console (#3726). File-less diagnostics are classified in `FilelessDiagnosticClassifier` and rendered by severity: red Unhandled exception panels only for exception dumps, Errors / Warnings / Hints as one message per line.
- Changelog add (#3956 diagnostics). Versioned `--products` fails before any GitHub fetch. The bulk “changelogs were created without rules.create…” summary only fires when a file was actually written. `rules.create` skips are hints; all-skipped bulk add returns success.

## Example

When I now run a command like:

```
docs-builder/release/docs-builder changelog add \
  --prs ./docs/temp/prs.txt \
  --concise \
  --products "cloud-serverless 2026-08-27, kibana"
```
The error message appears more quickly and has clearer advice:

```
info ::e.d.c.tionFileProvider:: ConfigurationSource.Embedded using embedded in binary configuration
info ::d.b.m.LoggerMiddleware:: Configuration source: Embedded
info ::d.b.m.LoggerMiddleware:: Version: 1.42.1-canary.0.13+0c435eede808887f0af31fc2280b924eb0d9bc96
info ::d.b.m.pwatchMiddleware:: add :: Starting...
error::d.b.d.Log             :: Product 'cloud-serverless' specifies version(s) '2026-08-27'. 'changelog add' does not require or allow product versions.
```

When I run a command that has a lot of messages, they're now grouped into separate categories (i.e. they're no longer all red errors). For example:

```
...
info ::e.c.c.gCreationService:: Processed 143 PR(s) successfully, skipped 38 PR(s), 132 PR(s) could not be fetched

Warnings
  Failed to fetch PR information from GitHub for PR: https://github.com/elastic/kibana/pull/285606. Generating basic changelog with provided values.
  Title is missing. The changelog will be created with title commented out. Please manually update the title field.
…
Hints
  [-exclude] Skipping changelog creation for PR https://github.com/elastic/kibana/pull/235587 due to blocking label 'release_note:skip' (match: any).
  [-exclude] Skipping changelog creation for PR https://github.com/elastic/kibana/pull/235592 due to blocking label 'release_note:skip' (match: any).
  [-exclude] Skipping changelog creation for PR https://github.com/elastic/kibana/pull/235658 due to blocking label 'release_note:skip' (match: any).
  [-exclude] Skipping changelog creation for PR https://github.com/elastic/kibana/pull/235664 due to blocking label 'release_note:skip' (match: any).
  [-exclude] Skipping changelog creation for PR https://github.com/elastic/kibana/pull/265867 due to blocking label 'release_note:skip' (match: any).
…
	0 Errors / 529 Warnings / 38 Hints

info ::d.b.m.pwatchMiddleware:: add :: Finished in '00:00:27.1721499'
```