### PR TITLE
Changelog gate: delete comment on resolution, inline labels

### DIFF
--- a/src/services/Elastic.Changelog/Creation/PrInfoProcessor.cs
+++ b/src/services/Elastic.Changelog/Creation/PrInfoProcessor.cs
@@ -411,6 +411,15 @@ public class PrInfoProcessor(IGitHubPrService? githubPrService, ILogger logger)
 			mappedType => mappedType != null
 		);
 
+	/// <summary>
+	/// Returns every label in <paramref name="labels"/> that has a mapping in
+	/// <paramref name="labelToTypeMapping"/>. More than one result means the PR carries conflicting
+	/// type labels; callers should surface this as an actionable error rather than silently picking
+	/// the first match.
+	/// </summary>
+	internal static IReadOnlyList<string> MatchingTypeLabels(string[] labels, IReadOnlyDictionary<string, string> labelToTypeMapping) =>
+		labels.Where(labelToTypeMapping.ContainsKey).ToList();
+
 	internal static List<string> MapLabelsToAreas(string[] labels, IReadOnlyDictionary<string, IReadOnlyList<string>> labelToAreasMapping)
 	{
 		var areas = new HashSet<string>();

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogCommentRenderer.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogCommentRenderer.cs
@@ -162,9 +162,16 @@ internal static class ChangelogCommentRenderer
 
 	/// <summary>
 	/// Renders the "resolved" body posted when a previously-failing PR now has the required labels,
-	/// clearing the stale Step 1 comment and confirming what happens next.
+	/// clearing the stale Step 1 comment and confirming the release-notes status is determined.
 	/// </summary>
 	internal static string RenderResolved() => string.Join("\n", Title, "", "✅ **Changelog label set** — release-notes status confirmed.");
+
+	/// <summary>
+	/// Renders the "skipped" body posted when a PR carries a <c>changelog:skip</c> label,
+	/// clearing any stale failure comment left from before the skip label was added.
+	/// </summary>
+	internal static string RenderSkipped() =>
+		string.Join("\n", Title, "", "⏭️ **Excluded from release notes** — this PR will not appear in the changelog.");
 
 	// ──────────────────────────────────────────────────────────────────────────────────────────
 	// Injection-hardening helpers (ported from comment-helper.js)

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogCommentRenderer.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogCommentRenderer.cs
@@ -114,22 +114,39 @@ internal static class ChangelogCommentRenderer
 	/// when those workflow paths are built.
 	/// </para>
 	/// </summary>
-	internal static string RenderLabelsNeeded(string? labelTable, string? productLabelTable, string? skipLabels, string? configFile)
+	internal static string RenderLabelsNeeded(
+		string? labelTable,
+		string? productLabelTable,
+		string? skipLabels,
+		string? configFile,
+		string? ambiguousTypeLabels = null
+	)
 	{
 		var configFileCode = WrapInlineCode(string.IsNullOrWhiteSpace(configFile) ? "docs/changelog.yml" : configFile);
 
+		var hasAmbiguousType = !string.IsNullOrWhiteSpace(ambiguousTypeLabels);
 		var hasTypeIssue = !string.IsNullOrWhiteSpace(labelTable);
 		var hasProductIssue = !string.IsNullOrWhiteSpace(productLabelTable);
 
-		var headline = hasTypeIssue && hasProductIssue
-			? "🏷️ **Changelog labels needed** — add type and product labels so we can determine this PR's release-notes status."
-			: hasProductIssue
-				? "🏷️ **Product label needed** — add a product label so we can determine this PR's release-notes status."
-				: "🏷️ **Changelog label needed** — add a type label so we can determine this PR's release-notes status.";
+		var headline = hasAmbiguousType
+			? "🏷️ **Multiple type labels set** — a PR can only have one type. Remove all but one."
+			: hasTypeIssue && hasProductIssue
+				? "🏷️ **Changelog labels needed** — add type and product labels so we can determine this PR's release-notes status."
+				: hasProductIssue
+					? "🏷️ **Product label needed** — add a product label so we can determine this PR's release-notes status."
+					: "🏷️ **Changelog label needed** — add a type label so we can determine this PR's release-notes status.";
 
 		var sections = new List<string>();
 
-		if (hasTypeIssue)
+		if (hasAmbiguousType)
+		{
+			var conflicting = ambiguousTypeLabels!.Split(
+				',',
+				StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
+			).Select(WrapInlineCode);
+			sections.Add($"\n🔖 Conflicting type labels found: {string.Join(", ", conflicting)}. Keep only one.");
+		}
+		else if (hasTypeIssue)
 			sections.Add(string.Join("\n", "", "🔖 Add one of these **type** labels to your PR:", "", labelTable));
 		else if (!hasProductIssue)
 			sections.Add($"\nAdd a type label that matches your {WrapInlineCode("pivot.types")} configuration in {configFileCode}.");

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogCommentRenderer.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogCommentRenderer.cs
@@ -119,10 +119,16 @@ internal static class ChangelogCommentRenderer
 		string? productLabelTable,
 		string? skipLabels,
 		string? configFile,
-		string? ambiguousTypeLabels = null
+		string? ambiguousTypeLabels = null,
+		string? owner = null,
+		string? repo = null,
+		string? defaultBranch = null
 	)
 	{
-		var configFileCode = WrapInlineCode(string.IsNullOrWhiteSpace(configFile) ? "docs/changelog.yml" : configFile);
+		var configFileName = string.IsNullOrWhiteSpace(configFile) ? "docs/changelog.yml" : configFile;
+		var configRef = !string.IsNullOrWhiteSpace(owner) && !string.IsNullOrWhiteSpace(repo)
+			? $"[{configFileName}](https://github.com/{owner}/{repo}/blob/{defaultBranch ?? "main"}/{configFileName})"
+			: WrapInlineCode(configFileName);
 
 		var hasAmbiguousType = !string.IsNullOrWhiteSpace(ambiguousTypeLabels);
 		var hasTypeIssue = !string.IsNullOrWhiteSpace(labelTable);
@@ -147,9 +153,14 @@ internal static class ChangelogCommentRenderer
 			sections.Add($"\n🔖 Conflicting type labels found: {string.Join(", ", conflicting)}. Keep only one.");
 		}
 		else if (hasTypeIssue)
-			sections.Add(string.Join("\n", "", "🔖 Add one of these **type** labels to your PR:", "", labelTable));
+		{
+			var inlineLabels = labelTable!.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Select(
+				WrapInlineCode
+			);
+			sections.Add($"\n🔖 Add one of these type labels to your PR: {string.Join(", ", inlineLabels)}");
+		}
 		else if (!hasProductIssue)
-			sections.Add($"\nAdd a type label that matches your {WrapInlineCode("pivot.types")} configuration in {configFileCode}.");
+			sections.Add($"\nAdd a type label that matches your {WrapInlineCode("pivot.types")} configuration in {configRef}.");
 
 		if (hasProductIssue)
 			sections.Add(string.Join("\n", "", "📦 Add one or more **product** labels to your PR:", "", productLabelTable));
@@ -165,14 +176,14 @@ internal static class ChangelogCommentRenderer
 		else
 		{
 			skipSection = $"\n⏭️ No exclude labels are configured. To allow excluding PRs from release notes, "
-				+ $"add a label to {WrapInlineCode("rules.create.exclude")} in {configFileCode}.";
+				+ $"add a label to {WrapInlineCode("rules.create.exclude")} in {configRef}.";
 		}
 
 		var allParts = new List<string> { Title, "", headline };
 		allParts.AddRange(sections);
 		allParts.Add(skipSection);
 		allParts.Add("");
-		allParts.Add($"📄 See {configFileCode} for the full changelog configuration.");
+		allParts.Add($"📄 See {configRef} for the full changelog configuration.");
 
 		return Truncate(string.Join("\n", allParts));
 	}

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogGithubCommentService.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogGithubCommentService.cs
@@ -53,11 +53,12 @@ public class ChangelogGithubCommentService(
 		var body = SelectBody(metadata, input.MetadataDir);
 		if (body is null)
 		{
-			if (IsSuccess(metadata.Status))
+			if (IsSuccess(metadata.Status) || IsSkipped(metadata.Status))
 			{
 				_logger.LogInformation(
-					"Labels validated for PR #{PrNumber} — deleting stale failure comment if present",
-					metadata.PrNumber
+					"PR #{PrNumber} is {Status} — deleting stale failure comment if present",
+					metadata.PrNumber,
+					metadata.Status
 				);
 				_ = await commentService.DeleteStickyCommentAsync(owner, repo, metadata.PrNumber, ctx);
 			}
@@ -68,17 +69,7 @@ public class ChangelogGithubCommentService(
 
 		var nodeId = await commentService.UpsertStickyCommentAsync(owner, repo, metadata.PrNumber, body, ctx);
 		if (nodeId is null)
-		{
 			_logger.LogWarning("Comment post did not succeed for PR #{PrNumber} — continuing", metadata.PrNumber);
-			return true;
-		}
-
-		// Minimize skipped comments so they are hidden (collapsed as 'resolved') on GitHub.
-		// Unminimize everything else so a previously-hidden comment resurfaces when the author
-		// removes the skip label and the PR goes back to needing labels.
-		_ = IsSkipped(metadata.Status)
-			? await commentService.MinimizeCommentAsync(nodeId, ctx)
-			: await commentService.UnminimizeCommentAsync(nodeId, ctx);
 
 		return true;
 	}
@@ -141,17 +132,7 @@ public class ChangelogGithubCommentService(
 			);
 		}
 
-		// Success with no staged file: signal to delete the sticky comment (no body needed).
-		if (isSuccess)
-			return null;
-
-		// Skipped: clear any stale failure comment.
-		if (IsSkipped(metadata.Status))
-		{
-			_logger.LogInformation("Rendering skipped body for PR #{PrNumber}", metadata.PrNumber);
-			return ChangelogCommentRenderer.RenderSkipped();
-		}
-
+		// Success or skipped: signal to delete the sticky comment (no body needed).
 		return null;
 	}
 

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogGithubCommentService.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogGithubCommentService.cs
@@ -50,7 +50,7 @@ public class ChangelogGithubCommentService(
 		var owner = input.Owner;
 		var repo = input.Repo;
 
-		var body = SelectBody(metadata, input.MetadataDir);
+		var body = SelectBody(metadata, input.MetadataDir, owner, repo);
 		if (body is null)
 		{
 			if (IsSuccess(metadata.Status) || IsSkipped(metadata.Status))
@@ -74,7 +74,7 @@ public class ChangelogGithubCommentService(
 		return true;
 	}
 
-	private string? SelectBody(GithubDecisionMetadata metadata, string metadataDir)
+	private string? SelectBody(GithubDecisionMetadata metadata, string metadataDir, string owner, string repo)
 	{
 		// Committed: entry-committed body with blob + edit links.
 		if (metadata.CommitOutcome == CommitOutcome.Committed && !string.IsNullOrWhiteSpace(metadata.CommittedFile))
@@ -129,7 +129,10 @@ public class ChangelogGithubCommentService(
 				metadata.ProductLabelTable,
 				metadata.SkipLabels,
 				metadata.ConfigFile,
-				metadata.AmbiguousTypeLabels
+				metadata.AmbiguousTypeLabels,
+				owner,
+				repo,
+				metadata.DefaultBranch
 			);
 		}
 

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogGithubCommentService.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogGithubCommentService.cs
@@ -56,9 +56,19 @@ public class ChangelogGithubCommentService(
 			return true;
 		}
 
-		var posted = await commentService.UpsertStickyCommentAsync(owner, repo, metadata.PrNumber, body, ctx);
-		if (!posted)
+		var nodeId = await commentService.UpsertStickyCommentAsync(owner, repo, metadata.PrNumber, body, ctx);
+		if (nodeId is null)
+		{
 			_logger.LogWarning("Comment post did not succeed for PR #{PrNumber} — continuing", metadata.PrNumber);
+			return true;
+		}
+
+		// Minimize skipped comments so they are hidden (collapsed as 'resolved') on GitHub.
+		// Unminimize everything else so a previously-hidden comment resurfaces when the author
+		// removes the skip label and the PR goes back to needing labels.
+		_ = IsSkipped(metadata.Status)
+			? await commentService.MinimizeCommentAsync(nodeId, ctx)
+			: await commentService.UnminimizeCommentAsync(nodeId, ctx);
 
 		return true;
 	}

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogGithubCommentService.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogGithubCommentService.cs
@@ -18,8 +18,9 @@ namespace Elastic.Changelog.Evaluation;
 ///   <item><term><c>CommitOutcome == Committed</c></term><description>Entry-committed body with blob + edit links.</description></item>
 ///   <item><term><c>CommitOutcome == Failed</c></term><description>Comment-only body, commit-failed variant.</description></item>
 ///   <item><term>Status success and <c>!CanCommit</c></term><description>Comment-only body (fork / comment-only strategy).</description></item>
-///   <item><term>Status no-label</term><description>Cannot-generate body with label tables.</description></item>
-///   <item><term>Status success, no staged file</term><description>Resolved body (clears a stale failure comment).</description></item>
+///   <item><term>Status no-label</term><description>Labels-needed body with label tables.</description></item>
+///   <item><term>Status skipped</term><description>Skipped body (hidden as 'resolved') to clear stale failure comment.</description></item>
+///   <item><term>Status success, no staged file</term><description>Deletes the sticky comment — no need to litter once labels are validated.</description></item>
 /// </list>
 /// </summary>
 public class ChangelogGithubCommentService(
@@ -52,7 +53,16 @@ public class ChangelogGithubCommentService(
 		var body = SelectBody(metadata, input.MetadataDir);
 		if (body is null)
 		{
-			_logger.LogInformation("No comment body selected for PR #{PrNumber} — nothing to post", metadata.PrNumber);
+			if (IsSuccess(metadata.Status))
+			{
+				_logger.LogInformation(
+					"Labels validated for PR #{PrNumber} — deleting stale failure comment if present",
+					metadata.PrNumber
+				);
+				_ = await commentService.DeleteStickyCommentAsync(owner, repo, metadata.PrNumber, ctx);
+			}
+			else
+				_logger.LogInformation("No comment body selected for PR #{PrNumber} — nothing to post", metadata.PrNumber);
 			return true;
 		}
 
@@ -131,12 +141,9 @@ public class ChangelogGithubCommentService(
 			);
 		}
 
-		// Success with no staged file: post resolved body to clear a stale failure comment.
+		// Success with no staged file: signal to delete the sticky comment (no body needed).
 		if (isSuccess)
-		{
-			_logger.LogInformation("Rendering resolved body for PR #{PrNumber}", metadata.PrNumber);
-			return ChangelogCommentRenderer.RenderResolved();
-		}
+			return null;
 
 		// Skipped: clear any stale failure comment.
 		if (IsSkipped(metadata.Status))

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogGithubCommentService.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogGithubCommentService.cs
@@ -128,6 +128,13 @@ public class ChangelogGithubCommentService(
 			return ChangelogCommentRenderer.RenderResolved();
 		}
 
+		// Skipped: clear any stale failure comment.
+		if (IsSkipped(metadata.Status))
+		{
+			_logger.LogInformation("Rendering skipped body for PR #{PrNumber}", metadata.PrNumber);
+			return ChangelogCommentRenderer.RenderSkipped();
+		}
+
 		return null;
 	}
 
@@ -161,6 +168,7 @@ public class ChangelogGithubCommentService(
 			|| string.Equals(status, "ok", StringComparison.OrdinalIgnoreCase);
 
 	private static bool IsNoLabel(string status) => string.Equals(status, "no-label", StringComparison.OrdinalIgnoreCase);
+	private static bool IsSkipped(string status) => string.Equals(status, "skipped", StringComparison.OrdinalIgnoreCase);
 }
 
 /// <summary>Arguments for the hidden <c>changelog github-comment</c> command.</summary>

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogGithubCommentService.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogGithubCommentService.cs
@@ -128,7 +128,8 @@ public class ChangelogGithubCommentService(
 				metadata.LabelTable,
 				metadata.ProductLabelTable,
 				metadata.SkipLabels,
-				metadata.ConfigFile
+				metadata.ConfigFile,
+				metadata.AmbiguousTypeLabels
 			);
 		}
 

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogLabelValidationService.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogLabelValidationService.cs
@@ -41,6 +41,7 @@ public class ChangelogLabelValidationService(
 	public async Task<bool> ValidateLabels(IDiagnosticsCollector collector, ValidateLabelsArguments input, Cancel ctx)
 	{
 		var config = await _configLoader.LoadChangelogConfiguration(collector, input.Config, ctx) ?? ChangelogConfiguration.Default;
+		var defaultBranch = config.Bundle?.Branch ?? "main";
 
 		// Label-based skip check: all products blocked → skipped
 		var skipLabels = ChangelogPrEvaluationService.CollectExcludeLabels(config.Rules?.Create);
@@ -67,7 +68,12 @@ public class ChangelogLabelValidationService(
 		{
 			_logger.LogInformation("Multiple type labels found on PR: {Labels}", ambiguousTypeLabels);
 			collector.EmitError(string.Empty, $"Multiple type labels found: {ambiguousTypeLabels}. Remove all but one.");
-			await Finish("no-label", ambiguousTypeLabels: ambiguousTypeLabels, skipLabels: skipLabels);
+			await Finish(
+				"no-label",
+				ambiguousTypeLabels: ambiguousTypeLabels,
+				skipLabels: skipLabels,
+				labelKeys: ChangelogPrEvaluationService.BuildLabelKeys(config.LabelToType)
+			);
 			return false;
 		}
 
@@ -99,7 +105,14 @@ public class ChangelogLabelValidationService(
 				"No matching changelog type label found on this PR. Add a label from your changelog.yml pivot.types, or a skip label."
 			);
 			var labelTable = ChangelogPrEvaluationService.BuildLabelTable(config.LabelToType);
-			await Finish("no-label", labelTable: labelTable, productLabelTable: productLabelTable, skipLabels: skipLabels);
+			var labelKeys = ChangelogPrEvaluationService.BuildLabelKeys(config.LabelToType);
+			await Finish(
+				"no-label",
+				labelTable: labelTable,
+				labelKeys: labelKeys,
+				productLabelTable: productLabelTable,
+				skipLabels: skipLabels
+			);
 			return false;
 		}
 
@@ -123,6 +136,7 @@ public class ChangelogLabelValidationService(
 			string? type = null,
 			string? products = null,
 			string? labelTable = null,
+			string? labelKeys = null,
 			string? productLabelTable = null,
 			string? skipLabels = null,
 			string? ambiguousTypeLabels = null
@@ -143,11 +157,12 @@ public class ChangelogLabelValidationService(
 					CanCommit = input.CanCommit,
 					MaintainerCanModify = input.MaintainerCanModify,
 					HeadRepo = input.HeadRepo,
-					LabelTable = labelTable,
+					LabelTable = labelKeys ?? labelTable,
 					ProductLabelTable = productLabelTable,
 					SkipLabels = skipLabels,
 					ConfigFile = input.ConfigFile,
-					AmbiguousTypeLabels = ambiguousTypeLabels
+					AmbiguousTypeLabels = ambiguousTypeLabels,
+					DefaultBranch = defaultBranch
 				};
 				await _metadataWriter.WriteAsync(metadata, ctx);
 			}

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogLabelValidationService.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogLabelValidationService.cs
@@ -51,10 +51,25 @@ public class ChangelogLabelValidationService(
 			return true;
 		}
 
-		// Resolve type
+		// Resolve type — detect multiple matching labels before picking one
 		string? resolvedType = null;
+		string? ambiguousTypeLabels = null;
 		if (config.LabelToType is { Count: > 0 })
-			resolvedType = PrInfoProcessor.MapLabelsToType(input.PrLabels, config.LabelToType);
+		{
+			var matching = PrInfoProcessor.MatchingTypeLabels(input.PrLabels, config.LabelToType);
+			if (matching.Count > 1)
+				ambiguousTypeLabels = string.Join(",", matching);
+			else
+				resolvedType = matching.Count == 1 ? config.LabelToType[matching[0]] : null;
+		}
+
+		if (ambiguousTypeLabels != null)
+		{
+			_logger.LogInformation("Multiple type labels found on PR: {Labels}", ambiguousTypeLabels);
+			collector.EmitError(string.Empty, $"Multiple type labels found: {ambiguousTypeLabels}. Remove all but one.");
+			await Finish("no-label", ambiguousTypeLabels: ambiguousTypeLabels, skipLabels: skipLabels);
+			return false;
+		}
 
 		// Resolve products
 		string? resolvedProducts = null;
@@ -109,10 +124,11 @@ public class ChangelogLabelValidationService(
 			string? products = null,
 			string? labelTable = null,
 			string? productLabelTable = null,
-			string? skipLabels = null
+			string? skipLabels = null,
+			string? ambiguousTypeLabels = null
 		)
 		{
-			_ = await SetOutputs(status, type, products, labelTable, productLabelTable, skipLabels);
+			_ = await SetOutputs(status, type, products, labelTable, productLabelTable, skipLabels, ambiguousTypeLabels);
 
 			if (env?.IsRunningOnCI == true && input.PrNumber > 0)
 			{
@@ -130,7 +146,8 @@ public class ChangelogLabelValidationService(
 					LabelTable = labelTable,
 					ProductLabelTable = productLabelTable,
 					SkipLabels = skipLabels,
-					ConfigFile = input.ConfigFile
+					ConfigFile = input.ConfigFile,
+					AmbiguousTypeLabels = ambiguousTypeLabels
 				};
 				await _metadataWriter.WriteAsync(metadata, ctx);
 			}
@@ -143,7 +160,8 @@ public class ChangelogLabelValidationService(
 		string? products = null,
 		string? labelTable = null,
 		string? productLabelTable = null,
-		string? skipLabels = null
+		string? skipLabels = null,
+		string? ambiguousTypeLabels = null
 	)
 	{
 		await coreService.SetOutputAsync("status", status);
@@ -163,6 +181,11 @@ public class ChangelogLabelValidationService(
 			);
 		if (skipLabels != null)
 			await coreService.SetOutputAsync("skip-labels", OutputSanitizer.SanitizeForOutput(skipLabels, OutputSanitizer.LabelsMaxLength));
+		if (ambiguousTypeLabels != null)
+			await coreService.SetOutputAsync(
+				"ambiguous-type-labels",
+				OutputSanitizer.SanitizeForOutput(ambiguousTypeLabels, OutputSanitizer.LabelsMaxLength)
+			);
 		return true;
 	}
 }

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogPrEvaluationService.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogPrEvaluationService.cs
@@ -112,10 +112,26 @@ public class ChangelogPrEvaluationService(
 			return false;
 		}
 
-		// Resolve type
+		// Resolve type — detect multiple matching labels before picking one
 		string? resolvedType = null;
+		string? ambiguousTypeLabels = null;
 		if (config.LabelToType is { Count: > 0 })
-			resolvedType = PrInfoProcessor.MapLabelsToType(input.PrLabels, config.LabelToType);
+		{
+			var matching = PrInfoProcessor.MatchingTypeLabels(input.PrLabels, config.LabelToType);
+			if (matching.Count > 1)
+				ambiguousTypeLabels = string.Join(",", matching);
+			else
+				resolvedType = matching.Count == 1 ? config.LabelToType[matching[0]] : null;
+		}
+
+		if (ambiguousTypeLabels != null)
+		{
+			_logger.LogInformation("Multiple type labels found on PR: {Labels}", ambiguousTypeLabels);
+			collector.EmitError(string.Empty, $"Multiple type labels found: {ambiguousTypeLabels}. Remove all but one.");
+			_ = await SetOutputs(PrEvaluationResult.NoLabel, skipLabels: skipLabels);
+			await WriteDecisionMetadataAsync(input, "no-label", ambiguousTypeLabels: ambiguousTypeLabels, skipLabels: skipLabels, ctx: ctx);
+			return false;
+		}
 
 		// Resolve products from labels
 		string? resolvedProducts = null;
@@ -249,7 +265,8 @@ public class ChangelogPrEvaluationService(
 		string? productLabelTable = null,
 		string? skipLabels = null,
 		string? changelogDir = null,
-		string? changelogFilename = null
+		string? changelogFilename = null,
+		string? ambiguousTypeLabels = null
 	)
 	{
 		if (env?.IsRunningOnCI != true || input.PrNumber <= 0)
@@ -270,7 +287,8 @@ public class ChangelogPrEvaluationService(
 			ProductLabelTable = productLabelTable,
 			SkipLabels = skipLabels,
 			ChangelogDir = changelogDir,
-			ChangelogFilename = changelogFilename
+			ChangelogFilename = changelogFilename,
+			AmbiguousTypeLabels = ambiguousTypeLabels
 		};
 		await _metadataWriter.WriteAsync(metadata, ctx);
 	}

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogPrEvaluationService.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogPrEvaluationService.cs
@@ -45,6 +45,7 @@ public class ChangelogPrEvaluationService(
 
 		var config = await _configLoader.LoadChangelogConfiguration(collector, input.Config, ctx) ?? ChangelogConfiguration.Default;
 		var changelogDir = config.Bundle?.Directory ?? "docs/changelog";
+		var defaultBranch = config.Bundle?.Branch ?? "main";
 
 		// Commit bot loop detection
 		if (input.EventAction == "synchronize")
@@ -129,7 +130,14 @@ public class ChangelogPrEvaluationService(
 			_logger.LogInformation("Multiple type labels found on PR: {Labels}", ambiguousTypeLabels);
 			collector.EmitError(string.Empty, $"Multiple type labels found: {ambiguousTypeLabels}. Remove all but one.");
 			_ = await SetOutputs(PrEvaluationResult.NoLabel, skipLabels: skipLabels);
-			await WriteDecisionMetadataAsync(input, "no-label", ambiguousTypeLabels: ambiguousTypeLabels, skipLabels: skipLabels, ctx: ctx);
+			await WriteDecisionMetadataAsync(
+				input,
+				"no-label",
+				ambiguousTypeLabels: ambiguousTypeLabels,
+				skipLabels: skipLabels,
+				defaultBranch: defaultBranch,
+				ctx: ctx
+			);
 			return false;
 		}
 
@@ -178,9 +186,10 @@ public class ChangelogPrEvaluationService(
 			await WriteDecisionMetadataAsync(
 				input,
 				"no-label",
-				labelTable: noTypeLabelTable,
+				labelTable: BuildLabelKeys(config.LabelToType),
 				productLabelTable: productLabelTable,
 				skipLabels: skipLabels,
+				defaultBranch: defaultBranch,
 				ctx: ctx
 			);
 			return false;
@@ -204,7 +213,14 @@ public class ChangelogPrEvaluationService(
 				productLabelTable: productLabelTable,
 				skipLabels: skipLabels
 			);
-			await WriteDecisionMetadataAsync(input, "no-label", productLabelTable: productLabelTable, skipLabels: skipLabels, ctx: ctx);
+			await WriteDecisionMetadataAsync(
+				input,
+				"no-label",
+				productLabelTable: productLabelTable,
+				skipLabels: skipLabels,
+				defaultBranch: defaultBranch,
+				ctx: ctx
+			);
 			return false;
 		}
 
@@ -235,6 +251,7 @@ public class ChangelogPrEvaluationService(
 			changelogDir: changelogDir,
 			changelogFilename: existingFilename,
 			skipLabels: skipLabels,
+			defaultBranch: defaultBranch,
 			ctx: ctx
 		);
 		return await SetOutputs(
@@ -266,7 +283,8 @@ public class ChangelogPrEvaluationService(
 		string? skipLabels = null,
 		string? changelogDir = null,
 		string? changelogFilename = null,
-		string? ambiguousTypeLabels = null
+		string? ambiguousTypeLabels = null,
+		string? defaultBranch = null
 	)
 	{
 		if (env?.IsRunningOnCI != true || input.PrNumber <= 0)
@@ -288,7 +306,8 @@ public class ChangelogPrEvaluationService(
 			SkipLabels = skipLabels,
 			ChangelogDir = changelogDir,
 			ChangelogFilename = changelogFilename,
-			AmbiguousTypeLabels = ambiguousTypeLabels
+			AmbiguousTypeLabels = ambiguousTypeLabels,
+			DefaultBranch = defaultBranch
 		};
 		await _metadataWriter.WriteAsync(metadata, ctx);
 	}
@@ -419,6 +438,9 @@ public class ChangelogPrEvaluationService(
 
 	internal static string BuildLabelTable(IReadOnlyDictionary<string, string>? labelToType) =>
 		ChangelogTableRenderers.BuildLabelTable(labelToType);
+
+	internal static string BuildLabelKeys(IReadOnlyDictionary<string, string>? labelToType) =>
+		ChangelogTableRenderers.BuildLabelKeys(labelToType);
 
 	internal static string BuildProductLabelTable(IReadOnlyDictionary<string, string>? labelToProducts) =>
 		ChangelogTableRenderers.BuildProductLabelTable(labelToProducts);

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogTableRenderers.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogTableRenderers.cs
@@ -13,6 +13,12 @@ internal static class ChangelogTableRenderers
 	internal static string BuildLabelTable(IReadOnlyDictionary<string, string>? labelToType) =>
 		BuildMappingTable(labelToType, "Label", "Type");
 
+	/// <summary>
+	/// Returns a comma-separated list of label keys for inline rendering in PR comments.
+	/// </summary>
+	internal static string BuildLabelKeys(IReadOnlyDictionary<string, string>? labelToType) =>
+		labelToType is { Count: > 0 } ? string.Join(",", labelToType.Keys) : "";
+
 	internal static string BuildProductLabelTable(IReadOnlyDictionary<string, string>? labelToProducts) =>
 		BuildMappingTable(labelToProducts, "Label", "Product");
 

--- a/src/services/Elastic.Changelog/Evaluation/GithubDecisionMetadata.cs
+++ b/src/services/Elastic.Changelog/Evaluation/GithubDecisionMetadata.cs
@@ -31,6 +31,8 @@ public record GithubDecisionMetadata
 	/// <summary>Comma-separated list of type labels that all matched when only one is allowed.</summary>
 	public string? AmbiguousTypeLabels { get; init; }
 	public string? ConfigFile { get; init; }
+	/// <summary>Default branch for building config file links (e.g. "main"). Defaults to "main" when null.</summary>
+	public string? DefaultBranch { get; init; }
 	public string? ChangelogDir { get; init; }
 	public string? ChangelogFilename { get; init; }
 	public CreateRules? CreateRules { get; init; }

--- a/src/services/Elastic.Changelog/Evaluation/GithubDecisionMetadata.cs
+++ b/src/services/Elastic.Changelog/Evaluation/GithubDecisionMetadata.cs
@@ -28,6 +28,8 @@ public record GithubDecisionMetadata
 	public string? LabelTable { get; init; }
 	public string? ProductLabelTable { get; init; }
 	public string? SkipLabels { get; init; }
+	/// <summary>Comma-separated list of type labels that all matched when only one is allowed.</summary>
+	public string? AmbiguousTypeLabels { get; init; }
 	public string? ConfigFile { get; init; }
 	public string? ChangelogDir { get; init; }
 	public string? ChangelogFilename { get; init; }

--- a/src/services/Elastic.Changelog/GitHub/GitHubApiTransport.cs
+++ b/src/services/Elastic.Changelog/GitHub/GitHubApiTransport.cs
@@ -104,6 +104,18 @@ public sealed class GitHubApiTransport : IDisposable
 	}
 
 	/// <summary>
+	/// Issues an authenticated DELETE against a GitHub REST API endpoint.
+	/// The caller owns the response and its status-code policy.
+	/// </summary>
+	public async Task<HttpResponseMessage> DeleteAsync(string url, Cancel ctx = default)
+	{
+		using var request = new HttpRequestMessage(HttpMethod.Delete, url);
+		request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+		AttachAuthorization(request);
+		return await _httpClient.SendAsync(request, ctx).ConfigureAwait(false);
+	}
+
+	/// <summary>
 	/// Posts a JSON body to the GitHub GraphQL endpoint. The GraphQL API rejects anonymous
 	/// requests, so callers should verify <see cref="ResolveToken"/> before building queries.
 	/// </summary>

--- a/src/services/Elastic.Changelog/GitHub/GitHubCommentService.cs
+++ b/src/services/Elastic.Changelog/GitHub/GitHubCommentService.cs
@@ -160,6 +160,38 @@ public partial class GitHubCommentService(ILoggerFactory loggerFactory, GitHubAp
 		}
 	}
 
+	/// <inheritdoc />
+	public async Task<bool> DeleteStickyCommentAsync(string owner, string repo, int prNumber, Cancel ctx = default)
+	{
+		try
+		{
+			var existing = await FindExistingCommentAsync(owner, repo, prNumber, ctx);
+			if (!existing.HasValue)
+				return true;
+
+			var deleteUrl = $"https://api.github.com/repos/{owner}/{repo}/issues/comments/{existing.Value.Id}";
+			using var response = await _transport.DeleteAsync(deleteUrl, ctx);
+			if (!response.IsSuccessStatusCode)
+			{
+				_logger.LogWarning(
+					"Failed to delete comment {CommentId} on PR #{PrNumber}: {Status}",
+					existing.Value.Id,
+					prNumber,
+					(int)response.StatusCode
+				);
+				return false;
+			}
+
+			_logger.LogInformation("Deleted changelog comment {CommentId} on PR #{PrNumber}", existing.Value.Id, prNumber);
+			return true;
+		}
+		catch (Exception ex) when (ex is not (OutOfMemoryException or StackOverflowException or ThreadAbortException))
+		{
+			_logger.LogWarning(ex, "Unexpected error deleting changelog comment on PR #{PrNumber}", prNumber);
+			return false;
+		}
+	}
+
 	/// <summary>
 	/// Paginates through all PR comments and returns the ID and node_id of the first comment that
 	/// matches either the HTML marker or the legacy title prefix; <c>null</c> when none is found.

--- a/src/services/Elastic.Changelog/GitHub/GitHubCommentService.cs
+++ b/src/services/Elastic.Changelog/GitHub/GitHubCommentService.cs
@@ -25,7 +25,7 @@ namespace Elastic.Changelog.GitHub;
 /// </para>
 /// <para>
 /// Failure policy: a transient error (rate-limit, 403, network blip) logs a warning and returns
-/// <c>false</c> without calling <c>EmitError</c>. Never let a comment failure flip the verdict.
+/// <c>null</c> without calling <c>EmitError</c>. Never let a comment failure flip the verdict.
 /// </para>
 /// </summary>
 public partial class GitHubCommentService(ILoggerFactory loggerFactory, GitHubApiTransport? transport = null) : IGitHubCommentService
@@ -47,32 +47,33 @@ public partial class GitHubCommentService(ILoggerFactory loggerFactory, GitHubAp
 	private readonly GitHubApiTransport _transport = transport ?? new GitHubApiTransport();
 
 	/// <inheritdoc />
-	public async Task<bool> UpsertStickyCommentAsync(string owner, string repo, int prNumber, string body, Cancel ctx = default)
+	public async Task<string?> UpsertStickyCommentAsync(string owner, string repo, int prNumber, string body, Cancel ctx = default)
 	{
 		var markedBody = body.TrimEnd() + "\n" + HtmlMarker;
 
 		try
 		{
-			var existingId = await FindExistingCommentIdAsync(owner, repo, prNumber, ctx);
+			var existing = await FindExistingCommentAsync(owner, repo, prNumber, ctx);
 
-			if (existingId.HasValue)
+			if (existing.HasValue)
 			{
-				var updateUrl = $"https://api.github.com/repos/{owner}/{repo}/issues/comments/{existingId.Value}";
+				var updateUrl = $"https://api.github.com/repos/{owner}/{repo}/issues/comments/{existing.Value.Id}";
 				var updatePayload = JsonSerializer.Serialize(new CommentBody { Body = markedBody }, CommentJsonContext.Default.CommentBody);
 				using var updateResponse = await _transport.PatchAsync(updateUrl, updatePayload, ctx);
 				if (!updateResponse.IsSuccessStatusCode)
 				{
 					_logger.LogWarning(
 						"Failed to update comment {CommentId} on PR #{PrNumber}: {Status}",
-						existingId.Value,
+						existing.Value.Id,
 						prNumber,
 						(int)updateResponse.StatusCode
 					);
-					return false;
+					return null;
 				}
 
-				_logger.LogInformation("Updated changelog comment {CommentId} on PR #{PrNumber}", existingId.Value, prNumber);
-				return true;
+				var nodeId = await ParseNodeIdAsync(updateResponse, ctx);
+				_logger.LogInformation("Updated changelog comment {CommentId} on PR #{PrNumber}", existing.Value.Id, prNumber);
+				return nodeId ?? existing.Value.NodeId;
 			}
 
 			var createUrl = $"https://api.github.com/repos/{owner}/{repo}/issues/{prNumber}/comments";
@@ -85,34 +86,85 @@ public partial class GitHubCommentService(ILoggerFactory loggerFactory, GitHubAp
 					prNumber,
 					(int)createResponse.StatusCode
 				);
-				return false;
+				return null;
 			}
 
+			var createdNodeId = await ParseNodeIdAsync(createResponse, ctx);
 			_logger.LogInformation("Created changelog comment on PR #{PrNumber}", prNumber);
-			return true;
+			return createdNodeId;
 		}
 		catch (HttpRequestException ex)
 		{
 			_logger.LogWarning(ex, "HTTP error posting changelog comment on PR #{PrNumber}", prNumber);
-			return false;
+			return null;
 		}
 		catch (TaskCanceledException)
 		{
 			_logger.LogWarning("Timeout posting changelog comment on PR #{PrNumber}", prNumber);
-			return false;
+			return null;
 		}
 		catch (Exception ex) when (ex is not (OutOfMemoryException or StackOverflowException or ThreadAbortException))
 		{
 			_logger.LogWarning(ex, "Unexpected error posting changelog comment on PR #{PrNumber}", prNumber);
+			return null;
+		}
+	}
+
+	/// <inheritdoc />
+	public async Task<bool> MinimizeCommentAsync(string nodeId, Cancel ctx = default)
+	{
+		// minimizeComment is a GraphQL-only mutation; no REST equivalent exists.
+		var query =
+			$"mutation {{ minimizeComment(input: {{subjectId: \"{nodeId}\", classifier: RESOLVED}}) {{ minimizedComment {{ isMinimized }} }} }}";
+		var payload = JsonSerializer.Serialize(new GraphQlRequest { Query = query }, CommentJsonContext.Default.GraphQlRequest);
+		try
+		{
+			using var response = await _transport.PostGraphQlAsync(payload, ctx);
+			if (!response.IsSuccessStatusCode)
+			{
+				_logger.LogWarning("Failed to minimize comment {NodeId}: {Status}", nodeId, (int)response.StatusCode);
+				return false;
+			}
+
+			_logger.LogInformation("Minimized comment {NodeId}", nodeId);
+			return true;
+		}
+		catch (Exception ex) when (ex is not (OutOfMemoryException or StackOverflowException or ThreadAbortException))
+		{
+			_logger.LogWarning(ex, "Unexpected error minimizing comment {NodeId}", nodeId);
+			return false;
+		}
+	}
+
+	/// <inheritdoc />
+	public async Task<bool> UnminimizeCommentAsync(string nodeId, Cancel ctx = default)
+	{
+		var query = $"mutation {{ unminimizeComment(input: {{subjectId: \"{nodeId}\"}}) {{ unMinimizedComment {{ isMinimized }} }} }}";
+		var payload = JsonSerializer.Serialize(new GraphQlRequest { Query = query }, CommentJsonContext.Default.GraphQlRequest);
+		try
+		{
+			using var response = await _transport.PostGraphQlAsync(payload, ctx);
+			if (!response.IsSuccessStatusCode)
+			{
+				_logger.LogWarning("Failed to unminimize comment {NodeId}: {Status}", nodeId, (int)response.StatusCode);
+				return false;
+			}
+
+			_logger.LogInformation("Unminimized comment {NodeId}", nodeId);
+			return true;
+		}
+		catch (Exception ex) when (ex is not (OutOfMemoryException or StackOverflowException or ThreadAbortException))
+		{
+			_logger.LogWarning(ex, "Unexpected error unminimizing comment {NodeId}", nodeId);
 			return false;
 		}
 	}
 
 	/// <summary>
-	/// Paginates through all PR comments and returns the ID of the first comment that matches
-	/// either the HTML marker or the legacy title prefix; <c>null</c> when none is found.
+	/// Paginates through all PR comments and returns the ID and node_id of the first comment that
+	/// matches either the HTML marker or the legacy title prefix; <c>null</c> when none is found.
 	/// </summary>
-	private async Task<long?> FindExistingCommentIdAsync(string owner, string repo, int prNumber, Cancel ctx)
+	private async Task<(long Id, string NodeId)?> FindExistingCommentAsync(string owner, string repo, int prNumber, Cancel ctx)
 	{
 		var page = 1;
 		const int perPage = 100;
@@ -149,7 +201,7 @@ public partial class GitHubCommentService(ILoggerFactory loggerFactory, GitHubAp
 					commentBody.Contains(HtmlMarker, StringComparison.Ordinal)
 					|| commentBody.StartsWith(LegacyTitlePrefix, StringComparison.Ordinal)
 				)
-					return comment.Id;
+					return (comment.Id, comment.NodeId ?? string.Empty);
 			}
 
 			// GitHub omits the Link header or returns fewer than perPage items on the last page.
@@ -160,9 +212,27 @@ public partial class GitHubCommentService(ILoggerFactory loggerFactory, GitHubAp
 		}
 	}
 
+	private async Task<string?> ParseNodeIdAsync(HttpResponseMessage response, Cancel ctx)
+	{
+		try
+		{
+			var json = await response.Content.ReadAsStringAsync(ctx);
+			var item = JsonSerializer.Deserialize(json, CommentJsonContext.Default.CommentItem);
+			return string.IsNullOrEmpty(item?.NodeId) ? null : item.NodeId;
+		}
+		catch (JsonException)
+		{
+			return null;
+		}
+	}
+
 	private sealed class CommentItem
 	{
 		public long Id { get; set; }
+
+		[JsonPropertyName("node_id")]
+		public string? NodeId { get; set; }
+
 		public string? Body { get; set; }
 		public CommentUser? User { get; set; }
 	}
@@ -178,9 +248,16 @@ public partial class GitHubCommentService(ILoggerFactory loggerFactory, GitHubAp
 		public string Body { get; set; } = string.Empty;
 	}
 
+	private sealed class GraphQlRequest
+	{
+		[JsonPropertyName("query")]
+		public string Query { get; set; } = string.Empty;
+	}
+
 	[JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
 	[JsonSerializable(typeof(CommentItem))]
 	[JsonSerializable(typeof(List<CommentItem>))]
 	[JsonSerializable(typeof(CommentBody))]
+	[JsonSerializable(typeof(GraphQlRequest))]
 	private sealed partial class CommentJsonContext : JsonSerializerContext;
 }

--- a/src/services/Elastic.Changelog/GitHub/IGitHubCommentService.cs
+++ b/src/services/Elastic.Changelog/GitHub/IGitHubCommentService.cs
@@ -14,8 +14,19 @@ public interface IGitHubCommentService
 	/// otherwise a new comment is created.
 	/// </summary>
 	/// <returns>
-	/// <c>true</c> on success or when the API responds with a transient non-fatal error;
-	/// <c>false</c> only when the operation is definitively known to have failed.
+	/// The comment's GraphQL <c>node_id</c> on success; <c>null</c> when the operation failed.
 	/// </returns>
-	Task<bool> UpsertStickyCommentAsync(string owner, string repo, int prNumber, string body, Cancel ctx = default);
+	Task<string?> UpsertStickyCommentAsync(string owner, string repo, int prNumber, string body, Cancel ctx = default);
+
+	/// <summary>
+	/// Minimizes (hides) the given comment on GitHub using the <c>RESOLVED</c> classifier.
+	/// Failures are logged as warnings and do not affect the command exit code.
+	/// </summary>
+	Task<bool> MinimizeCommentAsync(string nodeId, Cancel ctx = default);
+
+	/// <summary>
+	/// Un-minimizes (reveals) the given comment on GitHub so it is visible to the author again.
+	/// Failures are logged as warnings and do not affect the command exit code.
+	/// </summary>
+	Task<bool> UnminimizeCommentAsync(string nodeId, Cancel ctx = default);
 }

--- a/src/services/Elastic.Changelog/GitHub/IGitHubCommentService.cs
+++ b/src/services/Elastic.Changelog/GitHub/IGitHubCommentService.cs
@@ -19,6 +19,13 @@ public interface IGitHubCommentService
 	Task<string?> UpsertStickyCommentAsync(string owner, string repo, int prNumber, string body, Cancel ctx = default);
 
 	/// <summary>
+	/// Deletes the sticky changelog comment on the given pull request if one exists.
+	/// Returns <c>true</c> when no comment was found (nothing to delete) or when deletion succeeded;
+	/// <c>false</c> only on a definitive API failure.
+	/// </summary>
+	Task<bool> DeleteStickyCommentAsync(string owner, string repo, int prNumber, Cancel ctx = default);
+
+	/// <summary>
 	/// Minimizes (hides) the given comment on GitHub using the <c>RESOLVED</c> classifier.
 	/// Failures are logged as warnings and do not affect the command exit code.
 	/// </summary>

--- a/tests/Elastic.Changelog.Tests/Evaluation/ChangelogCommentRendererTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/ChangelogCommentRendererTests.cs
@@ -82,6 +82,16 @@ public class ChangelogCommentRendererTests
 	}
 
 	[Fact]
