### PR TITLE
Retone label-gate PR comment: labels needed, not generation failed

### DIFF
--- a/src/services/Elastic.Changelog/Evaluation/ChangelogCommentRenderer.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogCommentRenderer.cs
@@ -105,8 +105,13 @@ internal static class ChangelogCommentRenderer
 	}
 
 	/// <summary>
-	/// Renders the "cannot generate" body: the error headline plus optional label tables and skip-label
-	/// guidance, ported from <c>post-failure-comment.js</c>.
+	/// Renders the Step 1 (label gate) comment body: tells the author which labels are required
+	/// before a changelog entry can be generated. Tone is "labels not set yet", not "generation
+	/// failed" — the author just hasn't told us what type of change this is.
+	/// <para>
+	/// Step 2 (changelog file invalid) and Step 3 (full require-changelog-file failure) will use
+	/// separate render methods added when those workflow paths are built.
+	/// </para>
 	/// </summary>
 	internal static string RenderCannotGenerate(string? labelTable, string? productLabelTable, string? skipLabels, string? configFile)
 	{
@@ -116,10 +121,10 @@ internal static class ChangelogCommentRenderer
 		var hasProductIssue = !string.IsNullOrWhiteSpace(productLabelTable);
 
 		var headline = hasTypeIssue && hasProductIssue
-			? "⚠️ **Cannot generate changelog:** required type and product labels are missing on this PR."
+			? "🏷️ **Changelog labels needed** — add type and product labels to this PR to enable changelog generation."
 			: hasProductIssue
-				? "⚠️ **Cannot generate changelog:** no matching product label found on this PR."
-				: "⚠️ **Cannot generate changelog:** no matching type label found on this PR.";
+				? "🏷️ **Product label needed** — add a product label to this PR to enable changelog generation."
+				: "🏷️ **Changelog label needed** — add a type label to this PR to enable changelog generation.";
 
 		var sections = new List<string>();
 
@@ -155,10 +160,11 @@ internal static class ChangelogCommentRenderer
 	}
 
 	/// <summary>
-	/// Renders the "resolved" body posted when a previously-failing PR is now valid, to avoid leaving
-	/// a stale failure comment.
+	/// Renders the "resolved" body posted when a previously-failing PR now has the required labels,
+	/// clearing the stale Step 1 comment and confirming what happens next.
 	/// </summary>
-	internal static string RenderResolved() => string.Join("\n", Title, "", "✅ Changelog labels validated successfully.");
+	internal static string RenderResolved() =>
+		string.Join("\n", Title, "", "✅ **Changelog label set** — an entry will be generated on merge.");
 
 	// ──────────────────────────────────────────────────────────────────────────────────────────
 	// Injection-hardening helpers (ported from comment-helper.js)

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogCommentRenderer.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogCommentRenderer.cs
@@ -121,10 +121,10 @@ internal static class ChangelogCommentRenderer
 		var hasProductIssue = !string.IsNullOrWhiteSpace(productLabelTable);
 
 		var headline = hasTypeIssue && hasProductIssue
-			? "🏷️ **Changelog labels needed** — add type and product labels to this PR to enable changelog generation."
+			? "🏷️ **Changelog labels needed** — add type and product labels so we can determine this PR's release-notes status."
 			: hasProductIssue
-				? "🏷️ **Product label needed** — add a product label to this PR to enable changelog generation."
-				: "🏷️ **Changelog label needed** — add a type label to this PR to enable changelog generation.";
+				? "🏷️ **Product label needed** — add a product label so we can determine this PR's release-notes status."
+				: "🏷️ **Changelog label needed** — add a type label so we can determine this PR's release-notes status.";
 
 		var sections = new List<string>();
 
@@ -142,11 +142,11 @@ internal static class ChangelogCommentRenderer
 			var formatted = skipLabels.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Select(
 				WrapInlineCode
 			);
-			skipSection = $"\n⏭️ To skip changelog generation, add one of these labels: {string.Join(", ", formatted)}";
+			skipSection = $"\n⏭️ To exclude this PR from release notes, add one of these labels: {string.Join(", ", formatted)}";
 		}
 		else
 		{
-			skipSection = $"\n⏭️ No skip labels are configured. To allow skipping changelog generation, "
+			skipSection = $"\n⏭️ No exclude labels are configured. To allow excluding PRs from release notes, "
 				+ $"add a label to {WrapInlineCode("rules.create.exclude")} in {configFileCode}.";
 		}
 
@@ -163,8 +163,7 @@ internal static class ChangelogCommentRenderer
 	/// Renders the "resolved" body posted when a previously-failing PR now has the required labels,
 	/// clearing the stale Step 1 comment and confirming what happens next.
 	/// </summary>
