### PR TITLE
Add changelog validate-entries gate and fix label-gate comment tone

### DIFF
--- a/docs/cli-schema.json
+++ b/docs/cli-schema.json
@@ -5055,6 +5055,152 @@
           "path": [
             "changelog"
           ],
+          "name": "validate-entries",
+          "summary": "(CI and local) Validate changelog entry files that a PR added or modified. Checks YAML validity, required fields, config-value membership, PR existence, and entry hygiene. Exits non-zero on any error-level finding; warnings do not block.",
+          "usage": "docs-builder changelog validate-entries --config \u003Cfile\u003E --owner \u003Cstring\u003E --repo \u003Cstring\u003E --pr-number \u003Cint\u003E --pr-labels \u003Cstring\u003E [options]",
+          "examples": [],
+          "parameters": [
+            {
+              "role": "flag",
+              "name": "config",
+              "type": "string",
+              "required": true,
+              "summary": "Path to the changelog configuration file (docs/changelog.yml).",
+              "validations": [
+                {
+                  "kind": "fileExtensions",
+                  "values": [
+                    "yml",
+                    "yaml"
+                  ]
+                }
+              ]
+            },
+            {
+              "role": "flag",
+              "name": "owner",
+              "type": "string",
+              "required": true,
+              "summary": "GitHub repository owner."
+            },
+            {
+              "role": "flag",
+              "name": "repo",
+              "type": "string",
+              "required": true,
+              "summary": "GitHub repository name."
+            },
+            {
+              "role": "flag",
+              "name": "pr-number",
+              "type": "integer",
+              "required": true,
+              "summary": "Pull request number."
+            },
+            {
+              "role": "flag",
+              "name": "pr-labels",
+              "type": "string",
+              "required": true,
+              "summary": "Comma-separated list of PR labels (use ${{ join(github.event.pull_request.labels.*.name, \u0027,\u0027) }} in actions)."
+            },
+            {
+              "role": "flag",
+              "name": "files",
+              "type": "array",
+              "required": false,
+              "summary": "Optional explicit file list; bypasses GitHub API discovery. Useful for local runs.",
+              "repeatable": true,
+              "elementType": "string"
+            },
+            {
+              "role": "flag",
+              "name": "head-ref",
+              "type": "string",
+              "required": false,
+              "summary": "PR head branch ref \u2014 written to decision metadata when on CI."
+            },
+            {
+              "role": "flag",
+              "name": "head-sha",
+              "type": "string",
+              "required": false,
+              "summary": "PR head commit SHA \u2014 written to decision metadata when on CI."
+            },
+            {
+              "role": "flag",
+              "name": "is-fork",
+              "type": "boolean",
+              "required": false,
+              "summary": "Whether the PR is from a fork.",
+              "defaultValue": "false"
+            },
+            {
+              "role": "flag",
+              "name": "can-commit",
+              "type": "boolean",
+              "required": false,
+              "summary": "Whether the commit strategy allows committing.",
+              "defaultValue": "false"
+            },
+            {
+              "role": "flag",
+              "name": "maintainer-can-modify",
+              "type": "boolean",
+              "required": false,
+              "summary": "Whether the fork PR allows maintainer edits.",
+              "defaultValue": "false"
+            },
+            {
+              "role": "flag",
+              "name": "head-repo",
+              "type": "string",
+              "required": false,
+              "summary": "Fork repository full name (owner/repo)."
+            },
+            {
+              "role": "flag",
+              "name": "log-level",
+              "shortName": "l",
+              "type": "enum",
+              "required": false,
+              "summary": "Minimum log level. Default: information",
+              "enumValues": [
+                "trace",
+                "debug",
+                "information",
+                "warning",
+                "error",
+                "critical",
+                "none"
+              ]
+            },
+            {
+              "role": "flag",
+              "name": "config-source",
+              "shortName": "c",
+              "type": "enum",
+              "required": false,
+              "summary": "Override the configuration source: local, remote",
+              "enumValues": [
+                "local",
+                "remote",
+                "embedded"
+              ]
+            },
+            {
+              "role": "flag",
+              "name": "skip-private-repositories",
+              "type": "boolean",
+              "required": false,
+              "summary": "Skip cloning private repositories"
+            }
+          ]
+        },
+        {
+          "path": [
+            "changelog"
+          ],
           "name": "validate-labels",
           "summary": "(CI) Validate PR labels against the changelog config without writing any files or calling the GitHub API.",
           "notes": "A lightweight label-only gate intended for the pull_request event. Resolves\npivot.types, pivot.products, and rules.create skip labels against the PR\u0027s\nlabel set and exits non-zero on no-label. Does not perform title resolution, bot-loop\ndetection, or changelog-file lookup \u2014 use EvaluatePr when those are needed.\n\n\nOutputs: status (ok | no-label | skipped), type, products,\nlabel-table (shown on failure), product-label-table (shown on product failure),\nskip-labels.",

--- a/docs/cli/changelog/cmd-validate-entries.md
+++ b/docs/cli/changelog/cmd-validate-entries.md
@@ -1,0 +1,49 @@
+## Description
+
+:::{note}
+This command is intended for CI automation. It is used internally by the changelog GitHub Actions and is not typically invoked directly by users.
+:::
+
+Validate the content of changelog entry files that a pull request added or modified. Unlike `changelog evaluate-pr`, this command focuses exclusively on the YAML content of changelog entry files — not on which labels the PR carries or whether a changelog file exists at all. It runs four groups of checks:
+
+1. **Schema and required fields** — YAML parses, required fields (`title`, `type`, `products`) are present.
+2. **Config-value membership** — `type`, `subtype`, `areas`, and `lifecycle` values are recognised by the changelog configuration.
+3. **PR existence** — Own-repo PR references point to pull requests that actually exist (checked via GraphQL).
+4. **Entry hygiene** — `note-*` prefix files are excluded, `source-redirect` cannot be authored, `versions` cannot appear in entry files.
+
+Exits non-zero when any finding has `Error` severity. Warnings are logged but do not block.
+
+When running under GitHub Actions (the `GITHUB_ACTIONS` environment variable is set) and `--pr-number` is provided, the command writes a decision metadata file to `.artifacts/changelog-decision/metadata.json`. This file is picked up by the downstream `changelog github-comment` command to post or update the sticky PR comment.
+
+## File discovery
+
+When `--files` is not supplied, the command discovers changed files by calling the GitHub API (`GET /repos/{owner}/{repo}/pulls/{pr-number}/files`). Only files that are directly inside the configured changelog directory (no subdirectories), end in `.yaml` or `.yml`, and do not start with `note-` are validated.
+
+Supply `--files` to bypass API discovery and validate a known set of files — useful for local runs or custom CI setups.
+
+## Decision metadata
+
+When `--pr-number` is supplied and the command runs under GitHub Actions, it writes `.artifacts/changelog-decision/metadata.json` relative to the checkout root. The metadata carries the gate (`entries`), PR number, head ref/SHA, and a list of findings (file, severity, message). A consumer workflow uploads this file as the `changelog-decision` artifact and a `workflow_run` job picks it up to call `changelog github-comment`.
+
+## Examples
+
+```sh
+# CI mode: discover changed files from the GitHub API
+docs-builder changelog validate-entries \
+  --config docs/changelog.yml \
+  --owner elastic \
+  --repo my-repo \
+  --pr-number 42 \
+  --pr-labels "enhancement,Team:Core" \
+  --head-ref feature-branch \
+  --head-sha abc123
+
+# Local mode: validate specific files without GitHub API access
+docs-builder changelog validate-entries \
+  --config docs/changelog.yml \
+  --owner elastic \
+  --repo my-repo \
+  --pr-number 0 \
+  --pr-labels "" \
+  --files docs/changelog/42.yaml
+```

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogCommentRenderer.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogCommentRenderer.cs
@@ -126,9 +126,10 @@ internal static class ChangelogCommentRenderer
 	)
 	{
 		var configFileName = string.IsNullOrWhiteSpace(configFile) ? "docs/changelog.yml" : configFile;
-		var configRef = !string.IsNullOrWhiteSpace(owner) && !string.IsNullOrWhiteSpace(repo)
-			? $"[{configFileName}](https://github.com/{owner}/{repo}/blob/{defaultBranch ?? "main"}/{configFileName})"
-			: WrapInlineCode(configFileName);
+		var configUrl = !string.IsNullOrWhiteSpace(owner) && !string.IsNullOrWhiteSpace(repo)
+			? $"https://github.com/{owner}/{repo}/blob/{defaultBranch ?? "main"}/{configFileName}"
+			: null;
+		var configRef = configUrl != null ? $"[{configFileName}]({configUrl})" : WrapInlineCode(configFileName);
 
 		var hasAmbiguousType = !string.IsNullOrWhiteSpace(ambiguousTypeLabels);
 		var hasTypeIssue = !string.IsNullOrWhiteSpace(labelTable);
@@ -183,7 +184,10 @@ internal static class ChangelogCommentRenderer
 		allParts.AddRange(sections);
 		allParts.Add(skipSection);
 		allParts.Add("");
-		allParts.Add($"📄 See {configRef} for the full changelog configuration.");
+		var configFooter = configUrl != null
+			? $"📄 Inspect the [current changelog configuration]({configUrl})."
+			: $"📄 Inspect the current changelog configuration: {configRef}.";
+		allParts.Add(configFooter);
 
 		return Truncate(string.Join("\n", allParts));
 	}

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogCommentRenderer.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogCommentRenderer.cs
@@ -205,6 +205,59 @@ internal static class ChangelogCommentRenderer
 	internal static string RenderSkipped() =>
 		string.Join("\n", Title, "", "⏭️ **Excluded from release notes** — this PR will not appear in the changelog.");
 
