### PR TITLE
Show auth scheme badges on API operations

### DIFF
--- a/src/Elastic.ApiExplorer/Operations/OpenApiAuthSchemeResolver.cs
+++ b/src/Elastic.ApiExplorer/Operations/OpenApiAuthSchemeResolver.cs
@@ -1,0 +1,53 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Microsoft.OpenApi;
+
+namespace Elastic.ApiExplorer.Operations;
+
+public record AuthSchemeBadge(string Label);
+
+public static class OpenApiAuthSchemeResolver
+{
+	public static IReadOnlyList<AuthSchemeBadge> Resolve(OpenApiOperation operation, OpenApiDocument document)
+	{
+		// Omitted operation security is null (inherit). An empty list is an explicit override to none.
+		var requirements = operation.Security ?? document.Security;
+		if (requirements is not { Count: > 0 })
+			return [];
+
+		var seen = new HashSet<string>(StringComparer.Ordinal);
+		var badges = new List<AuthSchemeBadge>();
+		foreach (var requirement in requirements)
+		{
+			foreach (var scheme in requirement)
+			{
+				var label = LabelFor(Target(scheme.Key, document));
+				if (label is null || !seen.Add(label))
+					continue;
+				badges.Add(new AuthSchemeBadge(label));
+			}
+		}
+
+		return badges;
+	}
+
+	private static IOpenApiSecurityScheme? Target(IOpenApiSecurityScheme scheme, OpenApiDocument document)
+	{
+		if (
+			scheme is OpenApiSecuritySchemeReference { Reference.Id: { Length: > 0 } id }
+			&& document.Components?.SecuritySchemes?.TryGetValue(id, out var listed) == true
+		)
+			return listed;
+		return scheme;
+	}
+
+	private static string? LabelFor(IOpenApiSecurityScheme? scheme) => scheme?.Type switch
+	{
+		SecuritySchemeType.ApiKey => "Api key",
+		SecuritySchemeType.Http when string.Equals(scheme.Scheme, "basic", StringComparison.OrdinalIgnoreCase) => "Basic",
+		SecuritySchemeType.Http when string.Equals(scheme.Scheme, "bearer", StringComparison.OrdinalIgnoreCase) => "Bearer",
+		_ => null
+	};
+}

--- a/src/Elastic.ApiExplorer/Operations/OperationCommonMark.cs
+++ b/src/Elastic.ApiExplorer/Operations/OperationCommonMark.cs
@@ -29,7 +29,7 @@ internal static class OperationCommonMark
 		WritePrerequisites(markdown, prerequisites, apiBaseUrl);
 		WritePathParameters(markdown, page, apiBaseUrl);
 		WriteDescription(markdown, page, apiBaseUrl);
-		WriteSecurity(markdown, operation);
+		WriteSecurity(markdown, page);
 		WriteQueryParameters(markdown, page, apiBaseUrl);
 		WriteRequestBody(markdown, apiOperation, page, apiBaseUrl);
 		WriteResponses(markdown, page, apiBaseUrl);
@@ -131,20 +131,12 @@ internal static class OperationCommonMark
 			ApiCommonMark.Paragraph(markdown, ApiCommonMark.Link(docs.LinkText, docs.Url));
 	}
 
-	private static void WriteSecurity(StringBuilder markdown, OpenApiOperation operation)
+	private static void WriteSecurity(StringBuilder markdown, OperationPageModel page)
 	{
-		if (operation.Security is not { Count: > 0 })
+		if (page.AuthSchemes.Count == 0)
 			return;
 
-		var schemes = operation
-			.Security
-			.SelectMany(requirement => requirement)
-			.Select(scheme =>
-			{
-				var name = $"`{scheme.Key.Name}`";
-				return scheme.Value is { Count: > 0 } ? $"{name} ({string.Join(", ", scheme.Value)})" : name;
-			});
-		ApiCommonMark.Paragraph(markdown, "Authorization: " + string.Join(", ", schemes));
+		ApiCommonMark.Paragraph(markdown, "Authorization: " + string.Join(", ", page.AuthSchemes.Select(scheme => scheme.Label)));
 	}
 
 	private static void WriteQueryParameters(StringBuilder markdown, OperationPageModel page, string apiBaseUrl)

--- a/src/Elastic.ApiExplorer/Operations/OperationPageModel.cs
+++ b/src/Elastic.ApiExplorer/Operations/OperationPageModel.cs
@@ -111,6 +111,9 @@ public record OperationPageModel
 	/// <summary>Anchor of the first examples section; null when the page has no examples at all.</summary>
 	public required string? ExamplesAnchor { get; init; }
 
