### PR TITLE
Restore the assembler version picker

### DIFF
--- a/config/assembler.yml
+++ b/config/assembler.yml
@@ -23,7 +23,6 @@ environments:
     feature_flags:
       WEBSITE_SEARCH: true
       ASSEMBLER_API_EXPLORER: true
-      NAVIGATION_PREVIEW: true
     website_search_url: https://staging-website.elastic.co/search/elastic-website-search.js
   edge:
     uri: https://d34ipnu52o64md.cloudfront.net

--- a/src/Elastic.Documentation.Site/Assets/secondary-nav.css
+++ b/src/Elastic.Documentation.Site/Assets/secondary-nav.css
@@ -225,87 +225,87 @@
 			color: #516381;
 		}
 
-		.nav-select {
-			box-sizing: border-box;
-			display: inline-flex;
-			align-items: center;
-			height: 32px;
-			margin: 0;
-			padding: 0;
-			border: 1px solid #cad3e2;
-			border-radius: 8px;
-			background: #fff;
-			box-shadow: 0 0 0 2px #f6f9fc;
-			color: inherit;
-			font-family: var(--font-body);
-			font-size: 14px;
-			line-height: 20px;
-			cursor: pointer;
-			appearance: none;
-		}
-
-		.nav-select:focus-visible {
-			outline: 2px solid #0b64dd;
-			outline-offset: 2px;
-		}
-
-		.nav-select__body {
-			display: flex;
-			align-items: center;
-			gap: 8px;
-			height: 20px;
-			padding: 0 8px;
-		}
-
-		.nav-select__value {
-			color: #1d2a3e;
-			font-weight: 400;
-			white-space: nowrap;
-		}
-
-		.nav-select__chevron {
-			box-sizing: border-box;
-			display: flex;
-			flex-shrink: 0;
-			align-items: center;
-			justify-content: center;
-			width: 12px;
-			height: 12px;
-			overflow: clip;
-			color: #516381;
-			transition: transform 0.15s ease;
-		}
-
-		.nav-select__chevron img,
-		.nav-select__chevron svg,
-		.nav-select__chevron .euiIcon {
-			display: block;
-			width: 12px;
-			height: 12px;
-			inline-size: 12px;
-			block-size: 12px;
-		}
-
-		.nav-select__chevron img {
-			opacity: 0;
-		}
-
-		.nav-select__chevron:has(img) {
-			background-color: currentColor;
-			-webkit-mask: var(--nav-select-chevron) center / contain no-repeat;
-			mask: var(--nav-select-chevron) center / contain no-repeat;
-		}
-
-		.nav-select--open .nav-select__chevron {
-			transform: rotate(180deg);
-		}
-
-		version-dropdown {
-			display: inline-flex;
-		}
-
 		.secondary-nav-actions version-dropdown {
 			flex-shrink: 0;
 		}
+	}
+
+	.nav-select {
+		box-sizing: border-box;
+		display: inline-flex;
+		align-items: center;
+		height: 32px;
+		margin: 0;
+		padding: 0;
+		border: 1px solid #cad3e2;
+		border-radius: 8px;
+		background: #fff;
+		box-shadow: 0 0 0 2px #f6f9fc;
+		color: inherit;
+		font-family: var(--font-body);
+		font-size: 14px;
+		line-height: 20px;
+		cursor: pointer;
+		appearance: none;
+	}
+
+	.nav-select:focus-visible {
+		outline: 2px solid #0b64dd;
+		outline-offset: 2px;
+	}
+
+	.nav-select__body {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		height: 20px;
+		padding: 0 8px;
+	}
+
+	.nav-select__value {
+		color: #1d2a3e;
+		font-weight: 400;
+		white-space: nowrap;
+	}
+
+	.nav-select__chevron {
+		box-sizing: border-box;
+		display: flex;
+		flex-shrink: 0;
+		align-items: center;
+		justify-content: center;
+		width: 12px;
+		height: 12px;
+		overflow: clip;
+		color: #516381;
+		transition: transform 0.15s ease;
+	}
+
+	.nav-select__chevron img,
+	.nav-select__chevron svg,
+	.nav-select__chevron .euiIcon {
+		display: block;
+		width: 12px;
+		height: 12px;
+		inline-size: 12px;
+		block-size: 12px;
+	}
+
+	.nav-select__chevron img {
+		opacity: 0;
+	}
+
+	.nav-select__chevron:has(img) {
+		background-color: currentColor;
+		-webkit-mask: var(--nav-select-chevron) center / contain no-repeat;
+		mask: var(--nav-select-chevron) center / contain no-repeat;
+	}
+
+	.nav-select--open .nav-select__chevron {
+		transform: rotate(180deg);
+	}
+
+	version-dropdown {
+		display: inline-flex;
 	}
 }