+	/// <summary>
+	/// Renders the Step 2 (entry gate) body: one section per file listing errors first, then
+	/// warnings, each finding as a bullet. Files link to their GitHub blob URLs.
+	/// </summary>
+	internal static string RenderEntriesInvalid(IReadOnlyList<EntryFinding> findings, string? owner, string? repo, string? defaultBranch)
+	{
+		var branch = defaultBranch ?? "main";
+		var parts = new List<string> { Title, "", "📋 **Changelog entry file validation failed** — fix the issues below and push again." };
+
+		// Group by file, errors before warnings within each group
+		var byFile = findings.GroupBy(f => f.File).OrderBy(g => g.Key, StringComparer.OrdinalIgnoreCase);
+
+		foreach (var group in byFile)
+		{
+			var filePath = group.Key;
+			var fileRef = !string.IsNullOrWhiteSpace(owner) && !string.IsNullOrWhiteSpace(repo)
+				? $"[{WrapInlineCode(filePath)}](https://github.com/{owner}/{repo}/blob/{branch}/{Uri.EscapeDataString(filePath)})"
+				: WrapInlineCode(filePath);
+
+			parts.Add("");
+			parts.Add($"**{fileRef}**");
+
+			foreach (var finding in group.OrderBy(f => f.Severity))
+			{
+				var icon = finding.Severity == "Error" ? "❌" : "⚠️";
+				parts.Add($"- {icon} {finding.Message}");
+			}
+		}
+
+		return Truncate(string.Join("\n", parts));
+	}
+
+	/// <summary>
+	/// Renders the Step 2 (file gate) body: informs the author that no changelog entry file
+	/// was found for their PR and suggests the expected file path.
+	/// </summary>
+	internal static string RenderMissingEntry(string? changelogDir, int prNumber)
+	{
+		var dir = changelogDir ?? "docs/changelog";
+		var expectedPath = $"{dir}/{prNumber}.yaml";
+
+		return Truncate(
+			string.Join(
+				"\n",
+				Title,
+				"",
+				$"📋 **Changelog entry file required** — no entry file was found for PR #{prNumber}.",
+				"",
+				$"Add {WrapInlineCode(expectedPath)} to the PR branch, or disable the {WrapInlineCode("require-changelog-file")} gate in your {WrapInlineCode("release-notes.yml")} workflow."
+			)
+		);
+	}
+
 	// ──────────────────────────────────────────────────────────────────────────────────────────
 	// Injection-hardening helpers (ported from comment-helper.js)
 	// ──────────────────────────────────────────────────────────────────────────────────────────

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogEntryValidationService.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogEntryValidationService.cs
@@ -1,0 +1,303 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Changelog.GitHub;
+using Elastic.Documentation;
+using Elastic.Documentation.Configuration;
+using Elastic.Documentation.Configuration.Changelog;
+using Elastic.Documentation.Configuration.ReleaseNotes;
+using Elastic.Documentation.Diagnostics;
+using Elastic.Documentation.FileSystems;
+using Elastic.Documentation.ReleaseNotes;
+using Elastic.Documentation.Services;
+using Microsoft.Extensions.Logging;
+using YamlDotNet.Core;
+
+namespace Elastic.Changelog.Evaluation;
+
+/// <summary>
+/// Service implementing the <c>changelog validate-entries</c> gate.
+/// Validates changelog entry files that a PR added or modified: schema, config membership, PR existence, hygiene.
+/// </summary>
+public class ChangelogEntryValidationService(
+	ILoggerFactory logFactory,
+	IConfigurationContext configurationContext,
+	IGitHubPrService gitHubPrService,
+	IRunnerTempFileSystem fileSystem,
+	IEnvironmentVariables? env = null
+) : IService
+{
+	private readonly ILogger _logger = logFactory.CreateLogger<ChangelogEntryValidationService>();
+	private readonly ChangelogConfigurationLoader _configLoader = new(logFactory, configurationContext, fileSystem);
+	private readonly GithubDecisionMetadataWriter _metadataWriter = new(logFactory, fileSystem);
+
+	/// <summary>
+	/// Validates changelog entry files touched by the PR.
+	/// Returns true when all entry-level checks pass (warnings do not block).
+	/// </summary>
+	public async Task<bool> ValidateEntries(IDiagnosticsCollector collector, ValidateEntriesArguments input, Cancel ctx)
+	{
+		var config = await _configLoader.LoadChangelogConfiguration(collector, input.ConfigFile, ctx) ?? ChangelogConfiguration.Default;
+		var changelogDir = config.Bundle?.Directory ?? "docs/changelog";
+		var defaultBranch = config.Bundle?.Branch ?? "main";
+
+		// ── Resolve label-derived type ─────────────────────────────────────────────────────────
+		ChangelogEntryType? labelDerivedType = null;
+		if (config.LabelToType is { Count: > 0 })
+		{
+			var matchingLabels = input.PrLabels.Where(l => config.LabelToType.ContainsKey(l)).ToList();
+			if (matchingLabels.Count == 1 && config.LabelToType.TryGetValue(matchingLabels[0], out var typeStr))
+			{
+				if (ChangelogEntryTypeExtensions.TryParse(typeStr, out var t, ignoreCase: true, allowMatchingMetadataAttribute: true))
+					labelDerivedType = t;
+			}
+		}
+
+		// ── Discover files ─────────────────────────────────────────────────────────────────────
+		IReadOnlyList<string> filesToValidate;
+		if (input.Files is { Length: > 0 })
+		{
+			filesToValidate = FilterChangelogFiles(input.Files, changelogDir);
+		}
+		else
+		{
+			var changedFiles = await gitHubPrService.FetchChangedFilesAsync(input.Owner, input.Repo, input.PrNumber, ctx);
+			if (changedFiles is null)
+			{
+				collector.EmitError(
+					string.Empty,
+					$"Failed to fetch changed files for PR #{input.PrNumber} from GitHub API. Cannot validate changelog entries."
+				);
+				return false;
+			}
+			filesToValidate = FilterChangelogFiles(changedFiles, changelogDir);
+		}
+
+		if (filesToValidate.Count == 0)
+		{
+			_logger.LogInformation("No changelog entry files to validate for PR #{PrNumber}", input.PrNumber);
+			await WriteMetadataAsync(input, "ok", null, defaultBranch, ctx);
+			return true;
+		}
+
+		_logger.LogInformation("Validating {Count} changelog entry file(s) for PR #{PrNumber}", filesToValidate.Count, input.PrNumber);
+
+		// ── Known products ────────────────────────────────────────────────────────────────────
+		IReadOnlySet<string>? knownProducts = null;
+		var availableProducts = configurationContext.ProductsConfiguration.Products;
+		if (availableProducts is { Count: > 0 })
+			knownProducts = new HashSet<string>(availableProducts.Keys.Select(k => k.Replace('_', '-')), StringComparer.OrdinalIgnoreCase);
+
+		// ── Parse and run field-level rules ───────────────────────────────────────────────────
+		var allFindings = new List<EntryFileFinding>();
+		var entriesByFile = new Dictionary<string, ChangelogEntryDto?>(StringComparer.OrdinalIgnoreCase);
+
+		foreach (var relPath in filesToValidate)
+		{
+			var fullPath = fileSystem.Path.GetFullPath(relPath);
+			if (!fileSystem.File.Exists(fullPath))
+			{
+				// File is listed in the PR diff but not present on disk (deleted? wrong cwd?).
+				_logger.LogWarning("Changelog file {Path} listed in PR diff but not found on disk; skipping", relPath);
+				continue;
+			}
+
+			var rawYaml = await fileSystem.File.ReadAllTextAsync(fullPath, ctx);
+			ChangelogEntryDto? dto = null;
+			try
+			{
+				var normalized = ReleaseNotesSerialization.NormalizeYaml(rawYaml);
+				dto = ReleaseNotesSerialization.GetEntryDeserializer().Deserialize<ChangelogEntryDto>(normalized);
+				if (dto is not null)
+				{
+					var findings = ChangelogEntryValidator.Validate(relPath, dto, config, labelDerivedType, knownProducts);
+					allFindings.AddRange(findings);
+				}
+			}
+			catch (YamlException ex)
+			{
+				allFindings.Add(new EntryFileFinding(relPath, FindingSeverity.Error, $"YAML parse error: {ex.Message}"));
+			}
+
+			entriesByFile[relPath] = dto;
+		}
+
+		// ── Collect own-repo PR numbers for existence check ───────────────────────────────────
+		var ownRepoNumbers = new HashSet<int>();
+		var prToFiles = new Dictionary<int, List<string>>();
+		foreach (var (relPath, dto) in entriesByFile)
+		{
+			if (dto is null)
+				continue;
+			foreach (var prRef in ChangelogEntryValidator.CollectPrRefs(dto))
+			{
+				var (_, parsedRepo, parsedNum) = ParsePrRef(prRef, input.Owner, input.Repo);
+				if (parsedNum is null)
+					continue;
+				if (string.Equals(parsedRepo, input.Repo, StringComparison.OrdinalIgnoreCase))
+				{
+					_ = ownRepoNumbers.Add(parsedNum.Value);
+					if (!prToFiles.TryGetValue(parsedNum.Value, out var fileList))
+						prToFiles[parsedNum.Value] = fileList = [];
+					fileList.Add(relPath);
+				}
+			}
+		}
+
+		// ── Duplicate PR number detection ─────────────────────────────────────────────────────
+		foreach (var (prNum, files) in prToFiles)
+		{
+			if (files.Count > 1)
+				allFindings.Add(
+					new EntryFileFinding(
+						files[0],
+						FindingSeverity.Error,
+						$"PR #{prNum} is claimed by multiple files: {string.Join(", ", files)}"
+					)
+				);
+		}
+
+		// ── Batch PR existence check ───────────────────────────────────────────────────────────
+		var existenceResults = ownRepoNumbers.Count > 0
+			? await gitHubPrService.CheckPullRequestsExistAsync(input.Owner, input.Repo, [.. ownRepoNumbers], ctx)
+			: new Dictionary<int, bool>();
+
+		var linkAllowRepos = config.Bundle?.LinkAllowRepos;
+
+		// ── PR reference validation ───────────────────────────────────────────────────────────
+		foreach (var (relPath, dto) in entriesByFile)
+		{
+			if (dto is null)
+				continue;
+			var prRefFindings = ChangelogEntryValidator.ValidatePrReferences(
+				relPath,
+				dto,
+				input.Owner,
+				input.Repo,
+				existenceResults,
+				linkAllowRepos
+			);
+			allFindings.AddRange(prRefFindings);
+		}
+
+		// ── Write metadata and return ─────────────────────────────────────────────────────────
+		var hasErrors = allFindings.Any(f => f.Severity == FindingSeverity.Error);
+
+		if (hasErrors)
+		{
+			foreach (var finding in allFindings.Where(f => f.Severity == FindingSeverity.Error))
+				collector.EmitError(finding.File, finding.Message);
+			foreach (var finding in allFindings.Where(f => f.Severity == FindingSeverity.Warning))
+				collector.EmitWarning(finding.File, finding.Message);
+		}
+		else
+		{
+			foreach (var finding in allFindings.Where(f => f.Severity == FindingSeverity.Warning))
+				collector.EmitWarning(finding.File, finding.Message);
+		}
+
+		var entryFindings = allFindings.Count > 0 ? allFindings : null;
+		await WriteMetadataAsync(input, hasErrors ? "entries-invalid" : "ok", entryFindings, defaultBranch, ctx);
+
+		return !hasErrors;
+	}
+
+	/// <summary>Filters a list of file paths to changelog entry files in the changelog dir (top level only, no note-* files).</summary>
+	private static IReadOnlyList<string> FilterChangelogFiles(IEnumerable<string> files, string changelogDir)
+	{
+		var normalizedDir = changelogDir.TrimEnd('/');
+		return files.Where(f =>
+		{
+			var trimmed = f.TrimStart('/');
+			// Must be directly in the changelog dir, not a subdirectory
+			if (!trimmed.StartsWith(normalizedDir + "/", StringComparison.OrdinalIgnoreCase))
+				return false;
+			var remainder = trimmed[(normalizedDir.Length + 1)..];
+			// Top-level only — no subdirectories
+			if (remainder.Contains('/'))
+				return false;
+			// Must be yaml
+			if (
+				!remainder.EndsWith(".yaml", StringComparison.OrdinalIgnoreCase)
+				&& !remainder.EndsWith(".yml", StringComparison.OrdinalIgnoreCase)
+			)
+				return false;
+			// Skip note- files
+			if (remainder.StartsWith("note-", StringComparison.OrdinalIgnoreCase))
+				return false;
+			return true;
+		}).ToList();
+	}
+
+	private async Task WriteMetadataAsync(
+		ValidateEntriesArguments input,
+		string status,
+		List<EntryFileFinding>? findings,
+		string defaultBranch,
+		Cancel ctx
+	)
+	{
+		if (env?.IsRunningOnCI != true || input.PrNumber <= 0)
+			return;
+
+		var entryFindings = findings?.Select(
+			f => new EntryFinding { File = f.File, Severity = f.Severity.ToString(), Message = f.Message }
+		).ToList();
+
+		var metadata = new GithubDecisionMetadata
+		{
+			Gate = ValidationGate.Entries,
+			PrNumber = input.PrNumber,
+			HeadRef = input.HeadRef,
+			HeadSha = input.HeadSha,
+			Status = status,
+			IsFork = input.IsFork,
+			CanCommit = input.CanCommit,
+			MaintainerCanModify = input.MaintainerCanModify,
+			HeadRepo = input.HeadRepo,
+			ConfigFile = input.ConfigFile,
+			DefaultBranch = defaultBranch,
+			EntryFindings = entryFindings
+		};
+
+		await _metadataWriter.WriteAsync(metadata, ctx);
+	}
+
+	private static (string? owner, string? repo, int? number) ParsePrRef(string prRef, string defaultOwner, string defaultRepo)
+	{
+		if (
+			prRef.StartsWith("https://github.com/", StringComparison.OrdinalIgnoreCase)
+			|| prRef.StartsWith("http://github.com/", StringComparison.OrdinalIgnoreCase)
+		)
+		{
+			var uri = new Uri(prRef);
+			var segments = uri.Segments;
+			if (segments.Length >= 5 && segments[3].Equals("pull/", StringComparison.OrdinalIgnoreCase))
+			{
+				var owner = segments[1].TrimEnd('/');
+				var repo = segments[2].TrimEnd('/');
+				if (int.TryParse(segments[4].TrimEnd('/'), out var num))
+					return (owner, repo, num);
+			}
+			return (null, null, null);
+		}
+
+		var hashIdx = prRef.LastIndexOf('#');
+		if (hashIdx > 0 && hashIdx < prRef.Length - 1)
+		{
+			var repoPart = prRef[..hashIdx];
+			if (int.TryParse(prRef[(hashIdx + 1)..], out var num))
+			{
+				var parts = repoPart.Split('/');
+				if (parts.Length == 2)
+					return (parts[0], parts[1], num);
+			}
+		}
+
+		if (int.TryParse(prRef, out var bareNum))
+			return (defaultOwner, defaultRepo, bareNum);
+
+		return (null, null, null);
+	}
+}

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogEntryValidator.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogEntryValidator.cs
@@ -1,0 +1,323 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Documentation;
+using Elastic.Documentation.Configuration.Changelog;
+using Elastic.Documentation.Configuration.ReleaseNotes;
+using Elastic.Documentation.ReleaseNotes;
+
+namespace Elastic.Changelog.Evaluation;
+
+/// <summary>Finding severity level.</summary>
+public enum FindingSeverity
+{
+	Error,
+	Warning
+}
+
+/// <summary>A validation finding for a changelog entry file.</summary>
+public record EntryFileFinding(string File, FindingSeverity Severity, string Message);
+
+/// <summary>
+/// Pure, stateless rule engine for changelog entry files.
+/// A <see cref="YamlDotNet.Core.YamlException"/> during parse should be converted to a single
+/// <see cref="EntryFileFinding"/> error by the caller before calling <see cref="Validate"/>.
+/// </summary>
+public static class ChangelogEntryValidator
+{
+	/// <summary>
+	/// Validates an already-parsed <see cref="ChangelogEntryDto"/> against <paramref name="config"/>
+	/// and optionally against a <paramref name="labelDerivedType"/> from the PR labels.
+	/// </summary>
+	/// <param name="filePath">Repo-relative path used in finding messages.</param>
+	/// <param name="entry">The deserialized DTO.</param>
+	/// <param name="config">Changelog configuration.</param>
+	/// <param name="labelDerivedType">
+	/// Type derived from PR labels — null when no label context is available (local runs).
+	/// When non-null a missing or mismatching <c>type:</c> produces a label-aware message.
+	/// </param>
+	/// <param name="knownProducts">
+	/// Valid product IDs (already normalised to lower-kebab-case) from products.yml.
+	/// Null means skip product membership check.
+	/// </param>
+	public static IReadOnlyList<EntryFileFinding> Validate(
+		string filePath,
+		ChangelogEntryDto entry,
+		ChangelogConfiguration config,
+		ChangelogEntryType? labelDerivedType,
+		IReadOnlySet<string>? knownProducts
+	)
+	{
+		var findings = new List<EntryFileFinding>();
+
+		// ── Marker hygiene ───────────────────────────────────────────────────────────────────────
+		var isMarker = entry.Link is not null;
+		if (isMarker)
+		{
+			// A link: marker must carry nothing else.
+			var hasOtherFields = !string.IsNullOrWhiteSpace(entry.Title)
+				|| entry.Type is not null
+				|| entry.Products is { Count: > 0 }
+				|| entry.Prs is { Count: > 0 }
+				|| entry.Pr is not null
+				|| entry.Issues is { Count: > 0 };
+			if (hasOtherFields)
+				findings.Add(
+					Error(filePath, "marker entries (link:) must not contain other fields such as title, type, products, prs, or issues")
+				);
+
+			// source-redirect check still applies
+			if (entry.SourceRedirect is true)
+				findings.Add(Error(filePath, "source-redirect is written by the scrubber and must not appear in authored files"));
+
+			// For markers we skip all other field-level rules.
+			return findings;
+		}
+
+		// ── source-redirect ──────────────────────────────────────────────────────────────────────
+		if (entry.SourceRedirect is true)
+			findings.Add(Error(filePath, "source-redirect is written by the scrubber and must not appear in authored files"));
+
+		// ── Title ────────────────────────────────────────────────────────────────────────────────
+		if (string.IsNullOrWhiteSpace(entry.Title))
+			findings.Add(Error(filePath, "title is required"));
+		else if (entry.Title.Length > 80)
+			findings.Add(Warning(filePath, $"title exceeds 80 characters (current: {entry.Title.Length})"));
+
+		// ── Description ──────────────────────────────────────────────────────────────────────────
+		if (entry.Description is not null && entry.Description.Length > 600)
+			findings.Add(Warning(filePath, $"description exceeds 600 characters (current: {entry.Description.Length})"));
+
+		// ── Products ─────────────────────────────────────────────────────────────────────────────
+		if (entry.Products is null || entry.Products.Count == 0)
+			findings.Add(Error(filePath, "products is required"));
+		else
+		{
+			for (var i = 0; i < entry.Products.Count; i++)
+			{
+				var product = entry.Products[i];
+				if (string.IsNullOrWhiteSpace(product.Product))
+					findings.Add(Error(filePath, $"products[{i}].product is required"));
+				else if (knownProducts is not null)
+				{
+					var normalized = product.Product.Replace('_', '-');
+					if (!knownProducts.Contains(normalized))
+					{
+						var available = string.Join(", ", knownProducts.OrderBy(p => p));
+						findings.Add(
+							Error(
+								filePath,
+								$"product '{product.Product}' is not in the list of available products from config/products.yml. Available products: {available}"
+							)
+						);
+					}
+				}
+
+				// versions: not allowed on entries
+#pragma warning disable CS0618
+				if (product.Versions is { Count: > 0 })
+					findings.Add(Error(filePath, "products[].versions is only valid in changelog note files (note-*.yaml)"));
+
+				// obsolete target:
+				if (product.Target is not null)
+					findings.Add(Warning(filePath, "products[].target is obsolete; use products[].versions in a note file"));
+#pragma warning restore CS0618
+
+				// lifecycle
+				if (!string.IsNullOrWhiteSpace(product.Lifecycle))
+				{
+					var availableLifecycles = config.Lifecycles.Select(l => l.ToStringFast(true)).ToList();
+					if (
+						!LifecycleExtensions.TryParse(product.Lifecycle, out _, ignoreCase: true, allowMatchingMetadataAttribute: true)
+						|| !availableLifecycles.Contains(product.Lifecycle, StringComparer.OrdinalIgnoreCase)
+					)
+					{
+						findings.Add(
+							Error(
+								filePath,
+								$"lifecycle '{product.Lifecycle}' is not valid; expected one of: {string.Join(", ", availableLifecycles)}"
+							)
+						);
+					}
+				}
+			}
+		}
+
+		// ── Type ─────────────────────────────────────────────────────────────────────────────────
+		var parsedEntryType = string.IsNullOrEmpty(entry.Type)
+			? ChangelogEntryType.Invalid
+			: ChangelogEntryTypeExtensions.TryParse(entry.Type, out var t, ignoreCase: true, allowMatchingMetadataAttribute: true)
+				? t
+				: ChangelogEntryType.Invalid;
+		if (string.IsNullOrWhiteSpace(entry.Type) || parsedEntryType == ChangelogEntryType.Invalid)
+		{
+			if (string.IsNullOrWhiteSpace(entry.Type))
+			{
+				// Missing
+				if (labelDerivedType.HasValue)
+				{
+					var labelTypeName = labelDerivedType.Value.ToStringFast(true);
+					findings.Add(Error(filePath, $"type is omitted; add `type: {labelTypeName}` to match this PR's label"));
+				}
+				else
+					findings.Add(Error(filePath, "type is required"));
+			}
+			else
+			{
+				// Present but unrecognised
+				findings.Add(Error(filePath, $"type '{entry.Type}' is not recognised; valid values: {string.Join(", ", config.Types)}"));
+			}
+		}
+		else
+		{
+			// Present and valid — check against label-derived type
+			if (labelDerivedType.HasValue && parsedEntryType != labelDerivedType.Value)
+			{
+				var entryTypeName = parsedEntryType.ToStringFast(true);
+				var labelTypeName = labelDerivedType.Value.ToStringFast(true);
+				findings.Add(Error(filePath, $"type '{entryTypeName}' does not match label-derived type '{labelTypeName}'"));
+			}
+		}
+
+		// ── Subtype ──────────────────────────────────────────────────────────────────────────────
+		if (!string.IsNullOrWhiteSpace(entry.Subtype))
+		{
+			if (!config.SubTypes.Contains(entry.Subtype, StringComparer.OrdinalIgnoreCase))
+				findings.Add(
+					Error(filePath, $"subtype '{entry.Subtype}' is not valid; expected one of: {string.Join(", ", config.SubTypes)}")
+				);
+			else if (parsedEntryType is not (ChangelogEntryType.BreakingChange or ChangelogEntryType.Invalid))
+				findings.Add(Warning(filePath, "subtype is only expected on breaking-change entries"));
+		}
+
+		// ── Areas ────────────────────────────────────────────────────────────────────────────────
+		if (config.Areas is { Count: > 0 } && entry.Areas is { Count: > 0 })
+		{
+			foreach (var area in entry.Areas)
+			{
+				if (!config.Areas.Contains(area, StringComparer.OrdinalIgnoreCase))
+					findings.Add(Error(filePath, $"area '{area}' is not valid; expected one of: {string.Join(", ", config.Areas)}"));
+			}
+		}
+
+		return findings;
+	}
+
+	/// <summary>
+	/// Validates PR references in <paramref name="entry"/>, checking existence for own-repo refs.
+	/// </summary>
+	/// <param name="filePath">Repo-relative path used in finding messages.</param>
+	/// <param name="entry">The deserialized DTO.</param>
+	/// <param name="defaultOwner">Owner used for normalization (the configured bundle owner).</param>
+	/// <param name="defaultRepo">Repo used to identify own-repo refs.</param>
+	/// <param name="existenceResults">Number → exists, for own-repo PRs. Missing keys mean "unknown".</param>
+	/// <param name="linkAllowRepos">Repos allowed for foreign-repo refs (from bundle.link_allow_repos).</param>
+	public static IReadOnlyList<EntryFileFinding> ValidatePrReferences(
+		string filePath,
+		ChangelogEntryDto entry,
+		string defaultOwner,
+		string defaultRepo,
+		IReadOnlyDictionary<int, bool> existenceResults,
+		IReadOnlyList<string>? linkAllowRepos = null
+	)
+	{
+		var findings = new List<EntryFileFinding>();
+		var refs = CollectPrRefs(entry);
+
+		foreach (var prRef in refs)
+		{
+			var (parsedOwner, parsedRepo, parsedNumber) = ParsePrRef(prRef, defaultOwner, defaultRepo);
+			if (parsedNumber is null)
+			{
+				findings.Add(Error(filePath, $"PR reference '{prRef}' could not be parsed as a valid PR URL or number"));
+				continue;
+			}
+
+			var isOwnRepo = string.Equals(parsedRepo, defaultRepo, StringComparison.OrdinalIgnoreCase);
+			if (isOwnRepo)
+			{
+				if (existenceResults.TryGetValue(parsedNumber.Value, out var exists) && !exists)
+					findings.Add(Error(filePath, $"PR #{parsedNumber.Value} does not exist in {parsedOwner}/{parsedRepo}"));
+				// If not in existenceResults, it's "unknown" — warn-and-omit, not an error
+			}
+			else
+			{
+				// Foreign repo: warn if not on the allowlist
+				var foreignRepo = $"{parsedOwner}/{parsedRepo}";
+				if (linkAllowRepos is { Count: > 0 })
+				{
+					var allowed = linkAllowRepos.Any(
+						r => r.Contains('/')
+							? r.Equals(foreignRepo, StringComparison.OrdinalIgnoreCase)
+							: r.Equals(parsedRepo, StringComparison.OrdinalIgnoreCase)
+					);
+					if (!allowed)
+						findings.Add(
+							Warning(
+								filePath,
+								$"PR reference to '{foreignRepo}' is outside bundle.link_allow_repos; it will be scrubbed when published"
+							)
+						);
+				}
+			}
+		}
+
+		return findings;
+	}
+
+	/// <summary>Collect all PR reference strings from <c>pr:</c> and <c>prs:</c>.</summary>
+	public static IReadOnlyList<string> CollectPrRefs(ChangelogEntryDto entry)
+	{
+		var refs = new List<string>();
+		if (!string.IsNullOrWhiteSpace(entry.Pr))
+			refs.Add(entry.Pr.Trim());
+		if (entry.Prs is { Count: > 0 })
+			refs.AddRange(entry.Prs.Select(p => p.Trim()).Where(p => !string.IsNullOrWhiteSpace(p)));
+		return refs;
+	}
+
+	/// <summary>Parses a PR ref into (owner, repo, number). Returns nulls on failure.</summary>
+	private static (string? owner, string? repo, int? number) ParsePrRef(string prRef, string defaultOwner, string defaultRepo)
+	{
+		// Full URL: https://github.com/owner/repo/pull/123
+		if (
+			prRef.StartsWith("https://github.com/", StringComparison.OrdinalIgnoreCase)
+			|| prRef.StartsWith("http://github.com/", StringComparison.OrdinalIgnoreCase)
+		)
+		{
+			var uri = new Uri(prRef);
+			var segments = uri.Segments;
+			if (segments.Length >= 5 && segments[3].Equals("pull/", StringComparison.OrdinalIgnoreCase))
+			{
+				var owner = segments[1].TrimEnd('/');
+				var repo = segments[2].TrimEnd('/');
+				if (int.TryParse(segments[4].TrimEnd('/'), out var num))
+					return (owner, repo, num);
+			}
+			return (null, null, null);
+		}
+
+		// Short: owner/repo#123
+		var hashIdx = prRef.LastIndexOf('#');
+		if (hashIdx > 0 && hashIdx < prRef.Length - 1)
+		{
+			var repoPart = prRef[..hashIdx];
+			if (int.TryParse(prRef[(hashIdx + 1)..], out var num))
+			{
+				var parts = repoPart.Split('/');
+				if (parts.Length == 2)
+					return (parts[0], parts[1], num);
+			}
+		}
+
+		// Bare number
+		if (int.TryParse(prRef, out var bareNum))
+			return (defaultOwner, defaultRepo, bareNum);
+
+		return (null, null, null);
+	}
+
+	private static EntryFileFinding Error(string file, string message) => new(file, FindingSeverity.Error, message);
+	private static EntryFileFinding Warning(string file, string message) => new(file, FindingSeverity.Warning, message);
+}

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogGithubCommentService.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogGithubCommentService.cs
@@ -119,6 +119,20 @@ public class ChangelogGithubCommentService(
 			);
 		}
 
