### PR TITLE
Validate changelog entry filename; enforce pr: consistency when supplied

### DIFF
--- a/src/services/Elastic.Changelog/Evaluation/ChangelogEntryValidationService.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogEntryValidationService.cs
@@ -100,12 +100,17 @@ public class ChangelogEntryValidationService(
 		if (availableProducts is { Count: > 0 })
 			knownProducts = new HashSet<string>(availableProducts.Keys.Select(k => k.Replace('_', '-')), StringComparer.OrdinalIgnoreCase);
 
-		// ── Parse and run field-level rules ───────────────────────────────────────────────────
+		// ── Parse files, validate filenames, run field-level rules ───────────────────────────
 		var allFindings = new List<EntryFileFinding>();
 		var entriesByFile = new Dictionary<string, ChangelogEntryDto?>(StringComparer.OrdinalIgnoreCase);
-
+		var filenamePrNumbers = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 		foreach (var relPath in filesToValidate)
 		{
+			// Filename validation (must be <digits>[-<name>].yaml)
+			allFindings.AddRange(ChangelogEntryValidator.ValidateFilename(relPath));
+			if (ChangelogEntryValidator.TryParseFilenameAsPrNumber(relPath, out var fnPrNum))
+				filenamePrNumbers[relPath] = fnPrNum;
+
 			var fullPath = fileSystem.Path.GetFullPath(relPath);
 			if (!fileSystem.File.Exists(fullPath))
 			{
@@ -122,7 +127,8 @@ public class ChangelogEntryValidationService(
 				dto = ReleaseNotesSerialization.GetEntryDeserializer().Deserialize<ChangelogEntryDto>(normalized);
 				if (dto is not null)
 				{
-					var findings = ChangelogEntryValidator.Validate(relPath, dto, config, labelDerivedType, knownProducts);
+					var fnNum = filenamePrNumbers.TryGetValue(relPath, out var n) ? n : (int?)null;
+					var findings = ChangelogEntryValidator.Validate(relPath, dto, config, labelDerivedType, knownProducts, fnNum);
 					allFindings.AddRange(findings);
 				}
 			}
@@ -134,62 +140,21 @@ public class ChangelogEntryValidationService(
 			entriesByFile[relPath] = dto;
 		}
 
-		// ── Collect own-repo PR numbers for existence check ───────────────────────────────────
-		var ownRepoNumbers = new HashSet<int>();
-		var prToFiles = new Dictionary<int, List<string>>();
-		foreach (var (relPath, dto) in entriesByFile)
-		{
-			if (dto is null)
-				continue;
-			foreach (var prRef in ChangelogEntryValidator.CollectPrRefs(dto))
-			{
-				var (_, parsedRepo, parsedNum) = ParsePrRef(prRef, input.Owner, input.Repo);
-				if (parsedNum is null)
-					continue;
-				if (string.Equals(parsedRepo, input.Repo, StringComparison.OrdinalIgnoreCase))
-				{
-					_ = ownRepoNumbers.Add(parsedNum.Value);
-					if (!prToFiles.TryGetValue(parsedNum.Value, out var fileList))
-						prToFiles[parsedNum.Value] = fileList = [];
-					fileList.Add(relPath);
-				}
-			}
-		}
-
-		// ── Duplicate PR number detection ─────────────────────────────────────────────────────
-		foreach (var (prNum, files) in prToFiles)
-		{
-			if (files.Count > 1)
-				allFindings.Add(
-					new EntryFileFinding(
-						files[0],
-						FindingSeverity.Error,
-						$"PR #{prNum} is claimed by multiple files: {string.Join(", ", files)}"
-					)
-				);
-		}
+		// ── Collect own-repo PR numbers for existence check (from filenames) ──────────────────
+		var ownRepoNumbers = new HashSet<int>(filenamePrNumbers.Values);
 
 		// ── Batch PR existence check ───────────────────────────────────────────────────────────
 		var existenceResults = ownRepoNumbers.Count > 0
 			? await gitHubPrService.CheckPullRequestsExistAsync(input.Owner, input.Repo, [.. ownRepoNumbers], ctx)
 			: new Dictionary<int, bool>();
 
-		var linkAllowRepos = config.Bundle?.LinkAllowRepos;
-
-		// ── PR reference validation ───────────────────────────────────────────────────────────
-		foreach (var (relPath, dto) in entriesByFile)
+		// ── Filename PR existence check ───────────────────────────────────────────────────────
+		foreach (var (relPath, prNum) in filenamePrNumbers)
 		{
-			if (dto is null)
-				continue;
-			var prRefFindings = ChangelogEntryValidator.ValidatePrReferences(
-				relPath,
-				dto,
-				input.Owner,
-				input.Repo,
-				existenceResults,
-				linkAllowRepos
-			);
-			allFindings.AddRange(prRefFindings);
+			if (existenceResults.TryGetValue(prNum, out var exists) && !exists)
+				allFindings.Add(
+					new EntryFileFinding(relPath, FindingSeverity.Error, $"PR #{prNum} does not exist in {input.Owner}/{input.Repo}")
+				);
 		}
 
 		// ── Presence check ────────────────────────────────────────────────────────────────────
@@ -287,42 +252,5 @@ public class ChangelogEntryValidationService(
 		};
 
 		await _metadataWriter.WriteAsync(metadata, ctx);
-	}
-
-	private static (string? owner, string? repo, int? number) ParsePrRef(string prRef, string defaultOwner, string defaultRepo)
-	{
-		if (
-			prRef.StartsWith("https://github.com/", StringComparison.OrdinalIgnoreCase)
-			|| prRef.StartsWith("http://github.com/", StringComparison.OrdinalIgnoreCase)
-		)
-		{
-			var uri = new Uri(prRef);
-			var segments = uri.Segments;
-			if (segments.Length >= 5 && segments[3].Equals("pull/", StringComparison.OrdinalIgnoreCase))
-			{
-				var owner = segments[1].TrimEnd('/');
-				var repo = segments[2].TrimEnd('/');
-				if (int.TryParse(segments[4].TrimEnd('/'), out var num))
-					return (owner, repo, num);
-			}
-			return (null, null, null);
-		}
-
-		var hashIdx = prRef.LastIndexOf('#');
-		if (hashIdx > 0 && hashIdx < prRef.Length - 1)
-		{
-			var repoPart = prRef[..hashIdx];
-			if (int.TryParse(prRef[(hashIdx + 1)..], out var num))
-			{
-				var parts = repoPart.Split('/');
-				if (parts.Length == 2)
-					return (parts[0], parts[1], num);
-			}
-		}
-
-		if (int.TryParse(prRef, out var bareNum))
-			return (defaultOwner, defaultRepo, bareNum);
-
-		return (null, null, null);
 	}
 }

--- a/src/services/Elastic.Changelog/Evaluation/ChangelogEntryValidator.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogEntryValidator.cs
@@ -46,7 +46,8 @@ public static class ChangelogEntryValidator
 		ChangelogEntryDto entry,
 		ChangelogConfiguration config,
 		ChangelogEntryType? labelDerivedType,
-		IReadOnlySet<string>? knownProducts
+		IReadOnlySet<string>? knownProducts,
+		int? filenamePrNumber = null
 	)
 	{
 		var findings = new List<EntryFileFinding>();
@@ -191,6 +192,24 @@ public static class ChangelogEntryValidator
 				findings.Add(Warning(filePath, "subtype is only expected on breaking-change entries"));
 		}
 