+	public void RenderLabelsNeeded_AmbiguousTypeLabels_ContainsMultipleTypeHeadline()
+	{
+		var body = ChangelogCommentRenderer.RenderLabelsNeeded(null, null, null, null, ambiguousTypeLabels: "type:bug,type:feature");
+
+		body.Should().Contain("Multiple type labels set");
+		body.Should().Contain("type:bug");
+		body.Should().Contain("type:feature");
+	}
+
+	[Fact]
 	public void RenderLabelsNeeded_BothMissing_ContainsBothTables()
 	{
 		var body = ChangelogCommentRenderer.RenderLabelsNeeded("| type:feature | feature |", "| @Product:ECH | cloud |", null, null);

--- a/tests/Elastic.Changelog.Tests/Evaluation/ChangelogCommentRendererTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/ChangelogCommentRendererTests.cs
@@ -66,10 +66,37 @@ public class ChangelogCommentRendererTests
 	[Fact]
 	public void RenderLabelsNeeded_TypeMissing_ContainsTypeLabelHeadline()
 	{
-		var body = ChangelogCommentRenderer.RenderLabelsNeeded("| type:feature | feature |", null, null, null);
+		var body = ChangelogCommentRenderer.RenderLabelsNeeded("type:bug,type:feature", null, null, null);
 
 		body.Should().Contain("Changelog label needed");
 		body.Should().Contain("type:feature");
+		body.Should().Contain("type:bug");
+	}
+
+	[Fact]
+	public void RenderLabelsNeeded_TypeMissing_RendersInlineLabels()
+	{
+		var body = ChangelogCommentRenderer.RenderLabelsNeeded("type:bug,type:feature", null, null, null);
+
+		body.Should().Contain("`type:bug`");
+		body.Should().Contain("`type:feature`");
+		body.Should().NotContain("| Label |");
+	}
+
+	[Fact]
+	public void RenderLabelsNeeded_WithOwnerRepo_RendersConfigFileLink()
+	{
+		var body = ChangelogCommentRenderer.RenderLabelsNeeded(
+			"type:bug",
+			null,
+			null,
+			"docs/changelog.yml",
+			owner: "elastic",
+			repo: "docs",
+			defaultBranch: "main"
+		);
+
+		body.Should().Contain("[docs/changelog.yml](https://github.com/elastic/docs/blob/main/docs/changelog.yml)");
 	}
 
 	[Fact]
@@ -94,7 +121,7 @@ public class ChangelogCommentRendererTests
 	[Fact]
 	public void RenderLabelsNeeded_BothMissing_ContainsBothTables()
 	{
-		var body = ChangelogCommentRenderer.RenderLabelsNeeded("| type:feature | feature |", "| @Product:ECH | cloud |", null, null);
+		var body = ChangelogCommentRenderer.RenderLabelsNeeded("type:bug,type:feature", "| @Product:ECH | cloud |", null, null);
 
 		body.Should().Contain("Changelog labels needed");
 		body.Should().Contain("type:feature");
@@ -138,7 +165,7 @@ public class ChangelogCommentRendererTests
 		{
 			"entry-committed" => ChangelogCommentRenderer.RenderEntryCommitted("owner", "repo", "main", "file.yaml"),
 			"comment-only" => ChangelogCommentRenderer.RenderCommentOnly(null, "type: feature", "42.yaml", false, false),
-			"labels-needed" => ChangelogCommentRenderer.RenderLabelsNeeded("| label | type |", null, null, null),
+			"labels-needed" => ChangelogCommentRenderer.RenderLabelsNeeded("type:bug,type:feature", null, null, null),
 			"resolved" => ChangelogCommentRenderer.RenderResolved(),
 			_ => throw new InvalidOperationException()
 		};

--- a/tests/Elastic.Changelog.Tests/Evaluation/ChangelogGithubCommentServiceTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/ChangelogGithubCommentServiceTests.cs
@@ -153,28 +153,21 @@ public class ChangelogGithubCommentServiceTests(ITestOutputHelper output) : Chan
 	}
 
 	[Fact]
-	public async Task PostComment_SuccessWithNoYaml_RendersResolvedBody()
+	public async Task PostComment_SuccessWithNoYaml_DeletesStickyComment()
 	{
 		await WriteMetadata(BaseMetadata(status: "proceed", canCommit: true));
-		// no yaml file in MetadataDir
+		// no yaml file in MetadataDir — labels validated, comment should be deleted not updated
 		var commentSvc = A.Fake<IGitHubCommentService>();
-		A.CallTo(
-			() => commentSvc.UpsertStickyCommentAsync(A<string>._, A<string>._, A<int>._, A<string>._, A<CancellationToken>._)
-		).Returns((string?)"IC_test_node_id");
-		A.CallTo(() => commentSvc.MinimizeCommentAsync(A<string>._, A<CancellationToken>._)).Returns(true);
-		A.CallTo(() => commentSvc.UnminimizeCommentAsync(A<string>._, A<CancellationToken>._)).Returns(true);
+		A.CallTo(() => commentSvc.DeleteStickyCommentAsync(A<string>._, A<string>._, A<int>._, A<CancellationToken>._)).Returns(true);
 
 		await CreateService(commentSvc).PostComment(DefaultArgs(), CancellationToken.None);
 
 		A.CallTo(
-			() => commentSvc.UpsertStickyCommentAsync(
-				A<string>._,
-				A<string>._,
-				A<int>._,
-				A<string>.That.Contains("✅"),
-				A<CancellationToken>._
-			)
+			() => commentSvc.DeleteStickyCommentAsync("elastic", "test-repo", 42, A<CancellationToken>._)
 		).MustHaveHappenedOnceExactly();
+		A.CallTo(
+			() => commentSvc.UpsertStickyCommentAsync(A<string>._, A<string>._, A<int>._, A<string>._, A<CancellationToken>._)
+		).MustNotHaveHappened();
 	}
 
 	[Fact]

--- a/tests/Elastic.Changelog.Tests/Evaluation/ChangelogGithubCommentServiceTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/ChangelogGithubCommentServiceTests.cs
@@ -56,7 +56,9 @@ public class ChangelogGithubCommentServiceTests(ITestOutputHelper output) : Chan
 		var commentSvc = A.Fake<IGitHubCommentService>();
 		A.CallTo(
 			() => commentSvc.UpsertStickyCommentAsync(A<string>._, A<string>._, A<int>._, A<string>._, A<CancellationToken>._)
-		).Returns(true);
+		).Returns((string?)"IC_test_node_id");
+		A.CallTo(() => commentSvc.MinimizeCommentAsync(A<string>._, A<CancellationToken>._)).Returns(true);
+		A.CallTo(() => commentSvc.UnminimizeCommentAsync(A<string>._, A<CancellationToken>._)).Returns(true);
 
 		var result = await CreateService(commentSvc).PostComment(DefaultArgs(), CancellationToken.None);
 
