### PR TITLE
Register playground release-notes repos in assembler.yml scrubber allowlist

### DIFF
--- a/config/assembler.yml
+++ b/config/assembler.yml
@@ -229,7 +229,10 @@ references:
     next: main
     skip: true
     sparse_paths: ["docs", "config"]
+  # Playground repos for release-notes automation (changelog link filtering; do not publish docs)
   docs-playground-release-notes-changelogs:
     private: true
+    skip: true
   docs-playground-release-notes-tagged:
     private: true
+    skip: true

--- a/config/assembler.yml
+++ b/config/assembler.yml
@@ -229,3 +229,7 @@ references:
     next: main
     skip: true
     sparse_paths: ["docs", "config"]
+  docs-playground-release-notes-changelogs:
+    private: true
+  docs-playground-release-notes-tagged:
+    private: true


### PR DESCRIPTION
Adds `docs-playground-release-notes-changelogs` and `docs-playground-release-notes-tagged` to `config/assembler.yml` so PR and issue links in their bundled release notes survive the changelog scrubber. Both repos stay `private: true` (making them public requires IT approval).

**Affects:** Release notes

## Why

The changelog scrubber Lambda uses `assembler.yml` as its allowlist of repos whose links are permitted in the public CDN bucket. Without these entries, any PR link in a published bundle would be rewritten to a `PRIVATE:` sentinel. The repos are private, so only link metadata is scrubbed — no doc content is assembled from them.

**Risk:** `config/assembler.yml` is baked into the changelog-scrubber Lambda as its allowlist at build time. The deployed Lambda picks up the new allowlist on the next Lambda release after this merges.

**Stack:** 2 of 2, follow-on to #3978.