### PR TITLE
Add View as Markdown to API page sidebars

### DIFF
--- a/src/Elastic.ApiExplorer/_Layout.cshtml
+++ b/src/Elastic.ApiExplorer/_Layout.cshtml
@@ -33,7 +33,7 @@ else
 					</article>
 				</main>
 			</div>
-			@await RenderPartialAsync(_ApiToc.Create(Model.TocItems.ToArray()))
+			@await RenderPartialAsync(_ApiToc.Create(Model))
 		</div>
 		@await RenderPartialAsync(_ApiPagesNav.Create(Model))
 	</div>

--- a/src/Elastic.ApiExplorer/_Partials/Layout/_ApiToc.cshtml
+++ b/src/Elastic.ApiExplorer/_Partials/Layout/_ApiToc.cshtml
@@ -1,15 +1,25 @@
-@inherits RazorSlice<Elastic.ApiExplorer.Infrastructure.ApiTocItem[]>
+@inherits RazorSlice<Elastic.ApiExplorer.Infrastructure.ApiLayoutViewModel>
 <aside class="sidebar hidden lg:block w-full lg:max-w-65 px-6 lg:px-0">
 	<nav id="toc-nav" class="sidebar-nav lg:h-full">
+		<ul class="hidden md:flex items-center lg:block gap-4">
+			<li class="view-as-markdown hidden lg:block lg:not-first:mt-1">
+				<a href="@Model.MarkdownUrl" class="link text-sm" target="_blank">
+					<svg class="link-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 -1 24 24">
+						<path fill="currentColor" d="M22.131725 19.247H1.9386225C1.0239525 19.247 0.25 18.47305 0.25 17.558375v-11.11675c0 -0.914675 0.7739525 -1.688625 1.6886225 -1.688625H22.061375c0.914675 0 1.688625 0.77395 1.688625 1.688625v11.11675c0 0.914675 -0.7036 1.688625 -1.618275 1.688625ZM1.9386225 5.87875c-0.2814375 0 -0.562875 0.281425 -0.562875 0.562875v11.11675c0 0.3518 0.2814375 0.562875 0.562875 0.562875H22.061375c0.3518 0 0.562875 -0.281425 0.562875 -0.562875v-11.11675c0 -0.3518 -0.281425 -0.562875 -0.562875 -0.562875l-20.1227525 0ZM3.62725 15.86975V8.130225h2.2515l2.2515 2.814375 2.251475 -2.814375h2.2515V15.86975h-2.2515V11.437125L8.13025 14.2515l-2.2515 -2.814375V15.86975h-2.2515Zm14.1422 0L14.392225 12.140725h2.251475v-4.0105h2.2515v3.940125h2.2515L17.76945 15.86975Z" stroke-width="0.25"></path>
+					</svg>
+					View as Markdown
+				</a>
+			</li>
+		</ul>
 		<div class="pt-6">