-	internal static string RenderResolved() =>
-		string.Join("\n", Title, "", "✅ **Changelog label set** — an entry will be generated on merge.");
+	internal static string RenderResolved() => string.Join("\n", Title, "", "✅ **Changelog label set** — release-notes status confirmed.");
 
 	// ──────────────────────────────────────────────────────────────────────────────────────────
 	// Injection-hardening helpers (ported from comment-helper.js)

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogCommentRenderer.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogCommentRenderer.cs
@@ -13,7 +13,7 @@ namespace Elastic.Changelog.Evaluation;
 /// <list type="bullet">
 ///   <item><c>post-success-comment.js</c> → <see cref="RenderEntryCommitted"/></item>
 ///   <item><c>post-comment-only.js</c>     → <see cref="RenderCommentOnly"/></item>
-///   <item><c>post-failure-comment.js</c>  → <see cref="RenderCannotGenerate"/></item>
+///   <item><c>post-failure-comment.js</c>  → <see cref="RenderLabelsNeeded"/></item>
 /// </list>
 /// </para>
 /// <para>
@@ -106,14 +106,15 @@ internal static class ChangelogCommentRenderer
 
 	/// <summary>
 	/// Renders the Step 1 (label gate) comment body: tells the author which labels are required
-	/// before a changelog entry can be generated. Tone is "labels not set yet", not "generation
-	/// failed" — the author just hasn't told us what type of change this is.
+	/// so the PR's release-notes status can be determined. Tone is "labels not set yet", not
+	/// "generation failed" — the author just hasn't told us what type of change this is.
 	/// <para>
-	/// Step 2 (changelog file invalid) and Step 3 (full require-changelog-file failure) will use
-	/// separate render methods added when those workflow paths are built.
+	/// Step 2 (changelog file invalid — <c>evaluate-pr</c>, <see cref="ValidationGate.File"/>)
+	/// and Step 3 (full require-changelog-file failure) will use separate render methods added
+	/// when those workflow paths are built.
 	/// </para>
 	/// </summary>
-	internal static string RenderCannotGenerate(string? labelTable, string? productLabelTable, string? skipLabels, string? configFile)
+	internal static string RenderLabelsNeeded(string? labelTable, string? productLabelTable, string? skipLabels, string? configFile)
 	{
 		var configFileCode = WrapInlineCode(string.IsNullOrWhiteSpace(configFile) ? "docs/changelog.yml" : configFile);
 

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogGithubCommentService.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogGithubCommentService.cs
@@ -108,11 +108,12 @@ public class ChangelogGithubCommentService(
 			);
 		}
 