+		// ── pr: field (optional) ─────────────────────────────────────────────────────────────────
+		// If pr: is supplied it must match the PR number encoded in the filename.
+		if (!string.IsNullOrWhiteSpace(entry.Pr) && filenamePrNumber.HasValue)
+		{
+			var rawPr = entry.Pr.Trim().TrimStart('#');
+			if (int.TryParse(rawPr, out var declaredPr))
+			{
+				if (declaredPr != filenamePrNumber.Value)
+					findings.Add(
+						Error(filePath, $"pr: {declaredPr} does not match the PR number in the filename ({filenamePrNumber.Value})")
+					);
+			}
+			else
+			{
+				findings.Add(Error(filePath, $"pr: '{entry.Pr}' could not be parsed as a PR number"));
+			}
+		}
+
 		// ── Areas ────────────────────────────────────────────────────────────────────────────────
 		if (config.Areas is { Count: > 0 } && entry.Areas is { Count: > 0 })
 		{
@@ -205,117 +224,33 @@ public static class ChangelogEntryValidator
 	}
 
 	/// <summary>
-	/// Validates PR references in <paramref name="entry"/>, checking existence for own-repo refs.
+	/// Validates the filename convention: must be <c>&lt;digits&gt;[-&lt;name&gt;].yaml|yml</c>.
 	/// </summary>
