### PR TITLE
Let a TOC entry source its content from outside the docset root

### DIFF
--- a/docs/documentation/isolated/configure/index.md
+++ b/docs/documentation/isolated/configure/index.md
@@ -44,6 +44,36 @@ A `file` can include `children` to create a virtual grouping. Children must be s
     - file: configuration.md
 ```
 
+#### `source`
+
+Reads the page's content from somewhere else in the repository, so documentation can live next to the code it describes:
+
+```yaml
+toc:
+  - file: index.md
+  - file: feedback.md
+    source: ../packages/kbn-ui/feedback/feedback.md
+```
+
+`file:` stays the page's position in the documentation set — it drives the URL, the navigation entry, the output path and the cross-repository link reference. `source:` is only where the content is read from, resolved relative to the directory holding the `docset.yml` or `toc.yml` that declares the entry.
+
+Relative links, images and includes inside a sourced page resolve from its `file:` position, not from where the file sits on disk.
+
+Also works on a `hidden:` entry, and on the `folder:` + `file:` form:
+
+```yaml
+- folder: feedback
+  file: index.md
+  source: ../packages/kbn-ui/feedback/readme.md
+```
+
+Constraints:
+
+- Single markdown files only — there is no folder or glob equivalent.
+- The source must resolve outside the documentation set root; inside it, use a plain `file:` entry.
+- The source must stay inside the repository checkout.
+- The `file:` position must be free — no file of that name on disk, and no other entry sourcing it.
+
 ### `folder:`
 
 Groups pages under a directory. Without `children`, all markdown files in the folder are included automatically:

--- a/docs/documentation/isolated/configure/index.md
+++ b/docs/documentation/isolated/configure/index.md
@@ -74,6 +74,8 @@ Constraints:
 - The source must stay inside the repository checkout.
 - The `file:` position must be free — no file of that name on disk, and no other entry sourcing it.
 
+On the assembled documentation site, repositories are cloned with a partial checkout of `docs` only. A source outside that path needs the repository's `sparse_paths` or `checkout_strategy` widened in [`config/assembler.yml`](https://github.com/elastic/docs-builder/blob/main/config/assembler.yml).
+
 ### `folder:`
 
 Groups pages under a directory. Without `children`, all markdown files in the folder are included automatically:

--- a/docs/documentation/isolated/configure/index.md
+++ b/docs/documentation/isolated/configure/index.md
@@ -71,8 +71,8 @@ Constraints:
 
 - Single markdown files only — there is no folder or glob equivalent.
 - The source must resolve outside the documentation set root; inside it, use a plain `file:` entry.
-- The source must stay inside the repository checkout.
-- The `file:` position must be free — no file of that name on disk, and no other entry sourcing it.
+- The source must stay inside the repository checkout, and neither it nor any directory on the way to it may be a symlink.
+- The `file:` position must resolve inside the documentation set root and be free — no file of that name on disk, no page generated there by an extension, and no other entry sourcing it.
 
 On the assembled documentation site, repositories are cloned with a partial checkout of `docs` only. A source outside that path needs the repository's `sparse_paths` or `checkout_strategy` widened in [`config/assembler.yml`](https://github.com/elastic/docs-builder/blob/main/config/assembler.yml).
 

--- a/docs/documentation/isolated/navigation.md
+++ b/docs/documentation/isolated/navigation.md
@@ -135,6 +135,21 @@ Each child becomes its own subsection; none is consumed as the parent's index pa
 
 If the entry declares its own `children`, it keeps the virtual grouping behavior instead.
 
+### Content stored outside the documentation set
+
+Add `source:` to read a page from elsewhere in the repository while keeping its place in the documentation set. This lets a page live next to the code it documents without moving the docset root:
+
+```yaml
+toc:
+  - file: index.md
+  - file: feedback.md
+    source: ../packages/kbn-ui/feedback/feedback.md
+```
+
+`file:` remains the page's docset-relative position and drives the URL (`/feedback`), the navigation entry and the link reference other repositories resolve against. `source:` is resolved relative to the directory holding the `docset.yml` or `toc.yml` that declares the entry, and only determines which file is read.
+
+Single markdown files only, and the source must resolve outside the documentation set root but inside the repository checkout. See the [`source` reference](./configure/index.md#source) for the full set of rules.
+
 ### Nested toc reference
 
 Include a dedicated `toc.yml` for large sections:

--- a/src/Elastic.Documentation.Configuration/Toc/DocumentationSetFile.cs
+++ b/src/Elastic.Documentation.Configuration/Toc/DocumentationSetFile.cs
@@ -150,6 +150,13 @@ public class DocumentationSetFile : TableOfContentsFile
 	public HashSet<string> FolderExcludedFiles { get; private set; } = [];
 
 	/// <summary>
+	/// Entries that declared a <c>source:</c> outside the documentation set root. The file scan never sees these,
+	/// so they have to be registered from the table of contents itself.
+	/// </summary>
+	[YamlIgnore]
+	public IReadOnlyCollection<FileRef> ExternallySourcedFiles { get; private set; } = [];
+
+	/// <summary>
 	/// Loads a DocumentationSetFile from YAML string and recursively resolves all IsolatedTableOfContentsRef items,
 	/// replacing them with their resolved children and ensuring file paths carry over parent paths.
 	/// Validates the table of contents structure and emits diagnostics for issues.
@@ -178,6 +185,7 @@ public class DocumentationSetFile : TableOfContentsFile
 		);
 		// Collect excluded paths so they can be skipped during file processing (not just navigation)
 		docSet.FolderExcludedFiles = CollectFolderExcludedFiles(docSet.TableOfContents);
+		docSet.ExternallySourcedFiles = CollectExternallySourcedFiles(docSet.TableOfContents);
 		return docSet;
 	}
 
@@ -402,6 +410,8 @@ public class DocumentationSetFile : TableOfContentsFile
 			? fileRef.PathRelativeToDocumentationSet
 			: $"{parentPath}/{fileRef.PathRelativeToDocumentationSet}";
 
+		var sourceFullPath = ResolveSourceFullPath(collector, fileRef, baseDirectory, fileSystem, context);
+
 		// Special validation for FolderIndexFileRef (folder+file combination)
 		// Validate BEFORE early return so we catch cases with no children
 		if (fileRef is FolderIndexFileRef)
@@ -454,14 +464,16 @@ public class DocumentationSetFile : TableOfContentsFile
 		// Calculate PathRelativeToContainer: the file path relative to its container
 		var pathRelativeToContainer = string.IsNullOrEmpty(containerPath) ? fullPath : fullPath.Substring(containerPath.Length + 1);
 
+		// `with` keeps the concrete ref type (index, folder index) and every off-path key such as `source:`
 		if (fileRef.Children.Count == 0)
 		{
-			// Preserve specific types even when there are no children
-			return fileRef switch
+			return fileRef with
 			{
-				FolderIndexFileRef => new FolderIndexFileRef(fullPath, pathRelativeToContainer, fileRef.Hidden, [], context),
-				IndexFileRef => new IndexFileRef(fullPath, pathRelativeToContainer, fileRef.Hidden, [], context),
-				_ => new FileRef(fullPath, pathRelativeToContainer, fileRef.Hidden, [], context)
+				PathRelativeToDocumentationSet = fullPath,
+				PathRelativeToContainer = pathRelativeToContainer,
+				Children = [],
+				Context = context,
+				SourceFullPath = sourceFullPath
 			};
 		}
 
@@ -519,13 +531,55 @@ public class DocumentationSetFile : TableOfContentsFile
 			suppressDiagnostics
 		);
 
-		// Preserve the specific type when creating the resolved reference
-		return fileRef switch
+		return fileRef with
 		{
-			FolderIndexFileRef => new FolderIndexFileRef(fullPath, pathRelativeToContainer, fileRef.Hidden, resolvedChildren, context),
-			IndexFileRef => new IndexFileRef(fullPath, pathRelativeToContainer, fileRef.Hidden, resolvedChildren, context),
-			_ => new FileRef(fullPath, pathRelativeToContainer, fileRef.Hidden, resolvedChildren, context)
+			PathRelativeToDocumentationSet = fullPath,
+			PathRelativeToContainer = pathRelativeToContainer,
+			Children = resolvedChildren,
+			Context = context,
+			SourceFullPath = sourceFullPath
 		};
+	}
+
+	/// <summary>
+	/// Turns a <c>source:</c> value into an absolute path, anchored on the directory of the declaring YAML file.
+	/// Pure path arithmetic — the source must stay outside the documentation set root (inside it the ordinary
+	/// file scan already owns the page) and existence is verified later, when the file is registered.
+	/// </summary>
+	private static string? ResolveSourceFullPath(
+		IDiagnosticsCollector collector,
+		FileRef fileRef,
+		IDirectoryInfo baseDirectory,
+		IFileSystem fileSystem,
+		string context
+	)
+	{
+		if (fileRef.Source is not { Length: > 0 } source)
+			return null;
+
+		var contextDirectory = fileSystem.Path.GetDirectoryName(context);
+		var fullPath = fileSystem.Path.GetFullPath(
+			source,
+			string.IsNullOrEmpty(contextDirectory) ? baseDirectory.FullName : contextDirectory
+		);
+
+		if (fileSystem.Path.GetExtension(fullPath) != ".md")
+		{
+			collector.EmitError(context, $"'source: {source}' must point to a markdown file.");
+			return null;
+		}
+
+		if (IDirectoryInfoExtensions.IsPathWithin(fullPath, baseDirectory.FullName))
+		{
+			var relativeToRoot = fileSystem.Path.GetRelativePath(baseDirectory.FullName, fullPath).Replace('\\', '/');
+			collector.EmitError(
+				context,
+				$"'source: {source}' resolves inside the documentation set root, use 'file: {relativeToRoot}' instead."
+			);
+			return null;
+		}
+
+		return fullPath;
 	}
 
 	/// <summary>
@@ -875,6 +929,34 @@ public class DocumentationSetFile : TableOfContentsFile
 				};
 				if (children is { Count: > 0 })
 					CollectExcluded(children, result);
+			}
+		}
+	}
+
+	private static IReadOnlyCollection<FileRef> CollectExternallySourcedFiles(IReadOnlyCollection<ITableOfContentsItem> items)
+	{
+		var sourced = new List<FileRef>();
+		Collect(items, sourced);
+		return sourced;
+
+		static void Collect(IReadOnlyCollection<ITableOfContentsItem> items, List<FileRef> result)
+		{
+			foreach (var item in items)
+			{
+				if (item is FileRef { SourceFullPath: not null } fileRef)
+					result.Add(fileRef);
+
+				var children = item switch
+				{
+					FolderRef f => f.Children,
+					FileRef f => f.Children,
+					IsolatedTableOfContentsRef t => t.Children,
+					ListingRef l => l.Children,
+					ListingGroupRef g => g.Children,
+					_ => null
+				};
+				if (children is { Count: > 0 })
+					Collect(children, result);
 			}
 		}
 	}

--- a/src/Elastic.Documentation.Configuration/Toc/TableOfContentsItems.cs
+++ b/src/Elastic.Documentation.Configuration/Toc/TableOfContentsItems.cs
@@ -124,7 +124,19 @@ public record FileRef(
 	bool Hidden,
 	IReadOnlyCollection<ITableOfContentsItem> Children,
 	string Context
-) : ITableOfContentsItem;
+) : ITableOfContentsItem
+{
+	/// <summary>
+	/// Raw <c>source:</c> value — where this page's content lives on disk, relative to the directory holding the
+	/// declaring <c>docset.yml</c>/<c>toc.yml</c>. <see cref="ITableOfContentsItem.PathRelativeToDocumentationSet"/>
+	/// stays the virtual position that drives URL, navigation and link reference, so a page can be authored next to
+	/// the code it documents without a <c>../</c> escaping into generated URLs or output paths.
+	/// </summary>
+	public string? Source { get; init; }
+
+	/// <summary>Absolute, normalized <see cref="Source"/>. Set during <c>LoadAndResolve</c>; never touches the filesystem.</summary>
+	public string? SourceFullPath { get; init; }
+}
 
 public record IndexFileRef(
 	string PathRelativeToDocumentationSet,

--- a/src/Elastic.Documentation.Configuration/Toc/TableOfContentsItems.cs
+++ b/src/Elastic.Documentation.Configuration/Toc/TableOfContentsItems.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System.Globalization;
+using YamlDotNet.Serialization;
 
 namespace Elastic.Documentation.Configuration.Toc;
 
@@ -135,6 +136,7 @@ public record FileRef(
 	public string? Source { get; init; }
 
 	/// <summary>Absolute, normalized <see cref="Source"/>. Set during <c>LoadAndResolve</c>; never touches the filesystem.</summary>
+	[YamlIgnore]
 	public string? SourceFullPath { get; init; }
 }
 

--- a/src/Elastic.Documentation.Configuration/Toc/TableOfContentsYamlConverters.cs
+++ b/src/Elastic.Documentation.Configuration/Toc/TableOfContentsYamlConverters.cs
@@ -114,6 +114,11 @@ public class TocItemYamlConverter : IYamlTypeConverter
 		// Capture exclude list for folder auto-discovery
 		var exclude = dictionary.TryGetValue("exclude", out var excludeObj) && excludeObj is string[] excludeArr ? excludeArr : null;
 
+		// Capture the off-root content location; resolution happens in DocumentationSetFile.ResolveFileRef
+		var contentSource = dictionary.TryGetValue("source", out var sourceObj) && sourceObj is string sourceStr && sourceStr.Length > 0
+			? sourceStr
+			: null;
+
 		// Check for listing (listing: <folder>) — a glob-driven auto-discovered nav entry with generated index.
 		// Must come before folder: and file: so those keys can still appear on the entry as children context.
 		if (dictionary.TryGetValue("listing", out var listingPath) && listingPath is string listing)
@@ -172,7 +177,7 @@ public class TocItemYamlConverter : IYamlTypeConverter
 			// Store ONLY the file name - the folder path will be prepended during resolution
 			// This allows validation to check if the file itself has deep paths
 			// PathRelativeToContainer will be set during resolution
-			var indexFile = new FolderIndexFileRef(file, file, false, [], placeholderContext);
+			var indexFile = new FolderIndexFileRef(file, file, false, [], placeholderContext) { Source = contentSource };
 
 			// Create a list with the index file first, followed by user-specified children
 			var folderChildren = new List<ITableOfContentsItem> { indexFile };
@@ -208,23 +213,23 @@ public class TocItemYamlConverter : IYamlTypeConverter
 		if (dictionary.TryGetValue("file", out var filePathOnly) && filePathOnly is string fileOnly)
 		{
 			if (fileOnly == "index.md")
-				return new IndexFileRef(fileOnly, fileOnly, false, children, placeholderContext);
+				return new IndexFileRef(fileOnly, fileOnly, false, children, placeholderContext) { Source = contentSource };
 
 			// Sugar: childless "file: subdir/index.md" → single-page folder, so it isn't silently dropped competing for the parent's index slot.
 			if (children.Count == 0 && fileOnly.EndsWith("/index.md", StringComparison.Ordinal))
 			{
 				var indexFolderPath = fileOnly[..^"/index.md".Length];
-				var indexFile = new FolderIndexFileRef("index.md", "index.md", false, [], placeholderContext);
+				var indexFile = new FolderIndexFileRef("index.md", "index.md", false, [], placeholderContext) { Source = contentSource };
 				return new DeepLinkedFolderRef(indexFolderPath, indexFolderPath, [indexFile], placeholderContext);
 			}
 
-			return new FileRef(fileOnly, fileOnly, false, children, placeholderContext);
+			return new FileRef(fileOnly, fileOnly, false, children, placeholderContext) { Source = contentSource };
 		}
 
 		if (dictionary.TryGetValue("hidden", out var hiddenPath) && hiddenPath is string p)
 			return p == "index.md"
-				? new IndexFileRef(p, p, true, children, placeholderContext)
-				: new FileRef(p, p, true, children, placeholderContext);
+				? new IndexFileRef(p, p, true, children, placeholderContext) { Source = contentSource }
+				: new FileRef(p, p, true, children, placeholderContext) { Source = contentSource };
 
 		// Check for crosslink reference
 		if (dictionary.TryGetValue("crosslink", out var crosslink) && crosslink is string crosslinkStr)

--- a/src/Elastic.Documentation.Navigation/Isolated/Node/DocumentationSetNavigation.cs
+++ b/src/Elastic.Documentation.Navigation/Isolated/Node/DocumentationSetNavigation.cs
@@ -188,13 +188,21 @@ public class DocumentationSetNavigation<TModel> : IDocumentationSetNavigation, I
 	/// <summary>
 	/// Creates the documentation file from the factory, emitting an error if creation fails.
 	/// </summary>
-	private TModel? CreateDocumentationFile(IFileInfo fileInfo, IFileSystem fileSystem, IDocumentationSetContext context)
+	private TModel? CreateDocumentationFile(
+		IFileInfo fileInfo,
+		IFileSystem fileSystem,
+		IDocumentationSetContext context,
+		string? contentSource = null
+	)
 	{
 		var relativePath = Path.GetRelativePath(context.DocumentationSourceDirectory.FullName, fileInfo.FullName);
 		var documentationFile = _factory.TryCreateDocumentationFile(fileInfo, fileSystem);
 		if (documentationFile == null)
 		{
-			var reason = fileInfo.Exists ? "the file exists but is not a valid Markdown document" : "the file does not exist on disk";
+			// An externally sourced entry never has a file at its virtual path, so report the source instead.
+			var reason = contentSource is not null
+				? $"its 'source: {contentSource}' could not be registered"
+				: fileInfo.Exists ? "the file exists but is not a valid Markdown document" : "the file does not exist on disk";
 			context.EmitError(context.ConfigurationPath, $"Table of contents references '{relativePath}' but {reason}.");
 		}
 
@@ -244,7 +252,7 @@ public class DocumentationSetNavigation<TModel> : IDocumentationSetNavigation, I
 			DetectionRuleRef ruleRef => ruleRef.FileInfo,
 			_ => ResolveFileInfo(context, fullPath)
 		};
-		var documentationFile = CreateDocumentationFile(fileInfo, context.ReadFileSystem, context);
+		var documentationFile = CreateDocumentationFile(fileInfo, context.ReadFileSystem, context, fileRef.Source);
 		if (documentationFile == null)
 			return null;
 

--- a/src/Elastic.Documentation/Extensions/IFileInfoExtensions.cs
+++ b/src/Elastic.Documentation/Extensions/IFileInfoExtensions.cs
@@ -120,6 +120,20 @@ public static class IDirectoryInfoExtensions
 		fs.DirectoryInfo.New(path).IsSubPathOf(fs.DirectoryInfo.New(parent));
 
 	/// <summary>
+	/// Whether <paramref name="path"/> resolves inside <paramref name="root"/>, by path arithmetic alone.
+	/// Both must already be absolute. Unlike <see cref="IsSubPath"/> this allocates no <see cref="IDirectoryInfo"/>,
+	/// so it can be asked about paths a <c>ScopedFileSystem</c> would refuse to construct.
+	/// </summary>
+	public static bool IsPathWithin(string path, string root)
+	{
+		var relative = Path.GetRelativePath(root, path);
+		return !Path.IsPathRooted(relative)
+			&& relative != ".."
+			&& !relative.StartsWith($"..{Path.DirectorySeparatorChar}", Ordinal)
+			&& !relative.StartsWith($"..{Path.AltDirectorySeparatorChar}", Ordinal);
+	}
+
+	/// <summary>
 	/// Adds <paramref name="candidate"/> to <paramref name="roots"/> for a <c>ScopedFileSystemOptions</c>
 	/// root list, collapsing overlaps instead of just skipping them.
 	/// <para>

--- a/src/Elastic.Markdown/HtmlWriter.cs
+++ b/src/Elastic.Markdown/HtmlWriter.cs
@@ -97,12 +97,10 @@ public class HtmlWriter(
 		string? editUrl = null;
 		if (gitHubRepo is not null && DocumentationSet.Context.Git != GitCheckoutInformation.Unavailable)
 		{
+			// Anchored on the file actually read, not its position in the set: an externally sourced page
+			// (`source:` in the TOC) lives elsewhere in the repository than its virtual RelativePath.
 			var checkoutDirectory = DocumentationSet.Context.DocumentationCheckoutDirectory;
-			var relativeSourcePath = Path.GetRelativePath(
-				checkoutDirectory.FullName,
-				DocumentationSet.Context.DocumentationSourceDirectory.FullName
-			);
-			var path = UrlPath.Join(relativeSourcePath, markdown.RelativePath);
+			var path = Path.GetRelativePath(checkoutDirectory.FullName, markdown.SourceFile.FullName).Replace('\\', '/');
 			editUrl = $"https://github.com/{gitHubRepo}/edit/{branch}/{path}";
 		}
 

--- a/src/Elastic.Markdown/IO/DocumentationFile.cs
+++ b/src/Elastic.Markdown/IO/DocumentationFile.cs
@@ -12,17 +12,25 @@ namespace Elastic.Markdown.IO;
 
 public abstract record DocumentationFile
 {
-	protected DocumentationFile(IFileInfo sourceFile, IDirectoryInfo rootPath, string repository)
+	protected DocumentationFile(IFileInfo sourceFile, IDirectoryInfo rootPath, string repository, string? virtualRelativePath = null)
 	{
 		RootPath = rootPath;
 		Repository = repository;
 		SourceFile = sourceFile;
-		RelativePath = Path.GetRelativePath(RootPath.FullName, SourceFile.FullName);
-		RelativeFolder = Path.GetRelativePath(RootPath.FullName, SourceFile.Directory!.FullName);
+		RelativePath = virtualRelativePath ?? Path.GetRelativePath(RootPath.FullName, SourceFile.FullName);
+		RelativeFolder = virtualRelativePath is null
+			? Path.GetRelativePath(RootPath.FullName, SourceFile.Directory!.FullName)
+			: Path.GetDirectoryName(virtualRelativePath) is { Length: > 0 } folder ? folder : ".";
 		CrossLink = $"{Repository}://{RelativePath.Replace('\\', '/')}";
 	}
 
 	public IDirectoryInfo RootPath { get; }
+
+	/// <summary>
+	/// Position inside the documentation set — what drives URL, output path and link reference. Equals
+	/// <see cref="SourceFile"/> relative to <see cref="RootPath"/> unless the page was sourced from outside the
+	/// root via <c>source:</c>, in which case it is the virtual <c>file:</c> path the author declared.
+	/// </summary>
 	public string RelativePath { get; }
 	public string RelativeFolder { get; }
 	public string CrossLink { get; }

--- a/src/Elastic.Markdown/IO/DocumentationSet.cs
+++ b/src/Elastic.Markdown/IO/DocumentationSet.cs
@@ -125,6 +125,10 @@ public class DocumentationSet : INavigationTraversable
 		if (Context.BuildType != BuildType.Isolated || Configuration.Registry == DocSetRegistry.Public)
 			return;
 
+		// A root index declared with `source:` has no file at <docset>/index.md, so accept the registered position too.
+		if (Files.ContainsKey(new FilePath("index.md", SourceDirectory)))
+			return;
+
 		var indexFile = Context.ReadFileSystem.FileInfo.New(Path.Join(SourceDirectory.FullName, "index.md"));
 
 		if (!indexFile.Exists)

--- a/src/Elastic.Markdown/IO/ExternallySourcedMarkdownFile.cs
+++ b/src/Elastic.Markdown/IO/ExternallySourcedMarkdownFile.cs
@@ -1,0 +1,37 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions;
+using Elastic.Documentation.Configuration;
+using Elastic.Documentation.Extensions;
+using Elastic.Markdown.Myst;
+using Markdig.Syntax;
+
+namespace Elastic.Markdown.IO;
+
+/// <summary>
+/// A page read from outside the documentation set root, declared with <c>source:</c> on its table of contents entry.
+/// Everything derived from position — URL, output path, link reference, relative links inside the page — anchors on
+/// <see cref="VirtualFile"/>, the docset-relative <c>file:</c> path; only the content comes from
+/// <see cref="DocumentationFile.SourceFile"/>.
+/// </summary>
+public record ExternallySourcedMarkdownFile : MarkdownFile
+{
+	public ExternallySourcedMarkdownFile(
+		IFileInfo sourceFile,
+		string virtualRelativePath,
+		MarkdownParser parser,
+		BuildContext build
+	) : base(sourceFile, build.DocumentationSourceDirectory, parser, build, virtualRelativePath) =>
+		VirtualFile = build.ReadFileSystem.NewFileInfo(build.DocumentationSourceDirectory.FullName, virtualRelativePath);
+
+	/// <summary>The page's position inside the documentation set. Never exists on disk.</summary>
+	public IFileInfo VirtualFile { get; }
+
+	protected override async Task<MarkdownDocument> GetMinimalParseDocumentAsync(Cancel ctx) =>
+		await MarkdownParser.MinimalParseAsync(VirtualFile, SourceFile, ctx);
+
+	protected override async Task<MarkdownDocument> GetParseDocumentAsync(Cancel ctx) =>
+		await MarkdownParser.ParseAsync(VirtualFile, SourceFile, YamlFrontMatter, ctx);
+}

--- a/src/Elastic.Markdown/IO/ExternallySourcedMarkdownFile.cs
+++ b/src/Elastic.Markdown/IO/ExternallySourcedMarkdownFile.cs
@@ -29,9 +29,9 @@ public record ExternallySourcedMarkdownFile : MarkdownFile
 	/// <summary>The page's position inside the documentation set. Never exists on disk.</summary>
 	public IFileInfo VirtualFile { get; }
 
-	protected override async Task<MarkdownDocument> GetMinimalParseDocumentAsync(Cancel ctx) =>
-		await MarkdownParser.MinimalParseAsync(VirtualFile, SourceFile, ctx);
+	protected override Task<MarkdownDocument> GetMinimalParseDocumentAsync(Cancel ctx) =>
+		MarkdownParser.MinimalParseAsync(VirtualFile, SourceFile, ctx);
 
-	protected override async Task<MarkdownDocument> GetParseDocumentAsync(Cancel ctx) =>
-		await MarkdownParser.ParseAsync(VirtualFile, SourceFile, YamlFrontMatter, ctx);
+	protected override Task<MarkdownDocument> GetParseDocumentAsync(Cancel ctx) =>
+		MarkdownParser.ParseAsync(VirtualFile, SourceFile, YamlFrontMatter, ctx);
 }

--- a/src/Elastic.Markdown/IO/MarkdownFile.cs
+++ b/src/Elastic.Markdown/IO/MarkdownFile.cs
@@ -32,13 +32,15 @@ public record MarkdownFile : DocumentationFile, ITableOfContentsScope, IDocument
 
 	private readonly IReadOnlyDictionary<string, string> _globalSubstitutions;
 
-	public MarkdownFile(IFileInfo sourceFile, IDirectoryInfo rootPath, MarkdownParser parser, BuildContext build) : base(
-			sourceFile,
-			rootPath,
-			build.Git.RepositoryName
-		)
+	public MarkdownFile(
+		IFileInfo sourceFile,
+		IDirectoryInfo rootPath,
+		MarkdownParser parser,
+		BuildContext build,
+		string? virtualRelativePath = null
+	) : base(sourceFile, rootPath, build.Git.RepositoryName, virtualRelativePath)
 	{
-		FileName = sourceFile.Name;
+		FileName = Path.GetFileName(RelativePath);
 		FilePath = sourceFile.FullName;
 
 		UrlPathPrefix = build.UrlPathPrefix;
@@ -98,7 +100,10 @@ public record MarkdownFile : DocumentationFile, ITableOfContentsScope, IDocument
 	private readonly HashSet<string> _anchors = [with(StringComparer.OrdinalIgnoreCase)];
 	public IReadOnlySet<string> Anchors => _anchors;
 
+	/// <summary>Absolute path of the file on disk — what diagnostics point at.</summary>
 	public string FilePath { get; }
+
+	/// <summary>File name at the page's position in the documentation set, which an externally sourced page may rename.</summary>
 	public string FileName { get; }
 	public string? SourcePath => RelativePath;
 

--- a/src/Elastic.Markdown/IO/MarkdownFileFactory.cs
+++ b/src/Elastic.Markdown/IO/MarkdownFileFactory.cs
@@ -54,9 +54,11 @@ public class MarkdownFileFactory : IDocumentationFileFactory<MarkdownFile>
 
 		var files = ScanDocumentationFiles(context, context.DocumentationSourceDirectory);
 		var additionalSources = enabledExtensions.SelectMany(extension => extension.ScanDocumentationFiles(DefaultFileHandling)).ToArray();
+		var externallySourced = ScanExternallySourcedFiles(context);
 
 		Files = files
 			.Concat(additionalSources)
+			.Concat(externallySourced)
 			.Where(t => t.Item2 is not ExcludedFile)
 			.ToDictionary(kv => new FilePath(kv.Item1, context.DocumentationSourceDirectory), kv => kv.Item2)
 			.ToFrozenDictionary();
@@ -131,6 +133,58 @@ public class MarkdownFileFactory : IDocumentationFileFactory<MarkdownFile>
 						}
 				)
 		];
+	}
+
+	/// <summary>
+	/// Registers the pages a TOC entry sourced from outside the documentation set root with <c>source:</c>. They are
+	/// keyed under their virtual <c>file:</c> path — the same path navigation resolves against — while reading from
+	/// their real location on disk.
+	/// </summary>
+	private (IFileInfo, DocumentationFile)[] ScanExternallySourcedFiles(BuildContext context)
+	{
+		var checkoutDirectory = context.DocumentationCheckoutDirectory;
+		var registered = new List<(IFileInfo, DocumentationFile)>();
+		var claimedVirtualPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+		foreach (var fileRef in context.ConfigurationYaml.ExternallySourcedFiles)
+		{
+			// Checked before allocating the IFileInfo: reads are scoped to the checkout, so an out-of-scope
+			// source would throw out of the filesystem rather than surface as a diagnostic.
+			if (!IDirectoryInfoExtensions.IsPathWithin(fileRef.SourceFullPath!, checkoutDirectory.FullName))
+			{
+				context.Collector.EmitError(
+					fileRef.Context,
+					$"'source: {fileRef.Source}' resolves outside the repository checkout '{checkoutDirectory.FullName}'."
+				);
+				continue;
+			}
+
+			var sourceFile = context.ReadFileSystem.FileInfo.New(fileRef.SourceFullPath!);
+			if (!sourceFile.Exists)
+			{
+				context.Collector.EmitError(fileRef.Context, $"'source: {fileRef.Source}' does not exist.");
+				continue;
+			}
+
+			var virtualRelativePath = fileRef.PathRelativeToDocumentationSet.OptionalWindowsReplace();
+			var file = new ExternallySourcedMarkdownFile(sourceFile, virtualRelativePath, _markdownParser, context);
+
+			// Two files claiming one position would collide in the Files lookup, so refuse the second.
+			var occupant = file.VirtualFile.Exists ? "already exists on disk" : null;
+			occupant ??= claimedVirtualPaths.Add(virtualRelativePath) ? null : "is already sourced by another entry";
+			if (occupant is not null)
+			{
+				context.Collector.EmitError(
+					fileRef.Context,
+					$"'file: {fileRef.PathRelativeToDocumentationSet}' {occupant}, so it cannot also be sourced from '{fileRef.Source}'."
+				);
+				continue;
+			}
+
+			registered.Add((file.VirtualFile, file));
+		}
+
+		return [.. registered];
 	}
 
 	private DocumentationFile CreateImageFile(

--- a/src/Elastic.Markdown/IO/MarkdownFileFactory.cs
+++ b/src/Elastic.Markdown/IO/MarkdownFileFactory.cs
@@ -5,6 +5,7 @@
 using System.Collections.Frozen;
 using System.Diagnostics;
 using System.IO.Abstractions;
+using Elastic.Documentation;
 using Elastic.Documentation.Configuration;
 using Elastic.Documentation.Extensions;
 using Elastic.Documentation.Navigation.Isolated;
@@ -54,14 +55,18 @@ public class MarkdownFileFactory : IDocumentationFileFactory<MarkdownFile>
 
 		var files = ScanDocumentationFiles(context, context.DocumentationSourceDirectory);
 		var additionalSources = enabledExtensions.SelectMany(extension => extension.ScanDocumentationFiles(DefaultFileHandling)).ToArray();
-		var externallySourced = ScanExternallySourcedFiles(context);
 
-		Files = files
+		var discovered = files
 			.Concat(additionalSources)
-			.Concat(externallySourced)
 			.Where(t => t.Item2 is not ExcludedFile)
-			.ToDictionary(kv => new FilePath(kv.Item1, context.DocumentationSourceDirectory), kv => kv.Item2)
-			.ToFrozenDictionary();
+			.ToDictionary(kv => new FilePath(kv.Item1, context.DocumentationSourceDirectory), kv => kv.Item2);
+
+		// Externally sourced pages are registered last so they can be checked against every position already taken —
+		// by the scan, by an extension, or by an earlier `source:` entry.
+		foreach (var (path, file) in ScanExternallySourcedFiles(context, discovered.Keys.ToHashSet()))
+			discovered[path] = file;
+
+		Files = discovered.ToFrozenDictionary();
 	}
 
 	public FrozenDictionary<FilePath, DocumentationFile> Files { get; }
@@ -138,16 +143,41 @@ public class MarkdownFileFactory : IDocumentationFileFactory<MarkdownFile>
 	/// <summary>
 	/// Registers the pages a TOC entry sourced from outside the documentation set root with <c>source:</c>. They are
 	/// keyed under their virtual <c>file:</c> path — the same path navigation resolves against — while reading from
-	/// their real location on disk.
+	/// their real location on disk. <paramref name="takenPositions"/> is every position already registered, so a
+	/// sourced page cannot displace one.
 	/// </summary>
-	private (IFileInfo, DocumentationFile)[] ScanExternallySourcedFiles(BuildContext context)
+	private (FilePath, DocumentationFile)[] ScanExternallySourcedFiles(BuildContext context, HashSet<FilePath> takenPositions)
 	{
+		var sourceDirectory = context.DocumentationSourceDirectory;
 		var checkoutDirectory = context.DocumentationCheckoutDirectory;
-		var registered = new List<(IFileInfo, DocumentationFile)>();
-		var claimedVirtualPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+		var registered = new List<(FilePath, DocumentationFile)>();
 
 		foreach (var fileRef in context.ConfigurationYaml.ExternallySourcedFiles)
 		{
+			var virtualRelativePath = fileRef.PathRelativeToDocumentationSet.OptionalWindowsReplace();
+
+			// `file:` is not itself checked for containment, so a virtual path can still carry `../`. Registering one
+			// would push those segments through URL generation and write HTML outside the output directory.
+			var virtualFile = context.ReadFileSystem.NewFileInfo(sourceDirectory.FullName, virtualRelativePath);
+			if (!IDirectoryInfoExtensions.IsPathWithin(virtualFile.FullName, sourceDirectory.FullName))
+			{
+				context.Collector.EmitError(
+					fileRef.Context,
+					$"'file: {fileRef.PathRelativeToDocumentationSet}' resolves outside the documentation set root."
+				);
+				continue;
+			}
+
+			var position = new FilePath(virtualFile, sourceDirectory);
+			if (!takenPositions.Add(position))
+			{
+				context.Collector.EmitError(
+					fileRef.Context,
+					$"'file: {fileRef.PathRelativeToDocumentationSet}' is already taken, so it cannot also be sourced from '{fileRef.Source}'."
+				);
+				continue;
+			}
+
 			// Checked before allocating the IFileInfo: reads are scoped to the checkout, so an out-of-scope
 			// source would throw out of the filesystem rather than surface as a diagnostic.
 			if (!IDirectoryInfoExtensions.IsPathWithin(fileRef.SourceFullPath!, checkoutDirectory.FullName))
@@ -166,22 +196,15 @@ public class MarkdownFileFactory : IDocumentationFileFactory<MarkdownFile>
 				continue;
 			}
 
-			var virtualRelativePath = fileRef.PathRelativeToDocumentationSet.OptionalWindowsReplace();
-			var file = new ExternallySourcedMarkdownFile(sourceFile, virtualRelativePath, _markdownParser, context);
-
-			// Two files claiming one position would collide in the Files lookup, so refuse the second.
-			var occupant = file.VirtualFile.Exists ? "already exists on disk" : null;
-			occupant ??= claimedVirtualPaths.Add(virtualRelativePath) ? null : "is already sourced by another entry";
-			if (occupant is not null)
+			// The containment check above is lexical. A symlink anywhere on the path can still resolve outside the
+			// checkout, which is why the ordinary scan skips symlinks and control files are rejected outright.
+			if (SymlinkValidator.ValidateFileAccess(sourceFile, checkoutDirectory) is { } violation)
 			{
-				context.Collector.EmitError(
-					fileRef.Context,
-					$"'file: {fileRef.PathRelativeToDocumentationSet}' {occupant}, so it cannot also be sourced from '{fileRef.Source}'."
-				);
+				context.Collector.EmitError(fileRef.Context, $"'source: {fileRef.Source}' is not readable. {violation}");
 				continue;
 			}
 
-			registered.Add((file.VirtualFile, file));
+			registered.Add((position, new ExternallySourcedMarkdownFile(sourceFile, virtualRelativePath, _markdownParser, context)));
 		}
 
 		return [.. registered];

--- a/src/Elastic.Markdown/Myst/MarkdownParser.cs
+++ b/src/Elastic.Markdown/Myst/MarkdownParser.cs
@@ -35,15 +35,36 @@ public partial class MarkdownParser(BuildContext build, IParserResolvers resolve
 	public IParserResolvers Resolvers { get; } = resolvers;
 
 	public Task<MarkdownDocument> ParseAsync(IFileInfo path, YamlFrontMatter? matter, Cancel ctx) =>
-		ParseFromFile(path, matter, Pipeline, false, ctx);
+		ParseFromFile(path, path, matter, Pipeline, false, ctx);
 
-	public Task<MarkdownDocument> MinimalParseAsync(IFileInfo path, Cancel ctx) => ParseFromFile(path, null, MinimalPipeline, true, ctx);
+	public Task<MarkdownDocument> MinimalParseAsync(IFileInfo path, Cancel ctx) =>
+		ParseFromFile(path, path, null, MinimalPipeline, true, ctx);
 
-	private Task<MarkdownDocument> ParseFromFile(IFileInfo path, YamlFrontMatter? matter, MarkdownPipeline pipeline, bool skip, Cancel ctx)
+	/// <summary>
+	/// Parses <paramref name="contentFile"/> as though it lived at <paramref name="path"/>. Pages sourced from outside
+	/// the documentation set root anchor their links, includes and document lookups on their virtual position, while
+	/// diagnostics keep pointing at the file that was actually read.
+	/// </summary>
+	public Task<MarkdownDocument> ParseAsync(IFileInfo path, IFileInfo contentFile, YamlFrontMatter? matter, Cancel ctx) =>
+		ParseFromFile(path, contentFile, matter, Pipeline, false, ctx);
+
+	/// <inheritdoc cref="ParseAsync(IFileInfo,IFileInfo,YamlFrontMatter,Cancel)"/>
+	public Task<MarkdownDocument> MinimalParseAsync(IFileInfo path, IFileInfo contentFile, Cancel ctx) =>
+		ParseFromFile(path, contentFile, null, MinimalPipeline, true, ctx);
+
+	private Task<MarkdownDocument> ParseFromFile(
+		IFileInfo path,
+		IFileInfo contentFile,
+		YamlFrontMatter? matter,
+		MarkdownPipeline pipeline,
+		bool skip,
+		Cancel ctx
+	)
 	{
 		var state = new ParserState(Build)
 		{
 			MarkdownSourcePath = path,
+			OriginalSourcePath = ReferenceEquals(path, contentFile) ? null : contentFile,
 			YamlFrontMatter = matter,
 			TryFindDocument = Resolvers.TryFindDocument,
 			TryFindDocumentByRelativePath = Resolvers.TryFindDocumentByRelativePath,
@@ -53,7 +74,7 @@ public partial class MarkdownParser(BuildContext build, IParserResolvers resolve
 			SkipValidation = skip
 		};
 		var context = new ParserContext(state);
-		return ParseAsync(path, context, pipeline, ctx);
+		return ParseAsync(contentFile, context, pipeline, ctx);
 	}
 
 	public MarkdownDocument ParseStringAsync(string markdown, IFileInfo path, YamlFrontMatter? matter) =>

--- a/src/Elastic.Markdown/Myst/MarkdownParser.cs
+++ b/src/Elastic.Markdown/Myst/MarkdownParser.cs
@@ -34,11 +34,21 @@ public partial class MarkdownParser(BuildContext build, IParserResolvers resolve
 	private BuildContext Build { get; } = build;
 	public IParserResolvers Resolvers { get; } = resolvers;
 
+	/// <summary>Pipeline plus the validation behaviour that goes with it, so the two cannot be mixed at a call site.</summary>
+	private readonly record struct ParseMode(MarkdownPipeline Pipeline, bool SkipValidation)
+	{
+		/// <summary>The full pipeline. Validates links and cross-links.</summary>
+		public static ParseMode Full => new(MarkdownParser.Pipeline, SkipValidation: false);
+
+		/// <summary>Front matter, anchors and directives only. Validation is deferred to the full pass.</summary>
+		public static ParseMode Minimal => new(MarkdownParser.MinimalPipeline, SkipValidation: true);
+	}
+
 	public Task<MarkdownDocument> ParseAsync(IFileInfo path, YamlFrontMatter? matter, Cancel ctx) =>
-		ParseFromFile(path, path, matter, Pipeline, false, ctx);
+		ParseFromFile((path, path), matter, ParseMode.Full, ctx);
 
 	public Task<MarkdownDocument> MinimalParseAsync(IFileInfo path, Cancel ctx) =>
-		ParseFromFile(path, path, null, MinimalPipeline, true, ctx);
+		ParseFromFile((path, path), null, ParseMode.Minimal, ctx);
 
 	/// <summary>
 	/// Parses <paramref name="contentFile"/> as though it lived at <paramref name="path"/>. Pages sourced from outside
@@ -46,21 +56,20 @@ public partial class MarkdownParser(BuildContext build, IParserResolvers resolve
 	/// diagnostics keep pointing at the file that was actually read.
 	/// </summary>
 	public Task<MarkdownDocument> ParseAsync(IFileInfo path, IFileInfo contentFile, YamlFrontMatter? matter, Cancel ctx) =>
-		ParseFromFile(path, contentFile, matter, Pipeline, false, ctx);
+		ParseFromFile((path, contentFile), matter, ParseMode.Full, ctx);
 
 	/// <inheritdoc cref="ParseAsync(IFileInfo,IFileInfo,YamlFrontMatter,Cancel)"/>
 	public Task<MarkdownDocument> MinimalParseAsync(IFileInfo path, IFileInfo contentFile, Cancel ctx) =>
-		ParseFromFile(path, contentFile, null, MinimalPipeline, true, ctx);
+		ParseFromFile((path, contentFile), null, ParseMode.Minimal, ctx);
 
 	private Task<MarkdownDocument> ParseFromFile(
-		IFileInfo path,
-		IFileInfo contentFile,
+		(IFileInfo Path, IFileInfo ContentFile) file,
 		YamlFrontMatter? matter,
-		MarkdownPipeline pipeline,
-		bool skip,
+		ParseMode mode,
 		Cancel ctx
 	)
 	{
+		var (path, contentFile) = file;
 		var state = new ParserState(Build)
 		{
 			MarkdownSourcePath = path,
@@ -71,10 +80,10 @@ public partial class MarkdownParser(BuildContext build, IParserResolvers resolve
 			CrossLinkResolver = Resolvers.CrossLinkResolver,
 			ReleaseNotesResolver = Resolvers.ReleaseNotesResolver,
 			NavigationTraversable = Resolvers.NavigationTraversable,
-			SkipValidation = skip
+			SkipValidation = mode.SkipValidation
 		};
 		var context = new ParserContext(state);
-		return ParseAsync(contentFile, context, pipeline, ctx);
+		return ParseAsync(contentFile, context, mode.Pipeline, ctx);
 	}
 
 	public MarkdownDocument ParseStringAsync(string markdown, IFileInfo path, YamlFrontMatter? matter) =>

--- a/tests/Elastic.Documentation.Configuration.Tests/TocSourceTests.cs
+++ b/tests/Elastic.Documentation.Configuration.Tests/TocSourceTests.cs
@@ -27,7 +27,12 @@ internal sealed class RecordingDiagnosticsCollector() : DiagnosticsCollector([])
 /// <summary>Covers the <c>source:</c> key, which points a TOC entry at content outside the documentation set root.</summary>
 public class TocSourceTests
 {
-	private static DocumentationSetFile LoadAndResolve(
+	/// <summary>
+	/// Resolution is pure path arithmetic over the supplied filesystem, so assertions have to compute their
+	/// expected paths from that same filesystem — on Windows a mock rooted on <c>C:</c> does not match a real
+	/// <see cref="Path.GetFullPath(string)"/> anchored on the drive the tests run from.
+	/// </summary>
+	private static (DocumentationSetFile Result, MockFileSystem FileSystem) LoadAndResolve(
 		RecordingDiagnosticsCollector collector,
 		string docsetYaml,
 		params (string path, string content)[] additionalFiles
@@ -39,7 +44,8 @@ public class TocSourceTests
 			fileSystem.AddFile(path, new MockFileData(content));
 
 		var docsetPath = fileSystem.FileInfo.New("/repo/docs/docset.yml");
-		return DocumentationSetFile.LoadAndResolve(collector, docsetPath, new ScopedFileSystem(fileSystem, "/repo"));
+		var result = DocumentationSetFile.LoadAndResolve(collector, docsetPath, new ScopedFileSystem(fileSystem, "/repo"));
+		return (result, fileSystem);
 	}
 
 	[Fact]
@@ -75,13 +81,13 @@ public class TocSourceTests
 			""";
 
 		var collector = new RecordingDiagnosticsCollector();
-		var result = LoadAndResolve(collector, yaml);
+		var (result, fileSystem) = LoadAndResolve(collector, yaml);
 
 		collector.Errors.Should().Be(0);
 		var fileRef = result.TableOfContents.ElementAt(1).Should().BeOfType<FileRef>().Subject;
 		fileRef.PathRelativeToDocumentationSet.Should().Be("feedback.md", "'file:' stays the virtual, docset-relative path");
 		fileRef.Source.Should().Be("../packages/kbn-ui/feedback/feedback.md");
-		fileRef.SourceFullPath.Should().Be(Path.GetFullPath("/repo/packages/kbn-ui/feedback/feedback.md"));
+		fileRef.SourceFullPath.Should().Be(fileSystem.Path.GetFullPath("/repo/packages/kbn-ui/feedback/feedback.md"));
 		result.ExternallySourcedFiles.Should().ContainSingle().Which.Should().BeSameAs(fileRef);
 	}
 
@@ -98,7 +104,7 @@ public class TocSourceTests
 			""";
 
 		var collector = new RecordingDiagnosticsCollector();
-		var result = LoadAndResolve(
+		var (result, fileSystem) = LoadAndResolve(
 			collector,
 			yaml,
 			("/repo/docs/guides/toc.yml",
@@ -115,7 +121,7 @@ public class TocSourceTests
 		var toc = result.TableOfContents.ElementAt(1).Should().BeOfType<IsolatedTableOfContentsRef>().Subject;
 		var fileRef = toc.Children.ElementAt(1).Should().BeOfType<FileRef>().Subject;
 		fileRef.PathRelativeToDocumentationSet.Should().Be("guides/feedback.md", "the virtual path still carries the toc folder");
-		fileRef.SourceFullPath.Should().Be(Path.GetFullPath("/repo/packages/kbn-ui/feedback.md"));
+		fileRef.SourceFullPath.Should().Be(fileSystem.Path.GetFullPath("/repo/packages/kbn-ui/feedback.md"));
 	}
 
 	[Fact]
@@ -133,13 +139,13 @@ public class TocSourceTests
 			""";
 
 		var collector = new RecordingDiagnosticsCollector();
-		var result = LoadAndResolve(collector, yaml);
+		var (result, fileSystem) = LoadAndResolve(collector, yaml);
 
 		collector.Errors.Should().Be(0);
 		var folder = result.TableOfContents.ElementAt(1).Should().BeOfType<FolderRef>().Subject;
 		var indexRef = folder.Children.ElementAt(0).Should().BeOfType<FolderIndexFileRef>().Subject;
 		indexRef.PathRelativeToDocumentationSet.Should().Be("feedback/index.md");
-		indexRef.SourceFullPath.Should().Be(Path.GetFullPath("/repo/packages/kbn-ui/feedback/readme.md"));
+		indexRef.SourceFullPath.Should().Be(fileSystem.Path.GetFullPath("/repo/packages/kbn-ui/feedback/readme.md"));
 	}
 
 	[Fact]
@@ -156,12 +162,12 @@ public class TocSourceTests
 			""";
 
 		var collector = new RecordingDiagnosticsCollector();
-		var result = LoadAndResolve(collector, yaml);
+		var (result, fileSystem) = LoadAndResolve(collector, yaml);
 
 		collector.Errors.Should().Be(0);
 		var fileRef = result.TableOfContents.ElementAt(1).Should().BeOfType<FileRef>().Subject;
 		fileRef.Hidden.Should().BeTrue();
-		fileRef.SourceFullPath.Should().Be(Path.GetFullPath("/repo/packages/kbn-ui/internals.md"));
+		fileRef.SourceFullPath.Should().Be(fileSystem.Path.GetFullPath("/repo/packages/kbn-ui/internals.md"));
 	}
 
 	[Fact]
@@ -178,7 +184,7 @@ public class TocSourceTests
 			""";
 
 		var collector = new RecordingDiagnosticsCollector();
-		var result = LoadAndResolve(collector, yaml);
+		var (result, _) = LoadAndResolve(collector, yaml);
 
 		collector.Errors.Should().Be(1);
 		collector.Diagnostics.Should().Contain(d => d.Message.Contains("use 'file: reference/feedback.md' instead"));
@@ -199,7 +205,7 @@ public class TocSourceTests
 			""";
 
 		var collector = new RecordingDiagnosticsCollector();
-		var result = LoadAndResolve(collector, yaml);
+		var (result, _) = LoadAndResolve(collector, yaml);
 
 		collector.Errors.Should().Be(1);
 		collector.Diagnostics.Should().Contain(d => d.Message.Contains("must point to a markdown file"));
@@ -217,7 +223,7 @@ public class TocSourceTests
 			""";
 
 		var collector = new RecordingDiagnosticsCollector();
-		var result = LoadAndResolve(collector, yaml);
+		var (result, _) = LoadAndResolve(collector, yaml);
 
 		var fileRef = result.TableOfContents.ElementAt(0).Should().BeOfType<IndexFileRef>().Subject;
 		fileRef.Source.Should().BeNull();

--- a/tests/Elastic.Documentation.Configuration.Tests/TocSourceTests.cs
+++ b/tests/Elastic.Documentation.Configuration.Tests/TocSourceTests.cs
@@ -1,0 +1,227 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions.TestingHelpers;
+using AwesomeAssertions;
+using Elastic.Documentation.Configuration.Toc;
+using Elastic.Documentation.Diagnostics;
+using Nullean.ScopedFileSystem;
+
+namespace Elastic.Documentation.Configuration.Tests;
+
+/// <summary>Captures diagnostics in-memory; the channel-based base class needs a reader started to surface them.</summary>
+internal sealed class RecordingDiagnosticsCollector() : DiagnosticsCollector([])
+{
+	private readonly List<Diagnostic> _diagnostics = [];
+
+	public IReadOnlyCollection<Diagnostic> Diagnostics => _diagnostics;
+
+	public override void Write(Diagnostic diagnostic)
+	{
+		IncrementSeverityCount(diagnostic);
+		_diagnostics.Add(diagnostic);
+	}
+}
+
+/// <summary>Covers the <c>source:</c> key, which points a TOC entry at content outside the documentation set root.</summary>
+public class TocSourceTests
+{
+	private static DocumentationSetFile LoadAndResolve(
+		RecordingDiagnosticsCollector collector,
+		string docsetYaml,
+		params (string path, string content)[] additionalFiles
+	)
+	{
+		var fileSystem = new MockFileSystem();
+		fileSystem.AddFile("/repo/docs/docset.yml", new MockFileData(docsetYaml));
+		foreach (var (path, content) in additionalFiles)
+			fileSystem.AddFile(path, new MockFileData(content));
+
+		var docsetPath = fileSystem.FileInfo.New("/repo/docs/docset.yml");
+		return DocumentationSetFile.LoadAndResolve(collector, docsetPath, new ScopedFileSystem(fileSystem, "/repo"));
+	}
+
+	[Fact]
+	public void Deserialize_SourceOnFileEntry_IsCaptured()
+	{
+		// language=yaml
+		var yaml =
+			"""
+			project: 'test-project'
+			toc:
+			  - file: feedback.md
+			    source: ../packages/kbn-ui/feedback/feedback.md
+			""";
+
+		var result = ConfigurationFileProvider.Deserializer.Deserialize<DocumentationSetFile>(yaml);
+
+		var fileRef = result.TableOfContents.ElementAt(0).Should().BeOfType<FileRef>().Subject;
+		fileRef.Source.Should().Be("../packages/kbn-ui/feedback/feedback.md");
+		fileRef.SourceFullPath.Should().BeNull("resolution happens during LoadAndResolve");
+	}
+
+	[Fact]
+	public void LoadAndResolve_SourceOnFileEntry_KeepsVirtualPathAndResolvesSource()
+	{
+		// language=yaml
+		var yaml =
+			"""
+			project: 'test-project'
+			toc:
+			  - file: index.md
+			  - file: feedback.md
+			    source: ../packages/kbn-ui/feedback/feedback.md
+			""";
+
+		var collector = new RecordingDiagnosticsCollector();
+		var result = LoadAndResolve(collector, yaml);
+
+		collector.Errors.Should().Be(0);
+		var fileRef = result.TableOfContents.ElementAt(1).Should().BeOfType<FileRef>().Subject;
+		fileRef.PathRelativeToDocumentationSet.Should().Be("feedback.md", "'file:' stays the virtual, docset-relative path");
+		fileRef.Source.Should().Be("../packages/kbn-ui/feedback/feedback.md");
+		fileRef.SourceFullPath.Should().Be(Path.GetFullPath("/repo/packages/kbn-ui/feedback/feedback.md"));
+		result.ExternallySourcedFiles.Should().ContainSingle().Which.Should().BeSameAs(fileRef);
+	}
+
+	[Fact]
+	public void LoadAndResolve_SourceInsideNestedToc_ResolvesRelativeToThatTocYml()
+	{
+		// language=yaml
+		var yaml =
+			"""
+			project: 'test-project'
+			toc:
+			  - file: index.md
+			  - toc: guides
+			""";
+
+		var collector = new RecordingDiagnosticsCollector();
+		var result = LoadAndResolve(
+			collector,
+			yaml,
+			("/repo/docs/guides/toc.yml",
+			// language=yaml
+			"""
+				toc:
+				  - file: index.md
+				  - file: feedback.md
+				    source: ../../packages/kbn-ui/feedback.md
+				""")
+		);
+
+		collector.Errors.Should().Be(0);
+		var toc = result.TableOfContents.ElementAt(1).Should().BeOfType<IsolatedTableOfContentsRef>().Subject;
+		var fileRef = toc.Children.ElementAt(1).Should().BeOfType<FileRef>().Subject;
+		fileRef.PathRelativeToDocumentationSet.Should().Be("guides/feedback.md", "the virtual path still carries the toc folder");
+		fileRef.SourceFullPath.Should().Be(Path.GetFullPath("/repo/packages/kbn-ui/feedback.md"));
+	}
+
+	[Fact]
+	public void LoadAndResolve_SourceOnFolderIndexFile_IsCarriedToTheIndexRef()
+	{
+		// language=yaml
+		var yaml =
+			"""
+			project: 'test-project'
+			toc:
+			  - file: index.md
+			  - folder: feedback
+			    file: index.md
+			    source: ../packages/kbn-ui/feedback/readme.md
+			""";
+
+		var collector = new RecordingDiagnosticsCollector();
+		var result = LoadAndResolve(collector, yaml);
+
+		collector.Errors.Should().Be(0);
+		var folder = result.TableOfContents.ElementAt(1).Should().BeOfType<FolderRef>().Subject;
+		var indexRef = folder.Children.ElementAt(0).Should().BeOfType<FolderIndexFileRef>().Subject;
+		indexRef.PathRelativeToDocumentationSet.Should().Be("feedback/index.md");
+		indexRef.SourceFullPath.Should().Be(Path.GetFullPath("/repo/packages/kbn-ui/feedback/readme.md"));
+	}
+
+	[Fact]
+	public void LoadAndResolve_SourceOnHiddenEntry_IsCaptured()
+	{
+		// language=yaml
+		var yaml =
+			"""
+			project: 'test-project'
+			toc:
+			  - file: index.md
+			  - hidden: internals.md
+			    source: ../packages/kbn-ui/internals.md
+			""";
+
+		var collector = new RecordingDiagnosticsCollector();
+		var result = LoadAndResolve(collector, yaml);
+
+		collector.Errors.Should().Be(0);
+		var fileRef = result.TableOfContents.ElementAt(1).Should().BeOfType<FileRef>().Subject;
+		fileRef.Hidden.Should().BeTrue();
+		fileRef.SourceFullPath.Should().Be(Path.GetFullPath("/repo/packages/kbn-ui/internals.md"));
+	}
+
+	[Fact]
+	public void LoadAndResolve_SourceInsideDocumentationSetRoot_EmitsError()
+	{
+		// language=yaml
+		var yaml =
+			"""
+			project: 'test-project'
+			toc:
+			  - file: index.md
+			  - file: feedback.md
+			    source: ./reference/feedback.md
+			""";
+
+		var collector = new RecordingDiagnosticsCollector();
+		var result = LoadAndResolve(collector, yaml);
+
+		collector.Errors.Should().Be(1);
+		collector.Diagnostics.Should().Contain(d => d.Message.Contains("use 'file: reference/feedback.md' instead"));
+		result.ExternallySourcedFiles.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void LoadAndResolve_SourceIsNotMarkdown_EmitsError()
+	{
+		// language=yaml
+		var yaml =
+			"""
+			project: 'test-project'
+			toc:
+			  - file: index.md
+			  - file: feedback.md
+			    source: ../packages/kbn-ui/feedback.txt
+			""";
+
+		var collector = new RecordingDiagnosticsCollector();
+		var result = LoadAndResolve(collector, yaml);
+
+		collector.Errors.Should().Be(1);
+		collector.Diagnostics.Should().Contain(d => d.Message.Contains("must point to a markdown file"));
+		result.ExternallySourcedFiles.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void LoadAndResolve_NoSource_LeavesFileRefUnchanged()
+	{
+		// language=yaml
+		var yaml = """
+			project: 'test-project'
+			toc:
+			  - file: index.md
+			""";
+
+		var collector = new RecordingDiagnosticsCollector();
+		var result = LoadAndResolve(collector, yaml);
+
+		var fileRef = result.TableOfContents.ElementAt(0).Should().BeOfType<IndexFileRef>().Subject;
+		fileRef.Source.Should().BeNull();
+		fileRef.SourceFullPath.Should().BeNull();
+		result.ExternallySourcedFiles.Should().BeEmpty();
+	}
+}

--- a/tests/Elastic.Markdown.Tests/DocSet/ExternalSourceTests.cs
+++ b/tests/Elastic.Markdown.Tests/DocSet/ExternalSourceTests.cs
@@ -38,10 +38,11 @@ public class ExternalSourceTests(ITestOutputHelper output)
 	private (DocumentationSet Set, TestDiagnosticsCollector Collector, MockFileSystem FileSystem) Build(
 		string docsetYaml,
 		params (string path, string content)[] files
-	)
+	) => BuildFrom(CreateFileSystem(docsetYaml, files));
+
+	private (DocumentationSet Set, TestDiagnosticsCollector Collector, MockFileSystem FileSystem) BuildFrom(MockFileSystem fileSystem)
 	{
 		var logger = new TestLoggerFactory(output);
-		var fileSystem = CreateFileSystem(docsetYaml, files);
 		var collector = new TestDiagnosticsCollector(output);
 		var configurationContext = TestHelpers.CreateConfigurationContext(fileSystem);
 		var context = new BuildContext(collector, TestHelpers.CreateDocumentationFileSystem(fileSystem), configurationContext);
@@ -162,7 +163,7 @@ public class ExternalSourceTests(ITestOutputHelper output)
 		collector
 			.Diagnostics
 			.Should()
-			.Contain(d => d.Severity == Severity.Error && d.Message.Contains("'file: feedback.md' already exists on disk"));
+			.Contain(d => d.Severity == Severity.Error && d.Message.Contains("'file: feedback.md' is already taken"));
 	}
 
 	[Fact]
@@ -190,7 +191,95 @@ public class ExternalSourceTests(ITestOutputHelper output)
 		collector
 			.Diagnostics
 			.Should()
-			.Contain(d => d.Severity == Severity.Error && d.Message.Contains("is already sourced by another entry"));
+			.Contain(d => d.Severity == Severity.Error && d.Message.Contains("'file: feedback.md' is already taken"));
+	}
+
+	[Fact]
+	public void VirtualPathEscapingTheDocsetRoot_EmitsError()
+	{
+		var docsetYaml =
+			//language=yaml
+			"""
+			project: test
+			toc:
+			- file: index.md
+			- file: ../escaped.md
+			  source: ../packages/kbn-ui/feedback.md
+			""";
+
+		var (set, collector, _) = Build(docsetYaml, ("docs/index.md", "# Home"), ("packages/kbn-ui/feedback.md", "# Feedback"));
+
+		collector
+			.Diagnostics
+			.Should()
+			.Contain(d => d.Severity == Severity.Error && d.Message.Contains("resolves outside the documentation set root"));
+		set.MarkdownFiles.Should().NotContain(f => f.RelativePath.Contains("escaped.md"));
+	}
+
+	[Fact]
+	public void ExternalSourceClaimingAnExtensionGeneratedPosition_EmitsErrorRatherThanThrowing()
+	{
+		// The listing extension registers a synthetic index page that exists nowhere on disk, so only a check
+		// against the already-registered positions catches the clash.
+		var docsetYaml =
+			//language=yaml
+			"""
+			project: test
+			toc:
+			- file: index.md
+			- listing: guides
+			  glob: '**/*.md'
+			- hidden: guides/index.md
+			  source: ../packages/kbn-ui/overview.md
+			""";
+
+		var (set, collector, _) = Build(
+			docsetYaml,
+			("docs/index.md", "# Home"),
+			("docs/guides/quickstart.md", "# Quickstart"),
+			("packages/kbn-ui/overview.md", "# Overview")
+		);
+
+		set.Should().NotBeNull("a duplicate position must be diagnosed, not thrown out of the file lookup");
+		collector
+			.Diagnostics
+			.Should()
+			.Contain(d => d.Severity == Severity.Error && d.Message.Contains("'file: guides/index.md' is already taken"));
+	}
+
+	[Fact]
+	public void SourcedRootIndex_SatisfiesTheNonPublicIndexRequirement()
+	{
+		var docsetYaml =
+			//language=yaml
+			"""
+			project: test
+			registry: internal
+			toc:
+			- file: index.md
+			  source: ../packages/kbn-ui/readme.md
+			""";
+
+		var (_, collector, _) = Build(docsetYaml, ("packages/kbn-ui/readme.md", "# Home"));
+
+		collector.Diagnostics.Should().NotContain(d => d.Severity == Severity.Error && d.Message.Contains("require a root index.md"));
+	}
+
+	[Fact]
+	public void SymlinkedExternalSource_EmitsError()
+	{
+		// The checkout-boundary check is lexical, so a symlink inside the checkout passes it while resolving out.
+		var fileSystem = CreateFileSystem(DocsetYaml, ("docs/index.md", "# Home"));
+		var outside = Path.Join(Paths.WorkingDirectoryRoot.Parent!.FullName, "outside-the-repo", "feedback.md");
+		fileSystem.AddFile(outside, new MockFileData("# Smuggled"));
+		var linkPath = Path.Join(Paths.WorkingDirectoryRoot.FullName, "packages", "kbn-ui", "feedback", "feedback.md");
+		_ = fileSystem.Directory.CreateDirectory(Path.GetDirectoryName(linkPath)!);
+		fileSystem.File.CreateSymbolicLink(linkPath, outside);
+
+		var (set, collector, _) = BuildFrom(fileSystem);
+
+		collector.Diagnostics.Should().Contain(d => d.Severity == Severity.Error && d.Message.Contains("symlink"));
+		set.MarkdownFiles.Should().NotContain(f => f.RelativePath.EndsWith("feedback.md"));
 	}
 
 	[Fact]

--- a/tests/Elastic.Markdown.Tests/DocSet/ExternalSourceTests.cs
+++ b/tests/Elastic.Markdown.Tests/DocSet/ExternalSourceTests.cs
@@ -1,0 +1,216 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions.TestingHelpers;
+using AwesomeAssertions;
+using Elastic.Documentation;
+using Elastic.Documentation.Configuration;
+using Elastic.Documentation.Diagnostics;
+using Elastic.Markdown.IO;
+
+namespace Elastic.Markdown.Tests.DocSet;
+
+/// <summary>
+/// End-to-end coverage for <c>source:</c>: a page that lives outside the documentation set root keeps the
+/// docset-relative position declared by <c>file:</c> for its URL, output path and link reference.
+/// </summary>
+public class ExternalSourceTests(ITestOutputHelper output)
+{
+	private const string DocsetYaml =
+		//language=yaml
+		"""
+		project: test
+		toc:
+		- file: index.md
+		- file: feedback.md
+		  source: ../packages/kbn-ui/feedback/feedback.md
+		""";
+
+	private static MockFileSystem CreateFileSystem(string docsetYaml, params (string path, string content)[] files)
+	{
+		var contents = new Dictionary<string, MockFileData> { { "docs/docset.yml", new MockFileData(docsetYaml) } };
+		foreach (var (path, content) in files)
+			contents[path] = new MockFileData(content);
+		return new MockFileSystem(contents, new MockFileSystemOptions { CurrentDirectory = Paths.WorkingDirectoryRoot.FullName });
+	}
+
+	private (DocumentationSet Set, TestDiagnosticsCollector Collector, MockFileSystem FileSystem) Build(
+		string docsetYaml,
+		params (string path, string content)[] files
+	)
+	{
+		var logger = new TestLoggerFactory(output);
+		var fileSystem = CreateFileSystem(docsetYaml, files);
+		var collector = new TestDiagnosticsCollector(output);
+		var configurationContext = TestHelpers.CreateConfigurationContext(fileSystem);
+		var context = new BuildContext(collector, TestHelpers.CreateDocumentationFileSystem(fileSystem), configurationContext);
+		return (new DocumentationSet(context, logger, new TestCrossLinkResolver()), collector, fileSystem);
+	}
+
+	[Fact]
+	public void ExternalSource_IsRegisteredUnderItsVirtualPath()
+	{
+		var (set, collector, _) = Build(
+			DocsetYaml,
+			("docs/index.md", "# Home"),
+			("packages/kbn-ui/feedback/feedback.md", "# Feedback\n\nSourced from the package tree.")
+		);
+
+		collector.Diagnostics.Where(d => d.Severity == Severity.Error).Should().BeEmpty();
+
+		var feedback = set.MarkdownFiles.Should().ContainSingle(f => f.RelativePath.EndsWith("feedback.md")).Subject;
+		feedback.RelativePath.Should().Be("feedback.md", "the virtual path drives output and links, not the on-disk location");
+		feedback.SourceFile.FullName.Should().EndWith(Path.Join("packages", "kbn-ui", "feedback", "feedback.md"));
+		feedback.CrossLink.Should().EndWith("://feedback.md");
+		feedback.FileName.Should().Be("feedback.md");
+	}
+
+	[Fact]
+	public async Task ExternalSource_RendersToTheVirtualOutputPath()
+	{
+		var (set, collector, _) = Build(
+			DocsetYaml,
+			("docs/index.md", "# Home"),
+			("packages/kbn-ui/feedback/feedback.md", "# Feedback\n\nSourced from the package tree.")
+		);
+		var generator = new DocumentationGenerator(set, new TestLoggerFactory(output));
+
+		await generator.GenerateAll(TestContext.Current.CancellationToken);
+
+		collector.Diagnostics.Where(d => d.Severity == Severity.Error).Should().BeEmpty();
+		var outputFile = Path.Join(set.OutputDirectory.FullName, "feedback", "index.html");
+		set.OutputDirectory.FileSystem.File.Exists(outputFile).Should().BeTrue();
+		var html = await set.OutputDirectory.FileSystem.File.ReadAllTextAsync(outputFile, TestContext.Current.CancellationToken);
+		html.Should().Contain("Sourced from the package tree.");
+		html.Should().Contain(
+			"/edit/test-e35fcb27-5f60-4e/packages/kbn-ui/feedback/feedback.md",
+			"the edit link points at the file actually read"
+		);
+
+		var indexPath = Path.Join(set.OutputDirectory.FullName, "index.html");
+		var indexHtml = await set.OutputDirectory.FileSystem.File.ReadAllTextAsync(indexPath, TestContext.Current.CancellationToken);
+		indexHtml.Should().Contain("/edit/test-e35fcb27-5f60-4e/docs/index.md", "ordinary pages still edit through the docset directory");
+	}
+
+	[Fact]
+	public void ExternalSource_NavigationUsesTheVirtualUrl()
+	{
+		var (set, _, _) = Build(DocsetYaml, ("docs/index.md", "# Home"), ("packages/kbn-ui/feedback/feedback.md", "# Feedback"));
+
+		set.Navigation.NavigationItems.Should().ContainSingle().Which.Url.Should().Be("/feedback");
+	}
+
+	[Fact]
+	public async Task ExternalSource_ResolvesRelativeLinksFromItsVirtualPosition()
+	{
+		var docsetYaml =
+			//language=yaml
+			"""
+			project: test
+			toc:
+			- file: index.md
+			- folder: guides
+			  children:
+			  - file: index.md
+			  - file: feedback.md
+			    source: ../packages/kbn-ui/feedback.md
+			""";
+
+		var (set, collector, _) = Build(
+			docsetYaml,
+			("docs/index.md", "# Home"),
+			("docs/guides/index.md", "# Guides"),
+			("packages/kbn-ui/feedback.md", "# Feedback\n\nBack to the [guides](./index.md).")
+		);
+		var generator = new DocumentationGenerator(set, new TestLoggerFactory(output));
+
+		await generator.GenerateAll(TestContext.Current.CancellationToken);
+
+		collector.Diagnostics.Where(d => d.Severity == Severity.Error).Should().BeEmpty();
+		var outputFile = Path.Join(set.OutputDirectory.FullName, "guides", "feedback", "index.html");
+		var html = await set.OutputDirectory.FileSystem.File.ReadAllTextAsync(outputFile, TestContext.Current.CancellationToken);
+		html.Should().Contain(
+			"""Back to the <a href="/guides" preload="mousedown">guides</a>""",
+			"'./index.md' is the docset sibling, not a neighbour of the file on disk"
+		);
+	}
+
+	[Fact]
+	public void MissingExternalSource_EmitsErrorNamingTheSource()
+	{
+		var (_, collector, _) = Build(DocsetYaml, ("docs/index.md", "# Home"));
+
+		collector
+			.Diagnostics
+			.Should()
+			.Contain(
+				d => d.Severity == Severity.Error && d.Message.Contains("'source: ../packages/kbn-ui/feedback/feedback.md' does not exist")
+			);
+	}
+
+	[Fact]
+	public void ExternalSourceOnAPositionTakenByARealFile_EmitsError()
+	{
+		var (_, collector, _) = Build(
+			DocsetYaml,
+			("docs/index.md", "# Home"),
+			("docs/feedback.md", "# Feedback on disk"),
+			("packages/kbn-ui/feedback/feedback.md", "# Feedback")
+		);
+
+		collector
+			.Diagnostics
+			.Should()
+			.Contain(d => d.Severity == Severity.Error && d.Message.Contains("'file: feedback.md' already exists on disk"));
+	}
+
+	[Fact]
+	public void TwoEntriesSourcingTheSamePosition_EmitsError()
+	{
+		var docsetYaml =
+			//language=yaml
+			"""
+			project: test
+			toc:
+			- file: index.md
+			- file: feedback.md
+			  source: ../packages/kbn-ui/feedback.md
+			- hidden: feedback.md
+			  source: ../packages/kbn-es/feedback.md
+			""";
+
+		var (_, collector, _) = Build(
+			docsetYaml,
+			("docs/index.md", "# Home"),
+			("packages/kbn-ui/feedback.md", "# UI feedback"),
+			("packages/kbn-es/feedback.md", "# ES feedback")
+		);
+
+		collector
+			.Diagnostics
+			.Should()
+			.Contain(d => d.Severity == Severity.Error && d.Message.Contains("is already sourced by another entry"));
+	}
+
+	[Fact]
+	public void ExternalSourceAboveTheCheckout_EmitsError()
+	{
+		var docsetYaml =
+			//language=yaml
+			"""
+			project: test
+			toc:
+			- file: index.md
+			- file: feedback.md
+			  source: ../../outside-the-repo/feedback.md
+			""";
+
+		var (_, collector, _) = Build(docsetYaml, ("docs/index.md", "# Home"));
+
+		collector
+			.Diagnostics
+			.Should()
+			.Contain(d => d.Severity == Severity.Error && d.Message.Contains("resolves outside the repository checkout"));
+	}
+}


### PR DESCRIPTION
A `source:` key on a `file:` or `hidden:` table of contents entry reads the page's content from a markdown file elsewhere in the repository. A page can now live next to the code it documents without moving the documentation set root.

**Affects:** `Navigation`, `Authoring`, `Configuration`

**Prompt summary:** Implement [#3798](https://github.com/elastic/docs-builder/issues/3798). Kibana publishes internal developer docs to Codex from a `docs-dev/` docset while the packages those docs describe live under `src/platform/`, and the maintainers want each page checked in beside the code it documents so a component change and its documentation land in the same review. The ask is to let a table of contents entry keep its docset-relative position while sourcing content from above the root.

## Why

All table of contents paths resolve relative to the documentation set root, and a repository supports one docset per registry. Colocating a page with its code therefore means moving the docset root inside a package directory, which concedes the repository to a single internal docset. Keeping the docset where it is means the documentation cannot sit beside the code.

## What

#### The new `source:` key

An entry keeps `file:` as its position in the documentation set and gains `source:` for where the content is read:

```yaml
toc:
  - file: index.md
  - file: feedback.md
    source: ../packages/kbn-ui/feedback/feedback.md
