### PR TITLE
Strip Bump HTML from API operation descriptions

### DIFF
--- a/src/Elastic.ApiExplorer/Export/OpenApiDocumentExporter.cs
+++ b/src/Elastic.ApiExplorer/Export/OpenApiDocumentExporter.cs
@@ -8,7 +8,6 @@ using System.Text;
 using System.Text.RegularExpressions;
 using Elastic.ApiExplorer.Infrastructure;
 using Elastic.ApiExplorer.Model;
-using Elastic.ApiExplorer.Operations;
 using Elastic.Documentation;
 using Elastic.Documentation.AppliesTo;
 using Elastic.Documentation.Configuration.Inference;
@@ -33,9 +32,6 @@ public partial class OpenApiDocumentExporter(VersionsConfiguration versionsConfi
 
 	[GeneratedRegex(@"Added in (\d+\.\d+\.\d+)", RegexOptions.IgnoreCase)]
 	private static partial Regex AddedInVersionRegex();
-
-	[GeneratedRegex(@"<span class=""operation-verb (\w+)"">(\w+)</span>\s*<span class=""operation-path"">([^<]+)</span>", RegexOptions.IgnoreCase)]
-	private static partial Regex OperationVerbPathRegex();
 
 	/// <summary>
 	/// Fetches and processes both Elasticsearch and Kibana OpenAPI specifications.
@@ -107,7 +103,6 @@ public partial class OpenApiDocumentExporter(VersionsConfiguration versionsConfi
 
 	/// <summary>
 	/// Converts an OpenAPI document to DocumentationDocument instances.
-	/// Internal (rather than private) so tests can exercise it against an in-memory spec.
 	/// </summary>
 	internal IEnumerable<DocumentationDocument> ConvertToDocuments(OpenApiDocument openApiDocument, string product)
 	{
@@ -138,7 +133,7 @@ public partial class OpenApiDocumentExporter(VersionsConfiguration versionsConfi
 				// append the raw operation id (e.g. "_bulk") so the REST endpoint name is searchable —
 				// keep it verbatim (no case/underscore normalization) since that's exactly what users type.
 				var searchTitle = $"{title} - {operationId}";
-				var description = TransformOperationListToMarkdown(operation.Value.Description);
+				var description = ApiMarkdown.Clean(operation.Value.Description);
 
 				// Build body content from operation details
 				var bodyBuilder = new StringBuilder();
@@ -315,65 +310,5 @@ public partial class OpenApiDocumentExporter(VersionsConfiguration versionsConfi
 
 		var versionString = match.Groups[1].Value;
 		return VersionSpec.TryParse(versionString, out var version) ? version : null;
-	}
-
-	/// <summary>
-	/// Transforms HTML operation lists in descriptions to markdown format.
-	/// Detects "**All methods and paths for this operation:**" followed by HTML divs/spans
-	/// and converts them to a markdown list appended at the end.
-	/// </summary>
-	private static string TransformOperationListToMarkdown(string? description)
-	{
-		if (string.IsNullOrEmpty(description))
-			return description ?? string.Empty;
-
-		// Check if description starts with the operations list header
-		if (!description.Contains("**All methods and paths for this operation:**"))
-			return description;
-
-		// Extract all operation verb and path pairs
-		var matches = OperationVerbPathRegex().Matches(description);
-		if (matches.Count == 0)
-			return description;
-
-		// Find where the HTML content starts and ends
-		var htmlStartIndex = description.IndexOf("<div>", StringComparison.Ordinal);
-		var lastMatchEnd = matches[^1].Index + matches[^1].Length;
-
-		// Find the last closing div after the last match
-		var htmlEndIndex = description.IndexOf("</div>", lastMatchEnd, StringComparison.Ordinal);
-		if (htmlEndIndex == -1 || htmlStartIndex == -1)
-			return description;
-
-		// Build the clean description without HTML
-		var beforeHtml = description[..htmlStartIndex].Trim();
-		var afterHtml = description[(htmlEndIndex + 6)..].Trim();
-
-		// Build markdown list
-		var markdownList = new StringBuilder();
-		_ = markdownList.AppendLine();
-		_ = markdownList.AppendLine();
-
-		foreach (Match match in matches)
-		{
-			var verb = match.Groups[2].Value.ToUpperInvariant();
-			var path = match.Groups[3].Value;
-			_ = markdownList.AppendLine($"- **{verb}** `{path}`");
-		}
-
-		// Combine: clean description (before + after HTML) + markdown list at the end
-		var result = new StringBuilder();
-		_ = result.Append(beforeHtml);
-		if (!string.IsNullOrWhiteSpace(afterHtml))
-		{
-			_ = result.AppendLine();
-			_ = result.AppendLine();
-			_ = result.Append(afterHtml);
-		}
-
-		// Append markdown list at the end
-		_ = result.Append(markdownList);
-
-		return result.ToString().Trim();
 	}
 }

--- a/src/Elastic.ApiExplorer/Infrastructure/ApiMarkdown.cs
+++ b/src/Elastic.ApiExplorer/Infrastructure/ApiMarkdown.cs
@@ -55,9 +55,6 @@ public static partial class ApiMarkdown
 		return RewriteIntraApiLinks(escaped, apiBaseUrl);
 	}
 
-	/// <summary>
-	/// Spec description in. Markdown out. Never null. Idempotent.
-	/// </summary>
 	internal static string Clean(string? markdown)
 	{
 		if (string.IsNullOrEmpty(markdown))

--- a/src/Elastic.ApiExplorer/Infrastructure/ApiMarkdown.cs
+++ b/src/Elastic.ApiExplorer/Infrastructure/ApiMarkdown.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Collections.Frozen;
 using System.IO.Abstractions;
 using System.Text.RegularExpressions;
 using Elastic.ApiExplorer.Model;
@@ -18,6 +19,19 @@ namespace Elastic.ApiExplorer.Infrastructure;
 /// </summary>
 public static partial class ApiMarkdown
 {
+	private const string AllMethodsHeading = "**All methods and paths for this operation:**";
+
+	private static readonly FrozenDictionary<string, string> AdmonitionDirectives = new Dictionary<string, string>(
+		StringComparer.OrdinalIgnoreCase
+	)
+	{
+		["NOTE"] = "note",
+		["TIP"] = "tip",
+		["WARNING"] = "warning",
+		["IMPORTANT"] = "important",
+		["CAUTION"] = "warning"
+	}.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
 	public static HtmlString Render(ApiRenderContext context, string? markdown)
 	{
 		if (string.IsNullOrEmpty(markdown))
@@ -40,6 +54,53 @@ public static partial class ApiMarkdown
 		var escaped = MustachePattern().Replace(markdown, match => $"`{match.Value}`");
 		return RewriteIntraApiLinks(escaped, apiBaseUrl);
 	}
+
+	/// <summary>
+	/// Spec description in. Markdown out. Never null. Idempotent.
+	/// </summary>
+	internal static string Clean(string? markdown)
+	{
+		if (string.IsNullOrEmpty(markdown))
+			return string.Empty;
+
+		var withoutIsland = StripBumpIsland(markdown);
+		var withoutHeading = withoutIsland.Replace(AllMethodsHeading, string.Empty, StringComparison.Ordinal);
+		var withoutMarkup = StripLeftoverBumpMarkup(withoutHeading);
+		var withAdmonitions = AdmonitionPrefixRegex().Replace(withoutMarkup, ReplaceAdmonition);
+		return CollapseBlankLines(withAdmonitions).Trim();
+	}
+
+	private static string StripBumpIsland(string markdown)
+	{
+		var matches = OperationVerbPathRegex().Matches(markdown);
+		if (matches.Count == 0)
+			return markdown;
+
+		var htmlStartIndex = markdown.IndexOf("<div>", StringComparison.Ordinal);
+		var lastMatchEnd = matches[^1].Index + matches[^1].Length;
+		var htmlEndIndex = markdown.IndexOf("</div>", lastMatchEnd, StringComparison.Ordinal);
+		if (htmlStartIndex == -1 || htmlEndIndex == -1)
+			return markdown;
+
+		return markdown[..htmlStartIndex] + markdown[(htmlEndIndex + "</div>".Length)..];
+	}
+
+	private static string StripLeftoverBumpMarkup(string markdown)
+	{
+		var withoutSpans = LeftoverOperationSpanRegex().Replace(markdown, string.Empty);
+		return EmptyDivRegex().Replace(withoutSpans, string.Empty);
+	}
+
+	private static string ReplaceAdmonition(Match match)
+	{
+		var marker = match.Groups["marker"].Value;
+		if (!AdmonitionDirectives.TryGetValue(marker, out var directive))
+			return match.Value;
+
+		return $":::{{{directive}}}\n{match.Groups["body"].Value}\n:::";
+	}
+
+	private static string CollapseBlankLines(string markdown) => ExtraBlankLinesRegex().Replace(markdown, "\n\n");
 
 	internal static string RewriteIntraApiLinks(string markdown, string apiBaseUrl)
 	{
@@ -78,4 +139,19 @@ public static partial class ApiMarkdown
 	// Regex to match mustache-style patterns like {{var}} or {{{var}}} that conflict with docs-builder substitutions
 	[GeneratedRegex(@"\{\{\{?[^}]+\}?\}\}")]
 	private static partial Regex MustachePattern();
+
+	[GeneratedRegex(@"<span class=""operation-verb (\w+)"">(\w+)</span>\s*<span class=""operation-path"">([^<]+)</span>", RegexOptions.IgnoreCase)]
+	private static partial Regex OperationVerbPathRegex();
+
+	[GeneratedRegex(@"<span class=""operation-(?:verb[^""]*|path)"">[^<]*</span>", RegexOptions.IgnoreCase)]
+	private static partial Regex LeftoverOperationSpanRegex();
+
+	[GeneratedRegex(@"<div>\s*</div>", RegexOptions.IgnoreCase)]
+	private static partial Regex EmptyDivRegex();
+
+	[GeneratedRegex(@"^(?<marker>NOTE|TIP|WARNING|IMPORTANT|CAUTION):\s+(?<body>.+)$", RegexOptions.Multiline | RegexOptions.IgnoreCase)]
+	private static partial Regex AdmonitionPrefixRegex();
+
+	[GeneratedRegex(@"(?:\r?\n){3,}")]
+	private static partial Regex ExtraBlankLinesRegex();
 }

--- a/src/Elastic.ApiExplorer/Infrastructure/ApiMarkdownFrontMatter.cs
+++ b/src/Elastic.ApiExplorer/Infrastructure/ApiMarkdownFrontMatter.cs
@@ -92,9 +92,9 @@ internal static class ApiMarkdownFrontMatter
 			operation.Operation.OperationId is { Length: > 0 } operationId
 			&& context.OperationSupplemental.TryGetValue(operationId, out var doc)
 		)
-			return doc.DescriptionOr(spec);
+			return ApiMarkdown.Clean(doc.DescriptionOr(spec));
 
-		return spec;
+		return ApiMarkdown.Clean(spec);
 	}
 
 	private static string? Heading(string markdown)

--- a/src/Elastic.ApiExplorer/Operations/OperationPageModel.cs
+++ b/src/Elastic.ApiExplorer/Operations/OperationPageModel.cs
@@ -181,7 +181,7 @@ public record OperationPageModel
 					new PropertyTreeScope { Prefix = "req", IsRequest = true, DescriptionOverrides = supplemental?.RequestBodyOverrides }
 				)
 				: null,
-			DescriptionMarkdown = supplemental?.DescriptionOr(operation.Description) ?? operation.Description,
+			DescriptionMarkdown = ApiMarkdown.Clean(supplemental?.DescriptionOr(operation.Description) ?? operation.Description),
 			PostSections = ApiPostSection.From(context, supplemental?.PostSections ?? []),
 			RequestType = requestSchema is not null ? builder.Describe(requestSchema) : null,
 			Responses = BuildResponses(operation, analyzer, builder),

--- a/src/Elastic.ApiExplorer/Operations/OperationView.cshtml
+++ b/src/Elastic.ApiExplorer/Operations/OperationView.cshtml
@@ -101,9 +101,9 @@
 	@if (!string.IsNullOrWhiteSpace(pageModel.DescriptionMarkdown))
 	{
 		@(await RenderPartialAsync<_SectionHeader, SectionHeader>(new SectionHeader("Description", "description", Model.Operation.Route)))
-		<p>
+		<div class="api-operation-description">
 			@(Model.RenderMarkdown(pageModel.DescriptionMarkdown))
-		</p>
+		</div>
 		@if (pageModel.ExternalDocs is not null)
 		{
 			<a href="@pageModel.ExternalDocs.Url" class="docs-reference-btn" @(pageModel.ExternalDocs.IsElasticDocs ? "" : "target=\"_blank\" rel=\"noopener\"")>

--- a/tests/Elastic.ApiExplorer.Tests/ApiMarkdownCleanTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/ApiMarkdownCleanTests.cs
@@ -1,0 +1,105 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using AwesomeAssertions;
+using Elastic.ApiExplorer.Infrastructure;
+
+namespace Elastic.ApiExplorer.Tests;
+
+public class ApiMarkdownCleanTests
+{
+	private const string BumpSearchDescription =
+		"""
+		**All methods and paths for this operation:**
+
+		<div>
+		  <span class="operation-verb get">GET</span>
+		  <span class="operation-path">/_search</span>
+		  </div>
+		<div>
+		  <span class="operation-verb post">POST</span>
+		  <span class="operation-path">/_search</span>
+		  </div>
+		<div>
+		  <span class="operation-verb get">GET</span>
+		  <span class="operation-path">/{index}/_search</span>
+		  </div>
+		<div>
+		  <span class="operation-verb post">POST</span>
+		  <span class="operation-path">/{index}/_search</span>
+		  </div>
+
+		Returns hits that match the query defined in the request.
+
+		IMPORTANT: The same point-in-time ID should be used for all slices.
+		""";
+
+	[Fact]
+	public void Clean_Null_ReturnsEmpty() => ApiMarkdown.Clean(null).Should().BeEmpty();
+
+	[Fact]
+	public void Clean_Empty_ReturnsEmpty() => ApiMarkdown.Clean("").Should().BeEmpty();
+
+	[Fact]
+	public void Clean_BumpIslandAndImportant_StripsHtmlAndRewritesAdmonition()
+	{
+		var cleaned = ApiMarkdown.Clean(BumpSearchDescription);
+
+		cleaned.Should().NotContain("<div>");
+		cleaned.Should().NotContain("operation-verb");
+		cleaned.Should().NotContain("operation-path");
+		cleaned.Should().NotContain("All methods and paths");
+		cleaned.Should().Contain("Returns hits that match the query");
+		cleaned.Should().Contain(":::{important}");
+		cleaned.Should().Contain("The same point-in-time ID should be used for all slices.");
+		cleaned.Should().NotContain("- **GET**");
+	}
+
+	[Fact]
+	public void Clean_AlreadyClean_IsIdempotent()
+	{
+		var cleaned = ApiMarkdown.Clean(BumpSearchDescription);
+
+		ApiMarkdown.Clean(cleaned).Should().Be(cleaned);
+	}
+
+	[Fact]
+	public void Clean_NoteAndWarning_RewritesToMyst()
+	{
+		var cleaned = ApiMarkdown.Clean("NOTE: Check the index name.\n\nWARNING: This deletes data.");
+
+		cleaned.Should().Contain(":::{note}");
+		cleaned.Should().Contain("Check the index name.");
+		cleaned.Should().Contain(":::{warning}");
+		cleaned.Should().Contain("This deletes data.");
+	}
+
+	[Fact]
+	public void Clean_MidSentenceImportant_LeavesProse()
+	{
+		var cleaned = ApiMarkdown.Clean("This is IMPORTANT: keep the marker as prose.");
+
+		cleaned.Should().Be("This is IMPORTANT: keep the marker as prose.");
+		cleaned.Should().NotContain(":::{important}");
+	}
+
+	[Fact]
+	public void Clean_Caution_MapsToWarning()
+	{
+		var cleaned = ApiMarkdown.Clean("CAUTION: Do not run this in production.");
+
+		cleaned.Should().Contain(":::{warning}");
+		cleaned.Should().Contain("Do not run this in production.");
+		cleaned.Should().NotContain(":::{caution}");
+	}
+
+	[Fact]
+	public void Prepare_BumpHtml_DoesNotStrip()
+	{
+		var prepared = ApiMarkdown.Prepare(BumpSearchDescription, "/api/doc/elasticsearch");
+
+		prepared.Should().Contain("operation-verb");
+		prepared.Should().Contain("**All methods and paths for this operation:**");
+	}
+}

--- a/tests/Elastic.ApiExplorer.Tests/OpenApiDocumentExporterTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/OpenApiDocumentExporterTests.cs
@@ -5,14 +5,9 @@
 using System.Collections.Concurrent;
 using AwesomeAssertions;
 using Elastic.ApiExplorer.Export;
-using Elastic.ApiExplorer.Model;
-using Elastic.ApiExplorer.Operations;
-using Elastic.Documentation;
 using Elastic.Documentation.Configuration.Versions;
-using Elastic.Documentation.Search;
-using Elastic.Documentation.Search.Contract;
 using Elastic.Documentation.Versions;
-using static System.StringComparison;
+using Microsoft.OpenApi;
 
 namespace Elastic.ApiExplorer.Tests;
 
@@ -122,9 +117,8 @@ public class OpenApiDocumentExporterTests
 	}
 
 	[Fact]
-	public async Task DescriptionWithHtmlOperationsListShouldTransformToMarkdownAtEnd()
+	public void ConvertToDocuments_DescriptionWithBumpHtml_LeavesNoHtmlAndNoRebuiltList()
 	{
-		// Arrange
 		var versionsConfiguration = new VersionsConfiguration
 		{
 			VersioningSystems = new Dictionary<VersioningSystemId, VersioningSystem>
@@ -141,40 +135,44 @@ public class OpenApiDocumentExporterTests
 			}
 		};
 
-		var exporter = new OpenApiDocumentExporter(versionsConfiguration);
-
-		// Act - Get some Elasticsearch documents
-		var documents = new List<DocumentationDocument>();
-		await foreach (var doc in exporter.ExportDocuments(limitPerSource: 100, TestContext.Current.CancellationToken))
+		var spec = new OpenApiDocument
 		{
-			if (doc.Description != null && doc.Description.Contains("**All methods and paths for this operation:**"))
+			Paths = new OpenApiPaths
 			{
-				documents.Add(doc);
+				["/_search"] = new OpenApiPathItem
+				{
+					Operations = new Dictionary<HttpMethod, OpenApiOperation>
+					{
+						[HttpMethod.Get] = new OpenApiOperation
+						{
+							OperationId = "search",
+							Summary = "Run a search",
+							Description =
+								"""
+								**All methods and paths for this operation:**
+
+								<div>
+								  <span class="operation-verb get">GET</span>
+								  <span class="operation-path">/_search</span>
+								  </div>
+
+								Returns hits that match the query defined in the request.
+								"""
+						}
+					}
+				}
 			}
-		}
+		};
 
-		// Assert we found at least one document with the pattern
-		documents.Should().NotBeEmpty("there should be at least one document with operation list");
+		var exporter = new OpenApiDocumentExporter(versionsConfiguration);
+		var documents = exporter.ConvertToDocuments(spec, "elasticsearch").ToArray();
 
-		foreach (var doc in documents)
-		{
-			// Should not contain HTML
-			doc.Description.Should().NotContain("<div>", "HTML should be converted to markdown");
-			doc.Description.Should().NotContain("<span", "HTML should be converted to markdown");
-
-			// Should contain markdown list items
-			doc.Description.Should().Contain("- **", "should have markdown list items");
-			doc.Description.Should().Contain("`", "paths should be in code blocks");
-
-			// Check that the markdown list appears at the end
-			var lines = doc.Description.Split('\n', StringSplitOptions.TrimEntries);
-			var lastNonEmptyLines = lines.Where(l => !string.IsNullOrWhiteSpace(l)).TakeLast(5).ToList();
-
-			// At least one of the last few lines should be a Markdown list item
-			var hasMarkdownListAtEnd = lastNonEmptyLines.Any(l => l.StartsWith("- **", InvariantCulture));
-			hasMarkdownListAtEnd.Should().BeTrue(
-				$"markdown list should be at the end of the description. Last lines:\n{string.Join("\n", lastNonEmptyLines)}\n\nFull description:\n{doc.Description}"
-			);
-		}
+		documents.Should().ContainSingle();
+		var description = documents[0].Description;
+		description.Should().NotBeNull();
+		description.Should().NotContain("<div>");
+		description.Should().NotContain("<span");
+		description.Should().NotContain("- **GET**");
+		description.Should().Contain("Returns hits that match the query");
 	}
 }

