### PR TITLE
Emit CommonMark for generated API Explorer pages

### DIFF
--- a/docs/data/exporters/llm.md
+++ b/docs/data/exporters/llm.md
@@ -6,6 +6,8 @@ navigation_title: LLM Markdown
 
 The LLM Markdown exporter produces an optimized CommonMark version of every documentation page alongside the standard HTML output. This is **enabled by default** — every HTML page gets a corresponding `.md` file that web servers can serve through content negotiation.
 
+API Explorer pages use the same co-located file rule. The generator writes CommonMark next to each API HTML page. Preview and static hosts serve that file when the request path ends with `.md` or when `Accept` prefers `text/markdown`.
+
 ## How it works
 
 When a request arrives with an `Accept: text/markdown` header (or appends `.md` to a URL path), the web server returns the LLM-optimized Markdown instead of HTML. This is how [elastic.co/docs](https://www.elastic.co/docs/) serves documentation to AI agents — they receive clean, token-efficient Markdown rather than raw HTML, significantly reducing context window usage.

--- a/docs/data/exporters/llm.md
+++ b/docs/data/exporters/llm.md
@@ -45,6 +45,8 @@ applies_to:
 ---
 ```
 
+API Explorer pages use the same `title`, `description`, `url`, and `products` keys. They also set `type: api` and `resource` (the same URI as `url`) so an OKF consumer can read the file as a concept.
+
 ## Content negotiation
 
 Web servers (like the one serving elastic.co/docs) can use the co-located `.md` files to implement content negotiation:

--- a/src/Elastic.ApiExplorer/Components/PropertyTree/ApiProperty.cs
+++ b/src/Elastic.ApiExplorer/Components/PropertyTree/ApiProperty.cs
@@ -133,6 +133,7 @@ public record ApiProperty
 
 	/// <summary>Markdown-rendered description; empty when the schema has none.</summary>
 	public required HtmlString DescriptionHtml { get; init; }
+	public required string? DescriptionMarkdown { get; init; }
 	public bool HasDescription => DescriptionHtml.Value is { Length: > 0 };
 
 	public required bool ShowDeprecatedBadge { get; init; }

--- a/src/Elastic.ApiExplorer/Components/PropertyTree/ApiPropertyMarkdown.cs
+++ b/src/Elastic.ApiExplorer/Components/PropertyTree/ApiPropertyMarkdown.cs
@@ -1,0 +1,143 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text;
+using Elastic.ApiExplorer.Infrastructure;
+
+namespace Elastic.ApiExplorer.Components.PropertyTree;
+
+/// <summary>Serializes a property tree to readable CommonMark.</summary>
+internal static class ApiPropertyMarkdown
+{
+	public static void WriteList(StringBuilder markdown, ApiPropertyList? properties, string apiBaseUrl, int depth = 0)
+	{
+		if (properties is null || properties.Items.Count == 0)
+			return;
+
+		foreach (var property in properties.Items)
+			WriteProperty(markdown, property, apiBaseUrl, depth);
+	}
+
+	public static void WriteVariants(StringBuilder markdown, ApiUnionVariants? variants, string apiBaseUrl, int depth = 0)
+	{
+		if (variants is null || variants.Variants.Count == 0)
+			return;
+
+		foreach (var variant in variants.Variants)
+		{
+			var label = variant.IsArrayVariant ? $"[]{variant.DisplayName}" : variant.DisplayName;
+			_ = markdown.Append(Indent(depth));
+			_ = markdown.Append("- **");
+			_ = markdown.Append(label);
+			_ = markdown.AppendLine("**");
+			if (variant.Properties is not null)
+				WriteList(markdown, variant.Properties, apiBaseUrl, depth + 1);
+		}
+	}
+
+	public static void WriteType(StringBuilder markdown, TypeAnnotation? type)
+	{
+		if (type is null || string.IsNullOrEmpty(type.Text))
+			return;
+
+		_ = markdown.Append("Type: `");
+		_ = markdown.Append(type.Text);
+		_ = markdown.AppendLine("`");
+		_ = markdown.AppendLine();
+	}
+
+	private static void WriteProperty(StringBuilder markdown, ApiProperty property, string apiBaseUrl, int depth)
+	{
+		_ = markdown.Append(Indent(depth));
+		_ = markdown.Append("- `");
+		_ = markdown.Append(property.Name);
+		_ = markdown.Append('`');
+		if (!string.IsNullOrEmpty(property.Type.Text))
+		{
+			_ = markdown.Append(" (");
+			_ = markdown.Append(property.Type.Text.Trim());
+			_ = markdown.Append(')');
+		}
+
+		if (property.IsRequest)
+			_ = markdown.Append(property.IsRequired ? " — required" : " — optional");
+		if (property.ShowDeprecatedBadge)
+			_ = markdown.Append(" — deprecated");
+		if (property.IsRecursive)
+			_ = markdown.Append(" — recursive");
+		_ = markdown.AppendLine();
+
+		WriteNestedLine(markdown, depth, ApiMarkdown.Prepare(property.DescriptionMarkdown, apiBaseUrl));
+		WriteConstraints(markdown, property, depth);
+		WriteEnumOrUnion(markdown, property, depth);
+		if (property.TypeLink is { Url: { Length: > 0 } url })
+			WriteNestedLine(markdown, depth, $"See {ApiCommonMark.Link(property.TypeLink.TypeName, url)}");
+
+		WriteChildren(markdown, property, apiBaseUrl, depth);
+	}
+
+	private static void WriteConstraints(StringBuilder markdown, ApiProperty property, int depth)
+	{
+		foreach (var constraint in property.Constraints)
+		{
+			var text = constraint.Code is null ? constraint.Text : $"{constraint.Text}`{constraint.Code}`";
+			WriteNestedLine(markdown, depth, text);
+		}
+
+		if (property.ArrayItemTypeName is { Length: > 0 })
+			WriteNestedLine(markdown, depth, $"Array of: `{property.ArrayItemTypeName}`");
+	}
+
+	private static void WriteEnumOrUnion(StringBuilder markdown, ApiProperty property, int depth)
+	{
+		if (property.EnumValues.Count > 0)
+			WriteNestedLine(markdown, depth, "Values: " + string.Join(", ", property.EnumValues.Select(v => $"`{v}`")));
+
+		if (property.Union is null)
+			return;
+
+		switch (property.Union.Kind)
+		{
+			case UnionDisplayKind.EnumLike when property.Union.EnumLikeValues.Count > 0:
+				WriteNestedLine(markdown, depth, "Values: " + string.Join(", ", property.Union.EnumLikeValues.Select(v => $"`{v}`")));
+				break;
+			case UnionDisplayKind.SimpleArrayUnion when property.Union.SimpleUnionBaseName is { Length: > 0 } name:
+				WriteNestedLine(markdown, depth, $"One of: `{name}` or `[]{name}`");
+				break;
+			case UnionDisplayKind.Badges when property.Union.Badges.Count > 0:
+				WriteNestedLine(markdown, depth, "One of: " + string.Join(" or ", property.Union.Badges.Select(b => $"`{b.Text}`")));
+				break;
+		}
+	}
+
+	private static void WriteChildren(StringBuilder markdown, ApiProperty property, string apiBaseUrl, int depth)
+	{
+		switch (property.Children.Kind)
+		{
+			case ChildKind.PropertyList:
+			case ChildKind.SimpleUnionVariants:
+				WriteList(markdown, property.Children.Properties, apiBaseUrl, depth + 1);
+				WriteVariants(markdown, property.Children.Variants, apiBaseUrl, depth + 1);
+				break;
+			case ChildKind.UnionVariants:
+				WriteVariants(markdown, property.Children.Variants, apiBaseUrl, depth + 1);
+				break;
+			case ChildKind.Dictionary when property.Children.Dictionary is { } dictionary:
+				WriteNestedLine(markdown, depth, $"Map values ({dictionary.ValueType.Text})");
+				WriteList(markdown, dictionary.Properties, apiBaseUrl, depth + 1);
+				break;
+		}
+	}
+
+	private static void WriteNestedLine(StringBuilder markdown, int depth, string? text)
+	{
+		if (string.IsNullOrWhiteSpace(text))
+			return;
+
+		_ = markdown.Append(Indent(depth + 1));
+		_ = markdown.AppendLine(text.TrimEnd());
+	}
+
+	private static string Indent(int depth) => new(' ', depth * 2);
+}

