### PR TITLE
Don't write the build stamp on CI builds

### DIFF
--- a/src/services/Elastic.Documentation.Assembler/Building/AssemblerBuildService.cs
+++ b/src/services/Elastic.Documentation.Assembler/Building/AssemblerBuildService.cs
@@ -213,8 +213,10 @@ public class AssemblerBuildService(
 
 		var success = strict.Value ? collector.Errors + collector.Warnings == 0 : collector.Errors == 0;
 
-		// Write the stamp after a successful non-ES-only build so the next run can skip it.
-		if (success && !elasticsearchExportOnly)
+		// Write the stamp only for local dev runs (effectiveAssumeBuild=true) so the next
+		// local run can skip the build. Never write it on CI — stamps must not appear in
+		// deployed output, and CI always does a full build anyway.
+		if (success && !elasticsearchExportOnly && effectiveAssumeBuild)
 		{
 			var stampPath = Path.Join(assembleContext.OutputDirectory.FullName, AssemblerBuildStampService.StampFileName);
 			var stamp = AssemblerBuildStampService.Compute(


### PR DESCRIPTION
The assembler wrote `.assembler-build-stamp.json` into the output directory unconditionally after every successful build, including CI builds. The file was then deployed to staging, where `docs-internal-workflows` found it and failed.

**Affects:** Assembler builds, Deploys & previews

## Why

The build stamp was introduced in #3964 purely to speed up local dev rebuilds — when inputs haven't changed, the next local run can skip the build. That optimisation has no value on CI, where `effectiveAssumeBuild` is already `false` and the stamp check is skipped entirely. Writing the file on CI serves no purpose, but it lands in the assembled output and reaches the deploy step, which does not expect it.

## What

#### Stamp write gated on `effectiveAssumeBuild`

The write in `AssemblerBuildService` previously ran whenever the build succeeded and was not an Elasticsearch-only export. Adding `&& effectiveAssumeBuild` to that condition makes the stamp a purely local artefact. On CI, `effectiveAssumeBuild` resolves to `false` (unless `--assume-build` is passed, which is already rejected on CI with an exception), so the stamp is never written and never appears in deployed output.

The read path is unaffected — it already handles a missing file gracefully by returning `null` and triggering a full rebuild.