### PR TITLE
github-agentic: use v0.2.29

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -16,7 +16,7 @@ jobs:
       github.event.pull_request.draft == false &&
       !contains(github.event.pull_request.labels.*.name, 'skip-auto-pr-review') &&
       (github.event.action != 'labeled' && github.event.action != 'unlabeled' || github.event.label.name == 'skip-auto-pr-review')
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-pr-review.lock.yml@v0
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-pr-review.lock.yml@v0.2.29
     with:
       allowed-bot-users: "github-actions[bot],dependabot[bot]"
       intensity: aggressive


### PR DESCRIPTION
v0 uses the latest changes but something has changed recently so we need to point to a known version that worked fine while we can figure out what it actually got broken