### PR TITLE
Allow one repo to map to many products; deprecate bundle.repo/owner

### DIFF
--- a/config/products.yml
+++ b/config/products.yml
@@ -47,15 +47,18 @@ products:
   cloud-enterprise:
     display: 'Elastic Cloud Enterprise'
     versioning: 'ece'
+    repository: 'cloud'
   cloud-hosted:
     display: 'Elastic Cloud Hosted'
     versioning: 'ech'
+    repository: 'cloud'
   cloud-kubernetes:
     display: 'Elastic Cloud on Kubernetes'
     versioning: 'eck'
   cloud-serverless:
     display: 'Elastic Cloud Serverless'
     versioning: 'serverless'
+    repository: 'cloud'
   cloud-terraform:
     display: 'Elastic Cloud Terraform Provider'
     versioning: 'cloud-terraform'

--- a/src/Elastic.Documentation.Configuration/Changelog/BundleConfiguration.cs
+++ b/src/Elastic.Documentation.Configuration/Changelog/BundleConfiguration.cs
@@ -37,13 +37,22 @@ public record BundleConfiguration
 
 	/// <summary>
 	/// Default GitHub repository name applied to all profiles that do not specify their own.
-	/// Used for generating correct PR/issue links when the product ID differs from the repo name.
+	/// <para>
+	/// <b>Deprecated.</b> The repository is now derived automatically from the <c>GITHUB_REPOSITORY</c>
+	/// environment variable or the git remote origin, so this field is redundant in almost every case.
+	/// Remove it from <c>changelog.yml</c> unless the repo name genuinely differs from the derived value.
+	/// Setting it to a <em>different</em> repository than where the command runs is a hard error, because
+	/// it would silently repoint the S3 upload pool and GitHub API calls.
+	/// </para>
 	/// </summary>
+	[Obsolete("Derived automatically. Remove bundle.repo from changelog.yml; a mismatch with the running repo is a hard error.")]
 	public string? Repo { get; init; }
 
 	/// <summary>
 	/// Default GitHub repository owner applied to all profiles that do not specify their own.
+	/// <para><b>Deprecated.</b> Derived automatically alongside <c>bundle.repo</c>. Remove from <c>changelog.yml</c>.</para>
 	/// </summary>
+	[Obsolete("Derived automatically. Remove bundle.owner from changelog.yml.")]
 	public string? Owner { get; init; }
 
 	/// <summary>
@@ -118,14 +127,20 @@ public record BundleProfile
 
 	/// <summary>
 	/// GitHub repository name stored on each product in the bundle output.
-	/// Used for generating correct PR/issue links when the product ID differs from the repo name.
+	/// <para>
+	/// <b>Deprecated.</b> Per-product repo is now resolved from <c>products.yml</c> via the
+	/// product's <c>repository:</c> field, making the bundle-level override redundant.
+	/// Remove from profile config; a mismatch with the running repository is a hard error.
+	/// </para>
 	/// </summary>
+	[Obsolete("Derived from products.yml repository field. Remove from profile config.")]
 	public string? Repo { get; init; }
 
 	/// <summary>
 	/// GitHub repository owner stored on each product in the bundle output.
-	/// Used for generating correct PR/issue links. Defaults to "elastic" when not specified.
+	/// <para><b>Deprecated.</b> Derived automatically alongside <c>repo</c>. Remove from profile config.</para>
 	/// </summary>
+	[Obsolete("Derived automatically. Remove from profile config.")]
 	public string? Owner { get; init; }
 
 	/// <summary>

--- a/src/Elastic.Documentation.Configuration/Inference/ProductInferService.cs
+++ b/src/Elastic.Documentation.Configuration/Inference/ProductInferService.cs
@@ -13,18 +13,20 @@ namespace Elastic.Documentation.Configuration.Inference;
 public class ProductInferService(ProductsConfiguration productsConfiguration, GitCheckoutInformation? gitCheckout = null)
 {
 	/// <summary>
-	/// Infers a product from repository name.
-	/// Priority 1: Direct product match by repository name (products.yml key).
-	/// Priority 2: Product by repository configuration (product.repository).
+	/// Returns all products that map to <paramref name="repositoryName"/>.
+	/// One repo can map to many products (e.g., <c>cloud</c> → three cloud products).
+	/// </summary>
+	public IReadOnlyList<Product> InferProductsFromRepository(string repositoryName) =>
+		productsConfiguration.GetProductsByRepositoryName(repositoryName);
+
+	/// <summary>
+	/// Returns the single product for <paramref name="repositoryName"/>, or <c>null</c>
+	/// when there is no match or more than one match.
 	/// </summary>
 	public Product? InferProductFromRepository(string repositoryName)
 	{
-		// Priority 1: Direct product match by repository name
-		if (productsConfiguration.Products.TryGetValue(repositoryName, out var directMatch))
-			return directMatch;
-
-		// Priority 2: Product by repository configuration
-		return productsConfiguration.GetProductByRepositoryName(repositoryName);
+		var matches = InferProductsFromRepository(repositoryName);
+		return matches.Count == 1 ? matches[0] : null;
 	}
 
 	/// <summary>

--- a/src/Elastic.Documentation.Configuration/Products/Product.cs
+++ b/src/Elastic.Documentation.Configuration/Products/Product.cs
@@ -33,16 +33,33 @@ public record ProductsConfiguration : IProductNameLookup
 	public FrozenDictionary<string, string>.AlternateLookup<ReadOnlySpan<char>> DisplayNameLookup =>
 		_displayNameLookup ??= ProductDisplayNames.GetAlternateLookup<ReadOnlySpan<char>>();
 
-	public Product? GetProductByRepositoryName(string repository)
+	/// <summary>
+	/// Returns every product that maps to <paramref name="repository"/>.
+	/// A product matches when its ID equals the repo name, or when its explicit
+	/// <c>repository:</c> field equals the repo name (case-insensitive).
+	/// One repo → many products is valid (e.g., <c>cloud</c> → cloud-hosted / cloud-serverless / cloud-enterprise).
+	/// </summary>
+	public IReadOnlyList<Product> GetProductsByRepositoryName(string repository)
 	{
 		var tokens = repository.Split('/');
 		var repositoryName = tokens.Last();
-		if (Products.TryGetValue(repositoryName, out var product))
-			return product;
-		var match = Products.Values.SingleOrDefault(
-			p => p.Repository is not null && p.Repository.Equals(repositoryName, StringComparison.OrdinalIgnoreCase)
-		);
-		return match;
+		if (Products.TryGetValue(repositoryName, out var direct))
+			return [direct];
+		return Products
+			.Values
+			.Where(p => p.Repository is not null && p.Repository.Equals(repositoryName, StringComparison.OrdinalIgnoreCase))
+			.ToList();
+	}
+
+	/// <summary>
+	/// Returns the single product that maps to <paramref name="repository"/>, or <c>null</c>
+	/// when there is no match or more than one match. Use <see cref="GetProductsByRepositoryName"/>
+	/// when a repo may host multiple products.
+	/// </summary>
+	public Product? GetProductByRepositoryName(string repository)
+	{
+		var matches = GetProductsByRepositoryName(repository);
+		return matches.Count == 1 ? matches[0] : null;
 	}
 
 	/// <summary>

--- a/src/services/Elastic.Changelog/Bundling/BundleOutputNaming.cs
+++ b/src/services/Elastic.Changelog/Bundling/BundleOutputNaming.cs
@@ -106,6 +106,45 @@ public static class BundleOutputNaming
 	}
 
 	/// <summary>
