### PR TITLE
Derive repo identity in changelog gh-release; fix empty-repo crash

### DIFF
--- a/docs/cli-schema.json
+++ b/docs/cli-schema.json
@@ -3762,15 +3762,15 @@
           ],
           "name": "gh-release",
           "summary": "Create changelog entries from the PRs referenced in a GitHub release.",
-          "usage": "docs-builder changelog gh-release \u003Crepo\u003E [\u003Cversion\u003E] [options]",
+          "usage": "docs-builder changelog gh-release [\u003Crepo\u003E] [\u003Cversion\u003E] [options]",
           "examples": [],
           "parameters": [
             {
               "role": "positional",
               "name": "repo",
               "type": "string",
-              "required": true,
-              "summary": "Required: GitHub repository in owner/repo format (e.g., \u0022elastic/elasticsearch\u0022 or just \u0022elasticsearch\u0022 which defaults to elastic/elasticsearch)"
+              "required": false,
+              "summary": "Optional: GitHub repository in owner/repo format (e.g., \u0022elastic/elasticsearch\u0022 or just \u0022elasticsearch\u0022). When omitted, falls back to bundle.repo in changelog.yml, then the GITHUB_REPOSITORY env var, then the git remote origin."
             },
             {
               "role": "positional",

--- a/src/services/Elastic.Changelog/Bundling/BundleOutputNaming.cs
+++ b/src/services/Elastic.Changelog/Bundling/BundleOutputNaming.cs
@@ -103,12 +103,28 @@ public static class BundleOutputNaming
 		return $"{request.Product}-{request.Version}.yaml";
 	}
 
-	internal static string? ResolveAuthoringRepo(IFileSystem fileSystem, BundleOutputNameRequest request)
+	/// <summary>
+	/// Resolves the authoring repository for any changelog command. Precedence:
+	/// explicit value(s), <c>GITHUB_REPOSITORY</c> env var, git <c>origin</c>.
+	/// </summary>
+	public static string? ResolveRepo(IFileSystem fileSystem, string? configPath, params string?[] candidates)
 	{
-		var configured = FirstNonEmpty(request.CliRepo, request.ProfileRepo, request.BundleRepo);
+		var configured = FirstNonEmpty(candidates);
 		var normalized = ChangelogRepoOwnerResolver.NormalizeRepo(configured);
-		return !string.IsNullOrWhiteSpace(normalized) ? normalized : TryGitOriginRepo(fileSystem, request.ConfigPath);
+		if (!string.IsNullOrWhiteSpace(normalized))
+			return normalized;
+
+		// GITHUB_REPOSITORY is "owner/repo"; NormalizeRepo takes the last segment.
+		var githubRepository = Environment.GetEnvironmentVariable("GITHUB_REPOSITORY");
+		var ghNormalized = ChangelogRepoOwnerResolver.NormalizeRepo(githubRepository);
+		if (!string.IsNullOrWhiteSpace(ghNormalized))
+			return ghNormalized;
+
+		return TryGitOriginRepo(fileSystem, configPath);
 	}
+
+	internal static string? ResolveAuthoringRepo(IFileSystem fileSystem, BundleOutputNameRequest request) =>
+		ResolveRepo(fileSystem, request.ConfigPath, request.CliRepo, request.ProfileRepo, request.BundleRepo);
 
 	private static string? FirstNonEmpty(params string?[] values)
 	{

--- a/src/services/Elastic.Changelog/Bundling/BundleOutputNaming.cs
+++ b/src/services/Elastic.Changelog/Bundling/BundleOutputNaming.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System.IO.Abstractions;
+using Elastic.Documentation;
 using Elastic.Documentation.Configuration;
 using Elastic.Documentation.Diagnostics;
 using Elastic.Documentation.ReleaseNotes;
@@ -16,7 +17,8 @@ public readonly record struct BundleOutputNameRequest(
 	string? CliRepo,
 	string? ProfileRepo,
 	string? BundleRepo,
-	string? ConfigPath
+	string? ConfigPath,
+	IEnvironmentVariables? Env = null
 );
 
 /// <summary>
@@ -107,7 +109,14 @@ public static class BundleOutputNaming
 	/// Resolves the authoring repository for any changelog command. Precedence:
 	/// explicit value(s), <c>GITHUB_REPOSITORY</c> env var, git <c>origin</c>.
 	/// </summary>
-	public static string? ResolveRepo(IFileSystem fileSystem, string? configPath, params string?[] candidates)
+	public static string? ResolveRepo(IFileSystem fileSystem, string? configPath, params string?[] candidates) =>
+		ResolveRepo(fileSystem, configPath, null, candidates);
+
+	/// <summary>
+	/// Resolves the authoring repository with an injectable environment for testing.
+	/// When <paramref name="env"/> is null the real <see cref="Environment.GetEnvironmentVariable"/> is used.
+	/// </summary>
+	internal static string? ResolveRepo(IFileSystem fileSystem, string? configPath, IEnvironmentVariables? env, params string?[] candidates)
 	{
 		var configured = FirstNonEmpty(candidates);
 		var normalized = ChangelogRepoOwnerResolver.NormalizeRepo(configured);
@@ -115,7 +124,9 @@ public static class BundleOutputNaming
 			return normalized;
 
 		// GITHUB_REPOSITORY is "owner/repo"; NormalizeRepo takes the last segment.
-		var githubRepository = Environment.GetEnvironmentVariable("GITHUB_REPOSITORY");
+		var githubRepository = env != null
+			? env.GetEnvironmentVariable("GITHUB_REPOSITORY")
+			: Environment.GetEnvironmentVariable("GITHUB_REPOSITORY");
 		var ghNormalized = ChangelogRepoOwnerResolver.NormalizeRepo(githubRepository);
 		if (!string.IsNullOrWhiteSpace(ghNormalized))
 			return ghNormalized;
@@ -124,7 +135,7 @@ public static class BundleOutputNaming
 	}
 
 	internal static string? ResolveAuthoringRepo(IFileSystem fileSystem, BundleOutputNameRequest request) =>
-		ResolveRepo(fileSystem, request.ConfigPath, request.CliRepo, request.ProfileRepo, request.BundleRepo);
+		ResolveRepo(fileSystem, request.ConfigPath, request.Env, request.CliRepo, request.ProfileRepo, request.BundleRepo);
 
 	private static string? FirstNonEmpty(params string?[] values)
 	{

--- a/src/services/Elastic.Changelog/Bundling/ChangelogBundlingService.cs
+++ b/src/services/Elastic.Changelog/Bundling/ChangelogBundlingService.cs
@@ -183,11 +183,13 @@ public partial class ChangelogBundlingService(
 	IGitHubReleaseService? releaseService = null,
 	CdnChangelogEntryFetcher? entryFetcher = null,
 	IGitHubPrService? prService = null,
-	IGitHubCommitRangeService? commitRangeService = null
+	IGitHubCommitRangeService? commitRangeService = null,
+	IEnvironmentVariables? env = null
 ) : IService
 {
 	private readonly ILogger _logger = logFactory.CreateLogger<ChangelogBundlingService>();
 	private readonly IChangelogFileSystem _fileSystem = fileSystem;
+	private readonly IEnvironmentVariables? _env = env;
 	private readonly IGitHubReleaseService _releaseService = releaseService ?? new GitHubReleaseService(logFactory);
 	private readonly CdnChangelogEntryFetcher _entryFetcher = entryFetcher ?? new CdnChangelogEntryFetcher(logFactory);
 	private readonly IGitHubPrService _prService = prService ?? new GitHubPrService(logFactory);
@@ -694,7 +696,8 @@ public partial class ChangelogBundlingService(
 						input.Repo,
 						profile.Repo,
 						config.Bundle.Repo,
-						input.Config
+						input.Config,
+						_env
 					)
 				);
 				outputPath = JoinProfileOutputPath(config, input, fileName);
@@ -1151,7 +1154,15 @@ public partial class ChangelogBundlingService(
 			var fileName = BundleOutputNaming.ResolveFileName(
 				collector,
 				_fileSystem,
-				new BundleOutputNameRequest(primaryProduct, planVersion, input.Repo, profileDef.Repo, config?.Bundle?.Repo, input.Config)
+				new BundleOutputNameRequest(
+					primaryProduct,
+					planVersion,
+					input.Repo,
+					profileDef.Repo,
+					config?.Bundle?.Repo,
+					input.Config,
+					_env
+				)
 			);
 			outputPath = JoinProfileOutputPath(config, input, fileName);
 		}
@@ -1243,7 +1254,7 @@ public partial class ChangelogBundlingService(
 		var fileName = BundleOutputNaming.ResolveFileNameOrFallback(
 			collector,
 			_fileSystem,
-			new BundleOutputNameRequest(product, version, input.Repo, null, config?.Bundle?.Repo, input.Config)
+			new BundleOutputNameRequest(product, version, input.Repo, null, config?.Bundle?.Repo, input.Config, _env)
 		);
 		return _fileSystem.Path.Join(outputDir, fileName).OptionalWindowsReplace();
 	}

--- a/src/services/Elastic.Changelog/GithubRelease/GitHubReleaseChangelogService.cs
+++ b/src/services/Elastic.Changelog/GithubRelease/GitHubReleaseChangelogService.cs
@@ -127,7 +127,8 @@ public class GitHubReleaseChangelogService(
 				collector.EmitError(
 					string.Empty,
 					$"Could not find product for repository '{repo}' in products.yml. " +
-						"Ensure the repository name matches a product ID or a product has 'repository: {repo}' configured."
+						$"Add a product to config/products.yml whose ID is '{repo}', " +
+						$"or set 'repository: {repo}' on one or more existing products."
 				);
 				return false;
 			}

--- a/src/tooling/docs-builder/Commands/ChangelogCommand.cs
+++ b/src/tooling/docs-builder/Commands/ChangelogCommand.cs
@@ -1562,7 +1562,7 @@ internal sealed partial class ChangelogCommands(
 	}
 
 	/// <summary>Create changelog entries from the PRs referenced in a GitHub release.</summary>
-	/// <param name="repo">Required: GitHub repository in owner/repo format (e.g., "elastic/elasticsearch" or just "elasticsearch" which defaults to elastic/elasticsearch)</param>
+	/// <param name="repo">Optional: GitHub repository in owner/repo format (e.g., "elastic/elasticsearch" or just "elasticsearch"). When omitted, falls back to bundle.repo in changelog.yml, then the GITHUB_REPOSITORY env var, then the git remote origin.</param>
 	/// <param name="version">Optional: Version tag to fetch (e.g., "v9.0.0", "9.0.0"). Defaults to "latest"</param>
 	/// <param name="config">Optional: Path to the changelog.yml configuration file. Defaults to 'docs/changelog.yml'</param>
 	/// <param name="description">Optional: Bundle description text with placeholder support. Supports VERSION, LIFECYCLE, OWNER, and REPO placeholders. Overrides bundle.description from config.</param>
@@ -1573,7 +1573,7 @@ internal sealed partial class ChangelogCommands(
 	/// <param name="ctx"></param>
 	[NoOptionsInjection]
 	public async Task<int> GhRelease(
-		[Argument] string repo,
+		[Argument] string repo = "",
 		[Argument] string version = "latest",
 		[Existing, ExpandUserProfile, RejectSymbolicLinks, FileExtensions(Extensions = "yml,yaml")] FileInfo? config = null,
 		string? description = null,
@@ -1597,6 +1597,22 @@ internal sealed partial class ChangelogCommands(
 			? output
 			: (bundleConfig?.Bundle?.OutputDirectory ?? bundleConfig?.Bundle?.Directory);
 
+		// Repo precedence: positional arg > bundle.repo > GITHUB_REPOSITORY env var > git remote origin
+		var resolvedRepo = BundleOutputNaming.ResolveRepo(_fileSystem, config?.FullName, repo, bundleConfig?.Bundle?.Repo);
+		if (string.IsNullOrWhiteSpace(resolvedRepo))
+		{
+			collector.EmitError(
+				string.Empty,
+				"changelog gh-release could not determine the repository. " +
+					"Pass <repo> as the first argument, set bundle.repo in changelog.yml, " +
+					"or run where GITHUB_REPOSITORY or a git remote (github.com) is available."
+			);
+			_ = collector.StartAsync(ctx);
+			await collector.WaitForDrain();
+			await collector.StopAsync(ctx);
+			return 1;
+		}
+
 		IGitHubReleaseService releaseService = new GitHubReleaseService(logFactory);
 		IGitHubPrService prService = new GitHubPrService(logFactory);
 		var service = new GitHubReleaseChangelogService(logFactory, configurationContext, _fileSystem, releaseService, prService);
@@ -1613,7 +1629,7 @@ internal sealed partial class ChangelogCommands(
 
 		var input = new CreateChangelogsFromReleaseArguments
 		{
-			Repository = repo,
+			Repository = resolvedRepo,
 			Version = version,
 			Config = config?.FullName,
 			Output = resolvedOutput,

--- a/tests/Elastic.Changelog.Tests/Changelogs/BundleOutputConventionTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/BundleOutputConventionTests.cs
@@ -52,7 +52,7 @@ public class BundleOutputConventionTests(ITestOutputHelper output) : ChangelogTe
 		return configPath;
 	}
 
-	private ChangelogBundlingService Service() => new(LoggerFactory, FileSystem, ConfigurationContext);
+	private ChangelogBundlingService Service() => new(LoggerFactory, FileSystem, ConfigurationContext, env: EmptyEnvironment);
 
 	[Fact]
 	public async Task ProfileWithOutputPattern_EmitsHardError()

--- a/tests/Elastic.Changelog.Tests/Changelogs/BundlePlanTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/BundlePlanTests.cs
@@ -14,7 +14,8 @@ public class BundlePlanTests : ChangelogTestBase
 {
 	private ChangelogBundlingService Service { get; }
 
-	public BundlePlanTests(ITestOutputHelper output) : base(output) => Service = new(LoggerFactory, FileSystem, ConfigurationContext);
+	public BundlePlanTests(ITestOutputHelper output) : base(output) =>
+		Service = new(LoggerFactory, FileSystem, ConfigurationContext, env: EmptyEnvironment);
 
 	private async Task<string> CreateConfigAsync(string configContent)
 	{

--- a/tests/Elastic.Changelog.Tests/Changelogs/ChangelogTestBase.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/ChangelogTestBase.cs
@@ -169,4 +169,16 @@ public abstract class ChangelogTestBase : IDisposable
 		).ToList();
 		return Documentation.Configuration.ReleaseNotes.ReleaseNotesSerialization.SerializeBundle(bundle with { Entries = entries });
 	}
+
+	/// <summary>
+	/// Environment with no variables set — prevents <c>GITHUB_REPOSITORY</c> from leaking
+	/// into repo-resolution logic under test.
+	/// </summary>
+	protected static readonly IEnvironmentVariables EmptyEnvironment = new EmptyEnvironmentVariablesImpl();
+
+	private sealed class EmptyEnvironmentVariablesImpl : IEnvironmentVariables
+	{
+		public string? GetEnvironmentVariable(string name) => null;
+		public bool IsRunningOnCI => false;
+	}
 }


### PR DESCRIPTION
`changelog gh-release` crashed with `Could not find product for repository '' in products.yml` when `release-notes.yml`'s bundle job omitted the `repo` and `owner` inputs — which is the default when a repo adopts the workflow without explicitly passing them.

**Affects:** Release notes, CLI

**Prompt summary:** The `docs-playground-release-notes-tagged` release `0.2.1` failed at the bundle job. The root cause traces three layers deep: `release-notes.yml` passes no `repo`/`owner` to `changelog/bundle-create@v1`; `GhRelease` accepted the resulting blank positional with no fallback and no guard; and `GitHubReleaseChangelogService` resolved the product before loading config, so config could not have rescued it. The fix makes the positional optional and adds the same derivation chain that `BundleOutputNaming` already uses for file naming.

## Why

`GhRelease` took `repo` as a required positional argument. The `release-notes.yml` workflow's bundle job passed neither `repo` nor `owner` to the composite action, so the positional arrived blank. The command forwarded the blank string to `GitHubReleaseChangelogService`, which looked up `""` in `products.yml`, found nothing, and emitted an error whose second sentence contained a literal `{repo}` — an uninterpolated template placeholder.

## What

#### `gh-release` repo resolution

The `repo` positional is now optional (default `""`). After loading config, the command resolves the repository with the same precedence chain `BundleOutputNaming` uses for profile-mode file naming: explicit positional arg → `bundle.repo` in `changelog.yml` → `GITHUB_REPOSITORY` env var → git remote origin. When nothing resolves, the command errors with an actionable message rather than passing a blank string downstream.

```
changelog gh-release could not determine the repository.
Pass <repo> as the first argument, set bundle.repo in changelog.yml,
or run where GITHUB_REPOSITORY or a git remote (github.com) is available.
```

#### `BundleOutputNaming.ResolveRepo`

`ResolveAuthoringRepo` is lifted into a public `ResolveRepo(IFileSystem, configPath, params string?[] candidates)` helper so any command can use the full derivation chain without duplicating the git-remote walk. `GITHUB_REPOSITORY` is inserted between the configured values and the git remote — it has higher authority in Actions than reading the local checkout's remote URL.

#### Product-not-found error message

The `{repo}` literal in `GitHubReleaseChangelogService`'s "Could not find product" error was not interpolated. It now names the repo and tells the author exactly what to add to `config/products.yml`.

## Verify

```bash
dotnet test tests/Elastic.Changelog.Tests/

# Reproduce the crash: blank positional, no config fallback
dotnet run --project src/tooling/docs-builder -- changelog gh-release "" 0.2.1 \
  --config /path/to/playground/docs/changelog.yml
# Before: "Could not find product for repository '' in products.yml"
# After:  actionable guard error

# Derive from config: omit positional, bundle.repo supplies the repo
dotnet run --project src/tooling/docs-builder -- changelog gh-release \
  --config /path/to/playground/docs/changelog.yml
# Resolves elastic/docs-playground-release-notes-tagged

# Derive from env in CI (no positional, no bundle.repo)
GITHUB_REPOSITORY=elastic/docs-playground-release-notes-tagged \
  dotnet run --project src/tooling/docs-builder -- changelog gh-release \
  --config /path/to/playground/docs/changelog.yml
```