### PR TITLE
Grant issues:write so the PR Review workflow can start

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -7,7 +7,7 @@ permissions:
   actions: read
   contents: read
   copilot-requests: write
-  issues: read
+  issues: write # needed for failure tracking and no-op run tracking
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
The `PR Review` workflow has failed to start on every pull request since it was added — GitHub rejects it before any job runs.

**Affects:** Automation

## Why

The workflow's `permissions:` block grants only `issues: read`, but the reusable workflow it calls has `conclusion` and `safe_outputs` jobs that request `issues: write` for failure and no-op run tracking. GitHub validates that a caller's permissions cover every nested job's request, and rejects the whole run as a permission escalation when they don't. All 100 most recent runs of `pr-review.yml` ended in `startup_failure` with no jobs ever created.

## What

#### Workflow permissions

`.github/workflows/pr-review.yml` now grants `issues: write` instead of `issues: read`, matching the grant other Elastic repos already use successfully for the same reusable workflow (`elastic/ai-github-actions/.github/workflows/gh-aw-pr-review.lock.yml@v0`).

Made with [Cursor](https://cursor.com)