-			@if (Model.Length > 0)
+			@if (Model.TocItems.Count > 0)
 			{
 				<div class="font-sans">
 					<div class="font-bold mb-2">On this page</div>
 					<div class="relative toc-progress-container font-body">
 						<div class="toc-progress-indicator absolute top-0 h-0 w-[1px] bg-blue-elastic transition-[transform,height] duration-200 ease-out"></div>
 						<ul class="block w-full">
-							@foreach (var item in Model)
+							@foreach (var item in Model.TocItems)
 							{
 								<li class="has-[:hover]:border-l-grey-80 items-center px-4 border-l-1 border-l-grey-20 has-[.toc-current]:border-l-blue-elastic!">
 									<a class="sidebar-link inline-block my-1.5 @(item.Level == 3 ? "ml-4" : string.Empty)"

--- a/tests/Elastic.ApiExplorer.Tests/ApiTocRenderingTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/ApiTocRenderingTests.cs
@@ -1,0 +1,79 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions;
+using AwesomeAssertions;
+using Elastic.ApiExplorer._Partials.Layout;
+using Elastic.ApiExplorer.Infrastructure;
+using Elastic.ApiExplorer.Landing;
+using Elastic.Documentation;
+using Elastic.Documentation.Configuration;
+using Elastic.Documentation.Configuration.Assembler;
+using Elastic.Documentation.Configuration.Builder;
+using Elastic.Documentation.Diagnostics;
+using Elastic.Documentation.FileSystems;
+using Elastic.Documentation.Site;
+using Elastic.Documentation.Site.FileProviders;
+using RazorSlices;
+
+namespace Elastic.ApiExplorer.Tests;
+
+public class ApiTocRenderingTests
+{
+	[Fact]
+	public async Task Render_EmptyToc_IncludesViewAsMarkdownLink()
+	{
+		var html = await Render([]);
+
+		html.Should().Contain("View as Markdown");
+		html.Should().Contain("href=\"/api/doc/elasticsearch/v9.md\"");
+		html.Should().Contain("target=\"_blank\"");
+		html.Should().NotContain("On this page");
+	}
+
+	[Fact]
+	public async Task Render_WithTocItems_IncludesViewAsMarkdownAndHeadings()
+	{
+		var html = await Render([new ApiTocItem("Paths", "paths"), new ApiTocItem("Description", "description")]);
+
+		html.Should().Contain("View as Markdown");
+		html.Should().Contain("href=\"/api/doc/elasticsearch/v9.md\"");
+		html.Should().Contain("target=\"_blank\"");
+		html.Should().Contain("On this page");
+		html.Should().Contain("href=\"#paths\"");
+		html.Should().Contain("Paths");
+	}
+
+	private static async Task<string> Render(IReadOnlyList<ApiTocItem> tocItems)
+	{
+		var fs = new FileSystem();
+		var context = new BuildContext(
+			new DiagnosticsCollector([]),
+			DocumentationFileSystem.Resolve(Paths.WorkingDirectoryRoot.FullName),
+			TestHelpers.CreateConfigurationContext(fs)
+		);
+		var navigationItem = new LandingNavigationItem("/api/doc/elasticsearch/v9/").Index;
+		var model = new ApiLayoutViewModel
+		{
+			DocsBuilderVersion = "test",
+			DocSetName = "Api Explorer",
+			Description = string.Empty,
+			CurrentNavigationItem = navigationItem,
+			Previous = null,
+			Next = null,
+			NavigationHtml = string.Empty,
+			UrlPathPrefix = string.Empty,
+			AllowIndexing = false,
+			CanonicalBaseUrl = null,
+			GoogleTagManager = new GoogleTagManagerConfiguration(),
+			Optimizely = new OptimizelyConfiguration(),
+			Features = new FeatureFlags([]),
+			StaticFileContentHashProvider = new StaticFileContentHashProvider(new EmbeddedOrPhysicalFileProvider(context)),
+			TocItems = tocItems,
+			MarkdownUrl = "/api/doc/elasticsearch/v9.md",
+		};
+
+		return await _ApiToc.Create(model).RenderAsync(cancellationToken: TestContext.Current.CancellationToken);
+	}
+}

--- a/tests/Elastic.ApiExplorer.Tests/ApiTocRenderingTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/ApiTocRenderingTests.cs
@@ -13,7 +13,6 @@ using Elastic.Documentation.Configuration.Assembler;
 using Elastic.Documentation.Configuration.Builder;
 using Elastic.Documentation.Diagnostics;
 using Elastic.Documentation.FileSystems;
-using Elastic.Documentation.Site;
 using Elastic.Documentation.Site.FileProviders;
 using RazorSlices;
 
@@ -26,20 +25,15 @@ public class ApiTocRenderingTests
 	{
 		var html = await Render([]);
 
-		html.Should().Contain("View as Markdown");
-		html.Should().Contain("href=\"/api/doc/elasticsearch/v9.md\"");
-		html.Should().Contain("target=\"_blank\"");
+		html.Should().Contain("""<a href="/api/doc/elasticsearch/v9.md" class="link text-sm" target="_blank">""");
 		html.Should().NotContain("On this page");
 	}
 
 	[Fact]
-	public async Task Render_WithTocItems_IncludesViewAsMarkdownAndHeadings()
+	public async Task Render_WithTocItems_IncludesHeadings()
 	{
-		var html = await Render([new ApiTocItem("Paths", "paths"), new ApiTocItem("Description", "description")]);
+		var html = await Render([new ApiTocItem("Paths", "paths")]);
 
-		html.Should().Contain("View as Markdown");
-		html.Should().Contain("href=\"/api/doc/elasticsearch/v9.md\"");
-		html.Should().Contain("target=\"_blank\"");
 		html.Should().Contain("On this page");
 		html.Should().Contain("href=\"#paths\"");
 		html.Should().Contain("Paths");

--- a/tests/Elastic.ApiExplorer.Tests/OpenApiGeneratorMarkdownEmissionTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/OpenApiGeneratorMarkdownEmissionTests.cs
@@ -144,9 +144,13 @@ public class OpenApiGeneratorMarkdownEmissionTests(ApiExplorerFixture fixture) :
 			);
 
 		html.Should().Contain("""<link rel="alternate" type="text/markdown" href="/api/doc/elasticsearch.md" title="Markdown export"/>""");
+		html.Should().Contain("View as Markdown");
+		html.Should().Contain("href=\"/api/doc/elasticsearch.md\"");
 		operationHtml.Should().Contain(
 			"""<link rel="alternate" type="text/markdown" href="/api/doc/elasticsearch/operation/operation-search.md" title="Markdown export"/>"""
 		);
+		operationHtml.Should().Contain("View as Markdown");
+		operationHtml.Should().Contain("href=\"/api/doc/elasticsearch/operation/operation-search.md\"");
 	}
 
 	[Fact]

--- a/tests/Elastic.ApiExplorer.Tests/OpenApiGeneratorMarkdownEmissionTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/OpenApiGeneratorMarkdownEmissionTests.cs
@@ -145,12 +145,10 @@ public class OpenApiGeneratorMarkdownEmissionTests(ApiExplorerFixture fixture) :
 
 		html.Should().Contain("""<link rel="alternate" type="text/markdown" href="/api/doc/elasticsearch.md" title="Markdown export"/>""");
 		html.Should().Contain("View as Markdown");
-		html.Should().Contain("href=\"/api/doc/elasticsearch.md\"");
 		operationHtml.Should().Contain(
 			"""<link rel="alternate" type="text/markdown" href="/api/doc/elasticsearch/operation/operation-search.md" title="Markdown export"/>"""
 		);
 		operationHtml.Should().Contain("View as Markdown");
-		operationHtml.Should().Contain("href=\"/api/doc/elasticsearch/operation/operation-search.md\"");
 	}
 
 	[Fact]


