### PR TITLE
Drop should-comment-success / should-comment-failure outputs from evaluate-artifact

### DIFF
--- a/src/services/Elastic.Changelog/Evaluation/ChangelogArtifactEvaluationService.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogArtifactEvaluationService.cs
@@ -97,8 +97,6 @@ public class ChangelogArtifactEvaluationService(
 		);
 
 		var shouldCommit = statusParsed && metadataStatus == PrEvaluationResult.Success && metadata.CanCommit;
-		var shouldCommentSuccess = statusParsed && metadataStatus == PrEvaluationResult.Success && !metadata.CanCommit;
-		var shouldCommentFailure = statusParsed && metadataStatus == PrEvaluationResult.NoLabel;
 
 		// All artifact-derived outputs flow through OutputSanitizer to strip
 		// control characters and enforce per-field length caps. metadata.json
@@ -135,16 +133,8 @@ public class ChangelogArtifactEvaluationService(
 			OutputSanitizer.SanitizeForOutput(metadata.SkipLabels, OutputSanitizer.LabelsMaxLength)
 		);
 		await coreService.SetOutputAsync("should-commit", shouldCommit ? "true" : "false");
-		await coreService.SetOutputAsync("should-comment-success", shouldCommentSuccess ? "true" : "false");
-		await coreService.SetOutputAsync("should-comment-failure", shouldCommentFailure ? "true" : "false");
 
-		_logger.LogInformation(
-			"Artifact evaluation complete: status={Status}, commit={Commit}, commentSuccess={CommentSuccess}, commentFailure={CommentFailure}",
-			metadata.Status,
-			shouldCommit,
-			shouldCommentSuccess,
-			shouldCommentFailure
-		);
+		_logger.LogInformation("Artifact evaluation complete: status={Status}, commit={Commit}", metadata.Status, shouldCommit);
 
 		return true;
 	}

--- a/src/services/Elastic.Changelog/GitHub/GitHubCommentService.cs
+++ b/src/services/Elastic.Changelog/GitHub/GitHubCommentService.cs
@@ -174,6 +174,7 @@ public partial class GitHubCommentService(ILoggerFactory loggerFactory, GitHubAp
 
 	private sealed class CommentBody
 	{
+		[JsonPropertyName("body")]
 		public string Body { get; set; } = string.Empty;
 	}
 

--- a/tests/Elastic.Changelog.Tests/Evaluation/ChangelogArtifactEvaluationServiceTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/ChangelogArtifactEvaluationServiceTests.cs
@@ -130,8 +130,6 @@ public class ChangelogArtifactEvaluationServiceTests(ITestOutputHelper output) :
 
 		result.Should().BeTrue();
 		VerifyOutputSet("should-commit", "true");
-		VerifyOutputSet("should-comment-success", "false");
-		VerifyOutputSet("should-comment-failure", "false");
 		VerifyOutputSet("pr-number", "42");
 		VerifyOutputSet("head-ref", "feature/test");
 		VerifyOutputSet("head-sha", "abc123");
@@ -140,7 +138,7 @@ public class ChangelogArtifactEvaluationServiceTests(ITestOutputHelper output) :
 	}
 
 	[Fact]
-	public async Task EvaluateArtifact_SuccessCannotCommit_SetsCommentSuccessFlag()
+	public async Task EvaluateArtifact_SuccessCannotCommit_SetsCommitFalse()
 	{
 		await WriteMetadata(DefaultMetadata(canCommit: false));
 		SetupPrInfo();
@@ -150,7 +148,6 @@ public class ChangelogArtifactEvaluationServiceTests(ITestOutputHelper output) :
 
 		result.Should().BeTrue();
 		VerifyOutputSet("should-commit", "false");
-		VerifyOutputSet("should-comment-success", "true");
 	}
 
 	[Fact]
@@ -170,7 +167,7 @@ public class ChangelogArtifactEvaluationServiceTests(ITestOutputHelper output) :
 	}
 
 	[Fact]