--- a/tests/Elastic.ApiExplorer.Tests/OpenApiGeneratorMarkdownEmissionTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/OpenApiGeneratorMarkdownEmissionTests.cs
@@ -103,6 +103,9 @@ public class OpenApiGeneratorMarkdownEmissionTests(ApiExplorerFixture fixture) :
 		operation.Should().Contain("`/{index}/_search`");
 		operation.Should().Contain("## Description");
 		operation.Should().Contain("Returns hits that match the query");
+		operation.Should().Contain(":::{important}");
+		operation.Should().NotContain("operation-verb");
+		operation.Should().NotContain("All methods and paths");
 		operation.Should().NotContain("<!DOCTYPE");
 		operation.Should().NotContain("<html");
 
@@ -149,6 +152,10 @@ public class OpenApiGeneratorMarkdownEmissionTests(ApiExplorerFixture fixture) :
 			"""<link rel="alternate" type="text/markdown" href="/api/doc/elasticsearch/operation/operation-search.md" title="Markdown export"/>"""
 		);
 		operationHtml.Should().Contain("View as Markdown");
+		operationHtml.Should().Contain("class=\"api-operation-description\"");
+		operationHtml.Should().NotContain("operation-verb");
+		operationHtml.Should().Contain("POST");
+		operationHtml.Should().Contain("/{index}/_search");
 	}
 
 	[Fact]