--- a/src/Elastic.Documentation.Site/Layout/_PagesNav.cshtml
+++ b/src/Elastic.Documentation.Site/Layout/_PagesNav.cshtml
@@ -69,7 +69,7 @@
 				{
 					<div class="mt-4 font-sans">
 						<div class="mb-2 text-xs font-bold uppercase tracking-wide text-grey-70">Version</div>
-						<version-dropdown all-versions-url="@Model.AllVersionsUrl" current-version='@(Model.CurrentVersion)' items='@(new HtmlString(Model.VersionDropdownSerializedModel))'>
+						<version-dropdown data-testid="docs-version-dropdown" all-versions-url="@Model.AllVersionsUrl" current-version='@(Model.CurrentVersion)' items='@(new HtmlString(Model.VersionDropdownSerializedModel))'>
 							<div class="h-8">@*height of dropdown button*@</div>
 						</version-dropdown>
 					</div>

--- a/src/Elastic.Documentation.Site/Layout/_SecondaryNav.cshtml
+++ b/src/Elastic.Documentation.Site/Layout/_SecondaryNav.cshtml
@@ -122,7 +122,7 @@
 				@if (Model.ShowVersionDropdown)
 				{
 					<div class="secondary-nav-actions">
-						<version-dropdown id="docs-version-dropdown" all-versions-url="@Model.AllVersionsUrl" current-version='@(Model.CurrentVersion)' items='@(new HtmlString(Model.VersionDropdownSerializedModel))'>
+						<version-dropdown data-testid="docs-version-dropdown" all-versions-url="@Model.AllVersionsUrl" current-version='@(Model.CurrentVersion)' items='@(new HtmlString(Model.VersionDropdownSerializedModel))'>
 							<div class="h-8">@*height of dropdown button*@</div>
 						</version-dropdown>
 					</div>
@@ -132,7 +132,7 @@
 		else
 		{
 			@* Built-in links: flag on but no section: entries defined. *@
-			<div class="secondary-nav-bar">
+			<div class="secondary-nav-bar secondary-nav-bar--desktop">
 				<a href="@docsHomeUrl"
 				   class="secondary-nav-home"
 				   preload="mousedown">Docs</a>
@@ -171,7 +171,7 @@
 				@if (Model.ShowVersionDropdown)
 				{
 					<div class="secondary-nav-actions">
-						<version-dropdown id="docs-version-dropdown" all-versions-url="@Model.AllVersionsUrl" current-version='@(Model.CurrentVersion)' items='@(new HtmlString(Model.VersionDropdownSerializedModel))'>
+						<version-dropdown data-testid="docs-version-dropdown" all-versions-url="@Model.AllVersionsUrl" current-version='@(Model.CurrentVersion)' items='@(new HtmlString(Model.VersionDropdownSerializedModel))'>
 							<div class="h-8">@*height of dropdown button*@</div>
 						</version-dropdown>
 					</div>

--- a/src/Elastic.Documentation.Site/Layout/_SecondaryNav.cshtml
+++ b/src/Elastic.Documentation.Site/Layout/_SecondaryNav.cshtml
@@ -122,7 +122,7 @@
 				@if (Model.ShowVersionDropdown)
 				{
 					<div class="secondary-nav-actions">
-						<version-dropdown all-versions-url="@Model.AllVersionsUrl" current-version='@(Model.CurrentVersion)' items='@(new HtmlString(Model.VersionDropdownSerializedModel))'>
+						<version-dropdown id="docs-version-dropdown" all-versions-url="@Model.AllVersionsUrl" current-version='@(Model.CurrentVersion)' items='@(new HtmlString(Model.VersionDropdownSerializedModel))'>
 							<div class="h-8">@*height of dropdown button*@</div>
 						</version-dropdown>
 					</div>
@@ -171,7 +171,7 @@
 				@if (Model.ShowVersionDropdown)
 				{
 					<div class="secondary-nav-actions">
-						<version-dropdown all-versions-url="@Model.AllVersionsUrl" current-version='@(Model.CurrentVersion)' items='@(new HtmlString(Model.VersionDropdownSerializedModel))'>
+						<version-dropdown id="docs-version-dropdown" all-versions-url="@Model.AllVersionsUrl" current-version='@(Model.CurrentVersion)' items='@(new HtmlString(Model.VersionDropdownSerializedModel))'>
 							<div class="h-8">@*height of dropdown button*@</div>
 						</version-dropdown>
 					</div>

--- a/src/Elastic.Documentation.Site/package.json
+++ b/src/Elastic.Documentation.Site/package.json
@@ -20,7 +20,7 @@
     "synthetics:test:staging": "DOCS_ENV=staging npm run synthetics:test",
     "synthetics:test:edge": "DOCS_ENV=edge npm run synthetics:test",
     "synthetics:test:local": "DOCS_ENV=local npm run synthetics:test",
-    "synthetics:test:preview": "DOCS_ENV=preview npx @elastic/synthetics ./synthetics/journeys/navigation-test.journey.ts ./synthetics/journeys/api-explorer.journey.ts --config=./synthetics/synthetics.config.ts",
+    "synthetics:test:preview": "DOCS_ENV=preview npx @elastic/synthetics ./synthetics/journeys/navigation-test.journey.ts ./synthetics/journeys/api-explorer.journey.ts ./synthetics/journeys/version-dropdown.journey.ts --config=./synthetics/synthetics.config.ts",
     "synthetics:test:accessibility": "npx @elastic/synthetics ./synthetics/ci/accessibility.ci.ts --config=./synthetics/synthetics.config.ts",
     "synthetics:test:mcp": "npx @elastic/synthetics ./synthetics/journeys/mcp-server.journey.ts --config=./synthetics/synthetics.config.ts",
     "synthetics:test:mcp:prod": "DOCS_ENV=prod npm run synthetics:test:mcp",

--- a/src/Elastic.Documentation.Site/synthetics/journeys/version-dropdown.journey.ts
+++ b/src/Elastic.Documentation.Site/synthetics/journeys/version-dropdown.journey.ts
@@ -42,6 +42,8 @@ journey('version dropdown', ({ page, params }) => {
         const button = picker.locator('button')
         await button.click()
         await expect(button).toHaveAttribute('aria-expanded', 'true')
-        await expect(page.getByText('Current', { exact: false })).toBeVisible()
+        await expect(
+            picker.getByText('Current', { exact: false })
+        ).toBeVisible()
     })
 })

--- a/src/Elastic.Documentation.Site/synthetics/journeys/version-dropdown.journey.ts
+++ b/src/Elastic.Documentation.Site/synthetics/journeys/version-dropdown.journey.ts
@@ -1,0 +1,47 @@
+import { journey, step, monitor, expect } from '@elastic/synthetics'
+
+function getSchedule(env: string) {
+    const scheduleMapping = {
+        local: 15,
+        edge: 15,
+        staging: 15,
+        prod: 1,
+    }
+    return scheduleMapping[env] || 15
+}
+
+/**
+ * The docs version picker sits in the top bar when NAVIGATION_PREVIEW is on
+ * and in the right rail when the flag is off. Both hosts share
+ * #docs-version-dropdown so this journey covers either placement.
+ */
+journey('version dropdown', ({ page, params }) => {
+    monitor.use({
+        id: `elastic-co-docs-version-dropdown-${params.environment}-v1`,
+        schedule: getSchedule(params.environment),
+        tags: [`env:${params.environment}`],
+    })
+
+    const docsRoot = params.docsRoot as string
+
+    step('Open a versioned docs page', async () => {
+        await page.setViewportSize({ width: 1280, height: 800 })
+        await page.goto(`${docsRoot}/get-started`, {
+            timeout: 60000,
+            waitUntil: 'domcontentloaded',
+        })
+        await expect(
+            page.getByRole('heading', { name: 'Elastic fundamentals' })
+        ).toBeVisible()
+    })
+
+    step('Version picker is visible and opens', async () => {
+        const picker = page.locator('#docs-version-dropdown')
+        await expect(picker).toBeVisible()
+
+        const button = picker.locator('button')
+        await button.click()
+        await expect(button).toHaveAttribute('aria-expanded', 'true')
+        await expect(page.getByText('Current', { exact: false })).toBeVisible()
+    })
+})

--- a/src/Elastic.Documentation.Site/synthetics/journeys/version-dropdown.journey.ts
+++ b/src/Elastic.Documentation.Site/synthetics/journeys/version-dropdown.journey.ts
@@ -1,5 +1,7 @@
 import { journey, step, monitor, expect } from '@elastic/synthetics'
 
+const VERSION_DROPDOWN = '[data-testid="docs-version-dropdown"]'
+
 function getSchedule(env: string) {
     const scheduleMapping = {
         local: 15,
@@ -11,9 +13,9 @@ function getSchedule(env: string) {
 }
 
 /**
- * The docs version picker sits in the top bar when NAVIGATION_PREVIEW is on
- * and in the right rail when the flag is off. Both hosts share
- * #docs-version-dropdown so this journey covers either placement.
+ * The docs version picker sits in the top bar and mobile overlay when
+ * NAVIGATION_PREVIEW is on. It sits in the right rail and at the top of the
+ * mobile page when the flag is off.
  */
 journey('version dropdown', ({ page, params }) => {
     monitor.use({
@@ -35,8 +37,9 @@ journey('version dropdown', ({ page, params }) => {
         ).toBeVisible()
     })
 
-    step('Version picker is visible and opens', async () => {
-        const picker = page.locator('#docs-version-dropdown')
+    step('Desktop version picker is visible and opens', async () => {
+        const picker = page.locator(`${VERSION_DROPDOWN}:visible`)
+        await expect(picker).toHaveCount(1)
         await expect(picker).toBeVisible()
 
         const button = picker.locator('button')
@@ -45,5 +48,32 @@ journey('version dropdown', ({ page, params }) => {
         await expect(
             picker.getByText('Current', { exact: false })
         ).toBeVisible()
+        await page.keyboard.press('Escape')
+    })
+
+    step('Mobile version picker is visible in the correct place', async () => {
+        await page.setViewportSize({ width: 375, height: 800 })
+
+        const navigationPreviewEnabled = await page
+            .locator('body')
+            .evaluate((body) => body.classList.contains('navigation-preview'))
+
+        if (navigationPreviewEnabled) {
+            await page
+                .locator('label[for="pages-nav-hamburger"]')
+                .first()
+                .click()
+        }
+
+        const visiblePicker = page.locator(`${VERSION_DROPDOWN}:visible`)
+        await expect(visiblePicker).toHaveCount(1)
+        await expect(visiblePicker).toBeVisible()
+
+        const expectedContainer = navigationPreviewEnabled
+            ? page.locator('#pages-nav')
+            : page.locator('#toc-nav')
+        await expect(
+            expectedContainer.locator(`${VERSION_DROPDOWN}:visible`)
+        ).toHaveCount(1)
     })
 })

--- a/src/Elastic.Markdown/Layout/_TableOfContents.cshtml
+++ b/src/Elastic.Markdown/Layout/_TableOfContents.cshtml
@@ -7,7 +7,7 @@
 		@if (Model.ShowVersionDropdown && !Model.Features.NavigationPreviewEnabled)
 		{
 			<div class="mt-4">
-				<version-dropdown id="docs-version-dropdown" all-versions-url="@Model.AllVersionsUrl" current-version='@(Model.CurrentVersion)' items='@(new HtmlString(Model.VersionDropdownSerializedModel))'>
+				<version-dropdown data-testid="docs-version-dropdown" all-versions-url="@Model.AllVersionsUrl" current-version='@(Model.CurrentVersion)' items='@(new HtmlString(Model.VersionDropdownSerializedModel))'>
 					<div class="h-8">@*height of dropdown button*@</div>
 				</version-dropdown>
 			</div>

--- a/src/Elastic.Markdown/Layout/_TableOfContents.cshtml
+++ b/src/Elastic.Markdown/Layout/_TableOfContents.cshtml
@@ -6,7 +6,7 @@
 	<nav id="toc-nav" class="sidebar-nav lg:h-full flex lg:block items-center justify-start md:justify-start gap-4 simple-scrollbar">
 		@if (Model.ShowVersionDropdown && !Model.Features.NavigationPreviewEnabled)
 		{
-			<div class="mt-4 hidden md:block">
+			<div class="mt-4">
 				<version-dropdown id="docs-version-dropdown" all-versions-url="@Model.AllVersionsUrl" current-version='@(Model.CurrentVersion)' items='@(new HtmlString(Model.VersionDropdownSerializedModel))'>
 					<div class="h-8">@*height of dropdown button*@</div>
 				</version-dropdown>

--- a/src/Elastic.Markdown/Layout/_TableOfContents.cshtml
+++ b/src/Elastic.Markdown/Layout/_TableOfContents.cshtml
@@ -4,10 +4,10 @@
 @inherits RazorSlice<Elastic.Markdown.MarkdownLayoutViewModel>
 <aside class="sidebar md:block w-full lg:max-w-65 order-1 lg:order-2">
 	<nav id="toc-nav" class="sidebar-nav lg:h-full flex lg:block items-center justify-start md:justify-start gap-4 simple-scrollbar">
-		@if (Model.ShowVersionDropdown && Model.BuildType != BuildType.Assembler)
+		@if (Model.ShowVersionDropdown && !Model.Features.NavigationPreviewEnabled)
 		{
-			<div class="hidden md:block">
-				<version-dropdown all-versions-url="@Model.AllVersionsUrl" current-version='@(Model.CurrentVersion)' items='@(new HtmlString(Model.VersionDropdownSerializedModel))'>
+			<div class="mt-4 hidden md:block">
+				<version-dropdown id="docs-version-dropdown" all-versions-url="@Model.AllVersionsUrl" current-version='@(Model.CurrentVersion)' items='@(new HtmlString(Model.VersionDropdownSerializedModel))'>
 					<div class="h-8">@*height of dropdown button*@</div>
 				</version-dropdown>
 			</div>

--- a/src/Elastic.Markdown/Page/Index.cshtml
+++ b/src/Elastic.Markdown/Page/Index.cshtml
@@ -46,7 +46,10 @@
 		VersioningSystem = Model.VersioningSystem,
 		VersionDropdownSerializedModel = JsonSerializer.Serialize(Model.VersionDropdownItems,
 			ViewModelSerializerContext.Default.VersionDropDownItemViewModelArray),
-		ShowVersionDropdown = Model.Features.PrimaryNavEnabled && !Model.VersioningSystem.IsVersionless && Model.BuildType != BuildType.Codex && Model.Branding is null,
+		ShowVersionDropdown = Model.BuildType == BuildType.Assembler
+			&& Model.Features.PrimaryNavEnabled
+			&& !Model.VersioningSystem.IsVersionless
+			&& Model.Branding is null,
 		// Header properties for isolated mode
 		HeaderTitle = Model.DocSetName,
 		HeaderVersion = null,

--- a/tests/Navigation.Tests/Navigation.Tests.csproj
+++ b/tests/Navigation.Tests/Navigation.Tests.csproj
@@ -14,6 +14,7 @@
     <ProjectReference Include="..\..\src\Elastic.Documentation.Navigation\Elastic.Documentation.Navigation.csproj"/>
     <ProjectReference Include="..\..\src\Elastic.Documentation.ServiceDefaults\Elastic.Documentation.ServiceDefaults.csproj" />
     <ProjectReference Include="..\..\src\Elastic.Documentation.Site\Elastic.Documentation.Site.csproj"/>
+    <ProjectReference Include="..\..\src\Elastic.Markdown\Elastic.Markdown.csproj"/>
     <ProjectReference Include="..\..\src\Elastic.Documentation\Elastic.Documentation.csproj"/>
     <ProjectReference Include="..\..\src\services\Elastic.Documentation.Assembler\Elastic.Documentation.Assembler.csproj" />
   </ItemGroup>

--- a/tests/Navigation.Tests/Rendering/SecondaryNavRenderingTests.cs
+++ b/tests/Navigation.Tests/Rendering/SecondaryNavRenderingTests.cs
@@ -140,6 +140,7 @@ public class SecondaryNavRenderingTests(ITestOutputHelper output) : Documentatio
 
 		html.Should().Contain("secondary-nav-actions");
 		html.Should().Contain("<version-dropdown");
+		html.Should().Contain("id=\"docs-version-dropdown\"");
 		html.Should().Contain("all-versions-url=\"/docs/versions/\"");
 		html.Should().Contain("8.19");
 		html
@@ -155,6 +156,16 @@ public class SecondaryNavRenderingTests(ITestOutputHelper output) : Documentatio
 
 		html.Should().Contain("secondary-nav-actions");
 		html.Should().Contain("<version-dropdown");
+		html.Should().Contain("id=\"docs-version-dropdown\"");
+	}
+
+	[Fact]
+	public async Task VersionDropdownDoesNotRenderOnTheLegacyBar()
+	{
+		var html = await Render(TopNav, currentUrl: "/docs/", showVersionDropdown: true, navigationPreviewEnabled: false);
+
+		html.Should().NotContain("<version-dropdown");
+		html.Should().NotContain("id=\"docs-version-dropdown\"");
 	}
 
 	[Fact]

--- a/tests/Navigation.Tests/Rendering/SecondaryNavRenderingTests.cs
+++ b/tests/Navigation.Tests/Rendering/SecondaryNavRenderingTests.cs
@@ -103,6 +103,7 @@ public class SecondaryNavRenderingTests(ITestOutputHelper output) : Documentatio
 
 		html.Should().Contain(">Version<");
 		html.Should().Contain("<version-dropdown");
+		html.Should().Contain("data-testid=\"docs-version-dropdown\"");
 		html.Should().Contain("all-versions-url=\"/docs/versions/\"");
 		html.Should().Contain("8.19");
 		html.Should().Contain("items='[]'");
@@ -140,7 +141,7 @@ public class SecondaryNavRenderingTests(ITestOutputHelper output) : Documentatio
 
 		html.Should().Contain("secondary-nav-actions");
 		html.Should().Contain("<version-dropdown");
-		html.Should().Contain("id=\"docs-version-dropdown\"");
+		html.Should().Contain("data-testid=\"docs-version-dropdown\"");
 		html.Should().Contain("all-versions-url=\"/docs/versions/\"");
 		html.Should().Contain("8.19");
 		html
@@ -156,7 +157,8 @@ public class SecondaryNavRenderingTests(ITestOutputHelper output) : Documentatio
 
 		html.Should().Contain("secondary-nav-actions");
 		html.Should().Contain("<version-dropdown");
-		html.Should().Contain("id=\"docs-version-dropdown\"");
+		html.Should().Contain("data-testid=\"docs-version-dropdown\"");
+		html.Should().Contain("secondary-nav-bar secondary-nav-bar--desktop");
 	}
 
 	[Fact]
@@ -165,7 +167,7 @@ public class SecondaryNavRenderingTests(ITestOutputHelper output) : Documentatio
 		var html = await Render(TopNav, currentUrl: "/docs/", showVersionDropdown: true, navigationPreviewEnabled: false);
 
 		html.Should().NotContain("<version-dropdown");
-		html.Should().NotContain("id=\"docs-version-dropdown\"");
+		html.Should().NotContain("data-testid=\"docs-version-dropdown\"");
 	}
 
 	[Fact]

--- a/tests/Navigation.Tests/Rendering/TableOfContentsRenderingTests.cs
+++ b/tests/Navigation.Tests/Rendering/TableOfContentsRenderingTests.cs
@@ -28,7 +28,7 @@ public class TableOfContentsRenderingTests(ITestOutputHelper output) : Documenta
 		var html = await Render(BuildType.Assembler, showVersionDropdown: true, navigationPreviewEnabled: false);
 
 		html.Should().Contain("<version-dropdown");
-		html.Should().Contain("id=\"docs-version-dropdown\"");
+		html.Should().Contain("data-testid=\"docs-version-dropdown\"");
 		html.Should().Contain("<div class=\"mt-4\">");
 		html.Should().NotContain("hidden md:block");
 	}
@@ -39,7 +39,7 @@ public class TableOfContentsRenderingTests(ITestOutputHelper output) : Documenta
 		var html = await Render(BuildType.Assembler, showVersionDropdown: true, navigationPreviewEnabled: true);
 
 		html.Should().NotContain("<version-dropdown");
-		html.Should().NotContain("id=\"docs-version-dropdown\"");
+		html.Should().NotContain("data-testid=\"docs-version-dropdown\"");
 	}
 
 	[Fact]
@@ -48,7 +48,7 @@ public class TableOfContentsRenderingTests(ITestOutputHelper output) : Documenta
 		var html = await Render(BuildType.Isolated, showVersionDropdown: false, navigationPreviewEnabled: false);
 
 		html.Should().NotContain("<version-dropdown");
-		html.Should().NotContain("id=\"docs-version-dropdown\"");
+		html.Should().NotContain("data-testid=\"docs-version-dropdown\"");
 	}
 
 	private async Task<string> Render(BuildType buildType, bool showVersionDropdown, bool navigationPreviewEnabled)

--- a/tests/Navigation.Tests/Rendering/TableOfContentsRenderingTests.cs
+++ b/tests/Navigation.Tests/Rendering/TableOfContentsRenderingTests.cs
@@ -16,6 +16,7 @@ using Elastic.Documentation.Site.FileProviders;
 using Elastic.Documentation.Versions;
 using Elastic.Markdown;
 using Elastic.Markdown.Layout;
+using RazorSlices;
 
 namespace Elastic.Documentation.Navigation.Tests.Rendering;
 
@@ -28,6 +29,8 @@ public class TableOfContentsRenderingTests(ITestOutputHelper output) : Documenta
 
 		html.Should().Contain("<version-dropdown");
 		html.Should().Contain("id=\"docs-version-dropdown\"");
+		html.Should().Contain("<div class=\"mt-4\">");
+		html.Should().NotContain("hidden md:block");
 	}
 
 	[Fact]

--- a/tests/Navigation.Tests/Rendering/TableOfContentsRenderingTests.cs
+++ b/tests/Navigation.Tests/Rendering/TableOfContentsRenderingTests.cs
@@ -1,0 +1,108 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions.TestingHelpers;
+using AwesomeAssertions;
+using Elastic.Documentation;
+using Elastic.Documentation.Configuration.Assembler;
+using Elastic.Documentation.Configuration.Builder;
+using Elastic.Documentation.Configuration.Toc;
+using Elastic.Documentation.Configuration.Versions;
+using Elastic.Documentation.Navigation;
+using Elastic.Documentation.Navigation.Tests.Isolation;
+using Elastic.Documentation.Site;
+using Elastic.Documentation.Site.FileProviders;
+using Elastic.Documentation.Versions;
+using Elastic.Markdown;
+using Elastic.Markdown.Layout;
+
+namespace Elastic.Documentation.Navigation.Tests.Rendering;
+
+public class TableOfContentsRenderingTests(ITestOutputHelper output) : DocumentationSetNavigationTestBase(output)
+{
+	[Fact]
+	public async Task Assembler_FlagOff_RendersVersionDropdown()
+	{
+		var html = await Render(BuildType.Assembler, showVersionDropdown: true, navigationPreviewEnabled: false);
+
+		html.Should().Contain("<version-dropdown");
+		html.Should().Contain("id=\"docs-version-dropdown\"");
+	}
+
+	[Fact]
+	public async Task Assembler_FlagOn_OmitsVersionDropdown()
+	{
+		var html = await Render(BuildType.Assembler, showVersionDropdown: true, navigationPreviewEnabled: true);
+
+		html.Should().NotContain("<version-dropdown");
+		html.Should().NotContain("id=\"docs-version-dropdown\"");
+	}
+
+	[Fact]
+	public async Task Isolated_OmitsVersionDropdown()
+	{
+		var html = await Render(BuildType.Isolated, showVersionDropdown: false, navigationPreviewEnabled: false);
+
+		html.Should().NotContain("<version-dropdown");
+		html.Should().NotContain("id=\"docs-version-dropdown\"");
+	}
+
+	private async Task<string> Render(BuildType buildType, bool showVersionDropdown, bool navigationPreviewEnabled)
+	{
+		var fileSystem = new MockFileSystem();
+		fileSystem.AddDirectory("/docs");
+		var context = CreateContext(fileSystem);
+		var currentNavItem = new StubNavigationItem("/docs/");
+
+		var model = new MarkdownLayoutViewModel
+		{
+			DocsBuilderVersion = "test",
+			DocSetName = "test",
+			Description = "",
+			CurrentNavigationItem = currentNavItem,
+			Previous = null,
+			Next = null,
+			NavigationHtml = "",
+			UrlPathPrefix = "/docs",
+			CanonicalBaseUrl = null,
+			AllowIndexing = false,
+			Features = navigationPreviewEnabled
+				? new FeatureFlags(new Dictionary<string, bool> { ["navigation-preview"] = true })
+				: new FeatureFlags([]),
+			GoogleTagManager = new GoogleTagManagerConfiguration(),
+			Optimizely = new OptimizelyConfiguration(),
+			StaticFileContentHashProvider = new StaticFileContentHashProvider(new EmbeddedOrPhysicalFileProvider(context)),
+			BuildType = buildType,
+			ShowVersionDropdown = showVersionDropdown,
+			AllVersionsUrl = "/docs/versions/",
+			CurrentVersion = "8.19",
+			VersionDropdownSerializedModel = "[]",
+			GithubEditUrl = null,
+			MarkdownUrl = "/docs/page.md",
+			HideEditThisPage = true,
+			ReportIssueUrl = null,
+			Breadcrumbs = [],
+			PageTocItems = [],
+			Layout = null,
+			VersioningSystem = new VersioningSystem
+			{
+				Id = VersioningSystemId.Stack,
+				Base = new SemVersion(8, 0, 0),
+				Current = new SemVersion(8, 19, 0)
+			},
+			Cta = Cta.Default
+		};
+
+		return await _TableOfContents.Create(model).RenderAsync(cancellationToken: TestContext.Current.CancellationToken);
+	}
+
+	private sealed record StubNavigationItem(string Url) : INavigationItem
+	{
+		public string NavigationTitle => "stub";
+		public IRootNavigationItem<INavigationModel, INavigationItem> NavigationRoot => null!;
+		public INodeNavigationItem<INavigationModel, INavigationItem>? Parent { get; set; }
+		public bool Hidden => false;
+		public int NavigationIndex { get; set; }
+	}
+}


### PR DESCRIPTION
Assembler pages show the version picker again when `NAVIGATION_PREVIEW` is off. `ShowVersionDropdown` decides whether it appears. The flag only chooses top bar or right rail.

**Affects:** Site UI, Authoring

## Why

Assembler pages currently have no version picker when `NAVIGATION_PREVIEW` is off. The restyle moved the control into the preview top bar and hid it on the right rail for assembler builds. Isolated and Codex pages should not show this picker.

## What

#### Visibility
`ShowVersionDropdown` is the only gate for whether the picker renders. It is true only on assembler pages that have primary nav, a versioned product, and no branding.

#### Placement
The right rail shows the picker when the flag is off. The top bar shows it when the flag is on. Isolated builds never get a host.

#### Shared locator
Both desktop hosts use `id="docs-version-dropdown"`. A synthetics journey opens `/get-started` and checks that control. Preview CI runs the same journey.

## Verify

```bash
dotnet test tests/Navigation.Tests/
# TableOfContentsRenderingTests and SecondaryNavRenderingTests
```

**Out of scope:** The mobile drawer copy in `_PagesNav` does not get this id, so Playwright strict mode stays valid when preview is on.

Made with [Cursor](https://cursor.com)