### PR TITLE
Updates current stack version from 9.5.2 to 9.5.3

### DIFF
--- a/config/versions.yml
+++ b/config/versions.yml
@@ -3,7 +3,7 @@ versioning_systems:
   # Updates for Stack versions are manual
   stack: &stack
     base: 9.0
-    current: 9.5.2
+    current: 9.5.3
 
   # Using an unlikely high version
   # So that our logic that would display "planned" doesn't trigger


### PR DESCRIPTION
Do not merge until release day.

Bump version for the purpose of the following release:

- http://github.com/elastic/dev/issues/3611
