### PR TITLE
ci: drop RunConfiguration.CollectSourceInformation from test run

### DIFF
--- a/build/Targets.fs
+++ b/build/Targets.fs
@@ -144,7 +144,6 @@ let private runTests (testSuite: TestSuite) _ =
         run "dotnet" (
             ["test"; "-c"; "release"; "--no-restore"; "--no-build"; "--logger"; "GitHubActions"]
             @ testFilter
-            @ ["--"; "RunConfiguration.CollectSourceInformation=true"]
         )
     }
     


### PR DESCRIPTION
The `dotnet test` invocation in `build/Targets.fs` passes `RunConfiguration.CollectSourceInformation=true`, which collects source-line mapping data for test results. Nothing in CI reads that data. Removing it saves a small amount of I/O on every test run across all three OS legs.

**Affects:** Automation

## Why

`RunConfiguration.CollectSourceInformation=true` tells the VSTest host to resolve each test result back to a source file and line number. The GitHubActions logger and the CI summary both ignore it. The flag was present before the test runner was ported to `build/Targets.fs` and has never been consumed.

## What

#### Test invocation in `build/Targets.fs`

The `-- RunConfiguration.CollectSourceInformation=true` tail is removed from the `dotnet test` argument list. The three test-suite paths (`All`, `Unit`, `Integration`) share this invocation, so all three benefit.