+		// Step 2 (entry gate): changelog entry file content has validation errors.
+		if (metadata.Gate == ValidationGate.Entries && metadata.EntryFindings is { Count: > 0 })
+		{
+			_logger.LogInformation("Rendering entries-invalid body for PR #{PrNumber}", metadata.PrNumber);
+			return ChangelogCommentRenderer.RenderEntriesInvalid(metadata.EntryFindings, owner, repo, metadata.DefaultBranch);
+		}
+
+		// Step 2 (file gate): changelog file missing (require-changelog-file failure).
+		if (metadata.Gate == ValidationGate.File && string.Equals(metadata.Status, "missing-entry", StringComparison.OrdinalIgnoreCase))
+		{
+			_logger.LogInformation("Rendering missing-entry body for PR #{PrNumber}", metadata.PrNumber);
+			return ChangelogCommentRenderer.RenderMissingEntry(metadata.ChangelogDir, metadata.PrNumber);
+		}
+
 		// Step 1 (label gate): labels are missing — tell the author which ones to add.
 		// Dispatches on Gate when present; falls back to status for artifacts written before Gate was added.
 		if (isNoLabel && metadata.Gate is null or ValidationGate.Labels)

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogPrEvaluationService.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogPrEvaluationService.cs
@@ -235,6 +235,8 @@ public class ChangelogPrEvaluationService(
 					"Add a changelog entry file to the PR or disable the require-changelog-file gate."
 			);
 			_ = await SetOutputs(PrEvaluationResult.MissingEntry, changelogDir: changelogDir);
