### PR TITLE
ci: cache NuGet packages in bootstrap action

### DIFF
--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -13,6 +13,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/Directory.Packages.props', '**/*.csproj', '**/*.fsproj', 'dotnet-tools.json', 'global.json') }}
+        restore-keys: ${{ runner.os }}-nuget-
+
     # Ensure we fetch all tags
     - shell: bash
       run: |

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -6,6 +6,9 @@ on:
 permissions:
   contents: read
 
+env:
+  NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Every job that runs `bootstrap` today does a cold NuGet restore on every run. The `NUGET_PACKAGES` workspace redirect in `ci.yml` was set up for a cache that was never added. This PR adds the cache and closes the gap in `smoke-test.yml` so the path is consistent everywhere.

**Affects:** Automation

## Why

`ci.yml` sets `NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages` to redirect packages into the workspace — that variable was written in anticipation of a cache step that never arrived. Every job therefore restores the full package tree (~585 MB, ~23 s) from nuget.org on every run. `smoke-test.yml` does not set `NUGET_PACKAGES` at all, so its jobs write to the default `~/.nuget/packages`, which on Windows is on the slow C: drive.

## What

#### NuGet cache in `bootstrap/action.yml`

An `actions/cache@v4` step is added at the top of the bootstrap composite action, before `setup-dotnet`. The cache key hashes `Directory.Packages.props` and all `*.csproj`/`*.fsproj` files. Because central package management is on and this repo does not use `packages.lock.json`, the props file plus project files are sufficient to make the key deterministic. On a cache hit the restore step is near-instant; on a miss the job falls back to today's behaviour.

The cache path is `${{ github.workspace }}/.nuget/packages`, matching `NUGET_PACKAGES`. This keeps packages on the fast D: drive on Windows runners (the workspace is `D:\a\…` on hosted Windows), avoiding the ~4,300 IOPS C: drive.

#### `NUGET_PACKAGES` in `smoke-test.yml`

A top-level `env:` block is added so the smoke jobs write packages to the same path the cache reads from. Without this the cache would save to the workspace path but `dotnet restore` would read from `~/.nuget/packages` on the smoke runners, producing a permanent cache miss.

**Out of scope:** `docs-preview-local.yml` and `assembler-preview.yml` reference `bootstrap` via `elastic/docs-builder/.github/actions/bootstrap@main` rather than `./`, so they will not pick up the cache step until this merges to `main`.