### PR TITLE
Add an Edit page button and a site problem feedback reason

### DIFF
--- a/docs/development/page-feedback.md
+++ b/docs/development/page-feedback.md
@@ -30,7 +30,7 @@ clients and historical documents remain valid.
 
 Reason set version 3 presents these positive reasons in display order:
 `solvedProblem`, `easyToUnderstand`, `accurate`, `helpfulExamples`,
-`easyToFind`, and `anotherReason`. The negative reasons are `outOfDate`,
+`easyToFind`, and `anotherReason`. The negative reasons are
 `hardToUnderstand`, `inaccurate`, `codeSampleErrors`, `missingInformation`,
 `siteProblem`, and `anotherReason`. API pages use the same stored values
 and `reason_set_version`. They pass `surface="api"` so labels and descriptions
@@ -39,13 +39,21 @@ talk about the spec and examples instead of a product how-to.
 `siteProblem` reports a fault in the site rather than in the content. A broken
 link, a control that does nothing, or a search that returns nothing belongs
 here, while `inaccurate` and `codeSampleErrors` stay with the words on the page.
-Version 2 offered the same reasons without `siteProblem`, so a query that counts
-site faults must not read version 2 documents as an absence of them.
+
+`inaccurate` also covers content that describes an older version of the product.
+Version 3 retired `outOfDate` and folded it in, because a reader cannot tell a
+page that was never right from a page that stopped being right. Two negative
+sets therefore differ from version 2: it offered `outOfDate` and lacked
+`siteProblem`. A query that counts either one must scope itself to a version.
+
+`outOfDate` remains a stored value. Historical documents hold it, and a browser
+running a cached bundle still submits it, so the endpoint still accepts it.
 
 The endpoint accepts a reason only for the reaction it belongs to. A negative
 reason sent with `thumbsUp` fails validation in `IsReasonValidForReaction` and
 the request returns `400`. Adding an option means adding it to
 `PageFeedbackReason`, to that reaction's list, and to the browser's reason set.
+Retiring one means removing it from the browser's set alone.
 
 ## Provision the index
 

--- a/docs/development/page-feedback.md
+++ b/docs/development/page-feedback.md
@@ -28,13 +28,24 @@ presented the option. Display labels may change without changing their stored va
 enum value when an option's meaning changes, and retain retired values so older
 clients and historical documents remain valid.
 
-Reason set version 2 presents these positive reasons in display order:
+Reason set version 3 presents these positive reasons in display order:
 `solvedProblem`, `easyToUnderstand`, `accurate`, `helpfulExamples`,
 `easyToFind`, and `anotherReason`. The negative reasons are `outOfDate`,
-`hardToUnderstand`, `inaccurate`, `codeSampleErrors`, `missingInformation`, and
-`anotherReason`. API pages use the same stored values
+`hardToUnderstand`, `inaccurate`, `codeSampleErrors`, `missingInformation`,
+`siteProblem`, and `anotherReason`. API pages use the same stored values
 and `reason_set_version`. They pass `surface="api"` so labels and descriptions
 talk about the spec and examples instead of a product how-to.
+
+`siteProblem` reports a fault in the site rather than in the content. A broken
+link, a control that does nothing, or a search that returns nothing belongs
+here, while `inaccurate` and `codeSampleErrors` stay with the words on the page.
+Version 2 offered the same reasons without `siteProblem`, so a query that counts
+site faults must not read version 2 documents as an absence of them.
+
+The endpoint accepts a reason only for the reaction it belongs to. A negative
+reason sent with `thumbsUp` fails validation in `IsReasonValidForReaction` and
+the request returns `400`. Adding an option means adding it to
+`PageFeedbackReason`, to that reaction's list, and to the browser's reason set.
 
 ## Provision the index
 

--- a/src/Elastic.Documentation.Site/Assets/main.ts
+++ b/src/Elastic.Documentation.Site/Assets/main.ts
@@ -31,7 +31,7 @@ import {
 } from './web-components/shared/htmx/utils'
 import 'htmx-ext-head-support'
 import 'htmx-ext-preload'
-import { $, $optional, $$optional } from 'select-dom'
+import { $, $$optional } from 'select-dom'
 import { UAParser } from 'ua-parser-js'
 
 // Injected at build time from MinVer
@@ -92,7 +92,10 @@ async function runInitSteps(
 function applyEditParam() {
     const urlParams = new URLSearchParams(window.location.search)
     if (urlParams.has('edit')) {
-        $optional('.edit-this-page.hidden')?.classList.remove('hidden')
+        // Two copies exist: the right-rail CTA and the bottom-of-page one. Reveal both.
+        $$optional('.edit-this-page.hidden').forEach((el) =>
+            el.classList.remove('hidden')
+        )
     }
 }
 

--- a/src/Elastic.Documentation.Site/Assets/page-actions.css
+++ b/src/Elastic.Documentation.Site/Assets/page-actions.css
@@ -1,6 +1,6 @@
 /*
 	The markdown layout wraps <page-feedback> and .page-actions in .page-outro so the
-	"Report a docs issue" / "Edit this page" links sit on the Yes/No button row, right aligned.
+	"Edit page" / "Report issue" buttons sit on the Yes/No button row, right aligned.
 
 	The row takes over the top border and spacing that page-feedback.css sets on the
 	page-feedback element, which would otherwise stop at the left column. Layouts that render
@@ -42,8 +42,55 @@
 	flex-wrap: wrap;
 	align-items: center;
 	justify-content: flex-end;
-	gap: 0.5rem 1.5rem;
-	/* Centres the links on .page-feedback__choice: 1rem text, 0.375rem padding, 1px border. */
-	min-height: 2.375rem;
+	gap: 0.5rem;
 	margin-left: auto;
+}
+
+/*
+	The buttons copy .page-feedback__choice in page-feedback.css so the four controls on the row
+	read as one group. Keep the two rule sets in step. The layer matters: Tailwind's `hidden`
+	utility has to win over `display: inline-flex` for the HideEditThisPage path to work.
+*/
+@layer components {
+	.page-actions__action {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.375rem;
+		border: 1px solid var(--color-grey-30);
+		border-radius: 0.375rem;
+		background: var(--color-white);
+		padding: 0.375rem 0.625rem;
+		font: inherit;
+		font-size: 1rem;
+		font-weight: 500;
+		color: var(--color-grey-70);
+		text-wrap: nowrap;
+		transition:
+			border-color 120ms ease,
+			background-color 120ms ease,
+			color 120ms ease;
+	}
+
+	.page-actions__action:hover {
+		border-color: var(--color-blue-elastic);
+		color: var(--color-blue-elastic);
+	}
+
+	.page-actions__action:focus-visible {
+		outline: 2px solid var(--color-blue-elastic);
+		outline-offset: 2px;
+	}
+
+	.page-actions__action svg {
+		width: 1.125rem;
+		height: 1.125rem;
+		flex-shrink: 0;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.page-actions__action {
+		transition: none;
+	}
 }

--- a/src/Elastic.Documentation.Site/Assets/page-actions.css
+++ b/src/Elastic.Documentation.Site/Assets/page-actions.css
@@ -1,0 +1,49 @@
+/*
+	The markdown layout wraps <page-feedback> and .page-actions in .page-outro so the
+	"Report a docs issue" / "Edit this page" links sit on the Yes/No button row, right aligned.
+
+	The row takes over the top border and spacing that page-feedback.css sets on the
+	page-feedback element, which would otherwise stop at the left column. Layouts that render
+	page-feedback unwrapped (ApiExplorer, Codex) keep those element rules unchanged.
+
+	:has(*) keeps the border off an empty wrapper: both partials render nothing when the
+	feedback flag is off and neither CTA passes its gate, leaving only whitespace behind.
+*/
+.page-outro {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 1.5rem 2rem;
+}
+
+.page-outro:has(*) {
+	margin-top: 3rem;
+	border-top: 1px solid var(--color-grey-20);
+	padding-top: 4rem;
+}
+
+.page-outro:has(*) + #prev-next-nav {
+	margin-top: 4rem;
+}
+
+.page-outro > page-feedback {
+	flex: 1 1 24rem;
+	width: auto;
+	min-width: 0;
+	margin-top: 0;
+	border-top: 0;
+	padding-top: 0;
+}
+
+.page-actions {
+	display: flex;
+	flex: 0 0 auto;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: flex-end;
+	gap: 0.5rem 1.5rem;
+	/* Centres the links on .page-feedback__choice: 1rem text, 0.375rem padding, 1px border. */
+	min-height: 2.375rem;
+	margin-left: auto;
+}

