### PR TITLE
Apply navigation-preview styles on API explorer pages

### DIFF
--- a/src/Elastic.ApiExplorer/Infrastructure/ApiViewModel.cs
+++ b/src/Elastic.ApiExplorer/Infrastructure/ApiViewModel.cs
@@ -7,7 +7,6 @@ using Elastic.ApiExplorer.Operations;
 using Elastic.Documentation;
 using Elastic.Documentation.Configuration;
 using Elastic.Documentation.Configuration.Assembler;
-using Elastic.Documentation.Configuration.Builder;
 using Elastic.Documentation.Extensions;
 using Elastic.Documentation.Navigation;
 using Elastic.Documentation.Site;
@@ -80,7 +79,7 @@ public abstract class ApiViewModel(ApiRenderContext context)
 			CanonicalBaseUrl = BuildContext.CanonicalBaseUrl,
 			GoogleTagManager = new GoogleTagManagerConfiguration(),
 			Optimizely = new OptimizelyConfiguration(),
-			Features = new FeatureFlags([]),
+			Features = BuildContext.Configuration.Features,
 			StaticFileContentHashProvider = StaticFileContentHashProvider,
 			BuildType = BuildContext.BuildType,
 			TocItems = GetTocItems(),

--- a/tests/Elastic.ApiExplorer.Tests/ApiLayoutFeatureFlagsTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/ApiLayoutFeatureFlagsTests.cs
@@ -1,0 +1,68 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions;
+using AwesomeAssertions;
+using Elastic.ApiExplorer.Infrastructure;
+using Elastic.ApiExplorer.Landing;
+using Elastic.Documentation;
+using Elastic.Documentation.Configuration;
+using Elastic.Documentation.Diagnostics;
+using Elastic.Documentation.FileSystems;
+using Elastic.Documentation.Site.FileProviders;
+using Microsoft.OpenApi;
+using RazorSlices;
+
+namespace Elastic.ApiExplorer.Tests;
+
+public class ApiLayoutFeatureFlagsTests
+{
+	[Fact]
+	public async Task CreateGlobalLayoutModel_WhenNavigationPreviewEnabled_CopiesBuildContextFeatures()
+	{
+		var (context, viewModel) = CreateViewModel(navigationPreviewEnabled: true);
+		var layout = viewModel.CreateGlobalLayoutModel();
+
+		layout.Features.Should().BeSameAs(context.Configuration.Features);
+		layout.Features.NavigationPreviewEnabled.Should().BeTrue();
+
+		var html = await ApiCatalogView.Create(viewModel).RenderAsync(cancellationToken: TestContext.Current.CancellationToken);
+		html.Should().Contain("navigation-preview");
+	}
+
+	[Fact]
+	public void CreateGlobalLayoutModel_WhenNavigationPreviewDisabled_KeepsFlagOff()
+	{
+		var (context, viewModel) = CreateViewModel(navigationPreviewEnabled: false);
+		var layout = viewModel.CreateGlobalLayoutModel();
+
+		layout.Features.Should().BeSameAs(context.Configuration.Features);
+		layout.Features.NavigationPreviewEnabled.Should().BeFalse();
+	}
+
+	private static (BuildContext Context, ApiCatalogViewModel ViewModel) CreateViewModel(bool navigationPreviewEnabled)
+	{
+		var fs = new FileSystem();
+		var context = new BuildContext(
+			new DiagnosticsCollector([]),
+			DocumentationFileSystem.Resolve(Paths.WorkingDirectoryRoot.FullName),
+			TestHelpers.CreateConfigurationContext(fs)
+		);
+		context.Configuration.Features.NavigationPreviewEnabled = navigationPreviewEnabled;
+
+		var renderContext = new ApiRenderContext(
+			context,
+			new OpenApiDocument { Info = new OpenApiInfo { Title = "Test API", Version = "1.0" } },
+			new StaticFileContentHashProvider(new EmbeddedOrPhysicalFileProvider(context))
+		)
+		{
+			NavigationHtml = string.Empty,
+			CurrentNavigation = new LandingNavigationItem("/api/doc/test/").Index,
+			MarkdownRenderer = PassthroughMarkdownRenderer.Instance
+		};
+
+		var viewModel = new ApiCatalogViewModel(renderContext) { Entries = [] };
+		return (context, viewModel);
+	}
+}


### PR DESCRIPTION
API explorer pages now receive the build's feature flags. When `navigation-preview` is on, the left sidebar uses the same styles as markdown pages.

**Affects:** API reference, Site UI

**Prompt summary:** Fix the broken left navigation on API pages. The report pointed at a cloud-connect preview where folder labels and chevrons no longer lined up.

## Why

API explorer pages already emit the v2 sidebar markup when `navigation-preview` is on. The layout used to construct an empty `FeatureFlags` bag. The body never received the `navigation-preview` class that `pages-nav-figma.css` requires. Folder links stayed `inline-block` and chevrons wrapped under the labels.

## What

#### Layout feature flags
API pages now pass the build's `FeatureFlags` into the layout. When `navigation-preview` is on, the body gets that class. The existing sidebar CSS then styles folder links as full-width flex rows, matching markdown pages.

#### Regression test
`CreateGlobalLayoutModel` must keep the build's flags. A rendered catalog page includes `navigation-preview` on the body when the flag is on.

#### Flag-off path
When the flag is off, the layout still reports `NavigationPreviewEnabled` as false. The previous default is unchanged.

## Verify

```bash
dotnet test tests/Elastic.ApiExplorer.Tests/
# CreateGlobalLayoutModel_WhenNavigationPreviewEnabled_CopiesBuildContextFeatures
# CreateGlobalLayoutModel_WhenNavigationPreviewDisabled_KeepsFlagOff
```

**Out of scope:** `_ApiPagesNav` still hardcodes the older aside wrapper classes. The inner tree styles come from `body.navigation-preview`.

Made with [Cursor](https://cursor.com)