+			// Write metadata so the github-comment step can render a missing-entry body.
+			await WriteDecisionMetadataAsync(input, "missing-entry", changelogDir: changelogDir, defaultBranch: defaultBranch, ctx: ctx);
 			return false;
 		}
 

--- a/src/services/Elastic.Changelog/Evaluation/GithubDecisionMetadata.cs
+++ b/src/services/Elastic.Changelog/Evaluation/GithubDecisionMetadata.cs
@@ -42,6 +42,16 @@ public record GithubDecisionMetadata
 	public CommitOutcome? CommitOutcome { get; init; }
 	/// <summary>Repo-relative path to the committed changelog file, when <see cref="CommitOutcome"/> is <c>Committed</c>.</summary>
 	public string? CommittedFile { get; init; }
+	/// <summary>Findings from the entry-file validation gate. Non-null and non-empty when <see cref="Gate"/> is <see cref="ValidationGate.Entries"/> and validation failed.</summary>
+	public IReadOnlyList<EntryFinding>? EntryFindings { get; init; }
+}
+
+/// <summary>A single finding from the changelog entry file validation gate.</summary>
+public record EntryFinding
+{
+	public required string File { get; init; }
+	public required string Severity { get; init; }
+	public required string Message { get; init; }
 }
 
 /// <summary>
@@ -50,6 +60,7 @@ public record GithubDecisionMetadata
 /// <list type="bullet">
 ///   <item><see cref="Labels"/> — written by <c>validate-labels</c> (Step 1: label gate).</item>
 ///   <item><see cref="File"/> — written by <c>evaluate-pr</c> (Step 2: changelog file gate).</item>
+///   <item><see cref="Entries"/> — written by <c>validate-entries</c> (Step 2: entry-file content gate).</item>
 /// </list>
 /// Nullable on the record so artifacts without this field still deserialize.
 /// </summary>
@@ -57,8 +68,10 @@ public enum ValidationGate
 {
 	/// <summary>Written by <c>validate-labels</c>. Only label presence is checked.</summary>
 	Labels,
-	/// <summary>Written by <c>evaluate-pr</c>. The changelog file is also evaluated.</summary>
+	/// <summary>Written by <c>evaluate-pr</c>. The changelog file presence is evaluated.</summary>
 	File,
+	/// <summary>Written by <c>validate-entries</c>. The content of changelog entry files is validated.</summary>
+	Entries,
 }
 
 /// <summary>Outcome of the apply job's changelog commit step.</summary>
@@ -79,4 +92,6 @@ public enum CommitOutcome
 [JsonSerializable(typeof(CreateRules))]
 [JsonSerializable(typeof(FieldMode))]
 [JsonSerializable(typeof(MatchMode))]
+[JsonSerializable(typeof(EntryFinding))]
+[JsonSerializable(typeof(List<EntryFinding>))]
 public sealed partial class GithubDecisionMetadataJsonContext : JsonSerializerContext;

--- a/src/services/Elastic.Changelog/Evaluation/ValidateEntriesArguments.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ValidateEntriesArguments.cs
@@ -1,0 +1,25 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic.Changelog.Evaluation;
+
+/// <summary>Arguments for the <c>changelog validate-entries</c> command.</summary>
+public record ValidateEntriesArguments
+{
+	public required string ConfigFile { get; init; }
+	public required string Owner { get; init; }
+	public required string Repo { get; init; }
+	public required int PrNumber { get; init; }
+	public required string[] PrLabels { get; init; }
+	/// <summary>Explicit file list; bypasses API discovery when non-null. Null means discover via GitHub API.</summary>
+	public string[]? Files { get; init; }
+
+	// PR context — written to decision metadata when running on CI.
+	public string HeadRef { get; init; } = "";
+	public string HeadSha { get; init; } = "";
+	public bool IsFork { get; init; }
+	public bool CanCommit { get; init; }
+	public bool MaintainerCanModify { get; init; }
+	public string? HeadRepo { get; init; }
+}

