### PR TITLE
Add a mobile open control on API pages

### DIFF
--- a/src/Elastic.ApiExplorer/_Layout.cshtml
+++ b/src/Elastic.ApiExplorer/_Layout.cshtml
@@ -29,6 +29,7 @@ else
 				<main id="content-container" class="w-full flex flex-col relative pb-12 overflow-x-hidden">
 					<article id="markdown-content" class="content-container markdown-content md:px-4">
 						<input type="checkbox" class="hidden" id="pages-nav-hamburger">
+						@await RenderPartialAsync(_ApiMobileNavOpen.Create(Model))
 						@await RenderBodyAsync()
 					</article>
 				</main>

--- a/src/Elastic.ApiExplorer/_Partials/Layout/_ApiMobileNavOpen.cshtml
+++ b/src/Elastic.ApiExplorer/_Partials/Layout/_ApiMobileNavOpen.cshtml
@@ -1,0 +1,9 @@
+@inherits RazorSlice<Elastic.ApiExplorer.Infrastructure.ApiLayoutViewModel>
+@* ReSharper disable once Html.IdNotResolved *@
+<label role="button" class="md:hidden cursor-pointer mt-3" for="pages-nav-hamburger">
+	<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
+		stroke="currentColor" class="size-6">
+		<path stroke-linecap="round" stroke-linejoin="round"
+			d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25H12"/>
+	</svg>
+</label>

--- a/tests/Elastic.ApiExplorer.Tests/ApiMobileNavOpenRenderingTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/ApiMobileNavOpenRenderingTests.cs
@@ -1,0 +1,77 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions;
+using AwesomeAssertions;
+using Elastic.ApiExplorer._Partials.Layout;
+using Elastic.ApiExplorer.Infrastructure;
+using Elastic.ApiExplorer.Landing;
+using Elastic.Documentation;
+using Elastic.Documentation.Configuration;
+using Elastic.Documentation.Configuration.Assembler;
+using Elastic.Documentation.Configuration.Builder;
+using Elastic.Documentation.Diagnostics;
+using Elastic.Documentation.FileSystems;
+using Elastic.Documentation.Site.FileProviders;
+using RazorSlices;
+
+namespace Elastic.ApiExplorer.Tests;
+
+public class ApiMobileNavOpenRenderingTests
+{
+	[Fact]
+	public async Task Render_FlagOff_IncludesOpenLabel()
+	{
+		var html = await Render(new FeatureFlags([]));
+
+		AssertOpenLabel(html);
+	}
+
+	[Fact]
+	public async Task Render_FlagOn_IncludesOpenLabel()
+	{
+		var html = await Render(new FeatureFlags(new Dictionary<string, bool> { ["navigation-preview"] = true }));
+
+		AssertOpenLabel(html);
+	}
+
+	private static void AssertOpenLabel(string html)
+	{
+		html.Should().Contain("for=\"pages-nav-hamburger\"");
+		html.Should().Contain("role=\"button\"");
+		html.Should().Contain("md:hidden");
+	}
+
+	private static async Task<string> Render(FeatureFlags features)
+	{
+		var fs = new FileSystem();
+		var context = new BuildContext(
+			new DiagnosticsCollector([]),
+			DocumentationFileSystem.Resolve(Paths.WorkingDirectoryRoot.FullName),
+			TestHelpers.CreateConfigurationContext(fs)
+		);
+		var navigationItem = new LandingNavigationItem("/api/doc/elasticsearch/v9/").Index;
+		var model = new ApiLayoutViewModel
+		{
+			DocsBuilderVersion = "test",
+			DocSetName = "Api Explorer",
+			Description = string.Empty,
+			CurrentNavigationItem = navigationItem,
+			Previous = null,
+			Next = null,
+			NavigationHtml = string.Empty,
+			UrlPathPrefix = string.Empty,
+			AllowIndexing = false,
+			CanonicalBaseUrl = null,
+			GoogleTagManager = new GoogleTagManagerConfiguration(),
+			Optimizely = new OptimizelyConfiguration(),
+			Features = features,
+			StaticFileContentHashProvider = new StaticFileContentHashProvider(new EmbeddedOrPhysicalFileProvider(context)),
+			TocItems = [],
+			MarkdownUrl = "/api/doc/elasticsearch/v9.md",
+		};
+
+		return await _ApiMobileNavOpen.Create(model).RenderAsync(cancellationToken: TestContext.Current.CancellationToken);
+	}
+}


### PR DESCRIPTION
API pages now show a hamburger on narrow viewports so a reader can open the left nav. Desktop layout is unchanged.

**Affects:** API reference

**Prompt summary:** Implement [elastic/docs-eng-team#818](https://github.com/elastic/docs-eng-team/issues/818) and keep the open control working with `navigation-preview` on and off.

## Why

API pages already render the `#pages-nav-hamburger` checkbox, the close control, and the overlay. They do not render an open control. At 390px the left nav stays off-screen. Docs pages open the same drawer from the table of contents.

Closes elastic/docs-eng-team#818

## What

#### Mobile open control

A `md:hidden` label next to the existing checkbox targets `#pages-nav-hamburger`. The icon matches the docs TOC hamburger. The control is not gated on `NavigationPreviewEnabled`. API pages use `_ApiPagesNav`, not the flag-aware `_PagesNav`, so the same markup serves both flag paths.

#### Placement

The open label lives in the article, next to the checkbox. `_ApiToc` stays `hidden lg:block` and sits after the article, so a hamburger only there is invisible on a phone.

#### Tests

Render tests assert the label is present when `navigation-preview` is off and when it is on.

## Verify

```bash
dotnet test tests/Elastic.ApiExplorer.Tests/
# Render_FlagOff_IncludesOpenLabel
# Render_FlagOn_IncludesOpenLabel
```

Serve the docs set and open an API page at 390px. Confirm the hamburger opens and closes the left nav. At a desktop width the hamburger stays hidden.

**Out of scope** API layout `Features` still uses an empty `FeatureFlags` bag. This PR does not wire `navigation-preview` onto API page chrome.

Made with [Cursor](https://cursor.com)