### PR TITLE
Use canonical URLs in generated API Markdown links

### DIFF
--- a/src/Elastic.ApiExplorer/Infrastructure/ApiMarkdown.cs
+++ b/src/Elastic.ApiExplorer/Infrastructure/ApiMarkdown.cs
@@ -7,6 +7,7 @@ using System.Text.RegularExpressions;
 using Elastic.ApiExplorer.Model;
 using Elastic.ApiExplorer.Operations;
 using Elastic.Documentation;
+using Elastic.Documentation.Extensions;
 using Microsoft.AspNetCore.Html;
 
 namespace Elastic.ApiExplorer.Infrastructure;
@@ -47,6 +48,14 @@ public static partial class ApiMarkdown
 		return OperationLinkPattern().Replace(rewritten, match => $"]({baseUrl}operation/{match.Groups[1].Value})");
 	}
 
+	internal static string CanonicalizeLinks(string markdown, Uri? canonicalBaseUrl) =>
+		LinkDestinationPattern().Replace(markdown, match =>
+		{
+			var url = match.Groups["url"].Value;
+			var absolute = UrlPath.MakeAbsolute(canonicalBaseUrl, url);
+			return match.Groups["prefix"].Value + absolute;
+		});
+
 	private static IFileInfo CreateVirtualSource(ApiRenderContext context)
 	{
 		var relativePath = context.CurrentNavigation.Url.TrimStart('/').TrimEnd('/');
@@ -62,6 +71,9 @@ public static partial class ApiMarkdown
 
 	[GeneratedRegex(@"\]\(\.\./operation/([^)#]+)\)")]
 	private static partial Regex OperationLinkPattern();
+
+	[GeneratedRegex(@"(?<prefix>\]\()(?<url>[^)\s]+)")]
+	private static partial Regex LinkDestinationPattern();
 
 	// Regex to match mustache-style patterns like {{var}} or {{{var}}} that conflict with docs-builder substitutions
 	[GeneratedRegex(@"\{\{\{?[^}]+\}?\}\}")]

--- a/src/Elastic.ApiExplorer/Infrastructure/ApiMarkdownFrontMatter.cs
+++ b/src/Elastic.ApiExplorer/Infrastructure/ApiMarkdownFrontMatter.cs
@@ -7,6 +7,7 @@ using Elastic.ApiExplorer.Landing;
 using Elastic.ApiExplorer.Operations;
 using Elastic.ApiExplorer.Supplemental;
 using Elastic.ApiExplorer.Types;
+using Elastic.Documentation.Extensions;
 using Elastic.Documentation.Navigation;
 
 namespace Elastic.ApiExplorer.Infrastructure;
@@ -21,6 +22,7 @@ internal static class ApiMarkdownFrontMatter
 	public static string Wrap(string body, INavigationItem current, ApiRenderContext context, IApiModel page)
 	{
 		var content = StripLeadingFrontMatter(body).TrimStart();
+		content = ApiMarkdown.CanonicalizeLinks(content, context.BuildContext.CanonicalBaseUrl);
 		return Write(content, Collect(content, current, context, page));
 	}
 
@@ -62,14 +64,8 @@ internal static class ApiMarkdownFrontMatter
 		_ = markdown.AppendLine();
 	}
 
-	private static string CanonicalUrl(ApiRenderContext context, INavigationItem current)
-	{
-		var path = current.Url.TrimEnd('/');
-		if (path.Length == 0)
-			path = "/";
-
-		return context.BuildContext.CanonicalBaseUrl is { } baseUrl ? new Uri(baseUrl, path).ToString().TrimEnd('/') : path;
-	}
+	private static string CanonicalUrl(ApiRenderContext context, INavigationItem current) =>
+		UrlPath.MakeAbsolute(context.BuildContext.CanonicalBaseUrl, current.Url.TrimEnd('/'))?.TrimEnd('/') ?? current.Url.TrimEnd('/');
 
 	private static string? ResolveDescription(IApiModel page, ApiRenderContext context, string body)
 	{

--- a/src/Elastic.Documentation/Extensions/UrlPath.cs
+++ b/src/Elastic.Documentation/Extensions/UrlPath.cs
@@ -23,4 +23,25 @@ public static class UrlPath
 	/// Assumes both segments already use forward slashes.
 	/// </summary>
 	public static string JoinUrl(string left, string right) => $"{left.TrimEnd('/')}/{right.TrimStart('/')}";
+
+	/// <summary>Resolves a relative URL against the canonical base URL.</summary>
+	public static string? MakeAbsolute(Uri? baseUri, string? url)
+	{
+		if (
+			string.IsNullOrEmpty(url)
+			|| baseUri is null
+			|| Uri.IsWellFormedUriString(url, UriKind.Absolute)
+			|| !Uri.IsWellFormedUriString(url, UriKind.Relative)
+		)
+			return url;
+
+		try
+		{
+			return new Uri(baseUri, url).ToString();
+		}
+		catch
+		{
+			return url;
+		}
+	}
 }

