### PR TITLE
Write OpenAPI JSON and YAML next to API landings

### DIFF
--- a/src/Elastic.ApiExplorer/Infrastructure/ApiOutputPaths.cs
+++ b/src/Elastic.ApiExplorer/Infrastructure/ApiOutputPaths.cs
@@ -7,15 +7,15 @@ using System.Text.RegularExpressions;
 namespace Elastic.ApiExplorer.Infrastructure;
 
 /// <summary>
-/// Maps an API page URL to the sibling HTML and CommonMark files the generator writes.
+/// Maps an API page URL to the sibling HTML, CommonMark, and OpenAPI spec files the generator writes.
 /// </summary>
 public static class ApiOutputPaths
 {
-	public static string MarkdownUrl(string pageUrl)
-	{
-		var trimmed = pageUrl.TrimEnd('/');
-		return trimmed.Length == 0 ? "/index.md" : trimmed + ".md";
-	}
+	public static string MarkdownUrl(string pageUrl) => SiblingUrl(pageUrl, ".md");
+
+	public static string JsonUrl(string pageUrl) => SiblingUrl(pageUrl, ".json");
+
+	public static string YamlUrl(string pageUrl) => SiblingUrl(pageUrl, ".yaml");
 
 	public static string RelativeHtmlFile(string pageUrl, string? urlPathPrefix)
 	{
@@ -23,9 +23,21 @@ public static class ApiOutputPaths
 		return fileName.Trim('/');
 	}
 
-	public static string RelativeMarkdownFile(string pageUrl, string? urlPathPrefix)
+	public static string RelativeMarkdownFile(string pageUrl, string? urlPathPrefix) => RelativeSiblingFile(pageUrl, urlPathPrefix, ".md");
+
+	public static string RelativeJsonFile(string pageUrl, string? urlPathPrefix) => RelativeSiblingFile(pageUrl, urlPathPrefix, ".json");
+
+	public static string RelativeYamlFile(string pageUrl, string? urlPathPrefix) => RelativeSiblingFile(pageUrl, urlPathPrefix, ".yaml");
+
+	private static string SiblingUrl(string pageUrl, string extension)
 	{
-		var fileName = Regex.Replace(pageUrl.TrimEnd('/') + ".md", $"^{urlPathPrefix}", string.Empty);
+		var trimmed = pageUrl.TrimEnd('/');
+		return trimmed.Length == 0 ? "/index" + extension : trimmed + extension;
+	}
+
+	private static string RelativeSiblingFile(string pageUrl, string? urlPathPrefix, string extension)
+	{
+		var fileName = Regex.Replace(pageUrl.TrimEnd('/') + extension, $"^{urlPathPrefix}", string.Empty);
 		return fileName.Trim('/');
 	}
 }

--- a/src/Elastic.ApiExplorer/Landing/ApiCatalogView.cshtml
+++ b/src/Elastic.ApiExplorer/Landing/ApiCatalogView.cshtml
@@ -8,7 +8,7 @@
 	<ul>
 		@foreach (var entry in Model.Entries.OrderBy(e => e.Key))
 		{
-			<li><a href="@entry.Url">@entry.Title</a> (<code>@entry.Key</code>)</li>
+			<li><a href="@entry.Url">@entry.Title</a> (<code>@entry.Key</code>) <a href="@ApiOutputPaths.JsonUrl(entry.Url)" download>JSON</a> <a href="@ApiOutputPaths.YamlUrl(entry.Url)" download>YAML</a></li>
 		}
 	</ul>
 </section>

--- a/src/Elastic.ApiExplorer/Landing/LandingView.cshtml
+++ b/src/Elastic.ApiExplorer/Landing/LandingView.cshtml
@@ -9,6 +9,7 @@
 	<h1>@Model.ApiInfo.Title</h1>
 	<p>@Model.RenderMarkdown(Model.ApiInfo.Description)</p>
 	<p>License: @Model.ApiInfo.License?.Name</p>