-	/// <param name="filePath">Repo-relative path used in finding messages.</param>
-	/// <param name="entry">The deserialized DTO.</param>
-	/// <param name="defaultOwner">Owner used for normalization (the configured bundle owner).</param>
-	/// <param name="defaultRepo">Repo used to identify own-repo refs.</param>
-	/// <param name="existenceResults">Number → exists, for own-repo PRs. Missing keys mean "unknown".</param>
-	/// <param name="linkAllowRepos">Repos allowed for foreign-repo refs (from bundle.link_allow_repos).</param>
-	public static IReadOnlyList<EntryFileFinding> ValidatePrReferences(
-		string filePath,
-		ChangelogEntryDto entry,
-		string defaultOwner,
-		string defaultRepo,
-		IReadOnlyDictionary<int, bool> existenceResults,
-		IReadOnlyList<string>? linkAllowRepos = null
-	)
+	public static IReadOnlyList<EntryFileFinding> ValidateFilename(string filePath)
 	{
-		var findings = new List<EntryFileFinding>();
-		var refs = CollectPrRefs(entry);
-
-		foreach (var prRef in refs)
-		{
-			var (parsedOwner, parsedRepo, parsedNumber) = ParsePrRef(prRef, defaultOwner, defaultRepo);
-			if (parsedNumber is null)
-			{
-				findings.Add(Error(filePath, $"PR reference '{prRef}' could not be parsed as a valid PR URL or number"));
-				continue;
-			}
-
-			var isOwnRepo = string.Equals(parsedRepo, defaultRepo, StringComparison.OrdinalIgnoreCase);
-			if (isOwnRepo)
-			{
-				if (existenceResults.TryGetValue(parsedNumber.Value, out var exists) && !exists)
-					findings.Add(Error(filePath, $"PR #{parsedNumber.Value} does not exist in {parsedOwner}/{parsedRepo}"));
-				// If not in existenceResults, it's "unknown" — warn-and-omit, not an error
-			}
-			else
-			{
-				// Foreign repo: warn if not on the allowlist
-				var foreignRepo = $"{parsedOwner}/{parsedRepo}";
-				if (linkAllowRepos is { Count: > 0 })
-				{
-					var allowed = linkAllowRepos.Any(
-						r => r.Contains('/')
-							? r.Equals(foreignRepo, StringComparison.OrdinalIgnoreCase)
-							: r.Equals(parsedRepo, StringComparison.OrdinalIgnoreCase)
-					);
-					if (!allowed)
-						findings.Add(
-							Warning(
-								filePath,
-								$"PR reference to '{foreignRepo}' is outside bundle.link_allow_repos; it will be scrubbed when published"
-							)
-						);
-				}
-			}
-		}
-
-		return findings;
+		var filename = Path.GetFileName(filePath);
+		if (!TryParseFilenameAsPrNumber(filePath, out _))
+			return [Error(filePath, $"filename '{filename}' must start with a PR number (e.g. 14-my-feature.yaml or 14.yaml)")];
+		return [];
 	}
 