--- a/src/Elastic.Documentation.Site/Assets/page-actions.css
+++ b/src/Elastic.Documentation.Site/Assets/page-actions.css
@@ -1,6 +1,6 @@
 /*
 	The markdown layout wraps <page-feedback> and .page-actions in .page-outro so the
-	"Edit page" / "Report issue" buttons sit on the Yes/No button row, right aligned.
+	"Edit page" button sits on the Yes/No button row, right aligned.
 
 	The row takes over the top border and spacing that page-feedback.css sets on the
 	page-feedback element, which would otherwise stop at the left column. Layouts that render
@@ -47,7 +47,7 @@
 }
 
 /*
-	The buttons copy .page-feedback__choice in page-feedback.css so the four controls on the row
+	The button copies .page-feedback__choice in page-feedback.css so the three controls on the row
 	read as one group. Keep the two rule sets in step. The layer matters: Tailwind's `hidden`
 	utility has to win over `display: inline-flex` for the HideEditThisPage path to work.
 */

--- a/src/Elastic.Documentation.Site/Assets/styles.css
+++ b/src/Elastic.Documentation.Site/Assets/styles.css
@@ -14,6 +14,7 @@
 @import './markdown/kbd.css';
 @import './copybutton.css';
 @import './page-feedback.css';
+@import './page-actions.css';
 @import './markdown/admonition.css';
 @import './markdown/dropdown.css';
 @import './markdown/table.css';

--- a/src/Elastic.Documentation.Site/Assets/web-components/PageFeedback.test.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/PageFeedback.test.tsx
@@ -175,13 +175,53 @@ describe('PageFeedback', () => {
                     pageTitle: 'Test page',
                     reaction: 'thumbsDown',
                     reasons: ['inaccurate', 'outOfDate'],
-                    reasonSetVersion: 2,
+                    reasonSetVersion: 3,
                 }),
             })
         )
         expect(
             await screen.findByText('Thank you for your feedback.')
         ).toBeInTheDocument()
+    })
+
+    it('offers a site problem reason on the negative reaction only', async () => {
+        const user = userEvent.setup()
+        render(<PageFeedback pageUrl="/docs/test-page" pageTitle="Test page" />)
+
+        await user.click(
+            screen.getByRole('button', { name: 'Yes, this page was helpful' })
+        )
+        expect(
+            screen.queryByRole('checkbox', { name: /Something is broken/ })
+        ).not.toBeInTheDocument()
+
+        await user.click(
+            screen.getByRole('button', {
+                name: 'No, this page was not helpful',
+            })
+        )
+        await user.click(
+            screen.getByRole('checkbox', { name: /Something is broken/ })
+        )
+        await user.click(screen.getByRole('button', { name: 'Submit' }))
+
+        // No call count here: switching the reaction leaves a debounced reaction
+        // save that may or may not have flushed. The full payload is always last.
+        expect(
+            await screen.findByText('Thank you for your feedback.')
+        ).toBeInTheDocument()
+        expect(global.fetch).toHaveBeenLastCalledWith(
+            `/docs/_api/v1/page-feedback/${feedbackId}`,
+            expect.objectContaining({
+                body: JSON.stringify({
+                    pageUrl: '/docs/test-page',
+                    pageTitle: 'Test page',
+                    reaction: 'thumbsDown',
+                    reasons: ['siteProblem'],
+                    reasonSetVersion: 3,
+                }),
+            })
+        )
     })
 
     it('submits a single reason without a comment', async () => {
@@ -212,7 +252,7 @@ describe('PageFeedback', () => {
                     pageTitle: 'Test page',
                     reaction: 'thumbsDown',
                     reasons: ['missingInformation'],
-                    reasonSetVersion: 2,
+                    reasonSetVersion: 3,
                 }),
             })
         )

--- a/src/Elastic.Documentation.Site/Assets/web-components/PageFeedback.test.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/PageFeedback.test.tsx
@@ -73,7 +73,7 @@ describe('PageFeedback', () => {
             })
         ).toBeInTheDocument()
         expect(
-            screen.getByRole('checkbox', { name: /Out of date/ })
+            screen.getByRole('checkbox', { name: /Something is broken/ })
         ).toBeInTheDocument()
         expect(
             screen.queryByRole('checkbox', { name: /Solved my problem/ })
@@ -92,7 +92,7 @@ describe('PageFeedback', () => {
             screen.getByRole('checkbox', { name: /Easy to find/ })
         ).toBeInTheDocument()
         expect(
-            screen.queryByRole('checkbox', { name: /Out of date/ })
+            screen.queryByRole('checkbox', { name: /Something is broken/ })
         ).not.toBeInTheDocument()
     })
 
