### PR TITLE
ci: speed up shai-hulud scan with xargs

### DIFF
--- a/.github/actions/check-shai-hulud/action.yml
+++ b/.github/actions/check-shai-hulud/action.yml
@@ -42,7 +42,7 @@ runs:
         # match doesn't trip `set -e`. The explicit non-empty test below
         # is what decides pass/fail.
         v1_matches=$(
-          find "$SCAN_PATH" -type f -name "*.js" -exec sha256sum {} \; \
+          find "$SCAN_PATH" -type f -name "*.js" -print0 | xargs -0 sha256sum \
             | grep "$SHAI_HULUD_V1_SHA256" || true
         )
         if [ -n "$v1_matches" ]; then
@@ -52,7 +52,7 @@ runs:
         fi
 
         v2_matches=$(
-          find "$SCAN_PATH" -type f -name "*.js" -exec sha1sum {} \; \
+          find "$SCAN_PATH" -type f -name "*.js" -print0 | xargs -0 sha1sum \
             | grep "$SHAI_HULUD_V2_SHA1" || true
         )
         if [ -n "$v2_matches" ]; then


### PR DESCRIPTION
The shai-hulud supply-chain scan in `.github/actions/check-shai-hulud/action.yml` was spawning one `sha256sum` and one `sha1sum` process per JavaScript file. Batching into a single `xargs -0` invocation cuts the step from ~43 s to ~2 s.

**Affects:** Automation

## Why

The scan uses `-exec sha256sum {} \;` and `-exec sha1sum {} \;`, which fork a new process for every `.js` file found. On a `node_modules/` tree with thousands of files this accounts for almost all of the 43 s the step takes today. The hash logic itself is correct — only the invocation pattern is slow.

## What

#### Batched hash invocation

Both `find` pipelines are changed from `-exec <hasher> {} \;` to `-print0 | xargs -0 <hasher>`. `xargs` collects all paths and passes them to a single `sha256sum` or `sha1sum` invocation. The output format is identical — one `<hash>  <path>` line per file — so the `grep` and `awk` steps that follow are unaffected.