@@ -80,7 +82,9 @@ public class ChangelogGithubCommentServiceTests(ITestOutputHelper output) : Chan
 		var commentSvc = A.Fake<IGitHubCommentService>();
 		A.CallTo(
 			() => commentSvc.UpsertStickyCommentAsync(A<string>._, A<string>._, A<int>._, A<string>._, A<CancellationToken>._)
-		).Returns(true);
+		).Returns((string?)"IC_test_node_id");
+		A.CallTo(() => commentSvc.MinimizeCommentAsync(A<string>._, A<CancellationToken>._)).Returns(true);
+		A.CallTo(() => commentSvc.UnminimizeCommentAsync(A<string>._, A<CancellationToken>._)).Returns(true);
 
 		await CreateService(commentSvc).PostComment(DefaultArgs(), CancellationToken.None);
 
@@ -103,7 +107,9 @@ public class ChangelogGithubCommentServiceTests(ITestOutputHelper output) : Chan
 		var commentSvc = A.Fake<IGitHubCommentService>();
 		A.CallTo(
 			() => commentSvc.UpsertStickyCommentAsync(A<string>._, A<string>._, A<int>._, A<string>._, A<CancellationToken>._)
-		).Returns(true);
+		).Returns((string?)"IC_test_node_id");
+		A.CallTo(() => commentSvc.MinimizeCommentAsync(A<string>._, A<CancellationToken>._)).Returns(true);
+		A.CallTo(() => commentSvc.UnminimizeCommentAsync(A<string>._, A<CancellationToken>._)).Returns(true);
 
 		await CreateService(commentSvc).PostComment(DefaultArgs(), CancellationToken.None);
 