--- a/tests/Elastic.ApiExplorer.Tests/TestData/api-explorer-fixture.json
+++ b/tests/Elastic.ApiExplorer.Tests/TestData/api-explorer-fixture.json
@@ -69,7 +69,7 @@
         ],
         "tags": ["search"],
         "summary": "Run a search",
-        "description": "Returns hits that match the query defined in the request.\n\nSupports pagination through `size` and `from`.",
+        "description": "**All methods and paths for this operation:**\n\n<div>\n  <span class=\"operation-verb get\">GET</span>\n  <span class=\"operation-path\">/_search</span>\n  </div>\n<div>\n  <span class=\"operation-verb post\">POST</span>\n  <span class=\"operation-path\">/_search</span>\n  </div>\n<div>\n  <span class=\"operation-verb get\">GET</span>\n  <span class=\"operation-path\">/{index}/_search</span>\n  </div>\n<div>\n  <span class=\"operation-verb post\">POST</span>\n  <span class=\"operation-path\">/{index}/_search</span>\n  </div>\n\nReturns hits that match the query defined in the request.\n\nSupports pagination through `size` and `from`.\n\nIMPORTANT: The same point-in-time ID should be used for all slices.",
         "externalDocs": {
           "url": "https://www.elastic.co/docs/fixture/search-reference"
         },


