### PR TITLE
Drop mode: gh-release from changelog-publish — now auto-detected

### DIFF
--- a/.github/workflows/changelog-publish.yml
+++ b/.github/workflows/changelog-publish.yml
@@ -30,7 +30,6 @@ jobs:
       id-token: write
     uses: elastic/docs-actions/.github/workflows/changelog-bundle.yml@v1
     with:
-      mode: gh-release
       repo: docs-builder
       owner: elastic
       version: ${{ github.event.release.tag_name || inputs.version || 'latest' }}


### PR DESCRIPTION
## Why

`changelog-bundle.yml` accepted a `mode:` input and forwarded it to `bundle-create`, which used it to choose between `changelog bundle` and `changelog gh-release`. That input has been removed in docs-actions (elastic/docs-actions#313): `bundle-create` now always runs `bundle --plan` first, which resolves the mode from `changelog.yml` (no profiles → `gh-release`, profiles present → `bundle`). The explicit `mode: gh-release` here became dead weight the moment that landed.

## What

Removes the single `mode: gh-release` line from `.github/workflows/changelog-publish.yml`. No behavioral change — the mode is now inferred from the fact that `docs/changelog.yml` has no bundle profiles.