```

`file:` still drives the URL, the navigation entry, the output path and the cross-repository link reference. `source:` is resolved against the directory holding the `docset.yml` or `toc.yml` that declares the entry, and nothing else. It works on a `hidden:` entry and on the `folder:` + `file:` form.

#### Separating position from content

`DocumentationFile.RelativePath` is the page's position in the set and no longer has to equal `SourceFile` relative to the root. A sourced page parses as though it lived at that position, so relative links, images and includes inside it resolve from the virtual path rather than from where the file sits on disk. Because generated URLs and output paths derive from a path that cannot contain `../`, no page can write outside the output directory or emit `../` in a URL.

#### Registering a page the file scan never sees

The scan walks the documentation set root, so a sourced page has to be registered from the table of contents. `MarkdownFileFactory` keys it under its virtual path — the same path navigation resolves against — and registers it after everything else so it can be refused with a diagnostic when:

- the source escapes the repository checkout, either lexically or through a symlink on its path
- the source does not exist, or is not a markdown file
- the source resolves back inside the documentation set root, where the scan already owns it
- the `file:` position escapes the root, or is already held by a scanned file, an extension-generated page, or another sourced entry

A non-public docset can also declare its root `index.md` with `source:`; the root-index requirement accepts the registered position.

#### The edit link

The "Edit this page" link now derives from the file that was actually read instead of joining the docset directory with the position in the set. That is required for a sourced page, and it also corrects detection rule pages, whose `.toml` source produced a path with `../` segments in it.

#### `ResolveFileRef` rebuilds refs with `with`

Resolution previously reconstructed each ref through a three-arm `new` switch, which silently drops any key added to `FileRef` later. A `with` expression preserves the concrete ref type and every off-path key, so `source:` cannot be lost between parsing and navigation.

## Verify

```bash
./build.sh unit-test
# TocSourceTests — parsing, resolution anchoring, and the two path-shape errors
# ExternalSourceTests — registration, output path, relative links, edit link, root index, and the five registration errors
```

Then try it against this repository's own docs, pointing an entry at a file above `docs/`:

```bash
dotnet run --project src/tooling/docs-builder -- --path docs --strict
```

**Out of scope:** single markdown files only. There is no `source:` on `folder:`, `listing:` or `toc:`, and no glob form, per the issue. A sourced entry's `file:` is now checked for containment, but the general case the issue describes under Alternative Solutions — a bare `- file: ../../x.md` with no `source:` — is still accepted with no check. The author offered to track that separately and this PR leaves it alone.

**Risk:** assembled builds clone a repository with a partial checkout of `docs` only. A `source:` above that path needs the repository's `sparse_paths` or `checkout_strategy` widened in [`config/assembler.yml`](https://github.com/elastic/docs-builder/blob/main/config/assembler.yml), the same requirement the detection rules extension already has. Codex checkouts are not sparse, so the case in the issue works without a config change.