+	<p>Download source: <a href="@Model.JsonUrl" download>JSON</a> <a href="@Model.YamlUrl" download>YAML</a></p>
 	<div class="api-overview">
 		<table>
 			@foreach (var row in Model.OverviewRows)

--- a/src/Elastic.ApiExplorer/Landing/LandingViewModel.cs
+++ b/src/Elastic.ApiExplorer/Landing/LandingViewModel.cs
@@ -16,4 +16,7 @@ public class LandingViewModel(ApiRenderContext context) : ApiViewModel(context)
 
 	/// <summary>Flattened overview table rows; built before the slice renders.</summary>
 	public required IReadOnlyList<ApiOverviewRow> OverviewRows { get; init; }
+
+	public string JsonUrl { get; } = ApiOutputPaths.JsonUrl(context.CurrentNavigation.Url);
+	public string YamlUrl { get; } = ApiOutputPaths.YamlUrl(context.CurrentNavigation.Url);
 }

--- a/src/Elastic.ApiExplorer/OpenApiGenerator.cs
+++ b/src/Elastic.ApiExplorer/OpenApiGenerator.cs
@@ -301,6 +301,31 @@ public class OpenApiGenerator(
 		};
 
 		await RenderNavigationItems(renderContext, navigationRenderer, navigation, ctx).ConfigureAwait(false);
+		await WriteSpecDownloads(navigation, generation.Document, ctx).ConfigureAwait(false);
+	}
+
+	private async Task WriteSpecDownloads(INavigationItem landing, OpenApiDocument document, Cancel ctx)
+	{
+		await WriteSpecSibling(
+			ApiOutputPaths.RelativeJsonFile(landing.Url, context.UrlPathPrefix),
+			(stream, token) => document.SerializeAsJsonAsync(stream, OpenApiSpecVersion.OpenApi3_1, token),
+			ctx
+		).ConfigureAwait(false);
+		await WriteSpecSibling(
+			ApiOutputPaths.RelativeYamlFile(landing.Url, context.UrlPathPrefix),
+			(stream, token) => document.SerializeAsYamlAsync(stream, OpenApiSpecVersion.OpenApi3_1, token),
+			ctx
+		).ConfigureAwait(false);
+	}
+
+	private async Task WriteSpecSibling(string relativeFile, Func<Stream, Cancel, Task> write, Cancel ctx)
+	{
+		var file = _writeFileSystem.FileInfo.New(Path.Join(context.OutputDirectory.FullName, relativeFile));
+		if (!file.Directory!.Exists)
+			file.Directory.Create();
+
+		await using var stream = _writeFileSystem.FileStream.New(file.FullName, FileMode.Create);
+		await write(stream, ctx).ConfigureAwait(false);
 	}
 
 	/// <summary>

--- a/src/tooling/docs-builder/Http/DocumentationWebHost.cs
+++ b/src/tooling/docs-builder/Http/DocumentationWebHost.cs
@@ -304,11 +304,12 @@ public class DocumentationWebHost
 		var apiRoot = Path.GetFullPath(holder.ApiPath.FullName);
 		var outputRoot = Path.GetFullPath(holder.ApiPath.Parent!.FullName);
 		var trimmed = slug.Trim('/');
-		var wantsMarkdown = trimmed.EndsWith(".md", StringComparison.OrdinalIgnoreCase)
-			|| MarkdownAccept.PrefersMarkdown(http.Request.Headers.Accept);
-		var path = wantsMarkdown
-			? ApiMarkdownRequest.ResolveFile(apiRoot, trimmed)
-			: Path.GetFullPath(Path.Join(apiRoot, trimmed, "index.html"));
+		var specMime = SpecMime(trimmed);
+		var wantsMarkdown = specMime is null
+			&& (trimmed.EndsWith(".md", StringComparison.OrdinalIgnoreCase) || MarkdownAccept.PrefersMarkdown(http.Request.Headers.Accept));
+		var path = specMime is not null
+			? Path.GetFullPath(Path.Join(apiRoot, trimmed))
+			: wantsMarkdown ? ApiMarkdownRequest.ResolveFile(apiRoot, trimmed) : Path.GetFullPath(Path.Join(apiRoot, trimmed, "index.html"));
 		if (!path.StartsWith(outputRoot + Path.DirectorySeparatorChar, StringComparison.Ordinal))
 			return Results.NotFound();
 
