### PR TITLE
Accept multiple reasons per page feedback submission

### DIFF
--- a/docs/development/page-feedback.md
+++ b/docs/development/page-feedback.md
@@ -11,25 +11,28 @@ changes replace the same document.
 
 The thumbs-up or thumbs-down selection writes a document with the reaction after
 a short debounce, so quickly changing the selection records only the final
-choice. The follow-up questionnaire writes the same document again with a
-structured reason, the reason-set version, and optional details. The comment
-field sits under the selected option. Each option keeps its own comment draft,
-including when the reader switches between Yes and No. The browser stores that
-draft in `sessionStorage` for the current tab and page so an accidental refresh
-can restore it, and clears it after a successful submit. Submitting the questionnaire flushes any pending reaction write first.
+choice. The follow-up questionnaire writes the same document again with one or
+more structured reasons, the reason-set version, and optional details. Readers
+can select several reasons at once. One comment field applies to the whole
+submission. It keeps its value when the reader switches between Yes and No.
+Switching the reaction clears any selected reason that does not belong to the new
+reason set. The browser stores that draft in `sessionStorage` for the current tab
+and page so an accidental refresh can restore it, and clears it after a
+successful submit. Submitting the questionnaire flushes any pending reaction write first.
 This keeps abandoned questionnaires useful while ensuring the richer
 submission wins.
 
-Reasons are stored as keyword enum values for filtering and aggregation.
-`reason_set_version` identifies the questionnaire revision that presented the
-option. Display labels may change without changing their stored value. Add a new
+Reasons are stored in the multi-valued `reasons` keyword field for filtering and
+aggregation. `reason_set_version` identifies the questionnaire revision that
+presented the option. Display labels may change without changing their stored value. Add a new
 enum value when an option's meaning changes, and retain retired values so older
 clients and historical documents remain valid.
 
-The current positive reasons are `accurate`, `solvedProblem`,
-`easyToUnderstand`, `helpfulExamples`, and `anotherReason`. The current negative
-reasons are `inaccurate`, `missingInformation`, `hardToUnderstand`,
-`codeSampleErrors`, and `anotherReason`. API pages use the same stored values
+Reason set version 2 presents these positive reasons in display order:
+`solvedProblem`, `easyToUnderstand`, `accurate`, `helpfulExamples`,
+`easyToFind`, and `anotherReason`. The negative reasons are `outOfDate`,
+`hardToUnderstand`, `inaccurate`, `codeSampleErrors`, `missingInformation`, and
+`anotherReason`. API pages use the same stored values
 and `reason_set_version`. They pass `surface="api"` so labels and descriptions
 talk about the spec and examples instead of a product how-to.
 

