### PR TITLE
Add category filters to the API catalog

### DIFF
--- a/docs/_docset.yml
+++ b/docs/_docset.yml
@@ -50,6 +50,11 @@ api:
     - spec: elasticsearch.json
       product: elasticsearch
       repository: elastic/elasticsearch-specification
+      catalog:
+        categories:
+          - self
+          - ece
+          - ess
 
 cta:
   docs-builder:

--- a/docs/data/openapi/api-explorer.md
+++ b/docs/data/openapi/api-explorer.md
@@ -11,7 +11,9 @@ The API Explorer turns an OpenAPI spec into HTML pages. If you add an `api:` ent
 - one operation page per operation
 - schema type pages for shared types
 
-The assembler also writes a combined **API catalog** at `/docs/api/`: a grid of product cards on its own layout (no API sidebar). Each card opens the HTML landing page. Markdown, JSON, and YAML stay on the product landing page and in the catalog Markdown export. The card shows `info.description`, clamped to three lines.
+The assembler also writes a combined **API catalog** at `/docs/api/`: a grid of product cards on its own layout (no API sidebar). Each card opens the HTML landing page and includes REST and category badges plus JSON and YAML downloads. The card shows `info.description`, clamped to three lines.
+
+The catalog reuses the listing search field and filter chips. Categories are discovery labels only. They do not claim versioned availability. An API with no `catalog.categories` appears only when **All** is selected. The filter bar shows only categories that at least one API uses. Filter state is not stored in the URL.
 
 :::{warning}
 This feature is still under development and the functionality described on this page might change.
@@ -39,7 +41,7 @@ api:
 
 The map key is the URL suffix. This key produces `/api/doc/docs-builder-elasticsearch/`.
 