-		// No label: cannot-generate body with label tables.
-		if (isNoLabel)
+		// Step 1 (label gate): labels are missing — tell the author which ones to add.
+		// Dispatches on Gate when present; falls back to status for artifacts written before Gate was added.
+		if (isNoLabel && metadata.Gate is null or ValidationGate.Labels)
 		{
-			_logger.LogInformation("Rendering cannot-generate body for PR #{PrNumber}", metadata.PrNumber);
-			return ChangelogCommentRenderer.RenderCannotGenerate(
+			_logger.LogInformation("Rendering labels-needed body for PR #{PrNumber}", metadata.PrNumber);
+			return ChangelogCommentRenderer.RenderLabelsNeeded(
 				metadata.LabelTable,
 				metadata.ProductLabelTable,
 				metadata.SkipLabels,

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogLabelValidationService.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogLabelValidationService.cs
@@ -118,6 +118,7 @@ public class ChangelogLabelValidationService(
 			{
 				var metadata = new GithubDecisionMetadata
 				{
+					Gate = ValidationGate.Labels,
 					PrNumber = input.PrNumber,
 					HeadRef = input.HeadRef,
 					HeadSha = input.HeadSha,

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogPrEvaluationService.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogPrEvaluationService.cs
@@ -257,6 +257,7 @@ public class ChangelogPrEvaluationService(
 
 		var metadata = new GithubDecisionMetadata
 		{
+			Gate = ValidationGate.File,
 			PrNumber = input.PrNumber,
 			HeadRef = input.HeadRef,
 			HeadSha = input.HeadSha,

--- a/src/services/Elastic.Changelog/Evaluation/GithubDecisionMetadata.cs
+++ b/src/services/Elastic.Changelog/Evaluation/GithubDecisionMetadata.cs
@@ -32,10 +32,29 @@ public record GithubDecisionMetadata
 	public string? ChangelogDir { get; init; }
 	public string? ChangelogFilename { get; init; }
 	public CreateRules? CreateRules { get; init; }
+	/// <summary>Which validation gate wrote this record. Null for artifacts written before this field was added.</summary>
+	public ValidationGate? Gate { get; init; }
 	/// <summary>Outcome of the changelog commit step, written by <c>changelog github-decision</c> after apply.</summary>
 	public CommitOutcome? CommitOutcome { get; init; }
 	/// <summary>Repo-relative path to the committed changelog file, when <see cref="CommitOutcome"/> is <c>Committed</c>.</summary>
 	public string? CommittedFile { get; init; }
+}
+
+/// <summary>
+/// Which validation gate wrote the metadata, used by the comment renderer to select the
+/// stage-appropriate body.
+/// <list type="bullet">
+///   <item><see cref="Labels"/> — written by <c>validate-labels</c> (Step 1: label gate).</item>
+///   <item><see cref="File"/> — written by <c>evaluate-pr</c> (Step 2: changelog file gate).</item>
+/// </list>
+/// Nullable on the record so artifacts without this field still deserialize.
+/// </summary>
+public enum ValidationGate
+{
+	/// <summary>Written by <c>validate-labels</c>. Only label presence is checked.</summary>
+	Labels,
+	/// <summary>Written by <c>evaluate-pr</c>. The changelog file is also evaluated.</summary>
+	File,
 }
 
 /// <summary>Outcome of the apply job's changelog commit step.</summary>
@@ -51,6 +70,7 @@ public enum CommitOutcome
 
 [JsonSourceGenerationOptions(WriteIndented = true, UseStringEnumConverter = true, PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
 [JsonSerializable(typeof(GithubDecisionMetadata))]
+[JsonSerializable(typeof(ValidationGate))]
 [JsonSerializable(typeof(CommitOutcome))]
 [JsonSerializable(typeof(CreateRules))]
 [JsonSerializable(typeof(FieldMode))]

--- a/tests/Elastic.Changelog.Tests/Evaluation/ChangelogCommentRendererTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/ChangelogCommentRendererTests.cs
@@ -64,27 +64,27 @@ public class ChangelogCommentRendererTests
 	}
 
 	[Fact]
-	public void RenderCannotGenerate_TypeMissing_ContainsTypeLabelHeadline()
+	public void RenderLabelsNeeded_TypeMissing_ContainsTypeLabelHeadline()
 	{
-		var body = ChangelogCommentRenderer.RenderCannotGenerate("| type:feature | feature |", null, null, null);
+		var body = ChangelogCommentRenderer.RenderLabelsNeeded("| type:feature | feature |", null, null, null);
 
 		body.Should().Contain("Changelog label needed");
 		body.Should().Contain("type:feature");
 	}
 
 	[Fact]
-	public void RenderCannotGenerate_ProductMissing_ContainsProductLabelHeadline()
+	public void RenderLabelsNeeded_ProductMissing_ContainsProductLabelHeadline()
 	{
-		var body = ChangelogCommentRenderer.RenderCannotGenerate(null, "| @Product:ECH | cloud |", null, null);
+		var body = ChangelogCommentRenderer.RenderLabelsNeeded(null, "| @Product:ECH | cloud |", null, null);
 
 		body.Should().Contain("Product label needed");
 		body.Should().Contain("@Product:ECH");
 	}
 
 	[Fact]
-	public void RenderCannotGenerate_BothMissing_ContainsBothTables()
+	public void RenderLabelsNeeded_BothMissing_ContainsBothTables()
 	{
-		var body = ChangelogCommentRenderer.RenderCannotGenerate("| type:feature | feature |", "| @Product:ECH | cloud |", null, null);
+		var body = ChangelogCommentRenderer.RenderLabelsNeeded("| type:feature | feature |", "| @Product:ECH | cloud |", null, null);
 
 		body.Should().Contain("Changelog labels needed");
 		body.Should().Contain("type:feature");
@@ -120,7 +120,7 @@ public class ChangelogCommentRendererTests
 	[Theory]
 	[InlineData("entry-committed")]
 	[InlineData("comment-only")]
-	[InlineData("cannot-generate")]
+	[InlineData("labels-needed")]
 	[InlineData("resolved")]
 	public void AllBodies_StartWithTitle(string variant)
 	{
@@ -128,7 +128,7 @@ public class ChangelogCommentRendererTests
 		{
 			"entry-committed" => ChangelogCommentRenderer.RenderEntryCommitted("owner", "repo", "main", "file.yaml"),
 			"comment-only" => ChangelogCommentRenderer.RenderCommentOnly(null, "type: feature", "42.yaml", false, false),
-			"cannot-generate" => ChangelogCommentRenderer.RenderCannotGenerate("| label | type |", null, null, null),
+			"labels-needed" => ChangelogCommentRenderer.RenderLabelsNeeded("| label | type |", null, null, null),
 			"resolved" => ChangelogCommentRenderer.RenderResolved(),
 			_ => throw new InvalidOperationException()
 		};

--- a/tests/Elastic.Changelog.Tests/Evaluation/ChangelogCommentRendererTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/ChangelogCommentRendererTests.cs
@@ -68,7 +68,7 @@ public class ChangelogCommentRendererTests
 	{
 		var body = ChangelogCommentRenderer.RenderCannotGenerate("| type:feature | feature |", null, null, null);
 
-		body.Should().Contain("no matching type label");
+		body.Should().Contain("Changelog label needed");
 		body.Should().Contain("type:feature");
 	}
 
@@ -77,7 +77,7 @@ public class ChangelogCommentRendererTests
 	{
 		var body = ChangelogCommentRenderer.RenderCannotGenerate(null, "| @Product:ECH | cloud |", null, null);
 
-		body.Should().Contain("no matching product label");
+		body.Should().Contain("Product label needed");
 		body.Should().Contain("@Product:ECH");
 	}
 
@@ -86,7 +86,7 @@ public class ChangelogCommentRendererTests
 	{
 		var body = ChangelogCommentRenderer.RenderCannotGenerate("| type:feature | feature |", "| @Product:ECH | cloud |", null, null);
 
-		body.Should().Contain("type and product labels are missing");
+		body.Should().Contain("Changelog labels needed");
 		body.Should().Contain("type:feature");
 		body.Should().Contain("@Product:ECH");
 	}

--- a/tests/Elastic.Changelog.Tests/Evaluation/ChangelogGithubCommentServiceTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/ChangelogGithubCommentServiceTests.cs
@@ -138,7 +138,7 @@ public class ChangelogGithubCommentServiceTests(ITestOutputHelper output) : Chan
 				A<string>._,
 				A<string>._,
 				A<int>._,
-				A<string>.That.Contains("Cannot generate changelog"),
+				A<string>.That.Contains("Changelog label needed"),
 				A<CancellationToken>._
 			)
 		).MustHaveHappenedOnceExactly();

--- a/tests/Elastic.Changelog.Tests/Evaluation/ChangelogGithubCommentServiceTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/ChangelogGithubCommentServiceTests.cs
@@ -119,7 +119,7 @@ public class ChangelogGithubCommentServiceTests(ITestOutputHelper output) : Chan
 	}
 
 	[Fact]
-	public async Task PostComment_NoLabel_RendersCannotGenerateBody()
+	public async Task PostComment_NoLabel_RendersLabelsNeededBody()
 	{
 		await WriteMetadata(BaseMetadata(status: "no-label") with
 		{


### PR DESCRIPTION
The Step 1 (label gate) PR comment said "⚠️ Cannot generate changelog: no matching type label found." That framing is wrong — the author hasn't done anything wrong, they just haven't labeled their PR yet. This retones the message to match the actual stage.

**Affects:** Release notes

## Why

Three distinct failure stages each warrant a distinct tone:

- **Step 1 (label gate, now):** The PR has no type label. The author needs to pick one. Tone: "labels not set yet."
- **Step 2 (file gate, future):** A changelog file exists but is invalid. Tone: "the file you checked in is not valid."
- **Step 3 (require-changelog-file path, future):** Full generation failed. Tone: "cannot generate."

Using "Cannot generate changelog" for Step 1 sounds like the system broke, not like the author has a simple next action. The label table already shows exactly what to do — the headline just needs to frame it correctly.

## What

#### Label-gate headline

The three headline variants in `RenderCannotGenerate` change from "⚠️ Cannot generate changelog: ..." to "🏷️ Changelog label needed — add a type label to this PR to enable changelog generation." The `⚠️` drops because this is not an error; `🏷️` signals the action type directly.

#### Resolved message

`RenderResolved` changes from "✅ Changelog labels validated successfully." (describes the check, not the outcome) to "✅ **Changelog label set** — an entry will be generated on merge." The author now knows what happens next.

#### Step 2 / Step 3 placement

The `RenderCannotGenerate` doc comment notes where Step 2 and Step 3 renderers will go, so the distinction is preserved for the next implementer.

## Verify

```bash
dotnet test tests/Elastic.Changelog.Tests/ --filter "ChangelogCommentRenderer|ChangelogGithubComment"
```