### PR TITLE
Tighten commit, pr, and issue skills with linking rules and PR lifecycle awareness

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -78,3 +78,14 @@ git status
 ```
 
 Confirm a clean working tree.
+
+### 7. Refresh the PR description if one exists
+
+```bash
+gh pr view --json number,url,isDraft,baseRefName --jq '{number,url,isDraft,baseRefName}' 2>/dev/null
+```
+
+- **No PR** → done. Say nothing.
+- **PR exists** → compare the current body against the current diff versus the PR's base branch. A PR description always describes the current diff against the base branch. It is never a log of the commits on the branch and never records the direction the work took. If any section (`## What`, `## Verify`, `**Affects:**`, label) no longer describes that diff, the description is stale.
+- **Stale description** → read and follow [pr](../pr/SKILL.md)'s update path (step 7). Do not hand-edit the body inline from the commit skill. State plainly what was refreshed.
+- **Still accurate** → state that the description is still accurate. No edit needed.

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -13,7 +13,7 @@ Files a GitHub issue that matches the repo's templates, applies correct labels, 
 
 ### 1. Check for duplicates
 
-Search for near-duplicates before opening anything. Link any you find in the issue body rather than filing a second.
+Search for near-duplicates before opening anything. Link any you find in the issue body rather than filing a second. Use the full URL form for all links — see `## Linking to issues and pull requests` in [`writing-style.md`](../writing-style.md).
 
 ```bash
 gh issue list --search "<key terms>" --limit 10

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -45,6 +45,12 @@ Required structure:
 
 **Affects:** <one to three surfaces from surfaces.md, most affected first>
 
+**Prompt summary:** <One paragraph, two to three sentences. What the author was asked
+ to do in their own framing — the goal behind the branch, not the diff. Present tense,
+ active voice. This is the ask; ## Why is the problem in the code. They are not
+ interchangeable and neither restates the other. Omit only when the branch has no
+ originating ask.>
+
 ## Why
 <Two to four sentences. The concrete failure or gap. Active voice, present tense
  for current behaviour. Do not open with the history of a prior PR.>
@@ -69,7 +75,7 @@ Conditional add-ons — each is one or two sentences with a bold lead-in, no hea
 - **Breaking** — what a consumer must change and when it bites them. Pairs with the `breaking` label.
 - **Out of scope** — a gap this PR deliberately leaves, so a reviewer does not raise it as a finding.
 - **Risk** — shared or production state this touches. Required when the change reaches anything in `CLAUDE.md`'s "Boundaries: never touch / human-gated" list, or leaves state that a code revert will not undo.
-- **Stack** — position and links: `3 of 5, on top of #3855`. A bare `Stack: 3/5` with no links is not enough.
+- **Stack** — position and links: `3 of 5, on top of` [#3855](https://github.com/elastic/docs-builder/pull/3855). A bare `Stack: 3/5` with no links is not enough.
 
 **Do not** include bullet lists of changed files. Do not summarize what the diff already states plainly.
 
@@ -96,7 +102,43 @@ Never use `fix` (use `bug`) or `ci` (use `automation`) — both are release-draf
 
 **`breaking` guidance:** use it when an older `docs-builder` invocation or an existing repo config stops working. The canonical trigger is `Configuration` in the `**Affects:**` line plus a rename or removal — [#3856](https://github.com/elastic/docs-builder/pull/3856) removed `output:` from `changelog.yml` profiles and shipped as `feature`; it should have been `breaking`. Internal C# type renames and private method signature changes are not breaking.
 
-### 7. Create the PR
+### 7. Check whether a PR already exists
+
+```bash
+gh pr view --json number,url,baseRefName --jq '{number,url,baseRefName}' 2>/dev/null
+```
+
+**If a PR exists — update it.**
+
+Rebuild the body from the cumulative diff against the PR's own base branch (not a hardcoded `main`):
+
+```bash
+git diff origin/<baseRefName>...HEAD --stat
+git diff origin/<baseRefName>...HEAD
+```
+
+Write the description of **the current diff against the base** — never a log of the commits on the branch and never an "update" or "addendum" appended to the old body. Any section of the old body that no longer matches the diff is wrong, not history. Replace it.
+
+- Preserve the original `**Prompt summary:**` verbatim unless the ask itself changed; extend it rather than replace it when scope was added.
+- Reassess `**Affects:**` and the label — added commits can shift a `chore` to a `bug`, or bring in a new surface.
+- Apply in one call:
+
+```bash
+gh pr edit --title "<title>" --body "$(cat <<'EOF'
+<new body>
+EOF
+)"
+```
+
+Add or remove the label only if it changed:
+
+```bash
+gh pr edit --add-label "<new-label>" --remove-label "<old-label>"
+```
+
+**If no PR exists — create it.** Proceed to step 8.
+
+### 8. Create the PR
 
 One call — title, label, and body together. No follow-up `gh pr edit`:
 
@@ -125,6 +167,6 @@ EOF
 )"
 ```
 
-### 8. Return the PR URL
+### 9. Return the PR URL
 
 Always print the URL so the user can open it directly.

--- a/.claude/skills/writing-style.md
+++ b/.claude/skills/writing-style.md
@@ -73,6 +73,28 @@ Do **not** backtick prose nouns that merely share a name with code — the assem
 
 ---
 
+## Linking to issues and pull requests
+
+Link liberally. Any issue, PR, or discussion named in prose gets a link — first mention and every repeat.
+
+**Always the full URL.** Never a bare `#3855`, and never a short form like `elastic/repo#3855`. GitHub resolves `#num` against whatever repo the current page lives in — the same body pasted into a different repo silently points at the wrong thing.
+
+Markdown form: `[#3855](https://github.com/elastic/docs-builder/pull/3855)`. Keep the `#num` as link text so it stays scannable in a git log or review tool that strips HTML.
+
+Cross-repo mentions include the org and repo in the link text:
+
+```
+[elastic/docs-actions#412](https://github.com/elastic/docs-actions/pull/412)
+```
+
+| Wrong | Right |
+|---|---|
+| See #3855 for context | See [#3855](https://github.com/elastic/docs-builder/pull/3855) for context |
+| elastic/docs-actions#412 fixed this | [elastic/docs-actions#412](https://github.com/elastic/docs-actions/pull/412) fixed this |
+| Refs #3856 | Refs [#3856](https://github.com/elastic/docs-builder/pull/3856) |
+
+---
+
 ## Anti-mechanical rules for "What" sections
 
 `## What` uses `####` subheadings, not bullet points. Each subheading names the thing that changed (a file, a command, a concept). The prose under it states what changed and why it matters — two to four sentences, same plain-language rules as everywhere else.
@@ -97,13 +119,13 @@ Lead with the behaviour change; name the symbol second when the reviewer needs i
 
 These are the rules in action. If a new rule does not survive this test, the rule is wrong.
 
-**#3951 — `## What`, first bullet:**
+**[#3951](https://github.com/elastic/docs-builder/pull/3951) — `## What`, first bullet:**
 
 > ❌ `GitLocks.ClearStale(IFileSystem, ...)` sweeps `*.lock` files under `.git/` before each retry. Called only from the retry path — never before attempt 1, where a lock could belong to a concurrent process.
 
 > ✅ A retry clears stale `*.lock` files under `.git/` before it runs. The first attempt is never affected — a lock there can belong to a live process.
 
-**#3941 — opening of `## Why`:**
+**[#3941](https://github.com/elastic/docs-builder/pull/3941) — opening of `## Why`:**
 
 > ❌ [#3911](https://github.com/elastic/docs-builder/pull/3911) tried to fix stale CDN pool listings by bringing back `changelog/{org}/{repo}/{branch}/registry.json`. That approach was rejected…
 
@@ -111,7 +133,7 @@ These are the rules in action. If a new rule does not survive this test, the rul
 
 The history of a rejected PR is not the problem this PR solves. Lead with the problem.
 
-**#3856 — label:**
+**[#3856](https://github.com/elastic/docs-builder/pull/3856) — label:**
 
 > ❌ `feature`
 


### PR DESCRIPTION
The commit, pr, and issue skills gain a full-URL linking rule, a `**Prompt summary:**` field in PR bodies, and a PR-refresh step so a description always reflects the current diff against the base branch rather than an earlier state of the work.

**Affects:** Agentic Skills

**Prompt summary:** The ask was to amend the three agentic skills to enforce full-URL links to issues and PRs rather than bare `#num` references, add a paragraph to each PR body that captures the originating ask, and make the commit skill detect a stale PR description after new commits and refresh it via the pr skill.

## Why

Bare `#num` references resolve against whatever repo the text is rendered in. A PR body copied into a cross-repo comment or a different org silently points at the wrong issue. The skills had no rule for this, so every generated body was one paste away from broken links.

A reviewer reading a PR body can orient from the problem (`## Why`) and the change (`## What`), but not from the original ask. That context disappears after the conversation ends. And a commit made on a branch that already has a PR left the description frozen at the state of the diff when it was first opened, with no mechanism to notice or correct the drift.

## What

#### Full-URL linking rule

`writing-style.md` gains a `## Linking to issues and pull requests` section. The rule: always use the full GitHub URL, never a bare `#3855` or `elastic/repo#3855`. Link text stays as `#3855` so it scans quickly. Cross-repo mentions include org and repo in the link text. A wrong/right table illustrates the pattern. The example headings already in the file (`#3856`, `#3941`, `#3951`) are fixed to full links in the same commit.

#### PR body — prompt summary

The required body structure in `pr/SKILL.md` gains a `**Prompt summary:**` field between `**Affects:**` and `## Why`. It holds one paragraph stating what the author was asked to do — the goal behind the branch, not the diff. A note distinguishes it from `## Why`: the summary is the ask; `## Why` is the problem in the code. Neither restates the other.

#### PR skill — detect and update an existing PR

Step 7 of `pr/SKILL.md` now checks for an open PR before deciding whether to create one. When one exists, the skill rebuilds the body from the cumulative diff against the PR's own base branch, preserves the original `**Prompt summary:**`, reassesses `**Affects:**` and the label, and applies the update with one `gh pr edit` call. The create path is unchanged and is now step 8.

#### Commit skill — refresh stale PR descriptions

A new step 7 in `commit/SKILL.md` runs `gh pr view` after every successful commit. If a PR exists and any part of its body no longer matches the current diff, the step delegates to the pr skill's update path rather than editing inline. The governing rule is stated explicitly: a PR description always describes the current diff against the base branch, never a log of commits on the branch.

#### Issue skill — link rule pointer

The duplicate-check step in `issue/SKILL.md` gains a clause pointing at the new `## Linking` section in `writing-style.md`, so the full-URL form applies to issue bodies too.