--- a/src/Elastic.Markdown/Myst/Renderers/LlmMarkdown/LlmBlockRenderers.cs
+++ b/src/Elastic.Markdown/Myst/Renderers/LlmMarkdown/LlmBlockRenderers.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System.Net;
+using Elastic.Documentation.Extensions;
 using Elastic.Markdown.Helpers;
 using Elastic.Markdown.Myst.CodeBlocks;
 using Elastic.Markdown.Myst.Directives;
@@ -80,25 +81,7 @@ public static class LlmRenderingHelpers
 	/// <summary>
 	/// Converts relative URLs to absolute URLs for LLM consumption
 	/// </summary>
-	public static string? MakeAbsoluteUrl(Uri? baseUri, string? url)
-	{
-		if (
-			string.IsNullOrEmpty(url)
-			|| baseUri == null
-			|| Uri.IsWellFormedUriString(url, UriKind.Absolute)
-			|| !Uri.IsWellFormedUriString(url, UriKind.Relative)
-		)
-			return url;
-		try
-		{
-			var absoluteUri = new Uri(baseUri, url);
-			return absoluteUri.ToString();
-		}
-		catch
-		{
-			return url;
-		}
-	}
+	public static string? MakeAbsoluteUrl(Uri? baseUri, string? url) => UrlPath.MakeAbsolute(baseUri, url);
 
 	/// <summary>
 	/// Renders a markdown table from a list of rows (each row is a list of cell values).

--- a/tests/Elastic.ApiExplorer.Tests/ApiMarkdownIntraApiLinkTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/ApiMarkdownIntraApiLinkTests.cs
@@ -64,4 +64,22 @@ public class ApiMarkdownIntraApiLinkTests
 		renderer.LastMarkdown.Should().Contain("(/api/doc/kibana/group/endpoint-data-views)");
 		renderer.LastMarkdown.Should().Contain("(/api/doc/kibana/operation/operation-post-saved-objects-export)");
 	}
+
+	[Fact]
+	public void CanonicalizeLinks_UsesLlmAbsoluteUrlStrategyWithoutMarkdownSuffix()
+	{
+		var markdown =
+			"""
+			[Regions](/docs/api/doc/cloud-serverless/group/endpoint-regions)
+			[Relative](docs/api/doc/cloud-serverless/operation/operation-listregions)
+			[External](https://example.com/reference)
+			""";
+
+		var rewritten = ApiMarkdown.CanonicalizeLinks(markdown, new Uri("https://www.elastic.co"));
+
+		rewritten.Should().Contain("[Regions](https://www.elastic.co/docs/api/doc/cloud-serverless/group/endpoint-regions)");
+		rewritten.Should().Contain("[Relative](https://www.elastic.co/docs/api/doc/cloud-serverless/operation/operation-listregions)");
+		rewritten.Should().Contain("[External](https://example.com/reference)");
+		rewritten.Should().NotContain("endpoint-regions.md");
+	}
 }

--- a/tests/Elastic.Documentation.Tests/UrlPathTests.cs
+++ b/tests/Elastic.Documentation.Tests/UrlPathTests.cs
@@ -1,0 +1,25 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using AwesomeAssertions;
+using Elastic.Documentation.Extensions;
+
+namespace Elastic.Documentation.Tests;
+
+public class UrlPathTests
+{
+	[Theory]
+	[InlineData("/docs/api/doc/elasticsearch", "https://www.elastic.co/docs/api/doc/elasticsearch")]
+	[InlineData("docs/api/doc/elasticsearch", "https://www.elastic.co/docs/api/doc/elasticsearch")]
+	public void MakeAbsolute_RelativeUrl_UsesCanonicalBase(string url, string expected) =>
+		UrlPath.MakeAbsolute(new Uri("https://www.elastic.co"), url).Should().Be(expected);
+
+	[Fact]
+	public void MakeAbsolute_AbsoluteUrl_ReturnsUnchanged()
+	{
+		const string url = "https://example.com/reference";
+
+		UrlPath.MakeAbsolute(new Uri("https://www.elastic.co"), url).Should().Be(url);
+	}
+}


### PR DESCRIPTION
Generated API CommonMark now uses absolute canonical URLs for links. It follows the existing LLM Markdown strategy and keeps canonical links free of the representation-specific `.md` suffix.

**Affects:** API reference, Authoring

## Why

Generated API CommonMark currently contains root-relative links. Those links lose their host context when an agent reads or stores the file outside the site. The existing LLM renderer already resolves relative links against `CanonicalBaseUrl`.

## What

#### Shared URL resolution
The existing LLM URL resolver now uses `UrlPath.MakeAbsolute`. API CommonMark calls the same helper, so both outputs use one URL policy.

#### API CommonMark links
The frontmatter wrapper resolves relative link destinations against `CanonicalBaseUrl`. Absolute external links remain unchanged. Links identify canonical pages and do not add `.md`.

#### Frontmatter URLs
API frontmatter uses the shared resolver for `url` and `resource`. This keeps metadata and body links consistent.

## Verify

```bash
dotnet test tests/Elastic.Documentation.Tests/
dotnet test tests/Elastic.ApiExplorer.Tests/
dotnet test tests/Elastic.Markdown.Tests/
./build.sh lint
```

**Out of scope:** This PR does not change `.md` routing or content negotiation.

**Stack:** On top of https://github.com/elastic/docs-builder/pull/3994.

Made with [Cursor](https://cursor.com)