### PR TITLE
Align preview with production nav and fix HTMX expand

### DIFF
--- a/config/assembler.yml
+++ b/config/assembler.yml
@@ -60,7 +60,6 @@ environments:
     google_tag_manager:
       enabled: false
     feature_flags:
-      NAVIGATION_PREVIEW: true
       ASSEMBLER_API_EXPLORER: true
   air-gapped:
     uri: http://localhost:8080

--- a/src/Elastic.Documentation.Site/Assets/pages-nav.test.ts
+++ b/src/Elastic.Documentation.Site/Assets/pages-nav.test.ts
@@ -237,6 +237,70 @@ describe('syncPagesNavFromResponse', () => {
             document.querySelector<HTMLInputElement>('#other')?.checked
         ).toBe(false)
     })
+
+    it('expands the current path after an HTMX cross-tree swap on the production accordion', () => {
+        const path = window.location.pathname
+        const incoming = `
+            <nav id="pages-nav">
+                <ul id="nav-tree-deploy">
+                    <li class="nav-folder">
+                        <div class="peer nav-folder-peer">
+                            <a class="sidebar-link nav-folder-link" href="/docs/deploy-manage/deploy/">Deploy</a>
+                            <label for="deploy">
+                                <input id="deploy" type="checkbox" class="hidden">
+                            </label>
+                        </div>
+                        <ul class="nav-subtree">
+                            <li class="nav-folder">
+                                <div class="peer nav-folder-peer">
+                                    <a class="sidebar-link nav-folder-link current" href="${path}">Elastic Cloud</a>
+                                    <label for="cloud">
+                                        <input id="cloud" type="checkbox" class="hidden">
+                                    </label>
+                                </div>
+                                <ul class="nav-subtree"><li>Child page</li></ul>
+                            </li>
+                        </ul>
+                    </li>
+                </ul>
+            </nav>
+        `
+        document.body.innerHTML = `
+            <nav id="pages-nav">
+                <ul id="nav-tree-guides">
+                    <li><a class="sidebar-link current" href="/docs/get-started/">Get started</a></li>
+                </ul>
+            </nav>
+        `
+        initNav()
+        const raf = jest
+            .spyOn(window, 'requestAnimationFrame')
+            .mockImplementation((cb) => {
+                cb(0)
+                return 0
+            })
+
+        document.dispatchEvent(
+            new CustomEvent('htmx:afterSwap', {
+                detail: {
+                    xhr: { response: `<html><body>${incoming}</body></html>` },
+                },
+            })
+        )
+
+        expect(
+            document.querySelector<HTMLInputElement>('#deploy')?.checked
+        ).toBe(true)
+        expect(
+            document.querySelector<HTMLInputElement>('#cloud')?.checked
+        ).toBe(true)
+        expect(
+            document
+                .querySelector('#pages-nav a.sidebar-link.current')
+                ?.textContent?.trim()
+        ).toBe('Elastic Cloud')
+        raf.mockRestore()
+    })
 })
 
 describe('markCurrentPage', () => {

--- a/src/Elastic.Documentation.Site/Assets/pages-nav.ts
+++ b/src/Elastic.Documentation.Site/Assets/pages-nav.ts
@@ -961,7 +961,11 @@ function onAfterSwap(event: Event) {
         const replaced = html ? syncPagesNavFromResponse(html) : false
         if (!replaced) {
             keepLiveNav()
+            return
         }
+        // htmx:load already ran initNav on the pre-replace tree. The new
+        // accordion has no checked attrs, so expand the current path again.
+        initNav()
     }
     if (typeof requestAnimationFrame === 'function') {
         requestAnimationFrame(apply)

--- a/src/Elastic.Documentation.Site/synthetics/journeys/navigation-test.journey.ts
+++ b/src/Elastic.Documentation.Site/synthetics/journeys/navigation-test.journey.ts
@@ -181,47 +181,24 @@ journey('navigation test', ({ page, params }) => {
     step(
         'Sidebar click reaches Elasticsearch and back restores Reference',
         async () => {
-            const previewHeading = page.locator(
-                '#pages-nav .pages-nav-v2__heading-text'
-            )
-            const isPreviewNav =
-                (await page.locator('#pages-nav .pages-nav-v2-shell').count()) >
-                0
-            if (isPreviewNav)
-                await expect(previewHeading).toHaveText('Reference')
-
             await page
                 .locator('#pages-nav a[href$="/reference/elasticsearch"]')
                 .first()
                 .click()
             await expect(page).toHaveURL(/\/reference\/elasticsearch/)
-            if (isPreviewNav) {
-                await expect(previewHeading).toHaveText('Elasticsearch')
-                await expect(
-                    page.locator('#pages-nav .nav-v2-nav-text').first()
-                ).toHaveText('Overview')
-            } else {
-                await expect(
-                    page.locator(
-                        '#pages-nav a.sidebar-link.current[href*="/reference/elasticsearch"]'
-                    )
-                ).toBeVisible()
-            }
+            await expect(
+                page.locator(
+                    '#pages-nav a.sidebar-link.current[href*="/reference/elasticsearch"]'
+                )
+            ).toBeVisible()
 
             await page.goBack()
             await expect(page).toHaveURL(/\/reference\/?$/)
-            if (isPreviewNav) {
-                await expect(previewHeading).toHaveText('Reference')
-                await expect(
-                    page.locator('#pages-nav .nav-v2-nav-text').first()
-                ).toHaveText('Overview')
-            } else {
-                await expect(
-                    page.locator(
-                        '#pages-nav a.sidebar-link.current[href*="/reference"]'
-                    )
-                ).toBeVisible()
-            }
+            await expect(
+                page.locator(
+                    '#pages-nav a.sidebar-link.current[href*="/reference"]'
+                )
+            ).toBeVisible()
         }
     )
 

--- a/src/Elastic.Documentation.Site/synthetics/journeys/navigation-test.journey.ts
+++ b/src/Elastic.Documentation.Site/synthetics/journeys/navigation-test.journey.ts
@@ -192,13 +192,21 @@ journey('navigation test', ({ page, params }) => {
                 )
             ).toBeVisible()
 
+            // The hub page itself has no row in the tree, so nothing is
+            // current after back; the tree is visible and the old current
+            // marker is gone.
             await page.goBack()
             await expect(page).toHaveURL(/\/reference\/?$/)
             await expect(
-                page.locator(
-                    '#pages-nav a.sidebar-link.current[href*="/reference"]'
-                )
+                page
+                    .locator('#pages-nav a[href$="/reference/elasticsearch"]')
+                    .first()
             ).toBeVisible()
+            await expect(
+                page.locator(
+                    '#pages-nav a.sidebar-link.current[href*="/reference/elasticsearch"]'
+                )
+            ).toHaveCount(0)
         }
     )
 

--- a/src/Elastic.Documentation.Site/synthetics/journeys/navigation-test.journey.ts
+++ b/src/Elastic.Documentation.Site/synthetics/journeys/navigation-test.journey.ts
@@ -179,30 +179,49 @@ journey('navigation test', ({ page, params }) => {
     })
 
     step(
-        'Island click swaps heading and Overview, back restores them',
+        'Sidebar click reaches Elasticsearch and back restores Reference',
         async () => {
-            await expect(
-                page.locator('#pages-nav .pages-nav-v2__heading-text')
-            ).toHaveText('Reference')
+            const previewHeading = page.locator(
+                '#pages-nav .pages-nav-v2__heading-text'
+            )
+            const isPreviewNav =
+                (await page.locator('#pages-nav .pages-nav-v2-shell').count()) >
+                0
+            if (isPreviewNav)
+                await expect(previewHeading).toHaveText('Reference')
+
             await page
                 .locator('#pages-nav a[href$="/reference/elasticsearch"]')
                 .first()
                 .click()
             await expect(page).toHaveURL(/\/reference\/elasticsearch/)
-            await expect(
-                page.locator('#pages-nav .pages-nav-v2__heading-text')
-            ).toHaveText('Elasticsearch')
-            await expect(
-                page.locator('#pages-nav .nav-v2-nav-text').first()
-            ).toHaveText('Overview')
+            if (isPreviewNav) {
+                await expect(previewHeading).toHaveText('Elasticsearch')
+                await expect(
+                    page.locator('#pages-nav .nav-v2-nav-text').first()
+                ).toHaveText('Overview')
+            } else {
+                await expect(
+                    page.locator(
+                        '#pages-nav a.sidebar-link.current[href*="/reference/elasticsearch"]'
+                    )
+                ).toBeVisible()
+            }
+
             await page.goBack()
             await expect(page).toHaveURL(/\/reference\/?$/)
-            await expect(
-                page.locator('#pages-nav .pages-nav-v2__heading-text')
-            ).toHaveText('Reference')
-            await expect(
-                page.locator('#pages-nav .nav-v2-nav-text').first()
-            ).toHaveText('Overview')
+            if (isPreviewNav) {
+                await expect(previewHeading).toHaveText('Reference')
+                await expect(
+                    page.locator('#pages-nav .nav-v2-nav-text').first()
+                ).toHaveText('Overview')
+            } else {
+                await expect(
+                    page.locator(
+                        '#pages-nav a.sidebar-link.current[href*="/reference"]'
+                    )
+                ).toBeVisible()
+            }
         }
     )
 


### PR DESCRIPTION
Preview stops using `NAVIGATION_PREVIEW`, so it serves the same left nav as production. After a cross-tree HTMX jump, that accordion now expands the current path.

**Affects:** Site UI, Configuration

**Prompt summary:** Turn off `NAVIGATION_PREVIEW` in the preview assembler environment so preview no longer hides the production accordion. Then fix the remaining flag-off hole that staging e2e now catches: an in-article HTMX jump leaves the current sidebar row hidden.

## Why

Staging e2e used to run with `NAVIGATION_PREVIEW` on. Production leaves that flag unset. The gate tested a different sidebar than `elastic.co/docs` serves. That mismatch let [1.49.0](https://github.com/elastic/docs-builder/releases/tag/1.49.0) ship a left nav that would not expand. Production was rolled back to [1.47.0](https://github.com/elastic/docs-builder/releases/tag/1.47.0) after a 40-minute outage.

Preview still sets the flag. Once it is off, a boosted jump to another tree replaces `#pages-nav` after `htmx:load` already ran `initNav`. The new accordion has no `checked` attributes, so ancestor folders stay closed and the current row stays hidden. The navigation synthetics also looked for the v2 island heading, which the production accordion does not render.

The clip-wrapper mismatch came from [#4007](https://github.com/elastic/docs-builder/pull/4007). [#4039](https://github.com/elastic/docs-builder/pull/4039) and [#4040](https://github.com/elastic/docs-builder/pull/4040) fixed the flag-off CSS and gated folder animation. They did not cover this HTMX replace path.

## What

#### Preview uses the production accordion
The preview environment no longer sets `NAVIGATION_PREVIEW:`. Preview, staging, and production now share the same CSS accordion. A flagged nav can no longer pass the gate while production stays broken.

#### Sidebar expand after a tree replace
When HTMX replaces the sidebar, `initNav` runs again on the new tree. Ancestor folders of the current page open. Same-tree swaps still keep the live sidebar.

#### Flag-off HTMX coverage
A Jest case fires `htmx:afterSwap` with the production accordion markup. Incoming folders have no `checked` attributes. The current Elastic Cloud row must end up expanded.

#### Synthetics follow the production accordion
The navigation journey clicks Elasticsearch from Reference and asserts the current row. It does not check the v2 island heading. That path is the same one production serves.

## Verify

```bash
cd src/Elastic.Documentation.Site && npx jest Assets/pages-nav.test.ts
# expands the current path after an HTMX cross-tree swap on the production accordion
```

**Out of scope:** Promoting [1.50.0](https://github.com/elastic/docs-builder/releases/tag/1.50.0) to production. That is a pin bump in [elastic/docs-internal-workflows](https://github.com/elastic/docs-internal-workflows) after staging e2e is green.