-	/// <summary>Collect all PR reference strings from <c>pr:</c> and <c>prs:</c>.</summary>
-	public static IReadOnlyList<string> CollectPrRefs(ChangelogEntryDto entry)
+	/// <summary>
+	/// Tries to parse the leading PR number from a changelog entry filename.
+	/// Valid formats: <c>&lt;digits&gt;.yaml</c>, <c>&lt;digits&gt;-&lt;name&gt;.yaml</c>.
+	/// </summary>
+	public static bool TryParseFilenameAsPrNumber(string filePath, out int prNumber)
 	{
-		var refs = new List<string>();
-		if (!string.IsNullOrWhiteSpace(entry.Pr))
-			refs.Add(entry.Pr.Trim());
-		if (entry.Prs is { Count: > 0 })
-			refs.AddRange(entry.Prs.Select(p => p.Trim()).Where(p => !string.IsNullOrWhiteSpace(p)));
-		return refs;
-	}
-
-	/// <summary>Parses a PR ref into (owner, repo, number). Returns nulls on failure.</summary>
-	private static (string? owner, string? repo, int? number) ParsePrRef(string prRef, string defaultOwner, string defaultRepo)
-	{
-		// Full URL: https://github.com/owner/repo/pull/123
-		if (
-			prRef.StartsWith("https://github.com/", StringComparison.OrdinalIgnoreCase)
-			|| prRef.StartsWith("http://github.com/", StringComparison.OrdinalIgnoreCase)
-		)
-		{
-			var uri = new Uri(prRef);
-			var segments = uri.Segments;
-			if (segments.Length >= 5 && segments[3].Equals("pull/", StringComparison.OrdinalIgnoreCase))
-			{
-				var owner = segments[1].TrimEnd('/');
-				var repo = segments[2].TrimEnd('/');
-				if (int.TryParse(segments[4].TrimEnd('/'), out var num))
-					return (owner, repo, num);
-			}
-			return (null, null, null);
-		}
-
-		// Short: owner/repo#123
-		var hashIdx = prRef.LastIndexOf('#');
-		if (hashIdx > 0 && hashIdx < prRef.Length - 1)
-		{
-			var repoPart = prRef[..hashIdx];
-			if (int.TryParse(prRef[(hashIdx + 1)..], out var num))
-			{
-				var parts = repoPart.Split('/');
-				if (parts.Length == 2)
-					return (parts[0], parts[1], num);
-			}
-		}
-
-		// Bare number
-		if (int.TryParse(prRef, out var bareNum))
-			return (defaultOwner, defaultRepo, bareNum);
-
-		return (null, null, null);
+		prNumber = 0;
+		var stem = Path.GetFileNameWithoutExtension(filePath);
+		if (string.IsNullOrEmpty(stem))
+			return false;
+		var i = 0;
+		while (i < stem.Length && char.IsDigit(stem[i]))
+			i++;
+		// Must start with digits, followed by end-of-stem or a dash separator
+		if (i == 0 || (i < stem.Length && stem[i] != '-'))
+			return false;
+		return int.TryParse(stem[..i], out prNumber) && prNumber > 0;
 	}
 
 	private static EntryFileFinding Error(string file, string message) => new(file, FindingSeverity.Error, message);

--- a/tests/Elastic.Changelog.Tests/Evaluation/ChangelogEntryValidatorTests.cs
+++ b/tests/Elastic.Changelog.Tests/Evaluation/ChangelogEntryValidatorTests.cs
@@ -252,91 +252,76 @@ public class ChangelogEntryValidatorTests
 	}
 
 	// ─────────────────────────────────────────────────────────────────────────────────────────────
-	// PR reference collection
+	// ─────────────────────────────────────────────────────────────────────────────────────────────
+	// Filename validation
 	// ─────────────────────────────────────────────────────────────────────────────────────────────
 