--- a/src/Elastic.ApiExplorer/Components/PropertyTree/ApiPropertyTreeBuilder.cs
+++ b/src/Elastic.ApiExplorer/Components/PropertyTree/ApiPropertyTreeBuilder.cs
@@ -141,19 +141,23 @@ public class ApiPropertyTreeBuilder(OpenApiDocument document, PropertyDisplayOpt
 
 	private bool HasActualProperties(IOpenApiSchema? schema) => _analyzer.GetSchemaProperties(schema)?.Count > 0;
 
-	private HtmlString RenderDescription(string name, string? specDescription, PropertyTreeScope scope)
+	private (HtmlString Html, string? Markdown) RenderDescription(string name, string? specDescription, PropertyTreeScope scope)
 	{
 		// ponytail: match property Name only. Nested paths if authors need them.
 		var description = scope.IsRequest
 			&& scope.DescriptionOverrides is { Count: > 0 }
 			&& scope.DescriptionOverrides.TryGetValue(name, out var overrideText) ? overrideText : specDescription;
-		return string.IsNullOrWhiteSpace(description) ? HtmlString.Empty : options.RenderMarkdown(description);
+		if (string.IsNullOrWhiteSpace(description))
+			return (HtmlString.Empty, null);
+
+		return (options.RenderMarkdown(description), description);
 	}
 
 	private ApiProperty BuildProperty(PropertyRow row, PropertyTreeScope scope)
 	{
 		var (_, propSchema, typeInfo, _, _, _, isRecursive) = row;
 		var expansion = ComputeExpansion(propSchema, typeInfo, scope.Depth, isRecursive);
+		var (descriptionHtml, descriptionMarkdown) = RenderDescription(row.Name, propSchema.Description, scope);
 
 		return new ApiProperty
 		{
@@ -166,7 +170,8 @@ public class ApiPropertyTreeBuilder(OpenApiDocument document, PropertyDisplayOpt
 			IsRecursive = isRecursive,
 			IsRequest = scope.IsRequest,
 			Type = BuildAnnotation(typeInfo, HasActualProperties(propSchema)),
-			DescriptionHtml = RenderDescription(row.Name, propSchema.Description, scope),
+			DescriptionHtml = descriptionHtml,
+			DescriptionMarkdown = descriptionMarkdown,
 			ShowDeprecatedBadge = options.ShowDeprecated && propSchema.Deprecated,
 			Availability = options.ShowVersionInfo ? AvailabilityBadgeHelper.FromSchema(propSchema, options.VersionsConfiguration) : null,
 			ExternalDocs = BuildExternalDocs(propSchema, typeInfo),

--- a/src/Elastic.ApiExplorer/Components/PropertyTree/TypeAnnotation.cs
+++ b/src/Elastic.ApiExplorer/Components/PropertyTree/TypeAnnotation.cs
@@ -16,4 +16,7 @@ public record TypeSpan(string Text, string? CssClass = null, string? Title = nul
 /// <summary>
 /// The precomputed display form of a schema type (icons, keywords, name), rendered by <c>_SchemaType</c>.
 /// </summary>
-public record TypeAnnotation(IReadOnlyList<TypeSpan> Spans);
+public record TypeAnnotation(IReadOnlyList<TypeSpan> Spans)
+{
+	public string Text => string.Concat(Spans.Select(s => s.Text)).Trim();
+}

--- a/src/Elastic.ApiExplorer/Infrastructure/ApiCommonMark.cs
+++ b/src/Elastic.ApiExplorer/Infrastructure/ApiCommonMark.cs
@@ -1,0 +1,58 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text;
+
+namespace Elastic.ApiExplorer.Infrastructure;
+
+/// <summary>Small CommonMark helpers shared by API page writers.</summary>
+internal static class ApiCommonMark
+{
+	public static void Heading(StringBuilder markdown, int level, string text)
+	{
+		_ = markdown.Append('#', level);
+		_ = markdown.Append(' ');
+		_ = markdown.AppendLine(text);
+		_ = markdown.AppendLine();
+	}
+
+	public static void Paragraph(StringBuilder markdown, string? text)
+	{
+		if (string.IsNullOrWhiteSpace(text))
+			return;
+
+		_ = markdown.AppendLine(text.TrimEnd());
+		_ = markdown.AppendLine();
+	}
+
+	public static void Prepared(StringBuilder markdown, string? source, string apiBaseUrl)
+	{
+		var prepared = ApiMarkdown.Prepare(source, apiBaseUrl);
+		if (string.IsNullOrWhiteSpace(prepared))
+			return;
+
+		_ = markdown.AppendLine(prepared.TrimEnd());
+		_ = markdown.AppendLine();
+	}
+
+	public static void Fence(StringBuilder markdown, string language, string? source)
+	{
+		if (string.IsNullOrEmpty(source))
+			return;
+
+		_ = markdown.Append("```");
+		_ = markdown.AppendLine(language);
+		_ = markdown.AppendLine(source.TrimEnd());
+		_ = markdown.AppendLine("```");
+		_ = markdown.AppendLine();
+	}
+
+	public static string Link(string text, string? url)
+	{
+		if (string.IsNullOrEmpty(url))
+			return text;
+
+		return $"[{text}]({url})";
+	}
+}

--- a/src/Elastic.ApiExplorer/Infrastructure/ApiMarkdown.cs
+++ b/src/Elastic.ApiExplorer/Infrastructure/ApiMarkdown.cs
@@ -22,14 +22,25 @@ public static partial class ApiMarkdown
 		if (string.IsNullOrEmpty(markdown))
 			return HtmlString.Empty;
 
-		var escaped = MustachePattern().Replace(markdown, match => $"`{match.Value}`");
-		var rewritten = RewriteIntraApiLinks(escaped, context.CurrentNavigation.NavigationRoot.Url);
+		var rewritten = Prepare(markdown, context.CurrentNavigation.NavigationRoot.Url);
 		var source = CreateVirtualSource(context);
 		var html = context.MarkdownRenderer.RenderApiDescription(rewritten, source);
 		return new HtmlString(html);
 	}
 
-	private static string RewriteIntraApiLinks(string markdown, string apiBaseUrl)
+	/// <summary>
+	/// Keeps CommonMark readable: escape mustache substitutions and rewrite intra-API links.
+	/// </summary>
+	public static string Prepare(string? markdown, string apiBaseUrl)
+	{
+		if (string.IsNullOrEmpty(markdown))
+			return string.Empty;
+
+		var escaped = MustachePattern().Replace(markdown, match => $"`{match.Value}`");
+		return RewriteIntraApiLinks(escaped, apiBaseUrl);
+	}
+
+	internal static string RewriteIntraApiLinks(string markdown, string apiBaseUrl)
 	{
 		var baseUrl = apiBaseUrl.TrimEnd('/') + "/";
 		var rewritten = GroupLinkPattern().Replace(markdown, match => $"]({baseUrl}group/{match.Groups[1].Value})");

--- a/src/Elastic.ApiExplorer/Infrastructure/ApiMarkdownFrontMatter.cs
+++ b/src/Elastic.ApiExplorer/Infrastructure/ApiMarkdownFrontMatter.cs
@@ -1,0 +1,188 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text;
+using Elastic.ApiExplorer.Landing;
+using Elastic.ApiExplorer.Operations;
+using Elastic.ApiExplorer.Types;
+using Elastic.Documentation.Navigation;
+
+namespace Elastic.ApiExplorer.Infrastructure;
+
+internal readonly record struct ApiPageFrontMatter(string Title, string? Description, string Url, string? Product);
+
+/// <summary>
+/// Writes LLM-aligned YAML plus the OKF concept fields <c>type</c> and <c>resource</c>.
+/// </summary>
+internal static class ApiMarkdownFrontMatter
+{
+	public static string Wrap(string body, INavigationItem current, ApiRenderContext context, IApiModel page)
+	{
+		var content = StripLeadingFrontMatter(body).TrimStart();
+		return Write(content, Collect(content, current, context, page));
+	}
+
+	public static string Write(string body, ApiPageFrontMatter meta)
+	{
+		var markdown = new StringBuilder();
+		WriteYaml(markdown, meta);
+		_ = markdown.Append(body);
+		if (body.Length > 0 && body[^1] != '\n')
+			_ = markdown.AppendLine();
+		return markdown.ToString();
+	}
+
+	public static string StripLeadingFrontMatter(string markdown)
+	{
+		if (!markdown.StartsWith("---", StringComparison.Ordinal))
+			return markdown;
+
+		var end = markdown.IndexOf("\n---", 3, StringComparison.Ordinal);
+		if (end < 0)
+			return markdown;
+
+		var after = end + 4;
+		if (after < markdown.Length && markdown[after] == '\r')
+			after++;
+		if (after < markdown.Length && markdown[after] == '\n')
+			after++;
+		return markdown[after..];
+	}
+
+	internal static ApiPageFrontMatter Collect(string body, INavigationItem current, ApiRenderContext context, IApiModel page)
+	{
+		var title = Heading(body) ?? current.NavigationTitle;
+		return new(
+			title,
+			ResolveDescription(page, context) ?? FirstParagraph(body),
+			CanonicalUrl(context, current),
+			context.Product?.DisplayName
+		);
+	}
+
+	private static void WriteYaml(StringBuilder markdown, ApiPageFrontMatter meta)
+	{
+		_ = markdown.AppendLine("---");
+		_ = markdown.AppendLine("type: api");
+		_ = markdown.AppendLine($"title: {meta.Title}");
+		if (!string.IsNullOrWhiteSpace(meta.Description))
+			_ = markdown.AppendLine($"description: {meta.Description}");
+
+		_ = markdown.AppendLine($"url: {meta.Url}");
+		_ = markdown.AppendLine($"resource: {meta.Url}");
+		WriteList(markdown, "products", ProductItems(meta.Product));
+		_ = markdown.AppendLine("---");
+		_ = markdown.AppendLine();
+	}
+
+	private static void WriteList(StringBuilder markdown, string key, IReadOnlyList<string> items)
+	{
+		if (items.Count == 0)
+			return;
+
+		_ = markdown.AppendLine($"{key}:");
+		foreach (var item in items)
+			_ = markdown.AppendLine($"  - {item}");
+	}
+
+	private static IReadOnlyList<string> ProductItems(string? product) => string.IsNullOrWhiteSpace(product) ? [] : [product];
+
+	private static string CanonicalUrl(ApiRenderContext context, INavigationItem current)
+	{
+		var path = current.Url.TrimEnd('/');
+		if (path.Length == 0)
+			path = "/";
+
+		return context.BuildContext.CanonicalBaseUrl is { } baseUrl ? new Uri(baseUrl, path).ToString().TrimEnd('/') : path;
+	}
+
+	private static string? ResolveDescription(IApiModel page, ApiRenderContext context)
+	{
+		var apiBaseUrl = context.CurrentNavigation.NavigationRoot.Url;
+		return page switch
+		{
+			ApiCatalog => "API products in this documentation set.",
+			ApiLanding => FirstLine(ApiMarkdown.Prepare(context.Model.Info?.Description, apiBaseUrl)),
+			ApiTag tag => FirstLine(ApiMarkdown.Prepare(TagDescription(tag, context), apiBaseUrl)),
+			ApiOperation operation => FirstLine(ApiMarkdown.Prepare(OperationDescription(operation, context), apiBaseUrl)),
+			ApiSchema schema => FirstLine(ApiMarkdown.Prepare(schema.Schema.Description, apiBaseUrl)),
+			_ => null
+		};
+	}
+
+	private static string? TagDescription(ApiTag tag, ApiRenderContext context) =>
+		context.TagSupplemental.TryGetValue(tag.Name, out var doc) ? doc.DescriptionOr(tag.Description) : tag.Description;
+
+	private static string? OperationDescription(ApiOperation operation, ApiRenderContext context)
+	{
+		var spec = operation.Operation.Description;
+		if (
+			operation.Operation.OperationId is { Length: > 0 } operationId
+			&& context.OperationSupplemental.TryGetValue(operationId, out var doc)
+		)
+			return doc.DescriptionOr(spec);
+
+		return spec;
+	}
+
+	private static string? Heading(string markdown)
+	{
+		using var reader = new StringReader(markdown);
+		while (reader.ReadLine() is { } line)
+		{
+			if (line.StartsWith("# ", StringComparison.Ordinal))
+				return line[2..].Trim();
+		}
+
+		return null;
+	}
+
+	private static string? FirstParagraph(string markdown)
+	{
+		using var reader = new StringReader(markdown);
+		var buffer = new StringBuilder();
+		while (reader.ReadLine() is { } line)
+		{
+			if (line.StartsWith('#'))
+			{
+				if (buffer.Length > 0)
+					break;
+				continue;
+			}
+
+			if (string.IsNullOrWhiteSpace(line))
+			{
+				if (buffer.Length > 0)
+					break;
+				continue;
+			}
+
+			if (buffer.Length == 0 && IsSkippableLead(line))
+				continue;
+
+			if (buffer.Length > 0)
+				_ = buffer.Append(' ');
+			_ = buffer.Append(line.Trim());
+		}
+
+		return buffer.Length == 0 ? null : buffer.ToString();
+	}
+
+	private static bool IsSkippableLead(string line) =>
+		line.StartsWith("- ", StringComparison.Ordinal)
+			|| line.StartsWith("* ", StringComparison.Ordinal)
+			|| line.StartsWith('`')
+			|| line.StartsWith("Availability:", StringComparison.Ordinal)
+			|| line.Equals("deprecated", StringComparison.OrdinalIgnoreCase)
+			|| line.Equals("Beta", StringComparison.Ordinal);
+
+	private static string? FirstLine(string? text)
+	{
+		if (string.IsNullOrWhiteSpace(text))
+			return null;
+
+		using var reader = new StringReader(text.Trim());
+		return reader.ReadLine()?.Trim();
+	}
+}

--- a/src/Elastic.ApiExplorer/Infrastructure/ApiMarkdownFrontMatter.cs
+++ b/src/Elastic.ApiExplorer/Infrastructure/ApiMarkdownFrontMatter.cs
@@ -5,6 +5,7 @@
 using System.Text;
 using Elastic.ApiExplorer.Landing;
 using Elastic.ApiExplorer.Operations;
+using Elastic.ApiExplorer.Supplemental;
 using Elastic.ApiExplorer.Types;
 using Elastic.Documentation.Navigation;
 
@@ -33,32 +34,12 @@ internal static class ApiMarkdownFrontMatter
 		return markdown.ToString();
 	}
 
-	public static string StripLeadingFrontMatter(string markdown)
-	{
-		if (!markdown.StartsWith("---", StringComparison.Ordinal))
-			return markdown;
-
-		var end = markdown.IndexOf("\n---", 3, StringComparison.Ordinal);
-		if (end < 0)
-			return markdown;
-
-		var after = end + 4;
-		if (after < markdown.Length && markdown[after] == '\r')
-			after++;
-		if (after < markdown.Length && markdown[after] == '\n')
-			after++;
-		return markdown[after..];
-	}
+	public static string StripLeadingFrontMatter(string markdown) => ApiSupplementalDoc.ExtractFrontMatter(markdown).Content;
 
 	internal static ApiPageFrontMatter Collect(string body, INavigationItem current, ApiRenderContext context, IApiModel page)
 	{
 		var title = Heading(body) ?? current.NavigationTitle;
-		return new(
-			title,
-			ResolveDescription(page, context) ?? FirstParagraph(body),
-			CanonicalUrl(context, current),
-			context.Product?.DisplayName
-		);
+		return new(title, ResolveDescription(page, context, body), CanonicalUrl(context, current), context.Product?.DisplayName);
 	}
 
 	private static void WriteYaml(StringBuilder markdown, ApiPageFrontMatter meta)
@@ -71,22 +52,15 @@ internal static class ApiMarkdownFrontMatter
 
 		_ = markdown.AppendLine($"url: {meta.Url}");
 		_ = markdown.AppendLine($"resource: {meta.Url}");
-		WriteList(markdown, "products", ProductItems(meta.Product));
+		if (!string.IsNullOrWhiteSpace(meta.Product))
+		{
+			_ = markdown.AppendLine("products:");
+			_ = markdown.AppendLine($"  - {meta.Product}");
+		}
+
 		_ = markdown.AppendLine("---");
 		_ = markdown.AppendLine();
 	}
-
-	private static void WriteList(StringBuilder markdown, string key, IReadOnlyList<string> items)
-	{
-		if (items.Count == 0)
-			return;
-
-		_ = markdown.AppendLine($"{key}:");
-		foreach (var item in items)
-			_ = markdown.AppendLine($"  - {item}");
-	}
-
-	private static IReadOnlyList<string> ProductItems(string? product) => string.IsNullOrWhiteSpace(product) ? [] : [product];
 
 	private static string CanonicalUrl(ApiRenderContext context, INavigationItem current)
 	{
@@ -97,7 +71,7 @@ internal static class ApiMarkdownFrontMatter
 		return context.BuildContext.CanonicalBaseUrl is { } baseUrl ? new Uri(baseUrl, path).ToString().TrimEnd('/') : path;
 	}
 
-	private static string? ResolveDescription(IApiModel page, ApiRenderContext context)
+	private static string? ResolveDescription(IApiModel page, ApiRenderContext context, string body)
 	{
 		var apiBaseUrl = context.CurrentNavigation.NavigationRoot.Url;
 		return page switch
@@ -107,6 +81,7 @@ internal static class ApiMarkdownFrontMatter
 			ApiTag tag => FirstLine(ApiMarkdown.Prepare(TagDescription(tag, context), apiBaseUrl)),
 			ApiOperation operation => FirstLine(ApiMarkdown.Prepare(OperationDescription(operation, context), apiBaseUrl)),
 			ApiSchema schema => FirstLine(ApiMarkdown.Prepare(schema.Schema.Description, apiBaseUrl)),
+			SimpleMarkdownNavigationItem => FirstParagraph(body),
 			_ => null
 		};
 	}
@@ -158,9 +133,6 @@ internal static class ApiMarkdownFrontMatter
 				continue;
 			}
 
-			if (buffer.Length == 0 && IsSkippableLead(line))
-				continue;
-
 			if (buffer.Length > 0)
 				_ = buffer.Append(' ');
 			_ = buffer.Append(line.Trim());
@@ -168,14 +140,6 @@ internal static class ApiMarkdownFrontMatter
 
 		return buffer.Length == 0 ? null : buffer.ToString();
 	}
