### PR TITLE
Fix entries-invalid comment not posting — EntryFindings deserializes as null

### DIFF
--- a/src/services/Elastic.Changelog/Evaluation/GithubDecisionMetadata.cs
+++ b/src/services/Elastic.Changelog/Evaluation/GithubDecisionMetadata.cs
@@ -43,7 +43,7 @@ public record GithubDecisionMetadata
 	/// <summary>Repo-relative path to the committed changelog file, when <see cref="CommitOutcome"/> is <c>Committed</c>.</summary>
 	public string? CommittedFile { get; init; }
 	/// <summary>Findings from the entry-file validation gate. Non-null and non-empty when <see cref="Gate"/> is <see cref="ValidationGate.Entries"/> and validation failed.</summary>
-	public IReadOnlyList<EntryFinding>? EntryFindings { get; init; }
+	public List<EntryFinding>? EntryFindings { get; init; }
 }
 
 /// <summary>A single finding from the changelog entry file validation gate.</summary>


### PR DESCRIPTION
The entries-invalid sticky comment never posted even when `changelog validate` found errors. `SelectBody`'s `EntryFindings is { Count: > 0 }` guard always evaluated to false because `EntryFindings` deserialized as null, causing the renderer to fall through to the labels-needed path.

**Affects:** Release notes

## Why

`GithubDecisionMetadata.EntryFindings` was typed as `IReadOnlyList<EntryFinding>?`. `List<EntryFinding>` was registered in `GithubDecisionMetadataJsonContext`, but `IReadOnlyList<EntryFinding>` was not. The STJ source generator cannot resolve the interface type on read, so it silently produces null for the field regardless of the JSON payload.

## What

#### One-character type change
`IReadOnlyList<EntryFinding>?` → `List<EntryFinding>?` on `GithubDecisionMetadata.EntryFindings`. `List<EntryFinding>` is already registered in the JSON context, so deserialization now produces the populated list and `SelectBody` dispatches correctly to `RenderEntriesInvalid`.

## Verify

```bash
dotnet build src/services/Elastic.Changelog/
```