### PR TITLE
fix: drop implicit island promotion for nested toc: children

### DIFF
--- a/src/Elastic.Documentation.Navigation/Assembler/SiteNavigation.cs
+++ b/src/Elastic.Documentation.Navigation/Assembler/SiteNavigation.cs
@@ -359,14 +359,7 @@ public class SiteNavigation : IRootNavigationItem<IDocumentationFile, INavigatio
 			{
 				var childItem = CreateSiteTableOfContentsNavigation(child, childIndex++, context, node, root);
 				if (childItem != null)
-				{
-					// Nested `toc:` entries in navigation.yml are islands (arrow + own
-					// heading), even when they omit `island: true` — Release notes
-					// clients, Reference nested books, etc.
-					if (childItem is IAssignableIslandNavigation childIsland)
-						childIsland.IsIsland = true;
 					children.Add(childItem);
-				}
 			}
 		}
 

--- a/tests/Navigation.Tests/Assembler/IslandSiteNavigationTests.cs
+++ b/tests/Navigation.Tests/Assembler/IslandSiteNavigationTests.cs
@@ -216,4 +216,64 @@ public class IslandSiteNavigationTests(ITestOutputHelper output)
 		obsNode.IsIsland.Should().BeTrue("content-set set island: true; navigation.yml can't remove it");
 		obsNode.RendersAsIsland().Should().BeTrue();
 	}
+
+	// ──────────────────────────────────────────────────────────────
+	// Nested toc: children in a plain navigation.yml toc (no section:) must NOT
+	// be implicit islands — only explicit island: true or docset island: true counts.
+	// Regression: a1a434701 introduced unconditional IsIsland = true for every
+	// tocRef.Children entry, causing e.g. reference/elasticsearch to render as
+	// an island on prod even without NAVIGATION_PREVIEW.
+	// ──────────────────────────────────────────────────────────────
+	[Fact]
+	public void NestedTocChildren_InPlainNavigationYml_AreNotImplicitIslands()
+	{
+		// A top-level toc: with children: — the child must NOT be made an island
+		// just because it appears in the children: list.
+		// language=yaml
+		var siteNavYaml =
+			"""
+		                  toc:
+		                    - toc: observability://
+		                      path_prefix: reference
+		                      children:
+		                        - toc: serverless-search://
+		                          path_prefix: reference/search
+		                  """;
+
+		var siteNavFile = SiteNavigationFile.Deserialize(siteNavYaml);
+		var fileSystem = SiteNavigationTestFixture.CreateMultiRepositoryFileSystem();
+
+		var obsContext = SiteNavigationTestFixture.CreateAssemblerContext(fileSystem, "/checkouts/current/observability", output);
+		var obsDocset = DocumentationSetFile.LoadAndResolve(
+			obsContext.Collector,
+			fileSystem.FileInfo.New("/checkouts/current/observability/docs/docset.yml"),
+			new CheckoutsFileSystem(fileSystem.DirectoryInfo.New("/checkouts"), inner: fileSystem)
+		);
+		var obsNav = new DocumentationSetNavigation<IDocumentationFile>(obsDocset, obsContext, GenericDocumentationFileFactory.Instance);
+
+		var searchContext = SiteNavigationTestFixture.CreateAssemblerContext(fileSystem, "/checkouts/current/serverless-search", output);
+		var searchDocset = DocumentationSetFile.LoadAndResolve(
+			searchContext.Collector,
+			fileSystem.FileInfo.New("/checkouts/current/serverless-search/docs/docset.yml"),
+			new CheckoutsFileSystem(fileSystem.DirectoryInfo.New("/checkouts"), inner: fileSystem)
+		);
+		var searchNav = new DocumentationSetNavigation<IDocumentationFile>(
+			searchDocset,
+			searchContext,
+			GenericDocumentationFileFactory.Instance
+		);
+
+		var siteContext = SiteNavigationTestFixture.CreateContext(fileSystem, "/checkouts/current/observability", output);
+		var navigation = new SiteNavigation(siteNavFile, siteContext, [obsNav, searchNav], sitePrefix: null);
+
+		// The top-level entry (observability://) is an island — that's the defined behaviour for
+		// every top-level SiteTableOfContentsRef in navigation.yml.
+		var obsNode = navigation.NavigationItems.ElementAt(0).Should().BeOfType<DocumentationSetNavigation<IDocumentationFile>>().Subject;
+		obsNode.RendersAsIsland().Should().BeTrue("top-level toc: entries are always islands");
+
+		// The nested child (serverless-search://) must NOT be an implicit island.
+		// It has no island: true in navigation.yml and no island: true in its docset.yml.
+		searchNav.IsIsland.Should().BeFalse("nested toc: children without island: true are not implicit islands");
+		searchNav.RendersAsIsland().Should().BeFalse("nested child is not an island");
+	}
 }

