### PR TITLE
Fix HTTP 422 when posting changelog PR comment

### DIFF
--- a/src/services/Elastic.Changelog/GitHub/GitHubCommentService.cs
+++ b/src/services/Elastic.Changelog/GitHub/GitHubCommentService.cs
@@ -174,6 +174,7 @@ public partial class GitHubCommentService(ILoggerFactory loggerFactory, GitHubAp
 
 	private sealed class CommentBody
 	{
+		[JsonPropertyName("body")]
 		public string Body { get; set; } = string.Empty;
 	}
 

--- a/tests/Elastic.Changelog.Tests/Evaluation/GitHubCommentServiceTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/GitHubCommentServiceTests.cs
@@ -143,6 +143,25 @@ public class GitHubCommentServiceTests(ITestOutputHelper output)
 		postedBody!.Should().Contain("Changelog").And.Contain("Content");
 	}
 
+	[Fact]
+	public async Task UpsertStickyComment_PostedJson_UsesLowercaseBodyKey()
+	{
+		// GitHub's API requires lowercase "body" — PascalCase "Body" triggers HTTP 422.
+		string? postedJson = null;
+		var handler = new StubHandler(req =>
+		{
+			if (req.Method.Method == "GET")
+				return Json("[]");
+			postedJson = req.Content?.ReadAsStringAsync().GetAwaiter().GetResult();
+			return Created();
+		});
+
+		await Service(handler).UpsertStickyCommentAsync(Owner, Repo, PrNumber, "hello");
+
+		postedJson.Should().NotBeNull();
+		postedJson!.Should().Contain("\"body\"").And.NotContain("\"Body\"");
+	}
+
 	private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
 	{
 		protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken) => responder(request);


### PR DESCRIPTION
`changelog github-comment` was posting `{"Body": "..."}` (PascalCase) to GitHub's issues/comments API. GitHub's API is case-sensitive and requires lowercase `body`, so every comment attempt returned 422 and was silently swallowed.

**Affects:** Release notes

## Why

`GitHubCommentService` has a private `CommentBody` record that carries the comment text to the API. `CommentJsonContext` uses source-generated serialization with no naming policy, so the JSON key comes from the C# property name: `"Body"`. GitHub's `POST /repos/{owner}/{repo}/issues/{number}/comments` treats an unrecognised key as a missing `body` and returns 422 Unprocessable Entity.

The result was that `docs-builder changelog github-comment` ran to completion, logged the rendered body, and then silently failed every comment POST — the 422 was logged as a warning and the command exited 0, making the failure invisible in CI.

## What

#### Serialization key fix

`[JsonPropertyName("body")]` on `CommentBody.Body` ensures the serialized JSON uses the lowercase key GitHub requires. A `PATCH` to update an existing comment uses the same record, so the fix covers both the create and update paths.

#### Regression test

A new test, `UpsertStickyComment_PostedJson_UsesLowercaseBodyKey`, captures the raw JSON payload sent in the POST and asserts the key is `"body"`, not `"Body"`. Without the attribute, this test would have caught the bug at PR-review time.

## Verify

```bash
dotnet test tests/Elastic.Changelog.Tests/ --filter "GitHubCommentServiceTests"
# UpsertStickyComment_PostedJson_UsesLowercaseBodyKey — the regression guard
```