@@ -129,7 +135,9 @@ public class ChangelogGithubCommentServiceTests(ITestOutputHelper output) : Chan
 		var commentSvc = A.Fake<IGitHubCommentService>();
 		A.CallTo(
 			() => commentSvc.UpsertStickyCommentAsync(A<string>._, A<string>._, A<int>._, A<string>._, A<CancellationToken>._)
-		).Returns(true);
+		).Returns((string?)"IC_test_node_id");
+		A.CallTo(() => commentSvc.MinimizeCommentAsync(A<string>._, A<CancellationToken>._)).Returns(true);
+		A.CallTo(() => commentSvc.UnminimizeCommentAsync(A<string>._, A<CancellationToken>._)).Returns(true);
 
 		await CreateService(commentSvc).PostComment(DefaultArgs(), CancellationToken.None);
 
@@ -152,7 +160,9 @@ public class ChangelogGithubCommentServiceTests(ITestOutputHelper output) : Chan
 		var commentSvc = A.Fake<IGitHubCommentService>();
 		A.CallTo(
 			() => commentSvc.UpsertStickyCommentAsync(A<string>._, A<string>._, A<int>._, A<string>._, A<CancellationToken>._)
-		).Returns(true);
+		).Returns((string?)"IC_test_node_id");
+		A.CallTo(() => commentSvc.MinimizeCommentAsync(A<string>._, A<CancellationToken>._)).Returns(true);
+		A.CallTo(() => commentSvc.UnminimizeCommentAsync(A<string>._, A<CancellationToken>._)).Returns(true);
 
 		await CreateService(commentSvc).PostComment(DefaultArgs(), CancellationToken.None);
 
