### PR TITLE
Resolve bundle product repo from products.yml per product

### DIFF
--- a/src/services/Elastic.Changelog/Bundling/BundleBuilder.cs
+++ b/src/services/Elastic.Changelog/Bundling/BundleBuilder.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using Elastic.Documentation;
+using Elastic.Documentation.Configuration.Products;
 using Elastic.Documentation.Diagnostics;
 using Elastic.Documentation.ReleaseNotes;
 
@@ -20,20 +21,22 @@ public class BundleBuilder
 	/// <param name="collector">The diagnostics collector.</param>
 	/// <param name="entries">Matched changelog files to bundle.</param>
 	/// <param name="outputProducts">Optional explicit products to set in the output.</param>
-	/// <param name="repo">Optional GitHub repository name to set on products for link generation.</param>
-	/// <param name="owner">Optional GitHub owner to set on products for link generation.</param>
+	/// <param name="repo">Fallback GitHub repository name when a product cannot be resolved from <paramref name="productsConfiguration"/>.</param>
+	/// <param name="owner">GitHub owner for link generation.</param>
 	/// <param name="hideFeatures">Optional feature IDs to mark as hidden in the bundle.</param>
+	/// <param name="productsConfiguration">Optional product catalogue used to resolve per-product repository names.</param>
 	public BundleBuildResult BuildBundle(
 		IDiagnosticsCollector collector,
 		IReadOnlyList<MatchedChangelogFile> entries,
 		IReadOnlyList<ProductArgument>? outputProducts,
 		string? repo = null,
 		string? owner = null,
-		HashSet<string>? hideFeatures = null
+		HashSet<string>? hideFeatures = null,
+		ProductsConfiguration? productsConfiguration = null
 	)
 	{
 		// Build products list
-		var bundledProducts = BuildProducts(collector, entries, outputProducts, repo, owner);
+		var bundledProducts = BuildProducts(collector, entries, outputProducts, repo, owner, productsConfiguration);
 
 		// Build entries list
 		var bundledEntries = BuildResolvedEntries(collector, entries);
@@ -58,7 +61,8 @@ public class BundleBuilder
 		IReadOnlyList<MatchedChangelogFile> entries,
 		IReadOnlyList<ProductArgument>? outputProducts,
 		string? repo,
-		string? owner
+		string? owner,
+		ProductsConfiguration? productsConfiguration
 	)
 	{
 		List<BundledProduct> bundledProducts;
@@ -75,7 +79,7 @@ public class BundleBuilder
 						ProductId = p.Product ?? "",
 						Target = p.Target == "*" ? null : p.Target,
 						Lifecycle = ParseLifecycle(p.Lifecycle == "*" ? null : p.Lifecycle),
-						Repo = repo,
+						Repo = ResolveProductRepo(p.Product, productsConfiguration, repo),
 						Owner = owner
 					}
 				)
@@ -108,7 +112,7 @@ public class BundleBuilder
 						pv.product,
 						string.IsNullOrWhiteSpace(pv.version) ? null : pv.version,
 						pv.lifecycle,
-						repo,
+						ResolveProductRepo(pv.product, productsConfiguration, repo),
 						owner
 					)
 				)
@@ -139,6 +143,25 @@ public class BundleBuilder
 		}
 
 		return bundledProducts;
+	}
+
+	/// <summary>
+	/// Resolves the GitHub repository name for a product. Looks up the product in
+	/// <paramref name="productsConfiguration"/> and returns its <c>Repository</c> field
+	/// (which is already defaulted to the product ID when not explicitly set). Falls back
+	/// to <paramref name="bundleRepo"/> when the product is not found in the catalogue.
+	/// </summary>
+	private static string? ResolveProductRepo(string? productId, ProductsConfiguration? productsConfiguration, string? bundleRepo)
+	{
+		if (string.IsNullOrWhiteSpace(productId) || productsConfiguration == null)
+			return bundleRepo;
+
+		// product.Repository is the authoritative per-product repo when explicitly set in products.yml.
+		// When null (product created without an explicit repository: field), fall back to the bundle-level value.
+		if (productsConfiguration.Products.TryGetValue(productId, out var product))
+			return product.Repository ?? bundleRepo;
+
+		return bundleRepo;
 	}
 
 	private static Lifecycle? ParseLifecycle(string? value)

