### PR TITLE
Quote generated OKF frontmatter so exported bundles parse

### DIFF
--- a/.claude/skills/surfaces.md
+++ b/.claude/skills/surfaces.md
@@ -37,6 +37,7 @@ Named for what a reader *loses* when it breaks, not for the project that impleme
 | `Site UI` | `src/Elastic.Documentation.Site/` | Page chrome, layout, styling, client-side behaviour |
 | `API reference` | `src/Elastic.ApiExplorer/`, `src/Elastic.Documentation.OpenApiIndex/`, `src/infra/docs-lambda-openapi-index/` | OpenAPI-driven reference pages |
 | `Release notes` | `src/services/Elastic.Changelog/`, `src/infra/docs-lambda-changelog-scrubber/`, `docs/cli/changelog/` | Changelog entries, bundling, publishing |
+| `Content export` | `src/Elastic.Markdown/Exporters/` | The generated `llms.txt`, `.md` and `okf.zip` output — anyone consuming an export rather than the site |
 | `Search` | `src/Elastic.Documentation.Indexing/`, `src/services/search/`, `src/tooling/essc/`, `config/search.yml` | Docs search and elastic.co website search, indexing, ranking |
 | `Links & redirects` | `src/Elastic.Documentation.Links/`, `src/Elastic.Documentation.LinkIndex/`, `src/infra/docs-lambda-index-publisher/`, `docs/_redirects.yml`, `config/legacy-url-mappings.yml` | Cross-repo links, link validation, redirects |
 | `Assembler builds` | `src/services/Elastic.Documentation.Assembler/`, `src/tooling/docs-builder/Commands/Assembler/` | The multi-repo assembled site |

--- a/src/Elastic.Markdown/Exporters/OkfMarkdownExporter.cs
+++ b/src/Elastic.Markdown/Exporters/OkfMarkdownExporter.cs
@@ -9,6 +9,7 @@ using System.Text;
 using Elastic.Documentation.AppliesTo;
 using Elastic.Documentation.Configuration.Inference;
 using Elastic.Documentation.Configuration.Products;
+using Elastic.Documentation.Navigation;
 using Elastic.Markdown.Helpers;
 using Elastic.Markdown.IO;
 using Elastic.Markdown.Myst.Components;
@@ -135,19 +136,35 @@ public class OkfMarkdownExporter : IMarkdownExporter
 	}
 
 	/// <summary>
-	/// Derives the OKF <c>type</c> from the page's top-level navigation section (the first URL path
-	/// segment after any configured <see cref="Elastic.Documentation.Configuration.BuildContext.UrlPathPrefix"/>),
-	/// e.g. <c>/reference/query-languages/eql</c> -> <c>reference</c>.
+	/// Derives the OKF <c>type</c> — a query dimension for <c>okf search --type</c> — from the page's top-level
+	/// navigation section: the first URL path segment after any configured
+	/// <see cref="Elastic.Documentation.Configuration.BuildContext.UrlPathPrefix"/>, e.g.
+	/// <c>/reference/query-languages/eql</c> -> <c>reference</c>. A page sitting at the bundle root has no section
+	/// above it, so its single segment names the page itself rather than a section and would make every root-level
+	/// page its own singleton type; those fall back to <c>documentation</c>, matching the bundle root's own index.
+	/// <paramref name="isSectionLandingPage"/> keeps a section's landing page (<c>/reference</c>, one segment but
+	/// backed by a <c>reference/</c> directory) typed as its section.
 	/// </summary>
-	internal static string DeriveType(string navigationUrl, string? urlPathPrefix)
+	internal static string DeriveType(string navigationUrl, string? urlPathPrefix, bool isSectionLandingPage)
 	{
 		var prefix = urlPathPrefix ?? string.Empty;
 		var url = navigationUrl;
 		if (prefix.Length > 0 && url.StartsWith(prefix, StringComparison.Ordinal))
 			url = url[prefix.Length..];
 		var segments = url.Split('/', StringSplitOptions.RemoveEmptyEntries);
-		return segments.Length > 0 ? segments[0] : "documentation";
+		if (segments.Length == 0 || (segments.Length == 1 && !isSectionLandingPage))
+			return "documentation";
+		return segments[0];
 	}