--- a/tests/Navigation.Tests/Assembler/SectionNavigationTests.cs
+++ b/tests/Navigation.Tests/Assembler/SectionNavigationTests.cs
@@ -368,7 +368,7 @@ public class SectionNavigationTests(ITestOutputHelper output)
 		var (nav, _, searchNav) = BuildTwoChildSection(output, yaml);
 		var section = nav.NavigationItems.First().Should().BeOfType<SectionNavigation>().Subject;
 
-		searchNav.RendersAsIsland().Should().BeTrue("nested toc: children in navigation.yml are islands even without island: true");
+		searchNav.RendersAsIsland().Should().BeTrue("PromoteSectionListingIslands marks single-listing section children as islands");
 
 		var searchLeaf = nav
 			.NavigationIndexedByOrder


### PR DESCRIPTION
Pages under `reference/elasticsearch` (and other entries nested via `children:` in `navigation.yml`) rendered with an island sidebar on prod even though neither `navigation.yml` nor the content-set declared `island: true` for them. This restores the pre-regression behaviour.

**Affects:** Navigation, Assembler builds

## Why

`a1a434701` merged nav-restyle code that added an unconditional `IsIsland = true` for every node resolved from `tocRef.Children` inside `CreateSiteTableOfContentsNavigation`. That code path runs on every build regardless of the `NAVIGATION_PREVIEW` flag. In `navigation.yml`, the `reference` entry uses `children:` to nest sub-docsets such as `elasticsearch://reference/elasticsearch`. The unconditional promotion made all of them islands on assembled prod builds, changing sidebar rendering without any author opt-in.

## What

#### Unconditional island promotion removed

The seven lines that set `IsIsland = true` for every `tocRef.Children` entry are removed from `CreateSiteTableOfContentsNavigation`. Entries that should be islands in the preview layout already carry `island: true` in `navigation_preview.yml` and are handled by the existing `tocRef.Island` override at the top of that method. `PromoteSectionListingIslands` covers the single-listing section pattern used there.

#### Regression test added

`NestedTocChildren_InPlainNavigationYml_AreNotImplicitIslands` in `IslandSiteNavigationTests` asserts that a nested `toc:` child (no `island: true`, no docset-level `island: true`) is not an island after `SiteNavigation` assembles the tree. The test mirrors the `reference` → `elasticsearch://reference/elasticsearch` shape from `navigation.yml`.

#### Stale test reason corrected

The reason string in `SectionNavigationTests.NestedAssemblerToc_UnderListing_IsIsland` previously read "nested toc: children in navigation.yml are islands even without island: true". That section-based test still passes — the island flag comes from `PromoteSectionListingIslands`, not from the removed lines — but the reason now names the actual mechanism.

## Verify

```bash
dotnet test tests/Navigation.Tests/
# NestedTocChildren_InPlainNavigationYml_AreNotImplicitIslands — new regression guard
# NestedAssemblerToc_UnderListing_IsIsland — must still pass (section layout unaffected)
```