### PR TITLE
Show Base URL and version on API product landings

### DIFF
--- a/src/Elastic.ApiExplorer/Landing/LandingCommonMark.cs
+++ b/src/Elastic.ApiExplorer/Landing/LandingCommonMark.cs
@@ -20,13 +20,16 @@ internal static class LandingCommonMark
 		return markdown.ToString();
 	}
 
-	public static string Product(OpenApiInfo? info, IReadOnlyList<ApiOverviewRow> rows, string apiBaseUrl)
+	public static string Product(OpenApiInfo? info, LandingInfoNote note, IReadOnlyList<ApiOverviewRow> rows, string apiBaseUrl)
 	{
 		var markdown = new StringBuilder();
 		ApiCommonMark.Heading(markdown, 1, info?.Title ?? "API Documentation");
 		ApiCommonMark.Prepared(markdown, info?.Description, apiBaseUrl);
-		if (!string.IsNullOrEmpty(info?.License?.Name))
-			ApiCommonMark.Paragraph(markdown, $"License: {info.License.Name}");
+		WriteBaseUrls(markdown, note.Servers);
+		if (note.LicenseName is not null)
+			ApiCommonMark.Paragraph(markdown, $"License: {note.LicenseName}");
+		if (note.Version is not null)
+			ApiCommonMark.Paragraph(markdown, $"Version: {note.Version}");
 
 		WriteOverview(markdown, rows);
 		return markdown.ToString();
@@ -52,6 +55,22 @@ internal static class LandingCommonMark
 
 		WriteOverview(markdown, model.OverviewRows);
 		return markdown.ToString();
+	}
+
+	private static void WriteBaseUrls(StringBuilder markdown, IReadOnlyList<OpenApiServer> servers)
+	{
+		if (servers.Count == 0)
+			return;
+
+		foreach (var server in servers)
+		{
+			var line = $"`{server.Url}`";
+			if (!string.IsNullOrEmpty(server.Description))
+				line += $" ({server.Description})";
+			_ = markdown.AppendLine($"- Base URL: {line}");
+		}
+
+		_ = markdown.AppendLine();
 	}
 
 	private static void WriteOverview(StringBuilder markdown, IReadOnlyList<ApiOverviewRow> rows)

