### PR TITLE
Release-notes CLI: validate-labels, require-changelog-file, amend upload, on-release gaps

### DIFF
--- a/config/products.yml
+++ b/config/products.yml
@@ -69,6 +69,16 @@ products:
     repository: 'docs-builder'
     features:
       public-reference: false
+  docs-playground-release-notes-changelogs:
+    display: 'Release Notes Playground (Changelogs)'
+    features:
+      public-reference: false
+      release-notes: prestage
+  docs-playground-release-notes-tagged:
+    display: 'Release Notes Playground (Tagged)'
+    features:
+      public-reference: false
+      release-notes: on-release
   ecs:
     display: 'Elastic Common Schema (ECS)'
   ecs-logging:

--- a/docs/cli-schema.json
+++ b/docs/cli-schema.json
@@ -3677,6 +3677,13 @@
             },
             {
               "role": "flag",
+              "name": "require-changelog-file",
+              "type": "boolean",
+              "required": false,
+              "defaultValue": "false"
+            },
+            {
+              "role": "flag",
               "name": "bot-name",
               "type": "string",
               "required": false,
@@ -4844,6 +4851,78 @@
               "required": false,
               "summary": "Upload every discovered file even when its content hash matches the remote object. Use to re-trigger downstream scrubbers without changing file content.",
               "defaultValue": "false"
+            },
+            {
+              "role": "flag",
+              "name": "log-level",
+              "shortName": "l",
+              "type": "enum",
+              "required": false,
+              "summary": "Minimum log level. Default: information",
+              "enumValues": [
+                "trace",
+                "debug",
+                "information",
+                "warning",
+                "error",
+                "critical",
+                "none"
+              ]
+            },
+            {
+              "role": "flag",
+              "name": "config-source",
+              "shortName": "c",
+              "type": "enum",
+              "required": false,
+              "summary": "Override the configuration source: local, remote",
+              "enumValues": [
+                "local",
+                "remote",
+                "embedded"
+              ]
+            },
+            {
+              "role": "flag",
+              "name": "skip-private-repositories",
+              "type": "boolean",
+              "required": false,
+              "summary": "Skip cloning private repositories"
+            }
+          ]
+        },
+        {
+          "path": [
+            "changelog"
+          ],
+          "name": "validate-labels",
+          "summary": "(CI) Validate PR labels against the changelog config without writing any files or calling the GitHub API.",
+          "notes": "A lightweight label-only gate intended for the pull_request event. Resolves\npivot.types, pivot.products, and rules.create skip labels against the PR\u0027s\nlabel set and exits non-zero on no-label. Does not perform title resolution, bot-loop\ndetection, or changelog-file lookup \u2014 use EvaluatePr when those are needed.\n\n\nOutputs: status (ok | no-label | skipped), type, products,\nlabel-table (shown on failure), product-label-table (shown on product failure),\nskip-labels.",
+          "usage": "docs-builder changelog validate-labels --config \u003Cfile\u003E --pr-labels \u003Cstring\u003E",
+          "examples": [],
+          "parameters": [
+            {
+              "role": "flag",
+              "name": "config",
+              "type": "string",
+              "required": true,
+              "summary": "Path to the changelog.yml configuration file.",
+              "validations": [
+                {
+                  "kind": "fileExtensions",
+                  "values": [
+                    "yml",
+                    "yaml"
+                  ]
+                }
+              ]
+            },
+            {
+              "role": "flag",
+              "name": "pr-labels",
+              "type": "string",
+              "required": true,
+              "summary": "Comma-separated list of PR labels (use ${{ join(github.event.pull_request.labels.*.name, \u0027,\u0027) }} in actions)."
             },
             {
               "role": "flag",

--- a/docs/cli/changelog/cmd-bundle.md
+++ b/docs/cli/changelog/cmd-bundle.md
@@ -122,7 +122,16 @@ When you bundle from a PR list or GitHub release and the command is sourcing fro
 
 ## CI usage
 
-Pass `--plan` to emit GitHub Actions step outputs (`needs_network`, `needs_github_token`, `output_path`) without generating the bundle. Use this in a planning step to decide whether subsequent steps require a GitHub token or network access.
+Pass `--plan` to emit GitHub Actions step outputs without generating the bundle. Use this in a planning step to decide whether subsequent steps require a GitHub token or network access.
+
+| Output | Description |
+|--------|-------------|
+| `mode` | Resolved bundle mode: `gh-release` when no `bundle.profiles` are configured; `bundle` for profile-based bundling |
+| `output_path` | Resolved output file path for the bundle |
+| `needs_network` | `true` if the bundle step requires network access |
+| `needs_github_token` | `true` if the bundle step requires a GitHub token |
+
+When `mode` is `gh-release` (no profiles configured), pass only `--config` and a version — no profile name or filter flags are needed. The plan step resolves `output_path` from `bundle.output_directory` so the bundle-upload step does not need to discover the file separately.
 
 For full configuration reference, see [Bundle changelogs](/data/release-notes/bundle.md).
 

--- a/docs/cli/changelog/cmd-evaluate-pr.md
+++ b/docs/cli/changelog/cmd-evaluate-pr.md
@@ -10,16 +10,17 @@ Evaluate a pull request for changelog generation eligibility. Performs pre-fligh
 
 | Output | Description |
 |--------|-------------|
-| `status` | Evaluation result: `skipped`, `manually-edited`, `no-title`, `no-label`, or `proceed` |
+| `status` | Evaluation result: `skipped`, `manually-edited`, `no-title`, `no-label`, `missing-entry`, or `proceed` |
 | `should-generate` | `true` if `changelog add` should run |
-| `should-upload` | `true` if the artifact should be uploaded |
 | `title` | Resolved PR title |
 | `description` | Release note extracted from the PR body (when `extract.release_notes` is enabled and a release note is found). Long or multi-line release notes (over 120 characters) are placed here. Passed downstream as `CHANGELOG_DESCRIPTION` for `changelog add`. |
 | `type` | Resolved changelog type |
 | `products` | Comma-separated product specs resolved from PR labels via `pivot.products` mappings |
 | `label-table` | Markdown table of configured label-to-type mappings |
 | `product-label-table` | Markdown table of configured label-to-product mappings |
+| `changelog-dir` | Resolved changelog directory (from `bundle.directory` or default `docs/changelog`) |
 | `existing-changelog-filename` | Filename of a previously committed changelog for this PR (if any) |
+| `skip-labels` | Comma-separated list of configured skip labels (from `rules.create` exclude rules) |
 
 ## Environment variables
 
@@ -40,5 +41,8 @@ docs-builder changelog evaluate-pr \
   --head-ref feature-branch \
   --head-sha abc123 \
   --event-action opened \
-  --strip-title-prefix
+  --strip-title-prefix \
+  --require-changelog-file
 ```
+
+Pass `--require-changelog-file` to fail the PR (`missing-entry`) when no changelog entry file exists for the PR number. The entry file is looked up in `bundle.directory` (default `docs/changelog`). This flag is designed to be passed as a workflow input rather than hardcoded in `changelog.yml`.

--- a/docs/cli/changelog/cmd-validate-labels.md
+++ b/docs/cli/changelog/cmd-validate-labels.md
@@ -1,0 +1,28 @@
+## Description
+
+:::{note}
+This command is intended for CI automation. It is used internally by the changelog GitHub Actions and is not typically invoked directly by users.
+:::
+
+Validate that a pull request's labels contain a recognised changelog type label, and optionally a product label. Unlike `changelog evaluate-pr`, this command performs no GitHub API access, no title resolution, no bot-loop detection, and no manual-edit detection — it only resolves labels against the configured `pivot.types`, `pivot.products`, and `rules.create` settings. This makes it safe to run on `pull_request` events from forks without write permissions.
+
+Exits non-zero when `status` is `no-label`. All other statuses (`ok`, `skipped`) exit zero.
+
+## GitHub Actions outputs
+
+| Output | Description |
+|--------|-------------|
+| `status` | Validation result: `ok`, `no-label`, or `skipped` |
+| `type` | Resolved changelog type (when `ok`) |
+| `products` | Comma-separated product specs resolved from PR labels (when resolved) |
+| `label-table` | Markdown table of configured label-to-type mappings (when `no-label`) |
+| `product-label-table` | Markdown table of configured label-to-product mappings (when `no-label` due to missing product) |
+| `skip-labels` | Comma-separated list of configured skip labels (from `rules.create` exclude rules) |
+
+## Examples
+
+```sh
+docs-builder changelog validate-labels \
+  --config docs/changelog.yml \
+  --pr-labels "enhancement,Team:Core"
+```

--- a/src/services/Elastic.Changelog/Bundling/ChangelogBundlingService.cs
+++ b/src/services/Elastic.Changelog/Bundling/ChangelogBundlingService.cs
@@ -158,6 +158,13 @@ public record BundlePlanResult
 	/// filters). Consumed by the bundle-PR action to poll for and download the scrubbed copy.
 	/// </summary>
 	public string? CdnUrl { get; init; }
+
+	/// <summary>
+	/// Resolved release mode: <c>gh-release</c> when <c>bundle.profiles</c> is absent in the config
+	/// (the action should run <c>changelog gh-release</c>); <c>bundle</c> for profile-based bundling.
+	/// Null in legacy plan calls that do not query the config for mode resolution.
+	/// </summary>
+	public string? Mode { get; init; }
 }
 
 /// <summary>

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogLabelValidationService.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogLabelValidationService.cs
@@ -1,0 +1,132 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Actions.Core.Services;
+using Elastic.Changelog.Creation;
+using Elastic.Changelog.Utilities;
+using Elastic.Documentation.Configuration;
+using Elastic.Documentation.Configuration.Changelog;
+using Elastic.Documentation.Diagnostics;
+using Elastic.Documentation.FileSystems;
+using Elastic.Documentation.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Elastic.Changelog.Evaluation;
+
+/// <summary>
+/// Service implementing the changelog validate-labels CI command.
+/// Validates only label/type/product resolution — no GitHub API access, no title, no entry-pool lookup.
+/// Suitable as a label-only gate on <c>pull_request</c> events.
+/// </summary>
+public class ChangelogLabelValidationService(
+	ILoggerFactory logFactory,
+	IConfigurationContext configurationContext,
+	ICoreService coreService,
+	IRunnerTempFileSystem fileSystem
+) : IService
+{
+	private readonly ILogger _logger = logFactory.CreateLogger<ChangelogLabelValidationService>();
+	private readonly ChangelogConfigurationLoader _configLoader = new(logFactory, configurationContext, fileSystem);
+
+	/// <summary>
+	/// Validates that the PR's labels contain a recognised type label, optionally with product labels.
+	/// Exits non-zero only on <c>no-label</c>; all other paths (skipped, ok) return zero.
+	/// </summary>
+	public async Task<bool> ValidateLabels(IDiagnosticsCollector collector, ValidateLabelsArguments input, Cancel ctx)
+	{
+		var config = await _configLoader.LoadChangelogConfiguration(collector, input.Config, ctx) ?? ChangelogConfiguration.Default;
+
+		// Label-based skip check: all products blocked → skipped
+		var skipLabels = ChangelogPrEvaluationService.CollectExcludeLabels(config.Rules?.Create);
+		if (PrInfoProcessor.AreAllProductsBlocked(input.PrLabels, config.Rules?.Create))
+		{
+			_logger.LogInformation("All products blocked by label rules; skipping");
+			return await SetOutputs("skipped", skipLabels: skipLabels);
+		}
+
+		// Resolve type
+		string? resolvedType = null;
+		if (config.LabelToType is { Count: > 0 })
+			resolvedType = PrInfoProcessor.MapLabelsToType(input.PrLabels, config.LabelToType);
+
+		// Resolve products
+		string? resolvedProducts = null;
+		string? productLabelTable = null;
+		if (config.LabelToProducts is { Count: > 0 } labelToProducts)
+		{
+			var products = PrInfoProcessor.MapLabelsToProducts(input.PrLabels, labelToProducts);
+			if (products.Count > 0)
+			{
+				resolvedProducts = ProductArgument.FormatProductSpecs(products);
+			}
+			else
+			{
+				var distinctSpecs = labelToProducts.Values.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+				if (distinctSpecs.Count == 1)
+					resolvedProducts = ProductArgument.FormatProductSpecs(ProductArgument.ParseProductSpecs(distinctSpecs[0]));
+				else
+					productLabelTable = ChangelogPrEvaluationService.BuildProductLabelTable(labelToProducts);
+			}
+		}
+
+		if (resolvedType == null)
+		{
+			_logger.LogInformation("No type label found on PR");
+			collector.EmitError(
+				string.Empty,
+				"No matching changelog type label found on this PR. Add a label from your changelog.yml pivot.types, or a skip label."
+			);
+			_ = await SetOutputs(
+				"no-label",
+				labelTable: ChangelogPrEvaluationService.BuildLabelTable(config.LabelToType),
+				productLabelTable: productLabelTable,
+				skipLabels: skipLabels
+			);
+			return false;
+		}
+
+		if (productLabelTable != null && (config.ProductsConfiguration?.Default is null or { Count: 0 }))
+		{
+			_logger.LogInformation("Multiple products configured but no matching product label on PR");
+			collector.EmitError(
+				string.Empty,
+				"No matching product label found on this PR. Add a label from your changelog.yml pivot.products."
+			);
+			_ = await SetOutputs("no-label", productLabelTable: productLabelTable, skipLabels: skipLabels);
+			return false;
+		}
+
+		_logger.LogInformation("Label validation complete: type={Type}, products={Products}", resolvedType, resolvedProducts);
+		return await SetOutputs("ok", type: resolvedType, products: resolvedProducts, skipLabels: skipLabels);
+	}
+
+	private async Task<bool> SetOutputs(
+		string status,
+		string? type = null,
+		string? products = null,
+		string? labelTable = null,
+		string? productLabelTable = null,
+		string? skipLabels = null
+	)
+	{
+		await coreService.SetOutputAsync("status", status);
+		if (type != null)
+			await coreService.SetOutputAsync("type", OutputSanitizer.SanitizeForOutput(type, OutputSanitizer.TypeMaxLength));
+		if (products != null)
+			await coreService.SetOutputAsync("products", OutputSanitizer.SanitizeForOutput(products, OutputSanitizer.LabelsMaxLength));
+		if (labelTable != null)
+			await coreService.SetOutputAsync(
+				"label-table",
+				OutputSanitizer.SanitizeForOutput(labelTable, OutputSanitizer.LabelTableMaxLength)
+			);
+		if (productLabelTable != null)
+			await coreService.SetOutputAsync(
+				"product-label-table",
+				OutputSanitizer.SanitizeForOutput(productLabelTable, OutputSanitizer.LabelTableMaxLength)
+			);
+		if (skipLabels != null)
+			await coreService.SetOutputAsync("skip-labels", OutputSanitizer.SanitizeForOutput(skipLabels, OutputSanitizer.LabelsMaxLength));
+		return true;
+	}
+}

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogPrEvaluationService.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogPrEvaluationService.cs
@@ -179,6 +179,20 @@ public class ChangelogPrEvaluationService(
 			return false;
 		}
 
+		// Entry-required gate: fail when the flag is set and no file exists for this PR
+		if (input.RequireChangelogFile && existingFilename == null)
+		{
+			var expectedPath = $"{changelogDir}/{input.PrNumber}.yaml";
+			_logger.LogInformation("Missing changelog file for PR #{PrNumber}; require-changelog-file is set", input.PrNumber);
+			collector.EmitError(
+				string.Empty,
+				$"No changelog entry file found for PR #{input.PrNumber}. " + $"Expected: {expectedPath}. " +
+					"Add a changelog entry file to the PR or disable the require-changelog-file gate."
+			);
+			_ = await SetOutputs(PrEvaluationResult.MissingEntry, changelogDir: changelogDir);
+			return false;
+		}
+
 		_logger.LogInformation(
 			"PR evaluation complete: title={Title}, type={Type}, products={Products}, existingFile={File}",
 			title,

--- a/src/services/Elastic.Changelog/Evaluation/EvaluatePrArguments.cs
+++ b/src/services/Elastic.Changelog/Evaluation/EvaluatePrArguments.cs
@@ -21,4 +21,12 @@ public record EvaluatePrArguments
 	public bool BodyChanged { get; init; }
 	public bool StripTitlePrefix { get; init; }
 	public string BotName { get; init; } = "github-actions[bot]";
+
+	/// <summary>
+	/// When true, a missing changelog entry file causes evaluation to fail with
+	/// <see cref="PrEvaluationResult.MissingEntry"/> instead of proceeding.
+	/// Passed as a workflow input (<c>require-changelog-file</c>) so repos can opt into the gate
+	/// without editing <c>changelog.yml</c>.
+	/// </summary>
+	public bool RequireChangelogFile { get; init; }
 }

--- a/src/services/Elastic.Changelog/Evaluation/PrEvaluationResult.cs
+++ b/src/services/Elastic.Changelog/Evaluation/PrEvaluationResult.cs
@@ -31,6 +31,10 @@ public enum PrEvaluationResult
 	[Display(Name = "manually-edited")]
 	ManuallyEdited,
 
+	/// <summary>The <c>require-changelog-file</c> gate is on but no changelog entry file was found for this PR.</summary>
+	[Display(Name = "missing-entry")]
+	MissingEntry,
+
 	/// <summary>An error occurred during artifact preparation (e.g., generate step failed or YAML missing).</summary>
 	[Display(Name = "error")]
 	Error

--- a/src/services/Elastic.Changelog/Evaluation/ValidateLabelsArguments.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ValidateLabelsArguments.cs
@@ -1,0 +1,12 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic.Changelog.Evaluation;
+
+/// <summary>Arguments for the changelog validate-labels command.</summary>
+public record ValidateLabelsArguments
+{
+	public required string Config { get; init; }
+	public required string[] PrLabels { get; init; }
+}

--- a/src/services/Elastic.Changelog/Onboarding/ChangelogOnboardingValidationService.cs
+++ b/src/services/Elastic.Changelog/Onboarding/ChangelogOnboardingValidationService.cs
@@ -20,11 +20,9 @@ public record ValidateOnboardingArguments
 }
 
 /// <summary>
-/// Validates that every product registered with <c>features.release-notes: prestage</c> in
-/// <c>products.yml</c> actually has the scaffolding the Prestage path requires in its repository:
-/// the changelog configuration plus the entry-generation, upload, and bundle-stage workflows.
-/// A Prestage product without them would silently be skipped by the Prestage Release Orchestrator
-/// (or fail at freeze), so drift is surfaced here as a CI-gateable error.
+/// Validates that every product registered with <c>features.release-notes: prestage</c> or
+/// <c>on-release</c> in <c>products.yml</c> has the required onboarding files in its repository.
+/// A product without them would silently be skipped or fail at bundle time.
 /// </summary>
 public class ChangelogOnboardingValidationService(
 	ILoggerFactory logFactory,
@@ -32,8 +30,13 @@ public class ChangelogOnboardingValidationService(
 	GitHubApiTransport? transport = null
 ) : IService
 {
-	/// <summary>Workflow files every Prestage repository must carry (RFC onboarding steps).</summary>
-	internal static readonly string[] RequiredWorkflows =
+	/// <summary>
+	/// Workflow files a Prestage repository must carry. Covers both the legacy
+	/// <c>changelog-*.yml</c> callers (existing onboarded repos) and the new
+	/// <c>release-notes.yml</c> shape introduced by the shared workflow consolidation.
+	/// Legacy names are checked first; the new names are the forward target.
+	/// </summary>
+	internal static readonly string[] RequiredWorkflowsPrestage =
 	[
 		".github/workflows/changelog-validate.yml",
 		".github/workflows/changelog-submit.yml",
@@ -41,46 +44,88 @@ public class ChangelogOnboardingValidationService(
 		".github/workflows/changelog-bundle-stage.yml"
 	];
 
+	/// <summary>
+	/// Workflow files a Prestage repository must carry using the new shared-workflow shape.
+	/// Checked when the legacy files are absent (i.e. the repo has been migrated).
+	/// </summary>
+	internal static readonly string[] RequiredWorkflowsPrestageNew =
+	[
+		".github/workflows/release-notes.yml",
+		".github/workflows/release-notes-changelog-file.yml",
+		".github/workflows/changelog-bundle-stage.yml"
+	];
+
+	/// <summary>Workflow files an On-release repository must carry.</summary>
+	internal static readonly string[] RequiredWorkflowsOnRelease = [".github/workflows/release-notes.yml"];
+
 	/// <summary>Accepted changelog configuration locations, in discovery order.</summary>
 	internal static readonly string[] ChangelogConfigCandidates = ["docs/changelog.yml", "changelog.yml"];
+
+	// Keep the legacy property name for test compatibility
+	internal static string[] RequiredWorkflows => RequiredWorkflowsPrestage;
 
 	private readonly ILogger _logger = logFactory.CreateLogger<ChangelogOnboardingValidationService>();
 	private readonly GitHubApiTransport _transport = transport ?? new GitHubApiTransport();
 
 	public async Task<bool> ValidateOnboardingAsync(IDiagnosticsCollector collector, ValidateOnboardingArguments args, Cancel ctx)
 	{
-		var prestageProducts = configurationContext
+		var managedProducts = configurationContext
 			.ProductsConfiguration
 			.Products
 			.Values
-			.Where(p => p.Features.ReleaseNotes == ReleaseNotesPath.Prestage)
+			.Where(p => p.Features.ReleaseNotes is ReleaseNotesPath.Prestage or ReleaseNotesPath.OnRelease)
 			.OrderBy(p => p.Id, StringComparer.Ordinal)
 			.ToList();
 
-		if (prestageProducts.Count == 0)
+		if (managedProducts.Count == 0)
 		{
-			_logger.LogInformation("No products declare 'features.release-notes: prestage' in products.yml; nothing to validate.");
+			_logger.LogInformation(
+				"No products declare 'features.release-notes: prestage' or 'on-release' in products.yml; nothing to validate."
+			);
 			return true;
 		}
 
-		_logger.LogInformation("Validating release-notes onboarding for {Count} Prestage product(s)", prestageProducts.Count);
+		_logger.LogInformation("Validating release-notes onboarding for {Count} product(s)", managedProducts.Count);
 
 		var valid = true;
-		foreach (var product in prestageProducts)
+		foreach (var product in managedProducts)
 		{
 			ctx.ThrowIfCancellationRequested();
 			var repo = product.Repository ?? product.Id;
-			if (!await ValidateProduct(collector, product.Id, args.Owner, repo, ctx))
+			if (!await ValidateProduct(collector, product.Id, product.Features.ReleaseNotes, args.Owner, repo, ctx))
 				valid = false;
 		}
 
 		return valid;
 	}
 
-	private async Task<bool> ValidateProduct(IDiagnosticsCollector collector, string productId, string owner, string repo, Cancel ctx)
+	private async Task<bool> ValidateProduct(
+		IDiagnosticsCollector collector,
+		string productId,
+		ReleaseNotesPath path,
+		string owner,
+		string repo,
+		Cancel ctx
+	)
 	{
 		var missing = new List<string>();
-		foreach (var workflow in RequiredWorkflows)
+
+		// Choose the workflow set to check based on path and whether legacy or new shape is present
+		string[] workflowsToCheck;
+		if (path == ReleaseNotesPath.OnRelease)
+		{
+			workflowsToCheck = RequiredWorkflowsOnRelease;
+		}
+		else
+		{
+			// Prestage: check new shape first; fall back to legacy names if legacy names are present
+			var legacyPrimaryExists = await FileExistsAsync(collector, owner, repo, RequiredWorkflowsPrestage[0], ctx);
+			if (legacyPrimaryExists == null)
+				return false; // probe error already emitted
+			workflowsToCheck = legacyPrimaryExists == true ? RequiredWorkflowsPrestage : RequiredWorkflowsPrestageNew;
+		}
+
+		foreach (var workflow in workflowsToCheck)
 		{
 			var exists = await FileExistsAsync(collector, owner, repo, workflow, ctx);
 			if (exists == null)
@@ -107,15 +152,16 @@ public class ChangelogOnboardingValidationService(
 
 		if (missing.Count > 0)
 		{
+			var pathLabel = path == ReleaseNotesPath.Prestage ? "prestage" : "on-release";
 			collector.EmitError(
 				string.Empty,
-				$"Product '{productId}' declares 'features.release-notes: prestage' but {owner}/{repo} is missing required onboarding file(s): {string.Join(", ", missing)}. " +
-					"See the Prestage onboarding steps in the release-notes documentation, or change the product's release-notes path in products.yml."
+				$"Product '{productId}' declares 'features.release-notes: {pathLabel}' but {owner}/{repo} is missing required onboarding file(s): {string.Join(", ", missing)}. " +
+					"See the release-notes onboarding documentation, or change the product's release-notes path in products.yml."
 			);
 			return false;
 		}
 
-		_logger.LogInformation("Product '{ProductId}' ({Owner}/{Repo}): Prestage onboarding files present", productId, owner, repo);
+		_logger.LogInformation("Product '{ProductId}' ({Owner}/{Repo}): {Path} onboarding files present", productId, owner, repo, path);
 		return true;
 	}
 

--- a/src/services/Elastic.Changelog/Uploading/ChangelogUploadService.cs
+++ b/src/services/Elastic.Changelog/Uploading/ChangelogUploadService.cs
@@ -20,7 +20,16 @@ namespace Elastic.Changelog.Uploading;
 public enum ArtifactType
 {
 	Changelog,
-	Bundle
+	Bundle,
+
+	/// <summary>
+	/// Amend sidecars only: files matching <c>*.amend-{N}.yaml|yml</c> in the bundle output directory.
+	/// The Lambda-reserved <c>.amend-notes</c> suffix is excluded. Keyed identically to
+	/// <see cref="Bundle"/> (product list comes from the sidecar, falling back to the parent bundle).
+	/// Use this on <c>push</c> to sync manual post-release overrides from <c>main</c> without
+	/// accidentally overwriting a freshly-published parent bundle.
+	/// </summary>
+	Amend
 }
 
 public enum UploadTargetKind
@@ -89,7 +98,7 @@ public class ChangelogUploadService(
 			return true;
 		}
 
-		var directory = args.ArtifactType == ArtifactType.Bundle
+		var directory = args.ArtifactType is ArtifactType.Bundle or ArtifactType.Amend
 			? await ResolveBundleDirectory(collector, args, ctx)
 			: await ResolveChangelogDirectory(collector, args, ctx);
 
@@ -102,9 +111,12 @@ public class ChangelogUploadService(
 			return true;
 		}
 
-		var targets = args.ArtifactType == ArtifactType.Bundle
-			? DiscoverBundleUploadTargets(collector, directory)
-			: DiscoverUploadTargets(collector, directory, args.Owner, args.Repo, args.Branch);
+		var targets = args.ArtifactType switch
+		{
+			ArtifactType.Bundle => DiscoverBundleUploadTargets(collector, directory),
+			ArtifactType.Amend => DiscoverAmendUploadTargets(collector, directory),
+			_ => DiscoverUploadTargets(collector, directory, args.Owner, args.Repo, args.Branch)
+		};
 
 		// Entry uploads abort (rather than no-op) when the repo cannot be resolved: the keys would be
 		// unscoped and a silent skip would look like "nothing to upload".
@@ -274,6 +286,72 @@ public class ChangelogUploadService(
 		var markers = prNumbers.Skip(1).Select(pr => ($"{pr}.yaml", markerContent)).ToList();
 
 		return (canonicalFileName, markers);
+	}
+
+	/// <summary>
+	/// Discovers numbered amend sidecars (<c>*.amend-{N}.yaml|yml</c>) in <paramref name="bundleDir"/>.
+	/// The Lambda-reserved <c>.amend-notes.yaml</c> sidecar is excluded; only user-authored amends
+	/// (those with a positive numeric suffix) are returned. Each sidecar is keyed identically to a
+	/// parent bundle: product list comes from the sidecar, falling back to the sibling parent bundle
+	/// file when the sidecar predates the products-copy feature.
+	/// </summary>
+	internal IReadOnlyList<UploadTarget> DiscoverAmendUploadTargets(IDiagnosticsCollector collector, string bundleDir)
+	{
+		var rootDir = _fileSystem.DirectoryInfo.New(bundleDir);
+
+		var yamlFiles = _fileSystem
+			.Directory
+			.GetFiles(bundleDir, "*.yaml", SearchOption.TopDirectoryOnly)
+			.Concat(_fileSystem.Directory.GetFiles(bundleDir, "*.yml", SearchOption.TopDirectoryOnly))
+			.ToList();
+
+		var targets = new List<UploadTarget>();
+
+		foreach (var filePath in yamlFiles)
+		{
+			// Only numbered amend sidecars; skip parent bundles and the Lambda-reserved .amend-notes sidecar
+			if (!BundleAmendMerger.IsAmendFile(filePath))
+				continue;
+			if (BundleAmendMerger.GetAmendFileNumber(filePath) <= 0)
+				continue;
+
+			var fileInfo = _fileSystem.FileInfo.New(filePath);
+			if (SymlinkValidator.ValidateFileAccess(fileInfo, rootDir) is { } accessError)
+			{
+				collector.EmitWarning(filePath, $"Skipping: {accessError}");
+				continue;
+			}
+
+			var products = ReadProductsFromBundle(filePath);
+			if (products.Count == 0)
+			{
+				products = ReadProductsFromParentBundle(filePath);
+				if (products.Count == 0)
+				{
+					collector.EmitWarning(
+						filePath,
+						"Amend bundle declares no products and its parent bundle is missing or has none; " +
+							"skipping upload. Re-create the amend with a current docs-builder so it carries the parent's products."
+					);
+					continue;
+				}
+			}
+
+			var fileName = _fileSystem.Path.GetFileName(filePath);
+			foreach (var product in products)
+			{
+				if (!ChangelogKeys.IsValidProduct(product))
+				{
+					collector.EmitWarning(filePath, $"Skipping invalid product name \"{product}\" (must match [a-zA-Z0-9_-]+)");
+					continue;
+				}
+
+				var s3Key = ChangelogKeys.BundleFileKey(product, fileName);
+				targets.Add(new UploadTarget(filePath, s3Key));
+			}
+		}
+
+		return targets;
 	}
 
 	internal IReadOnlyList<UploadTarget> DiscoverBundleUploadTargets(IDiagnosticsCollector collector, string bundleDir)

--- a/src/tooling/docs-builder/Commands/ChangelogCommand.cs
+++ b/src/tooling/docs-builder/Commands/ChangelogCommand.cs
@@ -985,6 +985,39 @@ internal sealed partial class ChangelogCommands(
 
 			if (specifiedFilters.Count == 0)
 			{
+				// --plan with no filters and no profile: auto-resolve the release mode from the config.
+				// If the config has no profiles → gh-release mode; otherwise the caller must name a profile.
+				if (plan)
+				{
+					var bundleConfigLoader = new ChangelogConfigurationLoader(logFactory, configurationContext, _fileSystem);
+					var bundleConfig = await bundleConfigLoader.LoadChangelogConfiguration(collector, config?.FullName, ctx);
+
+					var profiles = bundleConfig?.Bundle?.Profiles;
+					if (profiles is { Count: > 0 })
+					{
+						var profileNames = string.Join(", ", profiles.Keys);
+						collector.EmitError(
+							string.Empty,
+							$"--plan without a profile: the config has {profiles.Count} profile(s) ({profileNames}). " +
+								"Pass the profile name as the first argument (e.g. 'bundle my-profile 9.2.0 --plan')."
+						);
+						_ = collector.StartAsync(ctx);
+						await collector.WaitForDrain();
+						await collector.StopAsync(ctx);
+						return 1;
+					}
+
+					// No profiles → gh-release mode. Resolve the output path the same way gh-release would.
+					var ghReleaseOutput = bundleConfig?.Bundle?.OutputDirectory ?? bundleConfig?.Bundle?.Directory;
+
+					await githubActionsService.SetOutputAsync("mode", "gh-release");
+					await githubActionsService.SetOutputAsync("needs_network", "true");
+					await githubActionsService.SetOutputAsync("needs_github_token", "true");
+					if (ghReleaseOutput != null)
+						await githubActionsService.SetOutputAsync("output_path", ghReleaseOutput);
+					return 0;
+				}
+
 				collector.EmitError(
 					string.Empty,
 					"At least one filter option must be specified: --all, --input-products, --prs, --issues, --report, --files, --start-git-ref/--end-git-ref, or use a profile (e.g., 'bundle elasticsearch-release 9.2.0')"
@@ -1120,6 +1153,7 @@ internal sealed partial class ChangelogCommands(
 			if (planResult == null)
 				return 1;
 
+			await githubActionsService.SetOutputAsync("mode", planResult.Mode ?? "bundle");
 			await githubActionsService.SetOutputAsync("needs_network", planResult.NeedsNetwork ? "true" : "false");
 			await githubActionsService.SetOutputAsync("needs_github_token", planResult.NeedsGithubToken ? "true" : "false");
 			if (planResult.OutputPath != null)
@@ -1549,13 +1583,15 @@ internal sealed partial class ChangelogCommands(
 		var ctx = ct;
 		await using var serviceInvoker = new ServiceInvoker(collector);
 
-		// --output CLI > bundle.directory config > ./changelogs (service default)
+		// --output CLI > bundle.output_directory > bundle.directory > ./changelogs (service default)
 		var bundleConfig = await new ChangelogConfigurationLoader(logFactory, configurationContext, _fileSystem).LoadChangelogConfiguration(
 			collector,
 			config?.FullName,
 			ctx
 		);
-		var resolvedOutput = !string.IsNullOrWhiteSpace(output) ? output : bundleConfig?.Bundle?.Directory;
+		var resolvedOutput = !string.IsNullOrWhiteSpace(output)
+			? output
+			: (bundleConfig?.Bundle?.OutputDirectory ?? bundleConfig?.Bundle?.Directory);
 
 		IGitHubReleaseService releaseService = new GitHubReleaseService(logFactory);
 		IGitHubPrService prService = new GitHubPrService(logFactory);
@@ -1691,6 +1727,7 @@ internal sealed partial class ChangelogCommands(
 		bool titleChanged = false,
 		bool bodyChanged = false,
 		bool stripTitlePrefix = false,
+		bool requireChangelogFile = false,
 		string botName = "github-actions[bot]",
 		CancellationToken ct = default
 	)
@@ -1722,11 +1759,51 @@ internal sealed partial class ChangelogCommands(
 			TitleChanged = titleChanged,
 			BodyChanged = bodyChanged,
 			StripTitlePrefix = stripTitlePrefix,
+			RequireChangelogFile = requireChangelogFile,
 			BotName = botName
 		};
 
 		serviceInvoker.AddCommand(service, args, static async (s, collector, state, ctx) => await s.EvaluatePr(collector, state, ctx));
 
+		return await serviceInvoker.InvokeAsync(ctx);
+	}
+
+	/// <summary>(CI) Validate PR labels against the changelog config without writing any files or calling the GitHub API.</summary>
+	/// <remarks>
+	/// A lightweight label-only gate intended for the <c>pull_request</c> event. Resolves
+	/// <c>pivot.types</c>, <c>pivot.products</c>, and <c>rules.create</c> skip labels against the PR's
+	/// label set and exits non-zero on <c>no-label</c>. Does not perform title resolution, bot-loop
+	/// detection, or changelog-file lookup — use <see cref="EvaluatePr"/> when those are needed.
+	///
+	/// <para>
+	/// Outputs: <c>status</c> (ok | no-label | skipped), <c>type</c>, <c>products</c>,
+	/// <c>label-table</c> (shown on failure), <c>product-label-table</c> (shown on product failure),
+	/// <c>skip-labels</c>.
+	/// </para>
+	/// </remarks>
+	/// <param name="config">Path to the changelog.yml configuration file.</param>
+	/// <param name="prLabels">Comma-separated list of PR labels (use <c>${{ join(github.event.pull_request.labels.*.name, ',') }}</c> in actions).</param>
+	/// <param name="ct">Cancellation token</param>
+	[NoOptionsInjection]
+	public async Task<int> ValidateLabels(
+		[FileExtensions(Extensions = "yml,yaml")] FileInfo config,
+		string prLabels,
+		CancellationToken ct = default
+	)
+	{
+		var ctx = ct;
+		await using var serviceInvoker = new ServiceInvoker(collector);
+
+		var fileSystem = RunnerTempFileSystem.ForEvaluatePr(environmentVariables);
+		var service = new ChangelogLabelValidationService(logFactory, configurationContext, githubActionsService, fileSystem);
+
+		var args = new ValidateLabelsArguments
+		{
+			Config = config.FullName,
+			PrLabels = prLabels.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+		};
+
+		serviceInvoker.AddCommand(service, args, static async (s, collector, state, ctx) => await s.ValidateLabels(collector, state, ctx));
 		return await serviceInvoker.InvokeAsync(ctx);
 	}
 
@@ -1924,9 +2001,23 @@ internal sealed partial class ChangelogCommands(
 	)
 	{
 		var ctx = ct;
-		if (!Enum.TryParse<ArtifactType>(artifactType, ignoreCase: true, out var parsedArtifactType))
+
+		// Accept a comma-separated list of artifact types (e.g. "changelog,amend")
+		var artifactTypeList = artifactType.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+		var parsedArtifactTypes = new List<ArtifactType>(artifactTypeList.Length);
+		foreach (var typeStr in artifactTypeList)
 		{
-			collector.EmitError(string.Empty, $"Invalid artifact type '{artifactType}'. Valid values: changelog, bundle");
+			if (!Enum.TryParse<ArtifactType>(typeStr, ignoreCase: true, out var parsed))
+			{
+				collector.EmitError(string.Empty, $"Invalid artifact type '{typeStr}'. Valid values: changelog, bundle, amend");
+				return 1;
+			}
+			parsedArtifactTypes.Add(parsed);
+		}
+
+		if (parsedArtifactTypes.Count == 0)
+		{
+			collector.EmitError(string.Empty, "--artifact-type must not be empty");
 			return 1;
 		}
 
@@ -1959,19 +2050,25 @@ internal sealed partial class ChangelogCommands(
 
 		await using var serviceInvoker = new ServiceInvoker(collector);
 		var service = new ChangelogUploadService(logFactory, _fileSystem, configurationContext);
-		var args = new ChangelogUploadArguments
+
+		// Run one upload per requested artifact type; all failures are collected
+		foreach (var parsedArtifactType in parsedArtifactTypes)
 		{
-			ArtifactType = parsedArtifactType,
-			Target = parsedTarget,
-			S3BucketName = s3BucketName,
-			Config = resolvedConfig,
-			Directory = resolvedDirectory,
-			Repo = resolvedRepo,
-			Owner = resolvedOwner,
-			Branch = resolvedBranch,
-			SkipEtagCheck = skipEtagCheck
-		};
-		serviceInvoker.AddCommand(service, args, static async (s, c, state, ct) => await s.Upload(c, state, ct));
+			var args = new ChangelogUploadArguments
+			{
+				ArtifactType = parsedArtifactType,
+				Target = parsedTarget,
+				S3BucketName = s3BucketName,
+				Config = resolvedConfig,
+				Directory = resolvedDirectory,
+				Repo = resolvedRepo,
+				Owner = resolvedOwner,
+				Branch = resolvedBranch,
+				SkipEtagCheck = skipEtagCheck
+			};
+			serviceInvoker.AddCommand(service, args, static async (s, c, state, ct) => await s.Upload(c, state, ct));
+		}
+
 		return await serviceInvoker.InvokeAsync(ctx);
 	}
 

--- a/tests/Elastic.Changelog.Tests/Onboarding/OnboardingValidationTests.cs
+++ b/tests/Elastic.Changelog.Tests/Onboarding/OnboardingValidationTests.cs
@@ -149,11 +149,14 @@ public class OnboardingValidationTests(ITestOutputHelper output) : ChangelogTest
 	}
 
 	[Fact]
-	public async Task NoPrestageProducts_PassesWithoutAnyRequest()
+	public async Task NoManagedProducts_PassesWithoutAnyRequest()
 	{
-		var onRelease = PrestageProduct("widget") with { Features = ProductFeatures.All };
+		var unmanaged = PrestageProduct("widget") with
+		{
+			Features = new ProductFeatures { PublicReference = true, ReleaseNotes = ReleaseNotesPath.None }
+		};
 		var handler = RepoWith("widget");
-		var service = Service(ContextWith(onRelease), handler);
+		var service = Service(ContextWith(unmanaged), handler);
 
 		var result = await service.ValidateOnboardingAsync(
 			Collector,
@@ -163,6 +166,44 @@ public class OnboardingValidationTests(ITestOutputHelper output) : ChangelogTest
 
 		result.Should().BeTrue();
 		handler.RequestedPaths.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task OnReleaseProductWithWorkflow_Passes()
+	{
+		var product = PrestageProduct("widget") with { Features = ProductFeatures.All };
+		var handler = RepoWith("widget", ".github/workflows/release-notes.yml", "docs/changelog.yml");
+		var service = Service(ContextWith(product), handler);
+
+		var result = await service.ValidateOnboardingAsync(
+			Collector,
+			new ValidateOnboardingArguments(),
+			TestContext.Current.CancellationToken
+		);
+
+		result.Should().BeTrue();
+		Collector.Errors.Should().Be(0);
+		handler.RequestedPaths.Should().Contain("/repos/elastic/widget/contents/.github/workflows/release-notes.yml");
+	}
+
+	[Fact]
+	public async Task OnReleaseProductMissingWorkflow_FailsListingTheFile()
+	{
+		var product = PrestageProduct("widget") with { Features = ProductFeatures.All };
+		var handler = RepoWith("widget", "docs/changelog.yml");
+		var service = Service(ContextWith(product), handler);
+
+		var result = await service.ValidateOnboardingAsync(
+			Collector,
+			new ValidateOnboardingArguments(),
+			TestContext.Current.CancellationToken
+		);
+
+		result.Should().BeFalse();
+		Collector
+			.Diagnostics
+			.Should()
+			.Contain(d => d.Severity == Severity.Error && d.Message.Contains("widget") && d.Message.Contains("release-notes.yml"));
 	}
 
 	[Fact]


### PR DESCRIPTION
Seven concrete gaps blocked onboarding two playground repos to the release-notes pipeline. This closes all of them in the CLI layer and registers both repos in `config/products.yml`, so the forthcoming `docs-actions` shared workflows can be built on a solid foundation.

**Affects:** Release notes, CLI, Configuration

## Why

The minimal (`gh-release`-driven) onboarding path was broken in at least three ways: `changelog gh-release` wrote its bundle to `bundle.directory` while `bundle-create/action.yml` searched `${OUTPUT:-docs/releases}/bundles`, so the bundle was never found. No label-only validation workflow existed — even minimal repos had to adopt the full four-workflow validate/submit pair. And `upload` hardcoded `--artifact-type changelog`, so manual-override amend sidecars could never be pushed from `main`. The full path added two more gaps: nothing could require a changelog entry file on a PR, and `validate-onboarding` silently skipped on-release repos.

## What

#### `changelog validate-labels` (new command)

A label-only gate safe for fork-triggered `pull_request` events. It resolves type and products from labels against `pivot.types`, `pivot.products`, and `rules.create` with no GitHub API access and no title resolution. Emits `status` (`ok` | `no-label` | `skipped`), `type`, `products`, `label-table`, and `skip-labels`. Exits non-zero only on `no-label`.

#### `--require-changelog-file` on `evaluate-pr`

Hard gate that fails the PR with `missing-entry` when no changelog entry file exists for the PR number and the flag is set. The flag is a workflow input — it belongs on the command line rather than in `changelog.yml`. It is fully detached from bot commit or comment behaviour, which `release-notes-changelog-file.yml` continues to own independently.

#### `--artifact-type amend` and comma-list support on `upload`

A new artifact type discovers `*.amend-{N}.yaml` sidecars in `bundle.output_directory`, excluding `.amend-notes`. The command now accepts a comma-separated list (`changelog,amend`) so sync can push entries and amends in one call — the fixed convention for the forthcoming `release-notes.yml` shared workflow. Syncing parent bundles from `main` is wrong for on-release repos; amends are what must travel.

#### `bundle --plan` `mode` output and output-path fix

The plan step now emits `mode: gh-release` when `bundle.profiles` is absent and resolves `output_path` from `bundle.output_directory`, letting `bundle-create` drop its `find`-based gh-release discovery entirely. `changelog gh-release` now prefers `bundle.output_directory` over `bundle.directory` for its output path, so writer and plan agree on one path.

#### `validate-onboarding` extended to on-release repos

The onboarding validator now checks products registered with `features.release-notes: on-release` in addition to `prestage`. On-release repos require `release-notes.yml` and `changelog.yml`; prestage repos keep the existing four-workflow check with a new-shape fallback for repos that have already migrated.

**Out of scope:** The `docs-actions` shared workflow (`release-notes.yml`, `release-notes-changelog-file.yml`) and the onboarding docs rewrite are separate PRs that depend on the `edge` image built from this branch. The `elastic/docs-infra` OIDC role PR and `config/assembler.yml` allowlist entry (D9, requires both repos to go public first) are also separate.

## Verify

```bash
./build.sh unit-test
# All 1076 changelog tests pass; ProductFeaturesTests confirms both playground products load correctly
```