--- a/src/services/Elastic.Changelog/Bundling/ChangelogBundlingService.cs
+++ b/src/services/Elastic.Changelog/Bundling/ChangelogBundlingService.cs
@@ -1164,7 +1164,7 @@ public partial class ChangelogBundlingService(
 				collector,
 				_fileSystem,
 #pragma warning disable CS0618
-			new BundleOutputNameRequest(
+				new BundleOutputNameRequest(
 					primaryProduct,
 					planVersion,
 					input.Repo,

--- a/src/services/Elastic.Changelog/Bundling/ChangelogBundlingService.cs
+++ b/src/services/Elastic.Changelog/Bundling/ChangelogBundlingService.cs
@@ -533,7 +533,8 @@ public partial class ChangelogBundlingService(
 			input.OutputProducts,
 			input.Repo,
 			input.Owner,
-			featureHidingResult.FeatureIdsToHide
+			featureHidingResult.FeatureIdsToHide,
+			configurationContext?.ProductsConfiguration
 		);
 
 		if (!buildResult.IsValid || buildResult.Data == null)

--- a/src/services/Elastic.Changelog/Bundling/ChangelogBundlingService.cs
+++ b/src/services/Elastic.Changelog/Bundling/ChangelogBundlingService.cs
@@ -1163,7 +1163,7 @@ public partial class ChangelogBundlingService(
 				collector,
 				_fileSystem,
 #pragma warning disable CS0618
-				new BundleOutputNameRequest(
+			new BundleOutputNameRequest(
 					primaryProduct,
 					planVersion,
 					input.Repo,

--- a/tests/Elastic.Changelog.Tests/Bundling/BundleBuilderPerProductRepoTests.cs
+++ b/tests/Elastic.Changelog.Tests/Bundling/BundleBuilderPerProductRepoTests.cs
@@ -1,0 +1,139 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Collections.Frozen;
+using AwesomeAssertions;
+using Elastic.Changelog.Bundling;
+using Elastic.Documentation.Configuration.Products;
+using Elastic.Documentation.Configuration.Versions;
+using Elastic.Documentation.ReleaseNotes;
+
+namespace Elastic.Changelog.Tests.Bundling;
+
+public class BundleBuilderPerProductRepoTests(ITestOutputHelper output)
+{
+	private readonly TestDiagnosticsCollector _collector = new(output);
+	private readonly BundleBuilder _builder = new();
+
+	private static MatchedChangelogFile MakeEntry(string productId, string version = "9.0.0") =>
+		new()
+		{
+			FilePath = $"{productId}.yaml",
+			FileName = $"{productId}.yaml",
+			Checksum = "abc",
+			Data = new ChangelogEntry
+			{
+				Title = "Test change",
+				Type = ChangelogEntryType.Feature,
+				Products = [new ProductReference { ProductId = productId, Versions = [version], Lifecycle = Lifecycle.Ga }]
+			}
+		};
+
+	private static ProductsConfiguration MakeProducts(params (string id, string? repository)[] products)
+	{
+		var dict = products.ToDictionary(p => p.id, p => new Product { Id = p.id, DisplayName = p.id, Repository = p.repository ?? p.id });
+		return new ProductsConfiguration
+		{
+			Products = dict.ToFrozenDictionary(),
+			PublicReferenceProducts = FrozenDictionary<string, Product>.Empty,
+			ProductDisplayNames = dict.ToDictionary(kv => kv.Key, kv => kv.Value.DisplayName).ToFrozenDictionary()
+		};
+	}
+
+	[Fact]
+	public void BuildBundle_WithProductsConfiguration_UsesPerProductRepo()
+	{
+		var entries = new[] { MakeEntry("cloud-hosted"), MakeEntry("cloud-serverless") };
+		var productsConfig = MakeProducts(("cloud-hosted", "cloud"), ("cloud-serverless", "cloud"));
+
+		var result = _builder.BuildBundle(
+			_collector,
+			entries,
+			outputProducts: null,
+			repo: "bundle-level-repo",
+			owner: "elastic",
+			productsConfiguration: productsConfig
+		);
+
+		result.IsValid.Should().BeTrue();
+		var products = result.Data!.Products;
+		products.Should().HaveCount(2);
+		products.All(p => p.Repo == "cloud").Should().BeTrue("each product resolves to its repository: cloud");
+	}
+
+	[Fact]
+	public void BuildBundle_ProductNotInCatalogue_FallsBackToBundleRepo()
+	{
+		var entries = new[] { MakeEntry("unknown-product") };
+		var productsConfig = MakeProducts(("elasticsearch", null));
+
+		var result = _builder.BuildBundle(
+			_collector,
+			entries,
+			outputProducts: null,
+			repo: "fallback-repo",
+			owner: "elastic",
+			productsConfiguration: productsConfig
+		);
+
+		result.IsValid.Should().BeTrue();
+		result.Data!.Products[0].Repo.Should().Be("fallback-repo");
+	}
+
+	[Fact]
+	public void BuildBundle_WithoutProductsConfiguration_UsesPassedRepo()
+	{
+		var entries = new[] { MakeEntry("elasticsearch") };
+
+		var result = _builder.BuildBundle(
+			_collector,
+			entries,
+			outputProducts: null,
+			repo: "elasticsearch",
+			owner: "elastic",
+			productsConfiguration: null
+		);
+
+		result.IsValid.Should().BeTrue();
+		result.Data!.Products[0].Repo.Should().Be("elasticsearch");
+	}
+
+	[Fact]
+	public void BuildBundle_ProductWithExplicitRepository_UsesThatRepository()
+	{
+		var entries = new[] { MakeEntry("cloud-serverless") };
+		var productsConfig = MakeProducts(("cloud-serverless", "cloud"));
+
+		var result = _builder.BuildBundle(
+			_collector,
+			entries,
+			outputProducts: null,
+			repo: "different-repo",
+			owner: "elastic",
+			productsConfiguration: productsConfig
+		);
+
+		result.IsValid.Should().BeTrue();
+		result.Data!.Products[0].Repo.Should().Be("cloud", "the product's repository field takes precedence over the bundle-level repo");
+	}
+
+	[Fact]
+	public void BuildBundle_ProductWithNoExplicitRepository_UsesProductId()
+	{
+		var entries = new[] { MakeEntry("elasticsearch") };
+		var productsConfig = MakeProducts(("elasticsearch", null));
+
+		var result = _builder.BuildBundle(
+			_collector,
+			entries,
+			outputProducts: null,
+			repo: "bundle-repo",
+			owner: "elastic",
+			productsConfiguration: productsConfig
+		);
+
+		result.IsValid.Should().BeTrue();
+		result.Data!.Products[0].Repo.Should().Be("elasticsearch", "product.Repository defaults to the product ID when not explicitly set");
+	}
+}


### PR DESCRIPTION
`BundleBuilder` stamped a single bundle-level `repo` and `owner` onto every product in the output. Now each product's repo is resolved from `ProductsConfiguration` via `product.Repository`, falling back to the bundle-level value when the product is absent from the catalogue or has no explicit `repository:` field.

**Affects:** Release notes

**Prompt summary:** Part of a multi-PR plan to fix `elastic/cloud` changelog pipeline. `elastic/cloud` hosts three products (`cloud-hosted`, `cloud-serverless`, `cloud-enterprise`) under one repo. Without per-product resolution, every bundle produced by `elastic/cloud` stamps the same bundle-level repo onto all products, making PR link rendering and scrubber decisions incorrect for the individual products.

## Why

`BundleBuilder.BuildProducts` set `Repo = repo` (the bundle-level value) unconditionally on every `BundledProduct`. For a repo like `elastic/cloud` that hosts multiple products, the resulting bundle had one repo for all products rather than the correct per-product repo. The downstream scrubber (`ChangelogContentScrubber`) and inline renderer (`ChangelogInlineRenderer`) both read `BundledProduct.Repo` to decide which links to hide — so a wrong value suppresses or exposes the wrong links.

## What

#### Per-product repo resolution in `BundleBuilder`

`BundleBuilder` now accepts a `ProductsConfiguration?` and resolves each product's `Repo` via a new `ResolveProductRepo` helper: look up the product in the catalogue and return `product.Repository`; fall back to the bundle-level `repo` when the product is missing or its `repository:` field is null. `product.Repository` is already defaulted to the product ID when not explicitly set in `products.yml`.

#### `ChangelogBundlingService` wires in the catalogue

The single `new BundleBuilder().BuildBundle(...)` call in `ChangelogBundlingService` now passes `configurationContext?.ProductsConfiguration` as the last argument. No signature change at the call sites outside this service — the parameter is optional.

#### Backward compatibility

When `productsConfiguration` is `null` (or the product is not found), behaviour is identical to before — the bundle-level `repo` is used. All existing tests pass unchanged.

## Verify

```bash
dotnet test tests/Elastic.Changelog.Tests/
# BundleBuilderPerProductRepoTests — 5 new cases covering per-product resolution,
# catalogue fallback, and null-catalogue backward compat
```

**Stack:** 3 of 5, on top of [#4022](https://github.com/elastic/docs-builder/pull/4022).