@@ -317,10 +318,21 @@ public class DocumentationWebHost
 			return Results.NotFound();
 
 		var contents = await _writeFileSystem.File.ReadAllTextAsync(info.FullName, ctx);
+		if (specMime is not null)
+			return Results.Content(contents, specMime);
 		if (wantsMarkdown)
 			return Results.Content(contents, "text/markdown; charset=utf-8");
 
 		return LiveReloadHtml(contents, Encoding.UTF8, 200);
+
+		static string? SpecMime(string slug)
+		{
+			if (slug.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+				return "application/json";
+			if (slug.EndsWith(".yaml", StringComparison.OrdinalIgnoreCase) || slug.EndsWith(".yml", StringComparison.OrdinalIgnoreCase))
+				return "text/yaml";
+			return null;
+		}
 	}
 
 	private static async Task<IResult> ServeDocumentationFile(

--- a/src/tooling/docs-builder/Http/StaticWebHost.cs
+++ b/src/tooling/docs-builder/Http/StaticWebHost.cs
@@ -160,6 +160,7 @@ public class StaticWebHost
 				".txt" => "text/plain",
 				".xml" => "text/xml",
 				".yml" => "text/yaml",
+				".yaml" => "text/yaml",
 				".md" => "text/markdown; charset=utf-8",
 				_ => "text/html"
 			};

--- a/tests/Elastic.ApiExplorer.Tests/ApiOutputPathsTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/ApiOutputPathsTests.cs
@@ -29,4 +29,32 @@ public class ApiOutputPathsTests
 	[InlineData("/api/doc/elasticsearch/operation/operation-search", "", "api/doc/elasticsearch/operation/operation-search.md")]
 	public void RelativeMarkdownFile_StripsPrefix(string pageUrl, string prefix, string expected) =>
 		ApiOutputPaths.RelativeMarkdownFile(pageUrl, prefix).Should().Be(expected);
+
+	[Theory]
+	[InlineData("/docs/api/doc/elasticsearch/", "/docs/api/doc/elasticsearch.json")]
+	[InlineData("/docs/api/doc/elasticsearch/v8/", "/docs/api/doc/elasticsearch/v8.json")]
+	[InlineData("/api/", "/api.json")]
+	[InlineData("/", "/index.json")]
+	public void JsonUrl_AppendsJsonToTrimmedPageUrl(string pageUrl, string expected) =>
+		ApiOutputPaths.JsonUrl(pageUrl).Should().Be(expected);
+
+	[Theory]
+	[InlineData("/docs/api/doc/elasticsearch/", "/docs/api/doc/elasticsearch.yaml")]
+	[InlineData("/docs/api/doc/elasticsearch/v8/", "/docs/api/doc/elasticsearch/v8.yaml")]
+	[InlineData("/api/", "/api.yaml")]
+	[InlineData("/", "/index.yaml")]
+	public void YamlUrl_AppendsYamlToTrimmedPageUrl(string pageUrl, string expected) =>
+		ApiOutputPaths.YamlUrl(pageUrl).Should().Be(expected);
+
+	[Theory]
+	[InlineData("docs/api/doc/elasticsearch", "docs", "api/doc/elasticsearch.json")]
+	[InlineData("/api/doc/elasticsearch/v8/", "", "api/doc/elasticsearch/v8.json")]
+	public void RelativeJsonFile_StripsPrefix(string pageUrl, string prefix, string expected) =>
+		ApiOutputPaths.RelativeJsonFile(pageUrl, prefix).Should().Be(expected);
+
+	[Theory]
+	[InlineData("docs/api/doc/elasticsearch", "docs", "api/doc/elasticsearch.yaml")]
+	[InlineData("/api/doc/elasticsearch/v8/", "", "api/doc/elasticsearch/v8.yaml")]
+	public void RelativeYamlFile_StripsPrefix(string pageUrl, string prefix, string expected) =>
+		ApiOutputPaths.RelativeYamlFile(pageUrl, prefix).Should().Be(expected);
 }