-
-	private static bool IsSkippableLead(string line) =>
-		line.StartsWith("- ", StringComparison.Ordinal)
-			|| line.StartsWith("* ", StringComparison.Ordinal)
-			|| line.StartsWith('`')
-			|| line.StartsWith("Availability:", StringComparison.Ordinal)
-			|| line.Equals("deprecated", StringComparison.OrdinalIgnoreCase)
-			|| line.Equals("Beta", StringComparison.Ordinal);
 
 	private static string? FirstLine(string? text)
 	{

--- a/src/Elastic.ApiExplorer/Infrastructure/ApiOutputPaths.cs
+++ b/src/Elastic.ApiExplorer/Infrastructure/ApiOutputPaths.cs
@@ -1,0 +1,31 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text.RegularExpressions;
+
+namespace Elastic.ApiExplorer.Infrastructure;
+
+/// <summary>
+/// Maps an API page URL to the sibling HTML and CommonMark files the generator writes.
+/// </summary>
+public static class ApiOutputPaths
+{
+	public static string MarkdownUrl(string pageUrl)
+	{
+		var trimmed = pageUrl.TrimEnd('/');
+		return trimmed.Length == 0 ? "/index.md" : trimmed + ".md";
+	}
+
+	public static string RelativeHtmlFile(string pageUrl, string? urlPathPrefix)
+	{
+		var fileName = Regex.Replace(pageUrl.TrimEnd('/') + "/index.html", $"^{urlPathPrefix}", string.Empty);
+		return fileName.Trim('/');
+	}
+
+	public static string RelativeMarkdownFile(string pageUrl, string? urlPathPrefix)
+	{
+		var fileName = Regex.Replace(pageUrl.TrimEnd('/') + ".md", $"^{urlPathPrefix}", string.Empty);
+		return fileName.Trim('/');
+	}
+}

--- a/src/Elastic.ApiExplorer/Infrastructure/ApiRenderContext.cs
+++ b/src/Elastic.ApiExplorer/Infrastructure/ApiRenderContext.cs
@@ -8,6 +8,7 @@ using Elastic.ApiExplorer.Operations;
 using Elastic.ApiExplorer.Supplemental;
 using Elastic.Documentation;
 using Elastic.Documentation.Configuration;
+using Elastic.Documentation.Configuration.Products;
 using Elastic.Documentation.Navigation;
 using Elastic.Documentation.Site.FileProviders;
 using Elastic.Documentation.Site.Navigation;
@@ -32,6 +33,9 @@ public record ApiRenderContext(
 	public ILogger? ApiExplorerLog { get; init; }
 
 	public IReadOnlyList<ApiVersionSwitcherItem> VersionSwitcherItems { get; init; } = [];
+
+	/// <summary>Product bound to this API key, or <see langword="null"/> on the combined catalog.</summary>
+	public Product? Product { get; init; }
 
 	internal IReadOnlyDictionary<string, ApiSupplementalDoc> OperationSupplemental
 	{

--- a/src/Elastic.ApiExplorer/Infrastructure/ApiViewModel.cs
+++ b/src/Elastic.ApiExplorer/Infrastructure/ApiViewModel.cs
@@ -23,6 +23,7 @@ public record ApiLayoutViewModel : GlobalLayoutViewModel
 {
 	public required IReadOnlyList<ApiTocItem> TocItems { get; init; }
 	public IReadOnlyList<ApiVersionSwitcherItem> VersionSwitcherItems { get; init; } = [];
+	public required string MarkdownUrl { get; init; }
 }
 
 public abstract class ApiViewModel(ApiRenderContext context)
@@ -84,6 +85,7 @@ public abstract class ApiViewModel(ApiRenderContext context)
 			BuildType = BuildContext.BuildType,
 			TocItems = GetTocItems(),
 			VersionSwitcherItems = RenderContext.VersionSwitcherItems,
+			MarkdownUrl = ApiOutputPaths.MarkdownUrl(CurrentNavigationItem.Url),
 			// Header properties for isolated mode
 			HeaderTitle = docTitle,
 			HeaderVersion = Document.Info?.Version ?? "1.0",

--- a/src/Elastic.ApiExplorer/Infrastructure/IApiModel.cs
+++ b/src/Elastic.ApiExplorer/Infrastructure/IApiModel.cs
@@ -9,6 +9,12 @@ using Elastic.Documentation.Site.Navigation;
 
 namespace Elastic.ApiExplorer.Infrastructure;
 
-public interface IApiModel : INavigationModel, IPageRenderer<ApiRenderContext>;
+public interface IApiModel : INavigationModel, IPageRenderer<ApiRenderContext>
+{
+	/// <summary>
+	/// Readable CommonMark for this page, or <see langword="null"/> when the model has no page.
+	/// </summary>
+	Task<string?> RenderCommonMarkAsync(ApiRenderContext context, Cancel ctx = default) => Task.FromResult<string?>(null);
+}
 
 public interface IApiGroupingModel : IApiModel;

--- a/src/Elastic.ApiExplorer/Infrastructure/SectionHeader.cs
+++ b/src/Elastic.ApiExplorer/Infrastructure/SectionHeader.cs
@@ -17,7 +17,7 @@ namespace Elastic.ApiExplorer.Infrastructure;
 public record SectionHeader(string Title, string Anchor, string? Route = null, string? ContentTypeBadge = null);
 
 /// <summary>A leftover <c>##</c> section from a supplemental file, pre-rendered for the view.</summary>
-public record ApiPostSection(string Heading, string Anchor, HtmlString BodyHtml)
+public record ApiPostSection(string Heading, string Anchor, HtmlString BodyHtml, string BodyMarkdown)
 {
 	internal static readonly FrozenSet<string> OperationReservedAnchors = FrozenSet.ToFrozenSet(
 		[
@@ -47,7 +47,7 @@ public record ApiPostSection(string Heading, string Anchor, HtmlString BodyHtml)
 		{
 			var (title, explicitId) = SplitHeading(s.Heading);
 			var anchor = ResolveAnchor(title, explicitId, used);
-			result.Add(new ApiPostSection(title, anchor, ApiMarkdown.Render(context, s.Body)));
+			result.Add(new ApiPostSection(title, anchor, ApiMarkdown.Render(context, s.Body), s.Body));
 		}
 
 		return result;

--- a/src/Elastic.ApiExplorer/Landing/ApiCatalog.cs
+++ b/src/Elastic.ApiExplorer/Landing/ApiCatalog.cs
@@ -24,6 +24,9 @@ public class ApiCatalog : IApiGroupingModel
 		var viewModel = new ApiCatalogViewModel(context) { Entries = Entries };
 		await ApiCatalogView.Create(viewModel).RenderAsync(stream, cancellationToken: ctx);
 	}
+
+	public Task<string?> RenderCommonMarkAsync(ApiRenderContext context, Cancel ctx = default) =>
+		Task.FromResult<string?>(LandingCommonMark.Catalog(Entries));
 }
 
 public class ApiCatalogNavigationItem : IRootNavigationItem<ApiCatalog, INavigationItem>, INavigationItem

--- a/src/Elastic.ApiExplorer/Landing/ApiTag.cs
+++ b/src/Elastic.ApiExplorer/Landing/ApiTag.cs
@@ -33,4 +33,14 @@ public record ApiTag(
 		var slice = TagLandingView.Create(viewModel);
 		await slice.RenderAsync(stream, cancellationToken: ctx);
 	}
+
+	public Task<string?> RenderCommonMarkAsync(ApiRenderContext context, Cancel ctx = default)
+	{
+		var viewModel = new TagLandingViewModel(context)
+		{
+			Tag = this,
+			OverviewRows = ApiOverviewBuilder.BuildTagChildren(context.CurrentNavigation)
+		};
+		return Task.FromResult<string?>(LandingCommonMark.Tag(viewModel));
+	}
 }

--- a/src/Elastic.ApiExplorer/Landing/LandingCommonMark.cs
+++ b/src/Elastic.ApiExplorer/Landing/LandingCommonMark.cs
@@ -1,0 +1,100 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text;
+using Elastic.ApiExplorer.Infrastructure;
+using Elastic.ApiExplorer.Operations;
+using Microsoft.OpenApi;
+
+namespace Elastic.ApiExplorer.Landing;
+
+internal static class LandingCommonMark
+{
+	public static string Catalog(IReadOnlyList<ApiCatalogEntry> entries)
+	{
+		var markdown = new StringBuilder();
+		ApiCommonMark.Heading(markdown, 1, "API Explorer");
+		foreach (var entry in entries.OrderBy(e => e.Key))
+			_ = markdown.AppendLine($"- {ApiCommonMark.Link(entry.Title, entry.Url)} (`{entry.Key}`)");
+		return markdown.ToString();
+	}
+
+	public static string Product(OpenApiInfo? info, IReadOnlyList<ApiOverviewRow> rows, string apiBaseUrl)
+	{
+		var markdown = new StringBuilder();
+		ApiCommonMark.Heading(markdown, 1, info?.Title ?? "API Documentation");
+		ApiCommonMark.Prepared(markdown, info?.Description, apiBaseUrl);
+		if (!string.IsNullOrEmpty(info?.License?.Name))
+			ApiCommonMark.Paragraph(markdown, $"License: {info.License.Name}");
+
+		WriteOverview(markdown, rows);
+		return markdown.ToString();
+	}
+
+	public static string Tag(TagLandingViewModel model)
+	{
+		var markdown = new StringBuilder();
+		var apiBaseUrl = model.CurrentNavigationItem.NavigationRoot.Url;
+		ApiCommonMark.Heading(markdown, 1, model.Tag.DisplayName);
+		if (!string.Equals(model.Tag.Name, model.Tag.DisplayName, StringComparison.Ordinal))
+			ApiCommonMark.Paragraph(markdown, $"`{model.Tag.Name}`");
+
+		ApiCommonMark.Prepared(markdown, model.DescriptionMarkdown, apiBaseUrl);
+		foreach (var extra in model.PostSections)
+		{
+			ApiCommonMark.Heading(markdown, 3, extra.Heading);
+			ApiCommonMark.Prepared(markdown, extra.BodyMarkdown, apiBaseUrl);
+		}
+
+		if (model.ExternalDocsDisplay is { } docs)
+			ApiCommonMark.Paragraph(markdown, ApiCommonMark.Link(docs.LinkText, docs.Url));
+
+		WriteOverview(markdown, model.OverviewRows);
+		return markdown.ToString();
+	}
+
+	private static void WriteOverview(StringBuilder markdown, IReadOnlyList<ApiOverviewRow> rows)
+	{
+		foreach (var row in rows)
+		{
+			switch (row.Kind)
+			{
+				case OverviewRowKind.ClassificationHeading:
+					ApiCommonMark.Heading(markdown, 2, row.Title);
+					break;
+				case OverviewRowKind.TagHeading:
+					ApiCommonMark.Heading(markdown, 3, ApiCommonMark.Link(row.Title, row.Url));
+					break;
+				case OverviewRowKind.SchemaCategoryHeading:
+					ApiCommonMark.Heading(markdown, 3, row.Title);
+					break;
+				case OverviewRowKind.Schema:
+					_ = markdown.AppendLine($"- {ApiCommonMark.Link(row.Title, row.Url)} (`{row.SchemaId}`)");
+					break;
+				case OverviewRowKind.MarkdownPage:
+					_ = markdown.AppendLine($"- {ApiCommonMark.Link(row.Title, row.Url)}");
+					break;
+				case OverviewRowKind.Endpoint:
+				case OverviewRowKind.Operation:
+					WriteOperationRow(markdown, row);
+					break;
+			}
+		}
+	}
+
+	private static void WriteOperationRow(StringBuilder markdown, ApiOverviewRow row)
+	{
+		if (row.Operations.Count == 0)
+		{
+			_ = markdown.AppendLine($"- {row.Title}");
+			return;
+		}
+
+		foreach (var operation in row.Operations)
+		{
+			var method = operation.Model.OperationType.ToString().ToUpperInvariant();
+			_ = markdown.AppendLine($"- {row.Title}: {ApiCommonMark.Link($"`{method}` `{operation.Model.Route}`", operation.Url)}");
+		}
+	}
+}

--- a/src/Elastic.ApiExplorer/Landing/LandingNavigationItem.cs
+++ b/src/Elastic.ApiExplorer/Landing/LandingNavigationItem.cs
@@ -26,6 +26,15 @@ public class ApiLanding : IApiGroupingModel
 		var slice = LandingView.Create(viewModel);
 		await slice.RenderAsync(stream, cancellationToken: ctx);
 	}
+
+	public Task<string?> RenderCommonMarkAsync(ApiRenderContext context, Cancel ctx = default) =>
+		Task.FromResult<string?>(
+			LandingCommonMark.Product(
+				context.Model.Info,
+				ApiOverviewBuilder.Build(context.CurrentNavigation.NavigationRoot),
+				context.CurrentNavigation.NavigationRoot.Url
+			)
+		);
 }
 
 public class LandingNavigationItem : IApiGroupingNavigationItem<ApiLanding, INavigationItem>, IRootNavigationItem<ApiLanding, INavigationItem>

--- a/src/Elastic.ApiExplorer/Landing/SimpleMarkdownNavigationItem.cs
+++ b/src/Elastic.ApiExplorer/Landing/SimpleMarkdownNavigationItem.cs
@@ -76,4 +76,10 @@ public class SimpleMarkdownNavigationItem(
 		var slice = MarkdownPageView.Create(viewModel);
 		await slice.RenderAsync(stream, cancellationToken: ctx);
 	}
+
+	public async Task<string?> RenderCommonMarkAsync(ApiRenderContext context, Cancel ctx = default)
+	{
+		var markdownContent = await context.BuildContext.ReadFileSystem.File.ReadAllTextAsync(FileInfo.FullName, ctx).ConfigureAwait(false);
+		return ApiMarkdown.Prepare(markdownContent, context.CurrentNavigation.NavigationRoot.Url);
+	}
 }