-Each key takes a sequence with exactly one entry. That entry requires `spec:` and `product:`. `repository:` and `children:` are optional. See [Reference](#reference).
+Each key takes a sequence with exactly one entry. That entry requires `spec:` and `product:`. `repository:`, `children:`, and `catalog:` are optional. See [Reference](#reference).
 
 ::::
 
@@ -112,6 +114,7 @@ Fix the file. Then rebuild. More messages are in [Writing supplemental content](
 | `product:` | yes | A product id from `products.yml`. This binds the API to that product's versioning system. |
 | `repository:` | no | `org/repo` used to look up the version index. Set this when the spec is published from a different GitHub repository than the docset. |
 | `children:` | no | Extra Markdown pages under `api/<key>/`, in declared order. See [children:](./supplemental.md#children-pages). |
+| `catalog.categories:` | no | Category chips on the API catalog. Accepted values: `self`, `ece`, `ess` (`ech` is an alias for `ess`), and `serverless`. These are filter labels, not `applies_to` availability claims. |
 
 Each product key must have exactly one sequence entry. That entry must have exactly one `spec:`. An empty sequence fails the build. A sequence with more than one entry also fails the build.
 
@@ -136,6 +139,29 @@ If you omit `repository:`, {{dbuild}} uses the GitHub remote of the current chec
 `children:` adds full Markdown pages under the product root. Supplemental `op-*.md` and `tag-*.md` files are not `children:` pages. They merge into generated operation and tag pages.
 
 {{dbuild}} does not emit child files as normal docset HTML. Do not add them to `exclude:`.
+
+### `catalog.categories:`
+
+Use this when an API should appear under one or more catalog chips. An API may list several categories. The same identifiers are used in `applies_to`, but a category here does not mean the API is generally available for every version of that deployment.
+
+```yaml
+api:
+  elasticsearch:
+    - spec: elasticsearch-openapi.json
+      product: elasticsearch
+      catalog:
+        categories:
+          - self
+          - ece
+          - ess
+```
+
+- `self` → Self-managed
+- `ece` → Elastic Cloud Enterprise
+- `ess` or `ech` → Elastic Cloud Hosted
+- `serverless` → Serverless
+
+Unknown values fail the build. Omit `catalog:` to keep the API visible only under **All**.
 
 ## Page URLs
 

--- a/docs/data/openapi/api-explorer.md
+++ b/docs/data/openapi/api-explorer.md
@@ -13,7 +13,7 @@ The API Explorer turns an OpenAPI spec into HTML pages. If you add an `api:` ent
 
 The assembler also writes a combined **API catalog** at `/docs/api/`: a grid of product cards on its own layout (no API sidebar). Each card opens the HTML landing page and includes REST and category badges plus JSON and YAML downloads. The card shows `info.description`, clamped to three lines.
 
-The catalog reuses the listing search field and filter chips. Categories are discovery labels only. They do not claim versioned availability. An API with no `catalog.categories` appears only when **All** is selected. The filter bar shows only categories that at least one API uses. Filter state is not stored in the URL.
+The catalog reuses listing filter chips. A click selects one category. Cmd or Ctrl click adds or removes categories. Categories are discovery labels only. They do not claim versioned availability. An API with no `catalog.categories` appears only when **All** is selected. The filter bar shows only categories that at least one API uses. Filter state is not stored in the URL.
 
 :::{warning}
 This feature is still under development and the functionality described on this page might change.

--- a/src/Elastic.ApiExplorer/Infrastructure/ApiHubSwitcher.cs
+++ b/src/Elastic.ApiExplorer/Infrastructure/ApiHubSwitcher.cs
@@ -20,7 +20,10 @@ public static class ApiHubSwitcher
 		var entries = new List<ApiCatalogEntry>(apiConfigurations.Count);
 		foreach (var (key, config) in apiConfigurations)
 		{
-			entries.Add(new(key, config.Product.DisplayName, $"{ApiUrlBuilder.ProductRoot(urlPathPrefix, key)}/"));
+			entries.Add(new(key, config.Product.DisplayName, $"{ApiUrlBuilder.ProductRoot(urlPathPrefix, key)}/", config.Product.Id)
+			{
+				CatalogCategories = config.CatalogCategories
+			});
 		}
 
 		return entries;

--- a/src/Elastic.ApiExplorer/Landing/ApiCatalog.cs
+++ b/src/Elastic.ApiExplorer/Landing/ApiCatalog.cs
@@ -13,7 +13,10 @@ using RazorSlices;
 
 namespace Elastic.ApiExplorer.Landing;
 
-public sealed record ApiCatalogEntry(string Key, string Title, string Url, string? ProductId = null, string? Description = null);
+public sealed record ApiCatalogEntry(string Key, string Title, string Url, string? ProductId = null, string? Description = null)
+{
+	public IReadOnlyList<string> CatalogCategories { get; init; } = [];
+}
 
 public class ApiCatalog : IApiGroupingModel
 {

--- a/src/Elastic.ApiExplorer/Landing/ApiCatalogView.cshtml
+++ b/src/Elastic.ApiExplorer/Landing/ApiCatalogView.cshtml
@@ -4,29 +4,66 @@
 @functions {
 	public ApiLayoutViewModel LayoutModel => Model.CreateGlobalLayoutModel();
 }
-<section id="elastic-docs-v3" class="api-catalog">
+<section id="elastic-docs-v3" class="api-catalog listing-root" data-listing-total="@Model.Tiles.Count">
 	<header class="api-catalog-header">
 		<h1>@ApiCatalog.PageTitle</h1>
 		<p class="api-catalog-lede">Choose a product to open its API reference.</p>
 	</header>
+	@if (Model.Tiles.Count > 0)
+	{
+		<div class="listing-filter-bar mt-4 mb-6">
+			<input
+				type="search"
+				class="listing-filter-input w-full border border-grey-20 rounded-lg px-4 py-2 text-sm focus:outline-none focus:border-blue-elastic"
+				placeholder="Filter @Model.Tiles.Count API@(Model.Tiles.Count == 1 ? "" : "s")…"
+				aria-label="Filter APIs"
+			/>
+			@if (Model.FilterChips.Count > 0)
+			{
+				<div class="listing-group-chips flex flex-wrap items-center gap-2 mt-3">
+					<button type="button" class="listing-chip listing-chip-all listing-chip-active px-3 py-1 text-xs rounded-full border border-blue-elastic text-blue-elastic" data-group="" aria-pressed="true">All</button>
+					<span class="text-grey-20 select-none">|</span>
+					@foreach (var chip in Model.FilterChips)
+					{
+						<button type="button" class="listing-chip px-3 py-1 text-xs rounded-full border border-grey-20 text-ink-light hover:border-blue-elastic hover:text-blue-elastic" data-group="@chip.Key" aria-pressed="false">@chip.Label</button>
+					}
+				</div>
+			}
+		</div>
+	}
 	<ul class="api-catalog-grid">
 		@foreach (var tile in Model.Tiles)
 		{
-			<li>
-				<a class="api-catalog-card" href="@tile.Url">
-					<div class="api-catalog-card-head">
-						@if (tile.IconSvg is not null)
+			<li data-listing-title="@($"{tile.Title} {tile.Key}".ToLowerInvariant())" data-listing-groups="@string.Join(' ', tile.Categories.Select(c => c.Key))">
+				<article class="api-catalog-card">
+					<a class="api-catalog-card-main" href="@tile.Url">
+						<div class="api-catalog-card-head">
+							@if (tile.IconSvg is not null)
+							{
+								<span class="api-catalog-card-icon">@(new HtmlString(tile.IconSvg))</span>
+							}
+							<h2 class="api-catalog-card-title">@tile.Title</h2>
+						</div>
+						<code class="api-catalog-card-key">@tile.Key</code>
+						<div class="api-catalog-card-badges">
+							<span class="api-catalog-badge api-catalog-badge-rest">REST</span>
+							@foreach (var category in tile.Categories)
+							{
+								<span class="api-catalog-badge">@category.Label</span>
+							}
+						</div>
+						@if (!string.IsNullOrWhiteSpace(tile.Description))
 						{
-							<span class="api-catalog-card-icon">@(new HtmlString(tile.IconSvg))</span>
+							<p class="api-catalog-card-desc line-clamp-3">@tile.Description</p>
 						}
-						<h2 class="api-catalog-card-title">@tile.Title</h2>
+					</a>
+					<div class="api-catalog-card-actions">
+						<a href="@tile.JsonUrl" download>JSON</a>
+						<a href="@tile.YamlUrl" download>YAML</a>
 					</div>
-					@if (!string.IsNullOrWhiteSpace(tile.Description))
-					{
-						<p class="api-catalog-card-desc line-clamp-3">@tile.Description</p>
-					}
-				</a>
+				</article>
 			</li>
 		}
 	</ul>
+	<p class="listing-no-results hidden text-sm text-ink-light mt-4">No APIs match your filter.</p>
 </section>

--- a/src/Elastic.ApiExplorer/Landing/ApiCatalogView.cshtml
+++ b/src/Elastic.ApiExplorer/Landing/ApiCatalogView.cshtml
@@ -9,25 +9,14 @@
 		<h1>@ApiCatalog.PageTitle</h1>
 		<p class="api-catalog-lede">Choose a product to open its API reference.</p>
 	</header>
-	@if (Model.Tiles.Count > 0)
+	@if (Model.FilterChips.Count > 0)
 	{
-		<div class="listing-filter-bar mt-4 mb-6">
-			<input
-				type="search"
-				class="listing-filter-input w-full border border-grey-20 rounded-lg px-4 py-2 text-sm focus:outline-none focus:border-blue-elastic"
-				placeholder="Filter @Model.Tiles.Count API@(Model.Tiles.Count == 1 ? "" : "s")…"
-				aria-label="Filter APIs"
-			/>
-			@if (Model.FilterChips.Count > 0)
+		<div class="listing-filter-bar listing-group-chips flex flex-wrap items-center gap-2 mt-4 mb-6">
+			<button type="button" class="listing-chip listing-chip-all listing-chip-active px-3 py-1 text-xs rounded-full border border-blue-elastic text-blue-elastic" data-group="" aria-pressed="true">All</button>
+			<span class="text-grey-20 select-none">|</span>
+			@foreach (var chip in Model.FilterChips)
 			{
-				<div class="listing-group-chips flex flex-wrap items-center gap-2 mt-3">
-					<button type="button" class="listing-chip listing-chip-all listing-chip-active px-3 py-1 text-xs rounded-full border border-blue-elastic text-blue-elastic" data-group="" aria-pressed="true">All</button>
-					<span class="text-grey-20 select-none">|</span>
-					@foreach (var chip in Model.FilterChips)
-					{
-						<button type="button" class="listing-chip px-3 py-1 text-xs rounded-full border border-grey-20 text-ink-light hover:border-blue-elastic hover:text-blue-elastic" data-group="@chip.Key" aria-pressed="false">@chip.Label</button>
-					}
-				</div>
+				<button type="button" class="listing-chip px-3 py-1 text-xs rounded-full border border-grey-20 text-ink-light hover:border-blue-elastic hover:text-blue-elastic" data-group="@chip.Key" aria-pressed="false">@chip.Label</button>
 			}
 		</div>
 	}

--- a/src/Elastic.ApiExplorer/Landing/ApiCatalogViewModel.cs
+++ b/src/Elastic.ApiExplorer/Landing/ApiCatalogViewModel.cs
@@ -3,22 +3,56 @@
 // See the LICENSE file in the project root for more information
 
 using Elastic.ApiExplorer.Infrastructure;
+using Elastic.Documentation.AppliesTo;
 using Elastic.Documentation.Site.Icons;
 
 namespace Elastic.ApiExplorer.Landing;
 
-public sealed record ApiCatalogTile(string Key, string Title, string Url, string? IconSvg, string? Description);
+public sealed record ApiCatalogCategoryChip(string Key, string Label);
+
+public sealed record ApiCatalogTile(
+	string Key,
+	string Title,
+	string Url,
+	string? IconSvg,
+	string? Description,
+	IReadOnlyList<ApiCatalogCategoryChip> Categories,
+	string JsonUrl,
+	string YamlUrl
+);
 
 public class ApiCatalogViewModel(ApiRenderContext context) : ApiViewModel(context)
 {
 	public required IReadOnlyList<ApiCatalogTile> Tiles { get; init; }
 
-	public static ApiCatalogViewModel FromEntries(ApiRenderContext context, IReadOnlyList<ApiCatalogEntry> entries) =>
-		new(context) { Tiles = entries.OrderBy(e => e.Key, StringComparer.Ordinal).Select(ToTile).ToArray() };
+	public required IReadOnlyList<ApiCatalogCategoryChip> FilterChips { get; init; }
 
-	private static ApiCatalogTile ToTile(ApiCatalogEntry entry)
+	public static ApiCatalogViewModel FromEntries(ApiRenderContext context, IReadOnlyList<ApiCatalogEntry> entries)
 	{
-		var iconKey = entry.ProductId ?? entry.Key;
-		return new(entry.Key, entry.Title, entry.Url, ProductIcons.Get(iconKey), entry.Description);
+		var tiles = entries.OrderBy(e => e.Key, StringComparer.Ordinal).Select(ToTile).ToArray();
+		return new(context) { Tiles = tiles, FilterChips = ToChips(tiles.SelectMany(t => t.Categories.Select(c => c.Key))) };
+	}
+
+	private static ApiCatalogTile ToTile(ApiCatalogEntry entry) =>
+		new(
+			entry.Key,
+			entry.Title,
+			entry.Url,
+			ProductIcons.Get(entry.ProductId ?? entry.Key),
+			entry.Description,
+			ToChips(entry.CatalogCategories),
+			ApiOutputPaths.JsonUrl(entry.Url),
+			ApiOutputPaths.YamlUrl(entry.Url)
+		);
+
+	private static ApiCatalogCategoryChip[] ToChips(IEnumerable<string> keys)
+	{
+		var used = keys as HashSet<string> ?? keys.ToHashSet(StringComparer.Ordinal);
+		return [
+			.. ApiCatalogCategory
+				.DisplayOrder
+				.Where(used.Contains)
+				.Select(key => new ApiCatalogCategoryChip(key, ApiCatalogCategory.DisplayName(key)))
+		];
 	}
 }

--- a/src/Elastic.ApiExplorer/OpenApiGenerator.cs
+++ b/src/Elastic.ApiExplorer/OpenApiGenerator.cs
@@ -151,7 +151,10 @@ public class OpenApiGenerator(
 		var canonical = versionedDocuments.FirstOrDefault(v => v.Version.Moniker == "main") ?? versionedDocuments[0];
 		var title = canonical.Document.Info?.Title ?? apiConfig.Product.DisplayName ?? prefix;
 		var url = $"{ApiUrlBuilder.ProductRoot(context.UrlPathPrefix, prefix)}/";
-		return new ApiCatalogEntry(prefix, title, url, apiConfig.Product.Id, canonical.Document.Info?.Description);
+		return new ApiCatalogEntry(prefix, title, url, apiConfig.Product.Id, canonical.Document.Info?.Description)
+		{
+			CatalogCategories = apiConfig.CatalogCategories
+		};
 	}
 
 	/// <summary>

--- a/src/Elastic.Documentation.Configuration/Builder/ConfigurationFile.cs
+++ b/src/Elastic.Documentation.Configuration/Builder/ConfigurationFile.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.IO.Abstractions;
 using DotNet.Globbing;
+using Elastic.Documentation.AppliesTo;
 using Elastic.Documentation.Configuration.Products;
 using Elastic.Documentation.Configuration.Suggestions;
 using Elastic.Documentation.Configuration.Toc;
@@ -601,8 +602,42 @@ public record ConfigurationFile
 			LocalSpecFile = localSpecFile,
 			Repository = repository,
 			Children = children,
-			ApiContentDirectory = apiContentDirectory
+			ApiContentDirectory = apiContentDirectory,
+			CatalogCategories = ResolveCatalogCategories(productKey, entry, context)
 		};
+	}
+
+	private static IReadOnlyList<string> ResolveCatalogCategories(
+		string productKey,
+		ApiProductEntry entry,
+		IDocumentationSetContext context
+	)
+	{
+		var raw = entry.Catalog?.Categories ?? [];
+		if (raw.Count == 0)
+			return [];
+
+		var seen = new HashSet<string>(StringComparer.Ordinal);
+		foreach (var item in raw)
+		{
+			if (ApiCatalogCategory.Normalize(item) is { } canonical)
+			{
+				_ = seen.Add(canonical);
+				continue;
+			}
+
+			context.Collector.Write(new Diagnostic
+			{
+				Severity = Severity.Error,
+				File = context.ConfigurationPath.FullName,
+				Line = entry.Catalog?.Line ?? entry.Line,
+				Column = entry.Catalog?.Column ?? entry.Column,
+				Message =
+					$"Unknown catalog category '{item}' for API '{productKey}'. Valid categories: {string.Join(", ", ApiCatalogCategory.DisplayOrder)} (or {ApplicabilityKeys.Ech} for {ApplicabilityKeys.Ess})."
+			});
+		}
+
+		return ApiCatalogCategory.DisplayOrder.Where(seen.Contains).ToArray();
 	}
 
 	/// Children resolve only under 'api/&lt;key&gt;/'; escaping paths and symlinks are rejected the

--- a/src/Elastic.Documentation.Configuration/Converters/ApplicableToYamlConverter.cs
+++ b/src/Elastic.Documentation.Configuration/Converters/ApplicableToYamlConverter.cs
@@ -17,22 +17,19 @@ public class ApplicableToYamlConverter(IReadOnlyCollection<string> productKeys) 
 {
 	private readonly string[] _knownKeys =
 	[
-		"stack",
-		"deployment",
-		"serverless",
-		"product", // Applicability categories
-
-		"ece",
-		"eck",
-		"ess",
-		"ech",
-		"self", // Deployment options ("ech" aliasing to "ess")
-
-		"elasticsearch",
-		"observability",
-		"security",
-		"vectordb", // Serverless flavors
-
+		ApplicabilityKeys.Stack,
+		ApplicabilityKeys.Deployment,
+		ApplicabilityKeys.Serverless,
+		ApplicabilityKeys.Product,
+		ApplicabilityKeys.Ece,
+		ApplicabilityKeys.Eck,
+		ApplicabilityKeys.Ess,
+		ApplicabilityKeys.Ech,
+		ApplicabilityKeys.Self,
+		ApplicabilityKeys.Elasticsearch,
+		ApplicabilityKeys.Observability,
+		ApplicabilityKeys.Security,
+		ApplicabilityKeys.VectorDb,
 		.. productKeys
 	];
 
@@ -135,7 +132,7 @@ public class ApplicableToYamlConverter(IReadOnlyCollection<string> productKeys) 
 		if (unknownKeys.Count > 0)
 			diagnostics.Add((Severity.Warning, $"Applies block does not support the following keys: {string.Join(", ", unknownKeys)}"));
 
-		if (TryGetApplicabilityOverTime(dictionary, "stack", diagnostics, out var stackAvailability))
+		if (TryGetApplicabilityOverTime(dictionary, ApplicabilityKeys.Stack, diagnostics, out var stackAvailability))
 			applicableTo.Stack = stackAvailability;
 
 		AssignProduct(dictionary, applicableTo, diagnostics);
@@ -176,7 +173,7 @@ public class ApplicableToYamlConverter(IReadOnlyCollection<string> productKeys) 
 		List<(Severity, string)> diagnostics
 	)
 	{
-		if (!dictionary.TryGetValue("deployment", out var deploymentType))
+		if (!dictionary.TryGetValue(ApplicabilityKeys.Deployment, out var deploymentType))
 			return;
 
 		if (deploymentType is null || (deploymentType is string s && string.IsNullOrWhiteSpace(s)))
@@ -185,7 +182,7 @@ public class ApplicableToYamlConverter(IReadOnlyCollection<string> productKeys) 
 		{
 			var applies = AppliesCollection.TryParse(deploymentTypeString, diagnostics, out var a) ? a : null;
 			if (applies is not null)
-				ValidateApplicabilityCollection("ess", applies, diagnostics);
+				ValidateApplicabilityCollection(ApplicabilityKeys.Ess, applies, diagnostics);
 			applicableTo.Deployment = new DeploymentApplicability { Ece = applies, Eck = applies, Ess = applies, Self = applies };
 		}
 		else if (deploymentType is Dictionary<object, object?> deploymentDictionary)
@@ -201,13 +198,13 @@ public class ApplicableToYamlConverter(IReadOnlyCollection<string> productKeys) 
 		List<(Severity, string)> diagnostics
 	)
 	{
-		if (!dictionary.TryGetValue("product", out var productValue))
+		if (!dictionary.TryGetValue(ApplicabilityKeys.Product, out var productValue))
 			return;
 
 		// This handles string, null, and empty string cases.
 		if (productValue is not Dictionary<object, object?> productDictionary)
 		{
-			if (TryGetApplicabilityOverTime(dictionary, "product", diagnostics, out var productAvailability))
+			if (TryGetApplicabilityOverTime(dictionary, ApplicabilityKeys.Product, diagnostics, out var productAvailability))
 				applicableTo.Product = productAvailability;
 			return;
 		}
@@ -223,7 +220,7 @@ public class ApplicableToYamlConverter(IReadOnlyCollection<string> productKeys) 
 		List<(Severity, string)> diagnostics
 	)
 	{
-		if (!dictionary.TryGetValue("serverless", out var serverless))
+		if (!dictionary.TryGetValue(ApplicabilityKeys.Serverless, out var serverless))
 			return;
 
 		if (serverless is null || (serverless is string s && string.IsNullOrWhiteSpace(s)))
@@ -232,7 +229,7 @@ public class ApplicableToYamlConverter(IReadOnlyCollection<string> productKeys) 
 		{
 			var applies = AppliesCollection.TryParse(serverlessString, diagnostics, out var a) ? a : null;
 			if (applies is not null)
-				ValidateApplicabilityCollection("serverless", applies, diagnostics);
+				ValidateApplicabilityCollection(ApplicabilityKeys.Serverless, applies, diagnostics);
 			applicableTo.Serverless = new ServerlessProjectApplicability
 			{
 				Elasticsearch = applies,
@@ -258,8 +255,8 @@ public class ApplicableToYamlConverter(IReadOnlyCollection<string> productKeys) 
 		var d = new DeploymentApplicability();
 		var assigned = false;
 
-		var hasEss = dictionary.ContainsKey("ess");
-		var hasEch = dictionary.ContainsKey("ech");
+		var hasEss = dictionary.ContainsKey(ApplicabilityKeys.Ess);
+		var hasEch = dictionary.ContainsKey(ApplicabilityKeys.Ech);
 		if (hasEss && hasEch)
 			diagnostics.Add(
 				(Severity.Warning, "Both 'ess' and 'ech' are defined. Move 'ess' content into 'ech' to avoid information loss.")
@@ -267,11 +264,11 @@ public class ApplicableToYamlConverter(IReadOnlyCollection<string> productKeys) 
 
 		var mapping = new Dictionary<string, Action<AppliesCollection?>>
 		{
-			{ "ece", a => d.Ece = a },
-			{ "eck", a => d.Eck = a },
-			{ "ess", a => d.Ess = a },
-			{ "ech", a => d.Ess = a },
-			{ "self", a => d.Self = a }
+			{ ApplicabilityKeys.Ece, a => d.Ece = a },
+			{ ApplicabilityKeys.Eck, a => d.Eck = a },
+			{ ApplicabilityKeys.Ess, a => d.Ess = a },
+			{ ApplicabilityKeys.Ech, a => d.Ess = a },
+			{ ApplicabilityKeys.Self, a => d.Self = a }
 		};
 
 		foreach (var (key, action) in mapping)
@@ -300,10 +297,10 @@ public class ApplicableToYamlConverter(IReadOnlyCollection<string> productKeys) 
 
 		var mapping = new Dictionary<string, Action<AppliesCollection?>>
 		{
-			["elasticsearch"] = a => serverlessAvailability.Elasticsearch = a,
-			["observability"] = a => serverlessAvailability.Observability = a,
-			["security"] = a => serverlessAvailability.Security = a,
-			["vectordb"] = a => serverlessAvailability.VectorDatabase = a
+			[ApplicabilityKeys.Elasticsearch] = a => serverlessAvailability.Elasticsearch = a,
+			[ApplicabilityKeys.Observability] = a => serverlessAvailability.Observability = a,
+			[ApplicabilityKeys.Security] = a => serverlessAvailability.Security = a,
+			[ApplicabilityKeys.VectorDb] = a => serverlessAvailability.VectorDatabase = a
 		};
 
 		foreach (var (key, action) in mapping)
@@ -374,13 +371,13 @@ public class ApplicableToYamlConverter(IReadOnlyCollection<string> productKeys) 
 
 	private static readonly HashSet<string> VersionlessKeys =
 	[
-		"ess",
-		"ech",
-		"serverless",
-		"elasticsearch",
-		"observability",
-		"security",
-		"vectordb"
+		ApplicabilityKeys.Ess,
+		ApplicabilityKeys.Ech,
+		ApplicabilityKeys.Serverless,
+		ApplicabilityKeys.Elasticsearch,
+		ApplicabilityKeys.Observability,
+		ApplicabilityKeys.Security,
+		ApplicabilityKeys.VectorDb
 	];
 
 	private static bool TryGetApplicabilityOverTime(

--- a/src/Elastic.Documentation.Configuration/Toc/ApiConfiguration.cs
+++ b/src/Elastic.Documentation.Configuration/Toc/ApiConfiguration.cs
@@ -71,6 +71,13 @@ public class ApiProductEntry
 	public List<ApiEntryChild> Children { get; set; } = [];
 
 	/// <summary>
+	/// Optional catalog grouping. Categories identify filter chips only; they do not
+	/// claim versioned availability.
+	/// </summary>
+	[YamlMember(Alias = "catalog")]
+	public ApiCatalogSettings? Catalog { get; set; }
+
+	/// <summary>
 	/// 1-based line of this entry's mapping start in the source YAML. Populated by
 	/// <see cref="ApiConfigurationConverter"/>; used to attribute diagnostics that have no more
 	/// specific location, such as a missing <c>product:</c> key.
@@ -117,6 +124,22 @@ public class ApiProductEntry
 
 	public bool HasSpec => !string.IsNullOrWhiteSpace(Spec);
 	public bool HasProduct => !string.IsNullOrWhiteSpace(Product);
+}
+
+/// <summary>
+/// Category-only catalog metadata under <c>catalog:</c> on an API entry.
+/// </summary>
+[YamlSerializable]
+public class ApiCatalogSettings
+{
+	[YamlMember(Alias = "categories")]
+	public List<string> Categories { get; set; } = [];
+
+	[YamlIgnore]
+	public int? Line { get; set; }
+
+	[YamlIgnore]
+	public int? Column { get; set; }
 }
 
 /// <summary>
@@ -184,6 +207,12 @@ public class ResolvedApiConfiguration
 	/// Supplemental <c>op-*.md</c> / <c>tag-*.md</c> files are discovered from here.
 	/// </summary>
 	public IDirectoryInfo? ApiContentDirectory { get; init; }
+
+	/// <summary>
+	/// Normalized catalog categories (<c>ece</c>, <c>ess</c>, <c>self</c>, <c>serverless</c>).
+	/// Empty when the API is unclassified and appears only under All.
+	/// </summary>
+	public IReadOnlyList<string> CatalogCategories { get; init; } = [];
 
 	/// <summary>
 	/// Whether <paramref name="fileName"/> is an auto-discovered supplemental file

--- a/src/Elastic.Documentation.Configuration/Toc/ApiConfigurationConverter.cs
+++ b/src/Elastic.Documentation.Configuration/Toc/ApiConfigurationConverter.cs
@@ -32,7 +32,9 @@ public class ApiConfigurationConverter : IYamlTypeConverter
 		+ "      repository: <org/repo> # optional; only needed if the spec is published from a\n"
 		+ "                              # different repo than the current checkout\n"
 		+ "      children:          # optional\n"
-		+ "        - file: getting-started.md";
+		+ "        - file: getting-started.md\n"
+		+ "      catalog:           # optional; category chips on the API catalog\n"
+		+ "        categories: [self, ece, ess, serverless]";
 
 	public bool Accepts(Type type) => type == typeof(ApiProductSequence) || type == typeof(ApiProductEntry);
 
@@ -128,6 +130,9 @@ public class ApiConfigurationConverter : IYamlTypeConverter
 				case "children":
 					entry.Children = ReadChildren(parser);
 					break;
+				case "catalog":
+					entry.Catalog = ReadCatalog(parser);
+					break;
 				case "file":
 					throw new YamlException(
 						key.Start,
@@ -142,6 +147,53 @@ public class ApiConfigurationConverter : IYamlTypeConverter
 		}
 		_ = parser.MoveNext(); // consume MappingEnd
 		return entry;
+	}
+
+	private static ApiCatalogSettings? ReadCatalog(IParser parser)
+	{
+		if (parser.Current is not MappingStart)
+		{
+			parser.SkipThisAndNestedEvents();
+			return null;
+		}
+
+		var start = parser.Current.Start;
+		_ = parser.MoveNext();
+		var catalog = new ApiCatalogSettings { Line = (int)start.Line, Column = (int)start.Column };
+		while (parser.Current is not MappingEnd)
+		{
+			var key = parser.Consume<Scalar>();
+			if (key.Value == "categories")
+				catalog.Categories = ReadStringSequence(parser);
+			else
+				parser.SkipThisAndNestedEvents();
+		}
+		_ = parser.MoveNext();
+		return catalog;
+	}
+
+	private static List<string> ReadStringSequence(IParser parser)
+	{
+		var values = new List<string>();
+		if (parser.Current is not SequenceStart)
+		{
+			parser.SkipThisAndNestedEvents();
+			return values;
+		}
+
+		_ = parser.MoveNext();
+		while (parser.Current is not SequenceEnd)
+		{
+			if (parser.Current is Scalar scalar)
+			{
+				values.Add(scalar.Value);
+				_ = parser.MoveNext();
+			}
+			else
+				parser.SkipThisAndNestedEvents();
+		}
+		_ = parser.MoveNext();
+		return values;
 	}
 
 	private static List<ApiEntryChild> ReadChildren(IParser parser)

--- a/src/Elastic.Documentation.Site/Assets/api-docs.css
+++ b/src/Elastic.Documentation.Site/Assets/api-docs.css
@@ -1190,7 +1190,8 @@
 }
 
 .api-catalog-grid .api-catalog-card {
-	display: block;
+	display: flex;
+	flex-direction: column;
 	height: 100%;
 	box-sizing: border-box;
 	padding: 22px;
@@ -1205,9 +1206,16 @@
 }
 
 .api-catalog-grid .api-catalog-card:hover,
-.api-catalog-grid .api-catalog-card:focus-visible {
+.api-catalog-grid .api-catalog-card:focus-within {
 	border-color: var(--color-grey-80);
 	box-shadow: 0 2px 8px rgb(0 0 0 / 0.05);
+}
+
+.api-catalog-card-main {
+	display: block;
+	flex: 1 1 auto;
+	text-decoration: none;
+	color: inherit;
 }
 
 .api-catalog-card-head {
@@ -1242,13 +1250,66 @@
 }
 
 .api-catalog-card:hover .api-catalog-card-title,
-.api-catalog-card:focus-visible .api-catalog-card-title {
+.api-catalog-card:focus-within .api-catalog-card-title {
 	color: var(--color-blue-elastic);
 }
 
+.api-catalog-card-key {
+	display: inline-block;
+	margin-top: 4px;
+	font-size: var(--text-sm);
+	color: var(--color-ink-light);
+}
+
+.api-catalog-card-badges {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+	margin-top: 10px;
+}
+
+.api-catalog-badge {
+	display: inline-flex;
+	align-items: center;
+	padding: 2px 8px;
+	border-radius: 999px;
+	border: 1px solid var(--color-grey-20);
+	background: var(--color-grey-10);
+	font-size: var(--text-xs);
+	line-height: 1.4;
+	color: var(--color-ink-light);
+}
+
+.api-catalog-badge-rest {
+	border-color: var(--color-blue-elastic-30);
+	background: var(--color-blue-elastic-10);
+	color: var(--color-blue-elastic);
+	font-weight: 600;
+}
+
 .api-catalog-card-desc {
-	margin: 0;
+	margin: 10px 0 0;
 	font-size: var(--text-base);
 	line-height: 1.5;
 	color: var(--color-ink-light);
+}
+
+.api-catalog-card-actions {
+	display: flex;
+	gap: 12px;
+	margin-top: 16px;
+	padding-top: 12px;
+	border-top: 1px solid var(--color-grey-20);
+}
+
+.api-catalog-card-actions a {
+	font-size: var(--text-sm);
+	font-weight: 600;
+	color: var(--color-blue-elastic);
+	text-decoration: none;
+}
+
+.api-catalog-card-actions a:hover,
+.api-catalog-card-actions a:focus-visible {
+	text-decoration: underline;
 }

--- a/src/Elastic.Documentation.Site/Assets/listing.test.ts
+++ b/src/Elastic.Documentation.Site/Assets/listing.test.ts
@@ -166,7 +166,7 @@ describe('initListing DOM behaviour', () => {
         expect(visible[0].dataset.listingGroup).toBe('draft')
     })
 
-    it('allows selecting multiple group chips independently', () => {
+    it('replaces the selection when another chip is clicked', () => {
         const acceptedChip = document.querySelector<HTMLButtonElement>(
             '[data-group="accepted"]'
         )!
@@ -176,10 +176,30 @@ describe('initListing DOM behaviour', () => {
         acceptedChip.click()
         draftChip.click()
 
-        // Both groups visible, ungrouped hidden
+        const visible = visibleCards()
+        expect(visible).toHaveLength(1)
+        expect(visible[0].dataset.listingGroup).toBe('draft')
+        expect(acceptedChip.getAttribute('aria-pressed')).toBe('false')
+        expect(draftChip.getAttribute('aria-pressed')).toBe('true')
+    })
+
+    it('adds a chip when clicked with Cmd or Ctrl', () => {
+        const acceptedChip = document.querySelector<HTMLButtonElement>(
+            '[data-group="accepted"]'
+        )!
+        const draftChip = document.querySelector<HTMLButtonElement>(
+            '[data-group="draft"]'
+        )!
+        acceptedChip.click()
+        draftChip.dispatchEvent(
+            new MouseEvent('click', { bubbles: true, metaKey: true })
+        )
+
         const visible = visibleCards()
         expect(visible).toHaveLength(3)
         expect(visible.every((c) => c.dataset.listingGroup !== '')).toBe(true)
+        expect(acceptedChip.getAttribute('aria-pressed')).toBe('true')
+        expect(draftChip.getAttribute('aria-pressed')).toBe('true')
     })
 
     it('deselects a chip by clicking it again', () => {

--- a/src/Elastic.Documentation.Site/Assets/listing.test.ts
+++ b/src/Elastic.Documentation.Site/Assets/listing.test.ts
@@ -62,6 +62,19 @@ describe('cardIsVisible predicate', () => {
         }
         expect(cardIsVisible('title', '', state)).toBe(false)
     })
+
+    it('matches a card that belongs to any of several groups', () => {
+        const state: ListingFilterState = {
+            query: '',
+            activeGroups: new Set(['self']),
+        }
+        expect(
+            cardIsVisible('elasticsearch elasticsearch', 'ess self', state)
+        ).toBe(true)
+        expect(
+            cardIsVisible('elasticsearch elasticsearch', 'serverless', state)
+        ).toBe(false)
+    })
 })
 
 // ---------------------------------------------------------------------------
@@ -240,5 +253,72 @@ describe('initListing DOM behaviour', () => {
             '.listing-no-results'
         )!
         expect(noResults.classList.contains('hidden')).toBe(true)
+    })
+
+    it('sets aria-pressed on chips', () => {
+        const draftChip = document.querySelector<HTMLButtonElement>(
+            '[data-group="draft"]'
+        )!
+        const allChip =
+            document.querySelector<HTMLButtonElement>('.listing-chip-all')!
+
+        draftChip.click()
+        expect(draftChip.getAttribute('aria-pressed')).toBe('true')
+        expect(allChip.getAttribute('aria-pressed')).toBe('false')
+
+        allChip.click()
+        expect(draftChip.getAttribute('aria-pressed')).toBe('false')
+        expect(allChip.getAttribute('aria-pressed')).toBe('true')
+    })
+})
+
+function buildMultiGroupListingHtml() {
+    return `
+        <div class="listing-root" data-listing-total="2">
+          <div class="listing-filter-bar">
+            <input class="listing-filter-input" type="search" />
+            <div class="listing-group-chips">
+              <button class="listing-chip listing-chip-all listing-chip-active" data-group="">All</button>
+              <button class="listing-chip" data-group="self">Self-managed</button>
+              <button class="listing-chip" data-group="serverless">Serverless</button>
+            </div>
+          </div>
+          <article data-listing-title="elasticsearch elasticsearch" data-listing-groups="self ess">Elasticsearch</article>
+          <article data-listing-title="serverless api" data-listing-groups="serverless">Serverless</article>
+          <p class="listing-no-results hidden">No APIs match your filter.</p>
+        </div>
+    `
+}
+
+describe('initListing multi-group cards', () => {
+    beforeEach(() => {
+        document.body.innerHTML = buildMultiGroupListingHtml()
+        initListing()
+    })
+
+    it('shows a multi-group card when one of its groups is selected', () => {
+        document
+            .querySelector<HTMLButtonElement>('[data-group="self"]')!
+            .click()
+
+        const visible = Array.from(
+            document.querySelectorAll<HTMLElement>('[data-listing-title]')
+        ).filter((c) => c.style.display !== 'none')
+        expect(visible).toHaveLength(1)
+        expect(visible[0].dataset.listingTitle).toContain('elasticsearch')
+    })
+
+    it('filters multi-group cards by title or key text', () => {
+        const input = document.querySelector<HTMLInputElement>(
+            '.listing-filter-input'
+        )!
+        input.value = 'elasticsearch'
+        input.dispatchEvent(new Event('input'))
+
+        const visible = Array.from(
+            document.querySelectorAll<HTMLElement>('[data-listing-title]')
+        ).filter((c) => c.style.display !== 'none')
+        expect(visible).toHaveLength(1)
+        expect(visible[0].dataset.listingGroups).toBe('self ess')
     })
 })

--- a/src/Elastic.Documentation.Site/Assets/listing.ts
+++ b/src/Elastic.Documentation.Site/Assets/listing.ts
@@ -7,8 +7,9 @@
  *
  * Supports:
  * - Text input: hides cards whose `data-listing-title` does not include the query.
- * - Group chips: independent toggles; a card is visible when any of its groups is in
- *   the active set (or when no groups are selected = show all). "All" clears the set.
+ * - Group chips: a click selects one group. Cmd or Ctrl click adds or
+ *   removes groups. A card is visible when any of its groups is in the active
+ *   set (or when no groups are selected = show all). "All" clears the set.
  * - One card may belong to several groups via space-separated
  *   `data-listing-groups` or a single `data-listing-group`.
  * - Hides group headings when all their cards are hidden.
@@ -119,17 +120,37 @@ function initListingRoot(root: HTMLElement) {
     })
 
     groupChips.forEach((chip) => {
-        chip.addEventListener('click', () => {
+        chip.addEventListener('click', (event) => {
             const group = chip.dataset.group ?? ''
-            if (state.activeGroups.has(group)) {
-                state.activeGroups.delete(group)
-            } else {
-                state.activeGroups.add(group)
-            }
+            selectGroup(state, group, isMultiSelectModifier(event))
             updateChipStyles(allChip, groupChips, state)
             applyFilter(root, state)
         })
     })
+}
+
+function isMultiSelectModifier(event: MouseEvent): boolean {
+    return event.metaKey || event.ctrlKey
+}
+
+function selectGroup(
+    state: ListingFilterState,
+    group: string,
+    additive: boolean
+) {
+    if (additive) {
+        if (state.activeGroups.has(group)) state.activeGroups.delete(group)
+        else state.activeGroups.add(group)
+        return
+    }
+
+    if (state.activeGroups.size === 1 && state.activeGroups.has(group)) {
+        state.activeGroups.clear()
+        return
+    }
+
+    state.activeGroups.clear()
+    state.activeGroups.add(group)
 }
 
 export function initListing() {

--- a/src/Elastic.Documentation.Site/Assets/listing.ts
+++ b/src/Elastic.Documentation.Site/Assets/listing.ts
@@ -7,8 +7,10 @@
  *
  * Supports:
  * - Text input: hides cards whose `data-listing-title` does not include the query.
- * - Group chips: independent toggles; a card is visible when its group is in the
- *   active set (or when no groups are selected = show all). "All" clears the set.
+ * - Group chips: independent toggles; a card is visible when any of its groups is in
+ *   the active set (or when no groups are selected = show all). "All" clears the set.
+ * - One card may belong to several groups via space-separated
+ *   `data-listing-groups` or a single `data-listing-group`.
  * - Hides group headings when all their cards are hidden.
  * - Shows a "No pages match" notice when no card is visible.
  */
@@ -18,28 +20,36 @@ export interface ListingFilterState {
     activeGroups: Set<string> // empty = all groups shown
 }
 
+function parseListingGroups(raw: string): string[] {
+    return raw.split(/\s+/).filter(Boolean)
+}
+
 /** Returns true when a card should be visible given the current filter state. */
 export function cardIsVisible(
     cardTitle: string,
     cardGroup: string,
     state: ListingFilterState
 ): boolean {
-    if (state.activeGroups.size > 0 && !state.activeGroups.has(cardGroup))
-        return false
+    if (state.activeGroups.size > 0) {
+        const groups = parseListingGroups(cardGroup)
+        if (!groups.some((group) => state.activeGroups.has(group))) return false
+    }
     if (state.query !== '' && !cardTitle.includes(state.query.toLowerCase()))
         return false
     return true
 }
 
+function cardGroupAttribute(card: HTMLElement): string {
+    return card.dataset.listingGroups ?? card.dataset.listingGroup ?? ''
+}
+
 function applyFilter(root: HTMLElement, state: ListingFilterState) {
-    const cards = root.querySelectorAll<HTMLAnchorElement>(
-        'a[data-listing-title]'
-    )
+    const cards = root.querySelectorAll<HTMLElement>('[data-listing-title]')
     let visibleCount = 0
 
     cards.forEach((card) => {
         const title = card.dataset.listingTitle ?? ''
-        const group = card.dataset.listingGroup ?? ''
+        const group = cardGroupAttribute(card)
         const visible = cardIsVisible(title, group, state)
         card.style.display = visible ? '' : 'none'
         if (visible) visibleCount++
@@ -49,9 +59,7 @@ function applyFilter(root: HTMLElement, state: ListingFilterState) {
     root.querySelectorAll<HTMLElement>('[data-group-key]').forEach(
         (groupEl) => {
             const visibleInGroup = Array.from(
-                groupEl.querySelectorAll<HTMLAnchorElement>(
-                    'a[data-listing-title]'
-                )
+                groupEl.querySelectorAll<HTMLElement>('[data-listing-title]')
             ).some((c) => c.style.display !== 'none')
             groupEl.style.display = visibleInGroup ? '' : 'none'
         }
@@ -76,6 +84,7 @@ function updateChipStyles(
         allChip.classList.toggle('text-blue-elastic', noneSelected)
         allChip.classList.toggle('border-grey-20', !noneSelected)
         allChip.classList.toggle('text-ink-light', !noneSelected)
+        allChip.setAttribute('aria-pressed', noneSelected ? 'true' : 'false')
     }
 
     groupChips.forEach((chip) => {
@@ -85,6 +94,7 @@ function updateChipStyles(
         chip.classList.toggle('text-blue-elastic', active)
         chip.classList.toggle('border-grey-20', !active)
         chip.classList.toggle('text-ink-light', !active)
+        chip.setAttribute('aria-pressed', active ? 'true' : 'false')
     })
 }
 

--- a/src/Elastic.Documentation/AppliesTo/ApplicabilityKeys.cs
+++ b/src/Elastic.Documentation/AppliesTo/ApplicabilityKeys.cs
@@ -1,0 +1,67 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic.Documentation.AppliesTo;
+
+/// <summary>
+/// Canonical <c>applies_to</c> identifiers. Catalog categories reuse the same keys
+/// without inheriting lifecycle or version semantics.
+/// </summary>
+public static class ApplicabilityKeys
+{
+	public const string Stack = "stack";
+	public const string Deployment = "deployment";
+	public const string Serverless = "serverless";
+	public const string Product = "product";
+
+	public const string Ece = "ece";
+	public const string Eck = "eck";
+	public const string Ess = "ess";
+	public const string Ech = "ech";
+	public const string Self = "self";
+
+	public const string Elasticsearch = "elasticsearch";
+	public const string Observability = "observability";
+	public const string Security = "security";
+	public const string VectorDb = "vectordb";
+}
+
+/// <summary>
+/// Category-only catalog membership. Distinct from <see cref="ApplicableTo"/> so
+/// declaring a filter chip never claims versioned availability.
+/// </summary>
+public static class ApiCatalogCategory
+{
+	public static readonly IReadOnlyList<string> DisplayOrder =
+	[
+		ApplicabilityKeys.Ece,
+		ApplicabilityKeys.Ess,
+		ApplicabilityKeys.Self,
+		ApplicabilityKeys.Serverless
+	];
+
+	public static string DisplayName(string canonical) => canonical switch
+	{
+		ApplicabilityKeys.Self => "Self-managed",
+		ApplicabilityKeys.Ece => "Elastic Cloud Enterprise",
+		ApplicabilityKeys.Ess => "Elastic Cloud Hosted",
+		ApplicabilityKeys.Serverless => "Serverless",
+		_ => canonical
+	};
+
+	public static string? Normalize(string? raw)
+	{
+		if (string.IsNullOrWhiteSpace(raw))
+			return null;
+
+		return raw.Trim().Replace('_', '-').ToLowerInvariant() switch
+		{
+			ApplicabilityKeys.Self => ApplicabilityKeys.Self,
+			ApplicabilityKeys.Ece => ApplicabilityKeys.Ece,
+			ApplicabilityKeys.Ess or ApplicabilityKeys.Ech => ApplicabilityKeys.Ess,
+			ApplicabilityKeys.Serverless => ApplicabilityKeys.Serverless,
+			_ => null
+		};
+	}
+}

--- a/src/Elastic.Markdown/Myst/Directives/Listing/ListingView.cshtml
+++ b/src/Elastic.Markdown/Myst/Directives/Listing/ListingView.cshtml
@@ -25,11 +25,11 @@
 		@if (hasGroups)
 		{
 			<div class="listing-group-chips flex flex-wrap items-center gap-2 mt-3">
-				<button class="listing-chip listing-chip-all listing-chip-active px-3 py-1 text-xs rounded-full border border-blue-elastic text-blue-elastic" data-group="">All</button>
+				<button type="button" class="listing-chip listing-chip-all listing-chip-active px-3 py-1 text-xs rounded-full border border-blue-elastic text-blue-elastic" data-group="" aria-pressed="true">All</button>
 				<span class="text-grey-20 select-none">|</span>
 				@foreach (var kvp in groupTitles)
 				{
-					<button class="listing-chip px-3 py-1 text-xs rounded-full border border-grey-20 text-ink-light hover:border-blue-elastic hover:text-blue-elastic" data-group="@kvp.Key">@kvp.Value</button>
+					<button type="button" class="listing-chip px-3 py-1 text-xs rounded-full border border-grey-20 text-ink-light hover:border-blue-elastic hover:text-blue-elastic" data-group="@kvp.Key" aria-pressed="false">@kvp.Value</button>
 				}
 			</div>
 		}

--- a/tests/Elastic.ApiExplorer.Tests/ApiHubSwitcherTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/ApiHubSwitcherTests.cs
@@ -45,13 +45,13 @@ public class ApiHubSwitcherTests
 			.ContainSingle(e => e.Key == "elasticsearch")
 			.Which
 			.Should()
-			.BeEquivalentTo(new ApiCatalogEntry("elasticsearch", "Elasticsearch", "/api/doc/elasticsearch/"));
+			.BeEquivalentTo(new ApiCatalogEntry("elasticsearch", "Elasticsearch", "/api/doc/elasticsearch/", "elasticsearch"));
 		entries
 			.Should()
 			.ContainSingle(e => e.Key == "kibana")
 			.Which
 			.Should()
-			.BeEquivalentTo(new ApiCatalogEntry("kibana", "Kibana", "/api/doc/kibana/"));
+			.BeEquivalentTo(new ApiCatalogEntry("kibana", "Kibana", "/api/doc/kibana/", "kibana"));
 	}
 
 	[Fact]
@@ -105,8 +105,27 @@ public class ApiHubSwitcherTests
 		items.Single(i => i.Selected).Label.Should().Be("Elasticsearch");
 	}
 
-	private static ResolvedApiConfiguration Config(string key, string displayName) =>
-		new() { ProductKey = key, Product = new Product { Id = key, DisplayName = displayName }, SpecFileName = $"{key}.json" };
+	[Fact]
+	public void CollectDeclaredEntries_PreservesCatalogCategories()
+	{
+		var configs = new Dictionary<string, ResolvedApiConfiguration>
+		{
+			["elasticsearch"] = Config("elasticsearch", "Elasticsearch", ["self", "ess"])
+		};
+
+		var entries = ApiHubSwitcher.CollectDeclaredEntries("", configs);
+
+		entries.Should().ContainSingle().Which.CatalogCategories.Should().Equal("self", "ess");
+	}
+
+	private static ResolvedApiConfiguration Config(string key, string displayName, IReadOnlyList<string>? categories = null) =>
+		new()
+		{
+			ProductKey = key,
+			Product = new Product { Id = key, DisplayName = displayName },
+			SpecFileName = $"{key}.json",
+			CatalogCategories = categories ?? []
+		};
 
 	private static ApiCatalogEntry Entry(string key, string title) => new(key, title, $"/api/doc/{key}/");
 }

--- a/tests/Elastic.ApiExplorer.Tests/OpenApiGeneratorCatalogSplitTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/OpenApiGeneratorCatalogSplitTests.cs
@@ -74,7 +74,7 @@ public class OpenApiGeneratorCatalogSplitTests
 		html.Should().Contain("<h1>API catalog</h1>");
 		html.Should().Contain("api-catalog-grid");
 		html.Should().Contain("listing-root");
-		html.Should().Contain("listing-filter-input");
+		html.Should().NotContain("listing-filter-input");
 		html.Should().NotContain("hub-card");
 		html.Should().NotContain("hub-page");
 		html.Should().Contain("<a class=\"api-catalog-card-main\" href=\"/docs/api/doc/elasticsearch/\">");

--- a/tests/Elastic.ApiExplorer.Tests/OpenApiGeneratorCatalogSplitTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/OpenApiGeneratorCatalogSplitTests.cs
@@ -48,6 +48,7 @@ public class OpenApiGeneratorCatalogSplitTests
 		entries.Should().ContainSingle();
 		entries[0].ProductId.Should().Be("elasticsearch");
 		entries[0].Description.Should().Be("A **distributed** [search](https://example.com) engine.\n\nMore detail.");
+		entries[0].CatalogCategories.Should().Equal("ece", "ess", "self");
 		context.WriteFileSystem.File.Exists(Path.Join(outputRoot, "api", "doc", "elasticsearch", "index.html")).Should().BeTrue();
 		context.WriteFileSystem.File.Exists(Path.Join(outputRoot, "api", "index.html")).Should().BeFalse();
 	}
@@ -72,14 +73,18 @@ public class OpenApiGeneratorCatalogSplitTests
 		var html = await context.WriteFileSystem.File.ReadAllTextAsync(catalogPath, TestContext.Current.CancellationToken);
 		html.Should().Contain("<h1>API catalog</h1>");
 		html.Should().Contain("api-catalog-grid");
+		html.Should().Contain("listing-root");
+		html.Should().Contain("listing-filter-input");
 		html.Should().NotContain("hub-card");
 		html.Should().NotContain("hub-page");
-		html.Should().Contain("""<a class="api-catalog-card" href="/docs/api/doc/elasticsearch/">""");
-		html.Should().Contain("""<a class="api-catalog-card" href="/docs/api/doc/kibana/">""");
+		html.Should().Contain("<a class=\"api-catalog-card-main\" href=\"/docs/api/doc/elasticsearch/\">");
+		html.Should().Contain("<a class=\"api-catalog-card-main\" href=\"/docs/api/doc/kibana/\">");
 		html.Should().Contain("A distributed search engine.");
-		html.Should().NotContain("elasticsearch.md");
-		html.Should().NotContain("elasticsearch.json");
-		html.Should().NotContain("elasticsearch.yaml");
+		html.Should().Contain(">REST<");
+		html.Should().Contain("<code class=\"api-catalog-card-key\">elasticsearch</code>");
+		html.Should().Contain("href=\"/docs/api/doc/elasticsearch.json\" download");
+		html.Should().Contain("href=\"/docs/api/doc/elasticsearch.yaml\" download");
+		html.Should().NotContain("listing-group-chips");
 		html.Should().NotContain("markdown-content");
 		html.Should().NotContain("id=\"pages-nav\"");
 	}
@@ -106,6 +111,9 @@ public class OpenApiGeneratorCatalogSplitTests
 		productHtml.Should().Contain("id=\"api-hub-switcher\"");
 		productHtml.Should().Contain("Back to hub");
 		catalogHtml.Should().NotContain("id=\"api-hub-switcher\"");
+		catalogHtml.Should().Contain("listing-group-chips");
+		catalogHtml.Should().Contain("data-group=\"self\"");
+		catalogHtml.Should().Contain("Self-managed");
 		context.WriteFileSystem.File.Exists(Path.Join(outputRoot, "api", "doc", "elasticsearch.md")).Should().BeTrue();
 		context.WriteFileSystem.File.Exists(Path.Join(outputRoot, "api.md")).Should().BeTrue();
 	}
@@ -139,6 +147,41 @@ public class OpenApiGeneratorCatalogSplitTests
 		productHtml.Should().Contain("<option value=\"/docs/api/doc/kibana/\">Kibana</option>");
 	}
 
+	[Fact]
+	public async Task GenerateCatalog_RendersUsedCategoryChipsOnly()
+	{
+		var outputRoot = Path.Join(Paths.WorkingDirectoryRoot.FullName, $"api-catalog-split-{Guid.NewGuid():N}");
+		var context = CreateGenerateContext(outputRoot);
+		using var versionIndexClient = new VersionIndexClient(BaseUri, MultiVersionHandler(), sleep: (_, _) => Task.CompletedTask);
+		var generator = new OpenApiGenerator(NullLoggerFactory.Instance, context, NoopMarkdownStringRenderer.Instance, versionIndexClient);
+		var entries = new List<ApiCatalogEntry>
+		{
+			new("elasticsearch", "Elasticsearch", "/docs/api/doc/elasticsearch/", "elasticsearch") { CatalogCategories = ["self", "ess"] },
+			new("serverless", "Elasticsearch Serverless", "/docs/api/doc/serverless/", "elasticsearch")
+			{
+				CatalogCategories = ["serverless"]
+			},
+			new("connect", "Cloud Connect", "/docs/api/doc/connect/", "cloud")
+		};
+
+		await generator.GenerateCatalog(entries, TestContext.Current.CancellationToken);
+
+		var html = await context
+			.WriteFileSystem
+			.File
+			.ReadAllTextAsync(Path.Join(outputRoot, "api", "index.html"), TestContext.Current.CancellationToken);
+		html.Should().Contain("listing-group-chips");
+		html.Should().Contain("data-group=\"ess\"");
+		html.Should().Contain("data-group=\"self\"");
+		html.Should().Contain("data-group=\"serverless\"");
+		html.Should().NotContain("data-group=\"ece\"");
+		html.Should().Contain("data-listing-groups=\"ess self\"");
+		html.Should().Contain("data-listing-groups=\"serverless\"");
+		html.Should().Contain("Elastic Cloud Hosted");
+		html.Should().Contain("Self-managed");
+		html.Should().Contain("No APIs match your filter.");
+	}
+
 	private static BuildContext CreateGenerateContext(string outputRoot)
 	{
 		var collector = new DiagnosticsCollector([]);
@@ -152,6 +195,11 @@ public class OpenApiGeneratorCatalogSplitTests
 			  elasticsearch:
 			    - spec: elasticsearch-openapi.json
 			      product: elasticsearch
+			      catalog:
+			        categories:
+			          - self
+			          - ece
+			          - ess
 			""";
 		var fs = new MockFileSystem(new MockFileSystemOptions { CurrentDirectory = Paths.WorkingDirectoryRoot.FullName });
 		fs.AddDirectory(Path.Join(repoRoot, ".git"));

--- a/tests/Elastic.Documentation.Configuration.Tests/ApiConfigurationTests.cs
+++ b/tests/Elastic.Documentation.Configuration.Tests/ApiConfigurationTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Frozen;
 using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
 using AwesomeAssertions;
+using Elastic.Documentation.AppliesTo;
 using Elastic.Documentation.Configuration.Builder;
 using Elastic.Documentation.Configuration.Products;
 using Elastic.Documentation.Configuration.Toc;
@@ -17,6 +18,34 @@ using YamlDotNet.Core;
 using YamlDotNet.Serialization;
 
 namespace Elastic.Documentation.Configuration.Tests;
+
+public class ApiCatalogCategoryTests
+{
+	[Theory]
+	[InlineData("self", "self")]
+	[InlineData("ECE", "ece")]
+	[InlineData("ess", "ess")]
+	[InlineData("ech", "ess")]
+	[InlineData("ECH", "ess")]
+	[InlineData("serverless", "serverless")]
+	public void TryNormalize_AcceptsCatalogKeysAndAliases(string raw, string canonical) =>
+		ApiCatalogCategory.Normalize(raw).Should().Be(canonical);
+
+	[Theory]
+	[InlineData("eck")]
+	[InlineData("stack")]
+	[InlineData("hosted")]
+	public void TryNormalize_RejectsUnknownKeys(string raw) => ApiCatalogCategory.Normalize(raw).Should().BeNull();
+
+	[Fact]
+	public void DisplayName_UsesCatalogLabels()
+	{
+		ApiCatalogCategory.DisplayName("self").Should().Be("Self-managed");
+		ApiCatalogCategory.DisplayName("ece").Should().Be("Elastic Cloud Enterprise");
+		ApiCatalogCategory.DisplayName("ess").Should().Be("Elastic Cloud Hosted");
+		ApiCatalogCategory.DisplayName("serverless").Should().Be("Serverless");
+	}
+}
 
 public class ApiProductEntryTests
 {
@@ -188,6 +217,55 @@ public class ApiConfigurationConverterTests
 
 		sequence.Entries.Should().HaveCount(2);
 		sequence.IsValid.Should().BeFalse();
+	}
+
+	[Fact]
+	public void AcceptsCatalogCategories()
+	{
+		const string yaml =
+			"""
+			- spec: elasticsearch-openapi.json
+			  product: elasticsearch
+			  catalog:
+			    categories:
+			      - self
+			      - ece
+			      - ess
+			""";
+
+		var sequence = _deserializer.Deserialize<ApiProductSequence>(yaml);
+
+		sequence.SingleEntry!.Catalog.Should().NotBeNull();
+		sequence.SingleEntry.Catalog!.Categories.Should().Equal("self", "ece", "ess");
+	}
+
+	[Fact]
+	public void AcceptsCatalogCategories_AsInlineSequence()
+	{
+		const string yaml =
+			"""
+			- spec: api.json
+			  product: elasticsearch
+			  catalog:
+			    categories: [self, serverless]
+			""";
+
+		var sequence = _deserializer.Deserialize<ApiProductSequence>(yaml);
+
+		sequence.SingleEntry!.Catalog!.Categories.Should().Equal("self", "serverless");
+	}
+
+	[Fact]
+	public void Catalog_IsOptional()
+	{
+		const string yaml = """
+			- spec: api.json
+			  product: elasticsearch
+			""";
+
+		var sequence = _deserializer.Deserialize<ApiProductSequence>(yaml);
+
+		sequence.SingleEntry!.Catalog.Should().BeNull();
 	}
 
 	[Fact]
@@ -457,6 +535,82 @@ public class ConfigurationFileApiTests
 
 		collector.Errors.Should().Be(0);
 		config.ApiConfigurations!["elasticsearch"].Repository.Should().Be("elastic/elasticsearch-specification");
+	}
+
+	[Fact]
+	public void ResolvesCatalogCategories_NormalizesAliasAndDedupes()
+	{
+		var docSetFile = new DocumentationSetFile
+		{
+			Api = new Dictionary<string, ApiProductSequence>
+			{
+				["elasticsearch"] = new()
+				{
+					Entries =
+					[
+						new ApiProductEntry
+						{
+							Spec = "elasticsearch-openapi.json",
+							Product = "elasticsearch",
+							Catalog = new ApiCatalogSettings { Categories = ["ECH", "self", "ech", "ece"] }
+						}
+					]
+				}
+			}
+		};
+
+		var (config, collector) = CreateConfiguration(docSetFile);
+
+		collector.Errors.Should().Be(0);
+		config.ApiConfigurations!["elasticsearch"].CatalogCategories.Should().Equal("ece", "ess", "self");
+	}
+
+	[Fact]
+	public void EmitsError_WhenCatalogCategoryUnknown()
+	{
+		var docSetFile = new DocumentationSetFile
+		{
+			Api = new Dictionary<string, ApiProductSequence>
+			{
+				["elasticsearch"] = new()
+				{
+					Entries =
+					[
+						new ApiProductEntry
+						{
+							Spec = "elasticsearch-openapi.json",
+							Product = "elasticsearch",
+							Catalog = new ApiCatalogSettings { Categories = ["self", "eck"] }
+						}
+					]
+				}
+			}
+		};
+
+		var (config, collector) = CreateConfiguration(docSetFile);
+
+		collector.Errors.Should().Be(1);
+		config.ApiConfigurations!["elasticsearch"].CatalogCategories.Should().Equal("self");
+	}
+
+	[Fact]
+	public void CatalogCategories_DefaultEmpty_WhenOmitted()
+	{
+		var docSetFile = new DocumentationSetFile
+		{
+			Api = new Dictionary<string, ApiProductSequence>
+			{
+				["elasticsearch"] = new()
+				{
+					Entries = [new ApiProductEntry { Spec = "elasticsearch-openapi.json", Product = "elasticsearch" }]
+				}
+			}
+		};
+
+		var (config, collector) = CreateConfiguration(docSetFile);
+
+		collector.Errors.Should().Be(0);
+		config.ApiConfigurations!["elasticsearch"].CatalogCategories.Should().BeEmpty();
 	}
 
 	[Fact]


### PR DESCRIPTION
The API catalog now lets readers filter APIs by deployment category. Authors declare those categories in `docset.yml` without claiming versioned availability.

**Affects:** API reference, Configuration, Site UI

**Prompt summary:** Add Elastic-docs-style grouping and filtering to the API catalog. Keep distinct API cards. Classify APIs with category-only metadata that reuses `applies_to` identifiers and does not claim versions.

## Why
The catalog is a static product grid. Readers cannot find which APIs belong to Serverless, Hosted, ECE, or self-managed. Reusing `applies_to` for this would imply version support that a category chip must not claim.

## What

#### Catalog categories
Authors set `catalog.categories:` on an `api:` entry. The accepted values are `self`, `ece`, `ess` (`ech` is an alias), and `serverless`. Unknown values fail the build. These keys match `applies_to`, but they are filter labels only.

#### Catalog page
Cards stay distinct from listing pages. Each card shows the product icon, title, key, REST and category badges, description, and JSON and YAML downloads. A chip click selects one category. Cmd or Ctrl click adds or removes categories. Only categories used by at least one API render. An unclassified API appears only under All. Filter state is not stored in the URL.

#### Listing filters
`listing.ts` accepts several groups on one card. A click selects one group. Cmd or Ctrl click adds or removes groups. Existing listing pages still use a single `data-listing-group`.

**Out of scope:** Categories do not drive `applies_to` badges on operation pages.

## Verify

```bash
dotnet test tests/Elastic.Documentation.Configuration.Tests/
# ResolvesCatalogCategories_NormalizesAliasAndDedupes
# EmitsError_WhenCatalogCategoryUnknown

dotnet test tests/Elastic.ApiExplorer.Tests/
# GenerateCatalog_RendersUsedCategoryChipsOnly

cd src/Elastic.Documentation.Site && npm test -- --testPathPatterns=listing
```

Made with [Cursor](https://cursor.com)