### PR TITLE
Fix nav expand/collapse and chevron alignment when NAVIGATION_PREVIEW is off

### DIFF
--- a/config/assembler.yml
+++ b/config/assembler.yml
@@ -23,7 +23,7 @@ environments:
     feature_flags:
       WEBSITE_SEARCH: true
       ASSEMBLER_API_EXPLORER: true
-      NAVIGATION_PREVIEW: true
+      NAVIGATION_PREVIEW: false
     website_search_url: https://staging-website.elastic.co/search/elastic-website-search.js
   edge:
     uri: https://d34ipnu52o64md.cloudfront.net
@@ -51,7 +51,7 @@ environments:
     path_prefix: docs
     feature_flags:
       WEBSITE_SEARCH: true
-      NAVIGATION_PREVIEW: true
+      NAVIGATION_PREVIEW: false
     website_search_url: http://localhost:4078/elastic-website-search.js
   preview:
     uri: https://docs-v3-preview.elastic.dev

--- a/src/Elastic.Documentation.Site/Assets/styles.css
+++ b/src/Elastic.Documentation.Site/Assets/styles.css
@@ -175,6 +175,10 @@ body {
 		@apply relative flex flex-wrap;
 	}
 
+	.nav-subtree-clip {
+		@apply w-full;
+	}
+
 	.nav-toggle-btn {
 		@apply hover:bg-grey-20 cursor-pointer rounded-sm p-1;
 	}

--- a/src/Elastic.Documentation.Site/Assets/styles.css
+++ b/src/Elastic.Documentation.Site/Assets/styles.css
@@ -190,7 +190,8 @@ body {
 		@apply relative ml-4 hidden w-full;
 
 		/* revealed when the sibling .peer div contains a checked checkbox */
-		.peer:has(:checked) ~ & {
+		.peer:has(:checked) ~ &,
+		.peer:has(:checked) ~ .nav-subtree-clip > & {
 			display: block;
 		}
 

--- a/src/Elastic.Documentation.Site/Assets/styles.css
+++ b/src/Elastic.Documentation.Site/Assets/styles.css
@@ -191,7 +191,7 @@ body {
 	}
 
 	.nav-subtree {
-		@apply relative ml-4 hidden w-full;
+		@apply relative ml-4 hidden;
 
 		/* revealed when the sibling .peer div contains a checked checkbox */
 		.peer:has(:checked) ~ &,


### PR DESCRIPTION
[PR #4007](https://github.com/elastic/docs-builder/pull/4007) introduced a `nav-subtree-clip` wrapper div that broke nav expand/collapse and chevron alignment in environments where `NAVIGATION_PREVIEW` is disabled. This PR fixes both regressions and disables the flag in the `staging` and `local` environments.

**Affects:** Site UI, Configuration

**Prompt summary:** Navigation folder items stopped expanding and collapsing on pages like `/docs/extend` after PR [#4007](https://github.com/elastic/docs-builder/pull/4007). The chevron icons were also misaligned — not stacking in a consistent right column. The author wanted both behaviours restored to match the pre-[#4007](https://github.com/elastic/docs-builder/pull/4007) baseline while keeping the new `nav-subtree-clip` wrapper in place.

## Why

[PR #4007](https://github.com/elastic/docs-builder/pull/4007) wrapped `ul.nav-subtree` in a new `div.nav-subtree-clip`. The expand/collapse CSS selector `.peer:has(:checked) ~ .nav-subtree` relies on `.peer` and `.nav-subtree` being direct siblings. The clip div sits between them, so the sibling combinator (`~`) no longer matches and subtrees stay hidden regardless of checkbox state.

The same wrapper also broke chevron alignment. `.nav-subtree-clip` had no width in non-preview mode, so it collapsed to content width. The `ul.nav-subtree` inherited that collapsed width via `w-full`, and the `grid-cols-[1fr_auto]` layout on each child row never reached the nav's right edge — chevrons sat adjacent to text instead of stacking in a column.

## What

#### Expand/collapse selector

The reveal rule in `styles.css` gains a second selector variant that traverses through the clip wrapper:

```css
.peer:has(:checked) ~ &,
.peer:has(:checked) ~ .nav-subtree-clip > & {
    display: block;
}
```

#### Chevron alignment

`.nav-subtree-clip` gets `w-full` so it stretches to the full flex row width, giving its child grid a stable right boundary. `.nav-subtree` drops its own `w-full` — as a block child of a full-width block container, it takes `clip_width − ml-4` automatically, which avoids the `margin + 100%` overflow that would otherwise compound at every nesting level.

#### NAVIGATION_PREVIEW flag

The `staging` and `local` environments in `config/assembler.yml` have `NAVIGATION_PREVIEW` set to `false`. The flag-gated CSS in `pages-nav-figma.css` masked the regressions for any environment where the flag was on.

## Verify

Start the local dev server and navigate to a page with nested navigation (for example `/docs/extend/kibana`). Folder items should expand and collapse on click, and all chevron icons should stack flush with the nav's right edge — both at the top level and in nested subtrees.