### PR TITLE
API Explorer: keep Infinity YAML scalars as strings

### DIFF
--- a/src/Elastic.ApiExplorer/Model/OpenApiReader.cs
+++ b/src/Elastic.ApiExplorer/Model/OpenApiReader.cs
@@ -120,7 +120,7 @@ public sealed class OpenApiReader : IOpenApiSpecificationReader
 			return;
 		}
 
-		if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var number))
+		if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var number) && double.IsFinite(number))
 		{
 			writer.WriteNumberValue(number);
 			return;

--- a/tests/Elastic.ApiExplorer.Tests/Elastic.ApiExplorer.Tests.csproj
+++ b/tests/Elastic.ApiExplorer.Tests/Elastic.ApiExplorer.Tests.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <Content Include="TestData\**\*.json" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\**\*.yaml" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/tests/Elastic.ApiExplorer.Tests/InfinityEnumSpecTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/InfinityEnumSpecTests.cs
@@ -1,0 +1,36 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text;
+using AwesomeAssertions;
+using Elastic.ApiExplorer.Model;
+using Microsoft.OpenApi;
+
+namespace Elastic.ApiExplorer.Tests;
+
+public class InfinityEnumSpecTests
+{
+	[Fact]
+	public async Task ReadAndSerialize_InfinityStringEnum_DoesNotThrow()
+	{
+		var yaml = await File.ReadAllTextAsync(
+			Path.Combine(AppContext.BaseDirectory, "TestData", "infinity-enum.yaml"),
+			TestContext.Current.CancellationToken
+		);
+		await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(yaml));
+		var document = await OpenApiReader.Instance.ReadAsync(stream, "infinity-enum.yaml");
+		document.Should().NotBeNull();
+
+		await using var json = new MemoryStream();
+		var writeJson =
+			async () => await document.SerializeAsJsonAsync(json, OpenApiSpecVersion.OpenApi3_1, TestContext.Current.CancellationToken);
+		await writeJson.Should().NotThrowAsync();
+		Encoding.UTF8.GetString(json.ToArray()).Should().Contain("\"Infinity\"");
+
+		await using var yamlOut = new MemoryStream();
+		var writeYaml =
+			async () => await document.SerializeAsYamlAsync(yamlOut, OpenApiSpecVersion.OpenApi3_1, TestContext.Current.CancellationToken);
+		await writeYaml.Should().NotThrowAsync();
+	}
+}

--- a/tests/Elastic.ApiExplorer.Tests/TestData/infinity-enum.yaml
+++ b/tests/Elastic.ApiExplorer.Tests/TestData/infinity-enum.yaml
@@ -1,0 +1,22 @@
+openapi: 3.1.0
+info:
+  title: Infinity enum fixture
+  version: "1.0"
+paths:
+  /flow:
+    get:
+      operationId: flow
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  current:
+                    oneOf:
+                      - type: number
+                        format: double
+                      - type: string
+                        enum: ["Infinity", "NaN", "-Infinity"]


### PR DESCRIPTION
## Why

- The OpenAPI reader treated YAML scalars such as `Infinity` as numbers. System.Text.Json cannot write those values, so Logstash API generation failed.

## What

- Keep non-finite YAML scalars as strings when converting a spec to JSON.
- Add a fixture test for string enums that use `Infinity`.

## Notes

- Needed before `elastic/docs-content` can declare Logstash in `api:`.