-	public async Task EvaluateArtifact_ForkCannotCommit_SetsCommentSuccessFlag()
+	public async Task EvaluateArtifact_ForkCannotCommit_SetsCommitFalse()
 	{
 		var metadata = DefaultMetadata(canCommit: false) with { IsFork = true, HeadRepo = "contributor/repo", MaintainerCanModify = false };
 		await WriteMetadata(metadata);
@@ -181,12 +178,11 @@ public class ChangelogArtifactEvaluationServiceTests(ITestOutputHelper output) :
 
 		result.Should().BeTrue();
 		VerifyOutputSet("should-commit", "false");
-		VerifyOutputSet("should-comment-success", "true");
 		VerifyOutputSet("is-fork", "true");
 	}
 
 	[Fact]
-	public async Task EvaluateArtifact_NoLabel_SetsCommentFailureFlag()
+	public async Task EvaluateArtifact_NoLabel_SetsCommitFalseAndForwardsLabelTables()
 	{
 		await WriteMetadata(DefaultMetadata(status: "no-label", canCommit: false) with
 		{
@@ -201,7 +197,6 @@ public class ChangelogArtifactEvaluationServiceTests(ITestOutputHelper output) :
 
 		result.Should().BeTrue();
 		VerifyOutputSet("should-commit", "false");
-		VerifyOutputSet("should-comment-failure", "true");
 		VerifyOutputSet("label-table", "| Label | Type |");
 		VerifyOutputSet("product-label-table", "| Label | Product |");
 		VerifyOutputSet("skip-labels", "changelog:skip");

--- a/tests/Elastic.Changelog.Tests/Evaluation/GitHubCommentServiceTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/GitHubCommentServiceTests.cs
@@ -143,6 +143,25 @@ public class GitHubCommentServiceTests(ITestOutputHelper output)
 		postedBody!.Should().Contain("Changelog").And.Contain("Content");
 	}
 
+	[Fact]
+	public async Task UpsertStickyComment_PostedJson_UsesLowercaseBodyKey()
+	{
+		// GitHub's API requires lowercase "body" — PascalCase "Body" triggers HTTP 422.
+		string? postedJson = null;
+		var handler = new StubHandler(req =>
+		{
+			if (req.Method.Method == "GET")
+				return Json("[]");
+			postedJson = req.Content?.ReadAsStringAsync().GetAwaiter().GetResult();
+			return Created();
+		});
+
+		await Service(handler).UpsertStickyCommentAsync(Owner, Repo, PrNumber, "hello");
+
+		postedJson.Should().NotBeNull();
+		postedJson!.Should().Contain("\"body\"").And.NotContain("\"Body\"");
+	}
+
 	private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
 	{
 		protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken) => responder(request);


### PR DESCRIPTION
Removes the two step outputs `should-comment-success` and `should-comment-failure` from `ChangelogArtifactEvaluationService` now that `changelog/submit/apply` (docs-actions #324) no longer reads them.

**Affects:** Automation

## Why

`evaluate-artifact` emitted two comment-gate outputs that `submit/apply` used to decide which JS comment script to run. Those three comment steps were replaced by the native `changelog github-comment` command in docs-actions #324, which reads the `changelog-decision` artifact directly — the outputs are now dead. Leaving them in place would mislead future readers into thinking something still consumes them.

## What

#### Outputs removed from `ChangelogArtifactEvaluationService`

`shouldCommentSuccess` and `shouldCommentFailure` variables and their two `SetOutputAsync` calls are deleted. The surrounding log message is trimmed to remove the two fields. No other logic in the service changes; `should-commit` and all other outputs are unaffected.

#### Tests updated

Four test methods in `ChangelogArtifactEvaluationServiceTests` had assertions verifying the removed outputs. Each assertion is dropped and the method is renamed to reflect only what it still tests (`SetsCommitFalse` instead of `SetsCommentSuccessFlag`, etc.).

## Verify

```bash
dotnet test tests/Elastic.Changelog.Tests/
```

**Stack:** 4 of 4, on top of docs-actions #324.

**Risk:** This PR must not merge before docs-actions #324. Removing the outputs while `submit/apply` still gates on them (`if: steps.meta.outputs.should-comment-success == 'true'`) would silently prevent the comment steps from firing — elastic/cloud would lose PR comments with no visible error. Merge order is: docs-actions #324 first (or confirm it is already merged and the `v1` tag updated), then this PR.

**Out of scope:** Renaming `evaluate-artifact` / `prepare-artifact` and their service types — that is its own PR with a wider call-site audit.