--- a/src/services/Elastic.Changelog/GitHub/GitHubPrService.cs
+++ b/src/services/Elastic.Changelog/GitHub/GitHubPrService.cs
@@ -397,6 +397,170 @@ public partial class GitHubPrService(ILoggerFactory loggerFactory, GitHubApiTran
 		return [.. prs];
 	}
 
+	/// <inheritdoc />
+	public async Task<IReadOnlyList<string>?> FetchChangedFilesAsync(
+		string owner,
+		string repo,
+		int prNumber,
+		CancellationToken ctx = default
+	)
+	{
+		try
+		{
+			var files = new List<string>();
+			var page = 1;
+			while (true)
+			{
+				var url = $"https://api.github.com/repos/{owner}/{repo}/pulls/{prNumber}/files?per_page=100&page={page}";
+				_logger.LogDebug("Fetching PR changed files page {Page}: {Url}", page, url);
+
+				using var response = await _transport.GetAsync(url, ctx);
+				if (!response.IsSuccessStatusCode)
+				{
+					_logger.LogWarning("Failed to fetch PR files. Status: {StatusCode}", response.StatusCode);
+					return null;
+				}
+
+				var json = await response.Content.ReadAsStringAsync(ctx);
+				var items = JsonSerializer.Deserialize(json, GitHubPrJsonContext.Default.ListGitHubPrFileItem);
+				if (items is null or { Count: 0 })
+					break;
+
+				foreach (var item in items)
+				{
+					if (item.Filename is not null && (item.Status == "added" || item.Status == "modified"))
+						files.Add(item.Filename);
+				}
+
+				if (items.Count < 100)
+					break;
+				page++;
+			}
+			return files;
+		}
+		catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+		{
+			_logger.LogWarning(ex, "Error fetching PR changed files for PR #{PrNumber}", prNumber);
+			return null;
+		}
+	}
+
+	private const int PrExistenceBatchSize = 50;
+
+	[GeneratedRegex("^[A-Za-z0-9_.-]+$")]
+	private static partial Regex SafeGraphQlIdentifierRegex();
+
+	/// <inheritdoc />
+	public async Task<IReadOnlyDictionary<int, bool>> CheckPullRequestsExistAsync(
+		string owner,
+		string repo,
+		IReadOnlyList<int> numbers,
+		CancellationToken ctx = default
+	)
+	{
+		if (numbers.Count == 0)
+			return new Dictionary<int, bool>();
+
+		var token = _transport.ResolveToken();
+		if (string.IsNullOrWhiteSpace(token))
+		{
+			_logger.LogWarning("No GITHUB_TOKEN — skipping PR existence check for {Count} numbers", numbers.Count);
+			return new Dictionary<int, bool>();
+		}
+
+		if (!SafeGraphQlIdentifierRegex().IsMatch(owner) || !SafeGraphQlIdentifierRegex().IsMatch(repo))
+		{
+			_logger.LogWarning("Invalid owner/repo for GraphQL: {Owner}/{Repo}", owner, repo);
+			return new Dictionary<int, bool>();
+		}
+
+		var result = new Dictionary<int, bool>();
+
+		for (var batchStart = 0; batchStart < numbers.Count; batchStart += PrExistenceBatchSize)
+		{
+			var batch = numbers.Skip(batchStart).Take(PrExistenceBatchSize).ToList();
+			var batchResult = await CheckPrBatchAsync(owner, repo, batch, ctx);
+			foreach (var (num, exists) in batchResult)
+				result[num] = exists;
+		}
+
+		return result;
+	}
+
+	private async Task<IReadOnlyDictionary<int, bool>> CheckPrBatchAsync(
+		string owner,
+		string repo,
+		IReadOnlyList<int> numbers,
+		CancellationToken ctx
+	)
+	{
+		var query = BuildPrExistenceQuery(owner, repo, numbers);
+		var requestJson = JsonSerializer.Serialize(new GraphQlRequest { Query = query }, GitHubPrJsonContext.Default.GraphQlRequest);
+
+		try
+		{
+			using var response = await _transport.PostGraphQlAsync(requestJson, ctx);
+			var responseJson = await response.Content.ReadAsStringAsync(ctx);
+
+			if (!response.IsSuccessStatusCode)
+			{
+				_logger.LogWarning("GraphQL PR existence check failed. Status: {StatusCode}", response.StatusCode);
+				return new Dictionary<int, bool>();
+			}
+
+			var parsed = JsonSerializer.Deserialize(responseJson, GitHubPrJsonContext.Default.PrExistenceGraphQlResponse);
+			if (parsed?.Data?.Repository is null)
+			{
+				_logger.LogWarning("GraphQL PR existence response had no repository data");
+				return new Dictionary<int, bool>();
+			}
+
+			// Build a set of numbers that had NOT_FOUND errors
+			var notFoundErrors = new HashSet<int>();
+			if (parsed.Errors is { Count: > 0 })
+			{
+				// Errors reference path like ["repository", "p1234"] — extract the index
+				foreach (var error in parsed.Errors)
+				{
+					if (error.Path is { Count: >= 2 } && error.Path[1] is string alias && alias.StartsWith('p'))
+					{
+						if (int.TryParse(alias[1..], out var idx) && idx >= 0 && idx < numbers.Count)
+							_ = notFoundErrors.Add(numbers[idx]);
+					}
+				}
+			}
+
+			var result = new Dictionary<int, bool>();
+			for (var i = 0; i < numbers.Count; i++)
+			{
+				var num = numbers[i];
+				var alias = $"p{i}";
+				if (parsed.Data.Repository.TryGetValue(alias, out var node))
+					result[num] = node is not null;
+				else
+					// alias not present in response — treat as unknown (omit)
+					_logger.LogDebug("PR #{Number} not present in GraphQL response; skipping", num);
+			}
+
+			return result;
+		}
+		catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException)
+		{
+			_logger.LogWarning(ex, "Error during GraphQL PR existence batch check");
+			return new Dictionary<int, bool>();
+		}
+	}
+
+	private static string BuildPrExistenceQuery(string owner, string repo, IReadOnlyList<int> numbers)
+	{
+		var sb = new System.Text.StringBuilder();
+		_ = sb.Append("query { repository(owner: \"").Append(owner).Append("\", name: \"").Append(repo).Append("\") {");
+		for (var i = 0; i < numbers.Count; i++)
+			_ = sb.Append(" p").Append(i).Append(": pullRequest(number: ").Append(numbers[i]).Append(") { number }");
+		_ = sb.Append(" } }");
+		return sb.ToString();
+	}
+
 	private sealed class GitHubPrResponse
 	{
 		public string Title { get; set; } = string.Empty;
@@ -447,6 +611,51 @@ public partial class GitHubPrService(ILoggerFactory loggerFactory, GitHubApiTran
 		public GitHubCommitAuthor? Author { get; set; }
 	}
 
+	private sealed class GitHubPrFileItem
+	{
+		[JsonPropertyName("filename")]
+		public string? Filename { get; set; }
+
+		[JsonPropertyName("status")]
+		public string? Status { get; set; }
+	}
+
+	private sealed class GraphQlRequest
+	{
+		[JsonPropertyName("query")]
+		public string Query { get; set; } = string.Empty;
+	}
+
+	private sealed class PrExistenceGraphQlResponse
+	{
+		[JsonPropertyName("data")]
+		public PrExistenceData? Data { get; set; }
+
+		[JsonPropertyName("errors")]
+		public List<PrExistenceError>? Errors { get; set; }
+	}
+
+	private sealed class PrExistenceData
+	{
+		[JsonPropertyName("repository")]
+		public Dictionary<string, PrExistenceNode?>? Repository { get; set; }
+	}
+
+	private sealed class PrExistenceNode
+	{
+		[JsonPropertyName("number")]
+		public int Number { get; set; }
+	}
+
+	private sealed class PrExistenceError
+	{
+		[JsonPropertyName("message")]
+		public string? Message { get; set; }
+
+		[JsonPropertyName("path")]
+		public List<string>? Path { get; set; }
+	}
+
 	[JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
 	[JsonSerializable(typeof(GitHubPrResponse))]
 	[JsonSerializable(typeof(GitHubIssueResponse))]
@@ -458,6 +667,15 @@ public partial class GitHubPrService(ILoggerFactory loggerFactory, GitHubApiTran
 	[JsonSerializable(typeof(GitHubCommitAuthor))]
 	[JsonSerializable(typeof(GitHubCommitListItem))]
 	[JsonSerializable(typeof(List<GitHubCommitListItem>))]
+	[JsonSerializable(typeof(GitHubPrFileItem))]
+	[JsonSerializable(typeof(List<GitHubPrFileItem>))]
+	[JsonSerializable(typeof(GraphQlRequest))]
+	[JsonSerializable(typeof(PrExistenceGraphQlResponse))]
+	[JsonSerializable(typeof(PrExistenceData))]
+	[JsonSerializable(typeof(Dictionary<string, PrExistenceNode?>))]
+	[JsonSerializable(typeof(PrExistenceNode))]
+	[JsonSerializable(typeof(PrExistenceError))]
+	[JsonSerializable(typeof(List<PrExistenceError>))]
 	private sealed partial class GitHubPrJsonContext : JsonSerializerContext;
 
 	[GeneratedRegex(@"https://github\.com/([a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+)/pull/(\d+)", RegexOptions.IgnoreCase

--- a/src/services/Elastic.Changelog/GitHub/IGitHubPrService.cs
+++ b/src/services/Elastic.Changelog/GitHub/IGitHubPrService.cs
@@ -40,4 +40,22 @@ public interface IGitHubPrService
 		string branch,
 		CancellationToken ctx = default
 	);
+
+	/// <summary>
+	/// Fetches the list of files changed by a pull request (status added or modified).
+	/// Returns null when the API call fails — callers decide whether that is fatal.
+	/// </summary>
+	Task<IReadOnlyList<string>?> FetchChangedFilesAsync(string owner, string repo, int prNumber, CancellationToken ctx = default);
+
+	/// <summary>
+	/// Checks whether each PR number in <paramref name="numbers"/> exists in the repository.
+	/// Returns a dictionary of number → exists. Numbers that cannot be determined (transport failure)
+	/// are omitted from the result — callers must treat omission as "unknown", not "absent".
+	/// </summary>
+	Task<IReadOnlyDictionary<int, bool>> CheckPullRequestsExistAsync(
+		string owner,
+		string repo,
+		IReadOnlyList<int> numbers,
+		CancellationToken ctx = default
+	);
 }

--- a/src/tooling/docs-builder/Commands/ChangelogCommand.cs
+++ b/src/tooling/docs-builder/Commands/ChangelogCommand.cs
@@ -1850,6 +1850,68 @@ internal sealed partial class ChangelogCommands(
 		return await serviceInvoker.InvokeAsync(ctx);
 	}
 
+	/// <summary>
+	/// (CI and local) Validate changelog entry files that a PR added or modified.
+	/// Checks YAML validity, required fields, config-value membership, PR existence, and entry hygiene.
+	/// Exits non-zero on any error-level finding; warnings do not block.
+	/// </summary>
+	/// <param name="config">Path to the changelog configuration file (docs/changelog.yml).</param>
+	/// <param name="owner">GitHub repository owner.</param>
+	/// <param name="repo">GitHub repository name.</param>
+	/// <param name="prNumber">Pull request number.</param>
+	/// <param name="prLabels">Comma-separated list of PR labels (use <c>${{ join(github.event.pull_request.labels.*.name, ',') }}</c> in actions).</param>
+	/// <param name="files">Optional explicit file list; bypasses GitHub API discovery. Useful for local runs.</param>
+	/// <param name="headRef">PR head branch ref — written to decision metadata when on CI.</param>
+	/// <param name="headSha">PR head commit SHA — written to decision metadata when on CI.</param>
+	/// <param name="isFork">Whether the PR is from a fork.</param>
+	/// <param name="canCommit">Whether the commit strategy allows committing.</param>
+	/// <param name="maintainerCanModify">Whether the fork PR allows maintainer edits.</param>
+	/// <param name="headRepo">Fork repository full name (owner/repo).</param>
+	/// <param name="ct">Cancellation token.</param>
+	[NoOptionsInjection]
+	public async Task<int> ValidateEntries(
+		[FileExtensions(Extensions = "yml,yaml")] FileInfo config,
+		string owner,
+		string repo,
+		int prNumber,
+		string prLabels,
+		string[]? files = null,
+		string headRef = "",
+		string headSha = "",
+		bool isFork = false,
+		bool canCommit = false,
+		bool maintainerCanModify = false,
+		string? headRepo = null,
+		CancellationToken ct = default
+	)
+	{
+		var ctx = ct;
+		await using var serviceInvoker = new ServiceInvoker(collector);
+
+		var fileSystem = RunnerTempFileSystem.ForEvaluatePr(environmentVariables);
+		IGitHubPrService prService = new GitHubPrService(logFactory);
+		var service = new ChangelogEntryValidationService(logFactory, configurationContext, prService, fileSystem, environmentVariables);
+
+		var args = new ValidateEntriesArguments
+		{
+			ConfigFile = config.FullName,
+			Owner = owner,
+			Repo = repo,
+			PrNumber = prNumber,
+			PrLabels = prLabels.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
+			Files = files,
+			HeadRef = headRef,
+			HeadSha = headSha,
+			IsFork = isFork,
+			CanCommit = canCommit,
+			MaintainerCanModify = maintainerCanModify,
+			HeadRepo = headRepo
+		};
+
+		serviceInvoker.AddCommand(service, args, static async (s, collector, state, ctx) => await s.ValidateEntries(collector, state, ctx));
+		return await serviceInvoker.InvokeAsync(ctx);
+	}
+
 	/// <summary>(CI) Package changelog artifact for cross-workflow transfer.</summary>
 	/// <remarks>
 	/// Resolves final status from evaluate-pr + changelog add outcomes, copies generated YAML,

--- a/tests/Elastic.Changelog.Tests/Evaluation/ChangelogCommentRendererTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/ChangelogCommentRendererTests.cs
@@ -96,7 +96,7 @@ public class ChangelogCommentRendererTests
 			defaultBranch: "main"
 		);
 
-		body.Should().Contain("[docs/changelog.yml](https://github.com/elastic/docs/blob/main/docs/changelog.yml)");
+		body.Should().Contain("[current changelog configuration](https://github.com/elastic/docs/blob/main/docs/changelog.yml)");
 	}
 
 	[Fact]

--- a/tests/Elastic.Changelog.Tests/Evaluation/ChangelogCommentRendererTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/ChangelogCommentRendererTests.cs
@@ -182,4 +182,111 @@ public class ChangelogCommentRendererTests
 		body.Length.Should().BeLessThanOrEqualTo(65_536);
 		body.Should().Contain("truncated");
 	}