+	/// Validates <paramref name="bundleRepo"/> against the authoring repository derived from
+	/// <c>GITHUB_REPOSITORY</c> and the git remote. Emits nothing when <paramref name="bundleRepo"/>
+	/// is unset (the target state). Emits an informational hint when it matches, and a hard error when
+	/// it points at a different repository (which would silently repoint the S3 pool).
+	/// </summary>
+	public static void ValidateBundleRepo(IDiagnosticsCollector collector, IFileSystem fileSystem, string? configPath, string? bundleRepo)
+	{
+		if (string.IsNullOrWhiteSpace(bundleRepo))
+			return;
+
+		var normalizedBundleRepo = ChangelogRepoOwnerResolver.NormalizeRepo(bundleRepo);
+
+		// Derive the authoritative repo WITHOUT the bundle.repo value itself.
+		var githubRepository = Environment.GetEnvironmentVariable("GITHUB_REPOSITORY");
+		var trueRepo = ChangelogRepoOwnerResolver.NormalizeRepo(githubRepository) ?? TryGitOriginRepo(fileSystem, configPath);
+
+		if (string.IsNullOrWhiteSpace(trueRepo))
+			return; // can't validate without an authoritative source — skip silently
+
+		if (string.Equals(normalizedBundleRepo, trueRepo, StringComparison.OrdinalIgnoreCase))
+		{
+			collector.EmitWarning(
+				string.Empty,
+				$"bundle.repo '{bundleRepo}' is redundant — it matches the derived repository '{trueRepo}'. " +
+					"Remove it from changelog.yml; the repository is now derived automatically."
+			);
+		}
+		else
+		{
+			collector.EmitError(
+				string.Empty,
+				$"bundle.repo '{bundleRepo}' does not match the repository running this command ('{trueRepo}'). " +
+					"This would silently repoint the S3 upload pool and GitHub API calls to a different repository. " +
+					"Remove bundle.repo from changelog.yml to derive it automatically."
+			);
+		}
+	}
+
+	/// <summary>
 	/// Resolves the authoring repository for any changelog command. Precedence:
 	/// explicit value(s), <c>GITHUB_REPOSITORY</c> env var, git <c>origin</c>.
 	/// </summary>

--- a/src/services/Elastic.Changelog/Bundling/BundleOutputNaming.cs
+++ b/src/services/Elastic.Changelog/Bundling/BundleOutputNaming.cs
@@ -111,7 +111,13 @@ public static class BundleOutputNaming
 	/// is unset (the target state). Emits an informational hint when it matches, and a hard error when
 	/// it points at a different repository (which would silently repoint the S3 pool).
 	/// </summary>