--- a/src/Elastic.Documentation.Site/Assets/page-feedback.css
+++ b/src/Elastic.Documentation.Site/Assets/page-feedback.css
@@ -150,8 +150,6 @@ page-feedback + #prev-next-nav {
 .page-feedback__details {
 	display: grid;
 	gap: 0.625rem;
-	margin-left: 1.625rem;
-	animation: page-feedback-content-reveal 180ms ease-out both;
 }
 
 .page-feedback__textarea {
@@ -268,7 +266,6 @@ page-feedback + #prev-next-nav {
 
 @media (prefers-reduced-motion: reduce) {
 	.page-feedback__choice,
-	.page-feedback__details,
 	.page-feedback__form,
 	.page-feedback__submit,
 	.page-feedback__thanks {

--- a/src/Elastic.Documentation.Site/Assets/web-components/PageFeedback.test.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/PageFeedback.test.tsx
@@ -45,12 +45,11 @@ describe('PageFeedback', () => {
         expect(
             screen.getByRole('group', { name: 'What did you like?' })
         ).toBeInTheDocument()
-        expect(screen.getByRole('radio', { name: /Accurate/ })).toHaveFocus()
         expect(
-            screen.queryByRole('radio', { name: /Inaccurate/ })
-        ).not.toBeInTheDocument()
+            screen.getByRole('checkbox', { name: /Solved my problem/ })
+        ).toHaveFocus()
         expect(
-            screen.queryByRole('textbox', { name: 'Tell us more (optional)' })
+            screen.queryByRole('checkbox', { name: /Inaccurate/ })
         ).not.toBeInTheDocument()
         expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled()
     })
@@ -69,12 +68,31 @@ describe('PageFeedback', () => {
             screen.getByRole('group', { name: 'What went wrong?' })
         ).toBeInTheDocument()
         expect(
-            screen.getByRole('radio', {
+            screen.getByRole('checkbox', {
                 name: /Couldn't find what I needed/,
             })
         ).toBeInTheDocument()
         expect(
-            screen.queryByRole('radio', { name: /Solved my problem/ })
+            screen.getByRole('checkbox', { name: /Out of date/ })
+        ).toBeInTheDocument()
+        expect(
+            screen.queryByRole('checkbox', { name: /Solved my problem/ })
+        ).not.toBeInTheDocument()
+    })
+
+    it('shows positive findability option after a positive reaction', async () => {
+        const user = userEvent.setup()
+        render(<PageFeedback pageUrl="/docs/test-page" pageTitle="Test page" />)
+
+        await user.click(
+            screen.getByRole('button', { name: 'Yes, this page was helpful' })
+        )
+
+        expect(
+            screen.getByRole('checkbox', { name: /Easy to find/ })
+        ).toBeInTheDocument()
+        expect(
+            screen.queryByRole('checkbox', { name: /Out of date/ })
         ).not.toBeInTheDocument()
     })
 
@@ -90,7 +108,7 @@ describe('PageFeedback', () => {
         })
 
         await user.click(yes)
-        await user.click(screen.getByRole('radio', { name: /Accurate/ }))
+        await user.click(screen.getByRole('checkbox', { name: /Accurate/ }))
         await user.click(no)
 
         expect(yes).toHaveAttribute('aria-pressed', 'false')
@@ -99,7 +117,7 @@ describe('PageFeedback', () => {
             screen.getByRole('group', { name: 'What went wrong?' })
         ).toBeInTheDocument()
         expect(
-            screen.queryByRole('radio', { name: /Accurate/ })
+            screen.queryByRole('checkbox', { name: /Accurate/ })
         ).not.toBeInTheDocument()
         await waitFor(() => {
             expect(global.fetch).toHaveBeenCalledTimes(1)
@@ -129,7 +147,7 @@ describe('PageFeedback', () => {
         ).not.toBeInTheDocument()
     })
 
-    it('submits a structured reason without requiring details', async () => {
+    it('allows selecting multiple reasons and submits them all', async () => {
         const user = userEvent.setup()
         render(<PageFeedback pageUrl="/docs/test-page" pageTitle="Test page" />)
 
@@ -138,14 +156,43 @@ describe('PageFeedback', () => {
                 name: 'No, this page was not helpful',
             })
         )
+
+        await user.click(screen.getByRole('checkbox', { name: /Inaccurate/ }))
+        await user.click(screen.getByRole('checkbox', { name: /Out of date/ }))
         expect(
-            screen.queryByRole('textbox', {
-                name: 'Tell us more (optional)',
+            screen.getByRole('button', { name: 'Submit' })
+        ).not.toBeDisabled()
+        await user.click(screen.getByRole('button', { name: 'Submit' }))
+
+        await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1))
+        expect(global.fetch).toHaveBeenLastCalledWith(
+            `/docs/_api/v1/page-feedback/${feedbackId}`,
+            expect.objectContaining({
+                body: JSON.stringify({
+                    pageUrl: '/docs/test-page',
+                    pageTitle: 'Test page',
+                    reaction: 'thumbsDown',
+                    reasons: ['inaccurate', 'outOfDate'],
+                    reasonSetVersion: 2,
+                }),
             })
-        ).not.toBeInTheDocument()
+        )
+        expect(
+            await screen.findByText('Thank you for your feedback.')
+        ).toBeInTheDocument()
+    })
+
+    it('submits a single reason without a comment', async () => {
+        const user = userEvent.setup()
+        render(<PageFeedback pageUrl="/docs/test-page" pageTitle="Test page" />)
 
         await user.click(
-            screen.getByRole('radio', {
+            screen.getByRole('button', {
+                name: 'No, this page was not helpful',
+            })
+        )
+        await user.click(
+            screen.getByRole('checkbox', {
                 name: /Couldn't find what I needed/,
             })
         )
@@ -162,8 +209,8 @@ describe('PageFeedback', () => {
                     pageUrl: '/docs/test-page',
                     pageTitle: 'Test page',
                     reaction: 'thumbsDown',
-                    reason: 'missingInformation',
-                    reasonSetVersion: 1,
+                    reasons: ['missingInformation'],
+                    reasonSetVersion: 2,
                 }),
             })
         )
@@ -172,61 +219,46 @@ describe('PageFeedback', () => {
         ).toBeInTheDocument()
     })
 
-    it('moves the comment field under the selected reason', async () => {
+    it('shows a single shared comment field once the reaction is selected', async () => {
         const user = userEvent.setup()
         render(<PageFeedback pageUrl="/docs/test-page" pageTitle="Test page" />)
 
-        await user.click(
-            screen.getByRole('button', {
-                name: 'Yes, this page was helpful',
-            })
-        )
-        const accurate = screen.getByRole('radio', { name: /Accurate/ })
-        const solved = screen.getByRole('radio', { name: /Solved my problem/ })
-
-        await user.click(accurate)
-        const firstComment = screen.getByRole('textbox', {
-            name: 'Tell us more (optional)',
-        })
-        expect(accurate.closest('.page-feedback__option')).toContainElement(
-            firstComment
-        )
-        await user.type(firstComment, 'Clear write-up.')
-
-        await user.click(solved)
-        const movedComment = screen.getByRole('textbox', {
-            name: 'Tell us more (optional)',
-        })
-        expect(movedComment).toHaveValue('')
-        expect(solved.closest('.page-feedback__option')).toContainElement(
-            movedComment
-        )
-        await user.type(movedComment, 'Fixed my issue.')
-
-        await user.click(accurate)
         expect(
-            screen.getByRole('textbox', { name: 'Tell us more (optional)' })
-        ).toHaveValue('Clear write-up.')
+            screen.queryByRole('textbox', { name: 'Tell us more (optional)' })
+        ).not.toBeInTheDocument()
+
+        await user.click(
+            screen.getByRole('button', { name: 'Yes, this page was helpful' })
+        )
+
+        const textarea = screen.getByRole('textbox', {
+            name: 'Tell us more (optional)',
+        })
+        expect(textarea).toBeInTheDocument()
+
+        await user.click(screen.getByRole('checkbox', { name: /Accurate/ }))
+        await user.click(
+            screen.getByRole('checkbox', { name: /Helpful examples/ })
+        )
+        expect(screen.getAllByRole('checkbox', { checked: true })).toHaveLength(
+            2
+        )
+        expect(textarea).toBeInTheDocument()
+        expect(
+            screen.getAllByRole('textbox', { name: 'Tell us more (optional)' })
+        ).toHaveLength(1)
     })
 
-    it('keeps per-option comments when switching between yes and no', async () => {
+    it('retains the comment when switching between reactions', async () => {
         const user = userEvent.setup()
         render(<PageFeedback pageUrl="/docs/test-page" pageTitle="Test page" />)
 
         await user.click(
-            screen.getByRole('button', {
-                name: 'Yes, this page was helpful',
-            })
+            screen.getByRole('button', { name: 'Yes, this page was helpful' })
         )
-        await user.click(screen.getByRole('radio', { name: /Accurate/ }))
         await user.type(
             screen.getByRole('textbox', { name: 'Tell us more (optional)' }),
-            'Clear write-up.'
-        )
-        await user.click(screen.getByRole('radio', { name: /Another reason/ }))
-        await user.type(
-            screen.getByRole('textbox', { name: 'Tell us more (optional)' }),
-            'Shared note.'
+            'Great page.'
         )
 
         await user.click(
@@ -234,28 +266,30 @@ describe('PageFeedback', () => {
                 name: 'No, this page was not helpful',
             })
         )
-        expect(
-            screen.getByRole('radio', { name: /Another reason/ })
-        ).toBeChecked()
+
         expect(
             screen.getByRole('textbox', { name: 'Tell us more (optional)' })
-        ).toHaveValue('Shared note.')
+        ).toHaveValue('Great page.')
+    })
+
+    it('clears reasons that are invalid for the new reaction when switching', async () => {
+        const user = userEvent.setup()
+        render(<PageFeedback pageUrl="/docs/test-page" pageTitle="Test page" />)
 
         await user.click(
+            screen.getByRole('button', { name: 'Yes, this page was helpful' })
+        )
+        await user.click(screen.getByRole('checkbox', { name: /Accurate/ }))
+        await user.click(
             screen.getByRole('button', {
-                name: 'Yes, this page was helpful',
+                name: 'No, this page was not helpful',
             })
         )
+
         expect(
-            screen.getByRole('radio', { name: /Another reason/ })
-        ).toBeChecked()
-        expect(
-            screen.getByRole('textbox', { name: 'Tell us more (optional)' })
-        ).toHaveValue('Shared note.')
-        await user.click(screen.getByRole('radio', { name: /Accurate/ }))
-        expect(
-            screen.getByRole('textbox', { name: 'Tell us more (optional)' })
-        ).toHaveValue('Clear write-up.')
+            screen.queryByRole('checkbox', { checked: true })
+        ).not.toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled()
     })
 
     it('waits for an in-flight reaction save before storing richer feedback', async () => {
@@ -275,7 +309,7 @@ describe('PageFeedback', () => {
             })
         )
         await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1))
-        await user.click(screen.getByRole('radio', { name: /Accurate/ }))
+        await user.click(screen.getByRole('checkbox', { name: /Accurate/ }))
         await user.click(screen.getByRole('button', { name: 'Submit' }))
 
         expect(global.fetch).toHaveBeenCalledTimes(1)
@@ -284,12 +318,12 @@ describe('PageFeedback', () => {
         expect(global.fetch).toHaveBeenLastCalledWith(
             `/docs/_api/v1/page-feedback/${feedbackId}`,
             expect.objectContaining({
-                body: expect.stringContaining('"reason":"accurate"'),
+                body: expect.stringContaining('"reasons":["accurate"]'),
             })
         )
     })
 
-    it('preserves the selected reason and details when submission is retried', async () => {
+    it('preserves selected reasons and comment when submission is retried', async () => {
         const user = userEvent.setup()
         jest.mocked(global.fetch)
             .mockResolvedValueOnce(successfulResponse)
@@ -303,7 +337,7 @@ describe('PageFeedback', () => {
             })
         )
         await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1))
-        const reason = screen.getByRole('radio', {
+        const reason = screen.getByRole('checkbox', {
             name: /Code sample errors/,
         })
         await user.click(reason)
@@ -327,7 +361,7 @@ describe('PageFeedback', () => {
         ).toBeInTheDocument()
     })
 
-    it('restores a per-option draft after remount and clears it on submit', async () => {
+    it('restores reasons and comment from draft after remount and clears on submit', async () => {
         const user = userEvent.setup()
         const { unmount } = render(
             <PageFeedback pageUrl="/docs/test-page" pageTitle="Test page" />
@@ -338,22 +372,18 @@ describe('PageFeedback', () => {
                 name: 'Yes, this page was helpful',
             })
         )
-        await user.click(screen.getByRole('radio', { name: /Accurate/ }))
-        await user.type(
-            screen.getByRole('textbox', { name: 'Tell us more (optional)' }),
-            'Clear write-up.'
-        )
+        await user.click(screen.getByRole('checkbox', { name: /Accurate/ }))
         await user.click(
-            screen.getByRole('radio', { name: /Solved my problem/ })
+            screen.getByRole('checkbox', { name: /Helpful examples/ })
         )
         await user.type(
             screen.getByRole('textbox', { name: 'Tell us more (optional)' }),
-            'Fixed my issue.'
+            'Great content.'
         )
         await waitFor(() =>
             expect(
                 sessionStorage.getItem('docs-page-feedback:/docs/test-page')
-            ).toContain('Fixed my issue.')
+            ).toContain('Great content.')
         )
 
         unmount()
@@ -362,17 +392,14 @@ describe('PageFeedback', () => {
         expect(
             screen.getByRole('button', { name: 'Yes, this page was helpful' })
         ).toHaveAttribute('aria-pressed', 'true')
+        expect(screen.getByRole('checkbox', { name: /Accurate/ })).toBeChecked()
         expect(
-            screen.getByRole('radio', { name: /Solved my problem/ })
+            screen.getByRole('checkbox', { name: /Helpful examples/ })
         ).toBeChecked()
         expect(
             screen.getByRole('textbox', { name: 'Tell us more (optional)' })
-        ).toHaveValue('Fixed my issue.')
+        ).toHaveValue('Great content.')
 
-        await user.click(screen.getByRole('radio', { name: /Accurate/ }))
-        expect(
-            screen.getByRole('textbox', { name: 'Tell us more (optional)' })
-        ).toHaveValue('Clear write-up.')
         await user.click(screen.getByRole('button', { name: 'Submit' }))
 
         expect(
@@ -403,7 +430,9 @@ describe('PageFeedback', () => {
                 'Missing a parameter, field, status, or auth detail.'
             )
         ).toBeInTheDocument()
-        await user.click(screen.getByRole('radio', { name: /Example errors/ }))
+        await user.click(
+            screen.getByRole('checkbox', { name: /Example errors/ })
+        )
         await user.click(screen.getByRole('button', { name: 'Submit' }))
 
         await waitFor(() =>
@@ -411,7 +440,7 @@ describe('PageFeedback', () => {
                 `/docs/_api/v1/page-feedback/${feedbackId}`,
                 expect.objectContaining({
                     body: expect.stringContaining(
-                        '"reason":"codeSampleErrors"'
+                        '"reasons":["codeSampleErrors"]'
                     ),
                 })
             )

--- a/src/Elastic.Documentation.Site/Assets/web-components/PageFeedback.test.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/PageFeedback.test.tsx
@@ -49,7 +49,7 @@ describe('PageFeedback', () => {
             screen.getByRole('checkbox', { name: /Solved my problem/ })
         ).toHaveFocus()
         expect(
-            screen.queryByRole('checkbox', { name: /Inaccurate/ })
+            screen.queryByRole('checkbox', { name: /Technically incorrect/ })
         ).not.toBeInTheDocument()
         expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled()
     })
@@ -157,7 +157,9 @@ describe('PageFeedback', () => {
             })
         )
 
-        await user.click(screen.getByRole('checkbox', { name: /Inaccurate/ }))
+        await user.click(
+            screen.getByRole('checkbox', { name: /Technically incorrect/ })
+        )
         await user.click(screen.getByRole('checkbox', { name: /Out of date/ }))
         expect(
             screen.getByRole('button', { name: 'Submit' })

--- a/src/Elastic.Documentation.Site/Assets/web-components/PageFeedback.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/PageFeedback.tsx
@@ -46,7 +46,7 @@ const API_COPY: Partial<Record<Reason, Partial<ReasonOption>>> = {
         description: 'I found the endpoint or schema I needed quickly.',
     },
     inaccurate: {
-        description: 'The reference is wrong or does not match the real API.',
+        description: 'The reference is wrong about how the API works.',
     },
     missingInformation: {
         description: 'Missing a parameter, field, status, or auth detail.',
@@ -56,7 +56,7 @@ const API_COPY: Partial<Record<Reason, Partial<ReasonOption>>> = {
         description: 'A request or response example is wrong.',
     },
     outOfDate: {
-        description: "The reference doesn't reflect the current API version.",
+        description: 'The reference describes an older version of the API.',
     },
 }
 
@@ -93,8 +93,7 @@ const NEGATIVE_REASONS: ReasonOption[] = [
     {
         value: 'outOfDate',
         label: 'Out of date',
-        description:
-            "The content doesn't reflect the current product or version.",
+        description: 'The page describes an older version of the product.',
     },
     {
         value: 'hardToUnderstand',
@@ -103,8 +102,8 @@ const NEGATIVE_REASONS: ReasonOption[] = [
     },
     {
         value: 'inaccurate',
-        label: 'Inaccurate',
-        description: 'The information is wrong or misleading.',
+        label: 'Technically incorrect',
+        description: 'The page is wrong about how the product works.',
     },
     {
         value: 'codeSampleErrors',

--- a/src/Elastic.Documentation.Site/Assets/web-components/PageFeedback.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/PageFeedback.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import { FormEvent, useEffect, useId, useRef, useState } from 'react'
 
 const COMMENT_MAX_LENGTH = 2000
-const REASON_SET_VERSION = 1
+const REASON_SET_VERSION = 2
 const REACTION_SAVE_DELAY = 400
 const DRAFT_STORAGE_PREFIX = 'docs-page-feedback:'
 
@@ -15,10 +15,12 @@ type Reason =
     | 'solvedProblem'
     | 'easyToUnderstand'
     | 'helpfulExamples'
+    | 'easyToFind'
     | 'inaccurate'
     | 'missingInformation'
     | 'hardToUnderstand'
     | 'codeSampleErrors'
+    | 'outOfDate'
     | 'anotherReason'
 
 interface ReasonOption {
@@ -28,7 +30,9 @@ interface ReasonOption {
 }
 
 const API_COPY: Partial<Record<Reason, Partial<ReasonOption>>> = {
-    accurate: { description: 'Matches the real API.' },
+    accurate: {
+        description: 'The reference is correct and matches the real API.',
+    },
     solvedProblem: {
         description: 'Helped me call the endpoint or use the schema.',
     },
@@ -38,7 +42,12 @@ const API_COPY: Partial<Record<Reason, Partial<ReasonOption>>> = {
     helpfulExamples: {
         description: 'The request or response examples helped.',
     },
-    inaccurate: { description: 'Does not match the real API.' },
+    easyToFind: {
+        description: 'I found the endpoint or schema I needed quickly.',
+    },
+    inaccurate: {
+        description: 'The reference is wrong or does not match the real API.',
+    },
     missingInformation: {
         description: 'Missing a parameter, field, status, or auth detail.',
     },
@@ -46,14 +55,12 @@ const API_COPY: Partial<Record<Reason, Partial<ReasonOption>>> = {
         label: 'Example errors',
         description: 'A request or response example is wrong.',
     },
+    outOfDate: {
+        description: "The reference doesn't reflect the current API version.",
+    },
 }
 
 const POSITIVE_REASONS: ReasonOption[] = [
-    {
-        value: 'accurate',
-        label: 'Accurate',
-        description: 'Accurately describes the product or feature.',
-    },
     {
         value: 'solvedProblem',
         label: 'Solved my problem',
@@ -65,23 +72,29 @@ const POSITIVE_REASONS: ReasonOption[] = [
         description: 'Clear and easy to follow.',
     },
     {
+        value: 'accurate',
+        label: 'Accurate',
+        description: 'The information is correct and up to date.',
+    },
+    {
         value: 'helpfulExamples',
         label: 'Helpful examples',
         description: 'The examples helped me complete my task.',
+    },
+    {
+        value: 'easyToFind',
+        label: 'Easy to find',
+        description: 'I found the information I was looking for quickly.',
     },
     { value: 'anotherReason', label: 'Another reason' },
 ]
 
 const NEGATIVE_REASONS: ReasonOption[] = [
     {
-        value: 'inaccurate',
-        label: 'Inaccurate',
-        description: "Doesn't accurately describe the product or feature.",
-    },
-    {
-        value: 'missingInformation',
-        label: "Couldn't find what I needed",
-        description: 'Missing important information.',
+        value: 'outOfDate',
+        label: 'Out of date',
+        description:
+            "The content doesn't reflect the current product or version.",
     },
     {
         value: 'hardToUnderstand',
@@ -89,9 +102,19 @@ const NEGATIVE_REASONS: ReasonOption[] = [
         description: 'Too complicated or unclear.',
     },
     {
+        value: 'inaccurate',
+        label: 'Inaccurate',
+        description: 'The information is wrong or misleading.',
+    },
+    {
         value: 'codeSampleErrors',
         label: 'Code sample errors',
         description: 'One or more code samples are incorrect.',
+    },
+    {
+        value: 'missingInformation',
+        label: "Couldn't find what I needed",
+        description: 'Missing important information.',
     },
     { value: 'anotherReason', label: 'Another reason' },
 ]
@@ -109,8 +132,8 @@ const REASON_VALUES = new Set<Reason>([
 interface FeedbackDraft {
     feedbackId: string
     reaction: Reaction
-    reason: Reason | null
-    comments: Partial<Record<Reason, string>>
+    reasons: Reason[]
+    comment: string
 }
 
 const draftKey = (pageUrl: string) => `${DRAFT_STORAGE_PREFIX}${pageUrl}`
@@ -128,17 +151,11 @@ const readDraft = (pageUrl: string): FeedbackDraft | null => {
             return null
         }
 
-        const comments: Partial<Record<Reason, string>> = {}
-        if (parsed.comments && typeof parsed.comments === 'object') {
-            for (const [value, comment] of Object.entries(parsed.comments)) {
-                if (
-                    REASON_VALUES.has(value as Reason) &&
-                    typeof comment === 'string'
-                ) {
-                    comments[value as Reason] = comment.slice(
-                        0,
-                        COMMENT_MAX_LENGTH
-                    )
+        const reasons: Reason[] = []
+        if (Array.isArray(parsed.reasons)) {
+            for (const value of parsed.reasons) {
+                if (REASON_VALUES.has(value as Reason)) {
+                    reasons.push(value as Reason)
                 }
             }
         }
@@ -146,11 +163,11 @@ const readDraft = (pageUrl: string): FeedbackDraft | null => {
         return {
             feedbackId: parsed.feedbackId,
             reaction: parsed.reaction,
-            reason:
-                parsed.reason && REASON_VALUES.has(parsed.reason)
-                    ? parsed.reason
-                    : null,
-            comments,
+            reasons,
+            comment:
+                typeof parsed.comment === 'string'
+                    ? parsed.comment.slice(0, COMMENT_MAX_LENGTH)
+                    : '',
         }
     } catch {
         return null
@@ -183,7 +200,7 @@ interface PageFeedbackPayload {
     pageUrl: string
     pageTitle: string
     reaction: Reaction
-    reason?: Reason
+    reasons?: Reason[]
     reasonSetVersion?: number
     comment?: string
 }
@@ -247,12 +264,8 @@ export const PageFeedback = ({
     const [reaction, setReaction] = useState<Reaction | null>(
         () => draft?.reaction ?? null
     )
-    const [reason, setReason] = useState<Reason | null>(
-        () => draft?.reason ?? null
-    )
-    const [comments, setComments] = useState<Partial<Record<Reason, string>>>(
-        () => draft?.comments ?? {}
-    )
+    const [reasons, setReasons] = useState<Reason[]>(() => draft?.reasons ?? [])
+    const [comment, setComment] = useState<string>(() => draft?.comment ?? '')
     const [isSaving, setIsSaving] = useState(false)
     const [showThanks, setShowThanks] = useState(false)
     const [error, setError] = useState(false)
@@ -269,8 +282,8 @@ export const PageFeedback = ({
 
     useEffect(() => {
         if (showThanks || !reaction) return
-        writeDraft(pageUrl, { feedbackId, reaction, reason, comments })
-    }, [pageUrl, feedbackId, reaction, reason, comments, showThanks])
+        writeDraft(pageUrl, { feedbackId, reaction, reasons, comment })
+    }, [pageUrl, feedbackId, reaction, reasons, comment, showThanks])
 
     useEffect(() => () => pendingReactionSaveRef.current?.(false), [])
 
@@ -290,14 +303,10 @@ export const PageFeedback = ({
         if (nextReaction === reaction) return
 
         setReaction(nextReaction)
-        setReason(
-            reason &&
-                (nextReaction === 'thumbsUp'
-                    ? POSITIVE_REASONS
-                    : NEGATIVE_REASONS
-                ).some((option) => option.value === reason)
-                ? reason
-                : null
+        const validSet =
+            nextReaction === 'thumbsUp' ? POSITIVE_REASONS : NEGATIVE_REASONS
+        setReasons((prev) =>
+            prev.filter((r) => validSet.some((o) => o.value === r))
         )
         setError(false)
         pendingReactionSaveRef.current?.(false)
@@ -325,16 +334,25 @@ export const PageFeedback = ({
         })
     }
 
+    const toggleReason = (value: Reason) => {
+        setReasons((prev) =>
+            prev.includes(value)
+                ? prev.filter((r) => r !== value)
+                : [...prev, value]
+        )
+        setError(false)
+    }
+
     const submitDetails = async (event: FormEvent) => {
         event.preventDefault()
-        if (!reaction || !reason || isSaving) return
-        const trimmedComment = (comments[reason] ?? '').trim()
+        if (!reaction || reasons.length === 0 || isSaving) return
+        const trimmedComment = comment.trim()
 
         const payload: PageFeedbackPayload = {
             pageUrl,
             pageTitle,
             reaction,
-            reason,
+            reasons,
             reasonSetVersion: REASON_SET_VERSION,
             ...(trimmedComment ? { comment: trimmedComment } : {}),
         }
@@ -423,90 +441,77 @@ export const PageFeedback = ({
                             reaction === 'thumbsUp'
                                 ? POSITIVE_REASONS
                                 : NEGATIVE_REASONS
-                        ).map((option, index) => {
-                            const optionComment = comments[option.value] ?? ''
-                            return (
-                                <div
-                                    key={option.value}
-                                    className="page-feedback__option"
-                                >
-                                    <label className="page-feedback__reason">
-                                        <input
-                                            ref={
-                                                index === 0
-                                                    ? firstReasonRef
-                                                    : undefined
-                                            }
-                                            type="radio"
-                                            name={`${questionId}-reason`}
-                                            value={option.value}
-                                            checked={reason === option.value}
-                                            onChange={() => {
-                                                setReason(option.value)
-                                                setError(false)
-                                            }}
-                                        />
-                                        <span>
-                                            <span className="page-feedback__reason-label">
-                                                {option.label}
-                                            </span>
-                                            {option.description && (
-                                                <span className="page-feedback__reason-description">
-                                                    {option.description}
-                                                </span>
-                                            )}
+                        ).map((option, index) => (
+                            <div
+                                key={option.value}
+                                className="page-feedback__option"
+                            >
+                                <label className="page-feedback__reason">
+                                    <input
+                                        ref={
+                                            index === 0
+                                                ? firstReasonRef
+                                                : undefined
+                                        }
+                                        type="checkbox"
+                                        name={`${questionId}-reason`}
+                                        value={option.value}
+                                        checked={reasons.includes(option.value)}
+                                        onChange={() =>
+                                            toggleReason(option.value)
+                                        }
+                                    />
+                                    <span>
+                                        <span className="page-feedback__reason-label">
+                                            {option.label}
                                         </span>
-                                    </label>
-                                    {reason === option.value && (
-                                        <div className="page-feedback__details">
-                                            <label
-                                                className="sr-only"
-                                                htmlFor={`${questionId}-comment-${option.value}`}
-                                            >
-                                                Tell us more (optional)
-                                            </label>
-                                            <textarea
-                                                id={`${questionId}-comment-${option.value}`}
-                                                className="page-feedback__textarea"
-                                                value={optionComment}
-                                                maxLength={COMMENT_MAX_LENGTH}
-                                                placeholder="Tell us more (optional)"
-                                                aria-describedby={guidanceId}
-                                                disabled={isSaving}
-                                                onChange={(event) =>
-                                                    setComments((current) => ({
-                                                        ...current,
-                                                        [option.value]:
-                                                            event.target.value,
-                                                    }))
-                                                }
-                                            />
-                                            <div className="page-feedback__form-footer">
-                                                <p
-                                                    id={guidanceId}
-                                                    className="page-feedback__guidance"
-                                                >
-                                                    Don&apos;t include
-                                                    passwords, API keys, or
-                                                    other sensitive information.
-                                                </p>
-                                                <span className="page-feedback__count">
-                                                    {optionComment.length}/
-                                                    {COMMENT_MAX_LENGTH}
-                                                </span>
-                                            </div>
-                                        </div>
-                                    )}
-                                </div>
-                            )
-                        })}
+                                        {option.description && (
+                                            <span className="page-feedback__reason-description">
+                                                {option.description}
+                                            </span>
+                                        )}
+                                    </span>
+                                </label>
+                            </div>
+                        ))}
                     </fieldset>
+
+                    <div className="page-feedback__details">
+                        <label
+                            className="sr-only"
+                            htmlFor={`${questionId}-comment`}
+                        >
+                            Tell us more (optional)
+                        </label>
+                        <textarea
+                            id={`${questionId}-comment`}
+                            className="page-feedback__textarea"
+                            value={comment}
+                            maxLength={COMMENT_MAX_LENGTH}
+                            placeholder="Tell us more (optional)"
+                            aria-describedby={guidanceId}
+                            disabled={isSaving}
+                            onChange={(event) => setComment(event.target.value)}
+                        />
+                        <div className="page-feedback__form-footer">
+                            <p
+                                id={guidanceId}
+                                className="page-feedback__guidance"
+                            >
+                                Don&apos;t include passwords, API keys, or other
+                                sensitive information.
+                            </p>
+                            <span className="page-feedback__count">
+                                {comment.length}/{COMMENT_MAX_LENGTH}
+                            </span>
+                        </div>
+                    </div>
 
                     <div className="page-feedback__actions">
                         <button
                             type="submit"
                             className="page-feedback__submit"
-                            disabled={isSaving || !reason}
+                            disabled={isSaving || reasons.length === 0}
                         >
                             {isSaving
                                 ? 'Sending…'

--- a/src/Elastic.Documentation.Site/Assets/web-components/PageFeedback.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/PageFeedback.tsx
@@ -31,7 +31,7 @@ interface ReasonOption {
 
 const API_COPY: Partial<Record<Reason, Partial<ReasonOption>>> = {
     accurate: {
-        description: 'The reference is correct and matches the real API.',
+        description: 'The reference is correct about how the API works.',
     },
     solvedProblem: {
         description: 'Helped me call the endpoint or use the schema.',
@@ -74,7 +74,7 @@ const POSITIVE_REASONS: ReasonOption[] = [
     {
         value: 'accurate',
         label: 'Accurate',
-        description: 'The information is correct and up to date.',
+        description: 'The page is correct about how the product works.',
     },
     {
         value: 'helpfulExamples',

--- a/src/api/Elastic.Documentation.Api/Adapters/PageFeedback/ElasticsearchPageFeedbackGateway.cs
+++ b/src/api/Elastic.Documentation.Api/Adapters/PageFeedback/ElasticsearchPageFeedbackGateway.cs
@@ -25,7 +25,7 @@ internal sealed class ElasticsearchPageFeedbackGateway(
 			PageUrl = record.PageUrl,
 			PageTitle = record.PageTitle,
 			Reaction = record.Reaction,
-			Reason = record.Reason,
+			Reasons = record.Reasons,
 			ReasonSetVersion = record.ReasonSetVersion,
 			Comment = record.Comment,
 			Euid = record.Euid,

--- a/src/api/Elastic.Documentation.Api/Adapters/PageFeedback/PageFeedbackMapping.cs
+++ b/src/api/Elastic.Documentation.Api/Adapters/PageFeedback/PageFeedbackMapping.cs
@@ -28,9 +28,9 @@ public sealed record PageFeedbackDocument
 	public required PageFeedbackReaction Reaction { get; init; }
 
 	[Keyword]
-	[JsonPropertyName("reason")]
+	[JsonPropertyName("reasons")]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-	public PageFeedbackReason? Reason { get; init; }
+	public IReadOnlyList<PageFeedbackReason>? Reasons { get; init; }
 
 	[JsonPropertyName("reason_set_version")]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -54,6 +54,7 @@ public sealed record PageFeedbackDocument
 [JsonSerializable(typeof(PageFeedbackDocument))]
 [JsonSerializable(typeof(PageFeedbackReaction))]
 [JsonSerializable(typeof(PageFeedbackReason))]
+[JsonSerializable(typeof(List<PageFeedbackReason>))]
 internal sealed partial class PageFeedbackJsonContext : JsonSerializerContext;
 
 [ElasticsearchMappingContext(JsonContext = typeof(PageFeedbackJsonContext))]

--- a/src/api/Elastic.Documentation.Api/MappingsExtensions.cs
+++ b/src/api/Elastic.Documentation.Api/MappingsExtensions.cs
@@ -232,20 +232,19 @@ public static class MappingsExtension
 
 	private static bool IsValidFeedbackDetails(PageFeedbackRequest request)
 	{
-		if (request.Reason is null)
+		if (request.Reasons is null or [])
 			return request.ReasonSetVersion is null && string.IsNullOrWhiteSpace(request.Comment);
 
 		return request.ReasonSetVersion is > 0
-			&& Enum.IsDefined(request.Reason.Value)
-			&& IsReasonValidForReaction(request.Reaction, request.Reason.Value);
+			&& request.Reasons.All(r => Enum.IsDefined(r) && IsReasonValidForReaction(request.Reaction, r));
 	}
 
 	private static bool IsReasonValidForReaction(PageFeedbackReaction reaction, PageFeedbackReason reason) => reaction switch
 	{
 		PageFeedbackReaction.ThumbsUp =>
-			reason is PageFeedbackReason.Accurate or PageFeedbackReason.SolvedProblem or PageFeedbackReason.EasyToUnderstand or PageFeedbackReason.HelpfulExamples or PageFeedbackReason.AnotherReason,
+			reason is PageFeedbackReason.Accurate or PageFeedbackReason.SolvedProblem or PageFeedbackReason.EasyToUnderstand or PageFeedbackReason.HelpfulExamples or PageFeedbackReason.EasyToFind or PageFeedbackReason.AnotherReason,
 		PageFeedbackReaction.ThumbsDown =>
-			reason is PageFeedbackReason.Inaccurate or PageFeedbackReason.MissingInformation or PageFeedbackReason.HardToUnderstand or PageFeedbackReason.CodeSampleErrors or PageFeedbackReason.AnotherReason,
+			reason is PageFeedbackReason.Inaccurate or PageFeedbackReason.MissingInformation or PageFeedbackReason.HardToUnderstand or PageFeedbackReason.CodeSampleErrors or PageFeedbackReason.OutOfDate or PageFeedbackReason.AnotherReason,
 		_ => false
 	};
 

--- a/src/api/Elastic.Documentation.Api/PageFeedback/IPageFeedbackService.cs
+++ b/src/api/Elastic.Documentation.Api/PageFeedback/IPageFeedbackService.cs
@@ -15,7 +15,7 @@ public record PageFeedbackRecord(
 	string PageUrl,
 	string PageTitle,
 	PageFeedbackReaction Reaction,
-	PageFeedbackReason? Reason,
+	IReadOnlyList<PageFeedbackReason>? Reasons,
 	int? ReasonSetVersion,
 	string? Comment,
 	string? Euid
@@ -27,7 +27,7 @@ public record PageFeedbackRecord(
 			request.PageUrl,
 			request.PageTitle,
 			request.Reaction,
-			request.Reason,
+			request.Reasons is null or [] ? null : request.Reasons,
 			request.ReasonSetVersion,
 			string.IsNullOrWhiteSpace(request.Comment) ? null : request.Comment.Trim(),
 			euid

--- a/src/api/Elastic.Documentation.Api/PageFeedback/PageFeedbackRequest.cs
+++ b/src/api/Elastic.Documentation.Api/PageFeedback/PageFeedbackRequest.cs
@@ -10,7 +10,7 @@ public record PageFeedbackRequest(
 	string PageUrl,
 	string PageTitle,
 	PageFeedbackReaction Reaction,
-	PageFeedbackReason? Reason,
+	IReadOnlyList<PageFeedbackReason>? Reasons,
 	int? ReasonSetVersion,
 	string? Comment
 );
@@ -43,6 +43,9 @@ public enum PageFeedbackReason
 	[JsonStringEnumMemberName("helpfulExamples")]
 	HelpfulExamples,
 
+	[JsonStringEnumMemberName("easyToFind")]
+	EasyToFind,
+
 	[JsonStringEnumMemberName("inaccurate")]
 	Inaccurate,
 
@@ -54,6 +57,9 @@ public enum PageFeedbackReason
 
 	[JsonStringEnumMemberName("codeSampleErrors")]
 	CodeSampleErrors,
+
+	[JsonStringEnumMemberName("outOfDate")]
+	OutOfDate,
 
 	[JsonStringEnumMemberName("anotherReason")]
 	AnotherReason

--- a/tests/Elastic.Documentation.Api.Tests/PageFeedbackEndpointTests.cs
+++ b/tests/Elastic.Documentation.Api.Tests/PageFeedbackEndpointTests.cs
@@ -35,8 +35,8 @@ public class PageFeedbackEndpointTests
 		recorded.FeedbackId.Should().Be(feedbackId);
 		recorded.PageUrl.Should().Be("/docs/test-page");
 		recorded.Reaction.Should().Be(PageFeedbackReaction.ThumbsUp);
-		recorded.Reason.Should().Be(PageFeedbackReason.Accurate);
-		recorded.ReasonSetVersion.Should().Be(1);
+		recorded.Reasons.Should().ContainSingle(r => r == PageFeedbackReason.Accurate);
+		recorded.ReasonSetVersion.Should().Be(2);
 		recorded.Comment.Should().Be("Useful page");
 		recorded.Euid.Should().Be("test-euid");
 	}
@@ -66,9 +66,39 @@ public class PageFeedbackEndpointTests
 
 		response.StatusCode.Should().Be(HttpStatusCode.NoContent);
 		recorded.Should().NotBeNull();
-		recorded.Reason.Should().BeNull();
+		recorded.Reasons.Should().BeNull();
 		recorded.ReasonSetVersion.Should().BeNull();
 		recorded.Comment.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task Put_MultipleReasons_RecordsAllReasons()
+	{
+		var feedbackService = A.Fake<IPageFeedbackService>();
+		PageFeedbackRecord? recorded = null;
+		A
+			.CallTo(() => feedbackService.UpsertFeedbackAsync(A<PageFeedbackRecord>._, A<CancellationToken>._))
+			.Invokes((PageFeedbackRecord record, CancellationToken _) => recorded = record)
+			.Returns(Task.FromResult(true));
+		using var factory = ApiWebApplicationFactory.WithMockedServices(replacements => replacements.Replace(feedbackService));
+		using var client = factory.CreateClient();
+		const string payload = /*lang=json,strict*/
+			"""
+			{
+				"pageUrl": "/docs/test-page",
+				"pageTitle": "Test page",
+				"reaction": "thumbsDown",
+				"reasons": ["inaccurate", "outOfDate"],
+				"reasonSetVersion": 2
+			}
+			""";
+		using var request = CreateRequest(Guid.NewGuid(), payload);
+
+		using var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+		response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+		recorded.Should().NotBeNull();
+		recorded.Reasons.Should().BeEquivalentTo([PageFeedbackReason.Inaccurate, PageFeedbackReason.OutOfDate]);
 	}
 
 	[Fact]
@@ -83,8 +113,8 @@ public class PageFeedbackEndpointTests
 				"pageUrl": "/docs/test-page",
 				"pageTitle": "Test page",
 				"reaction": "thumbsDown",
-				"reason": "inaccurate",
-				"reasonSetVersion": 1,
+				"reasons": ["inaccurate"],
+				"reasonSetVersion": 2,
 				"comment": "{{new string('x', 2001)}}"
 			}
 			""";
@@ -104,8 +134,8 @@ public class PageFeedbackEndpointTests
 			"pageUrl": "/docs/test-page",
 			"pageTitle": "Test page",
 			"reaction": "thumbsUp",
-			"reason": "inaccurate",
-			"reasonSetVersion": 1
+			"reasons": ["inaccurate"],
+			"reasonSetVersion": 2
 		}
 		""")]
 	[InlineData(
@@ -133,7 +163,7 @@ public class PageFeedbackEndpointTests
 			"pageUrl": "/docs/test-page",
 			"pageTitle": "Test page",
 			"reaction": "thumbsDown",
-			"reason": "inaccurate"
+			"reasons": ["inaccurate"]
 		}
 		""")]
 	public async Task Put_InvalidFeedback_ReturnsBadRequest(string payload)
@@ -186,8 +216,8 @@ public class PageFeedbackEndpointTests
 			"pageUrl": "/docs/test-page",
 			"pageTitle": "Test page",
 			"reaction": "thumbsUp",
-			"reason": "accurate",
-			"reasonSetVersion": 1,
+			"reasons": ["accurate"],
+			"reasonSetVersion": 2,
 			"comment": " Useful page "
 		}
 		""";

--- a/tests/Elastic.Documentation.Api.Tests/PageFeedbackGatewayTests.cs
+++ b/tests/Elastic.Documentation.Api.Tests/PageFeedbackGatewayTests.cs
@@ -91,8 +91,8 @@ public class PageFeedbackGatewayTests
 			"/docs/test-page",
 			"Test page",
 			PageFeedbackReaction.ThumbsUp,
-			PageFeedbackReason.Accurate,
-			1,
+			[PageFeedbackReason.Accurate],
+			2,
 			"Clear and useful.",
 			"test-euid"
 		);

--- a/tests/Elastic.Documentation.Api.Tests/PageFeedbackMappingTests.cs
+++ b/tests/Elastic.Documentation.Api.Tests/PageFeedbackMappingTests.cs
@@ -28,7 +28,7 @@ public class PageFeedbackMappingTests
 		properties.GetProperty("page_url").GetProperty("ignore_above").GetInt32().Should().Be(2048);
 		properties.GetProperty("page_title").GetProperty("ignore_above").GetInt32().Should().Be(500);
 		properties.GetProperty("reaction").GetProperty("type").GetString().Should().Be("keyword");
-		properties.GetProperty("reason").GetProperty("type").GetString().Should().Be("keyword");
+		properties.GetProperty("reasons").GetProperty("type").GetString().Should().Be("keyword");
 		properties.GetProperty("reason_set_version").GetProperty("type").GetString().Should().Be("integer");
 		properties.GetProperty("comment").GetProperty("type").GetString().Should().Be("text");
 		properties.GetProperty("euid").GetProperty("ignore_above").GetInt32().Should().Be(256);
@@ -44,7 +44,7 @@ public class PageFeedbackMappingTests
 			PageUrl = "/docs/test-page",
 			PageTitle = "Test page",
 			Reaction = PageFeedbackReaction.ThumbsUp,
-			Reason = PageFeedbackReason.HelpfulExamples,
+			Reasons = [PageFeedbackReason.HelpfulExamples, PageFeedbackReason.EasyToFind],
 			ReasonSetVersion = 2,
 			Timestamp = DateTimeOffset.UtcNow
 		};
@@ -52,7 +52,10 @@ public class PageFeedbackMappingTests
 		var json = JsonSerializer.Serialize(document, PageFeedbackJsonContext.Default.PageFeedbackDocument);
 		using var serialized = JsonDocument.Parse(json);
 
-		serialized.RootElement.GetProperty("reason").GetString().Should().Be("helpfulExamples");
+		var reasonsArray = serialized.RootElement.GetProperty("reasons");
+		reasonsArray.GetArrayLength().Should().Be(2);
+		reasonsArray[0].GetString().Should().Be("helpfulExamples");
+		reasonsArray[1].GetString().Should().Be("easyToFind");
 		serialized.RootElement.GetProperty("reason_set_version").GetInt32().Should().Be(2);
 	}
 }


### PR DESCRIPTION
Readers can pick several reasons when they rate a page instead of only one, and two new reasons cover stale content and findability. Each feedback record now stores a list of reasons rather than a single value.

**Affects:** `Site UI`, `Docs API`

**Prompt summary:** The ask was to review our page feedback options against comparable documentation sites and close whatever gaps that turned up. The review showed our option list derives from Stripe's, so this branch covers the reasons Stripe has no equivalent for and the single-select limit that was discarding signal. A later pass tightened the wording so that no two reasons describe the same problem.

## Why

A page can fail in more than one way at the same time. The questionnaire accepts one reason, so a reader who finds a page both hard to understand and out of date can record only one of those problems. The list also offers no way to report content that describes an older version, and the positive side has no findability signal to match `missingInformation` on the negative side. Microsoft Learn collects several reasons at once, and GitLab collects staleness.

## What

#### Several reasons per submission

The questionnaire takes a list of reasons, so a reader checks every box that applies. Submit stays disabled until at least one box is checked. Switching between Yes and No keeps the boxes that exist in both sets and drops the rest.

#### New reasons for staleness and findability

The list gains `outOfDate` for a page that describes an older version of a product, which the previous options had no way to report. It also gains `easyToFind`, a positive counterpart to `missingInformation`. Both carry their own copy on API reference pages.

#### A sharper split between wrong and stale

A reader who found a page wrong had to work out why before picking a reason, because two options said much the same thing. The "Inaccurate" label becomes "Technically incorrect" and its description covers only how the product works, while "Out of date" names the version gap. The positive "Accurate" option follows the same line and no longer claims the page is up to date. Stored values are untouched, so this part is copy only.

#### One comment field

A single comment covers the whole submission and keeps its text when the reader switches reaction. The previous design held a separate comment draft per option, which does not map onto a form where several options can be active together.

#### Stored shape

The document field becomes the multi-valued `reasons` keyword and `reason_set_version` moves to `2`, so a query can tell the two shapes apart. Elasticsearch indexes a keyword array without a mapping change beyond the rename. The index has not reached production, so no migration is needed.

**Out of scope:** The endpoint does not cap the length of the `reasons` array or reject duplicate values. The form can only send known values, so this matters only for a handcrafted request.

## Verify

```bash
dotnet test tests/Elastic.Documentation.Api.Tests/ --filter PageFeedback
```

```bash
cd src/Elastic.Documentation.Site && npm test -- PageFeedback
```

To see the widget, serve the repo's own docs with the flag on and open `/development/page-feedback`:

```bash
FEATURE_PAGE_FEEDBACK=true dotnet run --project src/tooling/docs-builder serve --path docs --port 4001
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qFe4JZUeEXN58iihNVsRf