### PR TITLE
Assembler: list API pages in llms.txt

### DIFF
--- a/docs/data/exporters/llm.md
+++ b/docs/data/exporters/llm.md
@@ -17,7 +17,8 @@ When a request arrives with an `Accept: text/markdown` header (or appends `.md` 
 The exporter generates:
 
 - **Per-page `.md` files** — one for every HTML page, placed alongside it in the output directory. For `section/page.html` → `section/page.md`. For `section/index.html` → `section.md` (so appending `.md` to the URL path works naturally).
-- **`llms.txt`** — an index file following the [llms.txt specification](https://llmstxt.org/) that lists all available pages with titles, descriptions, and URLs.
+- **`llms.txt`** — an index file following the [llms.txt specification](https://llmstxt.org/) that lists all available pages with titles, descriptions, and URLs. When `ASSEMBLER_API_EXPLORER` is on, the assembler appends an **APIs** section that links to each published API landing `.md` file.
+- **`docs/api/llms.txt`** — a hub index of those same API landing pages. The assembler writes this file next to the API catalog when the flag is on.
 - **`llm.zip`** — a compressed archive containing `llms.txt` and all per-page Markdown files for bulk download.
 
 ## What changes from source

--- a/src/services/Elastic.Documentation.Assembler/Building/AssemblerBuildService.cs
+++ b/src/services/Elastic.Documentation.Assembler/Building/AssemblerBuildService.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO.Abstractions;
 using System.Text;
 using Actions.Core.Services;
+using Elastic.ApiExplorer.Landing;
 using Elastic.Documentation;
 using Elastic.Documentation.Assembler.Navigation;
 using Elastic.Documentation.Assembler.Sourcing;
@@ -167,10 +168,11 @@ public class AssemblerBuildService(
 		if (assembleContext.WriteFileSystem.File.Exists(redirectsPath))
 			await githubActionsService.SetOutputAsync("redirects-artifact-path", redirectsPath);
 
+		IReadOnlyList<ApiCatalogEntry> catalogEntries = [];
 		if (exporters.Contains(Exporter.Html))
 		{
 			var openApiStopwatch = Stopwatch.StartNew();
-			await AssemblerOpenApiBuildStep.BuildAsync(logFactory, assembleContext, assembleSources, ctx);
+			catalogEntries = await AssemblerOpenApiBuildStep.BuildAsync(logFactory, assembleContext, assembleSources, ctx);
 			openApiStopwatch.Stop();
 			_logger.LogInformation("OpenAPI build step completed in {DurationMs} ms", openApiStopwatch.ElapsedMilliseconds);
 
@@ -204,7 +206,7 @@ public class AssemblerBuildService(
 		{
 			_logger.LogInformation("Enhancing llms.txt with navigation structure");
 			var llmsEnhancer = new LlmsNavigationEnhancer();
-			await EnhanceLlmsTxtFile(assembleContext, navigation, llmsEnhancer, ctx);
+			await EnhanceLlmsTxtFile(assembleContext, navigation, llmsEnhancer, catalogEntries, ctx);
 		}
 
 		await collector.StopAsync(ctx);
@@ -239,6 +241,7 @@ public class AssemblerBuildService(
 		AssembleContext context,
 		SiteNavigation navigation,
 		LlmsNavigationEnhancer enhancer,
+		IReadOnlyList<ApiCatalogEntry> catalogEntries,
 		Cancel ctx
 	)
 	{
@@ -252,9 +255,10 @@ public class AssemblerBuildService(
 		// Assembler always uses the production URL as canonical base URL
 		var canonicalBaseUrl = new Uri(context.Environment.Uri);
 		var navigationSections = enhancer.GenerateNavigationSections(navigation, canonicalBaseUrl);
+		var apiSection = enhancer.GenerateApiSection(catalogEntries, canonicalBaseUrl);
 
 		// Append the navigation sections to the existing boilerplate
-		var enhancedContent = existingContent + Environment.NewLine + navigationSections;
+		var enhancedContent = existingContent + Environment.NewLine + navigationSections + apiSection;
 
 		await context.WriteFileSystem.File.WriteAllTextAsync(llmsTxtPath, enhancedContent, Encoding.UTF8, ctx);
 	}

--- a/src/services/Elastic.Documentation.Assembler/Building/AssemblerOpenApiBuildStep.cs
+++ b/src/services/Elastic.Documentation.Assembler/Building/AssemblerOpenApiBuildStep.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Frozen;
 using System.Diagnostics;
+using System.Text;
 using Elastic.ApiExplorer;
 using Elastic.ApiExplorer.Landing;
 using Elastic.ApiExplorer.Model;
@@ -21,7 +22,7 @@ namespace Elastic.Documentation.Assembler.Building;
 /// </summary>
 public static class AssemblerOpenApiBuildStep
 {
-	public static async Task BuildAsync(
+	public static async Task<IReadOnlyList<ApiCatalogEntry>> BuildAsync(
 		ILoggerFactory logFactory,
 		AssembleContext assembleContext,
 		AssembleSources assembleSources,
@@ -37,14 +38,14 @@ public static class AssemblerOpenApiBuildStep
 		if (!features.AssemblerApiExplorerEnabled)
 		{
 			logger.LogInformation("Skipping OpenAPI generation: assembler-api-explorer feature flag is disabled");
-			return;
+			return [];
 		}
 
 		var owners = DiscoverApiOwners(assembleSources.AssembleSets, assembleContext.Collector);
 		if (owners.Count == 0)
 		{
 			logger.LogInformation("Skipping OpenAPI generation: no API declarations found in assembled docsets");
-			return;
+			return [];
 		}
 
 		var stopwatch = Stopwatch.StartNew();
@@ -75,6 +76,7 @@ public static class AssemblerOpenApiBuildStep
 				versionIndexClient
 			);
 			await catalogGenerator.GenerateCatalog(catalogEntries, ctx).ConfigureAwait(false);
+			await WriteApiLlmsTxt(assembleContext, catalogEntries, ctx).ConfigureAwait(false);
 		}
 
 		stopwatch.Stop();
@@ -83,6 +85,17 @@ public static class AssemblerOpenApiBuildStep
 			assembleContext.OutputWithPathPrefixDirectory.FullName,
 			stopwatch.ElapsedMilliseconds
 		);
+		return catalogEntries;
+	}
+
+	private static async Task WriteApiLlmsTxt(AssembleContext assembleContext, IReadOnlyList<ApiCatalogEntry> catalogEntries, Cancel ctx)
+	{
+		var canonicalBaseUrl = new Uri(assembleContext.Environment.Uri);
+		var content = new LlmsNavigationEnhancer().GenerateApiHubIndex(catalogEntries, canonicalBaseUrl);
+		var directory = assembleContext.WriteFileSystem.Path.Join(assembleContext.OutputWithPathPrefixDirectory.FullName, "api");
+		_ = assembleContext.WriteFileSystem.Directory.CreateDirectory(directory);
+		var path = assembleContext.WriteFileSystem.Path.Join(directory, "llms.txt");
+		await assembleContext.WriteFileSystem.File.WriteAllTextAsync(path, content, Encoding.UTF8, ctx).ConfigureAwait(false);
 	}
 
 	internal static IReadOnlyList<AssemblerApiOwner> DiscoverApiOwners(

--- a/src/services/Elastic.Documentation.Assembler/Navigation/LlmsNavigationEnhancer.cs
+++ b/src/services/Elastic.Documentation.Assembler/Navigation/LlmsNavigationEnhancer.cs
@@ -4,6 +4,8 @@
 
 using System.Globalization;
 using System.Text;
+using Elastic.ApiExplorer.Infrastructure;
+using Elastic.ApiExplorer.Landing;
 using Elastic.Documentation.Navigation;
 using Elastic.Documentation.Navigation.Assembler;
 using Elastic.Documentation.Navigation.Isolated;
@@ -51,6 +53,46 @@ public class LlmsNavigationEnhancer
 		}
 
 		return content.ToString();
+	}
+
+	public string GenerateApiHubIndex(IReadOnlyList<ApiCatalogEntry> entries, Uri canonicalBaseUrl)
+	{
+		if (entries.Count == 0)
+			return string.Empty;
+
+		var content = new StringBuilder();
+		_ = content.AppendLine("# APIs");
+		_ = content.AppendLine();
+		_ = content.AppendLine("> Landing pages for published API products.");
+		_ = content.AppendLine();
+		_ = content.AppendLine("## Products");
+		_ = content.AppendLine();
+		AppendApiProductLinks(content, entries, canonicalBaseUrl);
+		return content.ToString();
+	}
+
+	public string GenerateApiSection(IReadOnlyList<ApiCatalogEntry> entries, Uri canonicalBaseUrl)
+	{
+		if (entries.Count == 0)
+			return string.Empty;
+
+		var content = new StringBuilder();
+		_ = content.AppendLine("## APIs");
+		_ = content.AppendLine();
+		AppendApiProductLinks(content, entries, canonicalBaseUrl);
+		return content.ToString();
+	}
+
+	private static void AppendApiProductLinks(StringBuilder content, IReadOnlyList<ApiCatalogEntry> entries, Uri canonicalBaseUrl)
+	{
+		foreach (var entry in entries.OrderBy(e => e.Key, StringComparer.Ordinal))
+		{
+			var markdownUrl = ApiOutputPaths.MarkdownUrl(entry.Url);
+			var url = LlmRenderingHelpers.MakeAbsoluteUrl(canonicalBaseUrl, markdownUrl);
+			_ = content.AppendLine(CultureInfo.InvariantCulture, $"* [{entry.Title}]({url})");
+		}
+
+		_ = content.AppendLine();
 	}
 
 	private static IReadOnlyCollection<INavigationItem> GetFirstLevelChildren(

--- a/tests/Elastic.Documentation.Build.Tests/LlmsNavigationEnhancerTests.cs
+++ b/tests/Elastic.Documentation.Build.Tests/LlmsNavigationEnhancerTests.cs
@@ -1,0 +1,50 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using AwesomeAssertions;
+using Elastic.ApiExplorer.Landing;
+using Elastic.Documentation.Assembler.Navigation;
+
+namespace Elastic.Documentation.Build.Tests;
+
+public class LlmsNavigationEnhancerTests
+{
+	private static readonly Uri CanonicalBaseUrl = new("https://www.elastic.co");
+
+	private static readonly ApiCatalogEntry[] Catalog =
+	[
+		new("kibana", "Kibana", "/docs/api/doc/kibana/"),
+		new("elasticsearch", "Elasticsearch", "/docs/api/doc/elasticsearch/")
+	];
+
+	[Fact]
+	public void GenerateApiHubIndex_ListsSortedLandingMarkdownUrls()
+	{
+		var text = new LlmsNavigationEnhancer().GenerateApiHubIndex(Catalog, CanonicalBaseUrl);
+
+		text.Should().StartWith("# APIs");
+		text.Should().Contain("## Products");
+		text.Should().Contain("* [Elasticsearch](https://www.elastic.co/docs/api/doc/elasticsearch.md)");
+		text.Should().Contain("* [Kibana](https://www.elastic.co/docs/api/doc/kibana.md)");
+		text.IndexOf("elasticsearch.md", StringComparison.Ordinal).Should().BeLessThan(text.IndexOf("kibana.md", StringComparison.Ordinal));
+	}
+
+	[Fact]
+	public void GenerateApiSection_StartsWithApisHeadingAndSameLinks()
+	{
+		var text = new LlmsNavigationEnhancer().GenerateApiSection(Catalog, CanonicalBaseUrl);
+
+		text.Should().StartWith("## APIs");
+		text.Should().Contain("* [Elasticsearch](https://www.elastic.co/docs/api/doc/elasticsearch.md)");
+		text.Should().Contain("* [Kibana](https://www.elastic.co/docs/api/doc/kibana.md)");
+	}
+
+	[Fact]
+	public void GenerateApiHubIndex_EmptyCatalog_ReturnsEmpty() =>
+		new LlmsNavigationEnhancer().GenerateApiHubIndex([], CanonicalBaseUrl).Should().BeEmpty();
+
+	[Fact]
+	public void GenerateApiSection_EmptyCatalog_ReturnsEmpty() =>
+		new LlmsNavigationEnhancer().GenerateApiSection([], CanonicalBaseUrl).Should().BeEmpty();
+}


### PR DESCRIPTION
The assembler lists published API landing Markdown files in `llms.txt` so agents can find them.

**Affects:** Content export, Assembler builds, API reference

**Prompt summary:** Implement docs-eng-team#811. List API pages in llms.txt. Keep both the site-root APIs section and the hub `/docs/api/llms.txt` file.

## Why

- Site-root `llms.txt` skips ApiExplorer pages because they are not in SiteNavigation
- Hub `/docs/api/llms.txt` returns 404 even after API landing `.md` files exist

Closes elastic/docs-eng-team#811

## What

- Write `docs/api/llms.txt` from assembled API catalog entries
- Append an APIs section to site-root `llms.txt` with the same landing `.md` links

## Notes

- Per-product `llms.txt` is the existing landing `.md` file
- Verify on local preview or staging. Production `/docs/api/*` still proxies to bump.sh

## Verify

```bash
dotnet test tests/Elastic.Documentation.Build.Tests/ --filter FullyQualifiedName~LlmsNavigationEnhancer
```

After a staging or local assembler preview with `ASSEMBLER_API_EXPLORER` on, confirm `/docs/api/llms.txt` is 200 and lists Elasticsearch. Confirm site-root `/docs/llms.txt` includes an APIs section.

Made with [Cursor](https://cursor.com)