@@ -188,10 +198,42 @@ public class ChangelogGithubCommentServiceTests(ITestOutputHelper output) : Chan
 		var commentSvc = A.Fake<IGitHubCommentService>();
 		A.CallTo(
 			() => commentSvc.UpsertStickyCommentAsync(A<string>._, A<string>._, A<int>._, A<string>._, A<CancellationToken>._)
-		).Returns(false);
+		).Returns((string?)null);
 
 		var result = await CreateService(commentSvc).PostComment(DefaultArgs(), CancellationToken.None);
 
 		result.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task PostComment_Skipped_MinimizesComment()
+	{
+		await WriteMetadata(BaseMetadata(status: "skipped"));
+		var commentSvc = A.Fake<IGitHubCommentService>();
+		A.CallTo(
+			() => commentSvc.UpsertStickyCommentAsync(A<string>._, A<string>._, A<int>._, A<string>._, A<CancellationToken>._)
+		).Returns((string?)"IC_skipped_node_id");
+		A.CallTo(() => commentSvc.MinimizeCommentAsync(A<string>._, A<CancellationToken>._)).Returns(true);
+
+		await CreateService(commentSvc).PostComment(DefaultArgs(), CancellationToken.None);
+
+		A.CallTo(() => commentSvc.MinimizeCommentAsync("IC_skipped_node_id", A<CancellationToken>._)).MustHaveHappenedOnceExactly();
+		A.CallTo(() => commentSvc.UnminimizeCommentAsync(A<string>._, A<CancellationToken>._)).MustNotHaveHappened();
+	}
+
+	[Fact]
+	public async Task PostComment_NoLabel_UnminimizesComment()
+	{
+		await WriteMetadata(BaseMetadata(status: "no-label") with { LabelTable = "| type:feature | feature |" });
+		var commentSvc = A.Fake<IGitHubCommentService>();
+		A.CallTo(
+			() => commentSvc.UpsertStickyCommentAsync(A<string>._, A<string>._, A<int>._, A<string>._, A<CancellationToken>._)
+		).Returns((string?)"IC_nolabel_node_id");
+		A.CallTo(() => commentSvc.UnminimizeCommentAsync(A<string>._, A<CancellationToken>._)).Returns(true);
+
+		await CreateService(commentSvc).PostComment(DefaultArgs(), CancellationToken.None);
+
+		A.CallTo(() => commentSvc.UnminimizeCommentAsync("IC_nolabel_node_id", A<CancellationToken>._)).MustHaveHappenedOnceExactly();
+		A.CallTo(() => commentSvc.MinimizeCommentAsync(A<string>._, A<CancellationToken>._)).MustNotHaveHappened();
 	}
 }

