### PR TITLE
Shorten changelog gate comment config-file footer

### DIFF
--- a/src/services/Elastic.Changelog/Evaluation/ChangelogCommentRenderer.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogCommentRenderer.cs
@@ -126,9 +126,10 @@ internal static class ChangelogCommentRenderer
 	)
 	{
 		var configFileName = string.IsNullOrWhiteSpace(configFile) ? "docs/changelog.yml" : configFile;
-		var configRef = !string.IsNullOrWhiteSpace(owner) && !string.IsNullOrWhiteSpace(repo)
-			? $"[{configFileName}](https://github.com/{owner}/{repo}/blob/{defaultBranch ?? "main"}/{configFileName})"
-			: WrapInlineCode(configFileName);
+		var configUrl = !string.IsNullOrWhiteSpace(owner) && !string.IsNullOrWhiteSpace(repo)
+			? $"https://github.com/{owner}/{repo}/blob/{defaultBranch ?? "main"}/{configFileName}"
+			: null;
+		var configRef = configUrl != null ? $"[{configFileName}]({configUrl})" : WrapInlineCode(configFileName);
 
 		var hasAmbiguousType = !string.IsNullOrWhiteSpace(ambiguousTypeLabels);
 		var hasTypeIssue = !string.IsNullOrWhiteSpace(labelTable);
@@ -183,7 +184,10 @@ internal static class ChangelogCommentRenderer
 		allParts.AddRange(sections);
 		allParts.Add(skipSection);
 		allParts.Add("");
-		allParts.Add($"📄 See {configRef} for the full changelog configuration.");
+		var configFooter = configUrl != null
+			? $"📄 Inspect the [current changelog configuration]({configUrl})."
+			: $"📄 Inspect the current changelog configuration: {configRef}.";
+		allParts.Add(configFooter);
 
 		return Truncate(string.Join("\n", allParts));
 	}

--- a/tests/Elastic.Changelog.Tests/Evaluation/ChangelogCommentRendererTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/ChangelogCommentRendererTests.cs
@@ -96,7 +96,7 @@ public class ChangelogCommentRendererTests
 			defaultBranch: "main"
 		);
 
-		body.Should().Contain("[docs/changelog.yml](https://github.com/elastic/docs/blob/main/docs/changelog.yml)");
+		body.Should().Contain("[current changelog configuration](https://github.com/elastic/docs/blob/main/docs/changelog.yml)");
 	}
 
 	[Fact]


### PR DESCRIPTION
Changes the label-gate comment footer from `📄 See \`docs/changelog.yml\` for the full changelog configuration.` to `📄 Inspect the [current changelog configuration](link).` — shorter, the link text describes what it is rather than repeating the filename.

**Affects:** Release notes

## Why

The old line was verbose and buried the file path in prose. When a GitHub blob link is available the filename in the link text was redundant; `current changelog configuration` is shorter and reads naturally as a call to action.

## What

#### Footer copy

`"📄 See {configRef} for the full changelog configuration."` → `"📄 Inspect the [current changelog configuration]({url})."` when owner/repo are known; falls back to `"📄 Inspect the current changelog configuration: \`docs/changelog.yml\`."` when they are not.

The URL variable is now split out of `configRef` so the footer link text and the inline `configRef` (used in the skip section and the no-type-label fallback) can differ independently without nested markdown.

## Verify

```bash
dotnet test tests/Elastic.Changelog.Tests/ --filter ChangelogCommentRenderer
```