### PR DESCRIPTION
API pages now show a View as Markdown link in the right rail, matching regular docs. The link opens the sibling `.md` file that the generator already emits.

**Affects:** API reference

**Prompt summary:** Add View as Markdown on native API pages so they match regular docs. Do not add Copy as Markdown, Ask AI chat, or vendor LLM items in this change.

## Why
Regular docs already expose View as Markdown in the table of contents. API pages already emit and serve sibling `.md` files after [elastic/docs-eng-team#809](https://github.com/elastic/docs-eng-team/issues/809), and the layout model already has `MarkdownUrl`. The API right rail still has no link, so readers cannot open that markdown from the page chrome. This is the View as Markdown slice of [elastic/docs-eng-team#810](https://github.com/elastic/docs-eng-team/issues/810).

## What

#### View as Markdown link
The API right rail now renders the same View as Markdown control as regular docs. The link uses `MarkdownUrl`, opens in a new tab, and keeps the same classes and icon.

#### Empty TOC pages
Catalog and landing pages have no "On this page" headings. The markdown link still renders on those pages, so the action is not limited to operation pages.

#### Layout model
`_ApiToc` now receives `ApiLayoutViewModel` instead of a heading array, so the partial can read `MarkdownUrl` and `TocItems` together.

## Verify

```bash
dotnet test tests/Elastic.ApiExplorer.Tests/
```

On a local or staging API preview, open a landing page and an operation page. Confirm View as Markdown opens `{url}.md`. After an in-app HTMX navigation, confirm the link points at the new page. Do not check `www.elastic.co` until the API cutover.

**Out of scope** Copy as Markdown is deferred. It can land later for both API pages and regular docs.

Made with [Cursor](https://cursor.com)