--- a/tests/Elastic.Changelog.Tests/Evaluation/ChangelogGithubCommentServiceTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/ChangelogGithubCommentServiceTests.cs
@@ -199,34 +199,19 @@ public class ChangelogGithubCommentServiceTests(ITestOutputHelper output) : Chan
 	}
 
 	[Fact]
-	public async Task PostComment_Skipped_MinimizesComment()
+	public async Task PostComment_Skipped_DeletesStickyComment()
 	{
 		await WriteMetadata(BaseMetadata(status: "skipped"));
 		var commentSvc = A.Fake<IGitHubCommentService>();
-		A.CallTo(
-			() => commentSvc.UpsertStickyCommentAsync(A<string>._, A<string>._, A<int>._, A<string>._, A<CancellationToken>._)
-		).Returns((string?)"IC_skipped_node_id");
-		A.CallTo(() => commentSvc.MinimizeCommentAsync(A<string>._, A<CancellationToken>._)).Returns(true);
+		A.CallTo(() => commentSvc.DeleteStickyCommentAsync(A<string>._, A<string>._, A<int>._, A<CancellationToken>._)).Returns(true);
 
 		await CreateService(commentSvc).PostComment(DefaultArgs(), CancellationToken.None);
 
-		A.CallTo(() => commentSvc.MinimizeCommentAsync("IC_skipped_node_id", A<CancellationToken>._)).MustHaveHappenedOnceExactly();
-		A.CallTo(() => commentSvc.UnminimizeCommentAsync(A<string>._, A<CancellationToken>._)).MustNotHaveHappened();
-	}
-
-	[Fact]
-	public async Task PostComment_NoLabel_UnminimizesComment()
-	{
-		await WriteMetadata(BaseMetadata(status: "no-label") with { LabelTable = "| type:feature | feature |" });
-		var commentSvc = A.Fake<IGitHubCommentService>();
+		A.CallTo(
+			() => commentSvc.DeleteStickyCommentAsync("elastic", "test-repo", 42, A<CancellationToken>._)
+		).MustHaveHappenedOnceExactly();
 		A.CallTo(
 			() => commentSvc.UpsertStickyCommentAsync(A<string>._, A<string>._, A<int>._, A<string>._, A<CancellationToken>._)
-		).Returns((string?)"IC_nolabel_node_id");
-		A.CallTo(() => commentSvc.UnminimizeCommentAsync(A<string>._, A<CancellationToken>._)).Returns(true);
-
-		await CreateService(commentSvc).PostComment(DefaultArgs(), CancellationToken.None);
-
-		A.CallTo(() => commentSvc.UnminimizeCommentAsync("IC_nolabel_node_id", A<CancellationToken>._)).MustHaveHappenedOnceExactly();
-		A.CallTo(() => commentSvc.MinimizeCommentAsync(A<string>._, A<CancellationToken>._)).MustNotHaveHappened();
+		).MustNotHaveHappened();
 	}
 }