--- a/tests/Elastic.ApiExplorer.Tests/OpenApiGeneratorSpecDownloadTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/OpenApiGeneratorSpecDownloadTests.cs
@@ -1,0 +1,243 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Collections.Frozen;
+using System.IO.Abstractions.TestingHelpers;
+using System.Net;
+using AwesomeAssertions;
+using Elastic.ApiExplorer.Model;
+using Elastic.Documentation;
+using Elastic.Documentation.Configuration;
+using Elastic.Documentation.Configuration.Products;
+using Elastic.Documentation.Configuration.Versions;
+using Elastic.Documentation.Diagnostics;
+using Elastic.Documentation.FileSystems;
+using FakeItEasy;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.OpenApi;
+
+namespace Elastic.ApiExplorer.Tests;
+
+public class OpenApiGeneratorSpecDownloadTests(ApiExplorerFixture fixture) : IClassFixture<ApiExplorerFixture>
+{
+	private static readonly Uri BaseUri = new("https://cdn.example/");
+
+	[Fact]
+	public async Task Generate_WritesJsonAndYamlSiblingsForProductLanding()
+	{
+		var outputRoot = Path.Join(Paths.WorkingDirectoryRoot.FullName, $"api-spec-emit-{Guid.NewGuid():N}");
+		var context = CreateGenerateContext(outputRoot);
+		using var versionIndexClient = new VersionIndexClient(BaseUri, MainOnlyHandler(), sleep: (_, _) => Task.CompletedTask);
+		var reader = CreateSequentialReader(fixture.Document);
+		var generator = new OpenApiGenerator(
+			NullLoggerFactory.Instance,
+			context,
+			PassthroughMarkdownRenderer.Instance,
+			versionIndexClient,
+			reader
+		);
+
+		await generator.Generate(TestContext.Current.CancellationToken);
+
+		var write = context.WriteFileSystem.File;
+		var jsonPath = Path.Join(outputRoot, "api", "doc", "elasticsearch.json");
+		var yamlPath = Path.Join(outputRoot, "api", "doc", "elasticsearch.yaml");
+		write.Exists(jsonPath).Should().BeTrue();
+		write.Exists(yamlPath).Should().BeTrue();
+
+		var json = await write.ReadAllTextAsync(jsonPath, TestContext.Current.CancellationToken);
+		var yaml = await write.ReadAllTextAsync(yamlPath, TestContext.Current.CancellationToken);
+
+		json.Should().Contain("\"openapi\"");
+		json.Should().Contain("Fixture API");
+		json.Length.Should().BeGreaterThan(100);
+		yaml.Should().Contain("openapi:");
+		yaml.Should().Contain("Fixture API");
+		yaml.Length.Should().BeGreaterThan(100);
+	}
+
+	[Fact]
+	public async Task Generate_WritesVersionedSpecSiblings()
+	{
+		var outputRoot = Path.Join(Paths.WorkingDirectoryRoot.FullName, $"api-spec-v8-{Guid.NewGuid():N}");
+		var context = CreateGenerateContext(outputRoot);
+		using var versionIndexClient = new VersionIndexClient(BaseUri, MultiVersionHandler(), sleep: (_, _) => Task.CompletedTask);
+		var reader = CreateSequentialReader(fixture.Document, fixture.Document, fixture.Document);
+		var generator = new OpenApiGenerator(
+			NullLoggerFactory.Instance,
+			context,
+			PassthroughMarkdownRenderer.Instance,
+			versionIndexClient,
+			reader
+		);
+
+		await generator.Generate(TestContext.Current.CancellationToken);
+
+		var write = context.WriteFileSystem.File;
+		write.Exists(Path.Join(outputRoot, "api", "doc", "elasticsearch", "v8.json")).Should().BeTrue();
+		write.Exists(Path.Join(outputRoot, "api", "doc", "elasticsearch", "v8.yaml")).Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task Generate_LandingHtmlContainsDownloadSourceLinks()
+	{
+		var outputRoot = Path.Join(Paths.WorkingDirectoryRoot.FullName, $"api-spec-html-{Guid.NewGuid():N}");
+		var context = CreateGenerateContext(outputRoot);
+		using var versionIndexClient = new VersionIndexClient(BaseUri, MainOnlyHandler(), sleep: (_, _) => Task.CompletedTask);
+		var reader = CreateSequentialReader(fixture.Document);
+		var generator = new OpenApiGenerator(
+			NullLoggerFactory.Instance,
+			context,
+			PassthroughMarkdownRenderer.Instance,
+			versionIndexClient,
+			reader
+		);
+
+		await generator.Generate(TestContext.Current.CancellationToken);
+
+		var html = await context
+			.WriteFileSystem
+			.File
+			.ReadAllTextAsync(Path.Join(outputRoot, "api", "doc", "elasticsearch", "index.html"), TestContext.Current.CancellationToken);
+
+		html.Should().Contain("Download source");
+		html.Should().Contain("href=\"/api/doc/elasticsearch.json\"");
+		html.Should().Contain("href=\"/api/doc/elasticsearch.yaml\"");
+		html.Should().Contain("download");
+	}
+
+	private static BuildContext CreateGenerateContext(string outputRoot)
+	{
+		var collector = new DiagnosticsCollector([]);
+		var stack = TestHelpers.CreateStackVersionsConfiguration(currentMajor: 9);
+		var product = TestHelpers.CreateProduct("elasticsearch", stack.GetVersioningSystem(VersioningSystemId.Stack));
+		var repoRoot = Path.Join(Paths.WorkingDirectoryRoot.FullName, $"api-spec-repo-{Guid.NewGuid():N}");
+		var configPath = Path.Join(repoRoot, "docs", "docset.yml");
+		var docsetYaml =
+			"""
+			api:
+			  elasticsearch:
+			    - spec: elasticsearch-openapi.json
+			      product: elasticsearch
+			""";
+		var fs = new MockFileSystem(new MockFileSystemOptions { CurrentDirectory = Paths.WorkingDirectoryRoot.FullName });
+		fs.AddDirectory(Path.Join(repoRoot, ".git"));
+		fs.AddFile(configPath, new MockFileData(docsetYaml));
+		var products = new ProductsConfiguration
+		{
+			Products = new[] { product }.ToFrozenDictionary(p => p.Id, StringComparer.OrdinalIgnoreCase),
+			PublicReferenceProducts = new[] { product }.ToFrozenDictionary(p => p.Id, StringComparer.OrdinalIgnoreCase),
+			ProductDisplayNames = new Dictionary<string, string> { [product.Id] = product.DisplayName ?? product.Id }.ToFrozenDictionary(
+				StringComparer.OrdinalIgnoreCase
+			)
+		};
+		var configurationContext = TestHelpers.CreateConfigurationContext(fs, stack, products);
+
+		return new BuildContext(
+			collector,
+			DocumentationFileSystem.Resolve(
+				repoRoot,
+				new DocumentationScopeOptions
+				{
+					ConfigurationFile = configPath,
+					Output = outputRoot,
+					Git = new GitCheckoutInformation
+					{
+						Branch = "main",
+						Remote = "https://github.com/elastic/elasticsearch.git",
+						Ref = "refs/heads/main"
+					},
+					Inner = fs
+				}
+			),
+			configurationContext
+		);
+	}
+
+	private static IOpenApiSpecificationReader CreateSequentialReader(params OpenApiDocument[] documents)
+	{
+		var queue = new Queue<OpenApiDocument>(documents);
+		var reader = A.Fake<IOpenApiSpecificationReader>();
+		A.CallTo(() => reader.ReadAsync(A<Stream>._, A<string>._)).ReturnsLazily(_ => Task.FromResult<OpenApiDocument?>(queue.Dequeue()));
+		return reader;
+	}
+
+	private static HttpMessageHandler MainOnlyHandler() =>
+		new StubHandler(request =>
+		{
+			if (request.RequestUri!.AbsolutePath.EndsWith("index.json", StringComparison.Ordinal))
+			{
+				return new HttpResponseMessage(HttpStatusCode.OK)
+				{
+					Content = new StringContent(
+						/*lang=json,strict*/
+						"""
+						{
+							"elastic/elasticsearch": {
+								"elasticsearch-openapi.json": {
+									"main": { "version": "main" }
+								}
+							}
+						}
+						""",
+						System.Text.Encoding.UTF8,
+						"application/json"
+					)
+				};
+			}
+
+			return new HttpResponseMessage(HttpStatusCode.OK)
+			{
+				Content = new StringContent(
+					/*lang=json,strict*/
+					"""{"openapi":"3.1.0","info":{"title":"Spec","version":"1.0"},"paths":{}}""",
+					System.Text.Encoding.UTF8,
+					"application/json"
+				)
+			};
+		});
+
+	private static HttpMessageHandler MultiVersionHandler() =>
+		new StubHandler(request =>
+		{
+			if (request.RequestUri!.AbsolutePath.EndsWith("index.json", StringComparison.Ordinal))
+			{
+				return new HttpResponseMessage(HttpStatusCode.OK)
+				{
+					Content = new StringContent(
+						/*lang=json,strict*/
+						"""
+						{
+							"elastic/elasticsearch": {
+								"elasticsearch-openapi.json": {
+									"main": { "version": "main" },
+									"9": { "version": "9.4" },
+									"8": { "version": "8.19" }
+								}
+							}
+						}
+						""",
+						System.Text.Encoding.UTF8,
+						"application/json"
+					)
+				};
+			}
+
+			return new HttpResponseMessage(HttpStatusCode.OK)
+			{
+				Content = new StringContent(
+					/*lang=json,strict*/
+					"""{"openapi":"3.1.0","info":{"title":"Spec","version":"1.0"},"paths":{}}""",
+					System.Text.Encoding.UTF8,
+					"application/json"
+				)
+			};
+		});
+
+	private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
+	{
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+			Task.FromResult(responder(request));
+	}
+}


### PR DESCRIPTION
Product landings now write sibling OpenAPI JSON and YAML, and show a Download source control so readers can fetch the spec that the page rendered.

**Affects:** API reference, Isolated builds

**Prompt summary:** Implement [elastic/docs-eng-team#815](https://github.com/elastic/docs-eng-team/issues/815). Specs are already fetched for render. Write them to the output tree and add a Download source control on the product landing.

## Why

Specs are fetched for HTML render and then discarded. `GET /docs/api/doc/elasticsearch.json` 404s, and the landing has no Download control. Versioned landings need that version's spec, not a single shared file.

Closes elastic/docs-eng-team#815

## What

#### Spec files next to the landing

Each rendered product version writes sibling `.json` and `.yaml` from the resolved OpenAPI document. A landing at `/docs/api/doc/elasticsearch/` gets `elasticsearch.json` and `elasticsearch.yaml`. A `/v8/` landing gets `v8.json` and `v8.yaml`.

#### Download source control

The product landing has a Download source row with JSON and YAML links. The API catalog list adds the same links per product. Both use the landing URL stem, so a versioned page downloads that version.

#### Preview MIME

Isolated preview serves `.json`, `.yaml`, and `.yml` under `/api/` as files, not `index.html`. Assembled static preview maps `.yaml` to `text/yaml`.

## Verify

```bash
dotnet test tests/Elastic.ApiExplorer.Tests/
# Generate_WritesJsonAndYamlSiblingsForProductLanding
# Generate_WritesVersionedSpecSiblings
# Generate_LandingHtmlContainsDownloadSourceLinks
```

After a local API generate or assemble, curl the sibling files:

```bash
curl -I http://localhost:3000/docs/api/doc/elasticsearch.json
curl -I http://localhost:3000/docs/api/doc/elasticsearch.yaml
```

**Out of scope:** CommonMark export does not list the spec files. The catalog is still a list, not hub cards.


Made with [Cursor](https://cursor.com)