### PR TITLE
Keep the production sidebar accordion instant

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/pages-nav.test.ts
+++ b/src/Elastic.Documentation.Site/Assets/pages-nav.test.ts
@@ -12,14 +12,6 @@ import {
     syncPagesNavFromResponse,
 } from './pages-nav'
 
-beforeEach(() => {
-    document.body.classList.add('navigation-preview')
-})
-
-afterEach(() => {
-    document.body.classList.remove('navigation-preview')
-})
-
 function pagesNav(treeId: string, heading: string, extra = ''): string {
     const headingHtml = heading
         ? `<div class="pages-nav-v2__heading"><span class="pages-nav-v2__heading-text">${heading}</span></div>`
@@ -430,7 +422,6 @@ describe('ensureSubtreeClips', () => {
     })
 
     it('leaves the legacy accordion alone when navigation-preview is off', () => {
-        document.body.classList.remove('navigation-preview')
         document.body.innerHTML = `
             <nav id="pages-nav">
                 <li class="nav-folder">
@@ -456,12 +447,14 @@ describe('ensureSubtreeClips', () => {
     it('wraps a folder subtree once', () => {
         document.body.innerHTML = `
             <nav id="pages-nav">
-                <li class="nav-folder">
-                    <div class="peer nav-folder-peer">
-                        <input id="folder-a" type="checkbox">
-                    </div>
-                    <ul class="nav-subtree"><li>Child</li></ul>
-                </li>
+                <div class="pages-nav-v2-shell" data-nav-heading="Test">
+                    <li class="nav-folder">
+                        <div class="peer nav-folder-peer">
+                            <input id="folder-a" type="checkbox">
+                        </div>
+                        <ul class="nav-subtree"><li>Child</li></ul>
+                    </li>
+                </div>
             </nav>
         `
         const nav = document.querySelector<HTMLElement>('#pages-nav')!
@@ -478,12 +471,14 @@ describe('ensureSubtreeClips', () => {
     it('initNav wraps folders so open/close can animate without breaking layout', () => {
         document.body.innerHTML = `
             <nav id="pages-nav">
-                <li class="nav-folder">
-                    <div class="peer nav-folder-peer">
-                        <input id="folder-a" type="checkbox">
-                    </div>
-                    <ul class="nav-subtree"><li>Child</li></ul>
-                </li>
+                <div class="pages-nav-v2-shell" data-nav-heading="Test">
+                    <li class="nav-folder">
+                        <div class="peer nav-folder-peer">
+                            <input id="folder-a" type="checkbox">
+                        </div>
+                        <ul class="nav-subtree"><li>Child</li></ul>
+                    </li>
+                </div>
             </nav>
         `
         initNav()
@@ -496,12 +491,14 @@ describe('ensureSubtreeClips', () => {
     it('keeps a closed subtree in the document so the first open can animate', () => {
         document.body.innerHTML = `
             <nav id="pages-nav">
-                <li class="nav-folder">
-                    <div class="peer nav-folder-peer">
-                        <input id="folder-a" type="checkbox">
-                    </div>
-                    <ul class="nav-subtree"><li>Child</li></ul>
-                </li>
+                <div class="pages-nav-v2-shell" data-nav-heading="Test">
+                    <li class="nav-folder">
+                        <div class="peer nav-folder-peer">
+                            <input id="folder-a" type="checkbox">
+                        </div>
+                        <ul class="nav-subtree"><li>Child</li></ul>
+                    </li>
+                </div>
             </nav>
         `
         initNav()
@@ -522,12 +519,14 @@ describe('ensureSubtreeClips', () => {
     it('does not yank a clip that is already in the document back to closed', () => {
         document.body.innerHTML = `
             <nav id="pages-nav">
-                <li class="nav-folder">
-                    <div class="peer nav-folder-peer">
-                        <input id="folder-a" type="checkbox">
-                    </div>
-                    <ul class="nav-subtree"><li>Child</li></ul>
-                </li>
+                <div class="pages-nav-v2-shell" data-nav-heading="Test">
+                    <li class="nav-folder">
+                        <div class="peer nav-folder-peer">
+                            <input id="folder-a" type="checkbox">
+                        </div>
+                        <ul class="nav-subtree"><li>Child</li></ul>
+                    </li>
+                </div>
             </nav>
         `
         initNav()
@@ -641,20 +640,22 @@ describe('ensureSubtreeClips', () => {
     it('keeps nested closed subtrees out of the document when the parent is open', () => {
         document.body.innerHTML = `
             <nav id="pages-nav">
-                <li class="nav-folder">
-                    <div class="peer nav-folder-peer">
-                        <input id="parent" type="checkbox">
-                    </div>
-                    <ul class="nav-subtree">
-                        <li class="nav-folder">
-                            <div class="peer nav-folder-peer">
-                                <input id="child" type="checkbox">
-                            </div>
-                            <ul class="nav-subtree"><li>Grandchild</li></ul>
-                        </li>
-                        <li>Leaf</li>
-                    </ul>
-                </li>
+                <div class="pages-nav-v2-shell" data-nav-heading="Test">
+                    <li class="nav-folder">
+                        <div class="peer nav-folder-peer">
+                            <input id="parent" type="checkbox">
+                        </div>
+                        <ul class="nav-subtree">
+                            <li class="nav-folder">
+                                <div class="peer nav-folder-peer">
+                                    <input id="child" type="checkbox">
+                                </div>
+                                <ul class="nav-subtree"><li>Grandchild</li></ul>
+                            </li>
+                            <li>Leaf</li>
+                        </ul>
+                    </li>
+                </div>
             </nav>
         `
         initNav()

--- a/src/Elastic.Documentation.Site/Assets/pages-nav.test.ts
+++ b/src/Elastic.Documentation.Site/Assets/pages-nav.test.ts
@@ -12,6 +12,14 @@ import {
     syncPagesNavFromResponse,
 } from './pages-nav'
 
+beforeEach(() => {
+    document.body.classList.add('navigation-preview')
+})
+
+afterEach(() => {
+    document.body.classList.remove('navigation-preview')
+})
+
 function pagesNav(treeId: string, heading: string, extra = ''): string {
     const headingHtml = heading
         ? `<div class="pages-nav-v2__heading"><span class="pages-nav-v2__heading-text">${heading}</span></div>`
@@ -419,6 +427,30 @@ describe('collapseAllFolders', () => {
 describe('ensureSubtreeClips', () => {
     beforeEach(() => {
         sessionStorage.clear()
+    })
+
+    it('leaves the legacy accordion alone when navigation-preview is off', () => {
+        document.body.classList.remove('navigation-preview')
+        document.body.innerHTML = `
+            <nav id="pages-nav">
+                <li class="nav-folder">
+                    <div class="peer nav-folder-peer">
+                        <input id="folder-a" type="checkbox">
+                    </div>
+                    <ul class="nav-subtree"><li>Child</li></ul>
+                </li>
+            </nav>
+        `
+        initNav()
+        const cb = document.querySelector<HTMLInputElement>('#folder-a')!
+        cb.checked = true
+        cb.dispatchEvent(new Event('change', { bubbles: true }))
+
+        expect(document.querySelector('.nav-subtree-clip')).toBeNull()
+        expect(
+            document.querySelector('li.nav-folder > ul.nav-subtree')
+        ).not.toBeNull()
+        expect(document.body.textContent).toContain('Child')
     })
 
     it('wraps a folder subtree once', () => {

--- a/src/Elastic.Documentation.Site/Assets/pages-nav.ts
+++ b/src/Elastic.Documentation.Site/Assets/pages-nav.ts
@@ -4,7 +4,7 @@ import { $optional, $$optional } from 'select-dom'
 
 const NAV_STATE_KEY = 'nav-expanded'
 
-/** Folder clips and height animation are nav-preview only. Flag-off prod keeps the CSS accordion. */
+/** Folder clips and height animation follow the preview shell, not a body class. */
 function isNavigationPreview(node?: ParentNode | EventTarget | null) {
     const doc =
         node instanceof Document
@@ -12,7 +12,7 @@ function isNavigationPreview(node?: ParentNode | EventTarget | null) {
             : node instanceof Node
               ? node.ownerDocument
               : document
-    return Boolean(doc?.body.classList.contains('navigation-preview'))
+    return Boolean(doc?.querySelector('.pages-nav-v2-shell'))
 }
 
 function expandedStorageKey(nav: ParentNode) {

--- a/src/Elastic.Documentation.Site/Assets/pages-nav.ts
+++ b/src/Elastic.Documentation.Site/Assets/pages-nav.ts
@@ -4,6 +4,17 @@ import { $optional, $$optional } from 'select-dom'
 
 const NAV_STATE_KEY = 'nav-expanded'
 
+/** Folder clips and height animation are nav-preview only. Flag-off prod keeps the CSS accordion. */
+function isNavigationPreview(node?: ParentNode | EventTarget | null) {
+    const doc =
+        node instanceof Document
+            ? node
+            : node instanceof Node
+              ? node.ownerDocument
+              : document
+    return Boolean(doc?.body.classList.contains('navigation-preview'))
+}
+
 function expandedStorageKey(nav: ParentNode) {
     return `${NAV_STATE_KEY}:${navSurfaceKey(nav)}`
 }
@@ -80,6 +91,9 @@ function clearNavState(nav: ParentNode) {
 }
 
 export function ensureSubtreeClips(nav: HTMLElement) {
+    if (!isNavigationPreview(nav)) {
+        return
+    }
     $$optional('li.nav-folder > ul.nav-subtree', nav).forEach((ul) => {
         if (!(ul instanceof HTMLElement)) {
             return
@@ -219,6 +233,9 @@ export function syncFolderPanels(
     root: ParentNode,
     options?: { detachClosed?: boolean }
 ) {
+    if (!isNavigationPreview(root)) {
+        return
+    }
     if (root instanceof HTMLElement) {
         ensureSubtreeClips(root)
     }
@@ -366,6 +383,9 @@ function playFolderClose(input: HTMLInputElement, nav: HTMLElement) {
 }
 
 function onFolderCheckboxChange(input: HTMLInputElement) {
+    if (!isNavigationPreview(input)) {
+        return
+    }
     const nav = navFromInput(input)
     if (!nav) {
         return

--- a/src/Elastic.Documentation.Site/Assets/styles.css
+++ b/src/Elastic.Documentation.Site/Assets/styles.css
@@ -199,12 +199,6 @@ body {
 			display: block;
 		}
 
-		/* pages-nav.ts wraps the subtree in a clip on every page. NAVIGATION_PREVIEW
-		   CSS knows about that wrapper; flag-off prod still uses this sibling reveal. */
-		.peer:has(:checked) ~ .nav-subtree-clip > & {
-			display: block;
-		}
-
 		&::before {
 			content: '';
 			@apply bg-grey-20 absolute top-0 bottom-0 w-px;

--- a/src/Elastic.Documentation.Site/Assets/styles.css
+++ b/src/Elastic.Documentation.Site/Assets/styles.css
@@ -199,6 +199,12 @@ body {
 			display: block;
 		}
 
+		/* pages-nav.ts wraps the subtree in a clip on every page. NAVIGATION_PREVIEW
+		   CSS knows about that wrapper; flag-off prod still uses this sibling reveal. */
+		.peer:has(:checked) ~ .nav-subtree-clip > & {
+			display: block;
+		}
+
 		&::before {
 			content: '';
 			@apply bg-grey-20 absolute top-0 bottom-0 w-px;
@@ -207,7 +213,8 @@ body {
 
 		/* darken connector line when subtree contains the current page */
 		&:has(.current)::before,
-		.peer:has(.current) ~ &::before {
+		.peer:has(.current) ~ &::before,
+		.peer:has(.current) ~ .nav-subtree-clip > &::before {
 			@apply bg-grey-40;
 		}
 	}


### PR DESCRIPTION
Flag-off sidebar folders open and close at once again. The height animation stays on the preview nav only.

**Affects:** Site UI

**Prompt summary:** Production sidebar chevrons opened but showed no children, and the new folder slide leaked onto the flag-off accordion. Restore the old instant checkbox accordion on production without changing the preview nav.

## Why

[#4039](https://github.com/elastic/docs-builder/pull/4039) shows folder children again through the clip wrapper. The same wrap still animates height on every page. Flag-off production should keep the old CSS accordion.

## What

#### Preview-only folder animation

`ensureSubtreeClips`, `syncFolderPanels`, and `onFolderCheckboxChange` return immediately unless `body` has `navigation-preview`. Preview keeps clips, detach, and the measured height animation.

#### Connector through the clip

The current-page connector line also matches a subtree inside `.nav-subtree-clip`. Nested current pages keep the darker rail.

## Verify

```bash
cd src/Elastic.Documentation.Site && npx jest Assets/pages-nav.test.ts
# leaves the legacy accordion alone when navigation-preview is off
```

```bash
FEATURE_NAVIGATION_PREVIEW=false dotnet run --project src/tooling/docs-builder -- serve --port 3000
```

Open `http://localhost:3000/getting-started/`. Folders should reveal children at once, with no height slide.

**Out of scope:** Chevron alignment and the clip reveal selector landed in [#4039](https://github.com/elastic/docs-builder/pull/4039).