+
+	// ──────────────────────────────────────────────────────────────────────────────────────────────
+	// RenderEntriesInvalid
+	// ──────────────────────────────────────────────────────────────────────────────────────────────
+
+	[Fact]
+	public void RenderEntriesInvalid_StartsWithTitle()
+	{
+		var findings = new List<EntryFinding>
+		{
+			new() { File = "docs/changelog/42.yaml", Severity = "Error", Message = "title is required" }
+		};
+		var body = ChangelogCommentRenderer.RenderEntriesInvalid(findings, null, null, null);
+		body.Should().StartWith(ChangelogCommentRenderer.Title);
+	}
+
+	[Fact]
+	public void RenderEntriesInvalid_ContainsHeadline()
+	{
+		var findings = new List<EntryFinding>
+		{
+			new() { File = "docs/changelog/42.yaml", Severity = "Error", Message = "title is required" }
+		};
+		var body = ChangelogCommentRenderer.RenderEntriesInvalid(findings, null, null, null);
+		body.Should().Contain("validation failed");
+	}
+
+	[Fact]
+	public void RenderEntriesInvalid_ErrorFinding_ContainsRedCross()
+	{
+		var findings = new List<EntryFinding>
+		{
+			new() { File = "docs/changelog/42.yaml", Severity = "Error", Message = "title is required" }
+		};
+		var body = ChangelogCommentRenderer.RenderEntriesInvalid(findings, null, null, null);
+		body.Should().Contain("❌");
+		body.Should().Contain("title is required");
+	}
+
+	[Fact]
+	public void RenderEntriesInvalid_WarningFinding_ContainsWarningIcon()
+	{
+		var findings = new List<EntryFinding>
+		{
+			new() { File = "docs/changelog/42.yaml", Severity = "Warning", Message = "title exceeds 80 characters" }
+		};
+		var body = ChangelogCommentRenderer.RenderEntriesInvalid(findings, null, null, null);
+		body.Should().Contain("⚠️");
+		body.Should().Contain("title exceeds 80 characters");
+	}
+
+	[Fact]
+	public void RenderEntriesInvalid_WithOwnerRepo_RendersFileLink()
+	{
+		var findings = new List<EntryFinding>
+		{
+			new() { File = "docs/changelog/42.yaml", Severity = "Error", Message = "title is required" }
+		};
+		var body = ChangelogCommentRenderer.RenderEntriesInvalid(findings, "elastic", "my-repo", "main");
+		body.Should().Contain("https://github.com/elastic/my-repo/blob/main/");
+	}
+
+	[Fact]
+	public void RenderEntriesInvalid_MultipleFindingsSameFile_GroupedUnderFile()
+	{
+		var findings = new List<EntryFinding>
+		{
+			new() { File = "docs/changelog/42.yaml", Severity = "Error", Message = "title is required" },
+			new() { File = "docs/changelog/42.yaml", Severity = "Warning", Message = "description too long" }
+		};
+		var body = ChangelogCommentRenderer.RenderEntriesInvalid(findings, null, null, null);
+		// File should appear only once as a header
+		body.Split("42.yaml").Length.Should().Be(2);
+	}
+
+	// ──────────────────────────────────────────────────────────────────────────────────────────────
+	// RenderMissingEntry
+	// ──────────────────────────────────────────────────────────────────────────────────────────────
+
+	[Fact]
+	public void RenderMissingEntry_StartsWithTitle()
+	{
+		var body = ChangelogCommentRenderer.RenderMissingEntry(null, 42);
+		body.Should().StartWith(ChangelogCommentRenderer.Title);
+	}
+
+	[Fact]
+	public void RenderMissingEntry_ContainsPrNumber()
+	{
+		var body = ChangelogCommentRenderer.RenderMissingEntry("docs/changelog", 99);
+		body.Should().Contain("#99");
+		body.Should().Contain("99.yaml");
+	}
+
+	[Fact]
+	public void RenderMissingEntry_DefaultDir_UsesDefaultPath()
+	{
+		var body = ChangelogCommentRenderer.RenderMissingEntry(null, 7);
+		body.Should().Contain("docs/changelog/7.yaml");
+	}
+
+	[Fact]
+	public void RenderMissingEntry_CustomDir_UsesCustomPath()
+	{
+		var body = ChangelogCommentRenderer.RenderMissingEntry("changelogs", 7);
+		body.Should().Contain("changelogs/7.yaml");
+	}
 }