-	[Fact]
-	public void CollectPrRefs_BareNumber_ReturnsSingleRef()
+	[Theory]
+	[InlineData("docs/changelog/42.yaml")]
+	[InlineData("docs/changelog/42.yml")]
+	[InlineData("docs/changelog/42-my-feature.yaml")]
+	[InlineData("docs/changelog/1234-fix-something-long.yaml")]
+	public void ValidateFilename_ValidConvention_NoFindings(string filePath)
 	{
-		var entry = ParseYaml("pr: 42\ntype: feature\ntitle: Test\nproducts:\n  - product: elasticsearch");
-		var refs = ChangelogEntryValidator.CollectPrRefs(entry);
-		refs.Should().ContainSingle().Which.Should().Be("42");
-	}
-
-	[Fact]
-	public void CollectPrRefs_PrsList_ReturnsAll()
-	{
-		var entry = ParseYaml("prs:\n  - 1\n  - 2\ntype: feature\ntitle: Test\nproducts:\n  - product: elasticsearch");
-		var refs = ChangelogEntryValidator.CollectPrRefs(entry);
-		refs.Should().HaveCount(2).And.Contain("1").And.Contain("2");
-	}
-
-	// ─────────────────────────────────────────────────────────────────────────────────────────────
-	// PR existence validation
-	// ─────────────────────────────────────────────────────────────────────────────────────────────
-
-	[Fact]
-	public void ValidatePrReferences_ExistingOwnRepoPr_NoError()
-	{
-		var entry = ParseYaml("pr: 42\ntype: feature\ntitle: Test\nproducts:\n  - product: elasticsearch");
-		var findings = ChangelogEntryValidator.ValidatePrReferences(
-			"docs/changelog/42.yaml",
-			entry,
-			"elastic",
-			"my-repo",
-			new Dictionary<int, bool> { [42] = true }
-		);
+		var findings = ChangelogEntryValidator.ValidateFilename(filePath);
 		findings.Should().BeEmpty();
 	}
 
+	[Theory]
+	[InlineData("docs/changelog/my-feature.yaml")]
+	[InlineData("docs/changelog/changelog.yaml")]
+	[InlineData("docs/changelog/fix42.yaml")]
+	public void ValidateFilename_InvalidConvention_ProducesError(string filePath)
+	{
+		var findings = ChangelogEntryValidator.ValidateFilename(filePath);
+		findings.Should().ContainSingle(f => f.Severity == FindingSeverity.Error && f.Message.Contains("must start with a PR number"));
+	}
+
+	[Theory]
+	[InlineData("docs/changelog/42.yaml", 42)]
+	[InlineData("docs/changelog/100-feature.yaml", 100)]
+	[InlineData("docs/changelog/9999-x.yml", 9999)]
+	public void TryParseFilenameAsPrNumber_ValidFilename_ReturnsNumber(string filePath, int expected)
+	{
+		ChangelogEntryValidator.TryParseFilenameAsPrNumber(filePath, out var prNumber).Should().BeTrue();
+		prNumber.Should().Be(expected);
+	}
+
+	[Theory]
+	[InlineData("docs/changelog/feature.yaml")]
+	[InlineData("docs/changelog/changelog.yml")]
+	public void TryParseFilenameAsPrNumber_InvalidFilename_ReturnsFalse(string filePath) =>
+		ChangelogEntryValidator.TryParseFilenameAsPrNumber(filePath, out _).Should().BeFalse();
+
+	// ─────────────────────────────────────────────────────────────────────────────────────────────
+	// pr: field cross-check against filename
+	// ─────────────────────────────────────────────────────────────────────────────────────────────
+
 	[Fact]
-	public void ValidatePrReferences_NonExistentOwnRepoPr_ProducesError()
+	public void Validate_PrFieldMatchesFilename_NoError()
+	{
+		var entry = ParseYaml("pr: 42\ntype: feature\ntitle: Test\nproducts:\n  - product: elasticsearch");
+		var findings = ChangelogEntryValidator.Validate("docs/changelog/42.yaml", entry, Config, null, null, filenamePrNumber: 42);
+		findings.Should().NotContain(f => f.Message.Contains("does not match"));
+	}
+
+	[Fact]
+	public void Validate_PrFieldMismatchesFilename_ProducesError()
 	{
 		var entry = ParseYaml("pr: 99\ntype: feature\ntitle: Test\nproducts:\n  - product: elasticsearch");
-		var findings = ChangelogEntryValidator.ValidatePrReferences(
-			"docs/changelog/42.yaml",
-			entry,
-			"elastic",
-			"my-repo",
-			new Dictionary<int, bool> { [99] = false }
-		);
-		findings.Should().ContainSingle(f => f.Severity == FindingSeverity.Error && f.Message.Contains("does not exist"));
-	}
-
-	[Fact]
-	public void ValidatePrReferences_ForeignRepoNotAllowed_ProducesWarning()
-	{
-		var entry = ParseYaml(
-			"pr: https://github.com/other-org/other-repo/pull/5\ntype: feature\ntitle: Test\nproducts:\n  - product: elasticsearch"
-		);
-		var findings = ChangelogEntryValidator.ValidatePrReferences(
-			"docs/changelog/42.yaml",
-			entry,
-			"elastic",
-			"my-repo",
-			new Dictionary<int, bool>(),
-			linkAllowRepos: ["elastic/other-repo"]
-		);
-		// other-org/other-repo is not in the allowlist
+		var findings = ChangelogEntryValidator.Validate("docs/changelog/42.yaml", entry, Config, null, null, filenamePrNumber: 42);
 		findings.Should().ContainSingle(
-			f => f.Severity == FindingSeverity.Warning && f.Message.Contains("outside bundle.link_allow_repos")
+			f => f.Severity == FindingSeverity.Error && f.Message.Contains("does not match") && f.Message.Contains(
+				"99"
+			) && f.Message.Contains("42")
 		);
 	}
 
 	[Fact]