-	public static void ValidateBundleRepo(IDiagnosticsCollector collector, IFileSystem fileSystem, string? configPath, string? bundleRepo)
+	public static void ValidateBundleRepo(
+		IDiagnosticsCollector collector,
+		IFileSystem fileSystem,
+		string? configPath,
+		string? bundleRepo,
+		IEnvironmentVariables? env = null
+	)
 	{
 		if (string.IsNullOrWhiteSpace(bundleRepo))
 			return;
@@ -119,7 +125,9 @@ public static class BundleOutputNaming
 		var normalizedBundleRepo = ChangelogRepoOwnerResolver.NormalizeRepo(bundleRepo);
 
 		// Derive the authoritative repo WITHOUT the bundle.repo value itself.
-		var githubRepository = Environment.GetEnvironmentVariable("GITHUB_REPOSITORY");
+		var githubRepository = env != null
+			? env.GetEnvironmentVariable("GITHUB_REPOSITORY")
+			: Environment.GetEnvironmentVariable("GITHUB_REPOSITORY");
 		var trueRepo = ChangelogRepoOwnerResolver.NormalizeRepo(githubRepository) ?? TryGitOriginRepo(fileSystem, configPath);
 
 		if (string.IsNullOrWhiteSpace(trueRepo))

--- a/src/services/Elastic.Changelog/Bundling/ChangelogBundleAmendService.cs
+++ b/src/services/Elastic.Changelog/Bundling/ChangelogBundleAmendService.cs
@@ -123,9 +123,11 @@ public class ChangelogBundleAmendService(
 
 			var parentBundle = parent.Bundle;
 			var useLocalChangelogs = (changelogConfig?.Bundle?.UseLocalChangelogs ?? false) || input.ForceLocal;
+#pragma warning disable CS0618
 			var authoringRepo = ChangelogRepoOwnerResolver.NormalizeRepo(
 				changelogConfig?.Bundle?.Repo ?? (parentBundle.Products.Count > 0 ? parentBundle.Products[0].Repo : null)
 			);
+#pragma warning restore CS0618
 			var useCdn = ChangelogEntrySourcing.ShouldSourceFromCdn(authoringRepo, useLocalChangelogs: useLocalChangelogs);
 
 			IReadOnlyDictionary<string, string>? cdnContents = null;
@@ -354,11 +356,13 @@ public class ChangelogBundleAmendService(
 	)
 	{
 		var parentOwner = request.ParentBundle.Products.Count > 0 ? request.ParentBundle.Products[0].Owner : null;
+#pragma warning disable CS0618
 		var owner = ChangelogRepoOwnerResolver.ResolveOwner(
 			request.ChangelogConfig?.Bundle?.Owner,
 			request.ChangelogConfig?.Bundle?.Repo,
 			parentOwner
 		)
+#pragma warning restore CS0618
 			?? ChangelogEntrySourcing.DefaultOwner;
 		var configuredBranch = request.ChangelogConfig?.Bundle?.Branch;
 		var branch = string.IsNullOrWhiteSpace(configuredBranch) ? ChangelogEntrySourcing.DefaultBranch : configuredBranch;

--- a/src/services/Elastic.Changelog/Bundling/ChangelogBundlingService.cs
+++ b/src/services/Elastic.Changelog/Bundling/ChangelogBundlingService.cs
@@ -690,6 +690,7 @@ public partial class ChangelogBundlingService(
 				var fileName = BundleOutputNaming.ResolveFileName(
 					collector,
 					_fileSystem,
+#pragma warning disable CS0618
 					new BundleOutputNameRequest(
 						primaryProduct,
 						filterResult.Version,
@@ -699,6 +700,7 @@ public partial class ChangelogBundlingService(
 						input.Config,
 						_env
 					)
+#pragma warning restore CS0618
 				);
 				outputPath = JoinProfileOutputPath(config, input, fileName);
 			}
@@ -729,8 +731,10 @@ public partial class ChangelogBundlingService(
 			}
 
 			// Profile-level repo/owner/branch takes precedence; fall back to bundle-level defaults
+#pragma warning disable CS0618
 			repo = profile.Repo ?? config.Bundle.Repo;
 			owner = profile.Owner ?? config.Bundle.Owner;
+#pragma warning restore CS0618
 			branch = profile.Branch ?? config.Bundle.Branch;
 			mergedHideFeatures = profile.HideFeatures?.Count > 0 ? [.. profile.HideFeatures] : null;
 			profileSuppressReleaseDate = !(profile.ReleaseDates ?? config.Bundle.ReleaseDates ?? true);
@@ -1033,8 +1037,10 @@ public partial class ChangelogBundlingService(
 		var output = input.Output;
 
 		// Apply repo/owner/branch: CLI takes precedence; fall back to bundle-level config defaults.
+#pragma warning disable CS0618
 		var repo = input.Repo ?? config.Bundle.Repo;
 		var owner = input.Owner ?? config.Bundle.Owner;
+#pragma warning restore CS0618
 		var branch = input.Branch ?? config.Bundle.Branch;
 
 		// Apply description: CLI takes precedence; fall back to bundle-level config default
@@ -1121,7 +1127,9 @@ public partial class ChangelogBundlingService(
 		// local sourcing, and a CDN base is configured.
 		var useLocalChangelogs = (config?.Bundle?.UseLocalChangelogs ?? false) || input.ForceLocal;
 		var explicitDirectory = !string.IsNullOrWhiteSpace(input.Directory);
+#pragma warning disable CS0618
 		var authoringRepo = ChangelogRepoOwnerResolver.NormalizeRepo(input.Repo ?? profileDef?.Repo ?? config?.Bundle?.Repo);
+#pragma warning restore CS0618
 		if (
 			ChangelogEntrySourcing.ShouldSourceFromCdn(
 				authoringRepo,
@@ -1154,6 +1162,7 @@ public partial class ChangelogBundlingService(
 			var fileName = BundleOutputNaming.ResolveFileName(
 				collector,
 				_fileSystem,
+#pragma warning disable CS0618
 				new BundleOutputNameRequest(
 					primaryProduct,
 					planVersion,
@@ -1163,6 +1172,7 @@ public partial class ChangelogBundlingService(
 					input.Config,
 					_env
 				)
+#pragma warning restore CS0618
 			);
 			outputPath = JoinProfileOutputPath(config, input, fileName);
 		}
@@ -1254,7 +1264,9 @@ public partial class ChangelogBundlingService(
 		var fileName = BundleOutputNaming.ResolveFileNameOrFallback(
 			collector,
 			_fileSystem,
+#pragma warning disable CS0618
 			new BundleOutputNameRequest(product, version, input.Repo, null, config?.Bundle?.Repo, input.Config, _env)
+#pragma warning restore CS0618
 		);
 		return _fileSystem.Path.Join(outputDir, fileName).OptionalWindowsReplace();
 	}

--- a/src/services/Elastic.Changelog/Bundling/ChangelogRemoveService.cs
+++ b/src/services/Elastic.Changelog/Bundling/ChangelogRemoveService.cs
@@ -235,8 +235,10 @@ public class ChangelogRemoveService(
 		var directory = input.Directory ?? config?.Bundle?.Directory ?? _fileSystem.Directory.GetCurrentDirectory();
 
 		// Apply repo/owner: CLI takes precedence; fall back to bundle-level config defaults.
+#pragma warning disable CS0618
 		var repo = input.Repo ?? config?.Bundle?.Repo;
 		var owner = input.Owner ?? config?.Bundle?.Owner;
+#pragma warning restore CS0618
 
 		return input with { Directory = directory, Repo = repo, Owner = owner };
 	}

--- a/src/services/Elastic.Changelog/Bundling/ProfileFilterResolver.cs
+++ b/src/services/Elastic.Changelog/Bundling/ProfileFilterResolver.cs
@@ -482,8 +482,10 @@ public static partial class ProfileFilterResolver
 		}
 
 		// Resolve repo and owner: profile-level overrides bundle-level defaults
+#pragma warning disable CS0618
 		var repo = profile.Repo ?? config?.Bundle?.Repo;
 		var owner = profile.Owner ?? config?.Bundle?.Owner ?? "elastic";
+#pragma warning restore CS0618
 
 		if (string.IsNullOrWhiteSpace(repo))
 		{

--- a/src/services/Elastic.Changelog/Creation/ChangelogCreationService.cs
+++ b/src/services/Elastic.Changelog/Creation/ChangelogCreationService.cs
@@ -244,14 +244,40 @@ public class ChangelogCreationService(
 		}
 
 		// Second, try inference from the --repo argument (or bundle.repo from config)
-		var product = repoName != null ? _productInferService.InferProductFromRepository(repoName) : null;
-		if (product == null)
+		if (repoName == null)
 		{
-			_logger.LogDebug("Could not infer product from repository");
+			_logger.LogDebug("Could not infer product: no repo name available");
 			return null;
 		}
 
-		_logger.LogInformation("Inferred product '{ProductId}' from repository", product.Id);
+		var candidates = _productInferService.InferProductsFromRepository(repoName);
+		if (candidates.Count == 0)
+		{
+			_logger.LogDebug("Could not infer product from repository '{Repo}'", repoName);
+			return null;
+		}
+
+		// When the repo maps to multiple products (e.g., elastic/cloud → cloud-hosted/cloud-serverless/cloud-enterprise),
+		// intersect with products.available to narrow to one. If still ambiguous, don't infer — ask the user.
+		if (candidates.Count > 1 && productsConfig?.Available is { Count: > 0 })
+		{
+			var available = productsConfig.Available.ToHashSet(StringComparer.OrdinalIgnoreCase);
+			candidates = candidates.Where(p => available.Contains(p.Id)).ToList();
+		}
+
+		if (candidates.Count != 1)
+		{
+			_logger.LogDebug(
+				"Ambiguous product inference for '{Repo}': {Count} candidates ({Ids}) — specify --products explicitly",
+				repoName,
+				candidates.Count,
+				string.Join(", ", candidates.Select(p => p.Id))
+			);
+			return null;
+		}
+
+		var product = candidates[0];
+		_logger.LogInformation("Inferred product '{ProductId}' from repository '{Repo}'", product.Id, repoName);
 		return [new ProductArgument { Product = product.Id, Lifecycle = "ga" }];
 	}
 

--- a/src/services/Elastic.Changelog/GithubRelease/GitHubReleaseChangelogService.cs
+++ b/src/services/Elastic.Changelog/GithubRelease/GitHubReleaseChangelogService.cs
@@ -120,20 +120,27 @@ public class GitHubReleaseChangelogService(
 
 			_logger.LogInformation("Processing GitHub release from {Owner}/{Repo}", owner, repo);
 
-			// 2. Resolve product from repo name via products.yml
-			var product = configurationContext.ProductsConfiguration.GetProductByRepositoryName(repo);
-			if (product == null)
+			// 2. Resolve product(s) from repo name via products.yml
+			var products = configurationContext.ProductsConfiguration.GetProductsByRepositoryName(repo);
+			if (products.Count == 0)
 			{
 				collector.EmitError(
 					string.Empty,
-					$"Could not find product for repository '{repo}' in products.yml. " +
+					$"Could not find a product for repository '{repo}' in products.yml. " +
 						$"Add a product to config/products.yml whose ID is '{repo}', " +
 						$"or set 'repository: {repo}' on one or more existing products."
 				);
 				return false;
 			}
 
-			_logger.LogInformation("Resolved product: {ProductId} ({ProductDisplay})", product.Id, product.DisplayName);
+			// Use the first product for versioning context; multiple products (e.g., cloud) share the same versioning system.
+			var product = products[0];
+			_logger.LogInformation(
+				"Resolved {Count} product(s) for '{Repo}': {Products}",
+				products.Count,
+				repo,
+				string.Join(", ", products.Select(p => p.Id))
+			);
 
 			// 3. Load changelog configuration
 			var config = await _configLoader.LoadChangelogConfiguration(collector, input.Config, ctx);
@@ -283,7 +290,9 @@ public class GitHubReleaseChangelogService(
 		if (ChangelogCdn.ResolveBaseUri() is not { } baseUri)
 			return [];
 
+#pragma warning disable CS0618
 		var poolOwner = config.Bundle?.Owner ?? owner;
+#pragma warning restore CS0618
 		var poolBranch = config.Bundle?.Branch ?? "main";
 		var entries = await _entryFetcher.FetchAsync(
 			baseUri,

--- a/src/tooling/docs-builder/Commands/ChangelogCommand.cs
+++ b/src/tooling/docs-builder/Commands/ChangelogCommand.cs
@@ -341,8 +341,11 @@ internal sealed partial class ChangelogCommands(
 			config?.FullName,
 			ctx
 		);
+#pragma warning disable CS0618
+		BundleOutputNaming.ValidateBundleRepo(collector, _fileSystem, config?.FullName, bundleConfig?.Bundle?.Repo);
 		var resolvedRepo = !string.IsNullOrWhiteSpace(repo) ? repo : bundleConfig?.Bundle?.Repo;
 		var resolvedOwner = owner ?? bundleConfig?.Bundle?.Owner ?? "elastic";
+#pragma warning restore CS0618
 		var resolvedOutput = !string.IsNullOrWhiteSpace(output) ? output : bundleConfig?.Bundle?.Directory;
 
 		// Resolve stripTitlePrefix: CLI flag true → explicit true; otherwise null (use config default)
@@ -619,8 +622,11 @@ internal sealed partial class ChangelogCommands(
 			config?.FullName,
 			ctx
 		);
+#pragma warning disable CS0618
+		BundleOutputNaming.ValidateBundleRepo(collector, _fileSystem, config?.FullName, bundleConfig?.Bundle?.Repo);
 		var resolvedRepo = !string.IsNullOrWhiteSpace(repo) ? repo : bundleConfig?.Bundle?.Repo;
 		var resolvedOwner = owner ?? bundleConfig?.Bundle?.Owner ?? "elastic";
+#pragma warning restore CS0618
 		var resolvedOutput = !string.IsNullOrWhiteSpace(output) ? output : bundleConfig?.Bundle?.Directory;
 		var stripTitlePrefixResolved = stripTitlePrefix ? true : (bool?)null;
 		var extractReleaseNotes = noExtractReleaseNotes ? false : (bool?)null;
@@ -860,8 +866,11 @@ internal sealed partial class ChangelogCommands(
 					configurationContext,
 					_fileSystem
 				).LoadChangelogConfiguration(collector, config?.FullName, ctx);
+#pragma warning disable CS0618
+				BundleOutputNaming.ValidateBundleRepo(collector, _fileSystem, config?.FullName, bundleConfig?.Bundle?.Repo);
 				var resolvedRepo = !string.IsNullOrWhiteSpace(repo) ? repo : bundleConfig?.Bundle?.Repo;
 				var resolvedOwner = owner ?? bundleConfig?.Bundle?.Owner ?? "elastic";
+#pragma warning restore CS0618
 
 				if (string.IsNullOrWhiteSpace(resolvedRepo))
 				{
@@ -1303,8 +1312,11 @@ internal sealed partial class ChangelogCommands(
 				configurationContext,
 				_fileSystem
 			).LoadChangelogConfiguration(collector, config?.FullName, ctx);
+#pragma warning disable CS0618
+			BundleOutputNaming.ValidateBundleRepo(collector, _fileSystem, config?.FullName, bundleConfig?.Bundle?.Repo);
 			var resolvedRepo = !string.IsNullOrWhiteSpace(repo) ? repo : bundleConfig?.Bundle?.Repo;
 			var resolvedOwner = owner ?? bundleConfig?.Bundle?.Owner ?? "elastic";
+#pragma warning restore CS0618
 
 			if (string.IsNullOrWhiteSpace(resolvedRepo))
 			{
@@ -1597,8 +1609,15 @@ internal sealed partial class ChangelogCommands(
 			? output
 			: (bundleConfig?.Bundle?.OutputDirectory ?? bundleConfig?.Bundle?.Directory);
 
+		// Validate bundle.repo if set — mismatch with running repo is a hard error.
+#pragma warning disable CS0618
+		BundleOutputNaming.ValidateBundleRepo(collector, _fileSystem, config?.FullName, bundleConfig?.Bundle?.Repo);
+#pragma warning restore CS0618
+
 		// Repo precedence: positional arg > bundle.repo > GITHUB_REPOSITORY env var > git remote origin
+#pragma warning disable CS0618
 		var resolvedRepo = BundleOutputNaming.ResolveRepo(_fileSystem, config?.FullName, repo, bundleConfig?.Bundle?.Repo);
+#pragma warning restore CS0618
 		if (string.IsNullOrWhiteSpace(resolvedRepo))
 		{
 			collector.EmitError(
@@ -2433,9 +2452,11 @@ internal sealed partial class ChangelogCommands(
 		if (GitRemoteConfigurationReader.TryReadOriginUrl(_fileSystem, repoRoot, out var originUrl))
 			_ = GitHubRemoteParser.TryParseGitHubComOwnerRepo(originUrl, out gitOwner, out gitRepo);
 
+#pragma warning disable CS0618
 		var explicitRepo = !string.IsNullOrWhiteSpace(repoCli) ? repoCli : bundleConfig?.Bundle?.Repo;
 		var resolvedRepo = explicitRepo ?? gitRepo;
 		var resolvedOwner = ChangelogRepoOwnerResolver.ResolveOwner(ownerCli ?? bundleConfig?.Bundle?.Owner, explicitRepo, gitOwner);
+#pragma warning restore CS0618
 
 		// The producer branch is the branch being published: --branch, else the current checkout's branch.
 		// bundle.branch is intentionally not consulted here — it selects which pool to read when bundling.

--- a/tests/Elastic.Changelog.Tests/Bundling/ValidateBundleRepoTests.cs
+++ b/tests/Elastic.Changelog.Tests/Bundling/ValidateBundleRepoTests.cs
@@ -5,6 +5,7 @@
 using System.IO.Abstractions.TestingHelpers;
 using AwesomeAssertions;
 using Elastic.Changelog.Bundling;
+using Elastic.Documentation;
 using Elastic.Documentation.Diagnostics;
 
 namespace Elastic.Changelog.Tests.Bundling;
@@ -17,7 +18,7 @@ public class ValidateBundleRepoTests(ITestOutputHelper output)
 	[Fact]
 	public void ValidateBundleRepo_UnsetBundleRepo_EmitsNothing()
 	{
-		BundleOutputNaming.ValidateBundleRepo(_collector, _fileSystem, null, null);
+		BundleOutputNaming.ValidateBundleRepo(_collector, _fileSystem, null, null, EmptyEnvironment);
 
 		_collector.Errors.Should().Be(0);
 		_collector.Diagnostics.Should().BeEmpty();
@@ -26,7 +27,7 @@ public class ValidateBundleRepoTests(ITestOutputHelper output)
 	[Fact]
 	public void ValidateBundleRepo_EmptyBundleRepo_EmitsNothing()
 	{
-		BundleOutputNaming.ValidateBundleRepo(_collector, _fileSystem, null, string.Empty);
+		BundleOutputNaming.ValidateBundleRepo(_collector, _fileSystem, null, string.Empty, EmptyEnvironment);
 
 		_collector.Errors.Should().Be(0);
 		_collector.Diagnostics.Should().BeEmpty();
@@ -36,7 +37,7 @@ public class ValidateBundleRepoTests(ITestOutputHelper output)
 	public void ValidateBundleRepo_SetButNoAuthoritativeSource_EmitsNothing()
 	{
 		// No GITHUB_REPOSITORY env var, no git remote — cannot validate, so silently skip.
-		BundleOutputNaming.ValidateBundleRepo(_collector, _fileSystem, null, "docs-builder");
+		BundleOutputNaming.ValidateBundleRepo(_collector, _fileSystem, null, "docs-builder", EmptyEnvironment);
 
 		_collector.Errors.Should().Be(0);
 		_collector.Diagnostics.Should().BeEmpty();
@@ -45,36 +46,31 @@ public class ValidateBundleRepoTests(ITestOutputHelper output)
 	[Fact]
 	public void ValidateBundleRepo_MatchesGithubRepository_EmitsWarning()
 	{
-		Environment.SetEnvironmentVariable("GITHUB_REPOSITORY", "elastic/docs-builder");
-		try
-		{
-			BundleOutputNaming.ValidateBundleRepo(_collector, _fileSystem, null, "docs-builder");
+		BundleOutputNaming.ValidateBundleRepo(_collector, _fileSystem, null, "docs-builder", RepoEnvironment("elastic/docs-builder"));
 
-			_collector.Errors.Should().Be(0);
-			var warnings = _collector.Diagnostics.Where(d => d.Severity == Severity.Warning).ToList();
-			warnings.Should().HaveCount(1);
-			warnings[0].Message.Should().Contain("redundant");
-		}
-		finally
-		{
-			Environment.SetEnvironmentVariable("GITHUB_REPOSITORY", null);
-		}
+		_collector.Errors.Should().Be(0);
+		var warnings = _collector.Diagnostics.Where(d => d.Severity == Severity.Warning).ToList();
+		warnings.Should().HaveCount(1);
+		warnings[0].Message.Should().Contain("redundant");
 	}
 
 	[Fact]
 	public void ValidateBundleRepo_DiffersFromGithubRepository_EmitsError()
 	{
-		Environment.SetEnvironmentVariable("GITHUB_REPOSITORY", "elastic/docs-builder");
-		try
-		{
-			BundleOutputNaming.ValidateBundleRepo(_collector, _fileSystem, null, "kibana");
+		BundleOutputNaming.ValidateBundleRepo(_collector, _fileSystem, null, "kibana", RepoEnvironment("elastic/docs-builder"));
 
-			_collector.Errors.Should().Be(1);
-			_collector.Diagnostics.First(d => d.Severity == Severity.Error).Message.Should().Contain("docs-builder").And.Contain("kibana");
-		}
-		finally
-		{
-			Environment.SetEnvironmentVariable("GITHUB_REPOSITORY", null);
-		}
+		_collector.Errors.Should().Be(1);
+		_collector.Diagnostics.First(d => d.Severity == Severity.Error).Message.Should().Contain("docs-builder").And.Contain("kibana");
+	}
+
+	private static IEnvironmentVariables EmptyEnvironment { get; } = new MockEnvironmentVariables(null);
+
+	private static IEnvironmentVariables RepoEnvironment(string githubRepository) => new MockEnvironmentVariables(githubRepository);
+
+	private sealed class MockEnvironmentVariables(string? githubRepository) : IEnvironmentVariables
+	{
+		public string? GetEnvironmentVariable(string name) => name == "GITHUB_REPOSITORY" ? githubRepository : null;
+
+		public bool IsRunningOnCI => false;
 	}
 }

--- a/tests/Elastic.Changelog.Tests/Bundling/ValidateBundleRepoTests.cs
+++ b/tests/Elastic.Changelog.Tests/Bundling/ValidateBundleRepoTests.cs
@@ -1,0 +1,80 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions.TestingHelpers;
+using AwesomeAssertions;
+using Elastic.Changelog.Bundling;
+using Elastic.Documentation.Diagnostics;
+
+namespace Elastic.Changelog.Tests.Bundling;
+
+public class ValidateBundleRepoTests(ITestOutputHelper output)
+{
+	private readonly TestDiagnosticsCollector _collector = new(output);
+	private readonly MockFileSystem _fileSystem = new();
+
+	[Fact]
+	public void ValidateBundleRepo_UnsetBundleRepo_EmitsNothing()
+	{
+		BundleOutputNaming.ValidateBundleRepo(_collector, _fileSystem, null, null);
+
+		_collector.Errors.Should().Be(0);
+		_collector.Diagnostics.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void ValidateBundleRepo_EmptyBundleRepo_EmitsNothing()
+	{
+		BundleOutputNaming.ValidateBundleRepo(_collector, _fileSystem, null, string.Empty);
+
+		_collector.Errors.Should().Be(0);
+		_collector.Diagnostics.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void ValidateBundleRepo_SetButNoAuthoritativeSource_EmitsNothing()
+	{
+		// No GITHUB_REPOSITORY env var, no git remote — cannot validate, so silently skip.
+		BundleOutputNaming.ValidateBundleRepo(_collector, _fileSystem, null, "docs-builder");
+
+		_collector.Errors.Should().Be(0);
+		_collector.Diagnostics.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void ValidateBundleRepo_MatchesGithubRepository_EmitsWarning()
+	{
+		Environment.SetEnvironmentVariable("GITHUB_REPOSITORY", "elastic/docs-builder");
+		try
+		{
+			BundleOutputNaming.ValidateBundleRepo(_collector, _fileSystem, null, "docs-builder");
+
+			_collector.Errors.Should().Be(0);
+			var warnings = _collector.Diagnostics.Where(d => d.Severity == Severity.Warning).ToList();
+			warnings.Should().HaveCount(1);
+			warnings[0].Message.Should().Contain("redundant");
+		}
+		finally
+		{
+			Environment.SetEnvironmentVariable("GITHUB_REPOSITORY", null);
+		}
+	}
+
+	[Fact]
+	public void ValidateBundleRepo_DiffersFromGithubRepository_EmitsError()
+	{
+		Environment.SetEnvironmentVariable("GITHUB_REPOSITORY", "elastic/docs-builder");
+		try
+		{
+			BundleOutputNaming.ValidateBundleRepo(_collector, _fileSystem, null, "kibana");
+
+			_collector.Errors.Should().Be(1);
+			_collector.Diagnostics.First(d => d.Severity == Severity.Error).Message.Should().Contain("docs-builder").And.Contain("kibana");
+		}
+		finally
+		{
+			Environment.SetEnvironmentVariable("GITHUB_REPOSITORY", null);
+		}
+	}
+}

--- a/tests/Elastic.Documentation.Configuration.Tests/ProductsConfigurationTests.cs
+++ b/tests/Elastic.Documentation.Configuration.Tests/ProductsConfigurationTests.cs
@@ -1,0 +1,199 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using AwesomeAssertions;
+using Elastic.Documentation.Configuration.Products;
+using Elastic.Documentation.Configuration.Versions;
+using Elastic.Documentation.FileSystems;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Elastic.Documentation.Configuration.Tests;
+
+public class ProductsConfigurationTests
+{
+	[Fact]
+	public void GetProductsByRepositoryName_ProductIdMatch_ReturnsSingleElement()
+	{
+		var config = ParseProducts(
+			"""
+			products:
+			  elasticsearch:
+			    display: Elasticsearch
+			    versioning: stack
+			"""
+		);
+
+		var results = config.GetProductsByRepositoryName("elasticsearch");
+
+		results.Should().HaveCount(1);
+		results[0].Id.Should().Be("elasticsearch");
+	}
+
+	[Fact]
+	public void GetProductsByRepositoryName_OwnerRepoForm_UsesLastSegment()
+	{
+		var config = ParseProducts(
+			"""
+			products:
+			  elasticsearch:
+			    display: Elasticsearch
+			    versioning: stack
+			"""
+		);
+
+		var results = config.GetProductsByRepositoryName("elastic/elasticsearch");
+
+		results.Should().HaveCount(1);
+		results[0].Id.Should().Be("elasticsearch");
+	}
+
+	[Fact]
+	public void GetProductsByRepositoryName_ThreeProductsSharingRepository_ReturnsAllThree()
+	{
+		var config = ParseProducts(
+			"""
+			products:
+			  cloud-hosted:
+			    display: Cloud Hosted
+			    repository: 'cloud'
+			    features:
+			      public-reference: false
+			  cloud-serverless:
+			    display: Cloud Serverless
+			    repository: 'cloud'
+			    features:
+			      public-reference: false
+			  cloud-enterprise:
+			    display: Cloud Enterprise
+			    repository: 'cloud'
+			    features:
+			      public-reference: false
+			"""
+		);
+
+		var results = config.GetProductsByRepositoryName("cloud");
+
+		results.Should().HaveCount(3);
+		results.Select(p => p.Id).Should().Contain(["cloud-hosted", "cloud-serverless", "cloud-enterprise"]);
+	}
+
+	[Fact]
+	public void GetProductsByRepositoryName_BlankRepository_ReturnsEmpty()
+	{
+		var config = ParseProducts(
+			"""
+			products:
+			  elasticsearch:
+			    display: Elasticsearch
+			    versioning: stack
+			"""
+		);
+
+		var results = config.GetProductsByRepositoryName(string.Empty);
+
+		results.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void GetProductsByRepositoryName_UnknownRepository_ReturnsEmpty()
+	{
+		var config = ParseProducts(
+			"""
+			products:
+			  elasticsearch:
+			    display: Elasticsearch
+			    versioning: stack
+			"""
+		);
+
+		var results = config.GetProductsByRepositoryName("nonexistent");
+
+		results.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void GetProductByRepositoryName_SingleMatch_ReturnsProduct()
+	{
+		var config = ParseProducts(
+			"""
+			products:
+			  elasticsearch:
+			    display: Elasticsearch
+			    versioning: stack
+			"""
+		);
+
+		var product = config.GetProductByRepositoryName("elasticsearch");
+
+		product.Should().NotBeNull();
+		product!.Id.Should().Be("elasticsearch");
+	}
+
+	[Fact]
+	public void GetProductByRepositoryName_MultipleMatches_ReturnsNull()
+	{
+		var config = ParseProducts(
+			"""
+			products:
+			  cloud-hosted:
+			    display: Cloud Hosted
+			    repository: 'cloud'
+			    features:
+			      public-reference: false
+			  cloud-serverless:
+			    display: Cloud Serverless
+			    repository: 'cloud'
+			    features:
+			      public-reference: false
+			"""
+		);
+
+		var product = config.GetProductByRepositoryName("cloud");
+
+		product.Should().BeNull();
+	}
+
+	[Fact]
+	public void GetProductByRepositoryName_NoMatch_ReturnsNull()
+	{
+		var config = ParseProducts(
+			"""
+			products:
+			  elasticsearch:
+			    display: Elasticsearch
+			    versioning: stack
+			"""
+		);
+
+		var product = config.GetProductByRepositoryName("nonexistent");
+
+		product.Should().BeNull();
+	}
+
+	[Fact]
+	public void GetProductsByRepositoryName_ActualCloudProducts_ReturnsThreeProducts()
+	{
+		var config = LoadActualProductsConfiguration();
+
+		var results = config.GetProductsByRepositoryName("cloud");
+
+		results.Should().HaveCount(3, "elastic/cloud hosts cloud-hosted, cloud-serverless, and cloud-enterprise");
+		results.Select(p => p.Id).Should().Contain(["cloud-hosted", "cloud-serverless", "cloud-enterprise"]);
+	}
+
+	private static ProductsConfiguration ParseProducts(string yaml)
+	{
+		var provider = new ConfigurationFileProvider(new NullLoggerFactory(), new ConfigurationFileSystem());
+		var versionsConfig = provider.CreateVersionConfiguration();
+		using var reader = new StringReader(yaml);
+		return ProductExtensions.CreateProducts(reader, versionsConfig);
+	}
+
+	private static ProductsConfiguration LoadActualProductsConfiguration()
+	{
+		var provider = new ConfigurationFileProvider(new NullLoggerFactory(), new ConfigurationFileSystem());
+		var versionsConfig = provider.CreateVersionConfiguration();
+		return provider.CreateProducts(versionsConfig);
+	}
+}


### PR DESCRIPTION
`elastic/cloud` hosts three products under one repo name. `GetProductByRepositoryName` used `SingleOrDefault`, which throws when multiple products share the same `repository:` field. This adds a plural lookup, makes the three cloud products resolvable for the first time, and marks `bundle.repo`/`bundle.owner` as deprecated with mismatch detection.

**Affects:** Release notes, Configuration

**Prompt summary:** Part of a multi-PR plan to fix `changelog gh-release` failing with an empty repo and to model the one-repo-to-many-products relationship that `elastic/cloud` requires. This PR covers the product lookup model and the deprecation guard for `bundle.repo`/`bundle.owner`.

## Why

`GetProductByRepositoryName` called `SingleOrDefault`, so adding `repository: 'cloud'` to more than one product would throw an unhandled `InvalidOperationException`. `elastic/cloud` hosts `cloud-hosted`, `cloud-serverless`, and `cloud-enterprise`, so the lookup could never return a useful result. `bundle.repo` and `bundle.owner` are set redundantly in every one of 12 org-wide consumers — they match the repo the command already runs in — but a mismatch silently repoints the S3 upload pool to the wrong repository with no error.

## What

#### Plural product lookup

`ProductsConfiguration.GetProductsByRepositoryName` replaces the `SingleOrDefault` scan with a `Where` that returns every product whose `repository:` field matches case-insensitively. The existing `GetProductByRepositoryName` wrapper returns the single match or `null` when the count is not 1, so call sites that genuinely want one product are unchanged.

#### `repository: 'cloud'` in `products.yml`

All three cloud products (`cloud-hosted`, `cloud-serverless`, `cloud-enterprise`) now carry `repository: 'cloud'`. `elastic/cloud` resolves for the first time: `GetProductsByRepositoryName("cloud")` returns all three rather than throwing.

#### Bundle.repo/owner deprecation and mismatch guard

`BundleConfiguration.Repo/Owner` and `BundleProfile.Repo/Owner` are marked `[Obsolete]`. `BundleOutputNaming.ValidateBundleRepo` is a new method that emits a warning when `bundle.repo` matches the derived repo (redundant, safe to remove) and a hard error when it differs (would silently repoint S3). Every changelog command that loads `bundleConfig` now calls it before reading those fields.

#### Ambiguity-aware product inference

`ChangelogCreationService.InferProducts` calls the new `InferProductsFromRepository` (plural). When multiple candidates match, it narrows by `products.available` from `changelog.yml`; if still ambiguous, it returns nothing rather than throwing. `elastic/cloud`'s three products with its `available:` list narrows cleanly to the right one for a given entry.

#### `GitHubReleaseChangelogService` plural lookup

The gh-release path switches from `GetProductByRepositoryName` to `GetProductsByRepositoryName`. The first product in the list provides the versioning context; an empty result is now a clear error naming the missing `products.yml` entry.

## Verify

```bash
dotnet test tests/Elastic.Documentation.Configuration.Tests/
# GetProductsByRepositoryName_ActualCloudProducts_ReturnsThreeProducts
# GetProductsByRepositoryName_ThreeProductsSharingRepository_ReturnsAllThree

dotnet test tests/Elastic.Changelog.Tests/
# ValidateBundleRepo_DiffersFromGithubRepository_EmitsError
# ValidateBundleRepo_MatchesGithubRepository_EmitsWarning
```

**Stack:** 2 of 5, on top of [#4021](https://github.com/elastic/docs-builder/pull/4021).