### PR TITLE
Fix entries-invalid comment blob links encoding path separators

### DIFF
--- a/src/services/Elastic.Changelog/Evaluation/ChangelogCommentRenderer.cs
+++ b/src/services/Elastic.Changelog/Evaluation/ChangelogCommentRenderer.cs
@@ -221,7 +221,7 @@ internal static class ChangelogCommentRenderer
 		{
 			var filePath = group.Key;
 			var fileRef = !string.IsNullOrWhiteSpace(owner) && !string.IsNullOrWhiteSpace(repo)
-				? $"[{WrapInlineCode(filePath)}](https://github.com/{owner}/{repo}/blob/{branch}/{Uri.EscapeDataString(filePath)})"
+				? $"[{WrapInlineCode(filePath)}](https://github.com/{owner}/{repo}/blob/{branch}/{string.Join("/", filePath.Split('/').Select(Uri.EscapeDataString))})"
 				: WrapInlineCode(filePath);
 
 			parts.Add("");


### PR DESCRIPTION
The file links in the entries-invalid changelog comment were broken — path separators encoded as `%2F` instead of remaining as `/`, producing URLs like `docs%2Fchangelog%2F15-test.yaml` that GitHub does not resolve.

**Affects:** Release notes

## Why

`RenderEntriesInvalid` called `Uri.EscapeDataString` on the full relative path. That function encodes every character outside the unreserved set, including `/`. The same bug existed in `RenderEntryCommitted` and was already fixed there by splitting on `/` and encoding each segment individually. `RenderEntriesInvalid` missed the same treatment.

## What

#### Per-segment URL encoding
`Uri.EscapeDataString(filePath)` replaced with `string.Join("/", filePath.Split('/').Select(Uri.EscapeDataString))`, matching the pattern already used in `RenderEntryCommitted` on line 47 of the same file.