--- a/tests/Elastic.Changelog.Tests/Evaluation/GitHubCommentServiceTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/GitHubCommentServiceTests.cs
@@ -19,11 +19,17 @@ public class GitHubCommentServiceTests(ITestOutputHelper output)
 	private static HttpResponseMessage Json(string body) =>
 		new(HttpStatusCode.OK) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
 
-	private static HttpResponseMessage Created() => new(HttpStatusCode.Created);
-	private static HttpResponseMessage Ok() => new(HttpStatusCode.OK);
+	private static HttpResponseMessage Created(string nodeId = "IC_test_node_id") =>
+		new(HttpStatusCode.Created)
+		{
+			Content = new StringContent($"{{\"id\":1,\"node_id\":\"{nodeId}\"}}", Encoding.UTF8, "application/json")
+		};
 
-	private static string CommentListJson(long id, string body, string login = "github-actions[bot]") =>
-		$"[{{\"id\":{id},\"body\":{JsonSerializer.Serialize(body)},\"user\":{{\"login\":\"{login}\"}}}}]";
+	private static HttpResponseMessage Ok(string nodeId = "IC_test_node_id") =>
+		new(HttpStatusCode.OK) { Content = new StringContent($"{{\"id\":1,\"node_id\":\"{nodeId}\"}}", Encoding.UTF8, "application/json") };
+
+	private static string CommentListJson(long id, string body, string login = "github-actions[bot]", string nodeId = "IC_test_node_id") =>
+		$"[{{\"id\":{id},\"node_id\":\"{nodeId}\",\"body\":{JsonSerializer.Serialize(body)},\"user\":{{\"login\":\"{login}\"}}}}]";
 
 	private GitHubCommentService Service(StubHandler handler) =>
 		new(new TestLoggerFactory(output), new GitHubApiTransport(handler, "test-token"));
