### PR TITLE
Guide agents to documentation discovery resources

### DIFF
--- a/docs/data/exporters/llm.md
+++ b/docs/data/exporters/llm.md
@@ -43,6 +43,10 @@ applies_to:
 ---
 ```
 
+## Documentation discovery
+
+Each exported page includes a documentation resources note immediately after its title. The note directs agents to the site's `llms.txt` index before they explore other pages, and to the free Elastic Docs MCP server for targeted search, related-page discovery, and page retrieval.
+
 ## Content negotiation
 
 Web servers (like the one serving elastic.co/docs) can use the co-located `.md` files to implement content negotiation:

--- a/docs/data/exporters/llm.md
+++ b/docs/data/exporters/llm.md
@@ -45,7 +45,7 @@ applies_to:
 
 ## Documentation discovery
 
-Each exported page includes a documentation resources note immediately after its title. The note directs agents to the site's `llms.txt` index before they explore other pages, and to the free Elastic Docs MCP server for targeted search, related-page discovery, and page retrieval.
+Each exported public documentation page includes a documentation resources callout before its title. The callout directs agents to the site's `llms.txt` index before they explore other pages, and to the free Elastic Docs MCP server for targeted search, related-page discovery, and page retrieval. Internal and Codex pages omit the callout.
 
 ## Content negotiation
 

--- a/src/Elastic.Markdown/DocumentationGenerator.cs
+++ b/src/Elastic.Markdown/DocumentationGenerator.cs
@@ -557,7 +557,9 @@ public partial class DocumentationGenerator
 	{
 		await DocumentationSet.ResolveDirectoryTree(ctx);
 		var document = await markdown.ParseFullAsync(DocumentationSet.TryFindDocumentByRelativePath, ctx);
-		return LlmMarkdownExporter.ConvertToLlmMarkdown(document, DocumentationSet.Context);
+		var resources = LlmMarkdownExporter.CreateDocumentationResources(Context);
+		var content = LlmMarkdownExporter.ConvertToLlmMarkdown(document, DocumentationSet.Context);
+		return resources + content;
 	}
 
 	public async Task<RenderResult> RenderLayout(MarkdownFile markdown, Cancel ctx)

--- a/src/Elastic.Markdown/Exporters/LlmMarkdownExporter.cs
+++ b/src/Elastic.Markdown/Exporters/LlmMarkdownExporter.cs
@@ -8,6 +8,7 @@ using System.Text;
 using Elastic.Documentation;
 using Elastic.Documentation.AppliesTo;
 using Elastic.Documentation.Configuration;
+using Elastic.Documentation.Configuration.Builder;
 using Elastic.Documentation.Configuration.Inference;
 using Elastic.Documentation.Configuration.Products;
 using Elastic.Documentation.Extensions;
@@ -202,9 +203,8 @@ public class LlmMarkdownExporter(bool branded = false, DocumentationWriteFileSys
 
 		_ = metadata.AppendLine("---");
 		_ = metadata.AppendLine();
-		_ = metadata.AppendLine($"# {sourceFile.Title}");
-		_ = metadata.AppendLine();
 		_ = metadata.Append(CreateDocumentationResources(context.BuildContext));
+		_ = metadata.AppendLine($"# {sourceFile.Title}");
 		_ = metadata.Append(llmMarkdown);
 
 		return metadata.ToString();
@@ -212,6 +212,9 @@ public class LlmMarkdownExporter(bool branded = false, DocumentationWriteFileSys
 
 	internal static string CreateDocumentationResources(BuildContext context)
 	{
+		if (context.BuildType == BuildType.Codex || context.Configuration.Registry != DocSetRegistry.Public)
+			return string.Empty;
+
 		var documentationRoot = context.SiteRootPath ?? context.UrlPathPrefix ?? string.Empty;
 		var indexPath = UrlPath.JoinUrl(documentationRoot, "llms.txt");
 		var indexUrl = CreateAbsoluteUrl(context.CanonicalBaseUrl, indexPath, trailingSlash: false);
@@ -221,13 +224,13 @@ public class LlmMarkdownExporter(bool branded = false, DocumentationWriteFileSys
 			: string.Empty;
 
 		return $"""
-			## Documentation resources
-
-			Fetch the complete documentation index at: {indexUrl}
-			Use this file to discover all available pages before exploring further.
-
-			For targeted search and retrieval, use the {free}Elastic Docs MCP server at: {mcpUrl}
-			The server provides tools to search, discover related pages, and retrieve page content.
+			> ## Documentation resources
+			>
+			> Fetch the complete documentation index at: {indexUrl}
+			> Use this file to discover all available pages before exploring further.
+			>
+			> For targeted search and retrieval, use the {free}Elastic Docs MCP server at: {mcpUrl}
+			> The server provides tools to search, discover related pages, and retrieve page content.
 
 			""";
 	}

--- a/src/Elastic.Markdown/Exporters/LlmMarkdownExporter.cs
+++ b/src/Elastic.Markdown/Exporters/LlmMarkdownExporter.cs
@@ -10,6 +10,7 @@ using Elastic.Documentation.AppliesTo;
 using Elastic.Documentation.Configuration;
 using Elastic.Documentation.Configuration.Inference;
 using Elastic.Documentation.Configuration.Products;
+using Elastic.Documentation.Extensions;
 using Elastic.Documentation.FileSystems;
 using Elastic.Markdown.Helpers;
 using Elastic.Markdown.Myst.Components;
@@ -202,9 +203,39 @@ public class LlmMarkdownExporter(bool branded = false, DocumentationWriteFileSys
 		_ = metadata.AppendLine("---");
 		_ = metadata.AppendLine();
 		_ = metadata.AppendLine($"# {sourceFile.Title}");
+		_ = metadata.AppendLine();
+		_ = metadata.Append(CreateDocumentationResources(context.BuildContext));
 		_ = metadata.Append(llmMarkdown);
 
 		return metadata.ToString();
+	}
+
+	internal static string CreateDocumentationResources(BuildContext context)
+	{
+		var documentationRoot = context.SiteRootPath ?? context.UrlPathPrefix ?? string.Empty;
+		var indexPath = UrlPath.JoinUrl(documentationRoot, "llms.txt");
+		var indexUrl = CreateAbsoluteUrl(context.CanonicalBaseUrl, indexPath, trailingSlash: false);
+		var mcpUrl = CreateAbsoluteUrl(context.CanonicalBaseUrl, context.Environment.McpPrefix, trailingSlash: true);
+		var free = string.Equals(context.Environment.McpServerProfile, "public", StringComparison.OrdinalIgnoreCase)
+			? "free "
+			: string.Empty;
+
+		return $"""
+			## Documentation resources
+
+			Fetch the complete documentation index at: {indexUrl}
+			Use this file to discover all available pages before exploring further.
+
+			For targeted search and retrieval, use the {free}Elastic Docs MCP server at: {mcpUrl}
+			The server provides tools to search, discover related pages, and retrieve page content.
+
+			""";
+	}
+
+	private static string CreateAbsoluteUrl(Uri? canonicalBaseUrl, string path, bool trailingSlash)
+	{
+		var normalizedPath = $"/{path.Trim('/')}{(trailingSlash ? "/" : string.Empty)}";
+		return canonicalBaseUrl is null ? normalizedPath : new Uri(canonicalBaseUrl, normalizedPath).ToString();
 	}
 
 	private static List<string> GetAppliesToItems(ApplicableTo appliesTo, IDocumentationConfigurationContext buildContext)

--- a/tests/Elastic.Markdown.Tests/Exporters/LlmMarkdownExporterTests.cs
+++ b/tests/Elastic.Markdown.Tests/Exporters/LlmMarkdownExporterTests.cs
@@ -32,14 +32,55 @@ public class LlmMarkdownExporterTests(ITestOutputHelper output)
 	}
 
 	[Fact]
-	public void CreateDocumentationResources_PublicDocsBuild_LinksToIndexAndFreeMcpServer()
+	public void CreateDocumentationResources_PublicDocsBuild_ReturnsCalloutBeforeContent()
+	{
+		var context = CreateBuildContext(DocSetRegistry.Public, BuildType.Isolated);
+
+		var resources = LlmMarkdownExporter.CreateDocumentationResources(context);
+
+		resources.Should().Be(
+			"""
+			> ## Documentation resources
+			>
+			> Fetch the complete documentation index at: https://www.elastic.co/docs/llms.txt
+			> Use this file to discover all available pages before exploring further.
+			>
+			> For targeted search and retrieval, use the free Elastic Docs MCP server at: https://www.elastic.co/docs/_mcp/
+			> The server provides tools to search, discover related pages, and retrieve page content.
+
+			"""
+		);
+	}
+
+	[Fact]
+	public void CreateDocumentationResources_InternalDocsBuild_ReturnsEmpty()
+	{
+		var context = CreateBuildContext(DocSetRegistry.Internal, BuildType.Isolated);
+
+		var resources = LlmMarkdownExporter.CreateDocumentationResources(context);
+
+		resources.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void CreateDocumentationResources_CodexBuild_ReturnsEmpty()
+	{
+		var context = CreateBuildContext(DocSetRegistry.Public, BuildType.Codex);
+
+		var resources = LlmMarkdownExporter.CreateDocumentationResources(context);
+
+		resources.Should().BeEmpty();
+	}
+
+	private BuildContext CreateBuildContext(DocSetRegistry registry, BuildType buildType)
 	{
 		var fileSystem = new MockFileSystem(
 			new Dictionary<string, MockFileData>
 			{
 				["docs/docset.yml"] = new(
-					"""
+					$"""
 					project: test
+					registry: {registry.ToString().ToLowerInvariant()}
 					toc:
 					  - file: index.md
 					"""
@@ -49,28 +90,13 @@ public class LlmMarkdownExporterTests(ITestOutputHelper output)
 			new MockFileSystemOptions { CurrentDirectory = Paths.WorkingDirectoryRoot.FullName }
 		);
 		var configurationContext = TestHelpers.CreateConfigurationContext(fileSystem);
-		var context = new BuildContext(
+		return new BuildContext(
 			new TestDiagnosticsCollector(output),
 			TestHelpers.CreateDocumentationFileSystem(fileSystem),
 			configurationContext,
 			new PublicEnvironmentVariables()
 		)
-		{ CanonicalBaseUrl = new Uri("https://www.elastic.co/"), UrlPathPrefix = "/docs" };
-
-		var resources = LlmMarkdownExporter.CreateDocumentationResources(context);
-
-		resources.Should().Be(
-			"""
-			## Documentation resources
-
-			Fetch the complete documentation index at: https://www.elastic.co/docs/llms.txt
-			Use this file to discover all available pages before exploring further.
-
-			For targeted search and retrieval, use the free Elastic Docs MCP server at: https://www.elastic.co/docs/_mcp/
-			The server provides tools to search, discover related pages, and retrieve page content.
-
-			"""
-		);
+		{ BuildType = buildType, CanonicalBaseUrl = new Uri("https://www.elastic.co/"), UrlPathPrefix = "/docs" };
 	}
 
 	private sealed class PublicEnvironmentVariables : IEnvironmentVariables

--- a/tests/Elastic.Markdown.Tests/Exporters/LlmMarkdownExporterTests.cs
+++ b/tests/Elastic.Markdown.Tests/Exporters/LlmMarkdownExporterTests.cs
@@ -5,11 +5,14 @@
 using System.IO.Abstractions.TestingHelpers;
 using System.IO.Compression;
 using AwesomeAssertions;
+using Elastic.Documentation;
+using Elastic.Documentation.Configuration;
+using Elastic.Documentation.Configuration.Builder;
 using Elastic.Markdown.Exporters;
 
 namespace Elastic.Markdown.Tests.Exporters;
 
-public class LlmMarkdownExporterTests
+public class LlmMarkdownExporterTests(ITestOutputHelper output)
 {
 	[Fact]
 	public async Task FinishExportAsync_InMemoryFileSystem_CreatesArchiveFromInMemoryFiles()
@@ -26,5 +29,54 @@ public class LlmMarkdownExporterTests
 		await using var zipStream = fileSystem.File.OpenRead($"{outputPath}/llm.zip");
 		using var archive = new ZipArchive(zipStream, ZipArchiveMode.Read);
 		archive.Entries.Select(entry => entry.FullName).Should().BeEquivalentTo("llms.txt", "guide/page.md");
+	}
+
+	[Fact]
+	public void CreateDocumentationResources_PublicDocsBuild_LinksToIndexAndFreeMcpServer()
+	{
+		var fileSystem = new MockFileSystem(
+			new Dictionary<string, MockFileData>
+			{
+				["docs/docset.yml"] = new(
+					"""
+					project: test
+					toc:
+					  - file: index.md
+					"""
+				),
+				["docs/index.md"] = new("# Test")
+			},
+			new MockFileSystemOptions { CurrentDirectory = Paths.WorkingDirectoryRoot.FullName }
+		);
+		var configurationContext = TestHelpers.CreateConfigurationContext(fileSystem);
+		var context = new BuildContext(
+			new TestDiagnosticsCollector(output),
+			TestHelpers.CreateDocumentationFileSystem(fileSystem),
+			configurationContext,
+			new PublicEnvironmentVariables()
+		)
+		{ CanonicalBaseUrl = new Uri("https://www.elastic.co/"), UrlPathPrefix = "/docs" };
+
+		var resources = LlmMarkdownExporter.CreateDocumentationResources(context);
+
+		resources.Should().Be(
+			"""
+			## Documentation resources
+
+			Fetch the complete documentation index at: https://www.elastic.co/docs/llms.txt
+			Use this file to discover all available pages before exploring further.
+
+			For targeted search and retrieval, use the free Elastic Docs MCP server at: https://www.elastic.co/docs/_mcp/
+			The server provides tools to search, discover related pages, and retrieve page content.
+
+			"""
+		);
+	}
+
+	private sealed class PublicEnvironmentVariables : IEnvironmentVariables
+	{
+		public bool IsRunningOnCI => false;
+
+		public string? GetEnvironmentVariable(string name) => null;
 	}
 }


### PR DESCRIPTION
Public machine-readable documentation pages now open with a callout that directs agents to the complete documentation index and the Docs MCP server. Internal and Codex output remains unchanged.

**Affects:** Authoring, MCP

## Why

Agents that enter the documentation through one Markdown page cannot see the wider page map. The existing `llms.txt` index and free Docs MCP server solve this problem, but public page output does not advertise either resource. Internal documentation must not point agents toward public discovery services.

## What

#### Public page callout

Every public Markdown page places a documentation resources blockquote before the H1 and all other page content. The callout directs agents to inspect `llms.txt` first and names the MCP tools available for targeted discovery and retrieval.

#### Visibility guard

The exporter emits the callout only when the docset uses the public registry and the build is not Codex. Internal and Codex pages omit it entirely.

#### Environment-aware links and live rendering

The exporter derives the index and MCP URLs from the active build context. Live `.md` responses use the same visibility and placement rules as exported pages.

## Verify

```bash
dotnet test tests/Elastic.Markdown.Tests/
```