+	/// <summary>Effective auth scheme badges. Empty when the spec declares no schemes.</summary>
+	public required IReadOnlyList<AuthSchemeBadge> AuthSchemes { get; init; }
+
 	public static OperationPageModel Create(ApiOperation apiOperation, ApiRenderContext context)
 	{
 		var operation = apiOperation.Operation;
@@ -187,7 +190,8 @@ public record OperationPageModel
 			ResponseExamples = MapExamples(responseExamples, options.RenderMarkdown),
 			ShowRequestExamples = showRequestExamples,
 			ShowResponseExamples = showResponseExamples,
-			ExamplesAnchor = examplesAnchor
+			ExamplesAnchor = examplesAnchor,
+			AuthSchemes = OpenApiAuthSchemeResolver.Resolve(operation, document)
 		};
 	}
 

--- a/src/Elastic.ApiExplorer/Operations/OperationView.cshtml
+++ b/src/Elastic.ApiExplorer/Operations/OperationView.cshtml
@@ -118,22 +118,15 @@
 		</a>
 	}
 
-	@if (operation.Security is { Count: > 0 })
+	@if (pageModel.AuthSchemes.Count > 0)
 	{
 		<div class="security-requirements">
 			<span class="security-label">Authorization:</span>
-			@foreach (var requirement in operation.Security)
+			@foreach (var scheme in pageModel.AuthSchemes)
 			{
-				@foreach (var scheme in requirement)
-				{
-					<span class="security-scheme">
-						<code>@scheme.Key.Name</code>
-						@if (scheme.Value is { Count: > 0 })
-						{
-							<span class="security-scopes">(@string.Join(", ", scheme.Value))</span>
-						}
-					</span>
-				}
+				<span class="security-scheme">
+					<span class="security-scheme-badge">@scheme.Label</span>
+				</span>
 			}
 		</div>
 	}

--- a/src/Elastic.Documentation.Site/Assets/api-docs.css
+++ b/src/Elastic.Documentation.Site/Assets/api-docs.css
@@ -585,10 +585,10 @@
 
 .security-scheme {
 	@apply flex items-center gap-1;
+}
 