@@ -40,7 +46,7 @@ public class GitHubCommentServiceTests(ITestOutputHelper output)
 
 		var result = await Service(handler).UpsertStickyCommentAsync(Owner, Repo, PrNumber, "### 📋 Changelog\n\nHello");
 
-		result.Should().BeTrue();
+		result.Should().NotBeNull();
 		requests.Should().ContainSingle(r => r.method == "POST" && r.path.Contains($"/issues/{PrNumber}/comments"));
 	}
 
@@ -60,7 +66,7 @@ public class GitHubCommentServiceTests(ITestOutputHelper output)
 
 		var result = await Service(handler).UpsertStickyCommentAsync(Owner, Repo, PrNumber, "### 📋 Changelog\nNew");
 
-		result.Should().BeTrue();
+		result.Should().NotBeNull();
 		requests.Should().ContainSingle(r => r.method == "PATCH" && r.path.Contains($"/issues/comments/{existingId}"));
 		requests.Should().NotContain(r => r.method == "POST");
 	}
@@ -81,7 +87,7 @@ public class GitHubCommentServiceTests(ITestOutputHelper output)
 
 		var result = await Service(handler).UpsertStickyCommentAsync(Owner, Repo, PrNumber, "### 📋 Changelog\nNew");
 
-		result.Should().BeTrue();
+		result.Should().NotBeNull();
 		requests.Should().ContainSingle(r => r.method == "PATCH" && r.path.Contains($"/issues/comments/{existingId}"));
 	}
 
@@ -109,18 +115,18 @@ public class GitHubCommentServiceTests(ITestOutputHelper output)
 
 		var result = await Service(handler).UpsertStickyCommentAsync(Owner, Repo, PrNumber, "### 📋 Changelog\nNew");
 
-		result.Should().BeTrue();
+		result.Should().NotBeNull();
 		requests.Should().ContainSingle(r => r.method == "PATCH" && r.path.Contains($"/issues/comments/{existingId}"));
 	}
 
 	[Fact]
-	public async Task UpsertStickyComment_ApiReturns403_ReturnsFalseDoesNotThrow()
+	public async Task UpsertStickyComment_ApiReturns403_ReturnsNullDoesNotThrow()
 	{
 		var handler = new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.Forbidden));
 
 		var result = await Service(handler).UpsertStickyCommentAsync(Owner, Repo, PrNumber, "body");
 
-		result.Should().BeFalse();
+		result.Should().BeNull();
 	}
 
 	[Fact]


### PR DESCRIPTION
The changelog label-gate comment now deletes itself when the PR resolves (labels validated or `changelog:skip` added), renders type labels as inline code instead of a GFM table, links the config file to its GitHub blob URL, and errors when multiple conflicting type labels are set simultaneously.

**Affects:** Release notes

## Why

Four gaps in the existing comment behaviour:

1. When `changelog:skip` was added after a label failure, the stale "Changelog label needed" comment stayed on the PR — `SelectBody` returned `null` for `skipped`, which the comment service treated as nothing to do.
2. When labels validated, a "✅ Changelog label set" confirmation was posted. This clutter persisted on the PR after the gate passed.
3. A PR carrying both `type:bug` and `type:feature` silently picked the first matching type. The `<pr>.yml` changelog file holds only one `type:` field, so the choice was arbitrary.
4. Type labels in the comment body rendered as a `| Label | Type |` GFM table. The labels are self-descriptive; the table added noise without adding information.

## What

#### Comment deleted on resolution

Both `success` and `skipped` now return `null` from `SelectBody`. The comment service recognises these as determined states and calls `DeleteStickyCommentAsync` to remove any existing comment. The PR is clean once the gate resolves.

#### Minimize/Unminimize infra added but not yet used

`MinimizeCommentAsync` and `UnminimizeCommentAsync` (GraphQL mutations via `node_id`) are on the interface and implemented, available for future use without another infrastructure commit.

#### Multiple type labels raise an error

`PrInfoProcessor.MatchingTypeLabels` returns every key matching `pivot.types`. Both `validate-labels` and `evaluate-pr` check the count: if more than one matches, they set `AmbiguousTypeLabels` in metadata, emit a diagnostic error, and return false. The comment body lists the conflicting labels inline so the author knows which ones to remove.

#### Inline type labels and clickable config file link

Type labels render as `` `type:bug` ``, `` `type:feature` `` inline rather than as a GFM table column. The config-file footer becomes a `[docs/changelog.yml](https://github.com/{owner}/{repo}/blob/{branch}/docs/changelog.yml)` link; the branch comes from `config.Bundle?.Branch`, defaulting to `"main"`.

## Verify

```bash
dotnet test tests/Elastic.Changelog.Tests/
```

On `docs-playground-release-notes-tagged`: open a PR with no type label → comment appears with inline labels and a clickable config link. Add `changelog:skip` → comment disappears. Remove it, add the correct type label → comment disappears again. Add two type labels simultaneously → comment appears with the conflicting labels listed.