### PR TITLE
Fix changelog block hiding links for private+skip repos

### DIFF
--- a/src/Elastic.Documentation.Configuration/Assembler/AssemblyConfiguration.cs
+++ b/src/Elastic.Documentation.Configuration/Assembler/AssemblyConfiguration.cs
@@ -60,6 +60,13 @@ public record AssemblyConfiguration
 				.ToDictionary(kvp => kvp.Name, kvp => kvp);
 
 			config.PrivateRepositories = privateRepositories.Where(r => !r.Value.Skip).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+			// All repos marked private: true, regardless of skip: true. Skip means "does not publish
+			// docs", not "is not private". This set is used for render-time link visibility so that
+			// entries like kibana-team (private: true, skip: true) still have their links hidden.
+			config.AllPrivateRepositoryNames = new HashSet<string>(
+				privateRepositories.Select(r => r.Key),
+				StringComparer.OrdinalIgnoreCase
+			);
 			return config;
 		}
 		catch (Exception e)
@@ -118,6 +125,13 @@ public record AssemblyConfiguration
 	/// Repositories marked as private, these are listed under <see cref="AvailableRepositories"/> if `--skip-private-repositories` is not specified
 	[YamlIgnore]
 	public IReadOnlyDictionary<string, Repository> PrivateRepositories { get; private set; } = new Dictionary<string, Repository>();
+
+	/// All repository names marked <c>private: true</c>, regardless of <c>skip: true</c>.
+	/// <c>skip: true</c> means a repo does not publish docs, not that it is publicly visible.
+	/// Use this set for render-time link visibility rather than <see cref="PrivateRepositories"/>,
+	/// which excludes skipped repos because the cross-link fetcher has no link index for them.
+	[YamlIgnore]
+	public IReadOnlySet<string> AllPrivateRepositoryNames { get; private set; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
 	[YamlMember(Alias = "environments")]
 	public Dictionary<string, PublishEnvironment> Environments { get; set; } = [];

--- a/src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogBlock.cs
@@ -484,9 +484,13 @@ public class ChangelogBlock(DirectiveBlockParser parser, ParserContext context) 
 	{
 		try
 		{
-			// Try to load assembler configuration to get private repositories
+			// Try to load assembler configuration to get private repositories.
+			// Use AllPrivateRepositoryNames rather than PrivateRepositories.Keys: PrivateRepositories
+			// excludes skip:true entries (because the cross-link fetcher has no link index for them),
+			// but skip:true means "does not publish docs", not "is public". Repos like kibana-team
+			// (private:true, skip:true) must still have their links hidden at render time.
 			var assemblerConfig = AssemblyConfiguration.Create(Build.ConfigurationFileProvider);
-			foreach (var repoName in assemblerConfig.PrivateRepositories.Keys)
+			foreach (var repoName in assemblerConfig.AllPrivateRepositoryNames)
 				_ = PrivateRepositories.Add(repoName);
 		}
 		catch

--- a/tests/Elastic.Markdown.Tests/Directives/ChangelogHideLinksTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/ChangelogHideLinksTests.cs
@@ -131,6 +131,15 @@ public class ChangelogLinksDefaultBehaviorTests : DirectiveTest<ChangelogBlock>
 		Block!.PrivateRepositories.Should().NotBeNull();
 
 	[Fact]
+	public void LoadPrivateRepositories_IncludesSkipTruePrivateRepos()
+	{
+		// kibana-team is marked private: true, skip: true in the embedded assembler.yml.
+		// skip: true means "does not publish docs", not "is public". LoadPrivateRepositories
+		// must include it so that its links are hidden at render time.
+		Block!.PrivateRepositories.Should().Contain("kibana-team");
+	}
+
+	[Fact]
 	public void RendersPrLinksForPublicRepo()
 	{
 		// elasticsearch is a public repo, so PR link should be visible in the output


### PR DESCRIPTION
`ChangelogBlock` never hid PR links for the ten `private: true, skip: true` team repos in `assembler.yml` (`kibana-team`, `search-team`, `security-team`, and the rest). A local `{changelog}` render printed their links in plain text.

**Affects:** Release notes, Authoring

## Why

`LoadPrivateRepositories` populated the hidden-repo set from `PrivateRepositories.Keys`. That dictionary is built with `.Where(r => !r.Value.Skip)`, which excludes every repo with `skip: true`. The filter exists for good reason in `AssemblerCrossLinkFetcher` — a `skip: true` repo publishes no link index, so fetching cross-links for it would throw. But `skip: true` means "does not publish docs", not "is public". The two consumers need different subsets of the same snapshot, and they were sharing one.

The `:cdn:` publication path was already safe — the scrubber strips disallowed refs before a bundle reaches the public bucket. Local renders were the hole.

## What

#### Distinct set for render-time visibility

`AssemblyConfiguration` gains `AllPrivateRepositoryNames` — an `IReadOnlySet<string>` of every repo marked `private: true`, derived from the pre-removal snapshot without the `!Skip` filter. The existing `PrivateRepositories` dictionary and its cross-link consumer are unchanged.

#### `ChangelogBlock` uses the right set

`LoadPrivateRepositories` switches from `PrivateRepositories.Keys` to `AllPrivateRepositoryNames`. A repo that is private and skipped now hides its links at render time, matching the scrubber's behaviour at publication time.

#### Regression test

`LoadPrivateRepositories_IncludesSkipTruePrivateRepos` asserts that `kibana-team` — present in the embedded `assembler.yml` as `private: true, skip: true` — appears in `Block.PrivateRepositories` after initialisation. The test failed before this fix.

## Verify

```bash
dotnet test tests/Elastic.Markdown.Tests/ --filter "ChangelogLinksDefaultBehaviorTests"
# LoadPrivateRepositories_IncludesSkipTruePrivateRepos
```