+
+	/// <summary>
+	/// True when the page is a navigation node's index, i.e. a section landing page with a sibling <c>{folder}/</c>
+	/// directory in the bundle. <c>GetNavigationFor</c> resolves an index page to its node rather than to a leaf
+	/// (see <c>ListSubPagesBlock</c>), the only signal separating <c>/reference</c> from a root-level page like
+	/// <c>/colon</c> — the two are indistinguishable by URL shape.
+	/// </summary>
+	internal static bool IsSectionLandingPage(INavigationItem navigationItem) =>
+		navigationItem is INodeNavigationItem<INavigationModel, INavigationItem>;
 
 	/// <summary>
 	/// Rewrites an already-resolved link URL to its bundle-relative form via <see cref="ComputeBundlePath"/>.
@@ -213,7 +230,7 @@ public class OkfMarkdownExporter : IMarkdownExporter
 
 		var sourceFile = context.SourceFile;
 		var frontMatter = new ConceptFrontMatter(
-			DeriveType(context.NavigationItem.Url, context.BuildContext.UrlPathPrefix),
+			DeriveType(context.NavigationItem.Url, context.BuildContext.UrlPathPrefix, IsSectionLandingPage(context.NavigationItem)),
 			sourceFile.Title,
 			sourceFile.YamlFrontMatter?.NavigationTitle,
 			GetDescription(context),

--- a/src/Elastic.Markdown/Exporters/OkfMarkdownExporter.cs
+++ b/src/Elastic.Markdown/Exporters/OkfMarkdownExporter.cs
@@ -212,41 +212,112 @@ public class OkfMarkdownExporter : IMarkdownExporter
 		});
 
 		var sourceFile = context.SourceFile;
-		var frontMatter = DocumentationObjectPoolProvider.StringBuilderPool.Get();
+		var frontMatter = new ConceptFrontMatter(
+			DeriveType(context.NavigationItem.Url, context.BuildContext.UrlPathPrefix),
+			sourceFile.Title,
+			sourceFile.YamlFrontMatter?.NavigationTitle,
+			GetDescription(context),
+			GetResourceUrl(context),
+			GetTags(context)
+		);
+
+		var content = DocumentationObjectPoolProvider.StringBuilderPool.Get();
 		try
 		{
-			_ = frontMatter.AppendLine("---");
-			_ = frontMatter.AppendLine($"type: {DeriveType(context.NavigationItem.Url, context.BuildContext.UrlPathPrefix)}");
-			_ = frontMatter.AppendLine($"title: {sourceFile.Title}");
-			if (!string.IsNullOrEmpty(sourceFile.YamlFrontMatter?.NavigationTitle))
-				_ = frontMatter.AppendLine($"navigation_title: {sourceFile.YamlFrontMatter.NavigationTitle}");
-			_ = frontMatter.AppendLine($"description: {GetDescription(context)}");
-			_ = frontMatter.AppendLine($"resource: {GetResourceUrl(context)}");
-
-			var tags = GetTags(context);
-			if (tags.Count > 0)
-			{
-				_ = frontMatter.AppendLine("tags:");
-				foreach (var tag in tags)
-					_ = frontMatter.AppendLine($"  - {tag}");
-			}
-			_ = frontMatter.AppendLine("---");
-			_ = frontMatter.AppendLine();
-			_ = frontMatter.AppendLine($"# {sourceFile.Title}");
-			_ = frontMatter.Append(body);
+			_ = content.Append(RenderFrontMatter(frontMatter));
+			_ = content.AppendLine();
+			_ = content.AppendLine($"# {sourceFile.Title}");
+			_ = content.Append(body);
 			// AppendLine uses Environment.NewLine — normalize so bundle content is identical regardless of the OS the build runs on.
-			return frontMatter.ToString().Replace("\r\n", "\n", StringComparison.Ordinal);
+			return content.ToString().Replace("\r\n", "\n", StringComparison.Ordinal);
 		}
 		finally
 		{
-			DocumentationObjectPoolProvider.StringBuilderPool.Return(frontMatter);
+			DocumentationObjectPoolProvider.StringBuilderPool.Return(content);
+		}
+	}
+
+	internal static string RenderFrontMatter(ConceptFrontMatter frontMatter)
+	{
+		var sb = DocumentationObjectPoolProvider.StringBuilderPool.Get();
+		try
+		{
+			_ = sb.AppendLine("---");
+			_ = sb.AppendLine($"type: {YamlScalar(frontMatter.Type)}");
+			_ = sb.AppendLine($"title: {YamlScalar(frontMatter.Title)}");
+			if (!string.IsNullOrEmpty(frontMatter.NavigationTitle))
+				_ = sb.AppendLine($"navigation_title: {YamlScalar(frontMatter.NavigationTitle)}");
+			_ = sb.AppendLine($"description: {YamlScalar(frontMatter.Description)}");
+			_ = sb.AppendLine($"resource: {YamlScalar(frontMatter.Resource)}");
+
+			if (frontMatter.Tags.Count > 0)
+			{
+				_ = sb.AppendLine("tags:");
+				foreach (var tag in frontMatter.Tags)
+					_ = sb.AppendLine($"  - {YamlScalar(tag)}");
+			}
+			_ = sb.AppendLine("---");
+			// AppendLine uses Environment.NewLine — normalize so bundle content is identical regardless of the OS the build runs on.
+			return sb.ToString().Replace("\r\n", "\n", StringComparison.Ordinal);
+		}
+		finally
+		{
+			DocumentationObjectPoolProvider.StringBuilderPool.Return(sb);
+		}
+	}
+
+	/// <summary>
+	/// Renders a value as a double-quoted YAML scalar. Every value in this frontmatter derives from page prose, so a
+	/// plain scalar is never safe: a description containing <c>": "</c> makes the concept file unparseable, while a tag
+	/// like <c>Elastic Stack: Available</c> parses — as a mapping rather than a string. Quoting also keeps values that
+	/// YAML would otherwise retype (<c>true</c>, <c>1.2</c>) or reject for a leading indicator character.
+	/// </summary>
+	internal static string YamlScalar(string? value)
+	{
+		if (string.IsNullOrEmpty(value))
+			return "\"\"";
+
+		var sb = DocumentationObjectPoolProvider.StringBuilderPool.Get();
+		try
+		{
+			_ = sb.Append('"');
+			foreach (var c in value)
+			{
+				_ = c switch
+				{
+					'\\' => sb.Append("\\\\"),
+					'"' => sb.Append("\\\""),
+					'\n' => sb.Append("\\n"),
+					'\r' => sb.Append("\\r"),
+					'\t' => sb.Append("\\t"),
+					// char.IsControl covers only U+0000-U+001F and U+007F-U+009F, all representable as \xNN.
+					_ when char.IsControl(c) => sb.Append("\\x").Append(((int)c).ToString("x2")),
+					_ => sb.Append(c)
+				};
+			}
+			_ = sb.Append('"');
+			return sb.ToString();
+		}
+		finally
+		{
+			DocumentationObjectPoolProvider.StringBuilderPool.Return(sb);
 		}
 	}
 
 	private static string GetDescription(MarkdownExportFileContext context) =>
