### PR TITLE
Synthetics: add nav collapsible nested-link journey

### DIFF
--- a/src/Elastic.Documentation.Site/package.json
+++ b/src/Elastic.Documentation.Site/package.json
@@ -20,7 +20,7 @@
     "synthetics:test:staging": "DOCS_ENV=staging npm run synthetics:test",
     "synthetics:test:edge": "DOCS_ENV=edge npm run synthetics:test",
     "synthetics:test:local": "DOCS_ENV=local npm run synthetics:test",
-    "synthetics:test:preview": "DOCS_ENV=preview npx @elastic/synthetics ./synthetics/journeys/navigation-test.journey.ts ./synthetics/journeys/api-explorer.journey.ts ./synthetics/journeys/version-dropdown.journey.ts --config=./synthetics/synthetics.config.ts",
+    "synthetics:test:preview": "DOCS_ENV=preview npx @elastic/synthetics ./synthetics/journeys/navigation-test.journey.ts ./synthetics/journeys/api-explorer.journey.ts ./synthetics/journeys/version-dropdown.journey.ts ./synthetics/journeys/nav-collapsible.journey.ts --config=./synthetics/synthetics.config.ts",
     "synthetics:test:accessibility": "npx @elastic/synthetics ./synthetics/ci/accessibility.ci.ts --config=./synthetics/synthetics.config.ts",
     "synthetics:test:mcp": "npx @elastic/synthetics ./synthetics/journeys/mcp-server.journey.ts --config=./synthetics/synthetics.config.ts",
     "synthetics:test:mcp:prod": "DOCS_ENV=prod npm run synthetics:test:mcp",

--- a/src/Elastic.Documentation.Site/synthetics/journeys/nav-collapsible.journey.ts
+++ b/src/Elastic.Documentation.Site/synthetics/journeys/nav-collapsible.journey.ts
@@ -1,0 +1,83 @@
+import { journey, step, monitor, expect } from '@elastic/synthetics'
+
+const SCENARIO = {
+    startPath: '/deploy-manage',
+    folderHrefSuffix: '/deploy-manage/deploy',
+    nestedHrefSuffix: '/deploy-manage/deploy/elastic-cloud',
+    nestedName: 'Elastic Cloud',
+}
+
+function getSchedule(env: string) {
+    const scheduleMapping = {
+        local: 15,
+        edge: 15,
+        staging: 15,
+        prod: 1,
+    }
+    return scheduleMapping[env] || 15
+}
+
+function sidebarHref(scope: string, suffix: string) {
+    return `${scope}[href$="${suffix}"], ${scope}[href$="${suffix}/"]`
+}
+
+journey('nav collapsible', ({ page, params }) => {
+    monitor.use({
+        id: `elastic-co-docs-nav-collapsible-${params.environment}-v1`,
+        schedule: getSchedule(params.environment),
+        tags: [`env:${params.environment}`],
+    })
+
+    const docsRoot = params.docsRoot as string
+    const pagesNav = page.locator('#pages-nav')
+    const deployFolder = pagesNav.locator('li.nav-folder').filter({
+        has: page.locator(
+            sidebarHref(
+                ':scope > .peer > a.sidebar-link',
+                SCENARIO.folderHrefSuffix
+            )
+        ),
+    })
+    const nestedLink = pagesNav.locator(
+        sidebarHref('a.sidebar-link', SCENARIO.nestedHrefSuffix)
+    )
+
+    step('Open a section with collapsed nav folders', async () => {
+        await page.setViewportSize({ width: 1280, height: 800 })
+        await page.goto(`${docsRoot}${SCENARIO.startPath}`, {
+            timeout: 60000,
+            waitUntil: 'domcontentloaded',
+        })
+        await expect(
+            page.getByRole('heading', {
+                name: 'Deploy and manage',
+                exact: true,
+            })
+        ).toBeVisible()
+    })
+
+    step('Open the Deploy folder and reveal a nested link', async () => {
+        await expect(deployFolder).toBeVisible()
+        await expect(nestedLink).not.toBeVisible()
+
+        await deployFolder
+            .locator('.nav-folder-chevron, label, .nav-toggle-btn')
+            .first()
+            .click()
+
+        await expect(nestedLink).toBeVisible()
+    })
+
+    step('Click the nested Elastic Cloud sidebar link', async () => {
+        await nestedLink.click()
+        await expect(page).toHaveURL(
+            new RegExp(`${SCENARIO.nestedHrefSuffix}/?$`)
+        )
+        await expect(
+            page.getByRole('heading', {
+                name: SCENARIO.nestedName,
+                exact: true,
+            })
+        ).toBeVisible()
+    })
+})


### PR DESCRIPTION
## Why

- Collapsed sidebar folders hide nested links. On nav-v2, closed subtrees can leave the DOM.
- Existing navigation journeys click already-visible links. They do not prove that a reader can open a folder and reach a child page.

## What

- Add a dedicated synthetics journey that opens the Deploy folder on Deploy and manage, then clicks Elastic Cloud in the sidebar.
- Include the journey in the preview synthetics file list so pull request CI runs it.

## Notes

- This is a new journey, not a new step on the existing navigation journey. That journey shares one page and session storage, so earlier steps can expand folders before the assertion runs.
- I ran the journey against production. All three steps passed.


Made with [Cursor](https://cursor.com)