@@ -160,7 +160,9 @@ describe('PageFeedback', () => {
         await user.click(
             screen.getByRole('checkbox', { name: /Technically incorrect/ })
         )
-        await user.click(screen.getByRole('checkbox', { name: /Out of date/ }))
+        await user.click(
+            screen.getByRole('checkbox', { name: /Code sample errors/ })
+        )
         expect(
             screen.getByRole('button', { name: 'Submit' })
         ).not.toBeDisabled()
@@ -174,7 +176,7 @@ describe('PageFeedback', () => {
                     pageUrl: '/docs/test-page',
                     pageTitle: 'Test page',
                     reaction: 'thumbsDown',
-                    reasons: ['inaccurate', 'outOfDate'],
+                    reasons: ['inaccurate', 'codeSampleErrors'],
                     reasonSetVersion: 3,
                 }),
             })

--- a/src/Elastic.Documentation.Site/Assets/web-components/PageFeedback.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/PageFeedback.tsx
@@ -20,7 +20,6 @@ type Reason =
     | 'missingInformation'
     | 'hardToUnderstand'
     | 'codeSampleErrors'
-    | 'outOfDate'
     | 'siteProblem'
     | 'anotherReason'
 
@@ -47,7 +46,8 @@ const API_COPY: Partial<Record<Reason, Partial<ReasonOption>>> = {
         description: 'I found the endpoint or schema I needed quickly.',
     },
     inaccurate: {
-        description: 'The reference is wrong about how the API works.',
+        description:
+            'The reference is wrong about how the API works, or describes an older version.',
     },
     missingInformation: {
         description: 'Missing a parameter, field, status, or auth detail.',
@@ -55,9 +55,6 @@ const API_COPY: Partial<Record<Reason, Partial<ReasonOption>>> = {
     codeSampleErrors: {
         label: 'Example errors',
         description: 'A request or response example is wrong.',
-    },
-    outOfDate: {
-        description: 'The reference describes an older version of the API.',
     },
 }
 
@@ -92,11 +89,6 @@ const POSITIVE_REASONS: ReasonOption[] = [
 
 const NEGATIVE_REASONS: ReasonOption[] = [
     {
-        value: 'outOfDate',
-        label: 'Out of date',
-        description: 'The page describes an older version of the product.',
-    },
-    {
         value: 'hardToUnderstand',
         label: 'Hard to understand',
         description: 'Too complicated or unclear.',
@@ -104,7 +96,8 @@ const NEGATIVE_REASONS: ReasonOption[] = [
     {
         value: 'inaccurate',
         label: 'Technically incorrect',
-        description: 'The page is wrong about how the product works.',
+        description:
+            'The page is wrong about how the product works, or describes an older version.',
     },
     {
         value: 'codeSampleErrors',

--- a/src/Elastic.Documentation.Site/Assets/web-components/PageFeedback.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/PageFeedback.tsx
@@ -96,8 +96,7 @@ const NEGATIVE_REASONS: ReasonOption[] = [
     {
         value: 'inaccurate',
         label: 'Technically incorrect',
-        description:
-            'The page is wrong about how the product works, or describes an older version.',
+        description: 'The page is wrong or describes an older version.',
     },
     {
         value: 'codeSampleErrors',

--- a/src/Elastic.Documentation.Site/Assets/web-components/PageFeedback.tsx
+++ b/src/Elastic.Documentation.Site/Assets/web-components/PageFeedback.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import { FormEvent, useEffect, useId, useRef, useState } from 'react'
 
 const COMMENT_MAX_LENGTH = 2000
-const REASON_SET_VERSION = 2
+const REASON_SET_VERSION = 3
 const REACTION_SAVE_DELAY = 400
 const DRAFT_STORAGE_PREFIX = 'docs-page-feedback:'
 
@@ -21,6 +21,7 @@ type Reason =
     | 'hardToUnderstand'
     | 'codeSampleErrors'
     | 'outOfDate'
+    | 'siteProblem'
     | 'anotherReason'
 
 interface ReasonOption {
@@ -114,6 +115,12 @@ const NEGATIVE_REASONS: ReasonOption[] = [
         value: 'missingInformation',
         label: "Couldn't find what I needed",
         description: 'Missing important information.',
+    },
+    {
+        value: 'siteProblem',
+        label: 'Something is broken',
+        description:
+            'A link, button, search, or other part of the site does not work.',
     },
     { value: 'anotherReason', label: 'Another reason' },
 ]

--- a/src/Elastic.Markdown/Layout/_PageActions.cshtml
+++ b/src/Elastic.Markdown/Layout/_PageActions.cshtml
@@ -2,6 +2,7 @@
 @inherits RazorSlice<Elastic.Markdown.MarkdownLayoutViewModel>
 @*
 	Bottom-of-page duplicates of the right-rail "Report a docs issue" and "Edit this page" CTAs.
+	The labels are shorter here because the buttons sit next to Yes and No, which are one word each.
 	The gates below must stay identical to _TableOfContents.cshtml, otherwise the pair stops
 	being redundant and a page shows one copy but not the other.
 *@
@@ -12,22 +13,22 @@
 @if (showReportIssue || showEditPage)
 {
 	<div class="page-actions">
-		@if (showReportIssue)
-		{
-			<a href="@Model.ReportIssueUrl" class="report-an-issue link text-sm" target="_blank">
-				<svg class="link-icon" viewBox="0 0 98 96" xmlns="http://www.w3.org/2000/svg">
-					<path fill-rule="evenodd" clip-rule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" fill="currentColor"/>
-				</svg>
-				Report a docs issue
-			</a>
-		}
 		@if (showEditPage)
 		{
-			<a href="@Model.GithubEditUrl" class="edit-this-page link text-sm @(Model.HideEditThisPage ? "hidden" : string.Empty)" target="_blank">
-				<svg class="link-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+			<a href="@Model.GithubEditUrl" class="edit-this-page page-actions__action @(Model.HideEditThisPage ? "hidden" : string.Empty)" target="_blank">
+				<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
 					<path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125"/>
 				</svg>
-				Edit this page
+				Edit page
+			</a>
+		}
+		@if (showReportIssue)
+		{
+			<a href="@Model.ReportIssueUrl" class="report-an-issue page-actions__action" target="_blank">
+				<svg aria-hidden="true" viewBox="0 0 98 96" xmlns="http://www.w3.org/2000/svg">
+					<path fill-rule="evenodd" clip-rule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" fill="currentColor"/>
+				</svg>
+				Report issue
 			</a>
 		}
 	</div>

--- a/src/Elastic.Markdown/Layout/_PageActions.cshtml
+++ b/src/Elastic.Markdown/Layout/_PageActions.cshtml
@@ -1,0 +1,34 @@
+@using Elastic.Documentation
+@inherits RazorSlice<Elastic.Markdown.MarkdownLayoutViewModel>
+@*
+	Bottom-of-page duplicates of the right-rail "Report a docs issue" and "Edit this page" CTAs.
+	The gates below must stay identical to _TableOfContents.cshtml, otherwise the pair stops
+	being redundant and a page shows one copy but not the other.
+*@
+@{
+	var showReportIssue = Model.Features.PrimaryNavEnabled && Model.BuildType != BuildType.Codex && Model.Branding is null;
+	var showEditPage = !string.IsNullOrEmpty(Model.GithubEditUrl);
+}
+@if (showReportIssue || showEditPage)
+{
+	<div class="page-actions">
+		@if (showReportIssue)
+		{
+			<a href="@Model.ReportIssueUrl" class="report-an-issue link text-sm" target="_blank">
+				<svg class="link-icon" viewBox="0 0 98 96" xmlns="http://www.w3.org/2000/svg">
+					<path fill-rule="evenodd" clip-rule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" fill="currentColor"/>
+				</svg>
+				Report a docs issue
+			</a>
+		}
+		@if (showEditPage)
+		{
+			<a href="@Model.GithubEditUrl" class="edit-this-page link text-sm @(Model.HideEditThisPage ? "hidden" : string.Empty)" target="_blank">
+				<svg class="link-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+					<path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125"/>
+				</svg>
+				Edit this page
+			</a>
+		}
+	</div>
+}

--- a/src/Elastic.Markdown/Layout/_PageActions.cshtml
+++ b/src/Elastic.Markdown/Layout/_PageActions.cshtml
@@ -1,35 +1,17 @@
-@using Elastic.Documentation
 @inherits RazorSlice<Elastic.Markdown.MarkdownLayoutViewModel>
 @*
-	Bottom-of-page duplicates of the right-rail "Report a docs issue" and "Edit this page" CTAs.
-	The labels are shorter here because the buttons sit next to Yes and No, which are one word each.
-	The gates below must stay identical to _TableOfContents.cshtml, otherwise the pair stops
-	being redundant and a page shows one copy but not the other.
+	A bottom-of-page duplicate of the right-rail "Edit this page" CTA. The label is shorter here
+	because the button sits next to Yes and No, which are one word each. The gate must stay
+	identical to _TableOfContents.cshtml, otherwise a page shows one copy but not the other.
 *@
-@{
-	var showReportIssue = Model.Features.PrimaryNavEnabled && Model.BuildType != BuildType.Codex && Model.Branding is null;
-	var showEditPage = !string.IsNullOrEmpty(Model.GithubEditUrl);
-}
-@if (showReportIssue || showEditPage)
+@if (!string.IsNullOrEmpty(Model.GithubEditUrl))
 {
 	<div class="page-actions">
-		@if (showEditPage)
-		{
-			<a href="@Model.GithubEditUrl" class="edit-this-page page-actions__action @(Model.HideEditThisPage ? "hidden" : string.Empty)" target="_blank">
-				<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-					<path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125"/>
-				</svg>
-				Edit page
-			</a>
-		}
-		@if (showReportIssue)
-		{
-			<a href="@Model.ReportIssueUrl" class="report-an-issue page-actions__action" target="_blank">
-				<svg aria-hidden="true" viewBox="0 0 98 96" xmlns="http://www.w3.org/2000/svg">
-					<path fill-rule="evenodd" clip-rule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" fill="currentColor"/>
-				</svg>
-				Report issue
-			</a>
-		}
+		<a href="@Model.GithubEditUrl" class="edit-this-page page-actions__action @(Model.HideEditThisPage ? "hidden" : string.Empty)" target="_blank">
+			<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+				<path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125"/>
+			</svg>
+			Edit page
+		</a>
 	</div>
 }

--- a/src/Elastic.Markdown/Layout/_TableOfContents.cshtml
+++ b/src/Elastic.Markdown/Layout/_TableOfContents.cshtml
@@ -60,17 +60,6 @@
 					</a>
 				</li>
 			}
-			@if (Model.Features.PrimaryNavEnabled && Model.BuildType != BuildType.Codex && Model.Branding is null)
-			{
-				<li class="learn-how-to-contribute hidden lg:block lg:not-first:mt-1">
-					<a href="https://www.elastic.co/docs/contribute-docs/" class="link text-sm" target="_blank">
-						<svg class="link-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-							<path fill="currentColor" d="M8.8,0 C9.074,0 9.337,0.113 9.526,0.312 L12.726,3.74 C12.902,3.926 13,4.173 13,4.429 L13,13 C13,13.552 12.552,14 12,14 L2,14 C1.448,14 1,13.552 1,13 L1,1 C1,0.448 1.448,0 2,0 L8.8,0 Z M12,5 L8.5,5 C8.224,5 8,4.776 8,4.5 L8,1 L2,1 L2,13 L12,13 L12,5 Z M4.5,11 C4.22385763,11 4,10.7761424 4,10.5 C4,10.2238576 4.22385763,10 4.5,10 L9.5,10 C9.7761424,10 10,10.2238576 10,10.5 C10,10.7761424 9.7761424,11 9.5,11 L4.5,11 Z M4.5,8 C4.22385763,8 4,7.77614237 4,7.5 C4,7.22385763 4.22385763,7 4.5,7 L9.5,7 C9.7761424,7 10,7.22385763 10,7.5 C10,7.77614237 9.7761424,8 9.5,8 L4.5,8 Z M5.5,16 C5.22385763,16 5,15.7761424 5,15.5 C5,15.2238576 5.22385763,15 5.5,15 L14,15 L14,6.5 C14,6.22385763 14.2238576,6 14.5,6 C14.7761424,6 15,6.22385763 15,6.5 L15,15 C15,15.5522847 14.5522847,16 14,16 L5.5,16 Z"/>
-						</svg>
-						Learn how to contribute
-					</a>
-				</li>
-			}
 		</ul>
 		@if (Model.BuildType != BuildType.Codex && (Model.Cta.Name != Cta.DefaultName || (Model.BuildType == BuildType.Assembler && Model.Branding is null)))
 		{

--- a/src/Elastic.Markdown/_Layout.cshtml
+++ b/src/Elastic.Markdown/_Layout.cshtml
@@ -42,7 +42,10 @@
 								<input type="checkbox" class="hidden" id="pages-nav-hamburger">
 								@await RenderBodyAsync()
 							</article>
-							@await RenderPartialAsync(_PageFeedback.Create(Model))
+							<div class="page-outro">
+								@await RenderPartialAsync(_PageFeedback.Create(Model))
+								@await RenderPartialAsync(_PageActions.Create(Model))
+							</div>
 							@await RenderPartialAsync(_PrevNextNav.Create(Model))
 							@if (Model.Features.WebsiteSearchEnabled && Model.Features.WebsiteSearchScriptUrl is not null)
 							{

--- a/src/api/Elastic.Documentation.Api/MappingsExtensions.cs
+++ b/src/api/Elastic.Documentation.Api/MappingsExtensions.cs
@@ -244,7 +244,7 @@ public static class MappingsExtension
 		PageFeedbackReaction.ThumbsUp =>
 			reason is PageFeedbackReason.Accurate or PageFeedbackReason.SolvedProblem or PageFeedbackReason.EasyToUnderstand or PageFeedbackReason.HelpfulExamples or PageFeedbackReason.EasyToFind or PageFeedbackReason.AnotherReason,
 		PageFeedbackReaction.ThumbsDown =>
-			reason is PageFeedbackReason.Inaccurate or PageFeedbackReason.MissingInformation or PageFeedbackReason.HardToUnderstand or PageFeedbackReason.CodeSampleErrors or PageFeedbackReason.OutOfDate or PageFeedbackReason.AnotherReason,
+			reason is PageFeedbackReason.Inaccurate or PageFeedbackReason.MissingInformation or PageFeedbackReason.HardToUnderstand or PageFeedbackReason.CodeSampleErrors or PageFeedbackReason.OutOfDate or PageFeedbackReason.SiteProblem or PageFeedbackReason.AnotherReason,
 		_ => false
 	};
 

--- a/src/api/Elastic.Documentation.Api/PageFeedback/PageFeedbackRequest.cs
+++ b/src/api/Elastic.Documentation.Api/PageFeedback/PageFeedbackRequest.cs
@@ -58,6 +58,8 @@ public enum PageFeedbackReason
 	[JsonStringEnumMemberName("codeSampleErrors")]
 	CodeSampleErrors,
 
+	// Retired in reason set 3, folded into Inaccurate. Kept so historical documents stay readable
+	// and a cached browser bundle still submits successfully. Do not remove.
 	[JsonStringEnumMemberName("outOfDate")]
 	OutOfDate,
 

--- a/src/api/Elastic.Documentation.Api/PageFeedback/PageFeedbackRequest.cs
+++ b/src/api/Elastic.Documentation.Api/PageFeedback/PageFeedbackRequest.cs
@@ -61,6 +61,9 @@ public enum PageFeedbackReason
 	[JsonStringEnumMemberName("outOfDate")]
 	OutOfDate,
 
+	[JsonStringEnumMemberName("siteProblem")]
+	SiteProblem,
+
 	[JsonStringEnumMemberName("anotherReason")]
 	AnotherReason
 }

--- a/tests/Elastic.Documentation.Api.Tests/PageFeedbackEndpointTests.cs
+++ b/tests/Elastic.Documentation.Api.Tests/PageFeedbackEndpointTests.cs
@@ -102,6 +102,37 @@ public class PageFeedbackEndpointTests
 	}
 
 	[Fact]
+	public async Task Put_SiteProblemReason_RecordsSiteProblem()
+	{
+		var feedbackService = A.Fake<IPageFeedbackService>();
+		PageFeedbackRecord? recorded = null;
+		A
+			.CallTo(() => feedbackService.UpsertFeedbackAsync(A<PageFeedbackRecord>._, A<CancellationToken>._))
+			.Invokes((PageFeedbackRecord record, CancellationToken _) => recorded = record)
+			.Returns(Task.FromResult(true));
+		using var factory = ApiWebApplicationFactory.WithMockedServices(replacements => replacements.Replace(feedbackService));
+		using var client = factory.CreateClient();
+		const string payload = /*lang=json,strict*/
+			"""
+			{
+				"pageUrl": "/docs/test-page",
+				"pageTitle": "Test page",
+				"reaction": "thumbsDown",
+				"reasons": ["siteProblem"],
+				"reasonSetVersion": 3
+			}
+			""";
+		using var request = CreateRequest(Guid.NewGuid(), payload);
+
+		using var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+		response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+		recorded.Should().NotBeNull();
+		recorded.Reasons.Should().ContainSingle(r => r == PageFeedbackReason.SiteProblem);
+		recorded.ReasonSetVersion.Should().Be(3);
+	}
+
+	[Fact]
 	public async Task Put_CommentExceedsLimit_ReturnsBadRequest()
 	{
 		var feedbackService = A.Fake<IPageFeedbackService>();
@@ -136,6 +167,17 @@ public class PageFeedbackEndpointTests
 			"reaction": "thumbsUp",
 			"reasons": ["inaccurate"],
 			"reasonSetVersion": 2
+		}
+		""")]
+	[InlineData(
+	/*lang=json,strict*/
+	"""
+		{
+			"pageUrl": "/docs/test-page",
+			"pageTitle": "Test page",
+			"reaction": "thumbsUp",
+			"reasons": ["siteProblem"],
+			"reasonSetVersion": 3
 		}
 		""")]
 	[InlineData(

--- a/tests/Elastic.Documentation.Api.Tests/PageFeedbackEndpointTests.cs
+++ b/tests/Elastic.Documentation.Api.Tests/PageFeedbackEndpointTests.cs
@@ -71,6 +71,8 @@ public class PageFeedbackEndpointTests
 		recorded.Comment.Should().BeNull();
 	}
 
+	// Also the guard for retired reasons: reason set 3 stopped offering outOfDate, but a browser
+	// running a cached bundle still sends it and must still get a 204.
 	[Fact]
 	public async Task Put_MultipleReasons_RecordsAllReasons()
 	{

--- a/tests/Navigation.Tests/Rendering/PageActionsRenderingTests.cs
+++ b/tests/Navigation.Tests/Rendering/PageActionsRenderingTests.cs
@@ -21,55 +21,14 @@ namespace Elastic.Documentation.Navigation.Tests.Rendering;
 public class PageActionsRenderingTests(ITestOutputHelper output) : DocumentationSetNavigationTestBase(output)
 {
 	[Fact]
-	public async Task PrimaryNavOn_RendersBothCtas()
-	{
-		var html = await Render(new PageActionsScenario
-		{
-			PrimaryNavEnabled = true,
-			GithubEditUrl = "https://github.com/elastic/docs/edit/main/page.md"
-		});
-
-		html.Should().Contain("class=\"page-actions\"");
-		html.Should().Contain("Edit page");
-		html.Should().Contain("Report issue");
-		html.Should().Contain("href=\"https://github.com/elastic/docs/edit/main/page.md\"");
-		html.Should().NotContain("page-actions__action hidden");
-		html
-			.IndexOf("Edit page", StringComparison.Ordinal)
-			.Should()
-			.BeLessThan(html.IndexOf("Report issue", StringComparison.Ordinal), "the edit button comes first");
-	}
-
-	[Fact]
-	public async Task PrimaryNavOff_OmitsReportIssueButKeepsEditPage()
+	public async Task GithubEditUrl_RendersEditPageButton()
 	{
 		var html = await Render(new PageActionsScenario { GithubEditUrl = "https://github.com/elastic/docs/edit/main/page.md" });
 
-		html.Should().NotContain("Report issue");
+		html.Should().Contain("class=\"page-actions\"");
 		html.Should().Contain("Edit page");
-	}
-
-	[Fact]
-	public async Task Codex_OmitsReportIssue()
-	{
-		var html = await Render(new PageActionsScenario
-		{
-			BuildType = BuildType.Codex,
-			PrimaryNavEnabled = true,
-			GithubEditUrl = "https://github.com/elastic/docs/edit/main/page.md"
-		});
-
-		html.Should().NotContain("Report issue");
-		html.Should().Contain("Edit page");
-	}
-
-	[Fact]
-	public async Task NoGithubEditUrl_OmitsEditPage()
-	{
-		var html = await Render(new PageActionsScenario { PrimaryNavEnabled = true });
-
-		html.Should().Contain("Report issue");
-		html.Should().NotContain("Edit page");
+		html.Should().Contain("href=\"https://github.com/elastic/docs/edit/main/page.md\"");
+		html.Should().NotContain("page-actions__action hidden");
 	}
 
 	[Fact]
@@ -77,7 +36,6 @@ public class PageActionsRenderingTests(ITestOutputHelper output) : Documentation
 	{
 		var html = await Render(new PageActionsScenario
 		{
-			PrimaryNavEnabled = true,
 			GithubEditUrl = "https://github.com/elastic/docs/edit/main/page.md",
 			HideEditThisPage = true
 		});
@@ -87,7 +45,7 @@ public class PageActionsRenderingTests(ITestOutputHelper output) : Documentation
 	}
 
 	[Fact]
-	public async Task NoCtas_RendersNothing()
+	public async Task NoGithubEditUrl_RendersNothing()
 	{
 		var html = await Render(new PageActionsScenario());
 
@@ -98,7 +56,6 @@ public class PageActionsRenderingTests(ITestOutputHelper output) : Documentation
 	private sealed record PageActionsScenario
 	{
 		public BuildType BuildType { get; init; } = BuildType.Assembler;
-		public bool PrimaryNavEnabled { get; init; }
 		public string? GithubEditUrl { get; init; }
 		public bool HideEditThisPage { get; init; }
 	}
@@ -121,7 +78,7 @@ public class PageActionsRenderingTests(ITestOutputHelper output) : Documentation
 			UrlPathPrefix = "/docs",
 			CanonicalBaseUrl = null,
 			AllowIndexing = false,
-			Features = new FeatureFlags(new Dictionary<string, bool> { ["primary-nav"] = scenario.PrimaryNavEnabled }),
+			Features = new FeatureFlags([]),
 			GoogleTagManager = new GoogleTagManagerConfiguration(),
 			Optimizely = new OptimizelyConfiguration(),
 			StaticFileContentHashProvider = new StaticFileContentHashProvider(new EmbeddedOrPhysicalFileProvider(context)),

--- a/tests/Navigation.Tests/Rendering/PageActionsRenderingTests.cs
+++ b/tests/Navigation.Tests/Rendering/PageActionsRenderingTests.cs
@@ -1,0 +1,156 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions.TestingHelpers;
+using AwesomeAssertions;
+using Elastic.Documentation.Configuration.Assembler;
+using Elastic.Documentation.Configuration.Builder;
+using Elastic.Documentation.Configuration.Toc;
+using Elastic.Documentation.Configuration.Versions;
+using Elastic.Documentation.Navigation.Tests.Isolation;
+using Elastic.Documentation.Site;
+using Elastic.Documentation.Site.FileProviders;
+using Elastic.Documentation.Versions;
+using Elastic.Markdown;
+using Elastic.Markdown.Layout;
+using RazorSlices;
+
+namespace Elastic.Documentation.Navigation.Tests.Rendering;
+
+public class PageActionsRenderingTests(ITestOutputHelper output) : DocumentationSetNavigationTestBase(output)
+{
+	[Fact]
+	public async Task PrimaryNavOn_RendersBothCtas()
+	{
+		var html = await Render(new PageActionsScenario
+		{
+			PrimaryNavEnabled = true,
+			GithubEditUrl = "https://github.com/elastic/docs/edit/main/page.md"
+		});
+
+		html.Should().Contain("class=\"page-actions\"");
+		html.Should().Contain("Report a docs issue");
+		html.Should().Contain("Edit this page");
+		html.Should().Contain("href=\"https://github.com/elastic/docs/edit/main/page.md\"");
+		html.Should().NotContain("text-sm hidden");
+	}
+
+	[Fact]
+	public async Task PrimaryNavOff_OmitsReportIssueButKeepsEditPage()
+	{
+		var html = await Render(new PageActionsScenario { GithubEditUrl = "https://github.com/elastic/docs/edit/main/page.md" });
+
+		html.Should().NotContain("Report a docs issue");
+		html.Should().Contain("Edit this page");
+	}
+
+	[Fact]
+	public async Task Codex_OmitsReportIssue()
+	{
+		var html = await Render(new PageActionsScenario
+		{
+			BuildType = BuildType.Codex,
+			PrimaryNavEnabled = true,
+			GithubEditUrl = "https://github.com/elastic/docs/edit/main/page.md"
+		});
+
+		html.Should().NotContain("Report a docs issue");
+		html.Should().Contain("Edit this page");
+	}
+
+	[Fact]
+	public async Task NoGithubEditUrl_OmitsEditPage()
+	{
+		var html = await Render(new PageActionsScenario { PrimaryNavEnabled = true });
+
+		html.Should().Contain("Report a docs issue");
+		html.Should().NotContain("Edit this page");
+	}
+
+	[Fact]
+	public async Task HideEditThisPage_RendersEditPageHidden()
+	{
+		var html = await Render(new PageActionsScenario
+		{
+			PrimaryNavEnabled = true,
+			GithubEditUrl = "https://github.com/elastic/docs/edit/main/page.md",
+			HideEditThisPage = true
+		});
+
+		// main.ts reveals every ".edit-this-page.hidden" when ?edit is present, so the class pair matters.
+		html.Should().Contain("edit-this-page link text-sm hidden");
+	}
+
+	[Fact]
+	public async Task NoCtas_RendersNothing()
+	{
+		var html = await Render(new PageActionsScenario());
+
+		html.Should().NotContain("page-actions");
+		html.Trim().Should().BeEmpty();
+	}
+
+	private sealed record PageActionsScenario
+	{
+		public BuildType BuildType { get; init; } = BuildType.Assembler;
+		public bool PrimaryNavEnabled { get; init; }
+		public string? GithubEditUrl { get; init; }
+		public bool HideEditThisPage { get; init; }
+	}
+
+	private async Task<string> Render(PageActionsScenario scenario)
+	{
+		var fileSystem = new MockFileSystem();
+		fileSystem.AddDirectory("/docs");
+		var context = CreateContext(fileSystem);
+
+		var model = new MarkdownLayoutViewModel
+		{
+			DocsBuilderVersion = "test",
+			DocSetName = "test",
+			Description = "",
+			CurrentNavigationItem = new StubNavigationItem("/docs/"),
+			Previous = null,
+			Next = null,
+			NavigationHtml = "",
+			UrlPathPrefix = "/docs",
+			CanonicalBaseUrl = null,
+			AllowIndexing = false,
+			Features = new FeatureFlags(new Dictionary<string, bool> { ["primary-nav"] = scenario.PrimaryNavEnabled }),
+			GoogleTagManager = new GoogleTagManagerConfiguration(),
+			Optimizely = new OptimizelyConfiguration(),
+			StaticFileContentHashProvider = new StaticFileContentHashProvider(new EmbeddedOrPhysicalFileProvider(context)),
+			BuildType = scenario.BuildType,
+			ShowVersionDropdown = false,
+			AllVersionsUrl = "/docs/versions/",
+			CurrentVersion = "8.19",
+			VersionDropdownSerializedModel = "[]",
+			GithubEditUrl = scenario.GithubEditUrl,
+			MarkdownUrl = "/docs/page.md",
+			HideEditThisPage = scenario.HideEditThisPage,
+			ReportIssueUrl = "https://github.com/elastic/docs/issues/new",
+			Breadcrumbs = [],
+			PageTocItems = [],
+			Layout = null,
+			VersioningSystem = new VersioningSystem
+			{
+				Id = VersioningSystemId.Stack,
+				Base = new SemVersion(8, 0, 0),
+				Current = new SemVersion(8, 19, 0)
+			},
+			Cta = Cta.Default
+		};
+
+		return await _PageActions.Create(model).RenderAsync(cancellationToken: TestContext.Current.CancellationToken);
+	}
+
+	private sealed record StubNavigationItem(string Url) : INavigationItem
+	{
+		public string NavigationTitle => "stub";
+		public IRootNavigationItem<INavigationModel, INavigationItem> NavigationRoot => null!;
+		public INodeNavigationItem<INavigationModel, INavigationItem>? Parent { get; set; }
+		public bool Hidden => false;
+		public int NavigationIndex { get; set; }
+	}
+}

--- a/tests/Navigation.Tests/Rendering/PageActionsRenderingTests.cs
+++ b/tests/Navigation.Tests/Rendering/PageActionsRenderingTests.cs
@@ -30,10 +30,14 @@ public class PageActionsRenderingTests(ITestOutputHelper output) : Documentation
 		});
 
 		html.Should().Contain("class=\"page-actions\"");
-		html.Should().Contain("Report a docs issue");
-		html.Should().Contain("Edit this page");
+		html.Should().Contain("Edit page");
+		html.Should().Contain("Report issue");
 		html.Should().Contain("href=\"https://github.com/elastic/docs/edit/main/page.md\"");
-		html.Should().NotContain("text-sm hidden");
+		html.Should().NotContain("page-actions__action hidden");
+		html
+			.IndexOf("Edit page", StringComparison.Ordinal)
+			.Should()
+			.BeLessThan(html.IndexOf("Report issue", StringComparison.Ordinal), "the edit button comes first");
 	}
 
 	[Fact]
@@ -41,8 +45,8 @@ public class PageActionsRenderingTests(ITestOutputHelper output) : Documentation
 	{
 		var html = await Render(new PageActionsScenario { GithubEditUrl = "https://github.com/elastic/docs/edit/main/page.md" });
 
-		html.Should().NotContain("Report a docs issue");
-		html.Should().Contain("Edit this page");
+		html.Should().NotContain("Report issue");
+		html.Should().Contain("Edit page");
 	}
 
 	[Fact]
@@ -55,8 +59,8 @@ public class PageActionsRenderingTests(ITestOutputHelper output) : Documentation
 			GithubEditUrl = "https://github.com/elastic/docs/edit/main/page.md"
 		});
 
-		html.Should().NotContain("Report a docs issue");
-		html.Should().Contain("Edit this page");
+		html.Should().NotContain("Report issue");
+		html.Should().Contain("Edit page");
 	}
 
 	[Fact]
@@ -64,8 +68,8 @@ public class PageActionsRenderingTests(ITestOutputHelper output) : Documentation
 	{
 		var html = await Render(new PageActionsScenario { PrimaryNavEnabled = true });
 
-		html.Should().Contain("Report a docs issue");
-		html.Should().NotContain("Edit this page");
+		html.Should().Contain("Report issue");
+		html.Should().NotContain("Edit page");
 	}
 
 	[Fact]
@@ -79,7 +83,7 @@ public class PageActionsRenderingTests(ITestOutputHelper output) : Documentation
 		});
 
 		// main.ts reveals every ".edit-this-page.hidden" when ?edit is present, so the class pair matters.
-		html.Should().Contain("edit-this-page link text-sm hidden");
+		html.Should().Contain("edit-this-page page-actions__action hidden");
 	}
 
 	[Fact]

--- a/tests/Navigation.Tests/Rendering/TableOfContentsRenderingTests.cs
+++ b/tests/Navigation.Tests/Rendering/TableOfContentsRenderingTests.cs
@@ -51,7 +51,22 @@ public class TableOfContentsRenderingTests(ITestOutputHelper output) : Documenta
 		html.Should().NotContain("data-testid=\"docs-version-dropdown\"");
 	}
 
-	private async Task<string> Render(BuildType buildType, bool showVersionDropdown, bool navigationPreviewEnabled)
+	[Fact]
+	public async Task PrimaryNavOn_OmitsLearnHowToContribute()
+	{
+		var html = await Render(BuildType.Assembler, showVersionDropdown: false, navigationPreviewEnabled: false, primaryNavEnabled: true);
+
+		html.Should().Contain("Report a docs issue");
+		html.Should().NotContain("Learn how to contribute");
+		html.Should().NotContain("contribute-docs");
+	}
+
+	private async Task<string> Render(
+		BuildType buildType,
+		bool showVersionDropdown,
+		bool navigationPreviewEnabled,
+		bool primaryNavEnabled = false
+	)
 	{
 		var fileSystem = new MockFileSystem();
 		fileSystem.AddDirectory("/docs");
@@ -70,9 +85,11 @@ public class TableOfContentsRenderingTests(ITestOutputHelper output) : Documenta
 			UrlPathPrefix = "/docs",
 			CanonicalBaseUrl = null,
 			AllowIndexing = false,
-			Features = navigationPreviewEnabled
-				? new FeatureFlags(new Dictionary<string, bool> { ["navigation-preview"] = true })
-				: new FeatureFlags([]),
+			Features = new FeatureFlags(new Dictionary<string, bool>
+			{
+				["navigation-preview"] = navigationPreviewEnabled,
+				["primary-nav"] = primaryNavEnabled
+			}),
 			GoogleTagManager = new GoogleTagManagerConfiguration(),
 			Optimizely = new OptimizelyConfiguration(),
 			StaticFileContentHashProvider = new StaticFileContentHashProvider(new EmbeddedOrPhysicalFileProvider(context)),


### PR DESCRIPTION
Every docs page now ends with an "Edit page" button, right aligned on the row with the feedback prompt and styled to match Yes and No. The negative questionnaire gains a "Something is broken" reason for faults in the site rather than the content, "Out of date" folds into "Technically incorrect", and "Learn how to contribute" leaves the right rail.

**Affects:** Site UI, Docs API, Navigation

**Prompt summary:** The ask was to put the "Edit this page" and "Report an issue" links at the bottom of the page, on the same row as the feedback buttons and right aligned. The rail copies stay rather than move, so a reader can act from either place. The "Learn how to contribute" link goes. A follow-up ask turned the two links into buttons that match Yes and No, shortened their labels, and put edit first. A third ask dropped the "Report issue" button and asked whether a reader could instead report a site glitch through the feedback options. A fourth removed "Out of date" and folded it into "Technically incorrect".

## Why

A reader who reaches the end of a page has already scrolled past the right rail. The rail list carries `hidden md:flex`, so a phone reader sees no CTA at all, and `report-an-issue` stays hidden until the `lg` breakpoint. The moment someone wants to act on a page is the moment they finish reading, and nothing there offers a way to do it.

Reporting a broken link or a dead control was worse. The only route was a GitHub issue form, which asks a lot of a reader who just wants to flag a glitch, and none of the negative reasons fit: `inaccurate` and `codeSampleErrors` are both about the words on the page.

At the other end, two reasons asked for a distinction the reader cannot make. Telling a page that was never right from one that stopped being right needs the page's history, so `outOfDate` and `inaccurate` collapse into one option.

## What

#### An Edit page button under the article

The bottom of every docs page now carries an "Edit page" button, right aligned on the row with the feedback prompt. `.page-actions__action` reproduces the box that `.page-feedback__choice` draws, so the three controls on the row share a border, a radius, padding, and a colour. Hover parts company: this one turns `--color-blue-elastic`, not the green and red the feedback buttons use. A new `_PageActions` slice renders it, and its gate matches `_TableOfContents.cshtml`, so a page that shows the rail copy shows this one too.

#### Six negative reasons instead of six different ones

`siteProblem`, labelled "Something is broken", reports a fault in the site: a dead link, a control that does nothing, or a search that returns nothing. `outOfDate` leaves the questionnaire and "Technically incorrect" absorbs it, now reading "The page is wrong about how the product works, or describes an older version". `REASON_SET_VERSION` moves to 3 for both changes at once, since version 3 has not shipped. Against version 2 the negative set differs twice, so a query that counts either reason must scope itself to a version.

#### A retired reason is not a deleted one

`outOfDate` stays in `PageFeedbackReason` and on the `ThumbsDown` allowlist. Historical documents hold the value, and a browser running a cached bundle still submits it, so dropping either would answer a live reader with `400`. `Put_MultipleReasons_RecordsAllReasons` sends it and is the guard.

#### A new reason has to pass three gates

The endpoint validates each reason against the reaction it arrives with, so `siteProblem` joins the enum and the `ThumbsDown` branch of `IsReasonValidForReaction`. Without both, a submission returns `400`. The `reasons` field is a `keyword`, so neither the addition nor the retirement needs a mapping change or a reindex.

#### The feedback row shares its top border

`page-feedback.css` sets the top border and spacing on the `page-feedback` element itself, which would stop at the left column once the row holds two children. A `.page-outro` wrapper takes those over and zeroes them on the element. ApiExplorer and Codex render `page-feedback` unwrapped, so their spacing is untouched, and `:has(*)` keeps the border off the wrapper when both partials render nothing.

**Out of scope:** Codex renders `page-feedback` unwrapped in `_MarkdownLayout.cshtml`, so internal docs get no bottom row. The ApiExplorer layouts have no edit URL on their view model, so they are unchanged too. The `?edit` reveal in `main.ts` moved to `$$optional` so it clears the class on both `.edit-this-page` copies rather than the first.

## Verify

```bash
./build.sh unit-test
# PageFeedbackEndpointTests.Put_SiteProblemReason_RecordsSiteProblem — the new reason under thumbsDown
# PageFeedbackEndpointTests.Put_InvalidFeedback_ReturnsBadRequest — siteProblem under thumbsUp returns 400
# PageFeedbackEndpointTests.Put_MultipleReasons_RecordsAllReasons — retired outOfDate still accepted
# PageActionsRenderingTests — the edit button gate and the HideEditThisPage path
```

```bash
cd src/Elastic.Documentation.Site && npm run test && npm run fmt:check
```

To see both changes, build the assets and serve with the flags on:

```bash
cd src/Elastic.Documentation.Site && npm run build && cd -
FEATURE_PAGE_FEEDBACK=true FEATURE_PRIMARY_NAV=true dotnet run --project src/tooling/docs-builder serve
```

Open `http://localhost:3000/syntax/admonitions` and scroll to the end of the article. "Edit page" should match the height and centre line of Yes and No. Click No: six options, no "Out of date", and "Something is broken" fifth above "Another reason". Submitting locally returns `503` because there is no Elasticsearch, so the endpoint tests are the proof for the payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qFe4JZUeEXN58iihNVsRf