-		!string.IsNullOrEmpty(context.SourceFile.YamlFrontMatter?.Description)
-			? context.SourceFile.YamlFrontMatter.Description
-			: new DescriptionGenerator().GenerateDescription(context.Document);
+		NormalizeDescription(
+			!string.IsNullOrEmpty(context.SourceFile.YamlFrontMatter?.Description)
+				? context.SourceFile.YamlFrontMatter.Description
+				: new DescriptionGenerator().GenerateDescription(context.Document)
+		);
+
+	/// <summary>
+	/// Collapses a description to a single line: an authored <c>description: |</c> block keeps its newlines, and a
+	/// blank line among them terminates the markdown lists <see cref="RenderIndexContent"/> renders. Also drops the
+	/// trailing space <see cref="DescriptionGenerator"/> pads each block with, which a quoted scalar would preserve.
+	/// </summary>
+	internal static string NormalizeDescription(string description) =>
+		string.Join(' ', description.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
 
 	private static string GetResourceUrl(MarkdownExportFileContext context) =>
 		context.BuildContext.CanonicalBaseUrl is { } baseUrl
@@ -397,4 +468,13 @@ public class OkfMarkdownExporter : IMarkdownExporter
 	}
 
 	internal sealed record ConceptEntry(string BundlePath, string Title, string Description);
+
+	internal sealed record ConceptFrontMatter(
+		string Type,
+		string Title,
+		string? NavigationTitle,
+		string Description,
+		string Resource,
+		IReadOnlyCollection<string> Tags
+	);
 }