--- a/src/Elastic.ApiExplorer/OpenApiGenerator.cs
+++ b/src/Elastic.ApiExplorer/OpenApiGenerator.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information
 
 using System.IO.Abstractions;
-using System.Text.RegularExpressions;
 using Elastic.ApiExplorer.Infrastructure;
 using Elastic.ApiExplorer.Landing;
 using Elastic.ApiExplorer.Model;
@@ -362,14 +361,31 @@ public class OpenApiGenerator(
 		renderContext = renderContext with { CurrentNavigation = current, NavigationHtml = navigationRenderResult.Html };
 		await using var stream = _writeFileSystem.FileStream.New(outputFile.FullName, FileMode.OpenOrCreate);
 		await page.RenderAsync(stream, renderContext, ctx);
+
+		if (page is IApiModel apiPage)
+			await WriteCommonMark(current, apiPage, renderContext, ctx).ConfigureAwait(false);
+
 		return outputFile;
 
 		IFileInfo OutputFile(INavigationItem currentNavigation)
 		{
-			const string indexHtml = "index.html";
-			var fileName = Regex.Replace(currentNavigation.Url + "/" + indexHtml, $"^{context.UrlPathPrefix}", string.Empty);
-			var fileInfo = _writeFileSystem.FileInfo.New(Path.Join(context.OutputDirectory.FullName, fileName.Trim('/')));
-			return fileInfo;
+			var fileName = ApiOutputPaths.RelativeHtmlFile(currentNavigation.Url, context.UrlPathPrefix);
+			return _writeFileSystem.FileInfo.New(Path.Join(context.OutputDirectory.FullName, fileName));
 		}
+	}
+
+	private async Task WriteCommonMark(INavigationItem current, IApiModel page, ApiRenderContext renderContext, Cancel ctx)
+	{
+		var markdown = await page.RenderCommonMarkAsync(renderContext, ctx).ConfigureAwait(false);
+		if (string.IsNullOrEmpty(markdown))
+			return;
+
+		var markdownFile = _writeFileSystem.FileInfo.New(
+			Path.Join(context.OutputDirectory.FullName, ApiOutputPaths.RelativeMarkdownFile(current.Url, context.UrlPathPrefix))
+		);
+		if (!markdownFile.Directory!.Exists)
+			markdownFile.Directory.Create();
+
+		await _writeFileSystem.File.WriteAllTextAsync(markdownFile.FullName, markdown, ctx).ConfigureAwait(false);
 	}
 }

--- a/src/Elastic.ApiExplorer/OpenApiGenerator.cs
+++ b/src/Elastic.ApiExplorer/OpenApiGenerator.cs
@@ -296,7 +296,8 @@ public class OpenApiGenerator(
 			ApiExplorerLog = _logger,
 			VersionSwitcherItems = generation.VersionSwitcherItems,
 			OperationSupplemental = operations,
-			TagSupplemental = tags
+			TagSupplemental = tags,
+			Product = generation.ApiConfig?.Product
 		};
 
 		await RenderNavigationItems(renderContext, navigationRenderer, navigation, ctx).ConfigureAwait(false);
@@ -379,6 +380,8 @@ public class OpenApiGenerator(
 		var markdown = await page.RenderCommonMarkAsync(renderContext, ctx).ConfigureAwait(false);
 		if (string.IsNullOrEmpty(markdown))
 			return;
+
+		markdown = ApiMarkdownFrontMatter.Wrap(markdown, current, renderContext, page);
 
 		var markdownFile = _writeFileSystem.FileInfo.New(
 			Path.Join(context.OutputDirectory.FullName, ApiOutputPaths.RelativeMarkdownFile(current.Url, context.UrlPathPrefix))

--- a/src/Elastic.ApiExplorer/Operations/OperationCommonMark.cs
+++ b/src/Elastic.ApiExplorer/Operations/OperationCommonMark.cs
@@ -1,0 +1,286 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text;
+using Elastic.ApiExplorer.Components.PropertyTree;
+using Elastic.ApiExplorer.Infrastructure;
+using Microsoft.OpenApi;
+
+namespace Elastic.ApiExplorer.Operations;
+
+internal static class OperationCommonMark
+{
+	public static string Write(
+		ApiOperation apiOperation,
+		OperationPageModel page,
+		IReadOnlyList<string>? prerequisites,
+		ApiRenderContext context
+	)
+	{
+		var markdown = new StringBuilder();
+		var apiBaseUrl = context.CurrentNavigation.NavigationRoot.Url;
+		var operation = apiOperation.Operation;
+		var title = operation.Summary ?? apiOperation.ApiName;
+		ApiCommonMark.Heading(markdown, 1, title);
+		WriteBadges(markdown, operation, page);
+		WriteServers(markdown, page);
+		WritePaths(markdown, apiOperation, page);
+		WritePrerequisites(markdown, prerequisites, apiBaseUrl);
+		WritePathParameters(markdown, page, apiBaseUrl);
+		WriteDescription(markdown, page, apiBaseUrl);
+		WriteSecurity(markdown, operation);
+		WriteQueryParameters(markdown, page, apiBaseUrl);
+		WriteRequestBody(markdown, apiOperation, page, apiBaseUrl);
+		WriteResponses(markdown, page, apiBaseUrl);
+		WriteCodeSamples(markdown, page);
+		WriteExamples(markdown, "Request Examples", page.ShowRequestExamples, page.RequestExamples, apiBaseUrl);
+		WriteExamples(markdown, "Response Examples", page.ShowResponseExamples, page.ResponseExamples, apiBaseUrl);
+		foreach (var extra in page.PostSections)
+		{
+			ApiCommonMark.Heading(markdown, 2, extra.Heading);
+			ApiCommonMark.Prepared(markdown, extra.BodyMarkdown, apiBaseUrl);
+		}
+
+		return markdown.ToString();
+	}
+
+	private static void WriteBadges(StringBuilder markdown, OpenApiOperation operation, OperationPageModel page)
+	{
+		if (operation.Deprecated)
+			ApiCommonMark.Paragraph(markdown, "deprecated");
+		if (page.IsBeta)
+			ApiCommonMark.Paragraph(markdown, "Beta");
+		if (page.Availability is { } availability)
+		{
+			var text = availability.ShowVersion
+				? $"{availability.BadgeLifecycleText} {availability.BadgeVersion}".Trim()
+				: availability.BadgeLifecycleText;
+			ApiCommonMark.Paragraph(markdown, $"Availability: {text}");
+		}
+	}
+
+	private static void WriteServers(StringBuilder markdown, OperationPageModel page)
+	{
+		if (page.Servers is not { Count: > 0 })
+			return;
+
+		foreach (var server in page.Servers)
+		{
+			var line = $"`{server.Url}`";
+			if (!string.IsNullOrEmpty(server.Description))
+				line += $" ({server.Description})";
+			_ = markdown.AppendLine($"- Server: {line}");
+		}
+
+		_ = markdown.AppendLine();
+	}
+
+	private static void WritePaths(StringBuilder markdown, ApiOperation current, OperationPageModel page)
+	{
+		ApiCommonMark.Heading(markdown, 2, "Paths");
+		foreach (var overload in page.Overloads)
+		{
+			var method = overload.Model.OperationType.ToString().ToUpperInvariant();
+			var marker = overload.Model.Route == current.Route && overload.Model.OperationType == current.OperationType ? " (current)" : "";
+			var deprecated = overload.Model.Operation?.Deprecated == true ? " — deprecated" : "";
+			_ = markdown.AppendLine($"- `{method}` `{overload.Model.Route}`{marker}{deprecated}");
+		}
+
+		_ = markdown.AppendLine();
+	}
+
+	private static void WritePrerequisites(StringBuilder markdown, IReadOnlyList<string>? prerequisites, string apiBaseUrl)
+	{
+		if (prerequisites is not { Count: > 0 })
+			return;
+
+		ApiCommonMark.Heading(markdown, 2, "Prerequisites");
+		foreach (var line in prerequisites)
+			_ = markdown.AppendLine($"- {ApiMarkdown.Prepare(line, apiBaseUrl)}");
+		_ = markdown.AppendLine();
+	}
+
+	private static void WritePathParameters(StringBuilder markdown, OperationPageModel page, string apiBaseUrl)
+	{
+		if (page.PathParameters.Count == 0)
+			return;
+
+		ApiCommonMark.Heading(markdown, 4, "Path Parameters");
+		foreach (var path in page.PathParameters)
+		{
+			var deprecated = path.Deprecated is true ? " — deprecated" : "";
+			_ = markdown.AppendLine($"- `{path.Name}`{deprecated}");
+			var description = ApiMarkdown.Prepare(path.DescriptionMarkdown, apiBaseUrl);
+			if (!string.IsNullOrWhiteSpace(description))
+				_ = markdown.AppendLine($"  {description.TrimEnd()}");
+		}
+
+		_ = markdown.AppendLine();
+	}
+
+	private static void WriteDescription(StringBuilder markdown, OperationPageModel page, string apiBaseUrl)
+	{
+		if (!string.IsNullOrWhiteSpace(page.DescriptionMarkdown))
+		{
+			ApiCommonMark.Heading(markdown, 2, "Description");
+			ApiCommonMark.Prepared(markdown, page.DescriptionMarkdown, apiBaseUrl);
+		}
+
+		if (page.ExternalDocs is { } docs)
+			ApiCommonMark.Paragraph(markdown, ApiCommonMark.Link(docs.LinkText, docs.Url));
+	}
+
+	private static void WriteSecurity(StringBuilder markdown, OpenApiOperation operation)
+	{
+		if (operation.Security is not { Count: > 0 })
+			return;
+
+		var schemes = operation
+			.Security
+			.SelectMany(requirement => requirement)
+			.Select(scheme =>
+			{
+				var name = $"`{scheme.Key.Name}`";
+				return scheme.Value is { Count: > 0 } ? $"{name} ({string.Join(", ", scheme.Value)})" : name;
+			});
+		ApiCommonMark.Paragraph(markdown, "Authorization: " + string.Join(", ", schemes));
+	}
+
+	private static void WriteQueryParameters(StringBuilder markdown, OperationPageModel page, string apiBaseUrl)
+	{
+		if (page.QueryParameters.Count == 0)
+			return;
+
+		ApiCommonMark.Heading(markdown, 2, "Query String Parameters");
+		foreach (var query in page.QueryParameters)
+		{
+			var parameter = query.Parameter;
+			var type = query.Type is null ? "" : $" ({query.Type.Text})";
+			var deprecated = parameter.Deprecated ? " — deprecated" : "";
+			_ = markdown.AppendLine($"- `{parameter.Name}`{type}{deprecated}");
+			var description = ApiMarkdown.Prepare(query.DescriptionMarkdown, apiBaseUrl);
+			if (!string.IsNullOrWhiteSpace(description))
+				_ = markdown.AppendLine($"  {description.TrimEnd()}");
+
+			foreach (var constraint in query.Constraints)
+			{
+				var text = constraint.Code is null ? constraint.Text : $"{constraint.Text}`{constraint.Code}`";
+				_ = markdown.AppendLine($"  {text}");
+			}
+
+			if (query.UnionOptions.Count > 0 && query.EnumValues.Count == 0)
+				_ = markdown.AppendLine("  One of: " + string.Join(" or ", query.UnionOptions.Select(o => $"`{o.Text}`")));
+			if (query.EnumValues.Count > 0)
+				_ = markdown.AppendLine("  Values: " + string.Join(", ", query.EnumValues.Select(v => $"`{v}`")));
+		}
+
+		_ = markdown.AppendLine();
+	}
+
+	private static void WriteRequestBody(StringBuilder markdown, ApiOperation apiOperation, OperationPageModel page, string apiBaseUrl)
+	{
+		if (apiOperation.Operation.RequestBody is null)
+			return;
+
+		ApiCommonMark.Heading(markdown, 2, "Request Body");
+		if (!string.IsNullOrEmpty(page.RequestContentType))
+			ApiCommonMark.Paragraph(markdown, $"`{page.RequestContentType}`");
+		ApiCommonMark.Prepared(markdown, apiOperation.Operation.RequestBody.Description, apiBaseUrl);
+		if (page.RequestProperties is not null)
+			ApiPropertyMarkdown.WriteList(markdown, page.RequestProperties, apiBaseUrl);
+		else
+			ApiPropertyMarkdown.WriteType(markdown, page.RequestType);
+		_ = markdown.AppendLine();
+	}
+
+	private static void WriteResponses(StringBuilder markdown, OperationPageModel page, string apiBaseUrl)
+	{
+		if (page.Responses.Count == 0)
+			return;
+
+		var single = page.Responses.Count == 1;
+		ApiCommonMark.Heading(markdown, 2, single ? "Response" : "Responses");
+		foreach (var response in page.Responses)
+		{
+			if (!single)
+			{
+				var description = string.IsNullOrEmpty(response.Response.Description) ? "" : $" {response.Response.Description}";
+				ApiCommonMark.Heading(markdown, 4, $"`{response.StatusCode}`{description}");
+			}
+
+			foreach (var content in response.Contents)
+			{
+				if (!single)
+					ApiCommonMark.Paragraph(markdown, $"Content-Type: `{content.ContentType}`");
+				if (content.Properties is not null)
+					ApiPropertyMarkdown.WriteList(markdown, content.Properties, apiBaseUrl);
+				else if (content.ArrayItemProperties is not null)
+				{
+					ApiPropertyMarkdown.WriteType(markdown, content.Type);
+					ApiPropertyMarkdown.WriteList(markdown, content.ArrayItemProperties, apiBaseUrl);
+				}
+				else
+					ApiPropertyMarkdown.WriteType(markdown, content.Type);
+			}
+
+			WriteHeaders(markdown, response, apiBaseUrl);
+		}
+	}
+
+	private static void WriteHeaders(StringBuilder markdown, ApiResponse response, string apiBaseUrl)
+	{
+		if (response.Headers.Count == 0)
+			return;
+
+		ApiCommonMark.Heading(markdown, 5, "Response Headers");
+		foreach (var header in response.Headers)
+		{
+			var type = header.Type is null ? "" : $" ({header.Type.Text})";
+			var flags = header.Header?.Required == true ? " — required" : "";
+			if (header.Header?.Deprecated == true)
+				flags += " — deprecated";
+			_ = markdown.AppendLine($"- `{header.Name}`{type}{flags}");
+			var description = ApiMarkdown.Prepare(header.Header?.Description, apiBaseUrl);
+			if (!string.IsNullOrWhiteSpace(description))
+				_ = markdown.AppendLine($"  {description.TrimEnd()}");
+		}
+
+		_ = markdown.AppendLine();
+	}
+
+	private static void WriteCodeSamples(StringBuilder markdown, OperationPageModel page)
+	{
+		if (page.CodeSamples.Count == 0)
+			return;
+
+		ApiCommonMark.Heading(markdown, 2, "Code Examples");
+		foreach (var sample in page.CodeSamples)
+		{
+			ApiCommonMark.Heading(markdown, 4, sample.Language);
+			ApiCommonMark.Fence(markdown, sample.Language.ToLowerInvariant(), sample.Source);
+		}
+	}
+
+	private static void WriteExamples(
+		StringBuilder markdown,
+		string heading,
+		bool show,
+		IReadOnlyList<ExampleDisplay> examples,
+		string apiBaseUrl
+	)
+	{
+		if (!show || examples.Count == 0)
+			return;
+
+		ApiCommonMark.Heading(markdown, 2, heading);
+		foreach (var example in examples)
+		{
+			ApiCommonMark.Heading(markdown, 4, example.Title);
+			ApiCommonMark.Prepared(markdown, example.DescriptionMarkdown, apiBaseUrl);
+			if (!string.IsNullOrEmpty(example.ExternalValue))
+				ApiCommonMark.Paragraph(markdown, ApiCommonMark.Link(example.ExternalValue, example.ExternalValue));
+			ApiCommonMark.Fence(markdown, "json", example.JsonValue);
+		}
+	}
+}

--- a/src/Elastic.ApiExplorer/Operations/OperationNavigationItem.cs
+++ b/src/Elastic.ApiExplorer/Operations/OperationNavigationItem.cs
@@ -27,6 +27,13 @@ public record ApiOperation(
 		var slice = OperationView.Create(viewModel);
 		await slice.RenderAsync(stream, cancellationToken: ctx);
 	}
+
+	public Task<string?> RenderCommonMarkAsync(ApiRenderContext context, Cancel ctx = default)
+	{
+		var page = OperationPageModel.Create(this, context);
+		var prerequisites = OpenApiXReqAuthParser.TryGetPrerequisiteLines(Operation, context.ApiExplorerLog, Route, Operation.OperationId);
+		return Task.FromResult<string?>(OperationCommonMark.Write(this, page, prerequisites, context));
+	}
 }
 
 public class OperationNavigationItem : ILeafNavigationItem<ApiOperation>, IEndpointOrOperationNavigationItem

--- a/src/Elastic.ApiExplorer/Operations/OperationPageModel.cs
+++ b/src/Elastic.ApiExplorer/Operations/OperationPageModel.cs
@@ -15,7 +15,13 @@ using Microsoft.OpenApi;
 namespace Elastic.ApiExplorer.Operations;
 
 /// <summary>A request/response example with its markdown description prerendered.</summary>
-public record ExampleDisplay(string Title, HtmlString? DescriptionHtml, string? JsonValue, string? ExternalValue);
+public record ExampleDisplay(
+	string Title,
+	HtmlString? DescriptionHtml,
+	string? JsonValue,
+	string? ExternalValue,
+	string? DescriptionMarkdown
+);
 
 /// <summary>Model for the <c>_ExamplesSection</c> partial.</summary>
 public record ExamplesSection(SectionHeader Header, IReadOnlyList<ExampleDisplay> Examples);
@@ -31,6 +37,7 @@ public record ApiQueryParameter
 	public required IReadOnlyList<string> EnumValues { get; init; }
 	public required IReadOnlyList<UnionBadge> UnionOptions { get; init; }
 	public required HtmlString DescriptionHtml { get; init; }
+	public required string? DescriptionMarkdown { get; init; }
 }
 
 /// <summary>A path parameter with its effective description precomputed.</summary>
