### PR TITLE
Enable navigation preview on edge and staging

### DIFF
--- a/config/assembler.yml
+++ b/config/assembler.yml
@@ -23,6 +23,7 @@ environments:
     feature_flags:
       WEBSITE_SEARCH: true
       ASSEMBLER_API_EXPLORER: true
+      NAVIGATION_PREVIEW: true
     website_search_url: https://staging-website.elastic.co/search/elastic-website-search.js
   edge:
     uri: https://d34ipnu52o64md.cloudfront.net
@@ -30,6 +31,8 @@ environments:
     content_source: edge
     google_tag_manager:
       enabled: false
+    feature_flags:
+      NAVIGATION_PREVIEW: true
   # TODO: remove 'local' and switch CI synthetics to use 'dev' explicitly once
   # NAVIGATION_PREVIEW is the default (at which point the pages-dropdown step
   # in navigation-test.journey.ts should be replaced with a top-nav step).


### PR DESCRIPTION
Turns on the `NAVIGATION_PREVIEW` feature flag for the `edge` and `staging` environments in `config/assembler.yml`.

**Affects:** Configuration, Deploys & previews

## Why

The nav preview flag was only on in `dev` and `preview`, so the new navigation could not be checked on a real deployed environment. Enabling it on `edge` and `staging` lets reviewers verify the new nav before it becomes the default everywhere.

## What

#### `assembler.yml` environments
The `staging` and `edge` environments each gain a `NAVIGATION_PREVIEW: true` entry under `feature_flags:`. `staging` already had a `feature_flags:` block; `edge` gains a new one.

## Verify

```bash
dotnet test tests/Elastic.Documentation.Configuration.Tests/
```

Made with [Cursor](https://cursor.com)