--- a/tests/Elastic.Changelog.Tests/Evaluation/ChangelogEntryValidatorTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/ChangelogEntryValidatorTests.cs
@@ -1,0 +1,342 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using AwesomeAssertions;
+using Elastic.Changelog.Evaluation;
+using Elastic.Documentation.Configuration.Changelog;
+using Elastic.Documentation.Configuration.ReleaseNotes;
+using Elastic.Documentation.ReleaseNotes;
+
+namespace Elastic.Changelog.Tests.Evaluation;
+
+public class ChangelogEntryValidatorTests
+{
+	private static readonly ChangelogConfiguration Config = ChangelogConfiguration.Default;
+
+	private static ChangelogEntryDto ParseYaml(string yaml)
+	{
+		var normalized = ReleaseNotesSerialization.NormalizeYaml(yaml);
+		return ReleaseNotesSerialization.GetEntryDeserializer().Deserialize<ChangelogEntryDto>(normalized) ?? new ChangelogEntryDto();
+	}
+
+	private static IReadOnlyList<EntryFileFinding> Validate(
+		ChangelogEntryDto entry,
+		ChangelogEntryType? labelDerivedType = null,
+		IReadOnlySet<string>? knownProducts = null
+	) => ChangelogEntryValidator.Validate("docs/changelog/42.yaml", entry, Config, labelDerivedType, knownProducts);
+
+	// ─────────────────────────────────────────────────────────────────────────────────────────────
+	// Title rules
+	// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+	[Fact]
+	public void Validate_MissingTitle_ProducesError()
+	{
+		var entry = ParseYaml("type: feature\nproducts:\n  - product: elasticsearch");
+		var findings = Validate(entry);
+		findings.Should().ContainSingle(f => f.Severity == FindingSeverity.Error && f.Message.Contains("title is required"));
+	}
+
+	[Fact]
+	public void Validate_TitleOver80Chars_ProducesWarning()
+	{
+		var longTitle = new string('x', 81);
+		var entry = ParseYaml($"type: feature\ntitle: {longTitle}\nproducts:\n  - product: elasticsearch");
+		var findings = Validate(entry);
+		findings.Should().ContainSingle(f => f.Severity == FindingSeverity.Warning && f.Message.Contains("title exceeds 80 characters"));
+	}
+
+	[Fact]
+	public void Validate_TitleExactly80Chars_NoWarning()
+	{
+		var title = new string('x', 80);
+		var entry = ParseYaml($"type: feature\ntitle: {title}\nproducts:\n  - product: elasticsearch");
+		var findings = Validate(entry);
+		findings.Should().NotContain(f => f.Message.Contains("title exceeds"));
+	}
+
+	// ─────────────────────────────────────────────────────────────────────────────────────────────
+	// Products rules
+	// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+	[Fact]
+	public void Validate_MissingProducts_ProducesError()
+	{
+		var entry = ParseYaml("type: feature\ntitle: Test");
+		var findings = Validate(entry);
+		findings.Should().ContainSingle(f => f.Severity == FindingSeverity.Error && f.Message.Contains("products is required"));
+	}
+
+	[Fact]
+	public void Validate_UnknownProduct_ProducesError()
+	{
+		var entry = ParseYaml("type: feature\ntitle: Test\nproducts:\n  - product: no-such-product");
+		var known = new HashSet<string>(["elasticsearch", "kibana"], StringComparer.OrdinalIgnoreCase);
+		var findings = Validate(entry, knownProducts: known);
+		findings.Should().ContainSingle(
+			f => f.Severity == FindingSeverity.Error && f.Message.Contains("not in the list of available products")
+		);
+	}
+
+	[Fact]
+	public void Validate_KnownProduct_NoProductError()
+	{
+		var entry = ParseYaml("type: feature\ntitle: Test\nproducts:\n  - product: elasticsearch");
+		var known = new HashSet<string>(["elasticsearch", "kibana"], StringComparer.OrdinalIgnoreCase);
+		var findings = Validate(entry, knownProducts: known);
+		findings.Should().NotContain(f => f.Message.Contains("not in the list of available products"));
+	}
+
+	[Fact]
+	public void Validate_ProductVersionsSet_ProducesError()
+	{
+		var entry = ParseYaml("type: feature\ntitle: Test\nproducts:\n  - product: elasticsearch\n    versions: [\"9.2.0\"]");
+		var findings = Validate(entry);
+		findings.Should().ContainSingle(
+			f => f.Severity == FindingSeverity.Error && f.Message.Contains("versions is only valid in changelog note files")
+		);
+	}
+
+	[Fact]
+	public void Validate_InvalidLifecycle_ProducesError()
+	{
+		var entry = ParseYaml("type: feature\ntitle: Test\nproducts:\n  - product: elasticsearch\n    lifecycle: nonexistent-lifecycle");
+		var findings = Validate(entry);
+		findings.Should().ContainSingle(
+			f => f.Severity == FindingSeverity.Error && f.Message.Contains("lifecycle") && f.Message.Contains("not valid")
+		);
+	}
+
+	// ─────────────────────────────────────────────────────────────────────────────────────────────
+	// Type rules
+	// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+	[Fact]
+	public void Validate_MissingType_ProducesError()
+	{
+		var entry = ParseYaml("title: Test\nproducts:\n  - product: elasticsearch");
+		var findings = Validate(entry);
+		findings.Should().ContainSingle(f => f.Severity == FindingSeverity.Error && f.Message.Contains("type is required"));
+	}
+
+	[Fact]
+	public void Validate_MissingType_WithLabelDerived_ProducesLabelAwareError()
+	{
+		var entry = ParseYaml("title: Test\nproducts:\n  - product: elasticsearch");
+		var findings = Validate(entry, labelDerivedType: ChangelogEntryType.Feature);
+		findings.Should().ContainSingle(f => f.Severity == FindingSeverity.Error && f.Message.Contains("type: feature"));
+	}
+
+	[Fact]
+	public void Validate_UnrecognisedType_ProducesError()
+	{
+		var entry = ParseYaml("type: not-a-type\ntitle: Test\nproducts:\n  - product: elasticsearch");
+		var findings = Validate(entry);
+		findings.Should().ContainSingle(f => f.Severity == FindingSeverity.Error && f.Message.Contains("not recognised"));
+	}
+
+	[Fact]
+	public void Validate_TypeMismatchesLabel_ProducesError()
+	{
+		var entry = ParseYaml("type: bug-fix\ntitle: Test\nproducts:\n  - product: elasticsearch");
+		var findings = Validate(entry, labelDerivedType: ChangelogEntryType.Feature);
+		findings.Should().ContainSingle(
+			f => f.Severity == FindingSeverity.Error && f.Message.Contains("does not match label-derived type")
+		);
+	}
+
+	[Fact]
+	public void Validate_TypeMatchesLabel_NoTypeMismatch()
+	{
+		var entry = ParseYaml("type: feature\ntitle: Test\nproducts:\n  - product: elasticsearch");
+		var findings = Validate(entry, labelDerivedType: ChangelogEntryType.Feature);
+		findings.Should().NotContain(f => f.Message.Contains("does not match"));
+	}
+
+	// ─────────────────────────────────────────────────────────────────────────────────────────────
+	// Subtype rules
+	// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+	[Fact]
+	public void Validate_InvalidSubtype_ProducesError()
+	{
+		var entry = ParseYaml("type: breaking-change\ntitle: Test\nproducts:\n  - product: elasticsearch\nsubtype: not-a-subtype");
+		var findings = Validate(entry);
+		findings.Should().ContainSingle(
+			f => f.Severity == FindingSeverity.Error && f.Message.Contains("subtype") && f.Message.Contains("not valid")
+		);
+	}
+
+	[Fact]
+	public void Validate_SubtypeOnNonBreakingChange_ProducesWarning()
+	{
+		// Get a valid subtype from defaults
+		var validSubtype = ChangelogConfiguration.DefaultSubtypes[0];
+		var entry = ParseYaml($"type: feature\ntitle: Test\nproducts:\n  - product: elasticsearch\nsubtype: {validSubtype}");
+		var findings = Validate(entry);
+		findings.Should().ContainSingle(
+			f => f.Severity == FindingSeverity.Warning && f.Message.Contains("subtype is only expected on breaking-change")
+		);
+	}
+
+	// ─────────────────────────────────────────────────────────────────────────────────────────────
+	// Areas rules
+	// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+	[Fact]
+	public void Validate_InvalidArea_ProducesError()
+	{
+		var configWithAreas = Config with { Areas = ["query-dsl", "mappings"] };
+		var entry = ParseYaml("type: feature\ntitle: Test\nproducts:\n  - product: elasticsearch\nareas:\n  - not-an-area");
+		var findings = ChangelogEntryValidator.Validate("docs/changelog/42.yaml", entry, configWithAreas, null, null);
+		findings.Should().ContainSingle(
+			f => f.Severity == FindingSeverity.Error && f.Message.Contains("area") && f.Message.Contains("not valid")
+		);
+	}
+
+	// ─────────────────────────────────────────────────────────────────────────────────────────────
+	// Marker / link: rules
+	// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+	[Fact]
+	public void Validate_MarkerWithOtherFields_ProducesError()
+	{
+		var entry = ParseYaml("link: https://example.com\ntitle: Should not be here");
+		var findings = Validate(entry);
+		findings.Should().ContainSingle(f => f.Severity == FindingSeverity.Error && f.Message.Contains("marker entries"));
+	}
+
+	[Fact]
+	public void Validate_MarkerOnly_NoErrors()
+	{
+		var entry = ParseYaml("link: https://example.com");
+		var findings = Validate(entry);
+		findings.Should().NotContain(f => f.Severity == FindingSeverity.Error);
+	}
+
+	[Fact]
+	public void Validate_SourceRedirectInEntry_ProducesError()
+	{
+		var entry = ParseYaml("type: feature\ntitle: Test\nproducts:\n  - product: elasticsearch\nsource-redirect: true");
+		var findings = Validate(entry);
+		findings.Should().ContainSingle(f => f.Severity == FindingSeverity.Error && f.Message.Contains("source-redirect"));
+	}
+
+	// ─────────────────────────────────────────────────────────────────────────────────────────────
+	// Description length
+	// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+	[Fact]
+	public void Validate_DescriptionOver600Chars_ProducesWarning()
+	{
+		var longDesc = new string('x', 601);
+		var yaml = $"type: feature\ntitle: Test\nproducts:\n  - product: elasticsearch\ndescription: |\n  {longDesc}";
+		var entry = ParseYaml(yaml);
+		var findings = Validate(entry);
+		findings.Should().ContainSingle(
+			f => f.Severity == FindingSeverity.Warning && f.Message.Contains("description exceeds 600 characters")
+		);
+	}
+
+	// ─────────────────────────────────────────────────────────────────────────────────────────────
+	// Valid entry
+	// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+	[Fact]
+	public void Validate_ValidMinimalEntry_NoFindings()
+	{
+		var entry = ParseYaml("type: feature\ntitle: Test\nproducts:\n  - product: elasticsearch");
+		var findings = Validate(entry);
+		findings.Should().BeEmpty();
+	}
+
+	// ─────────────────────────────────────────────────────────────────────────────────────────────
+	// PR reference collection
+	// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+	[Fact]
+	public void CollectPrRefs_BareNumber_ReturnsSingleRef()
+	{
+		var entry = ParseYaml("pr: 42\ntype: feature\ntitle: Test\nproducts:\n  - product: elasticsearch");
+		var refs = ChangelogEntryValidator.CollectPrRefs(entry);
+		refs.Should().ContainSingle().Which.Should().Be("42");
+	}
+
+	[Fact]
+	public void CollectPrRefs_PrsList_ReturnsAll()
+	{
+		var entry = ParseYaml("prs:\n  - 1\n  - 2\ntype: feature\ntitle: Test\nproducts:\n  - product: elasticsearch");
+		var refs = ChangelogEntryValidator.CollectPrRefs(entry);
+		refs.Should().HaveCount(2).And.Contain("1").And.Contain("2");
+	}
+
+	// ─────────────────────────────────────────────────────────────────────────────────────────────
+	// PR existence validation
+	// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+	[Fact]
+	public void ValidatePrReferences_ExistingOwnRepoPr_NoError()
+	{
+		var entry = ParseYaml("pr: 42\ntype: feature\ntitle: Test\nproducts:\n  - product: elasticsearch");
+		var findings = ChangelogEntryValidator.ValidatePrReferences(
+			"docs/changelog/42.yaml",
+			entry,
+			"elastic",
+			"my-repo",
+			new Dictionary<int, bool> { [42] = true }
+		);
+		findings.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void ValidatePrReferences_NonExistentOwnRepoPr_ProducesError()
+	{
+		var entry = ParseYaml("pr: 99\ntype: feature\ntitle: Test\nproducts:\n  - product: elasticsearch");
+		var findings = ChangelogEntryValidator.ValidatePrReferences(
+			"docs/changelog/42.yaml",
+			entry,
+			"elastic",
+			"my-repo",
+			new Dictionary<int, bool> { [99] = false }
+		);
+		findings.Should().ContainSingle(f => f.Severity == FindingSeverity.Error && f.Message.Contains("does not exist"));
+	}
+
+	[Fact]
+	public void ValidatePrReferences_ForeignRepoNotAllowed_ProducesWarning()
+	{
+		var entry = ParseYaml(
+			"pr: https://github.com/other-org/other-repo/pull/5\ntype: feature\ntitle: Test\nproducts:\n  - product: elasticsearch"
+		);
+		var findings = ChangelogEntryValidator.ValidatePrReferences(
+			"docs/changelog/42.yaml",
+			entry,
+			"elastic",
+			"my-repo",
+			new Dictionary<int, bool>(),
+			linkAllowRepos: ["elastic/other-repo"]
+		);
+		// other-org/other-repo is not in the allowlist
+		findings.Should().ContainSingle(
+			f => f.Severity == FindingSeverity.Warning && f.Message.Contains("outside bundle.link_allow_repos")
+		);
+	}
+
+	[Fact]
+	public void ValidatePrReferences_ForeignRepoAllowed_NoWarning()
+	{
+		var entry = ParseYaml(
+			"pr: https://github.com/elastic/other-repo/pull/5\ntype: feature\ntitle: Test\nproducts:\n  - product: elasticsearch"
+		);
+		var findings = ChangelogEntryValidator.ValidatePrReferences(
+			"docs/changelog/42.yaml",
+			entry,
+			"elastic",
+			"my-repo",
+			new Dictionary<int, bool>(),
+			linkAllowRepos: ["elastic/other-repo"]
+		);
+		findings.Should().NotContain(f => f.Message.Contains("outside bundle.link_allow_repos"));
+	}
+}

--- a/tests/Elastic.Changelog.Tests/Evaluation/ChangelogGithubCommentServiceTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/ChangelogGithubCommentServiceTests.cs
@@ -214,4 +214,70 @@ public class ChangelogGithubCommentServiceTests(ITestOutputHelper output) : Chan
 			() => commentSvc.UpsertStickyCommentAsync(A<string>._, A<string>._, A<int>._, A<string>._, A<CancellationToken>._)
 		).MustNotHaveHappened();
 	}