--- a/src/Elastic.ApiExplorer/Landing/LandingNavigationItem.cs
+++ b/src/Elastic.ApiExplorer/Landing/LandingNavigationItem.cs
@@ -17,24 +17,30 @@ public class ApiLanding : IApiGroupingModel
 {
 	public async Task RenderAsync(FileSystemStream stream, ApiRenderContext context, Cancel ctx = default)
 	{
+		var infoNote = LandingInfoNote.From(context.Model);
 		var viewModel = new LandingViewModel(context)
 		{
 			Landing = this,
 			ApiInfo = context.Model.Info,
+			InfoNote = infoNote,
 			OverviewRows = ApiOverviewBuilder.Build(context.CurrentNavigation.NavigationRoot)
 		};
 		var slice = LandingView.Create(viewModel);
 		await slice.RenderAsync(stream, cancellationToken: ctx);
 	}
 
-	public Task<string?> RenderCommonMarkAsync(ApiRenderContext context, Cancel ctx = default) =>
-		Task.FromResult<string?>(
+	public Task<string?> RenderCommonMarkAsync(ApiRenderContext context, Cancel ctx = default)
+	{
+		var infoNote = LandingInfoNote.From(context.Model);
+		return Task.FromResult<string?>(
 			LandingCommonMark.Product(
 				context.Model.Info,
+				infoNote,
 				ApiOverviewBuilder.Build(context.CurrentNavigation.NavigationRoot),
 				context.CurrentNavigation.NavigationRoot.Url
 			)
 		);
+	}
 }
 
 public class LandingNavigationItem : IApiGroupingNavigationItem<ApiLanding, INavigationItem>, IRootNavigationItem<ApiLanding, INavigationItem>

--- a/src/Elastic.ApiExplorer/Landing/LandingView.cshtml
+++ b/src/Elastic.ApiExplorer/Landing/LandingView.cshtml
@@ -8,7 +8,40 @@
 <section id="elastic-docs-v3">
 	<h1>@Model.ApiInfo.Title</h1>
 	<p>@Model.RenderMarkdown(Model.ApiInfo.Description)</p>
-	<p>License: @Model.ApiInfo.License?.Name</p>
+	@if (Model.InfoNote.Servers.Count > 0)
+	{
+		<div class="server-info">
+			<span class="server-label">Base URL@(Model.InfoNote.Servers.Count > 1 ? "s" : ""):</span>
+			@foreach (var server in Model.InfoNote.Servers)
+			{
+				<span class="server-url">
+					<code>@server.Url</code>
+					@if (!string.IsNullOrEmpty(server.Description))
+					{
+						<span class="server-description">(@server.Description)</span>
+					}
+				</span>
+			}
+		</div>
+	}
+	@if (Model.InfoNote.LicenseName is { } licenseName)
+	{
+		<p>
+			License:
+			@if (Model.InfoNote.LicenseUrl is { } licenseUrl)
+			{
+				<a href="@licenseUrl">@licenseName</a>
+			}
+			else
+			{
+				@licenseName
+			}
+		</p>
+	}
+	@if (Model.InfoNote.Version is { } version)
+	{
+		<p>Version: @version</p>
+	}
 	<div class="api-overview">
 		<table>
 			@foreach (var row in Model.OverviewRows)

--- a/src/Elastic.ApiExplorer/Landing/LandingViewModel.cs
+++ b/src/Elastic.ApiExplorer/Landing/LandingViewModel.cs
@@ -9,10 +9,23 @@ using Microsoft.OpenApi;
 
 namespace Elastic.ApiExplorer.Landing;
 
+public sealed record LandingInfoNote(IReadOnlyList<OpenApiServer> Servers, string? LicenseName, Uri? LicenseUrl, string? Version)
+{
+	public static LandingInfoNote From(OpenApiDocument document)
+	{
+		var info = document.Info;
+		IReadOnlyList<OpenApiServer> servers = document.Servers is { Count: > 0 } ? [.. document.Servers] : [];
+		var licenseName = string.IsNullOrEmpty(info?.License?.Name) ? null : info.License.Name;
+		var version = string.IsNullOrEmpty(info?.Version) ? null : info.Version;
+		return new(servers, licenseName, info?.License?.Url, version);
+	}
+}
+
 public class LandingViewModel(ApiRenderContext context) : ApiViewModel(context)
 {
 	public required ApiLanding Landing { get; init; }
 	public required OpenApiInfo ApiInfo { get; init; }
+	public required LandingInfoNote InfoNote { get; init; }
 
 	/// <summary>Flattened overview table rows; built before the slice renders.</summary>
 	public required IReadOnlyList<ApiOverviewRow> OverviewRows { get; init; }

--- a/src/Elastic.Documentation.Site/Assets/api-docs.css
+++ b/src/Elastic.Documentation.Site/Assets/api-docs.css
@@ -619,6 +619,7 @@
 
 .server-url {
 	@apply flex items-center gap-1;
+	position: relative;
 
 	code {
 		@apply text-grey-80 bg-grey-10 rounded px-1.5 py-0.5 font-mono text-xs;

--- a/src/Elastic.Documentation.Site/Assets/copybutton.css
+++ b/src/Elastic.Documentation.Site/Assets/copybutton.css
@@ -39,8 +39,15 @@ div.highlight {
 
 /* Show the copybutton */
 .highlight:hover button.copybtn,
+.server-url:hover button.copybtn,
 button.copybtn.success {
 	opacity: 1;
+}
+
+.server-url button.copybtn {
+	position: static;
+	top: auto;
+	right: auto;
 }
 
 /**

--- a/src/Elastic.Documentation.Site/Assets/copybutton.ts
+++ b/src/Elastic.Documentation.Site/Assets/copybutton.ts
@@ -138,7 +138,9 @@ const addCopyButtonToCodeCells = (
             }
         }
 
-        codeCell.insertAdjacentElement('afterend', clipboardButton)
+        if (codeCell.classList.contains('server-url'))
+            codeCell.appendChild(clipboardButton)
+        else codeCell.insertAdjacentElement('afterend', clipboardButton)
     })
 
     function escapeRegExp(str: string) {
@@ -229,7 +231,7 @@ const addCopyButtonToCodeCells = (
 }
 
 export function initCopyButton(
-    selector: string = '.highlight pre',
+    selector: string = '.highlight pre, .server-url',
     baseElement: ParentNode = document,
     prefix: string = 'markdown-content-codecell-'
 ) {

--- a/tests/Elastic.ApiExplorer.Tests/OpenApiGeneratorMarkdownEmissionTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/OpenApiGeneratorMarkdownEmissionTests.cs
@@ -150,6 +150,66 @@ public class OpenApiGeneratorMarkdownEmissionTests(ApiExplorerFixture fixture) :
 	}
 
 	[Fact]
+	public async Task Generate_FixtureProductLandingHtml_ContainsBaseUrlLicenseVersionAndCatalog()
+	{
+		var outputRoot = Path.Join(Paths.WorkingDirectoryRoot.FullName, $"api-landing-html-{Guid.NewGuid():N}");
+		var context = await Generate(outputRoot, fixture.Document, TestContext.Current.CancellationToken);
+		var html = await context
+			.WriteFileSystem
+			.File
+			.ReadAllTextAsync(Path.Join(outputRoot, "api", "doc", "elasticsearch", "index.html"), TestContext.Current.CancellationToken);
+
+		html.Should().Contain("https://fixture.example.com");
+		html.Should().Contain("class=\"server-url\"");
+		html.Should().Contain("Base URL");
+		html.Should().Contain("Apache 2.0");
+		html.Should().Contain("1.2.3");
+		html.Should().Contain("Search APIs");
+	}
+
+	[Fact]
+	public async Task Generate_FixtureProductLandingMarkdown_ContainsBaseUrlLicenseVersionAndCatalog()
+	{
+		var outputRoot = Path.Join(Paths.WorkingDirectoryRoot.FullName, $"api-landing-md-{Guid.NewGuid():N}");
+		var context = await Generate(outputRoot, fixture.Document, TestContext.Current.CancellationToken);
+		var markdown = await context
+			.WriteFileSystem
+			.File
+			.ReadAllTextAsync(Path.Join(outputRoot, "api", "doc", "elasticsearch.md"), TestContext.Current.CancellationToken);
+
+		markdown.Should().Contain("https://fixture.example.com");
+		markdown.Should().Contain("Base URL");
+		markdown.Should().Contain("Apache 2.0");
+		markdown.Should().Contain("1.2.3");
+		markdown.Should().Contain("Search APIs");
+	}
+
+	[Fact]
+	public async Task Generate_TitleOnlyDocument_OmitsEmptyInfoHeadings()
+	{
+		var document = new OpenApiDocument { Info = new OpenApiInfo { Title = "Title Only API", Version = "" }, Paths = [] };
+		var outputRoot = Path.Join(Paths.WorkingDirectoryRoot.FullName, $"api-landing-empty-{Guid.NewGuid():N}");
+		var context = await Generate(outputRoot, document, TestContext.Current.CancellationToken);
+		var html = await context
+			.WriteFileSystem
+			.File
+			.ReadAllTextAsync(Path.Join(outputRoot, "api", "doc", "elasticsearch", "index.html"), TestContext.Current.CancellationToken);
+		var markdown = await context
+			.WriteFileSystem
+			.File
+			.ReadAllTextAsync(Path.Join(outputRoot, "api", "doc", "elasticsearch.md"), TestContext.Current.CancellationToken);
+
+		html.Should().Contain("Title Only API");
+		html.Should().NotContain("License:");
+		html.Should().NotContain("Version:");
+		html.Should().NotContain("Base URL");
+		markdown.Should().Contain("# Title Only API");
+		markdown.Should().NotContain("License:");
+		markdown.Should().NotContain("Version:");
+		markdown.Should().NotContain("Base URL");
+	}
+
+	[Fact]
 	public async Task SimpleMarkdownPage_WritesAuthoredSource()
 	{
 		var introPath = Path.Combine(
@@ -181,6 +241,22 @@ public class OpenApiGeneratorMarkdownEmissionTests(ApiExplorerFixture fixture) :
 		wrapped.Should().Contain("description: Spaces enable you to organize");
 		wrapped.Should().Contain("# Kibana spaces");
 		wrapped.Should().NotContain("<!DOCTYPE");
+	}
+
+	private async Task<BuildContext> Generate(string outputRoot, OpenApiDocument document, Cancel ctx)
+	{
+		var context = CreateGenerateContext(outputRoot);
+		using var versionIndexClient = new VersionIndexClient(BaseUri, MainOnlyHandler(), sleep: (_, _) => Task.CompletedTask);
+		var reader = CreateSequentialReader(document);
+		var generator = new OpenApiGenerator(
+			NullLoggerFactory.Instance,
+			context,
+			PassthroughMarkdownRenderer.Instance,
+			versionIndexClient,
+			reader
+		);
+		await generator.Generate(ctx);
+		return context;
 	}
 
 	private static BuildContext CreateGenerateContext(string outputRoot)


### PR DESCRIPTION
API product landings now show a copyable Base URL, license, and version when those fields exist on the OpenAPI document. The catalog table stays in place. An empty `License:` line no longer appears when the spec has no license.

**Affects:** API reference, Site UI

**Prompt summary:** Implement https://github.com/elastic/docs-eng-team/issues/814. Add a Base URL row with copy on the product landing when `document.Servers` is present. Show license and version only when those fields exist on `info`. Keep the operation catalog. Do not replace the landing with the Introduction topic.

## Why

The product landing already prints title, description, and a full operation catalog. It does not show servers, so a reader cannot copy the Base URL. It always prints `License:` even when `info.license` is missing. Operation pages already list servers, but `.server-url` has no copy control.

Implements https://github.com/elastic/docs-eng-team/issues/814.

## What

#### Landing extras
`LandingInfoNote` is built once from the OpenAPI document. The landing view prints Base URL, license, and version only when those values exist. License becomes a link when `info.license.url` is set. Source and last-update stay out. OpenAPI `info` does not have those fields.

#### Copy on server URLs
`initCopyButton` also targets `.server-url`. The button is appended inside that chip so hover CSS can show it. Code-block buttons still insert after the `pre`. Operation pages pick up the same copy control.

#### Markdown export
`LandingCommonMark.Product` takes the same `LandingInfoNote` and writes matching Base URL, license, and version lines.

## Verify

```bash
dotnet test tests/Elastic.ApiExplorer.Tests/
```

```bash
# Generate_FixtureProductLandingHtml_ContainsBaseUrlLicenseVersionAndCatalog
# Generate_FixtureProductLandingMarkdown_ContainsBaseUrlLicenseVersionAndCatalog
# Generate_TitleOnlyDocument_OmitsEmptyInfoHeadings
```

Run against local preview or staging. Production `/docs/api/*` still proxies to bump.sh.

**Out of scope:** Source and last-update rows. Those fields are not on OpenAPI `info`.

Made with [Cursor](https://cursor.com)