### PR TITLE
Codex: warn and skip clones that the token cannot access

### DIFF
--- a/src/Elastic.Codex/Sourcing/CodexCloneService.cs
+++ b/src/Elastic.Codex/Sourcing/CodexCloneService.cs
@@ -84,6 +84,11 @@ public class CodexCloneService(ILoggerFactory logFactory, ILinkIndexReader linkI
 			try
 			{
 				var git = new CodexGitRepository(loggerFactory, context.Collector, subDir);
+				if (!git.HasHead())
+				{
+					logger.LogWarning("Could not read commit for {Name}; skipping", repoName);
+					continue;
+				}
 				currentCommit = git.GetCurrentCommit();
 			}
 			catch (OperationCanceledException)
@@ -186,7 +191,10 @@ public class CodexCloneService(ILoggerFactory logFactory, ILinkIndexReader linkI
 
 		try
 		{
-			var git = new CodexGitRepository(logFactory, context.Collector, repoDir);
+			// Git command failures emit collector errors. Use a local collector so a
+			// missing clone token policy warns and skips instead of failing the job.
+			var gitCollector = new DiagnosticsCollector([]);
+			var git = new CodexGitRepository(logFactory, gitCollector, repoDir);
 
 			if (assumeCloned && git.IsInitialized())
 			{

--- a/src/Elastic.Codex/Sourcing/CodexGitRepository.cs
+++ b/src/Elastic.Codex/Sourcing/CodexGitRepository.cs
@@ -53,25 +53,34 @@ public class CodexGitRepository(
 
 	public bool IsInitialized() => Directory.Exists(Path.Join(WorkingDirectory.FullName, ".git"));
 
-	public void Fetch(string reference) =>
-		_ = ExecInWithRetry(
-			EnvironmentVars,
-			NetworkRetry,
-			"git",
-			"fetch",
-			"--no-tags",
-			"--prune",
-			"--no-recurse-submodules",
-			"--depth",
-			"1",
-			"origin",
-			reference
-		);
+	public void Fetch(string reference)
+	{
+		if (
+			!ExecInWithRetry(
+				EnvironmentVars,
+				NetworkRetry,
+				"git",
+				"fetch",
+				"--no-tags",
+				"--prune",
+				"--no-recurse-submodules",
+				"--depth",
+				"1",
+				"origin",
+				reference
+			)
+		)
+			throw new InvalidOperationException($"git fetch failed for '{reference}'");
+	}
 
 	public void EnableSparseCheckout(string[] folders) =>
 		ExecIn(EnvironmentVars, "git", ["sparse-checkout", "set", "--no-cone", .. folders]);
 
-	public void Checkout(string reference) => ExecIn(EnvironmentVars, "git", "checkout", "--force", reference);
+	public void Checkout(string reference)
+	{
+		if (!ExecInWithRetry(EnvironmentVars, RetryPolicy.None, "git", "checkout", "--force", reference))
+			throw new InvalidOperationException($"git checkout failed for '{reference}'");
+	}
 
 	public void GitAddOrigin(string origin) => ExecIn(EnvironmentVars, "git", "remote", "add", "origin", origin);
 }

--- a/tests/Navigation.Tests/Codex/CodexGitRepositoryTests.cs
+++ b/tests/Navigation.Tests/Codex/CodexGitRepositoryTests.cs
@@ -1,0 +1,77 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
+using AwesomeAssertions;
+using Elastic.Codex.Sourcing;
+using Elastic.Documentation.Diagnostics;
+using Elastic.Documentation.ExternalCommands;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Elastic.Documentation.Navigation.Tests.Codex;
+
+public class CodexGitRepositoryTests
+{
+	[Fact]
+	public void Fetch_WhenGitFails_ThrowsWithoutLeavingTheFailureAsAnUncaughtJobError()
+	{
+		var gitCollector = new DiagnosticsCollector([]);
+		var git = CreateGit(gitCollector, ExitCode(128), ExitCode(128), ExitCode(128));
+
+		var act = () => git.Fetch("abc123");
+
+		act.Should().Throw<InvalidOperationException>().WithMessage("git fetch failed for 'abc123'");
+		gitCollector.Errors.Should().Be(1);
+	}
+
+	[Fact]
+	public void Checkout_WhenGitFails_ThrowsAfterRecordingTheFailureOnTheGitCollector()
+	{
+		var gitCollector = new DiagnosticsCollector([]);
+		var git = CreateGit(gitCollector, ExitCode(1));
+
+		var act = () => git.Checkout("FETCH_HEAD");
+
+		act.Should().Throw<InvalidOperationException>().WithMessage("git checkout failed for 'FETCH_HEAD'");
+		gitCollector.Errors.Should().Be(1);
+	}
+
+	private static Func<int> ExitCode(int code) => () => code;
+
+	private static ScriptedCodexGitRepository CreateGit(IDiagnosticsCollector gitCollector, params Func<int>[] steps)
+	{
+		var fileSystem = new MockFileSystem();
+		var workingDirectory = fileSystem.DirectoryInfo.New("/tmp/clone/repo");
+		workingDirectory.Create();
+		return new ScriptedCodexGitRepository(gitCollector, workingDirectory, steps);
+	}
+
+	private sealed class ScriptedCodexGitRepository(
+		IDiagnosticsCollector collector,
+		IDirectoryInfo workingDirectory,
+		Func<int>[] steps
+	) : CodexGitRepository(NullLoggerFactory.Instance, collector, workingDirectory)
+	{
+		private int _callCount;
+
+		protected override int ExecInCore(
+			Dictionary<string, string> environmentVars,
+			TimeSpan? attemptTimeout,
+			string binary,
+			params string[] args
+		)
+		{
+			if (_callCount >= steps.Length)
+				throw new InvalidOperationException($"Unexpected invocation {_callCount + 1}");
+			return steps[_callCount++]();
+		}
+
+		protected override void DelayBeforeRetry(TimeSpan delay)
+		{
+			// Tests must not wait on the production 5s fetch back-off.
+		}
+	}
+}

--- a/tests/Navigation.Tests/Navigation.Tests.csproj
+++ b/tests/Navigation.Tests/Navigation.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Elastic.Codex\Elastic.Codex.csproj"/>
+    <ProjectReference Include="..\..\src\Elastic.Documentation.Tooling\Elastic.Documentation.Tooling.csproj"/>
     <ProjectReference Include="..\..\src\Elastic.Documentation.Configuration\Elastic.Documentation.Configuration.csproj"/>
     <ProjectReference Include="..\..\src\Elastic.Documentation.Navigation\Elastic.Documentation.Navigation.csproj"/>
     <ProjectReference Include="..\..\src\Elastic.Documentation.ServiceDefaults\Elastic.Documentation.ServiceDefaults.csproj" />


### PR DESCRIPTION
`docs-builder codex clone` warns and skips a repository when the clone token cannot read it. The rest of the Codex publish job continues.

**Affects:** Codex builds

## Why

A Codex repository can land in the link index before the clone token policy grants read access. `codex clone` already catches that failure and emits a warning. After docs-builder 1.42.0, git still records collector errors for the failed fetch, so the warning path does not save the job. One missing policy then stops the whole Codex publish.

## What

#### Isolated git diagnostics

Clone git work writes errors to a local collector, not the job collector. The job still sees the existing warning and skip. Assembler clone behaviour does not change.

#### Failed fetch and checkout

A failed `Fetch` or `Checkout` throws after retries instead of continuing into `rev-parse`. The catch in `CodexCloneService` turns that into a warning.

#### Empty checkouts after a skip

`DiscoverCheckouts` skips a repository whose `.git` has no HEAD. A failed clone no longer breaks the later `codex build` step.

## Verify

```bash
dotnet test tests/Navigation.Tests/ --filter FullyQualifiedName~CodexGitRepositoryTests
# Fetch_WhenGitFails_ThrowsWithoutLeavingTheFailureAsAnUncaughtJobError
# Checkout_WhenGitFails_ThrowsAfterRecordingTheFailureOnTheGitCollector
```

**Out of scope:** This PR does not add `elastic/amer-fed-education-docs` to the clone token policy. That repo still stays unpublished until the policy exists.

Made with [Cursor](https://cursor.com)