+
+	// ── Gate.Entries dispatch ──────────────────────────────────────────────────────────────────────
+
+	[Fact]
+	public async Task PostComment_EntriesGateWithFindings_RendersEntriesInvalidBody()
+	{
+		await WriteMetadata(BaseMetadata(status: "entries-invalid") with
+		{
+			Gate = ValidationGate.Entries,
+			EntryFindings = [new EntryFinding { File = "docs/changelog/42.yaml", Severity = "Error", Message = "title is required" }]
+		});
+		var commentSvc = A.Fake<IGitHubCommentService>();
+		A.CallTo(
+			() => commentSvc.UpsertStickyCommentAsync(A<string>._, A<string>._, A<int>._, A<string>._, A<CancellationToken>._)
+		).Returns((string?)"IC_test_node_id");
+
+		await CreateService(commentSvc).PostComment(DefaultArgs(), CancellationToken.None);
+
+		A.CallTo(
+			() => commentSvc.UpsertStickyCommentAsync(
+				A<string>._,
+				A<string>._,
+				A<int>._,
+				A<string>.That.Contains("validation failed"),
+				A<CancellationToken>._
+			)
+		).MustHaveHappenedOnceExactly();
+	}
+
+	[Fact]
+	public async Task PostComment_EntriesGateNoFindings_DeletesStickyComment()
+	{
+		await WriteMetadata(BaseMetadata(status: "ok", canCommit: true) with { Gate = ValidationGate.Entries, EntryFindings = null });
+		var commentSvc = A.Fake<IGitHubCommentService>();
+		A.CallTo(() => commentSvc.DeleteStickyCommentAsync(A<string>._, A<string>._, A<int>._, A<CancellationToken>._)).Returns(true);
+
+		await CreateService(commentSvc).PostComment(DefaultArgs(), CancellationToken.None);
+
+		A.CallTo(
+			() => commentSvc.DeleteStickyCommentAsync("elastic", "test-repo", 42, A<CancellationToken>._)
+		).MustHaveHappenedOnceExactly();
+	}
+
+	// ── Gate.File + missing-entry dispatch ────────────────────────────────────────────────────────
+
+	[Fact]
+	public async Task PostComment_FileGateMissingEntry_RendersMissingEntryBody()
+	{
+		await WriteMetadata(BaseMetadata(status: "missing-entry") with { Gate = ValidationGate.File, ChangelogDir = "docs/changelog" });
+		var commentSvc = A.Fake<IGitHubCommentService>();
+		A.CallTo(
+			() => commentSvc.UpsertStickyCommentAsync(A<string>._, A<string>._, A<int>._, A<string>._, A<CancellationToken>._)
+		).Returns((string?)"IC_test_node_id");
+
+		await CreateService(commentSvc).PostComment(DefaultArgs(), CancellationToken.None);
+
+		A.CallTo(
+			() => commentSvc.UpsertStickyCommentAsync(
+				A<string>._,
+				A<string>._,
+				A<int>._,
+				A<string>.That.Contains("entry file required"),
+				A<CancellationToken>._
+			)
+		).MustHaveHappenedOnceExactly();
+	}
 }

--- a/tests/Elastic.Changelog.Tests/Evaluation/GithubDecisionMetadataTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/GithubDecisionMetadataTests.cs
@@ -161,6 +161,61 @@ public class GithubDecisionMetadataTests
 	}
 
 	[Fact]
+	public void SerializationRoundTrip_WithEntryFindings_PreservesFindings()
+	{
+		var metadata = new GithubDecisionMetadata
+		{
+			PrNumber = 42,
+			HeadRef = "feature/test",
+			HeadSha = "abc123",
+			Status = "entries-invalid",
+			IsFork = false,
+			CanCommit = true,
+			MaintainerCanModify = false,
+			Gate = ValidationGate.Entries,
+			EntryFindings =
+			[
+				new EntryFinding { File = "docs/changelog/42.yaml", Severity = "Error", Message = "title is required" },
+				new EntryFinding { File = "docs/changelog/43.yaml", Severity = "Warning", Message = "title exceeds 80 characters" }
+			]
+		};
+
+		var json = JsonSerializer.Serialize(metadata, GithubDecisionMetadataJsonContext.Default.GithubDecisionMetadata);
+		var deserialized = JsonSerializer.Deserialize(json, GithubDecisionMetadataJsonContext.Default.GithubDecisionMetadata);
+
+		deserialized.Should().NotBeNull();
+		deserialized.Gate.Should().Be(ValidationGate.Entries);
+		deserialized.EntryFindings.Should().HaveCount(2);
+		deserialized.EntryFindings![0].File.Should().Be("docs/changelog/42.yaml");
+		deserialized.EntryFindings[0].Severity.Should().Be("Error");
+		deserialized.EntryFindings[0].Message.Should().Be("title is required");
+		deserialized.EntryFindings[1].Severity.Should().Be("Warning");
+	}
+
+	[Fact]
+	public void Deserialization_OldMetadataWithoutEntryFindings_EntryFindingsNull()
+	{
+		const string legacyJson =
+			"""
+			{
+			  "pr_number": 7,
+			  "head_ref": "fix/typo",
+			  "head_sha": "cafebabe",
+			  "status": "no-label",
+			  "is_fork": false,
+			  "can_commit": true,
+			  "maintainer_can_modify": false
+			}
+			""";
+
+		var deserialized = JsonSerializer.Deserialize(legacyJson, GithubDecisionMetadataJsonContext.Default.GithubDecisionMetadata);
+
+		deserialized.Should().NotBeNull();
+		deserialized.EntryFindings.Should().BeNull();
+		deserialized.Gate.Should().BeNull();
+	}
+
+	[Fact]
 	public void Deserialization_OldMetadataWithoutCommitOutcomeFields_Succeeds()
 	{
 		// Verify wire-safety: a metadata.json written before the CommitOutcome/CommittedFile


### PR DESCRIPTION
A new `changelog validate-entries` CLI command validates changelog entry YAML files that a PR adds or modifies. It also adds two previously-empty comment renderer methods (`RenderEntriesInvalid`, `RenderMissingEntry`) and wires them into the comment dispatch, so failures get useful PR feedback. A separate fix shortens the config-file footer in the label-gate comment.

**Affects:** Release notes, CLI

## Why

The `changelog evaluate-pr` step checked labels and committed generated entries, but never validated hand-authored `changelog/*.yaml` files. A contributor could push a YAML file with an unrecognised `type:`, a misspelled product, or a reference to a PR that does not exist and it would silently pass CI. The comment dispatch also had two empty method bodies for `RenderEntriesInvalid` and `RenderMissingEntry`, so those failure paths posted no feedback at all.

## What

#### Entry file validation
The new `ChangelogEntryValidationService` runs four rule groups against each added or modified changelog file: YAML parse and required-field checks (`title`, `type`, `products`); config-value membership for `type`, `subtype`, `areas`, and `lifecycle`; own-repo PR existence via batched GraphQL (batch size 50); and hygiene rules (`source-redirect`, `versions` in entry files, `note-*` prefix exclusion). Warnings log but do not block; any error-severity finding causes a non-zero exit.

#### GitHub API integration
`IGitHubPrService` gains two new methods. `FetchChangedFilesAsync` pages the REST `pulls/{n}/files` endpoint to discover which changelog files a PR touched. `CheckPullRequestsExistAsync` runs a batched GraphQL query against the same repo and returns a `Dictionary<int, bool>` for PR existence, mirroring the pattern in `GitHubCommitRangeService`.

#### Comment rendering
`RenderEntriesInvalid` groups findings by file, orders errors before warnings, and renders each as a bullet with an ❌ or ⚠️ icon and an optional GitHub blob link. `RenderMissingEntry` tells the author the expected file path and which gate to disable if they want to opt out. Both were present as stubs; this commit gives them bodies.

#### Comment dispatch
`ChangelogGithubCommentService.SelectBody` now dispatches on `Gate.Entries` with findings (renders `RenderEntriesInvalid`) and on `Gate.File` + `missing-entry` status (renders `RenderMissingEntry`) before falling through to the existing labels-needed path. The `ChangelogPrEvaluationService` missing-entry path now also writes its metadata, fixing a silent failure.

#### CLI command
`changelog validate-entries` accepts `--config`, `--owner`, `--repo`, `--pr-number`, `--pr-labels`, and an optional `--files` override. Without `--files`, it discovers changed files from the GitHub API. A docs page at `docs/cli/changelog/cmd-validate-entries.md` covers the command.

## Verify

```bash
dotnet test tests/Elastic.Changelog.Tests/
# ChangelogEntryValidatorTests — one test per validation rule
# ChangelogCommentRendererTests — RenderEntriesInvalid and RenderMissingEntry bodies
# ChangelogGithubCommentServiceTests — Gate.Entries and Gate.File + missing-entry dispatch
# GithubDecisionMetadataTests — EntryFindings round-trip and backward compat
```

**Out of scope:** The `release-notes.yml` step that calls `validate-entries` in CI lives in `elastic/docs-actions` and ships as a separate PR to that repo.