--- a/tests/Elastic.Markdown.Tests/Exporters/OkfMarkdownExporterTests.cs
+++ b/tests/Elastic.Markdown.Tests/Exporters/OkfMarkdownExporterTests.cs
@@ -47,7 +47,7 @@ public class OkfMarkdownExporterTests
 	[Fact]
 	public void DeriveType_UrlWithPrefixAndSection_ReturnsFirstSegmentAfterPrefix()
 	{
-		var type = OkfMarkdownExporter.DeriveType("/docs/reference/query-languages/eql", "/docs");
+		var type = OkfMarkdownExporter.DeriveType("/docs/reference/query-languages/eql", "/docs", isSectionLandingPage: false);
 
 		type.Should().Be("reference");
 	}
@@ -55,7 +55,7 @@ public class OkfMarkdownExporterTests
 	[Fact]
 	public void DeriveType_NoPrefixConfigured_ReturnsFirstSegment()
 	{
-		var type = OkfMarkdownExporter.DeriveType("/solutions/search", urlPathPrefix: "");
+		var type = OkfMarkdownExporter.DeriveType("/solutions/search", urlPathPrefix: "", isSectionLandingPage: false);
 
 		type.Should().Be("solutions");
 	}
@@ -63,9 +63,36 @@ public class OkfMarkdownExporterTests
 	[Fact]
 	public void DeriveType_RootUrl_ReturnsDocumentationFallback()
 	{
-		var type = OkfMarkdownExporter.DeriveType("/", urlPathPrefix: "");
+		var type = OkfMarkdownExporter.DeriveType("/", urlPathPrefix: "", isSectionLandingPage: true);
 
 		type.Should().Be("documentation");
+	}
+
+	[Fact]
+	public void DeriveType_RootLevelLeafPage_ReturnsDocumentationRatherThanFileStem()
+	{
+		// A page at the bundle root has no section above it, so its one segment names the page itself —
+		// typing it "colon" would make every root-level page its own singleton `okf search --type` value.
+		var type = OkfMarkdownExporter.DeriveType("/colon", urlPathPrefix: "", isSectionLandingPage: false);
+
+		type.Should().Be("documentation");
+	}
+
+	[Fact]
+	public void DeriveType_SectionLandingPage_ReturnsItsOwnSegment()
+	{
+		// "/reference" is also a single segment, but it is backed by a "reference/" directory in the bundle.
+		var type = OkfMarkdownExporter.DeriveType("/docs/reference", urlPathPrefix: "/docs", isSectionLandingPage: true);
+
+		type.Should().Be("reference");
+	}
+
+	[Fact]
+	public void IsSectionLandingPage_NodeIndexVersusLeaf_SeparatesSectionFromRootLevelPage()
+	{
+		// GetNavigationFor resolves a folder's index page to the node itself rather than to a leaf.
+		OkfMarkdownExporter.IsSectionLandingPage(new FakeNodeNavigationItem()).Should().BeTrue();
+		OkfMarkdownExporter.IsSectionLandingPage(new FakeLeafNavigationItem()).Should().BeFalse();
 	}
 
 	[Fact]
@@ -322,5 +349,29 @@ public class OkfMarkdownExporterTests
 		lines.First().Should().Be("---");
 		var body = string.Join('\n', lines.Skip(1).TakeWhile(l => l != "---"));
 		return new DeserializerBuilder().Build().Deserialize<Dictionary<string, object>>(body);
+	}
+
+	private sealed class FakeNavigationModel : INavigationModel;
+
+	private abstract class FakeNavigationItemBase : INavigationItem
+	{
+		public string Url => "/reference";
+		public string NavigationTitle => "Reference";
+		public IRootNavigationItem<INavigationModel, INavigationItem> NavigationRoot => null!;
+		public INodeNavigationItem<INavigationModel, INavigationItem>? Parent { get; set; }
+		public bool Hidden => false;
+		public int NavigationIndex { get; set; }
+	}
+
+	private sealed class FakeLeafNavigationItem : FakeNavigationItemBase, ILeafNavigationItem<INavigationModel>
+	{
+		public INavigationModel Model { get; } = new FakeNavigationModel();
+	}
+
+	private sealed class FakeNodeNavigationItem : FakeNavigationItemBase, INodeNavigationItem<INavigationModel, INavigationItem>
+	{
+		public string Id => NavigationTitle;
+		public ILeafNavigationItem<INavigationModel> Index => null!;
+		public IReadOnlyCollection<INavigationItem> NavigationItems => [];
 	}
 }

--- a/tests/Elastic.Markdown.Tests/Exporters/OkfMarkdownExporterTests.cs
+++ b/tests/Elastic.Markdown.Tests/Exporters/OkfMarkdownExporterTests.cs
@@ -3,8 +3,10 @@
 // See the LICENSE file in the project root for more information
 
 using AwesomeAssertions;
