### PR TITLE
Grant artifact-metadata write for container attestations

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -54,6 +54,7 @@ jobs:
       # Required for `actions/attest-build-provenance`
       id-token: write
       attestations: write
+      artifact-metadata: write
     outputs:
       full-version: ${{ steps.bootstrap.outputs.full-version }}
       major-version: ${{ steps.bootstrap.outputs.major-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
       # Required for `actions/attest-build-provenance`
       id-token: write
       attestations: write
+      artifact-metadata: write
     outputs:
       full-version: ${{ steps.bootstrap.outputs.full-version }}
       major-version: ${{ steps.bootstrap.outputs.major-version }}


### PR DESCRIPTION
Container attestation steps now get `artifact-metadata: write` so the attest action can persist org storage records.

**Affects:** Automation

## Why

`actions/attest-build-provenance` writes an org storage record when `push-to-registry` is true. The `containers` job in `release.yml` and the `build` job in `prerelease.yml` omitted `artifact-metadata: write`. Each attest step then warned that no artifacts were found.

## What

#### Release container attestations

The `containers` job token now includes `artifact-metadata: write`. The three image attest steps can persist storage records for the pushed GHCR images.

#### Prerelease container attestations

The `build` job had the same gap and warned on every main push. It now includes the same permission.

Made with [Cursor](https://cursor.com)