### PR TITLE
Add Iubenda privacy choice links to the docs footer

### DIFF
--- a/config/assembler.yml
+++ b/config/assembler.yml
@@ -25,6 +25,7 @@ environments:
       ASSEMBLER_API_EXPLORER: true
       NAVIGATION_PREVIEW: false
       PAGE_FEEDBACK: true
+      PRIVACY_CONSENT: true
     website_search_url: https://staging-website.elastic.co/search/elastic-website-search.js
   edge:
     uri: https://d34ipnu52o64md.cloudfront.net

--- a/src/Elastic.Documentation.Configuration/Builder/FeatureFlags.cs
+++ b/src/Elastic.Documentation.Configuration/Builder/FeatureFlags.cs
@@ -44,6 +44,8 @@ public class FeatureFlags(Dictionary<string, bool> initFeatureFlags)
 
 	public bool PageFeedbackEnabled { get => IsEnabled("page-feedback"); set => _featureFlags["page-feedback"] = value; }
 
+	public bool PrivacyConsentEnabled { get => IsEnabled("privacy-consent"); set => _featureFlags["privacy-consent"] = value; }
+
 	private bool IsEnabled(string key)
 	{
 		var envKey = $"FEATURE_{key.ToUpperInvariant().Replace('-', '_')}";

--- a/src/Elastic.Documentation.Site/Assets/main.ts
+++ b/src/Elastic.Documentation.Site/Assets/main.ts
@@ -9,6 +9,7 @@ import { initListing } from './listing'
 import { initMermaid } from './mermaid'
 import { openDetailsWithAnchor } from './open-details-with-anchor'
 import { initNav } from './pages-nav'
+import { initPrivacyConsent } from './privacy-consent'
 import { initSecondaryNav } from './secondary-nav'
 import { initSmoothScroll } from './smooth-scroll'
 import { initTable } from './table'
@@ -241,6 +242,7 @@ function handleCtaActivation(event: MouseEvent) {
     logCtaEvent('cta_clicked', cta)
 }
 document.addEventListener('click', handleCtaActivation)
+initPrivacyConsent()
 initSecondaryNav()
 // 'auxclick' with button 1 covers middle-click (open in new tab), which does NOT
 // fire 'click' per the DOM spec - without this those opens went untracked. Button 2

--- a/src/Elastic.Documentation.Site/Assets/privacy-consent.test.ts
+++ b/src/Elastic.Documentation.Site/Assets/privacy-consent.test.ts
@@ -1,0 +1,65 @@
+import { handlePrivacyConsentClick, iubendaActionFor } from './privacy-consent'
+
+function clickOn(html: string): Event {
+    document.body.innerHTML = html
+    const el = document.body.querySelector('a, button, svg')
+    if (!el) throw new Error('missing fixture element')
+    return { target: el, preventDefault: jest.fn() } as unknown as Event
+}
+
+describe('iubendaActionFor', () => {
+    afterEach(() => {
+        document.body.innerHTML = ''
+    })
+
+    it('maps the preferences link, including icon clicks', () => {
+        const event = clickOn(
+            '<a class="iubenda-cs-preferences-link" href="#"><svg></svg>Your Privacy Choices</a>'
+        )
+        expect(iubendaActionFor(event.target)).toBe('preferences')
+    })
+
+    it('maps the notice-at-collection link', () => {
+        const event = clickOn(
+            '<a class="iubenda-cs-uspr-link" href="#">Notice at Collection</a>'
+        )
+        expect(iubendaActionFor(event.target)).toBe('uspr')
+    })
+
+    it('ignores other links', () => {
+        const event = clickOn(
+            '<a href="https://www.elastic.co/legal/privacy-statement">Privacy</a>'
+        )
+        expect(iubendaActionFor(event.target)).toBeNull()
+    })
+})
+
+describe('handlePrivacyConsentClick', () => {
+    afterEach(() => {
+        document.body.innerHTML = ''
+        delete window._iub
+    })
+
+    it('opens preferences and stops the hash navigation', () => {
+        const openPreferences = jest.fn()
+        window._iub = { cs: { api: { openPreferences } } }
+        const event = clickOn(
+            '<a class="iubenda-cs-preferences-link" href="#">Your Privacy Choices</a>'
+        )
+
+        handlePrivacyConsentClick(event)
+
+        expect(event.preventDefault).toHaveBeenCalled()
+        expect(openPreferences).toHaveBeenCalled()
+    })
+
+    it('does nothing when Iubenda has not loaded', () => {
+        const event = clickOn(
+            '<a class="iubenda-cs-preferences-link" href="#">Your Privacy Choices</a>'
+        )
+
+        handlePrivacyConsentClick(event)
+
+        expect(event.preventDefault).toHaveBeenCalled()
+    })
+})

--- a/src/Elastic.Documentation.Site/Assets/privacy-consent.test.ts
+++ b/src/Elastic.Documentation.Site/Assets/privacy-consent.test.ts
@@ -19,11 +19,11 @@ describe('iubendaActionFor', () => {
         expect(iubendaActionFor(event.target)).toBe('preferences')
     })
 
-    it('maps the notice-at-collection link', () => {
+    it('leaves the notice-at-collection link alone', () => {
         const event = clickOn(
             '<a class="iubenda-cs-uspr-link" href="#">Notice at Collection</a>'
         )
-        expect(iubendaActionFor(event.target)).toBe('uspr')
+        expect(iubendaActionFor(event.target)).toBeNull()
     })
 
     it('ignores other links', () => {
@@ -61,5 +61,17 @@ describe('handlePrivacyConsentClick', () => {
         handlePrivacyConsentClick(event)
 
         expect(event.preventDefault).toHaveBeenCalled()
+    })
+
+    it('does not intercept Notice at Collection', () => {
+        window._iub = { cs: { api: { openPreferences: jest.fn() } } }
+        const event = clickOn(
+            '<a class="iubenda-cs-uspr-link" href="#">Notice at Collection</a>'
+        )
+
+        handlePrivacyConsentClick(event)
+
+        expect(event.preventDefault).not.toHaveBeenCalled()
+        expect(window._iub.cs?.api?.openPreferences).not.toHaveBeenCalled()
     })
 })

--- a/src/Elastic.Documentation.Site/Assets/privacy-consent.ts
+++ b/src/Elastic.Documentation.Site/Assets/privacy-consent.ts
@@ -1,6 +1,5 @@
 type IubendaApi = {
     openPreferences?: () => void
-    showBanner?: () => void
 }
 
 type IubendaRoot = {
@@ -17,10 +16,9 @@ declare global {
 
 export function iubendaActionFor(
     target: EventTarget | null
-): 'preferences' | 'uspr' | null {
+): 'preferences' | null {
     if (!(target instanceof Element)) return null
     if (target.closest('.iubenda-cs-preferences-link')) return 'preferences'
-    if (target.closest('.iubenda-cs-uspr-link')) return 'uspr'
     return null
 }
 
@@ -29,15 +27,10 @@ function iubendaApi(): IubendaApi | undefined {
 }
 
 export function handlePrivacyConsentClick(event: Event): void {
-    const action = iubendaActionFor(event.target)
-    if (!action) return
+    if (iubendaActionFor(event.target) !== 'preferences') return
 
     event.preventDefault()
-    const api = iubendaApi()
-    if (!api) return
-
-    if (action === 'preferences') api.openPreferences?.()
-    else api.showBanner?.()
+    iubendaApi()?.openPreferences?.()
 }
 
 export function initPrivacyConsent(): void {

--- a/src/Elastic.Documentation.Site/Assets/privacy-consent.ts
+++ b/src/Elastic.Documentation.Site/Assets/privacy-consent.ts
@@ -1,0 +1,45 @@
+type IubendaApi = {
+    openPreferences?: () => void
+    showBanner?: () => void
+}
+
+type IubendaRoot = {
+    cs?: {
+        api?: IubendaApi
+    }
+}
+
+declare global {
+    interface Window {
+        _iub?: IubendaRoot
+    }
+}
+
+export function iubendaActionFor(
+    target: EventTarget | null
+): 'preferences' | 'uspr' | null {
+    if (!(target instanceof Element)) return null
+    if (target.closest('.iubenda-cs-preferences-link')) return 'preferences'
+    if (target.closest('.iubenda-cs-uspr-link')) return 'uspr'
+    return null
+}
+
+function iubendaApi(): IubendaApi | undefined {
+    return window._iub?.cs?.api
+}
+
+export function handlePrivacyConsentClick(event: Event): void {
+    const action = iubendaActionFor(event.target)
+    if (!action) return
+
+    event.preventDefault()
+    const api = iubendaApi()
+    if (!api) return
+
+    if (action === 'preferences') api.openPreferences?.()
+    else api.showBanner?.()
+}
+
+export function initPrivacyConsent(): void {
+    document.addEventListener('click', handlePrivacyConsentClick, true)
+}

--- a/src/Elastic.Documentation.Site/Layout/_AssemblerFooter.cshtml
+++ b/src/Elastic.Documentation.Site/Layout/_AssemblerFooter.cshtml
@@ -22,20 +22,23 @@
 				<li>
 					<a class="underline hover:text-white" href="https://www.elastic.co/sitemap">Sitemap</a>
 				</li>
-				<li>
-					<a class="underline hover:text-white iubenda-cs-uspr-link" href="#">Notice at Collection</a>
-				</li>
-				<li>
-					<a class="underline hover:text-white iubenda-cs-preferences-link inline-flex items-center" href="#">
-						<svg class="w-8 mr-1.5" width="30" height="14" viewBox="0 0 30 14" aria-hidden="true" focusable="false">
-							<path fill-rule="evenodd" fill="#FFFFFF" d="M7.4 12.8h6.8l3.1-11.6H7.4C4.2 1.2 1.6 3.8 1.6 7s2.6 5.8 5.8 5.8z"/>
-							<path fill-rule="evenodd" fill="#0066FF" d="M22.6 0H7.4a7 7 0 0 0 0 14h15.2a7 7 0 0 0 0-14zM1.6 7A5.8 5.8 0 0 1 7.4 1.2h9.9L14.2 12.8H7.4A5.8 5.8 0 0 1 1.6 7z"/>
-							<path fill="#FFFFFF" d="M24.6 4a.55.55 0 0 1 0 .8L22.5 7l2.2 2.2a.55.55 0 0 1-.8.8L21.7 7.8 19.5 10a.55.55 0 0 1-.8-.8L20.8 7l-2.2-2.2a.55.55 0 0 1 .8-.8l2.2 2.2L23.8 4a.55.55 0 0 1 .8 0z"/>
-							<path fill="#0066FF" d="M12.7 4.1a.55.55 0 0 1 .1.8L8.6 9.8a.55.55 0 0 1-.7-.1L5.4 7.7a.55.55 0 0 1 .8-.8L8 8.6l3.8-4.5a.55.55 0 0 1 .9 0z"/>
-						</svg>
-						Your Privacy Choices
-					</a>
-				</li>
+				@if (Model.Features.PrivacyConsentEnabled)
+				{
+					<li>
+						<a class="underline hover:text-white iubenda-cs-uspr-link" href="#">Notice at Collection</a>
+					</li>
+					<li>
+						<a class="underline hover:text-white iubenda-cs-preferences-link inline-flex items-center" href="#">
+							<svg class="w-8 mr-1.5" width="30" height="14" viewBox="0 0 30 14" aria-hidden="true" focusable="false">
+								<path fill-rule="evenodd" fill="#FFFFFF" d="M7.4 12.8h6.8l3.1-11.6H7.4C4.2 1.2 1.6 3.8 1.6 7s2.6 5.8 5.8 5.8z"/>
+								<path fill-rule="evenodd" fill="#0066FF" d="M22.6 0H7.4a7 7 0 0 0 0 14h15.2a7 7 0 0 0 0-14zM1.6 7A5.8 5.8 0 0 1 7.4 1.2h9.9L14.2 12.8H7.4A5.8 5.8 0 0 1 1.6 7z"/>
+								<path fill="#FFFFFF" d="M24.6 4a.55.55 0 0 1 0 .8L22.5 7l2.2 2.2a.55.55 0 0 1-.8.8L21.7 7.8 19.5 10a.55.55 0 0 1-.8-.8L20.8 7l-2.2-2.2a.55.55 0 0 1 .8-.8l2.2 2.2L23.8 4a.55.55 0 0 1 .8 0z"/>
+								<path fill="#0066FF" d="M12.7 4.1a.55.55 0 0 1 .1.8L8.6 9.8a.55.55 0 0 1-.7-.1L5.4 7.7a.55.55 0 0 1 .8-.8L8 8.6l3.8-4.5a.55.55 0 0 1 .9 0z"/>
+							</svg>
+							Your Privacy Choices
+						</a>
+					</li>
+				}
 			</ul>
 			<p class="mt-4">
 				© @(DateTime.Today.Year) Elasticsearch B.V. All Rights Reserved.

--- a/src/Elastic.Documentation.Site/Layout/_AssemblerFooter.cshtml
+++ b/src/Elastic.Documentation.Site/Layout/_AssemblerFooter.cshtml
@@ -9,7 +9,7 @@
 	</div>
 	<div class="text-grey-20 text-[12px] bg-ink-dark grid grid-cols-1 md:grid-cols-2 gap-2 items-center">
 		<div>
-			<ul class="mt-4 flex gap-3">
+			<ul class="mt-4 flex flex-wrap gap-3">
 				<li>
 					<a class="underline hover:text-white" href="https://www.elastic.co/legal/trademarks">Trademarks</a>
 				</li>
@@ -21,6 +21,20 @@
 				</li>
 				<li>
 					<a class="underline hover:text-white" href="https://www.elastic.co/sitemap">Sitemap</a>
+				</li>
+				<li>
+					<a class="underline hover:text-white iubenda-cs-uspr-link" href="#">Notice at Collection</a>
+				</li>
+				<li>
+					<a class="underline hover:text-white iubenda-cs-preferences-link inline-flex items-center" href="#">
+						<svg class="w-8 mr-1.5" width="30" height="14" viewBox="0 0 30 14" aria-hidden="true" focusable="false">
+							<path fill-rule="evenodd" fill="#FFFFFF" d="M7.4 12.8h6.8l3.1-11.6H7.4C4.2 1.2 1.6 3.8 1.6 7s2.6 5.8 5.8 5.8z"/>
+							<path fill-rule="evenodd" fill="#0066FF" d="M22.6 0H7.4a7 7 0 0 0 0 14h15.2a7 7 0 0 0 0-14zM1.6 7A5.8 5.8 0 0 1 7.4 1.2h9.9L14.2 12.8H7.4A5.8 5.8 0 0 1 1.6 7z"/>
+							<path fill="#FFFFFF" d="M24.6 4a.55.55 0 0 1 0 .8L22.5 7l2.2 2.2a.55.55 0 0 1-.8.8L21.7 7.8 19.5 10a.55.55 0 0 1-.8-.8L20.8 7l-2.2-2.2a.55.55 0 0 1 .8-.8l2.2 2.2L23.8 4a.55.55 0 0 1 .8 0z"/>
+							<path fill="#0066FF" d="M12.7 4.1a.55.55 0 0 1 .1.8L8.6 9.8a.55.55 0 0 1-.7-.1L5.4 7.7a.55.55 0 0 1 .8-.8L8 8.6l3.8-4.5a.55.55 0 0 1 .9 0z"/>
+						</svg>
+						Your Privacy Choices
+					</a>
 				</li>
 			</ul>
 			<p class="mt-4">

--- a/tests/Elastic.Documentation.Build.Tests/FeatureFlagsTests.cs
+++ b/tests/Elastic.Documentation.Build.Tests/FeatureFlagsTests.cs
@@ -82,4 +82,45 @@ public class FeatureFlagsTests
 			features.Set(key, value);
 		features.AssemblerApiExplorerEnabled.Should().BeFalse();
 	}
+
+	[Fact]
+	public void PrivacyConsentEnabled_DefaultsToFalse()
+	{
+		var flags = new FeatureFlags([]);
+
+		flags.PrivacyConsentEnabled.Should().BeFalse();
+	}
+
+	[Fact]
+	public void StagingEnvironment_EnablesPrivacyConsent()
+	{
+		var config = AssemblyConfiguration.Create(
+			new ConfigurationFileProvider(new TestLoggerFactory(null), new ConfigurationFileSystem())
+		);
+		var environment = config.Environments["staging"];
+
+		environment.FeatureFlags.Should().ContainKey("PRIVACY_CONSENT").WhoseValue.Should().BeTrue();
+
+		var features = new FeatureFlags([]);
+		foreach (var (key, value) in environment.FeatureFlags)
+			features.Set(key, value);
+		features.PrivacyConsentEnabled.Should().BeTrue();
+		features.AssemblerApiExplorerEnabled.Should().BeTrue();
+	}
+
+	[Fact]
+	public void ProdEnvironment_DoesNotEnablePrivacyConsent()
+	{
+		var config = AssemblyConfiguration.Create(
+			new ConfigurationFileProvider(new TestLoggerFactory(null), new ConfigurationFileSystem())
+		);
+		var prod = config.Environments["prod"];
+
+		prod.FeatureFlags.Should().NotContainKey("PRIVACY_CONSENT");
+
+		var features = new FeatureFlags([]);
+		foreach (var (key, value) in prod.FeatureFlags)
+			features.Set(key, value);
+		features.PrivacyConsentEnabled.Should().BeFalse();
+	}
 }

--- a/tests/Elastic.Documentation.Configuration.Tests/UseNavigationPreviewTests.cs
+++ b/tests/Elastic.Documentation.Configuration.Tests/UseNavigationPreviewTests.cs
@@ -100,6 +100,7 @@ public class UseNavigationPreviewTests
 		flags.WebsiteSearchEnabled.Should().BeFalse();
 		flags.AirGappedEnabled.Should().BeFalse();
 		flags.PrimaryNavEnabled.Should().BeFalse();
+		flags.PrivacyConsentEnabled.Should().BeFalse();
 	}
 
 	[Fact]

--- a/tests/Navigation.Tests/Rendering/FooterRenderingTests.cs
+++ b/tests/Navigation.Tests/Rendering/FooterRenderingTests.cs
@@ -1,0 +1,67 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions.TestingHelpers;
+using AwesomeAssertions;
+using Elastic.Documentation.Configuration.Assembler;
+using Elastic.Documentation.Configuration.Builder;
+using Elastic.Documentation.Navigation;
+using Elastic.Documentation.Navigation.Tests.Isolation;
+using Elastic.Documentation.Site;
+using Elastic.Documentation.Site.FileProviders;
+using Elastic.Documentation.Site.Layout;
+using RazorSlices;
+
+namespace Elastic.Documentation.Navigation.Tests.Rendering;
+
+public class FooterRenderingTests(ITestOutputHelper output) : DocumentationSetNavigationTestBase(output)
+{
+	[Fact]
+	public async Task AssemblerFooter_RendersIubendaPrivacyChoiceLinks()
+	{
+		var html = await RenderAssemblerFooter();
+
+		html.Should().Contain("iubenda-cs-uspr-link");
+		html.Should().Contain("Notice at Collection");
+		html.Should().Contain("iubenda-cs-preferences-link");
+		html.Should().Contain("Your Privacy Choices");
+	}
+
+	private async Task<string> RenderAssemblerFooter()
+	{
+		var fileSystem = new MockFileSystem();
+		fileSystem.AddDirectory("/docs");
+		var context = CreateContext(fileSystem);
+
+		var model = new GlobalLayoutViewModel
+		{
+			DocsBuilderVersion = "test",
+			DocSetName = "test",
+			Description = "",
+			CurrentNavigationItem = new StubNavigationItem("/docs/"),
+			Previous = null,
+			Next = null,
+			NavigationHtml = "",
+			UrlPathPrefix = "/docs",
+			CanonicalBaseUrl = null,
+			AllowIndexing = false,
+			Features = new FeatureFlags([]),
+			GoogleTagManager = new GoogleTagManagerConfiguration(),
+			Optimizely = new OptimizelyConfiguration(),
+			StaticFileContentHashProvider = new StaticFileContentHashProvider(new EmbeddedOrPhysicalFileProvider(context)),
+			BuildType = BuildType.Assembler
+		};
+
+		return await _AssemblerFooter.Create(model).RenderAsync(cancellationToken: TestContext.Current.CancellationToken);
+	}
+
+	private sealed record StubNavigationItem(string Url) : INavigationItem
+	{
+		public string NavigationTitle => "stub";
+		public IRootNavigationItem<INavigationModel, INavigationItem> NavigationRoot => null!;
+		public INodeNavigationItem<INavigationModel, INavigationItem>? Parent { get; set; }
+		public bool Hidden => false;
+		public int NavigationIndex { get; set; }
+	}
+}

--- a/tests/Navigation.Tests/Rendering/FooterRenderingTests.cs
+++ b/tests/Navigation.Tests/Rendering/FooterRenderingTests.cs
@@ -18,9 +18,21 @@ namespace Elastic.Documentation.Navigation.Tests.Rendering;
 public class FooterRenderingTests(ITestOutputHelper output) : DocumentationSetNavigationTestBase(output)
 {
 	[Fact]
-	public async Task AssemblerFooter_RendersIubendaPrivacyChoiceLinks()
+	public async Task AssemblerFooter_FlagOff_OmitsIubendaPrivacyChoiceLinks()
 	{
-		var html = await RenderAssemblerFooter();
+		var html = await RenderAssemblerFooter(privacyConsentEnabled: false);
+
+		html.Should().Contain("privacy-statement");
+		html.Should().NotContain("iubenda-cs-uspr-link");
+		html.Should().NotContain("Notice at Collection");
+		html.Should().NotContain("iubenda-cs-preferences-link");
+		html.Should().NotContain("Your Privacy Choices");
+	}
+
+	[Fact]
+	public async Task AssemblerFooter_FlagOn_RendersIubendaPrivacyChoiceLinks()
+	{
+		var html = await RenderAssemblerFooter(privacyConsentEnabled: true);
 
 		html.Should().Contain("iubenda-cs-uspr-link");
 		html.Should().Contain("Notice at Collection");
@@ -28,7 +40,7 @@ public class FooterRenderingTests(ITestOutputHelper output) : DocumentationSetNa
 		html.Should().Contain("Your Privacy Choices");
 	}
 
-	private async Task<string> RenderAssemblerFooter()
+	private async Task<string> RenderAssemblerFooter(bool privacyConsentEnabled)
 	{
 		var fileSystem = new MockFileSystem();
 		fileSystem.AddDirectory("/docs");
@@ -46,7 +58,7 @@ public class FooterRenderingTests(ITestOutputHelper output) : DocumentationSetNa
 			UrlPathPrefix = "/docs",
 			CanonicalBaseUrl = null,
 			AllowIndexing = false,
-			Features = new FeatureFlags([]),
+			Features = new FeatureFlags(privacyConsentEnabled ? new Dictionary<string, bool> { ["privacy-consent"] = true } : []),
 			GoogleTagManager = new GoogleTagManagerConfiguration(),
 			Optimizely = new OptimizelyConfiguration(),
 			StaticFileContentHashProvider = new StaticFileContentHashProvider(new EmbeddedOrPhysicalFileProvider(context)),


### PR DESCRIPTION
The assembler footer can show Iubenda Notice at Collection and Your Privacy Choices. Those links are on in staging only.

**Affects:** Site UI, Configuration

**Prompt summary:** Implement [elastic/docs-eng-team#742](https://github.com/elastic/docs-eng-team/issues/742). Port elastic.co privacy consent controls onto the /docs footer, using the existing Iubenda classes. Gate the links to staging until the banner and preference center are confirmed on assembled /docs with GTM.

## Why

The /docs footer has no Iubenda entry points. GTM already loads the cookie solution on assembled /docs pages. Visitors in the US and the EU cannot open or change privacy choices from the docs site. Isolated local serve uses a different footer and usually has GTM off, so it cannot prove that behaviour.

Closes [elastic/docs-eng-team#742](https://github.com/elastic/docs-eng-team/issues/742)

## What

#### Privacy choice links

The assembler footer includes the Iubenda `iubenda-cs-uspr-link` and `iubenda-cs-preferences-link` anchors when the flag is on. Your Privacy Choices uses the CCPA opt-out icon. Both links use `href="#"`, the same markup as elastic.co. Iubenda binds Notice at Collection and sends the visitor to the destination it chooses.

#### Preference center

Your Privacy Choices calls `_iub.cs.api.openPreferences()` and stops the hash navigation. Iubenda's class hook does not reliably intercept that click. Notice at Collection is left to Iubenda.

#### Staging flag

`PRIVACY_CONSENT` is on for staging only. Flag-off omits the new links and leaves the footer as it is today. Prod does not enable the flag.

## Verify

```bash
dotnet test tests/Navigation.Tests/ --filter FooterRenderingTests
# AssemblerFooter_FlagOff_OmitsIubendaPrivacyChoiceLinks
# AssemblerFooter_FlagOn_RendersIubendaPrivacyChoiceLinks
```

```bash
cd src/Elastic.Documentation.Site && npm run test -- --testPathPatterns=privacy-consent
# leaves the notice-at-collection link alone
# does not intercept Notice at Collection
```

Confirm on staging /docs in Chrome with GTM loaded. Brave often blocks Iubenda.

**Out of scope:** Isolated and Codex footers. This PR does not add an Iubenda script. GTM already ships that on /docs.

**Risk:** `config/assembler.yml` also feeds the changelog-scrubber public-bucket allowlist. This change only adds `PRIVACY_CONSENT:` under the staging environment flags.

Made with [Cursor](https://cursor.com)