-	public void ValidatePrReferences_ForeignRepoAllowed_NoWarning()
+	public void Validate_PrFieldAbsent_NoFilenameError()
 	{
-		var entry = ParseYaml(
-			"pr: https://github.com/elastic/other-repo/pull/5\ntype: feature\ntitle: Test\nproducts:\n  - product: elasticsearch"
-		);
-		var findings = ChangelogEntryValidator.ValidatePrReferences(
-			"docs/changelog/42.yaml",
-			entry,
-			"elastic",
-			"my-repo",
-			new Dictionary<int, bool>(),
-			linkAllowRepos: ["elastic/other-repo"]
-		);
-		findings.Should().NotContain(f => f.Message.Contains("outside bundle.link_allow_repos"));
+		var entry = ParseYaml("type: feature\ntitle: Test\nproducts:\n  - product: elasticsearch");
+		var findings = ChangelogEntryValidator.Validate("docs/changelog/42.yaml", entry, Config, null, null, filenamePrNumber: 42);
+		findings.Should().NotContain(f => f.Message.Contains("does not match"));
 	}
 }


### PR DESCRIPTION
The `changelog validate` gate now checks that each entry file follows the `<pr-number>[-<description>].yaml` naming convention and that the PR it names exists in the repo. If `pr:` is also present in the YAML it must equal the filename's PR number — a mismatch is an error, not a silent override.

**Affects:** Release notes, CLI

**Prompt summary:** The filename is now the canonical source of PR association for changelog entries. Validate that it follows `<digits>[-<name>].yaml`, use those digits for the GitHub PR-existence check (replacing the old `pr:`/`prs:` field scan), and surface a clear error when `pr:` is present but disagrees with the filename.

## Why

The old gate derived PR numbers from `pr:` and `prs:` YAML fields. Nothing stopped an author from naming a file `999.yaml` with `pr: 14` inside — the file-presence check would pass for PR #14, but the sync job would upload it under the wrong number. The filename is the only identity that the upload path actually uses, so it is the right thing to validate and existence-check.

## What

#### Filename convention validation
`ValidateFilename` and `TryParseFilenameAsPrNumber` replace the old `CollectPrRefs`/`ValidatePrReferences` pair. An entry file must be named `<digits>[-<description>].yaml`; a file like `my-feature.yaml` or `changelog.yaml` is an error, not a warning. The digits are the PR number.

#### Existence check from filename
The service collects PR numbers from filenames — not from `pr:`/`prs:` fields — and batch-checks them against the GitHub API. An entry for a PR that does not exist in the repo is an error.

#### Optional `pr:` cross-check
`pr:` remains supported (it is used by the bundler for link rendering) but is now optional. When present it must equal the filename's PR number. A bare integer, `#99`, or any parseable form is accepted; a mismatch names both values in the error message.

#### Tests
`CollectPrRefs` and `ValidatePrReferences` test cases replaced by coverage for `ValidateFilename`, `TryParseFilenameAsPrNumber`, and the `pr:` cross-check, exercised via theory cases for the valid and invalid filename patterns.

## Verify

```bash
dotnet test tests/Elastic.Changelog.Tests/
```