-	code {
-		@apply text-blue-elastic rounded bg-white px-1.5 py-0.5 font-mono text-xs;
-	}
+.security-scheme-badge {
+	@apply text-blue-elastic rounded bg-white px-1.5 py-0.5 text-xs font-medium;
 }
 
 .security-scopes {

--- a/tests/Elastic.ApiExplorer.Tests/AuthSchemeTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/AuthSchemeTests.cs
@@ -1,0 +1,134 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions;
+using AwesomeAssertions;
+using Elastic.ApiExplorer.Model;
+using Elastic.ApiExplorer.Operations;
+using Elastic.Documentation.Configuration;
+using Microsoft.OpenApi;
+using Microsoft.OpenApi.Reader;
+
+namespace Elastic.ApiExplorer.Tests;
+
+public class AuthSchemeTests
+{
+	[Fact]
+	public async Task Resolve_DocumentSecurity_MapsApiKeyBasicBearer()
+	{
+		var (op, doc) = await Load(EsShapedSpec(operationSecurity: null));
+
+		OpenApiAuthSchemeResolver.Resolve(op, doc).Select(b => b.Label).Should().Equal("Api key", "Basic", "Bearer");
+	}
+
+	[Fact]
+	public async Task Resolve_OperationSecurity_OverridesDocument()
+	{
+		var (op, doc) = await Load(EsShapedSpec(operationSecurity: """{ "apiKeyAuth": [] }"""));
+
+		OpenApiAuthSchemeResolver.Resolve(op, doc).Select(b => b.Label).Should().Equal("Api key");
+	}
+
+	[Fact]
+	public async Task Resolve_EmptyOperationSecurity_ReturnsNoBadges()
+	{
+		var (op, doc) = await Load(EsShapedSpec(operationSecurity: ""));
+
+		OpenApiAuthSchemeResolver.Resolve(op, doc).Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task Resolve_NoSchemes_ReturnsNoBadges()
+	{
+		var json = /*lang=json,strict*/
+			"""
+			{
+			  "openapi": "3.0.3",
+			  "info": { "title": "t", "version": "1" },
+			  "paths": {
+			    "/a": {
+			      "get": {
+			        "operationId": "op-a",
+			        "responses": { "200": { "description": "ok" } }
+			      }
+			    }
+			  }
+			}
+			""";
+		var (op, doc) = await Load(json);
+
+		OpenApiAuthSchemeResolver.Resolve(op, doc).Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task ElasticsearchSearch_InheritsDocumentSchemes()
+	{
+		var specPath = Path.Join(Paths.WorkingDirectoryRoot.FullName, "docs", "elasticsearch.json");
+		File.Exists(specPath).Should().BeTrue($"Fixture missing: {specPath}");
+
+		var doc = await OpenApiReader.Instance.ReadAsync(new FileSystem().FileInfo.New(specPath));
+		doc.Should().NotBeNull();
+		var search = doc!.Paths!["/_search"].Operations![HttpMethod.Get]!;
+
+		OpenApiAuthSchemeResolver.Resolve(search, doc).Select(b => b.Label).Should().Equal("Api key", "Basic", "Bearer");
+	}
+
+	private static string EsShapedSpec(string? operationSecurity)
+	{
+		var operationSecurityJson = operationSecurity switch
+		{
+			null => "",
+			"" => """ "security": [], """,
+			_ => $""" "security": [ {operationSecurity} ], """
+		};
+		return /*lang=json,strict*/  $$"""
+			{
+			  "openapi": "3.0.3",
+			  "info": { "title": "t", "version": "1" },
+			  "paths": {
+			    "/a": {
+			      "get": {
+			        "operationId": "op-a",
+			        {{operationSecurityJson}}
+			        "responses": { "200": { "description": "ok" } }
+			      }
+			    }
+			  },
+			  "components": {
+			    "securitySchemes": {
+			      "apiKeyAuth": { "type": "apiKey", "in": "header", "name": "Authorization" },
+			      "basicAuth": { "type": "http", "scheme": "basic" },
+			      "bearerAuth": { "type": "http", "scheme": "bearer" }
+			    }
+			  },
+			  "security": [
+			    { "apiKeyAuth": [] },
+			    { "basicAuth": [] },
+			    { "bearerAuth": [] }
+			  ]
+			}
+			""";
+	}
+
+	private static async Task<(OpenApiOperation Op, OpenApiDocument Doc)> Load(string json)
+	{
+		var jsonPath = Path.Join(Path.GetTempPath(), $"auth-scheme-{Guid.NewGuid():N}.json");
+		try
+		{
+			await File.WriteAllTextAsync(jsonPath, json, TestContext.Current.CancellationToken);
+			var loaded = await OpenApiDocument.LoadAsync(
+				jsonPath,
+				new OpenApiReaderSettings { LeaveStreamOpen = false },
+				TestContext.Current.CancellationToken
+			);
+			var doc = loaded.Document!;
+			return (doc.Paths!["/a"].Operations![HttpMethod.Get]!, doc);
+		}
+		finally
+		{
+			if (File.Exists(jsonPath))
+				File.Delete(jsonPath);
+		}
+	}
+}


### PR DESCRIPTION
Operation pages now show Bump-style auth badges (Api key, Basic, Bearer) from effective OpenAPI security, including document-level schemes.

**Affects:** API reference, Site UI

**Prompt summary:** Implement [elastic/docs-eng-team#813](https://github.com/elastic/docs-eng-team/issues/813). Operation pages must resolve inherited security, map scheme types to human labels, and render badges without waiting for topic pages.

## Why

The Elasticsearch spec declares `apiKey`, `basic`, and `bearer` at document level. `operation-search` has no operation `security:`, so the page inherited nothing and printed no schemes. When operation security was present, the view printed raw scheme keys in `code`, not the labels Bump shows.

Closes elastic/docs-eng-team#813

## What

#### Effective security
An omitted operation `security:` inherits the document list. An empty operation list overrides that list and shows no badges. The page model stores the resolved badges. The HTML view and the markdown export both print that list.

#### Human labels
Each scheme is looked up in `components.securitySchemes`. `apiKey` becomes Api key. HTTP `basic` becomes Basic. HTTP `bearer` becomes Bearer. Prerequisites from `x-req-auth` stay on their own list.

#### Tests
Resolver tests cover document inherit, operation override, empty override, and a spec with no schemes. One test loads `docs/elasticsearch.json` and checks that `/_search` resolves to Api key, Basic, Bearer.

## Verify

```bash
dotnet test tests/Elastic.ApiExplorer.Tests/ --filter AuthSchemeTests
# ElasticsearchSearch_InheritsDocumentSchemes — search inherits document schemes
```

**Out of scope:** Badge links to Authentications topic pages. That waits on [elastic/docs-eng-team#820](https://github.com/elastic/docs-eng-team/issues/820).

Made with [Cursor](https://cursor.com)