+using Elastic.Documentation.Navigation;
 using Elastic.Markdown;
 using Elastic.Markdown.Exporters;
+using YamlDotNet.Serialization;
 
 namespace Elastic.Markdown.Tests.Exporters;
 
@@ -242,5 +244,83 @@ public class OkfMarkdownExporterTests
 
 		content.Should().Contain("* [foo](foo/)");
 		content.Should().NotContain("* [foo](foo/) -");
+	}
+
+	[Theory]
+	// The reproduction from https://github.com/elastic/docs-builder/issues/3999 — a `": "` in prose.
+	[InlineData("What each entry point exports. Types: PrimitiveDefinition, PrimitiveNode.")]
+	[InlineData("Last updated: May 3, 2026")]
+	[InlineData("A description with \"double quotes\" in it")]
+	[InlineData(@"A Windows path C:\Users\foo and a trailing backslash \")]
+	[InlineData("A description\nspanning two lines")]
+	[InlineData("#leading indicator characters *&!|>%@`")]
+	[InlineData("true")]
+	[InlineData("{not: a, flow: mapping}")]
+	[InlineData("")]
+	public void RenderFrontMatter_ArbitraryProseDescription_RoundTripsVerbatim(string description)
+	{
+		var rendered = OkfMarkdownExporter.RenderFrontMatter(FrontMatter(description: description));
+
+		ParseFrontMatter(rendered)["description"].Should().Be(description);
+	}
+
+	[Fact]
+	public void RenderFrontMatter_AppliesToTags_RoundTripAsStringsNotMappings()
+	{
+		// GetAppliesToItems formats every tag as "{displayName}: {availability}" — unquoted that is valid
+		// YAML, which makes this the quieter half of the bug: the sequence entry parses as a mapping.
+		string[] tags = ["Elastic Stack: Available", "Serverless: Planned, GA"];
+
+		var rendered = OkfMarkdownExporter.RenderFrontMatter(FrontMatter(tags: tags));
+
+		ParseFrontMatter(rendered)["tags"].Should().BeEquivalentTo(tags);
+	}
+
+	[Fact]
+	public void RenderFrontMatter_TitleContainingColon_RoundTripsVerbatim()
+	{
+		var rendered = OkfMarkdownExporter.RenderFrontMatter(FrontMatter(title: "Kibana: getting started"));
+
+		var parsed = ParseFrontMatter(rendered);
+		parsed["title"].Should().Be("Kibana: getting started");
+		parsed["resource"].Should().Be("https://www.elastic.co/docs/reference/foo");
+	}
+
+	[Fact]
+	public void RenderFrontMatter_NavigationTitleEmpty_KeyIsOmitted()
+	{
+		var rendered = OkfMarkdownExporter.RenderFrontMatter(FrontMatter());
+
+		ParseFrontMatter(rendered).Should().NotContainKey("navigation_title");
+		ParseFrontMatter(OkfMarkdownExporter.RenderFrontMatter(FrontMatter(navigationTitle: "Foo: short")))["navigation_title"]
+			.Should()
+			.Be("Foo: short");
+	}
+
+	[Theory]
+	[InlineData("First line.\nSecond line: with a colon.", "First line. Second line: with a colon.")]
+	// A `description: |` block with a blank line would otherwise terminate the index list it is rendered into.
+	[InlineData("Para one.\n\nPara two.", "Para one. Para two.")]
+	// DescriptionGenerator pads each block it appends with a trailing space.
+	[InlineData("A generated description. ", "A generated description.")]
+	[InlineData("  padded\tand\r\nragged  ", "padded and ragged")]
+	[InlineData("", "")]
+	public void NormalizeDescription_MultiLineOrPaddedProse_CollapsesToASingleLine(string description, string expected) =>
+		OkfMarkdownExporter.NormalizeDescription(description).Should().Be(expected);
+
+	private static OkfMarkdownExporter.ConceptFrontMatter FrontMatter(
+		string title = "Foo",
+		string? navigationTitle = null,
+		string description = "A description",
+		IReadOnlyCollection<string>? tags = null
+	) => new("reference", title, navigationTitle, description, "https://www.elastic.co/docs/reference/foo", tags ?? []);
+
+	/// <summary>Parses the emitted block as YAML, the only assertion that proves arbitrary prose survives escaping.</summary>
+	private static Dictionary<string, object> ParseFrontMatter(string rendered)
+	{
+		var lines = rendered.Split('\n');
+		lines.First().Should().Be("---");
+		var body = string.Join('\n', lines.Skip(1).TakeWhile(l => l != "---"));
+		return new DeserializerBuilder().Build().Deserialize<Dictionary<string, object>>(body);
 	}
 }


### PR DESCRIPTION
> Closes #3999 

The OKF exporter wrote frontmatter values as plain YAML scalars, so ordinary prose containing `": "` produced concept files that no YAML parser accepts. `okf validate` rejected the whole bundle, which made the export unusable by the tooling it exists to feed.

**Affects:** `Content export` — not in the map; added as a row in the same PR · `Authoring`

**Prompt summary:** Fix the OKF export failure reported in [#3999](https://github.com/elastic/docs-builder/issues/3999). Once the quoting fix was verified, also close out the `type:` oddity that the reporter raised as an aside on the same issue.

## Why

A description is derived from page prose, so a sentence like `Types: PrimitiveDefinition, PrimitiveNode.` is enough to break the file. The reporter measured 29 of 83 exported concepts carrying an unparseable description. The build stays silent about it and reports `0 Errors`, so the first sign of trouble is `okf validate` failing to load the bundle.

Tags fail more quietly. `GetAppliesToItems` formats each one as `{displayName}: {availability}`, and unquoted that is *valid* YAML — the sequence entry parses as a mapping rather than a string, so `okf search --tag` silently matches nothing.

## What

#### Quoted frontmatter scalars

Every generated value now goes through `YamlScalar`, which double-quotes it and escapes `\` before `"`, then the whitespace controls, then any remaining control character as `\xNN`. This covers `type`, `title`, `navigation_title`, `description`, `resource` and each tag. The frontmatter block moved out of `CreateConceptContent` into `RenderFrontMatter`, so a test can assert on the emitted YAML without running a build.

#### Single-line descriptions

A description collapses to a single line. `DescriptionGenerator` pads each block with a trailing space, which a plain scalar discarded and a quoted one keeps. The worse case is an authored `description: |` block: it keeps its newlines, and a blank line among them ends the markdown list that `RenderIndexContent` writes into every `index.md`, truncating the directory index.

#### Root-level concept types

`type` is a query dimension for `okf search --type`, and `DeriveType` read it from the first URL segment. A page at the bundle root therefore got its own file stem, so `colon.md` became `type: colon` and every root-level page was a singleton type. Those now fall back to `documentation`, which the bundle root's own index already used. `IsSectionLandingPage` keeps a section's landing page typed as its section: `GetNavigationFor` resolves an index page to its navigation node rather than a leaf, and that is the only thing separating `/reference` from `/colon`.

## Verify

```bash
dotnet test tests/Elastic.Markdown.Tests/ --filter "FullyQualifiedName~Okf"
# RenderFrontMatter_ArbitraryProseDescription_RoundTripsVerbatim — parses the emitted YAML and compares to the input
# RenderFrontMatter_AppliesToTags_RoundTripAsStringsNotMappings — the quiet half of the bug
# DeriveType_RootLevelLeafPage_ReturnsDocumentationRatherThanFileStem — the reported aside
```

Against the reproduction docset from the issue, built with `--exporters okf` and unzipped, the reference [`okf`](https://github.com/okfcli/okf) CLI reports `"valid": true` with `errors: 0`, where the same bundle built from `main` fails with `error[io]`. `okf list` shows the root-level pages typed `documentation` and the section and its children typed `section`, and `okf search --tag "Elastic Stack: Generally available since 9.1"` now returns a match.

**Out of scope:** `LlmMarkdownExporter` has the identical interpolation bug at [`LlmMarkdownExporter.cs:157`](https://github.com/elastic/docs-builder/blob/main/src/Elastic.Markdown/Exporters/LlmMarkdownExporter.cs#L157). That output is served as `.md` at every docs URL for people and language models to read, not parsed as a strict bundle, so there is no failing case to point at and no validator to confirm a fix against. It also enshrines the tag bug as expected output in [`LlmMarkdownOutput.fs:266`](https://github.com/elastic/docs-builder/blob/main/tests/authoring/LlmMarkdown/LlmMarkdownOutput.fs#L266), so changing it is a decision about the llms.txt contract. Worth its own issue.

Concept files also carry a UTF-8 BOM ahead of the opening `---`, which predates this change. The reporter's own bisect shows colon-free files load with it present, so it is not implicated here.