### PR TITLE
Fix SingleOrDefault crash in version inference when a repo maps to multiple products

### DIFF
--- a/src/Elastic.Documentation.Configuration/Inference/VersionInference.cs
+++ b/src/Elastic.Documentation.Configuration/Inference/VersionInference.cs
@@ -49,14 +49,17 @@ public class ProductVersionInferrerService(
 				return versioningFromApplicability;
 		}
 
+		var repositoryMatches = ProductsConfiguration
+			.Products
+			.Values
+			.Where(p => p.Repository is not null && p.Repository.Equals(repositoryName, StringComparison.OrdinalIgnoreCase))
+			.ToList();
+
 		var versioning = ProductsConfiguration.Products.TryGetValue(repositoryName, out var belonging)
 			? belonging.VersioningSystem! //If the page's docset has a name with a direct product match, use the versioning system of the product
 
-			: ProductsConfiguration
-				.Products
-				.Values
-				.SingleOrDefault(p => p.Repository is not null && p.Repository.Equals(repositoryName, StringComparison.OrdinalIgnoreCase)) is { } repositoryMatch
-				? repositoryMatch.VersioningSystem! // Verify if the page belongs to a repository linked to a product, and if so, use the versioning system of the product
+			: repositoryMatches is [{ } repositoryMatch]
+				? repositoryMatch.VersioningSystem! // Verify if the page belongs to a repository linked to exactly one product, and if so, use the versioning system of the product
 
 				: VersionsConfiguration.VersioningSystems[VersioningSystemId.Stack]; // Fallback to the stack versioning system
 


### PR DESCRIPTION
`ProductVersionInferrerService.InferVersion` threw `InvalidOperationException: Sequence contains more than one element` when inferring the versioning system for any file from the `cloud` repository. Three products share that repository — `cloud-enterprise`, `cloud-hosted`, and `cloud-serverless` — so the `.SingleOrDefault()` lookup returned more than one match and crashed.

**Affects:** Configuration, Assembler builds

**Prompt summary:** Investigate a CI failure in `docs-internal-workflows` where assembler builds for cloud-hosted files crash with a sequence-contains-more-than-one-element exception, and fix it.

## Why

[#4022](https://github.com/elastic/docs-builder/pull/4022) fixed the same pattern in `GetProductByRepositoryName` but the identical `.SingleOrDefault()` call in `VersionInference.cs` was not updated at the same time. The three cloud products each have a different versioning system (`ece`, `ech`, `serverless`), so a `FirstOrDefault` fallback is not semantically correct — the right behaviour when the repository is ambiguous is to fall through to the Stack default.

## What

#### Version inference for shared repositories

The `.SingleOrDefault()` call is replaced with a pre-computed list and a list pattern that matches only when there is exactly one result. Zero matches and multiple matches both fall through to the Stack versioning system, which is the same behaviour the zero-match path had before. Direct product-key lookups via `TryGetValue` are unaffected and still short-circuit first.

## Verify

```bash
dotnet test tests/Elastic.Markdown.Tests/
```