@@ -38,6 +45,7 @@ public record ApiPathParameter
 {
 	public required IOpenApiParameter Parameter { get; init; }
 	public required HtmlString DescriptionHtml { get; init; }
+	public required string? DescriptionMarkdown { get; init; }
 
 	public string? Name => Parameter.Name;
 	public bool? Deprecated => Parameter.Deprecated;
@@ -148,16 +156,16 @@ public record OperationPageModel
 			Overloads = ResolveOverloads(context),
 			PathParameters = (operation.Parameters ?? [])
 				.Where(p => p.In == ParameterLocation.Path)
-				.Select(
-					p => new ApiPathParameter
+				.Select(p =>
+				{
+					var description = supplemental?.ParameterOr(p.Name ?? "", p.Description) ?? p.Description;
+					return new ApiPathParameter
 					{
 						Parameter = p,
-						DescriptionHtml = ApiMarkdown.Render(
-							context,
-							supplemental?.ParameterOr(p.Name ?? "", p.Description) ?? p.Description
-						)
-					}
-				)
+						DescriptionHtml = ApiMarkdown.Render(context, description),
+						DescriptionMarkdown = description
+					};
+				})
 				.ToArray(),
 			QueryParameters = (operation.Parameters ?? [])
 				.Where(p => p.In == ParameterLocation.Query)
@@ -194,7 +202,8 @@ public record OperationPageModel
 					string.IsNullOrEmpty(e.Value?.Summary) ? e.Key : e.Value.Summary,
 					string.IsNullOrEmpty(e.Value?.Description) ? null : renderMarkdown(e.Value.Description),
 					e.Value?.Value?.ToString(),
-					string.IsNullOrEmpty(e.Value?.ExternalValue) ? null : e.Value.ExternalValue
+					string.IsNullOrEmpty(e.Value?.ExternalValue) ? null : e.Value.ExternalValue,
+					string.IsNullOrEmpty(e.Value?.Description) ? null : e.Value.Description
 				)
 			).ToArray();
 
@@ -217,6 +226,7 @@ public record OperationPageModel
 	)
 	{
 		var schema = parameter.Schema;
+		var description = supplemental?.ParameterOr(parameter.Name ?? "", parameter.Description) ?? parameter.Description;
 		return new ApiQueryParameter
 		{
 			Parameter = parameter,
@@ -226,10 +236,8 @@ public record OperationPageModel
 			UnionOptions = CollectUnionOptionNames(schema, analyzer)
 				.Select(n => new UnionBadge(n, ApiPropertyTreeBuilder.IsTypeOptionBadge(n)))
 				.ToArray(),
-			DescriptionHtml = ApiMarkdown.Render(
-				context,
-				supplemental?.ParameterOr(parameter.Name ?? "", parameter.Description) ?? parameter.Description
-			)
+			DescriptionHtml = ApiMarkdown.Render(context, description),
+			DescriptionMarkdown = description
 		};
 	}
 