### PR DESCRIPTION
Operation pages no longer show Bump path-list HTML or a literal `IMPORTANT:` prefix. Those descriptions become Myst callouts, and the Paths list still comes from overloads.

**Affects:** API reference, Search

**Prompt summary:** Implement [elastic/docs-eng-team#812](https://github.com/elastic/docs-eng-team/issues/812). Strip leaked Bump HTML from operation descriptions and map `IMPORTANT` markers to Myst admonitions so the page matches search export.

## Why

Spec descriptions include a Bump "All methods and paths" HTML block and Asciidoc prefixes such as `IMPORTANT:`. Page render sent that string through `ApiMarkdown` without stripping it. Search export already removed the HTML island. The Paths section already lists every method and path from `Overloads`.

Closes elastic/docs-eng-team#812

## What

#### Shared description cleaner

`ApiMarkdown.Clean` drops the Bump path-list HTML and rewrites line-start `NOTE`, `TIP`, `WARNING`, `IMPORTANT`, and `CAUTION` prefixes to Myst fences. `CAUTION` maps to `{warning}` because Myst does not support `{caution}`. The function is idempotent. `Prepare` still only escapes mustache tokens and rewrites intra-API links, so parameter and property text stay unchanged.

#### Page and search call sites

The operation page model and front matter store the cleaned description. An HTML-only description no longer creates an empty Description section. Search export calls the same cleaner and no longer rebuilds a markdown method list. Each search document already has Method and Path fields. The Description wrapper is a `div`, so lists and callouts are valid HTML.

#### Tests

A fixture search description now includes the leaked HTML snippet and an `IMPORTANT:` line. Unit tests assert no leftover `operation-verb` source, Myst rewrite, and idempotence. Emission tests assert the Paths list still shows `POST` `/{index}/_search`. The CloudFront exporter check is replaced with an in-memory spec.

## Verify

```bash
dotnet test tests/Elastic.ApiExplorer.Tests/
# Clean_BumpIslandAndImportant_StripsHtmlAndRewritesAdmonition
# ConvertToDocuments_DescriptionWithBumpHtml_LeavesNoHtmlAndNoRebuiltList
```

**Out of scope:** These tests use `PassthroughMarkdownRenderer`, so they prove the Myst fence in markdown, not a rendered `admonition important` div. Existing Markdown admonition tests cover that render path. A wrapped `IMPORTANT:` body with no blank line stays prose.

Made with [Cursor](https://cursor.com)