--- a/src/Elastic.ApiExplorer/Supplemental/ApiSupplementalDoc.cs
+++ b/src/Elastic.ApiExplorer/Supplemental/ApiSupplementalDoc.cs
@@ -174,7 +174,7 @@ internal sealed partial record ApiSupplementalDoc(
 			|| heading.Equals("Query parameters", StringComparison.OrdinalIgnoreCase)
 			|| heading.Equals("Path parameters", StringComparison.OrdinalIgnoreCase);
 
-	private static (string? FrontMatter, string Content) ExtractFrontMatter(string raw)
+	internal static (string? FrontMatter, string Content) ExtractFrontMatter(string raw)
 	{
 		var match = FrontMatterRegex().Match(raw);
 		if (!match.Success)

--- a/src/Elastic.ApiExplorer/Types/SchemaCommonMark.cs
+++ b/src/Elastic.ApiExplorer/Types/SchemaCommonMark.cs
@@ -1,0 +1,79 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text;
+using Elastic.ApiExplorer.Components.PropertyTree;
+using Elastic.ApiExplorer.Infrastructure;
+
+namespace Elastic.ApiExplorer.Types;
+
+internal static class SchemaCommonMark
+{
+	public static string Write(ApiSchema schema, SchemaPageModel page, ApiRenderContext context)
+	{
+		var markdown = new StringBuilder();
+		var apiBaseUrl = context.CurrentNavigation.NavigationRoot.Url;
+		var openApiSchema = schema.Schema;
+		ApiCommonMark.Heading(markdown, 1, schema.DisplayName);
+		ApiCommonMark.Paragraph(markdown, $"`{schema.SchemaId}`");
+
+		if (!string.IsNullOrEmpty(page.DictionaryTypeName))
+		{
+			ApiCommonMark.Paragraph(markdown, $"`{page.DictionaryTypeName}`");
+			ApiCommonMark.Paragraph(markdown, $"This type represents a dictionary mapping string keys to `{schema.DisplayName}` values.");
+		}
+
+		if (!string.IsNullOrEmpty(openApiSchema.Description))
+		{
+			ApiCommonMark.Heading(markdown, 2, "Description");
+			ApiCommonMark.Prepared(markdown, openApiSchema.Description, apiBaseUrl);
+		}
+
+		if (page.ExternalDocs is { } docs)
+			ApiCommonMark.Paragraph(markdown, ApiCommonMark.Link(docs.LinkText, docs.Url));
+
+		if (openApiSchema.Enum is { Count: > 0 })
+		{
+			ApiCommonMark.Heading(markdown, 2, "Enum Values");
+			foreach (var enumValue in openApiSchema.Enum)
+				_ = markdown.AppendLine($"- `{enumValue}`");
+			_ = markdown.AppendLine();
+		}
+
+		WriteUnion(markdown, page.OneOfVariants, "Union Types (oneOf)", "This type can be one of the following:", apiBaseUrl);
+		WriteUnion(markdown, page.AnyOfVariants, "Union Types (anyOf)", "This type can be any of the following:", apiBaseUrl);
+
+		if (page.Properties is not null)
+		{
+			ApiCommonMark.Heading(markdown, 2, "Properties");
+			ApiPropertyMarkdown.WriteList(markdown, page.Properties, apiBaseUrl);
+			_ = markdown.AppendLine();
+		}
+
+		if (page.AdditionalPropertiesType is not null)
+		{
+			ApiCommonMark.Heading(markdown, 2, "Additional Properties");
+			ApiPropertyMarkdown.WriteType(markdown, page.AdditionalPropertiesType);
+		}
+
+		if (openApiSchema.Example is not null)
+		{
+			ApiCommonMark.Heading(markdown, 2, "Example");
+			ApiCommonMark.Fence(markdown, "json", openApiSchema.Example.ToString());
+		}
+
+		return markdown.ToString();
+	}
+
+	private static void WriteUnion(StringBuilder markdown, ApiUnionVariants? variants, string heading, string intro, string apiBaseUrl)
+	{
+		if (variants is null)
+			return;
+
+		ApiCommonMark.Heading(markdown, 2, heading);
+		ApiCommonMark.Paragraph(markdown, intro);
+		ApiPropertyMarkdown.WriteVariants(markdown, variants, apiBaseUrl);
+		_ = markdown.AppendLine();
+	}
+}

--- a/src/Elastic.ApiExplorer/Types/SchemaNavigationItem.cs
+++ b/src/Elastic.ApiExplorer/Types/SchemaNavigationItem.cs
@@ -22,6 +22,12 @@ public record ApiSchema(string SchemaId, string DisplayName, string Category, IO
 		var slice = SchemaView.Create(viewModel);
 		await slice.RenderAsync(stream, cancellationToken: ctx);
 	}
+
+	public Task<string?> RenderCommonMarkAsync(ApiRenderContext context, Cancel ctx = default)
+	{
+		var page = SchemaPageModel.Create(this, context);
+		return Task.FromResult<string?>(SchemaCommonMark.Write(this, page, context));
+	}
 }
 
 public class SchemaNavigationItem : ILeafNavigationItem<ApiSchema>

--- a/src/Elastic.ApiExplorer/_Layout.cshtml
+++ b/src/Elastic.ApiExplorer/_Layout.cshtml
@@ -2,6 +2,14 @@
 @implements IUsesLayout<Elastic.Documentation.Site._GlobalLayout, GlobalLayoutViewModel>
 @functions {
 	public GlobalLayoutViewModel LayoutModel => Model;
+	protected override Task ExecuteSectionAsync(string name)
+	{
+		if (name == GlobalSections.Head)
+		{
+			<link rel="alternate" type="text/markdown" href="@(Model.MarkdownUrl)" title="Markdown export"/>
+		}
+		return Task.CompletedTask;
+	}
 }
 @if (Model.BuildType == BuildType.Assembler)
 {

--- a/src/Elastic.Documentation/Http/ApiMarkdownRequest.cs
+++ b/src/Elastic.Documentation/Http/ApiMarkdownRequest.cs
@@ -1,0 +1,27 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic.Documentation.Http;
+
+/// <summary>Resolves a generated API CommonMark file from a preview or static request slug.</summary>
+public static class ApiMarkdownRequest
+{
+	public static string ResolveFile(string apiRoot, string slug)
+	{
+		var trimmed = slug.Trim('/');
+		if (trimmed.Length == 0 || trimmed.Equals("api.md", StringComparison.OrdinalIgnoreCase))
+			return Path.GetFullPath(Path.Join(Directory.GetParent(apiRoot)!.FullName, "api.md"));
+
+		if (trimmed.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+			return Path.GetFullPath(Path.Join(apiRoot, trimmed.Replace('/', Path.DirectorySeparatorChar)));
+
+		return Path.GetFullPath(Path.Join(apiRoot, trimmed.Replace('/', Path.DirectorySeparatorChar) + ".md"));
+	}
+
+	public static string SiblingOfDirectory(string directoryPath)
+	{
+		var directory = new DirectoryInfo(directoryPath);
+		return Path.GetFullPath(Path.Join(directory.Parent!.FullName, directory.Name + ".md"));
+	}
+}

--- a/src/Elastic.Documentation/Http/MarkdownAccept.cs
+++ b/src/Elastic.Documentation/Http/MarkdownAccept.cs
@@ -1,0 +1,57 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Globalization;
+
+namespace Elastic.Documentation.Http;
+
+/// <summary>
+/// Chooses Markdown only when <c>Accept</c> lists <c>text/markdown</c> ahead of <c>text/html</c>.
+/// </summary>
+public static class MarkdownAccept
+{
+	public static bool PrefersMarkdown(string? acceptHeader)
+	{
+		if (string.IsNullOrWhiteSpace(acceptHeader))
+			return false;
+
+		var markdown = MediaQuality(acceptHeader, "text/markdown");
+		if (markdown is null)
+			return false;
+
+		var html = MediaQuality(acceptHeader, "text/html") ?? 0;
+		return markdown.Value > html;
+	}
+
+	private static double? MediaQuality(string accept, string mediaType)
+	{
+		double? best = null;
+		foreach (var part in accept.Split(','))
+		{
+			var item = part.Trim();
+			if (item.Length == 0)
+				continue;
+
+			var segments = item.Split(';');
+			var type = segments[0].Trim();
+			if (!type.Equals(mediaType, StringComparison.OrdinalIgnoreCase))
+				continue;
+
+			var quality = 1.0;
+			for (var i = 1; i < segments.Length; i++)
+			{
+				var parameter = segments[i].Trim();
+				if (
+					parameter.StartsWith("q=", StringComparison.OrdinalIgnoreCase)
+					&& double.TryParse(parameter[2..], NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)
+				)
+					quality = parsed;
+			}
+
+			best = best is null ? quality : Math.Max(best.Value, quality);
+		}
+
+		return best;
+	}
+}

--- a/src/tooling/docs-builder/Http/DocumentationWebHost.cs
+++ b/src/tooling/docs-builder/Http/DocumentationWebHost.cs
@@ -12,6 +12,7 @@ using System.Text.Json;
 using Documentation.Builder.Diagnostics.LiveMode;
 using Elastic.Documentation;
 using Elastic.Documentation.Diagnostics;
+using Elastic.Documentation.Http;
 #if DEBUG
 using Elastic.Documentation.Api;
 #endif
@@ -175,11 +176,19 @@ public class DocumentationWebHost
 			(ReloadableGeneratorState holder, Cancel ctx) => ServeDocumentationFile(holder, "index", _writeFileSystem, ctx)
 		);
 
-		_ = _webApplication.MapGet("/api/", (ReloadableGeneratorState holder, Cancel ctx) => ServeApiFile(holder, "", ctx));
+		_ = _webApplication.MapGet(
+			"/api.md",
+			(ReloadableGeneratorState holder, HttpContext http, Cancel ctx) => ServeApiFile(holder, "api.md", http, ctx)
+		);
+
+		_ = _webApplication.MapGet(
+			"/api/",
+			(ReloadableGeneratorState holder, HttpContext http, Cancel ctx) => ServeApiFile(holder, "", http, ctx)
+		);
 
 		_ = _webApplication.MapGet(
 			"/api/{**slug}",
-			(string slug, ReloadableGeneratorState holder, Cancel ctx) => ServeApiFile(holder, slug, ctx)
+			(string slug, ReloadableGeneratorState holder, HttpContext http, Cancel ctx) => ServeApiFile(holder, slug, http, ctx)
 		);
 
 #if DEBUG
@@ -272,7 +281,7 @@ public class DocumentationWebHost
 		await response.Body.FlushAsync(ct);
 	}
 
-	private async Task<IResult> ServeApiFile(ReloadableGeneratorState holder, string slug, Cancel ctx)
+	private async Task<IResult> ServeApiFile(ReloadableGeneratorState holder, string slug, HttpContext http, Cancel ctx)
 	{
 		try
 		{
@@ -293,18 +302,25 @@ public class DocumentationWebHost
 		}
 
 		var apiRoot = Path.GetFullPath(holder.ApiPath.FullName);
-		var path = Path.GetFullPath(Path.Join(apiRoot, slug.Trim('/'), "index.html"));
-		if (!path.StartsWith(apiRoot + Path.DirectorySeparatorChar, StringComparison.Ordinal))
+		var outputRoot = Path.GetFullPath(holder.ApiPath.Parent!.FullName);
+		var trimmed = slug.Trim('/');
+		var wantsMarkdown = trimmed.EndsWith(".md", StringComparison.OrdinalIgnoreCase)
+			|| MarkdownAccept.PrefersMarkdown(http.Request.Headers.Accept);
+		var path = wantsMarkdown
+			? ApiMarkdownRequest.ResolveFile(apiRoot, trimmed)
+			: Path.GetFullPath(Path.Join(apiRoot, trimmed, "index.html"));
+		if (!path.StartsWith(outputRoot + Path.DirectorySeparatorChar, StringComparison.Ordinal))
 			return Results.NotFound();
-		var info = _writeFileSystem.FileInfo.New(path);
-		if (info.Exists)
-		{
-			//TODO STREAM
-			var contents = await _writeFileSystem.File.ReadAllTextAsync(info.FullName, ctx);
-			return LiveReloadHtml(contents, Encoding.UTF8, 200);
-		}
 
-		return Results.NotFound();
+		var info = _writeFileSystem.FileInfo.New(path);
+		if (!info.Exists)
+			return Results.NotFound();
+
+		var contents = await _writeFileSystem.File.ReadAllTextAsync(info.FullName, ctx);
+		if (wantsMarkdown)
+			return Results.Content(contents, "text/markdown; charset=utf-8");
+
+		return LiveReloadHtml(contents, Encoding.UTF8, 200);
 	}
 
 	private static async Task<IResult> ServeDocumentationFile(

--- a/src/tooling/docs-builder/Http/StaticWebHost.cs
+++ b/src/tooling/docs-builder/Http/StaticWebHost.cs
@@ -7,6 +7,7 @@ using System.IO.Abstractions;
 using Elastic.Documentation.Api;
 #endif
 using Elastic.Documentation.Configuration;
+using Elastic.Documentation.Http;
 using Elastic.Documentation.FileSystems;
 using Elastic.Documentation.Extensions;
 using Elastic.Documentation.ServiceDefaults;
@@ -115,7 +116,7 @@ public class StaticWebHost
 		return Task.FromResult(Results.Redirect("docs"));
 	}
 
-	private async Task<IResult> ServeDocumentationFile(string slug, Cancel _)
+	private async Task<IResult> ServeDocumentationFile(string slug, HttpContext http, Cancel _)
 	{
 		// from the injected top level navigation which expects us to run on elastic.co
 		if (slug.StartsWith("static-res/"))
@@ -129,7 +130,19 @@ public class StaticWebHost
 		var fileInfo = new FileInfo(localPath);
 		var directoryInfo = new DirectoryInfo(localPath);
 		if (directoryInfo.Exists)
+		{
+			if (MarkdownAccept.PrefersMarkdown(http.Request.Headers.Accept))
+			{
+				var markdownPath = ApiMarkdownRequest.SiblingOfDirectory(directoryInfo.FullName);
+				if (
+					markdownPath.StartsWith(contentRoot + Path.DirectorySeparatorChar, StringComparison.Ordinal)
+					&& File.Exists(markdownPath)
+				)
+					return Results.File(markdownPath, "text/markdown; charset=utf-8");
+			}
+
 			fileInfo = new FileInfo(Path.Join(directoryInfo.FullName, "index.html"));
+		}
 
 		if (fileInfo.Exists)
 		{
@@ -147,7 +160,7 @@ public class StaticWebHost
 				".txt" => "text/plain",
 				".xml" => "text/xml",
 				".yml" => "text/yaml",
-				".md" => "text/markdown",
+				".md" => "text/markdown; charset=utf-8",
 				_ => "text/html"
 			};
 			return Results.File(fileInfo.FullName, mimetype);

--- a/tests/Elastic.ApiExplorer.Tests/ApiMarkdownFrontMatterTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/ApiMarkdownFrontMatterTests.cs
@@ -1,0 +1,71 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using AwesomeAssertions;
+using Elastic.ApiExplorer.Infrastructure;
+
+namespace Elastic.ApiExplorer.Tests;
+
+public class ApiMarkdownFrontMatterTests
+{
+	[Fact]
+	public void Write_EmitsLlmAndOkfFields()
+	{
+		var markdown = ApiMarkdownFrontMatter.Write(
+			"# Run a search\n\nReturns hits.\n",
+			new ApiPageFrontMatter(
+				"Run a search",
+				"Returns hits that match the query",
+				"https://cdn.example/api/doc/elasticsearch/operation/operation-search",
+				"Elasticsearch"
+			)
+		);
+
+		markdown.Should().StartWith("---");
+		markdown.Should().Contain("type: api");
+		markdown.Should().Contain("title: Run a search");
+		markdown.Should().Contain("description: Returns hits that match the query");
+		markdown.Should().NotContain("navigation_title:");
+		markdown.Should().Contain("url: https://cdn.example/api/doc/elasticsearch/operation/operation-search");
+		markdown.Should().Contain("resource: https://cdn.example/api/doc/elasticsearch/operation/operation-search");
+		markdown.Should().Contain("products:");
+		markdown.Should().Contain("  - Elasticsearch");
+		markdown.Should().NotContain("applies_to:");
+		markdown.Should().Contain("# Run a search");
+	}
+
+	[Fact]
+	public void Write_OmitsOptionalKeysWhenMissing()
+	{
+		var markdown = ApiMarkdownFrontMatter.Write("# API Explorer\n", new ApiPageFrontMatter("API Explorer", null, "/api", null));
+
+		markdown.Should().Contain("type: api");
+		markdown.Should().Contain("title: API Explorer");
+		markdown.Should().Contain("url: /api");
+		markdown.Should().Contain("resource: /api");
+		markdown.Should().NotContain("navigation_title:");
+		markdown.Should().NotContain("description:");
+		markdown.Should().NotContain("products:");
+		markdown.Should().NotContain("applies_to:");
+	}
+
+	[Fact]
+	public void StripLeadingFrontMatter_RemovesAuthoredYaml()
+	{
+		var source =
+			"""
+			---
+			navigation_title: Spaces
+			---
+			# Kibana spaces
+
+			Spaces enable you to organize dashboards.
+			""";
+
+		var stripped = ApiMarkdownFrontMatter.StripLeadingFrontMatter(source);
+
+		stripped.Should().StartWith("# Kibana spaces");
+		stripped.Should().NotContain("navigation_title:");
+	}
+}

--- a/tests/Elastic.ApiExplorer.Tests/ApiOutputPathsTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/ApiOutputPathsTests.cs
@@ -1,0 +1,32 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using AwesomeAssertions;
+using Elastic.ApiExplorer.Infrastructure;
+
+namespace Elastic.ApiExplorer.Tests;
+
+public class ApiOutputPathsTests
+{
+	[Theory]
+	[InlineData("/api/doc/elasticsearch/", "/api/doc/elasticsearch.md")]
+	[InlineData("/api/doc/elasticsearch/operation/operation-search", "/api/doc/elasticsearch/operation/operation-search.md")]
+	[InlineData("/api/", "/api.md")]
+	[InlineData("/", "/index.md")]
+	public void MarkdownUrl_AppendsMdToTrimmedPageUrl(string pageUrl, string expected) =>
+		ApiOutputPaths.MarkdownUrl(pageUrl).Should().Be(expected);
+
+	[Theory]
+	[InlineData("docs/api/doc/elasticsearch", "docs", "api/doc/elasticsearch/index.html")]
+	[InlineData("/api/doc/elasticsearch/operation/operation-search", "", "api/doc/elasticsearch/operation/operation-search/index.html")]
+	public void RelativeHtmlFile_StripsPrefix(string pageUrl, string prefix, string expected) =>
+		ApiOutputPaths.RelativeHtmlFile(pageUrl, prefix).Should().Be(expected);
+
+	[Theory]
+	[InlineData("docs/api/doc/elasticsearch", "docs", "api/doc/elasticsearch.md")]
+	[InlineData("docs/api/", "docs", "api.md")]
+	[InlineData("/api/doc/elasticsearch/operation/operation-search", "", "api/doc/elasticsearch/operation/operation-search.md")]
+	public void RelativeMarkdownFile_StripsPrefix(string pageUrl, string prefix, string expected) =>
+		ApiOutputPaths.RelativeMarkdownFile(pageUrl, prefix).Should().Be(expected);
+}

--- a/tests/Elastic.ApiExplorer.Tests/ApiPagesNavRenderingTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/ApiPagesNavRenderingTests.cs
@@ -49,6 +49,7 @@ public partial class ApiPagesNavRenderingTests
 			Features = new FeatureFlags([]),
 			StaticFileContentHashProvider = new StaticFileContentHashProvider(new EmbeddedOrPhysicalFileProvider(context)),
 			TocItems = [],
+			MarkdownUrl = "/api/doc/elasticsearch/v9.md",
 			VersionSwitcherItems =
 			[
 				new("Latest", "/api/doc/elasticsearch/", Selected: false),

--- a/tests/Elastic.ApiExplorer.Tests/OpenApiGeneratorCatalogSplitTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/OpenApiGeneratorCatalogSplitTests.cs
@@ -87,6 +87,8 @@ public class OpenApiGeneratorCatalogSplitTests
 
 		context.WriteFileSystem.File.Exists(Path.Join(outputRoot, "api", "doc", "elasticsearch", "index.html")).Should().BeTrue();
 		context.WriteFileSystem.File.Exists(Path.Join(outputRoot, "api", "index.html")).Should().BeTrue();
+		context.WriteFileSystem.File.Exists(Path.Join(outputRoot, "api", "doc", "elasticsearch.md")).Should().BeTrue();
+		context.WriteFileSystem.File.Exists(Path.Join(outputRoot, "api.md")).Should().BeTrue();
 	}
 
 	private static BuildContext CreateGenerateContext(string outputRoot)

--- a/tests/Elastic.ApiExplorer.Tests/OpenApiGeneratorMarkdownEmissionTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/OpenApiGeneratorMarkdownEmissionTests.cs
@@ -84,11 +84,20 @@ public class OpenApiGeneratorMarkdownEmissionTests(ApiExplorerFixture fixture) :
 			.File
 			.ReadAllTextAsync(Path.Join(outputRoot, "api.md"), TestContext.Current.CancellationToken);
 
-		landing.Should().StartWith("# Fixture API");
+		landing.Should().StartWith("---");
+		landing.Should().Contain("type: api");
+		landing.Should().Contain("title: Fixture API");
+		landing.Should().Contain("url: /api/doc/elasticsearch");
+		landing.Should().Contain("resource: /api/doc/elasticsearch");
+		landing.Should().Contain("  - elasticsearch");
+		landing.Should().NotContain("applies_to:");
+		landing.Should().Contain("# Fixture API");
 		landing.Should().Contain("Search APIs");
 		landing.Should().NotContain("<!DOCTYPE");
 		landing.Should().NotContain("<html");
 
+		operation.Should().Contain("type: api");
+		operation.Should().Contain("title: Run a search");
 		operation.Should().Contain("# Run a search");
 		operation.Should().Contain("`POST`");
 		operation.Should().Contain("`/{index}/_search`");
@@ -97,6 +106,9 @@ public class OpenApiGeneratorMarkdownEmissionTests(ApiExplorerFixture fixture) :
 		operation.Should().NotContain("<!DOCTYPE");
 		operation.Should().NotContain("<html");
 
+		catalog.Should().Contain("type: api");
+		catalog.Should().Contain("title: API Explorer");
+		catalog.Should().Contain("description: API products in this documentation set.");
 		catalog.Should().Contain("# API Explorer");
 		catalog.Should().Contain("Fixture API");
 		catalog.Should().Contain("`elasticsearch`");
@@ -160,9 +172,15 @@ public class OpenApiGeneratorMarkdownEmissionTests(ApiExplorerFixture fixture) :
 
 		var markdown = await item.RenderCommonMarkAsync(renderContext, TestContext.Current.CancellationToken);
 
-		markdown.Should().Contain("# Kibana spaces");
-		markdown.Should().Contain("Spaces enable you to organize");
-		markdown.Should().NotContain("<!DOCTYPE");
+		var wrapped = ApiMarkdownFrontMatter.Wrap(markdown!, item, renderContext, item);
+
+		wrapped.Should().StartWith("---");
+		wrapped.Should().Contain("type: api");
+		wrapped.Should().Contain("title: Kibana spaces");
+		wrapped.Should().NotContain("navigation_title:");
+		wrapped.Should().Contain("description: Spaces enable you to organize");
+		wrapped.Should().Contain("# Kibana spaces");
+		wrapped.Should().NotContain("<!DOCTYPE");
 	}
 
 	private static BuildContext CreateGenerateContext(string outputRoot)

--- a/tests/Elastic.ApiExplorer.Tests/OpenApiGeneratorMarkdownEmissionTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/OpenApiGeneratorMarkdownEmissionTests.cs
@@ -1,0 +1,264 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Collections.Frozen;
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
+using System.Net;
+using AwesomeAssertions;
+using Elastic.ApiExplorer.Infrastructure;
+using Elastic.ApiExplorer.Landing;
+using Elastic.ApiExplorer.Model;
+using Elastic.Documentation;
+using Elastic.Documentation.Configuration;
+using Elastic.Documentation.Configuration.Products;
+using Elastic.Documentation.Configuration.Versions;
+using Elastic.Documentation.Diagnostics;
+using Elastic.Documentation.FileSystems;
+using FakeItEasy;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.OpenApi;
+
+namespace Elastic.ApiExplorer.Tests;
+
+public class OpenApiGeneratorMarkdownEmissionTests(ApiExplorerFixture fixture) : IClassFixture<ApiExplorerFixture>
+{
+	private static readonly Uri BaseUri = new("https://cdn.example/");
+
+	[Fact]
+	public async Task Generate_WritesSiblingMarkdownForEveryRenderedPage()
+	{
+		var outputRoot = Path.Join(Paths.WorkingDirectoryRoot.FullName, $"api-md-emit-{Guid.NewGuid():N}");
+		var context = CreateGenerateContext(outputRoot);
+		using var versionIndexClient = new VersionIndexClient(BaseUri, MainOnlyHandler(), sleep: (_, _) => Task.CompletedTask);
+		var reader = CreateSequentialReader(fixture.Document);
+		var generator = new OpenApiGenerator(
+			NullLoggerFactory.Instance,
+			context,
+			PassthroughMarkdownRenderer.Instance,
+			versionIndexClient,
+			reader
+		);
+
+		await generator.Generate(TestContext.Current.CancellationToken);
+
+		var write = context.WriteFileSystem.File;
+		write.Exists(Path.Join(outputRoot, "api.md")).Should().BeTrue();
+		write.Exists(Path.Join(outputRoot, "api", "doc", "elasticsearch.md")).Should().BeTrue();
+		write.Exists(Path.Join(outputRoot, "api", "doc", "elasticsearch", "group", "endpoint-search.md")).Should().BeTrue();
+		write.Exists(Path.Join(outputRoot, "api", "doc", "elasticsearch", "operation", "operation-search.md")).Should().BeTrue();
+		write.Exists(Path.Join(outputRoot, "api", "doc", "elasticsearch", "types", "_types-query_dsl-querycontainer.md")).Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task Generate_WritesReadableCommonMarkNotHtmlDocument()
+	{
+		var outputRoot = Path.Join(Paths.WorkingDirectoryRoot.FullName, $"api-md-content-{Guid.NewGuid():N}");
+		var context = CreateGenerateContext(outputRoot);
+		using var versionIndexClient = new VersionIndexClient(BaseUri, MainOnlyHandler(), sleep: (_, _) => Task.CompletedTask);
+		var reader = CreateSequentialReader(fixture.Document);
+		var generator = new OpenApiGenerator(
+			NullLoggerFactory.Instance,
+			context,
+			PassthroughMarkdownRenderer.Instance,
+			versionIndexClient,
+			reader
+		);
+
+		await generator.Generate(TestContext.Current.CancellationToken);
+
+		var landing = await context
+			.WriteFileSystem
+			.File
+			.ReadAllTextAsync(Path.Join(outputRoot, "api", "doc", "elasticsearch.md"), TestContext.Current.CancellationToken);
+		var operation = await context
+			.WriteFileSystem
+			.File
+			.ReadAllTextAsync(
+				Path.Join(outputRoot, "api", "doc", "elasticsearch", "operation", "operation-search.md"),
+				TestContext.Current.CancellationToken
+			);
+		var catalog = await context
+			.WriteFileSystem
+			.File
+			.ReadAllTextAsync(Path.Join(outputRoot, "api.md"), TestContext.Current.CancellationToken);
+
+		landing.Should().StartWith("# Fixture API");
+		landing.Should().Contain("Search APIs");
+		landing.Should().NotContain("<!DOCTYPE");
+		landing.Should().NotContain("<html");
+
+		operation.Should().Contain("# Run a search");
+		operation.Should().Contain("`POST`");
+		operation.Should().Contain("`/{index}/_search`");
+		operation.Should().Contain("## Description");
+		operation.Should().Contain("Returns hits that match the query");
+		operation.Should().NotContain("<!DOCTYPE");
+		operation.Should().NotContain("<html");
+
+		catalog.Should().Contain("# API Explorer");
+		catalog.Should().Contain("Fixture API");
+		catalog.Should().Contain("`elasticsearch`");
+	}
+
+	[Fact]
+	public async Task Generate_WritesAlternateLinkOnApiHtml()
+	{
+		var outputRoot = Path.Join(Paths.WorkingDirectoryRoot.FullName, $"api-md-alt-{Guid.NewGuid():N}");
+		var context = CreateGenerateContext(outputRoot);
+		using var versionIndexClient = new VersionIndexClient(BaseUri, MainOnlyHandler(), sleep: (_, _) => Task.CompletedTask);
+		var reader = CreateSequentialReader(fixture.Document);
+		var generator = new OpenApiGenerator(
+			NullLoggerFactory.Instance,
+			context,
+			PassthroughMarkdownRenderer.Instance,
+			versionIndexClient,
+			reader
+		);
+
+		await generator.Generate(TestContext.Current.CancellationToken);
+
+		var html = await context
+			.WriteFileSystem
+			.File
+			.ReadAllTextAsync(Path.Join(outputRoot, "api", "doc", "elasticsearch", "index.html"), TestContext.Current.CancellationToken);
+		var operationHtml = await context
+			.WriteFileSystem
+			.File
+			.ReadAllTextAsync(
+				Path.Join(outputRoot, "api", "doc", "elasticsearch", "operation", "operation-search", "index.html"),
+				TestContext.Current.CancellationToken
+			);
+
+		html.Should().Contain("""<link rel="alternate" type="text/markdown" href="/api/doc/elasticsearch.md" title="Markdown export"/>""");
+		operationHtml.Should().Contain(
+			"""<link rel="alternate" type="text/markdown" href="/api/doc/elasticsearch/operation/operation-search.md" title="Markdown export"/>"""
+		);
+	}
+
+	[Fact]
+	public async Task SimpleMarkdownPage_WritesAuthoredSource()
+	{
+		var introPath = Path.Combine(
+			Paths.WorkingDirectoryRoot.FullName,
+			"tests",
+			"Elastic.ApiExplorer.Tests",
+			"TestData",
+			"kibana-api-overview.md"
+		);
+		var file = new FileSystem().FileInfo.New(introPath);
+		var item = new SimpleMarkdownNavigationItem("/api/doc/kibana/kibana-api-overview", "Spaces", file, fixture.Navigation);
+		var renderContext = new ApiRenderContext(
+			fixture.Context,
+			fixture.Document,
+			new Elastic.Documentation.Site.FileProviders.StaticFileContentHashProvider(
+				new Elastic.Documentation.Site.FileProviders.EmbeddedOrPhysicalFileProvider(fixture.Context)
+			)
+		)
+		{ NavigationHtml = string.Empty, CurrentNavigation = item, MarkdownRenderer = PassthroughMarkdownRenderer.Instance };
+
+		var markdown = await item.RenderCommonMarkAsync(renderContext, TestContext.Current.CancellationToken);
+
+		markdown.Should().Contain("# Kibana spaces");
+		markdown.Should().Contain("Spaces enable you to organize");
+		markdown.Should().NotContain("<!DOCTYPE");
+	}
+
+	private static BuildContext CreateGenerateContext(string outputRoot)
+	{
+		var collector = new DiagnosticsCollector([]);
+		var stack = TestHelpers.CreateStackVersionsConfiguration(currentMajor: 9);
+		var product = TestHelpers.CreateProduct("elasticsearch", stack.GetVersioningSystem(VersioningSystemId.Stack));
+		var repoRoot = Path.Join(Paths.WorkingDirectoryRoot.FullName, $"api-md-repo-{Guid.NewGuid():N}");
+		var configPath = Path.Join(repoRoot, "docs", "docset.yml");
+		var docsetYaml =
+			"""
+			api:
+			  elasticsearch:
+			    - spec: elasticsearch-openapi.json
+			      product: elasticsearch
+			""";
+		var fs = new MockFileSystem(new MockFileSystemOptions { CurrentDirectory = Paths.WorkingDirectoryRoot.FullName });
+		fs.AddDirectory(Path.Join(repoRoot, ".git"));
+		fs.AddFile(configPath, new MockFileData(docsetYaml));
+		var products = new ProductsConfiguration
+		{
+			Products = new[] { product }.ToFrozenDictionary(p => p.Id, StringComparer.OrdinalIgnoreCase),
+			PublicReferenceProducts = new[] { product }.ToFrozenDictionary(p => p.Id, StringComparer.OrdinalIgnoreCase),
+			ProductDisplayNames = new Dictionary<string, string> { [product.Id] = product.DisplayName ?? product.Id }.ToFrozenDictionary(
+				StringComparer.OrdinalIgnoreCase
+			)
+		};
+		var configurationContext = TestHelpers.CreateConfigurationContext(fs, stack, products);
+
+		return new BuildContext(
+			collector,
+			DocumentationFileSystem.Resolve(
+				repoRoot,
+				new DocumentationScopeOptions
+				{
+					ConfigurationFile = configPath,
+					Output = outputRoot,
+					Git = new GitCheckoutInformation
+					{
+						Branch = "main",
+						Remote = "https://github.com/elastic/elasticsearch.git",
+						Ref = "refs/heads/main"
+					},
+					Inner = fs
+				}
+			),
+			configurationContext
+		);
+	}
+
+	private static IOpenApiSpecificationReader CreateSequentialReader(params OpenApiDocument[] documents)
+	{
+		var queue = new Queue<OpenApiDocument>(documents);
+		var reader = A.Fake<IOpenApiSpecificationReader>();
+		A.CallTo(() => reader.ReadAsync(A<Stream>._, A<string>._)).ReturnsLazily(_ => Task.FromResult<OpenApiDocument?>(queue.Dequeue()));
+		return reader;
+	}
+
+	private static HttpMessageHandler MainOnlyHandler() =>
+		new StubHandler(request =>
+		{
+			if (request.RequestUri!.AbsolutePath.EndsWith("index.json", StringComparison.Ordinal))
+			{
+				return new HttpResponseMessage(HttpStatusCode.OK)
+				{
+					Content = new StringContent(
+						/*lang=json,strict*/
+						"""
+						{
+							"elastic/elasticsearch": {
+								"elasticsearch-openapi.json": {
+									"main": { "version": "main" }
+								}
+							}
+						}
+						""",
+						System.Text.Encoding.UTF8,
+						"application/json"
+					)
+				};
+			}
+
+			return new HttpResponseMessage(HttpStatusCode.OK)
+			{
+				Content = new StringContent(
+					/*lang=json,strict*/
+					"""{"openapi":"3.1.0","info":{"title":"Spec","version":"1.0"},"paths":{}}""",
+					System.Text.Encoding.UTF8,
+					"application/json"
+				)
+			};
+		});
+
+	private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
+	{
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+			Task.FromResult(responder(request));
+	}
+}

--- a/tests/Elastic.ApiExplorer.Tests/OpenApiGeneratorMultiVersionTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/OpenApiGeneratorMultiVersionTests.cs
@@ -280,6 +280,15 @@ public class OpenApiGeneratorMultiVersionTests
 			.Exists(Path.Join(outputRoot, "api", "doc", "elasticsearch", "v8", "operation", "operation-ping", "index.html"))
 			.Should()
 			.BeTrue();
+		context.WriteFileSystem.File.Exists(Path.Join(outputRoot, "api", "doc", "elasticsearch.md")).Should().BeTrue();
+		context.WriteFileSystem.File.Exists(Path.Join(outputRoot, "api", "doc", "elasticsearch", "v9.md")).Should().BeTrue();
+		context.WriteFileSystem.File.Exists(Path.Join(outputRoot, "api", "doc", "elasticsearch", "v8.md")).Should().BeTrue();
+		context
+			.WriteFileSystem
+			.File
+			.Exists(Path.Join(outputRoot, "api", "doc", "elasticsearch", "v8", "operation", "operation-ping.md"))
+			.Should()
+			.BeTrue();
 	}
 
 	private static BuildContext CreateGenerateContext(

--- a/tests/Elastic.Documentation.Tests/Http/MarkdownAcceptTests.cs
+++ b/tests/Elastic.Documentation.Tests/Http/MarkdownAcceptTests.cs
@@ -1,0 +1,67 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using AwesomeAssertions;
+using Elastic.Documentation.Http;
+
+namespace Elastic.Documentation.Tests.Http;
+
+public class MarkdownAcceptTests
+{
+	[Theory]
+	[InlineData("text/markdown")]
+	[InlineData("text/markdown; charset=utf-8")]
+	[InlineData("text/markdown, text/html;q=0.9")]
+	public void PrefersMarkdown_WhenMarkdownOutranksHtml(string accept) => MarkdownAccept.PrefersMarkdown(accept).Should().BeTrue();
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")]
+	[InlineData("text/html, text/markdown;q=0.5")]
+	[InlineData("text/html, text/markdown")]
+	public void PrefersMarkdown_WhenHtmlWinsOrMarkdownMissing(string? accept) => MarkdownAccept.PrefersMarkdown(accept).Should().BeFalse();
+}
+
+public class ApiMarkdownRequestTests
+{
+	[Fact]
+	public void ResolveFile_CatalogSlugUsesParentApiMd()
+	{
+		var apiRoot = Path.GetFullPath(Path.Join(Path.GetTempPath(), "out", "api"));
+		var expected = Path.GetFullPath(Path.Join(Path.GetTempPath(), "out", "api.md"));
+
+		ApiMarkdownRequest.ResolveFile(apiRoot, "").Should().Be(expected);
+		ApiMarkdownRequest.ResolveFile(apiRoot, "api.md").Should().Be(expected);
+	}
+
+	[Fact]
+	public void ResolveFile_PageSlugUsesSiblingMd()
+	{
+		var apiRoot = Path.GetFullPath(Path.Join(Path.GetTempPath(), "out", "api"));
+
+		ApiMarkdownRequest
+			.ResolveFile(apiRoot, "doc/elasticsearch")
+			.Should()
+			.Be(Path.GetFullPath(Path.Join(apiRoot, "doc", "elasticsearch.md")));
+		ApiMarkdownRequest
+			.ResolveFile(apiRoot, "doc/elasticsearch.md")
+			.Should()
+			.Be(Path.GetFullPath(Path.Join(apiRoot, "doc", "elasticsearch.md")));
+		ApiMarkdownRequest
+			.ResolveFile(apiRoot, "doc/elasticsearch/operation/operation-search")
+			.Should()
+			.Be(Path.GetFullPath(Path.Join(apiRoot, "doc", "elasticsearch", "operation", "operation-search.md")));
+	}
+
+	[Fact]
+	public void SiblingOfDirectory_UsesParentNameMd()
+	{
+		var directory = Path.Join(Path.GetTempPath(), "out", "api", "doc", "elasticsearch");
+		ApiMarkdownRequest
+			.SiblingOfDirectory(directory)
+			.Should()
+			.Be(Path.GetFullPath(Path.Join(Path.GetTempPath(), "out", "api", "doc", "elasticsearch.md")));
+	}
+}


### PR DESCRIPTION
Generated API Explorer pages now write a sibling CommonMark file and serve it through a `.md` suffix or `Accept: text/markdown`. Agents and tools can read native API pages without scraping HTML. (The serving part already exists in infra)

**Affects:** API reference, Isolated builds

## Why

Local preview and isolated builds publish API HTML only. A request for Markdown on an `/api/doc/` URL returns HTML or `404`. [elastic/docs-eng-team#809](https://github.com/elastic/docs-eng-team/issues/809) needs readable CommonMark next to each generated API page.

## What

#### Sibling CommonMark files
Each successful `index.html` write also writes a sibling `.md` file from the page models. Grouping models that render no page still emit no file. The generator does not convert Razor HTML.

#### Preview and static serving
Preview and static hosts serve that file when the path ends with `.md` or when `Accept` prefers `text/markdown`. Browser and `text/html` requests still receive HTML. Path traversal checks apply to both file types.

#### Alternate link
The API layout emits one `<link rel="alternate" type="text/markdown">` in the document head. There is no visible View as Markdown or Copy as Markdown control.

**Out of scope:** `OkfMarkdownExporter` still skips live `/api/*` links. Production `www.elastic.co` still proxies API pages to bump.sh until the API Explorer cutover.

## Verify

```bash
dotnet test tests/Elastic.ApiExplorer.Tests/
dotnet test tests/Elastic.Documentation.Tests/
dotnet run --project src/tooling/docs-builder -- serve
```

```bash
curl -D - http://localhost:3000/api/doc/docs-builder-elasticsearch.md
curl -D - -H 'Accept: text/markdown' http://localhost:3000/api/doc/docs-builder-elasticsearch/
curl -D - http://localhost:3000/api/doc/docs-builder-elasticsearch/operation/operation-async-search-get.md
```

Expect `200` and `text/markdown; charset=utf-8` with readable CommonMark. A normal browser request to the HTML URL must still return HTML.

Made with [Cursor](https://cursor.com)