### PR TITLE
Render features and enhancements separately in release notes

### DIFF
--- a/docs/changelog/bundles/0.100.0.yaml
+++ b/docs/changelog/bundles/0.100.0.yaml
@@ -2,7 +2,7 @@ products:
   - product: docs-builder
     target: 0.100.0
 entries:
-  # Features and enhancements
+  # Features
   - type: feature
     title: Add PR label blockers to changelog creation
     products:

--- a/docs/syntax/changelog.md
+++ b/docs/syntax/changelog.md
@@ -25,7 +25,7 @@ The directive supports the following options:
 | `:type: value` | Filter entries by type | Excludes separated types |
 | `:subsections:` | Group entries by area/component | false |
 | `:link-visibility: value` | Visibility of pull request (PR) and issue links | `auto` |
-| `:description-visibility: value` | Visibility of changelog **record** descriptions (YAML `description` on each entry) | `auto` |
+| `:description-visibility: value[, value…]` | Visibility of changelog descriptions (YAML `description` on each entry). Comma-separated tokens are combined. | `auto` |
 | `:dropdowns:` | Render breaking changes, deprecations, known issues, and highlights as expandable dropdowns instead of flattened bulleted lists | false |
 | `:highlights:` | Emit a dedicated highlights section for entries with `highlight: true` (entries still appear under their type sections) | false |
 | `:release-dates:` | Render the bundle `release-date` field as _Released: …_ after the version heading | false |
@@ -124,16 +124,32 @@ This aligns with the `changelog render` command's link visibility controls.
 
 #### `:description-visibility:`
 
-Controls whether the **`description`** text on each **changelog record** appears in output (bullet body text under each item, or the first paragraph inside a breaking-change, deprecation, known-issue, or highlight entry when [`:dropdowns:`](#dropdowns) is enabled). This is **different** from the optional **bundle** `description` field (release intro prose after `_Released:_`), which is always shown when present. See [Rendered output](#rendered-output).
+Controls whether the `description` text for each changelog appears in the output (bullet body text under each item, or the first paragraph inside a breaking-change, deprecation, known-issue, or highlight entry when [`:dropdowns:`](#dropdowns) is enabled).
+This is different from the optional bundle `description` field (release intro prose after `_Released:_`), which is always shown when present. 
+See [Rendered output](#rendered-output).
+
+Pass one or more comma-separated tokens.
+There is at most one _base token_ (`auto`, `keep-descriptions`, or `hide-descriptions`).
+_Overlay tokens_ (`keep-highlight-descriptions`, `keep-feature-descriptions`) combine with each other and with a base.
 
 | Value | Behavior |
 |-------|----------|
-| `auto` | When **every** constituent repository in the bundle’s resolved repo identity is **public** (same private-repo detection as `:link-visibility:` from `assembler.yml`, including `repo1+repo2` merged bundles), **omit** record `description` bodies. When **any** constituent is marked **private**, **show** those bodies. In standalone builds without `assembler.yml`, every repo is treated as public ⇒ changelog descriptions are omitted under `auto`. |
+| `auto` | When every constituent repository in the bundle’s resolved repo identity is public (same private-repo detection as `:link-visibility:` from `assembler.yml`, including `repo1+repo2` merged bundles), omit record `description` bodies. When any constituent is marked private, show those bodies. In standalone builds without `assembler.yml`, every repo is treated as public ⇒ changelog descriptions are omitted under `auto`. Overlay tokens still show descriptions in their sections. |
 | `keep-descriptions` | Always render changelog descriptions when present in the bundle source. Use this on pages such as deprecations or breaking changes when you still want full release-note prose alongside public repos. |
-| `keep-highlight-descriptions` | Show changelog descriptions **only** in the [`:highlights:`](#highlights) section. Hide them in every other section, including the type-section copy of a highlighted entry. When `:highlights:` is omitted, descriptions are hidden everywhere. |
-| `hide-descriptions` | Always omit changelog descriptions (titles, PR/issue links, impact, and action sections and bundle-level intros are unaffected). |
+| `keep-highlight-descriptions` | Overlay: always show changelog descriptions in the [Highlights](#highlights) section. When used alone, hide them in every other section, including the type-section copy of a highlighted entry. When `:highlights:` is omitted, the overlay has no visible effect. |
+| `keep-feature-descriptions` | Overlay: always show changelog descriptions in the "Features" section. When used alone, hide them in every other section. |
+| `hide-descriptions` | Omit changelog descriptions in unmarked sections (titles, PR/issue links, impact, and action sections and bundle-level intros are unaffected). Overlay tokens still show descriptions in their sections. |
 
-**Contrast with `:link-visibility:`:** `:link-visibility: auto` hides **links** when a repo is **private**. `:description-visibility: auto` **shows** richer record **description** prose when **any** source repo is **private**, and hides that prose for bundles that resolve to **only public** repositories.
+```markdown
+:::{changelog}
+:highlights:
+:description-visibility: keep-feature-descriptions, keep-highlight-descriptions
+:::
+```
+
+The example shows prose in Features and Highlights, and hides it in Enhancements, Fixes, and other type sections.
+
+**Contrast with `:link-visibility:`:** `:link-visibility: auto` hides **links** when a repo is **private**. `:description-visibility: auto` **shows** richer record **description** prose when **any** source repo is **private**, and hides that prose for bundles that resolve to **only public** repositories (except where an overlay token applies).
 
 #### `:dropdowns:` [dropdowns]
 
@@ -154,12 +170,12 @@ Controls whether entries with `highlight: true` get a dedicated **Highlights** s
 
 | Mode | Behavior |
 |------|----------|
-| (omitted, default) | Inline only: highlighted entries appear under their normal type sections (for example Features and enhancements). No `### Highlights` section. |
+| (omitted, default) | Inline only: highlighted entries appear under their normal type sections (for example Features). No `### Highlights` section. |
 | `:highlights:` | Section: emit a `### Highlights` section and keep those entries under their type sections. |
 
 Use `:highlights:` on general release notes when you want a highlights section alongside features, enhancements, and bug fixes — without requiring `:type: all` (which also pulls in breaking changes, deprecations, and known issues).
 
-Changelog descriptions follow [`:description-visibility:`](#description-visibility). Use `keep-descriptions` to show prose in every section, or `keep-highlight-descriptions` to show prose only in the highlights section.
+Changelog descriptions follow [`:description-visibility:`](#description-visibility). Use `keep-descriptions` to show prose in every section, `keep-highlight-descriptions` for Highlights only, `keep-feature-descriptions` for Features only, or combine overlays: `keep-feature-descriptions, keep-highlight-descriptions`.
 
 #### `:release-dates:` [release-dates]
 
@@ -379,13 +395,15 @@ This release includes new features and bug fixes.
 
 Download the release binaries: https://github.com/elastic/elasticsearch/releases/tag/v0.100.0
 
-### Features and enhancements
+### Features
+...
+### Enhancements
 ...
 ### Fixes
 ...
 
 ## 2025-08-05
-### Features and enhancements
+### Features
 ...
 ```
 
@@ -403,7 +421,8 @@ Each changelog entry may have its own `description` field in YAML (shown as body
 
 | Section | Entry type | Rendering |
 |---------|------------|-----------|
-| Features and enhancements | `feature`, `enhancement` | Grouped by area |
+| Features | `feature` | Grouped by area |
+| Enhancements | `enhancement` | Grouped by area |
 | Fixes | `bug-fix`, `security` | Grouped by area |
 | Documentation | `docs` | Grouped by area |
 | Regressions | `regression` | Grouped by area |
@@ -416,11 +435,13 @@ Each changelog entry may have its own `description` field in YAML (shown as body
 **Note about highlights:**
 
 - The highlights section appears only when [`:highlights:`](#highlights) is set and at least one entry has `highlight: true`
-- When the section is shown, highlighted entries appear in **both** the highlights section and their original type section (for example, both the "highlights" and "features and enhancements" sections)
+- When the section is shown, highlighted entries appear in **both** the highlights section and their original type section (for example, both the "highlights" and "features" sections)
 - When `:highlights:` is omitted, flagged entries still appear under their type sections (inline only)
 - You can combine `:highlights:` with the default type filter (no `:type:`) to show highlights alongside features and fixes without including breaking changes, deprecations, or known issues
 
 Sections with no entries of that type are omitted from the output. Releases with no entries after the `:type:` filter are omitted entirely, except on general release notes (`:type: all` or default) when the bundle has a `description`.
+
+Section heading anchors use `-features` and `-enhancements` suffixes. Pages that previously linked to `-features-enhancements` need those links updated.
 
 ## Error behavior for invalid entries [changelog-missing-files]
 

--- a/docs/syntax/changelog.md
+++ b/docs/syntax/changelog.md
@@ -153,14 +153,16 @@ The example shows prose in Features and Highlights, and hides it in Enhancements
 
 #### `:dropdowns:` [dropdowns]
 
-Controls how the "separated" entry types (`breaking-change`, `deprecation`, `known-issue`, and entries flagged `highlight: true`) are rendered. This option only affects these types; features, enhancements, security, bug fixes, documentation, regressions, and other changes are always rendered as flat bulleted lists.
+Controls how breaking changes, deprecations, features, highlights, and known issues are rendered. Enhancements, security, bug fixes, documentation, regressions, and other changes stay flat bulleted lists.
 
 | Mode | Behavior |
 |------|----------|
 | (omitted, default) | Flattened: each entry renders as a bullet with its title, links, and (when present) `Impact:` / `Action:` lines as indented continuation. |
 | `:dropdowns:` | Dropdowns: each entry renders as an expandable `{dropdown}` with the title as the summary and description, links, `**Impact**`, and `**Action**` inside. |
 
-Use dropdowns when breaking-change and deprecation entries have long `description`, `impact`, or `action` prose that benefits from being collapsed by default. Use the flattened default for compact release notes where the list itself is the primary content.
+Use dropdowns when breaking changes, deprecations, features, or highlights have long `description`, `impact`, or `action` prose that benefits from being collapsed by default.
+Use the flattened default for compact release notes where the list itself is the primary content.
+`:dropdowns:` does not group entries by area; use [`:subsections:`](#subsections) for that.
 
 Entry titles may contain inline markdown markers from changelog YAML (for example, `` `setting.name` ``). Dropdown titles are plain text; see [Plain-text titles](/syntax/dropdowns.md#plain-text-titles).
 
@@ -190,11 +192,12 @@ Use this option for semver or agent releases where an explicit release date adds
 
 This is **render-time** control only. To include or omit `release-date` in bundle YAML at build time, use `bundle.release_dates` in `changelog.yml` or the `--release-date` / `--no-release-date` flags on [`changelog bundle`](/cli/changelog/bundle.md) (option-based mode). The `changelog render` command does not provide an equivalent flag; it always renders release dates when present in the bundle.
 
-#### `:subsections:`
+#### `:subsections:` [subsections]
 
 When enabled, entries are grouped by "area" within each section.
 By default, entries are listed without area grouping.
 If a changelog has multiple area values, only the first one is used.
+This option is independent of [`:dropdowns:`](#dropdowns).
 
 #### `:config:`
 
@@ -421,27 +424,33 @@ Each changelog entry may have its own `description` field in YAML (shown as body
 
 | Section | Entry type | Rendering |
 |---------|------------|-----------|
-| Features | `feature` | Grouped by area |
-| Enhancements | `enhancement` | Grouped by area |
-| Fixes | `bug-fix`, `security` | Grouped by area |
-| Documentation | `docs` | Grouped by area |
-| Regressions | `regression` | Grouped by area |
-| Other changes | `other` | Grouped by area |
+| Features | `feature` | Flattened bullets by default; expandable dropdowns with [`:dropdowns:`](#dropdowns) |
+| Enhancements | `enhancement` | Flattened bullets |
+| Fixes | `bug-fix` | Flattened bullets |
+| Security | `security` | Flattened bullets |
+| Documentation | `docs` | Flattened bullets |
+| Regressions | `regression` | Flattened bullets |
+| Other changes | `other` | Flattened bullets |
 | Breaking changes | `breaking-change` | Flattened bullets by default; expandable dropdowns with [`:dropdowns:`](#dropdowns) |
 | Highlights | Entries with `highlight: true` | Dedicated section only when [`:highlights:`](#highlights) is set; flattened bullets by default; expandable dropdowns with [`:dropdowns:`](#dropdowns) |
 | Deprecations | `deprecation` | Flattened bullets by default; expandable dropdowns with [`:dropdowns:`](#dropdowns) |
 | Known issues | `known-issue` | Flattened bullets by default; expandable dropdowns with [`:dropdowns:`](#dropdowns) |
 
-**Note about highlights:**
+Use [`:subsections:`](#subsections) to group entries by area within a section. Area grouping is off by default and is independent of `:dropdowns:`.
+
+:::{admonition} Highlights
 
 - The highlights section appears only when [`:highlights:`](#highlights) is set and at least one entry has `highlight: true`
-- When the section is shown, highlighted entries appear in **both** the highlights section and their original type section (for example, both the "highlights" and "features" sections)
+- When the section is shown, highlighted entries appear in both the highlights section and their original type section (for example, both the "highlights" and "features" sections)
 - When `:highlights:` is omitted, flagged entries still appear under their type sections (inline only)
 - You can combine `:highlights:` with the default type filter (no `:type:`) to show highlights alongside features and fixes without including breaking changes, deprecations, or known issues
 
+:::
+
 Sections with no entries of that type are omitted from the output. Releases with no entries after the `:type:` filter are omitted entirely, except on general release notes (`:type: all` or default) when the bundle has a `description`.
 
-Section heading anchors use `-features` and `-enhancements` suffixes. Pages that previously linked to `-features-enhancements` need those links updated.
+Section heading anchors use `-features` and `-enhancements` suffixes.
+Pages that previously linked to `-features-enhancements` need those links updated.
 
 ## Error behavior for invalid entries [changelog-missing-files]
 

--- a/src/Elastic.Documentation/ReleaseNotes/ChangelogEntryType.cs
+++ b/src/Elastic.Documentation/ReleaseNotes/ChangelogEntryType.cs
@@ -17,7 +17,7 @@ public enum ChangelogEntryType
 	[Display(Name = "invalid")]
 	Invalid = 0,
 
-	/// <summary>A new feature or enhancement.</summary>
+	/// <summary>A new capability that did not exist before.</summary>
 	[Display(Name = "feature")]
 	Feature,
 

--- a/src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogBlock.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogBlock.cs
@@ -284,23 +284,74 @@ public class ChangelogBlock(DirectiveBlockParser parser, ParserContext context) 
 		if (string.IsNullOrWhiteSpace(value))
 			return ChangelogDescriptionVisibility.Auto;
 
-		return value.ToLowerInvariant() switch
-		{
-			"auto" => ChangelogDescriptionVisibility.Auto,
-			"keep-descriptions" => ChangelogDescriptionVisibility.KeepDescriptions,
-			"keep-highlight-descriptions" => ChangelogDescriptionVisibility.KeepHighlightDescriptions,
-			"hide-descriptions" => ChangelogDescriptionVisibility.HideDescriptions,
-			_ => EmitInvalidDescriptionVisibilityWarning(value)
-		};
+		var result = ChangelogDescriptionVisibility.None;
+		var sawBase = false;
+		var hadValid = false;
+
+		foreach (var raw in value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+			hadValid |= TryAccumulateDescriptionVisibilityToken(raw, ref result, ref sawBase);
+
+		return hadValid ? result : ChangelogDescriptionVisibility.Auto;
 	}
 
-	private ChangelogDescriptionVisibility EmitInvalidDescriptionVisibilityWarning(string value)
+	private bool TryAccumulateDescriptionVisibilityToken(string raw, ref ChangelogDescriptionVisibility result, ref bool sawBase)
 	{
-		this.EmitWarning(
-			$"Invalid :description-visibility: value '{value}'. Valid values are: auto, keep-descriptions, keep-highlight-descriptions, hide-descriptions. Using auto."
-		);
-		return ChangelogDescriptionVisibility.Auto;
+		if (!TryMapDescriptionVisibilityToken(raw, out var token, out var isBase))
+		{
+			EmitInvalidDescriptionVisibilityWarning(raw);
+			return false;
+		}
+
+		if (isBase && sawBase)
+		{
+			this.EmitWarning(
+				$"Multiple :description-visibility: base values; ignoring '{raw}'. Valid base values are: auto, keep-descriptions, hide-descriptions."
+			);
+			return true;
+		}
+
+		if (isBase)
+			sawBase = true;
+
+		result |= token;
+		return true;
 	}
+
+	private static bool TryMapDescriptionVisibilityToken(string raw, out ChangelogDescriptionVisibility token, out bool isBase)
+	{
+		switch (raw.ToLowerInvariant())
+		{
+			case "auto":
+				token = ChangelogDescriptionVisibility.Auto;
+				isBase = true;
+				return true;
+			case "keep-descriptions":
+				token = ChangelogDescriptionVisibility.KeepDescriptions;
+				isBase = true;
+				return true;
+			case "hide-descriptions":
+				token = ChangelogDescriptionVisibility.HideDescriptions;
+				isBase = true;
+				return true;
+			case "keep-highlight-descriptions":
+				token = ChangelogDescriptionVisibility.KeepHighlightDescriptions;
+				isBase = false;
+				return true;
+			case "keep-feature-descriptions":
+				token = ChangelogDescriptionVisibility.KeepFeatureDescriptions;
+				isBase = false;
+				return true;
+			default:
+				token = ChangelogDescriptionVisibility.None;
+				isBase = false;
+				return false;
+		}
+	}
+
+	private void EmitInvalidDescriptionVisibilityWarning(string value) =>
+		this.EmitWarning(
+			$"Invalid :description-visibility: value '{value}'. Valid values are: auto, keep-descriptions, keep-highlight-descriptions, keep-feature-descriptions, hide-descriptions. Using auto when no valid tokens remain."
+		);
 
 	/// <summary>
 	/// Parses and validates the :type: option.
@@ -663,12 +714,13 @@ public class ChangelogBlock(DirectiveBlockParser parser, ParserContext context) 
 			)
 				yield return $"{repo}-{anchorSlug}-deprecations";
 
+			if (!dedicatedPage && shouldInclude(ChangelogEntryType.Feature) && entriesByType.ContainsKey(ChangelogEntryType.Feature))
+				yield return $"{repo}-{anchorSlug}-features";
+
 			if (
-				!dedicatedPage
-				&& shouldInclude(ChangelogEntryType.Feature)
-				&& (entriesByType.ContainsKey(ChangelogEntryType.Feature) || entriesByType.ContainsKey(ChangelogEntryType.Enhancement))
+				!dedicatedPage && shouldInclude(ChangelogEntryType.Enhancement) && entriesByType.ContainsKey(ChangelogEntryType.Enhancement)
 			)
-				yield return $"{repo}-{anchorSlug}-features-enhancements";
+				yield return $"{repo}-{anchorSlug}-enhancements";
 
 			if (!dedicatedPage && shouldInclude(ChangelogEntryType.BugFix) && entriesByType.ContainsKey(ChangelogEntryType.BugFix))
 				yield return $"{repo}-{anchorSlug}-fixes";
@@ -755,16 +807,11 @@ public class ChangelogBlock(DirectiveBlockParser parser, ParserContext context) 
 			if (shouldInclude(ChangelogEntryType.Deprecation) && entriesByType.ContainsKey(ChangelogEntryType.Deprecation))
 				yield return new PageTocItem { Heading = "Deprecations", Slug = SectionSlug("deprecations"), Level = 3 };
 
-			if (
-				shouldInclude(ChangelogEntryType.Feature)
-				&& (entriesByType.ContainsKey(ChangelogEntryType.Feature) || entriesByType.ContainsKey(ChangelogEntryType.Enhancement))
-			)
-				yield return new PageTocItem
-				{
-					Heading = "Features and enhancements",
-					Slug = SectionSlug("features-enhancements"),
-					Level = 3
-				};
+			if (shouldInclude(ChangelogEntryType.Feature) && entriesByType.ContainsKey(ChangelogEntryType.Feature))
+				yield return new PageTocItem { Heading = "Features", Slug = SectionSlug("features"), Level = 3 };
+
+			if (shouldInclude(ChangelogEntryType.Enhancement) && entriesByType.ContainsKey(ChangelogEntryType.Enhancement))
+				yield return new PageTocItem { Heading = "Enhancements", Slug = SectionSlug("enhancements"), Level = 3 };
 
 			if (shouldInclude(ChangelogEntryType.BugFix) && entriesByType.ContainsKey(ChangelogEntryType.BugFix))
 				yield return new PageTocItem { Heading = "Fixes", Slug = SectionSlug("fixes"), Level = 3 };

--- a/src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogDescriptionVisibility.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogDescriptionVisibility.cs
@@ -6,29 +6,41 @@ namespace Elastic.Markdown.Myst.Directives.Changelog;
 
 /// <summary>
 /// Controls changelog entry description (body text) rendering for the {changelog} directive.
-/// Mirrors the structure of <see cref="ChangelogLinkVisibility"/> while using opposite privacy defaults for <see cref="Auto"/>.
+/// Combinable flags: at most one base token (<see cref="Auto"/>, <see cref="KeepDescriptions"/>, or
+/// <see cref="HideDescriptions"/>) plus optional overlays (<see cref="KeepHighlightDescriptions"/>,
+/// <see cref="KeepFeatureDescriptions"/>).
 /// </summary>
+[Flags]
 public enum ChangelogDescriptionVisibility
 {
+	None = 0,
+
 	/// <summary>
 	/// Hide record descriptions when the bundle has only public constituent repos (per assembler.yml);
 	/// show when any constituent is private. With no private repos configured, hides descriptions everywhere.
 	/// </summary>
-	Auto,
+	Auto = 1,
 
 	/// <summary>
 	/// Always render record descriptions when present in source YAML.
 	/// </summary>
-	KeepDescriptions,
+	KeepDescriptions = 1 << 1,
 
 	/// <summary>
-	/// Always render record descriptions in the Highlights section only; hide them in every other section.
-	/// When <c>:highlights:</c> is omitted, descriptions are hidden everywhere.
+	/// Never render record descriptions (including dropdown authoring placeholders), except where an overlay applies.
 	/// </summary>
-	KeepHighlightDescriptions,
+	HideDescriptions = 1 << 2,
 
 	/// <summary>
-	/// Never render record descriptions (including dropdown authoring placeholders).
+	/// Always render record descriptions in the Highlights section. Combine with other tokens to control remaining sections.
+	/// When used alone, descriptions are hidden everywhere except Highlights. When <c>:highlights:</c> is omitted, the
+	/// Highlights overlay has no visible effect.
 	/// </summary>
-	HideDescriptions
+	KeepHighlightDescriptions = 1 << 3,
+
+	/// <summary>
+	/// Always render record descriptions in the Features section. Combine with other tokens to control remaining sections.
+	/// When used alone, descriptions are hidden everywhere except Features.
+	/// </summary>
+	KeepFeatureDescriptions = 1 << 4
 }

--- a/src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogInlineRenderer.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogInlineRenderer.cs
@@ -198,14 +198,25 @@ public static class ChangelogInlineRenderer
 		string bundleRepo,
 		HashSet<string> privateRepositories,
 		ChangelogDescriptionVisibility visibility
-	) => visibility switch
+	)
 	{
-		ChangelogDescriptionVisibility.HideDescriptions => true,
-		ChangelogDescriptionVisibility.KeepHighlightDescriptions => true,
-		ChangelogDescriptionVisibility.KeepDescriptions => false,
-		ChangelogDescriptionVisibility.Auto => !HasAnyPrivateRepoConstituent(bundleRepo, privateRepositories),
-		_ => !HasAnyPrivateRepoConstituent(bundleRepo, privateRepositories)
-	};
+		if (visibility.HasFlag(ChangelogDescriptionVisibility.KeepDescriptions))
+			return false;
+
+		if (visibility.HasFlag(ChangelogDescriptionVisibility.HideDescriptions))
+			return true;
+
+		if (visibility.HasFlag(ChangelogDescriptionVisibility.Auto))
+			return !HasAnyPrivateRepoConstituent(bundleRepo, privateRepositories);
+
+		if (
+			visibility.HasFlag(ChangelogDescriptionVisibility.KeepHighlightDescriptions)
+			|| visibility.HasFlag(ChangelogDescriptionVisibility.KeepFeatureDescriptions)
+		)
+			return true;
+
+		return !HasAnyPrivateRepoConstituent(bundleRepo, privateRepositories);
+	}
 
 	/// <summary>
 	/// True when merged <paramref name="bundleRepo"/> (<c>elasticsearch+kibana</c>-style) has at least one
@@ -242,7 +253,9 @@ public static class ChangelogInlineRenderer
 		var subsections = options.Subsections;
 		var hideLinks = model.HideLinks;
 		var hideEntryDescriptions = model.HideEntryDescriptions;
-		var hideHighlightDescriptions = options.DescriptionVisibility is not ChangelogDescriptionVisibility.KeepHighlightDescriptions
+		var hideHighlightDescriptions = !options.DescriptionVisibility.HasFlag(ChangelogDescriptionVisibility.KeepHighlightDescriptions)
+			&& hideEntryDescriptions;
+		var hideFeatureDescriptions = !options.DescriptionVisibility.HasFlag(ChangelogDescriptionVisibility.KeepFeatureDescriptions)
 			&& hideEntryDescriptions;
 		var dropdownsEnabled = options.DropdownsEnabled;
 		var typeFilter = options.TypeFilter;
@@ -372,12 +385,18 @@ public static class ChangelogInlineRenderer
 			);
 		}
 
-		if (features.Count > 0 || enhancements.Count > 0)
+		if (features.Count > 0)
 		{
 			_ = sb.AppendLine();
-			_ = sb.AppendLine(CultureInfo.InvariantCulture, $"### Features and enhancements [{repo}-{titleSlug}-features-enhancements]");
-			var combined = features.Concat(enhancements).ToList();
-			RenderEntriesByArea(sb, combined, repo, owner, subsections, hideLinks, hideEntryDescriptions, publishBlocker);
+			_ = sb.AppendLine(CultureInfo.InvariantCulture, $"### Features [{repo}-{titleSlug}-features]");
+			RenderEntriesByArea(sb, features, repo, owner, subsections, hideLinks, hideFeatureDescriptions, publishBlocker);
+		}
+
+		if (enhancements.Count > 0)
+		{
+			_ = sb.AppendLine();
+			_ = sb.AppendLine(CultureInfo.InvariantCulture, $"### Enhancements [{repo}-{titleSlug}-enhancements]");
+			RenderEntriesByArea(sb, enhancements, repo, owner, subsections, hideLinks, hideEntryDescriptions, publishBlocker);
 		}
 
 		if (bugFixes.Count > 0)

--- a/src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogInlineRenderer.cs
+++ b/src/Elastic.Markdown/Myst/Directives/Changelog/ChangelogInlineRenderer.cs
@@ -319,6 +319,7 @@ public static class ChangelogInlineRenderer
 					groupBySubtype: true,
 					hideLinks,
 					hideEntryDescriptions,
+					subsections,
 					publishBlocker
 				);
 			else
@@ -338,6 +339,7 @@ public static class ChangelogInlineRenderer
 					groupBySubtype: false,
 					hideLinks,
 					hideHighlightDescriptions,
+					subsections,
 					publishBlocker
 				);
 			else
@@ -389,7 +391,20 @@ public static class ChangelogInlineRenderer
 		{
 			_ = sb.AppendLine();
 			_ = sb.AppendLine(CultureInfo.InvariantCulture, $"### Features [{repo}-{titleSlug}-features]");
-			RenderEntriesByArea(sb, features, repo, owner, subsections, hideLinks, hideFeatureDescriptions, publishBlocker);
+			if (dropdownsEnabled)
+				RenderDetailedEntries(
+					sb,
+					features,
+					repo,
+					owner,
+					groupBySubtype: false,
+					hideLinks,
+					hideFeatureDescriptions,
+					subsections,
+					publishBlocker
+				);
+			else
+				RenderEntriesByArea(sb, features, repo, owner, subsections, hideLinks, hideFeatureDescriptions, publishBlocker);
 		}
 
 		if (enhancements.Count > 0)
@@ -528,12 +543,11 @@ public static class ChangelogInlineRenderer
 		bool groupBySubtype,
 		bool hideLinks,
 		bool hideEntryDescriptions,
+		bool subsections,
 		PublishBlocker? publishBlocker
 	)
 	{
-		var grouped = groupBySubtype
-			? entries.GroupBy(e => e.Subtype?.ToStringFast(true) ?? string.Empty).OrderBy(g => g.Key).ToList()
-			: entries.GroupBy(e => publishBlocker.GetPreferredArea(e)).OrderBy(g => g.Key).ToList();
+		var grouped = GroupDetailedEntries(entries, groupBySubtype, subsections, publishBlocker);
 
 		foreach (var group in grouped)
 		{
@@ -549,6 +563,22 @@ public static class ChangelogInlineRenderer
 			foreach (var entry in group)
 				RenderDetailedEntry(sb, entry, repo, owner, hideLinks, hideEntryDescriptions);
 		}
+	}
+
+	private static List<IGrouping<string, ChangelogEntry>> GroupDetailedEntries(
+		List<ChangelogEntry> entries,
+		bool groupBySubtype,
+		bool subsections,
+		PublishBlocker? publishBlocker
+	)
+	{
+		if (groupBySubtype)
+			return entries.GroupBy(e => e.Subtype?.ToStringFast(true) ?? string.Empty).OrderBy(g => g.Key).ToList();
+
+		if (!subsections)
+			return entries.GroupBy(_ => string.Empty).ToList();
+
+		return entries.GroupBy(e => publishBlocker.GetPreferredArea(e)).OrderBy(g => g.Key).ToList();
 	}
 
 	private static void RenderDetailedEntriesFlattened(
@@ -831,7 +861,7 @@ public static class ChangelogInlineRenderer
 	{
 		if (dropdownsEnabled)
 		{
-			RenderDetailedEntries(sb, entries, repo, owner, groupBySubtype, hideLinks, hideEntryDescriptions, publishBlocker);
+			RenderDetailedEntries(sb, entries, repo, owner, groupBySubtype, hideLinks, hideEntryDescriptions, subsections, publishBlocker);
 			return;
 		}
 

--- a/src/services/Elastic.Changelog/Rendering/Asciidoc/ChangelogAsciidocRenderer.cs
+++ b/src/services/Elastic.Changelog/Rendering/Asciidoc/ChangelogAsciidocRenderer.cs
@@ -83,12 +83,17 @@ public class ChangelogAsciidocRenderer(IFileSystem fileSystem)
 			_ = sb.AppendLine();
 		}
 
-		// Render features and enhancements
-		if (features.Count > 0 || enhancements.Count > 0)
+		if (features.Count > 0)
 		{
-			RenderSectionHeader(sb, "features-enhancements", context.TitleSlug, "New features and enhancements");
-			var combined = features.Concat(enhancements).ToList();
-			entriesByAreaRenderer.Render(combined, context);
+			RenderSectionHeader(sb, "features", context.TitleSlug, "Features");
+			entriesByAreaRenderer.Render(features, context);
+			_ = sb.AppendLine();
+		}
+
+		if (enhancements.Count > 0)
+		{
+			RenderSectionHeader(sb, "enhancements", context.TitleSlug, "Enhancements");
+			entriesByAreaRenderer.Render(enhancements, context);
 			_ = sb.AppendLine();
 		}
 

--- a/src/services/Elastic.Changelog/Rendering/Markdown/ChangelogGfmRenderer.cs
+++ b/src/services/Elastic.Changelog/Rendering/Markdown/ChangelogGfmRenderer.cs
@@ -71,16 +71,18 @@ public class ChangelogGfmRenderer(IChangelogFileSystem fileSystem) : MarkdownRen
 			_ = sb.AppendLine();
 		}
 
-		// Features and enhancements
-		if (features.Count > 0 || enhancements.Count > 0)
+		if (features.Count > 0 && !AllEntriesHidden(features))
 		{
-			var combined = features.Concat(enhancements).ToList();
-			if (!AllEntriesHidden(combined))
-			{
-				_ = sb.AppendLine("### Features and enhancements");
-				RenderEntriesByArea(sb, combined, context);
-				_ = sb.AppendLine();
-			}
+			_ = sb.AppendLine("### Features");
+			RenderEntriesByArea(sb, features, context);
+			_ = sb.AppendLine();
+		}
+
+		if (enhancements.Count > 0 && !AllEntriesHidden(enhancements))
+		{
+			_ = sb.AppendLine("### Enhancements");
+			RenderEntriesByArea(sb, enhancements, context);
+			_ = sb.AppendLine();
 		}
 
 		// Breaking changes

--- a/src/services/Elastic.Changelog/Rendering/Markdown/IndexMarkdownRenderer.cs
+++ b/src/services/Elastic.Changelog/Rendering/Markdown/IndexMarkdownRenderer.cs
@@ -61,25 +61,33 @@ public class IndexMarkdownRenderer(IChangelogFileSystem fileSystem) : MarkdownRe
 			entries.Count > 0 && entries.All(entry => ChangelogRenderUtilities.ShouldHideEntry(entry, context.FeatureIdsToHide, context));
 
 		// Check if each category has visible entries
-		var hasVisibleFeatures = (features.Count > 0 || enhancements.Count > 0)
-			&& !(AllEntriesHidden(features) && AllEntriesHidden(enhancements));
+		var hasVisibleFeatures = features.Count > 0 && !AllEntriesHidden(features);
+		var hasVisibleEnhancements = enhancements.Count > 0 && !AllEntriesHidden(enhancements);
 		var hasVisibleFixes = (security.Count > 0 || bugFixes.Count > 0) && !(AllEntriesHidden(security) && AllEntriesHidden(bugFixes));
 		var hasVisibleDocs = docs.Count > 0 && !AllEntriesHidden(docs);
 		var hasVisibleRegressions = regressions.Count > 0 && !AllEntriesHidden(regressions);
 		var hasVisibleOther = other.Count > 0 && !AllEntriesHidden(other);
 
-		var hasAnyVisibleEntries = hasVisibleFeatures || hasVisibleFixes || hasVisibleDocs || hasVisibleRegressions || hasVisibleOther;
+		var hasAnyVisibleEntries = hasVisibleFeatures
+			|| hasVisibleEnhancements
+			|| hasVisibleFixes
+			|| hasVisibleDocs
+			|| hasVisibleRegressions
+			|| hasVisibleOther;
 
 		if (hasAnyEntries)
 		{
-			if (features.Count > 0 || enhancements.Count > 0)
+			if (features.Count > 0)
 			{
-				var combined = features.Concat(enhancements).ToList();
-				_ = sb.AppendLine(
-					InvariantCulture,
-					$"### Features and enhancements [{context.Repo}-{context.TitleSlug}-features-enhancements]"
-				);
-				RenderEntriesByArea(sb, combined, context);
+				_ = sb.AppendLine(InvariantCulture, $"### Features [{context.Repo}-{context.TitleSlug}-features]");
+				RenderEntriesByArea(sb, features, context);
+			}
+
+			if (enhancements.Count > 0)
+			{
+				_ = sb.AppendLine();
+				_ = sb.AppendLine(InvariantCulture, $"### Enhancements [{context.Repo}-{context.TitleSlug}-enhancements]");
+				RenderEntriesByArea(sb, enhancements, context);
 			}
 
 			if (security.Count > 0 || bugFixes.Count > 0)

--- a/tests/Elastic.Changelog.Tests/Changelogs/Render/GfmRenderTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/Render/GfmRenderTests.cs
@@ -70,13 +70,13 @@ public class GfmRenderTests(ITestOutputHelper output) : RenderChangelogTestBase(
 
 		var content = await FileSystem.File.ReadAllTextAsync(outputFile, TestContext.Current.CancellationToken);
 		content.Should().Contain("## 9.2.0");
-		content.Should().Contain("### Features and enhancements");
+		content.Should().Contain("### Features");
 		content.Should().Contain("Test feature");
 		content.Should().Contain("[#100](https://github.com/elastic/elasticsearch/pull/100)");
 
 		// Should NOT contain anchor brackets in headings
 		content.Should().NotContain("## 9.2.0 [");
-		content.Should().NotContain("### Features and enhancements [");
+		content.Should().NotContain("### Features [");
 	}
 
 	[Fact]
@@ -175,7 +175,7 @@ public class GfmRenderTests(ITestOutputHelper output) : RenderChangelogTestBase(
 		var content = await FileSystem.File.ReadAllTextAsync(outputChangelogPath, TestContext.Current.CancellationToken);
 
 		// Should include all section types in the proper order
-		content.Should().Contain("### Features and enhancements");
+		content.Should().Contain("### Features");
 		content.Should().Contain("### Breaking changes");
 		content.Should().Contain("### Deprecations");
 		content.Should().Contain("### Bug fixes");
@@ -189,7 +189,7 @@ public class GfmRenderTests(ITestOutputHelper output) : RenderChangelogTestBase(
 		content.Should().Contain("Known issue");
 
 		// Check section ordering (features should come before breaking changes)
-		var featuresIndex = content.IndexOf("### Features and enhancements", StringComparison.Ordinal);
+		var featuresIndex = content.IndexOf("### Features", StringComparison.Ordinal);
 		var breakingIndex = content.IndexOf("### Breaking changes", StringComparison.Ordinal);
 		var deprecationIndex = content.IndexOf("### Deprecations", StringComparison.Ordinal);
 		var bugFixIndex = content.IndexOf("### Bug fixes", StringComparison.Ordinal);
@@ -266,11 +266,11 @@ public class GfmRenderTests(ITestOutputHelper output) : RenderChangelogTestBase(
 
 		// Should include highlights section first
 		content.Should().Contain("### Highlights");
-		content.Should().Contain("### Features and enhancements");
+		content.Should().Contain("### Features");
 
 		// Highlights should come first
 		var highlightsIndex = content.IndexOf("### Highlights", StringComparison.Ordinal);
-		var featuresIndex = content.IndexOf("### Features and enhancements", StringComparison.Ordinal);
+		var featuresIndex = content.IndexOf("### Features", StringComparison.Ordinal);
 		highlightsIndex.Should().BeLessThan(featuresIndex);
 
 		// Both features should be present

--- a/tests/Elastic.Changelog.Tests/Changelogs/Render/OutputFormatTests.cs
+++ b/tests/Elastic.Changelog.Tests/Changelogs/Render/OutputFormatTests.cs
@@ -141,8 +141,8 @@ public class OutputFormatTests(ITestOutputHelper output) : RenderChangelogTestBa
 		// Verify valid asciidoc format elements
 		asciidocContent.Should().Contain("[[release-notes-", "should contain anchor");
 		asciidocContent.Should().Contain("== 9.2.0", "should contain section header");
-		asciidocContent.Should().Contain("[[features-enhancements-", "should contain features section anchor");
-		asciidocContent.Should().Contain("=== New features and enhancements", "should contain features section header");
+		asciidocContent.Should().Contain("[[features-", "should contain features section anchor");
+		asciidocContent.Should().Contain("=== Features", "should contain features section header");
 		asciidocContent.Should().Contain("* Test feature", "should contain changelog entry");
 		asciidocContent.Should().Contain("This is a test feature", "should contain description");
 
@@ -247,8 +247,8 @@ public class OutputFormatTests(ITestOutputHelper output) : RenderChangelogTestBa
 		asciidocContent.Should().Contain("[float]", "should contain float attribute");
 		asciidocContent.Should().Contain("=== Bug fixes", "should contain bug fixes header");
 
-		asciidocContent.Should().Contain("[[features-enhancements-9.2.0]]", "should contain features anchor");
-		asciidocContent.Should().Contain("=== New features and enhancements", "should contain features header");
+		asciidocContent.Should().Contain("[[features-9.2.0]]", "should contain features anchor");
+		asciidocContent.Should().Contain("=== Features", "should contain features header");
 
 		asciidocContent.Should().Contain("[[breaking-changes-9.2.0]]", "should contain breaking changes anchor");
 		asciidocContent.Should().Contain("=== Breaking changes", "should contain breaking changes header");

--- a/tests/Elastic.Markdown.Tests/Directives/ChangelogBasicTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/ChangelogBasicTests.cs
@@ -77,7 +77,7 @@ public class ChangelogBasicTests : DirectiveTest<ChangelogBlock>
 	public void RendersMarkdownContent()
 	{
 		Html.Should().Contain("9.3.0");
-		Html.Should().Contain("Features and enhancements");
+		Html.Should().Contain("Features");
 		Html.Should().Contain("Add new feature");
 		Html.Should().Contain("Fixes");
 		Html.Should().Contain("Fix important bug");
@@ -490,7 +490,7 @@ public class ChangelogCdnRenderTests(ITestOutputHelper output) : DirectiveTest<C
 	public void RendersCdnBundleBody()
 	{
 		Html.Should().Contain("9.4.0");
-		Html.Should().Contain("Features and enhancements");
+		Html.Should().Contain("Enhancements");
 		Html.Should().Contain("Faster vector search on the CDN");
 	}
 }
@@ -1002,7 +1002,7 @@ public class ChangelogSectionOrderTests : DirectiveTest<ChangelogBlock>
 	public void BreakingChangesAppearsFirst()
 	{
 		var breakingIdx = Html.IndexOf("Breaking changes", StringComparison.Ordinal);
-		var featuresIdx = Html.IndexOf("Features and enhancements", StringComparison.Ordinal);
+		var featuresIdx = Html.IndexOf("Features", StringComparison.Ordinal);
 		var fixesIdx = Html.IndexOf(">Fixes<", StringComparison.Ordinal);
 
 		breakingIdx.Should().BeLessThan(featuresIdx, "Breaking changes should appear before Features");
@@ -1013,7 +1013,7 @@ public class ChangelogSectionOrderTests : DirectiveTest<ChangelogBlock>
 	public void SecurityAppearsBeforeFeatures()
 	{
 		var securityIdx = Html.IndexOf(">Security<", StringComparison.Ordinal);
-		var featuresIdx = Html.IndexOf("Features and enhancements", StringComparison.Ordinal);
+		var featuresIdx = Html.IndexOf("Features", StringComparison.Ordinal);
 
 		securityIdx.Should().BeLessThan(featuresIdx, "Security should appear before Features");
 	}
@@ -1022,7 +1022,7 @@ public class ChangelogSectionOrderTests : DirectiveTest<ChangelogBlock>
 	public void KnownIssuesAppearsBeforeFeatures()
 	{
 		var knownIssuesIdx = Html.IndexOf("Known issues", StringComparison.Ordinal);
-		var featuresIdx = Html.IndexOf("Features and enhancements", StringComparison.Ordinal);
+		var featuresIdx = Html.IndexOf("Features", StringComparison.Ordinal);
 
 		knownIssuesIdx.Should().BeLessThan(featuresIdx, "Known issues should appear before Features");
 	}
@@ -1031,7 +1031,7 @@ public class ChangelogSectionOrderTests : DirectiveTest<ChangelogBlock>
 	public void DeprecationsAppearsBeforeFeatures()
 	{
 		var deprecationsIdx = Html.IndexOf("Deprecations", StringComparison.Ordinal);
-		var featuresIdx = Html.IndexOf("Features and enhancements", StringComparison.Ordinal);
+		var featuresIdx = Html.IndexOf("Features", StringComparison.Ordinal);
 
 		deprecationsIdx.Should().BeLessThan(featuresIdx, "Deprecations should appear before Features");
 	}

--- a/tests/Elastic.Markdown.Tests/Directives/ChangelogConfigTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/ChangelogConfigTests.cs
@@ -89,7 +89,7 @@ public class ChangelogConfigLoadAutoDiscoverTests : DirectiveTest<ChangelogBlock
 	}
 
 	[Fact]
-	public void RendersFeaturesSection() => Html.Should().Contain("Features and enhancements");
+	public void RendersFeaturesSection() => Html.Should().Contain("Features");
 
 	[Fact]
 	public void RendersDeprecationsSection() => Html.Should().Contain("Deprecations");

--- a/tests/Elastic.Markdown.Tests/Directives/ChangelogDescriptionVisibilityTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/ChangelogDescriptionVisibilityTests.cs
@@ -38,14 +38,33 @@ public class ChangelogShouldHideEntryDescriptionsTests
 	}
 
 	[Fact]
-	public void KeepHighlightDescriptions_AlwaysReturnsTrue()
+	public void KeepFeatureDescriptions_AlwaysReturnsTrue()
 	{
-		// Default path hides descriptions; Highlights section overrides separately in the renderer.
 		var result = ChangelogInlineRenderer.ShouldHideEntryDescriptionsForRepo(
 			"kibana",
 			[],
-			ChangelogDescriptionVisibility.KeepHighlightDescriptions
+			ChangelogDescriptionVisibility.KeepFeatureDescriptions
 		);
+
+		result.Should().BeTrue();
+	}
+
+	[Fact]
+	public void CombinedFeatureAndHighlightOverlays_AlwaysReturnsTrue()
+	{
+		var visibility = ChangelogDescriptionVisibility.KeepFeatureDescriptions | ChangelogDescriptionVisibility.KeepHighlightDescriptions;
+
+		var result = ChangelogInlineRenderer.ShouldHideEntryDescriptionsForRepo("kibana", [], visibility);
+
+		result.Should().BeTrue();
+	}
+
+	[Fact]
+	public void AutoPlusFeatureOverlay_WithPublicRepo_HidesDefaultBodies()
+	{
+		var visibility = ChangelogDescriptionVisibility.Auto | ChangelogDescriptionVisibility.KeepFeatureDescriptions;
+
+		var result = ChangelogInlineRenderer.ShouldHideEntryDescriptionsForRepo("kibana", [], visibility);
 
 		result.Should().BeTrue();
 	}
@@ -312,4 +331,235 @@ public class ChangelogDescriptionVisibilityInvalidTests(ITestOutputHelper output
 
 	[Fact]
 	public void AutoTreatsFullyPublic_AsHideBody() => Html.Should().NotContain("BODY_INVALID_VISIBILITY");
+}
+
+public class ChangelogKeepFeatureDescriptionsTests(ITestOutputHelper output) : DirectiveTest<ChangelogBlock>(
+	output,
+	"""
+	:::{changelog}
+	:description-visibility: keep-feature-descriptions
+	:::
+	"""
+)
+{
+	protected override void AddToFileSystem(MockFileSystem fileSystem) =>
+		fileSystem.AddFile(
+			"docs/changelog/bundles/9.3.0.yaml",
+			new MockFileData(
+				"""
+			products:
+			- product: elasticsearch
+			  target: 9.3.0
+			entries:
+			- title: Feature with body
+			  type: feature
+			  products:
+			  - product: elasticsearch
+			    target: 9.3.0
+			  description: FEATURE_ONLY_BODY
+			- title: Enhancement with body
+			  type: enhancement
+			  products:
+			  - product: elasticsearch
+			    target: 9.3.0
+			  description: ENHANCEMENT_HIDDEN_BODY
+			"""
+			)
+		);
+
+	[Fact]
+	public void ParsesKeepFeatureDescriptions() =>
+		Block!.DescriptionVisibility.Should().Be(ChangelogDescriptionVisibility.KeepFeatureDescriptions);
+
+	[Fact]
+	public void ShowsFeatureBodies() => Html.Should().Contain("FEATURE_ONLY_BODY");
+
+	[Fact]
+	public void HidesEnhancementBodies() => Html.Should().NotContain("ENHANCEMENT_HIDDEN_BODY");
+}
+
+public class ChangelogCombinedFeatureAndHighlightDescriptionsTests(ITestOutputHelper output) : DirectiveTest<ChangelogBlock>(
+	output,
+	"""
+	:::{changelog}
+	:highlights:
+	:description-visibility: keep-feature-descriptions, keep-highlight-descriptions
+	:::
+	"""
+)
+{
+	protected override void AddToFileSystem(MockFileSystem fileSystem) =>
+		fileSystem.AddFile(
+			"docs/changelog/bundles/9.3.0.yaml",
+			new MockFileData(
+				"""
+			products:
+			- product: elasticsearch
+			  target: 9.3.0
+			entries:
+			- title: Highlighted feature
+			  type: feature
+			  highlight: true
+			  products:
+			  - product: elasticsearch
+			    target: 9.3.0
+			  description: HIGHLIGHT_SECTION_BODY
+			- title: Regular feature
+			  type: feature
+			  products:
+			  - product: elasticsearch
+			    target: 9.3.0
+			  description: FEATURE_SECTION_BODY
+			- title: Enhancement with body
+			  type: enhancement
+			  products:
+			  - product: elasticsearch
+			    target: 9.3.0
+			  description: ENHANCEMENT_HIDDEN_BODY
+			"""
+			)
+		);
+
+	[Fact]
+	public void ParsesBothOverlays()
+	{
+		Block!.DescriptionVisibility.HasFlag(ChangelogDescriptionVisibility.KeepFeatureDescriptions).Should().BeTrue();
+		Block!.DescriptionVisibility.HasFlag(ChangelogDescriptionVisibility.KeepHighlightDescriptions).Should().BeTrue();
+	}
+
+	[Fact]
+	public void ShowsHighlightBodies() => Html.Should().Contain("HIGHLIGHT_SECTION_BODY");
+
+	[Fact]
+	public void ShowsFeatureBodies() => Html.Should().Contain("FEATURE_SECTION_BODY");
+
+	[Fact]
+	public void HidesEnhancementBodies() => Html.Should().NotContain("ENHANCEMENT_HIDDEN_BODY");
+}
+
+public class ChangelogAutoPlusFeatureDescriptionsTests(ITestOutputHelper output) : DirectiveTest<ChangelogBlock>(
+	output,
+	"""
+	:::{changelog}
+	:description-visibility: auto, keep-feature-descriptions
+	:::
+	"""
+)
+{
+	protected override void AddToFileSystem(MockFileSystem fileSystem) =>
+		fileSystem.AddFile(
+			"docs/changelog/bundles/9.3.0.yaml",
+			new MockFileData(
+				"""
+			products:
+			- product: elasticsearch
+			  target: 9.3.0
+			entries:
+			- title: Feature with body
+			  type: feature
+			  products:
+			  - product: elasticsearch
+			    target: 9.3.0
+			  description: FEATURE_AUTO_OVERLAY_BODY
+			- title: Enhancement with body
+			  type: enhancement
+			  products:
+			  - product: elasticsearch
+			    target: 9.3.0
+			  description: ENHANCEMENT_AUTO_BODY
+			"""
+			)
+		);
+
+	[Fact]
+	public void ParsesAutoPlusFeatureOverlay()
+	{
+		Block!.DescriptionVisibility.HasFlag(ChangelogDescriptionVisibility.Auto).Should().BeTrue();
+		Block!.DescriptionVisibility.HasFlag(ChangelogDescriptionVisibility.KeepFeatureDescriptions).Should().BeTrue();
+	}
+
+	[Fact]
+	public void ShowsFeatureBodiesOnPublicRepos() => Html.Should().Contain("FEATURE_AUTO_OVERLAY_BODY");
+
+	[Fact]
+	public void HidesEnhancementBodiesOnPublicRepos() => Html.Should().NotContain("ENHANCEMENT_AUTO_BODY");
+}
+
+public class ChangelogDuplicateBaseDescriptionVisibilityTests(ITestOutputHelper output) : DirectiveTest<ChangelogBlock>(
+	output,
+	"""
+	:::{changelog}
+	:description-visibility: keep-descriptions, hide-descriptions
+	:::
+	"""
+)
+{
+	protected override void AddToFileSystem(MockFileSystem fileSystem) =>
+		fileSystem.AddFile(
+			"docs/changelog/bundles/9.3.0.yaml",
+			new MockFileData(
+				"""
+			products:
+			- product: elasticsearch
+			  target: 9.3.0
+			entries:
+			- title: Feature keep first
+			  type: feature
+			  products:
+			  - product: elasticsearch
+			    target: 9.3.0
+			  description: BODY_FIRST_BASE_WINS
+			"""
+			)
+		);
+
+	[Fact]
+	public void KeepsFirstBaseToken() => Block!.DescriptionVisibility.Should().Be(ChangelogDescriptionVisibility.KeepDescriptions);
+
+	[Fact]
+	public void EmitsWarning() => Collector.Warnings.Should().BeGreaterThan(0);
+
+	[Fact]
+	public void RendersBodiesUsingFirstBase() => Html.Should().Contain("BODY_FIRST_BASE_WINS");
+}
+
+public class ChangelogHideDescriptionsPlusFeatureOverlayTests(ITestOutputHelper output) : DirectiveTest<ChangelogBlock>(
+	output,
+	"""
+	:::{changelog}
+	:description-visibility: hide-descriptions, keep-feature-descriptions
+	:::
+	"""
+)
+{
+	protected override void AddToFileSystem(MockFileSystem fileSystem) =>
+		fileSystem.AddFile(
+			"docs/changelog/bundles/9.3.0.yaml",
+			new MockFileData(
+				"""
+			products:
+			- product: elasticsearch
+			  target: 9.3.0
+			entries:
+			- title: Feature with body
+			  type: feature
+			  products:
+			  - product: elasticsearch
+			    target: 9.3.0
+			  description: FEATURE_OVERLAY_WINS
+			- title: Enhancement with body
+			  type: enhancement
+			  products:
+			  - product: elasticsearch
+			    target: 9.3.0
+			  description: ENHANCEMENT_STILL_HIDDEN
+			"""
+			)
+		);
+
+	[Fact]
+	public void ShowsFeatureBodiesDespiteHideBase() => Html.Should().Contain("FEATURE_OVERLAY_WINS");
+
+	[Fact]
+	public void HidesEnhancementBodies() => Html.Should().NotContain("ENHANCEMENT_STILL_HIDDEN");
 }

--- a/tests/Elastic.Markdown.Tests/Directives/ChangelogDropdownsTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/ChangelogDropdownsTests.cs
@@ -10,9 +10,9 @@ namespace Elastic.Markdown.Tests.Directives;
 
 /// <summary>
 /// Tests for the :dropdowns: parameter on the changelog directive.
-/// By default (omitted), separated types (breaking changes, deprecations, known issues, highlights) 
-/// are rendered as flattened bulleted lists.
-/// With :dropdowns:, they render as Myst dropdown sections.
+/// By default (omitted), separated types (breaking changes, deprecations, known issues, highlights)
+/// are rendered as flattened bulleted lists; Features stay flat bullets.
+/// With :dropdowns:, those types and Features render as Myst dropdown sections.
 /// </summary>
 public class ChangelogDropdownsDefaultTests : DirectiveTest<ChangelogBlock>
 {
@@ -408,15 +408,12 @@ public class ChangelogDropdownsExplicitWithDifferentTypesTests : DirectiveTest<C
 	[Fact]
 	public void ExplicitDropdownsRendersMixedTypesCorrectly()
 	{
-		// Regular types should still render as bulleted lists (unchanged behavior)
-		Html.Should().Contain("Feature addition."); // Regular feature type (in <li> tags)
-
-		// Separated types should render as dropdowns (explicit :dropdowns:)
 		Html.Should().Contain("<details class=\"dropdown\">");
+		Html.Should().Contain("Feature addition.");
 		Html.Should().Contain("Breaking API change.");
 		Html.Should().Contain("Known issue with search.");
 
-		// Should NOT contain flattened format for separated types (check they're in dropdown, not flat list)
+		Html.Should().NotContain("<li><p>Feature addition.");
 		Html.Should().NotContain("<li><p>Breaking API change.");
 		Html.Should().NotContain("<li><p>Known issue with search.");
 	}
@@ -466,5 +463,257 @@ public class ChangelogDropdownsPlainTextTitleTests : DirectiveTest<ChangelogBloc
 	{
 		Html.Should().Contain("The ElasticAgentVersion parameter is malformed.");
 		Html.Should().NotContain("`ElasticAgentVersion`");
+	}
+}
+
+public class ChangelogDropdownsDefaultFeaturesStayListTests : DirectiveTest<ChangelogBlock>
+{
+	public ChangelogDropdownsDefaultFeaturesStayListTests(ITestOutputHelper output) : base(
+			output,
+			"""
+		:::{changelog}
+		:description-visibility: keep-descriptions
+		:::
+		"""
+		) =>
+		FileSystem.AddFile(
+			"docs/changelog/bundles/9.3.0.yaml",
+			new MockFileData(
+				"""
+		products:
+		- product: elasticsearch
+		  target: 9.3.0
+		entries:
+		- title: Feature addition
+		  type: feature
+		  products:
+		  - product: elasticsearch
+		    target: 9.3.0
+		  description: FEATURE_FLAT_BODY
+		  prs:
+		  - "111111"
+		"""
+			)
+		);
+
+	[Fact]
+	public void FeaturesStayBulletsWithoutDropdownsOption()
+	{
+		Html.Should().NotContain("<details class=\"dropdown\">");
+		Html.Should().Contain("<li>");
+		Html.Should().Contain("Feature addition");
+		Html.Should().Contain("FEATURE_FLAT_BODY");
+	}
+}
+
+public class ChangelogDropdownsFeaturesNotEnhancementsTests : DirectiveTest<ChangelogBlock>
+{
+	public ChangelogDropdownsFeaturesNotEnhancementsTests(ITestOutputHelper output) : base(
+			output,
+			"""
+		:::{changelog}
+		:dropdowns:
+		:description-visibility: keep-feature-descriptions
+		:::
+		"""
+		) =>
+		FileSystem.AddFile(
+			"docs/changelog/bundles/9.3.0.yaml",
+			new MockFileData(
+				"""
+		products:
+		- product: elasticsearch
+		  target: 9.3.0
+		entries:
+		- title: Feature addition
+		  type: feature
+		  products:
+		  - product: elasticsearch
+		    target: 9.3.0
+		  description: FEATURE_DROPDOWN_BODY
+		  prs:
+		  - "111111"
+		- title: Faster existing query
+		  type: enhancement
+		  products:
+		  - product: elasticsearch
+		    target: 9.3.0
+		  description: ENHANCEMENT_LIST_BODY
+		  prs:
+		  - "222222"
+		"""
+			)
+		);
+
+	[Fact]
+	public void FeaturesRenderAsDropdowns()
+	{
+		Html.Should().Contain("<details class=\"dropdown\">");
+		Html.Should().Contain("Feature addition");
+		Html.Should().Contain("FEATURE_DROPDOWN_BODY");
+		Html.Should().NotContain("<li><p>Feature addition");
+	}
+
+	[Fact]
+	public void EnhancementsStayBullets()
+	{
+		Html.Should().Contain("Faster existing query");
+		Html.Should().NotContain("ENHANCEMENT_LIST_BODY");
+	}
+}
+
+public class ChangelogDropdownsFeaturesAutoHidesDescriptionTests : DirectiveTest<ChangelogBlock>
+{
+	public ChangelogDropdownsFeaturesAutoHidesDescriptionTests(ITestOutputHelper output) : base(
+			output,
+			"""
+		:::{changelog}
+		:dropdowns:
+		:::
+		"""
+		) =>
+		FileSystem.AddFile(
+			"docs/changelog/bundles/9.3.0.yaml",
+			new MockFileData(
+				"""
+		products:
+		- product: elasticsearch
+		  target: 9.3.0
+		entries:
+		- title: Feature addition
+		  type: feature
+		  products:
+		  - product: elasticsearch
+		    target: 9.3.0
+		  description: FEATURE_AUTO_HIDDEN_BODY
+		  prs:
+		  - "111111"
+		"""
+			)
+		);
+
+	[Fact]
+	public void RendersFeatureDropdownWithoutDescription()
+	{
+		Html.Should().Contain("<details class=\"dropdown\">");
+		Html.Should().Contain("Feature addition");
+		Html.Should().Contain("#111111");
+		Html.Should().NotContain("FEATURE_AUTO_HIDDEN_BODY");
+	}
+}
+
+public class ChangelogDropdownsWithoutSubsectionsOmitsAreaHeadersTests : DirectiveTest<ChangelogBlock>
+{
+	public ChangelogDropdownsWithoutSubsectionsOmitsAreaHeadersTests(ITestOutputHelper output) : base(
+			output,
+			"""
+		:::{changelog}
+		:dropdowns:
+		:description-visibility: keep-feature-descriptions
+		:::
+		"""
+		) =>
+		FileSystem.AddFile(
+			"docs/changelog/bundles/9.3.0.yaml",
+			new MockFileData(
+				"""
+		products:
+		- product: elasticsearch
+		  target: 9.3.0
+		entries:
+		- title: Feature in Search
+		  type: feature
+		  products:
+		  - product: elasticsearch
+		    target: 9.3.0
+		  areas:
+		  - Search
+		  description: Search feature body
+		  prs:
+		  - "111111"
+		- title: Feature in Indexing
+		  type: feature
+		  products:
+		  - product: elasticsearch
+		    target: 9.3.0
+		  areas:
+		  - Indexing
+		  description: Indexing feature body
+		  prs:
+		  - "222222"
+		"""
+			)
+		);
+
+	[Fact]
+	public void RendersDropdowns() => Html.Should().Contain("<details class=\"dropdown\">");
+
+	[Fact]
+	public void OmitsAreaHeaders()
+	{
+		Html.Should().NotContain("<strong>Search</strong>");
+		Html.Should().NotContain("<strong>Indexing</strong>");
+	}
+
+	[Fact]
+	public void StillRendersFeatureTitles()
+	{
+		Html.Should().Contain("Feature in Search");
+		Html.Should().Contain("Feature in Indexing");
+	}
+}
+
+public class ChangelogDropdownsWithSubsectionsRendersAreaHeadersTests : DirectiveTest<ChangelogBlock>
+{
+	public ChangelogDropdownsWithSubsectionsRendersAreaHeadersTests(ITestOutputHelper output) : base(
+			output,
+			"""
+		:::{changelog}
+		:dropdowns:
+		:subsections:
+		:description-visibility: keep-feature-descriptions
+		:::
+		"""
+		) =>
+		FileSystem.AddFile(
+			"docs/changelog/bundles/9.3.0.yaml",
+			new MockFileData(
+				"""
+		products:
+		- product: elasticsearch
+		  target: 9.3.0
+		entries:
+		- title: Feature in Search
+		  type: feature
+		  products:
+		  - product: elasticsearch
+		    target: 9.3.0
+		  areas:
+		  - Search
+		  description: Search feature body
+		  prs:
+		  - "111111"
+		- title: Feature in Indexing
+		  type: feature
+		  products:
+		  - product: elasticsearch
+		    target: 9.3.0
+		  areas:
+		  - Indexing
+		  description: Indexing feature body
+		  prs:
+		  - "222222"
+		"""
+			)
+		);
+
+	[Fact]
+	public void RendersDropdowns() => Html.Should().Contain("<details class=\"dropdown\">");
+
+	[Fact]
+	public void RendersAreaHeaders()
+	{
+		Html.Should().Contain("<strong>Search</strong>");
+		Html.Should().Contain("<strong>Indexing</strong>");
 	}
 }

--- a/tests/Elastic.Markdown.Tests/Directives/ChangelogFeatureEnhancementSectionTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/ChangelogFeatureEnhancementSectionTests.cs
@@ -1,0 +1,145 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions.TestingHelpers;
+using AwesomeAssertions;
+using Elastic.Markdown.Myst.Directives.Changelog;
+
+namespace Elastic.Markdown.Tests.Directives;
+
+public class ChangelogFeatureAndEnhancementSectionsTests(ITestOutputHelper output) : DirectiveTest<ChangelogBlock>(
+	output,
+	"""
+	:::{changelog}
+	:::
+	"""
+)
+{
+	protected override void AddToFileSystem(MockFileSystem fileSystem) =>
+		fileSystem.AddFile(
+			"docs/changelog/bundles/9.3.0.yaml",
+			new MockFileData(
+				"""
+			products:
+			- product: elasticsearch
+			  target: 9.3.0
+			entries:
+			- title: Brand new capability
+			  type: feature
+			  products:
+			  - product: elasticsearch
+			    target: 9.3.0
+			- title: Improved existing capability
+			  type: enhancement
+			  products:
+			  - product: elasticsearch
+			    target: 9.3.0
+			- title: Bug fix
+			  type: bug-fix
+			  products:
+			  - product: elasticsearch
+			    target: 9.3.0
+			"""
+			)
+		);
+
+	[Fact]
+	public void RendersSeparateFeaturesHeading() => Html.Should().Contain(">Features<");
+
+	[Fact]
+	public void RendersSeparateEnhancementsHeading() => Html.Should().Contain(">Enhancements<");
+
+	[Fact]
+	public void OmitsCombinedHeading() => Html.Should().NotContain("Features and enhancements");
+
+	[Fact]
+	public void FeaturesAppearBeforeEnhancements()
+	{
+		var featuresIdx = Html.IndexOf(">Features<", StringComparison.Ordinal);
+		var enhancementsIdx = Html.IndexOf(">Enhancements<", StringComparison.Ordinal);
+		featuresIdx.Should().BeLessThan(enhancementsIdx);
+	}
+
+	[Fact]
+	public void TocIncludesBothSections()
+	{
+		var toc = Block!.GeneratedTableOfContent.ToList();
+		toc.Should().Contain(t => t.Heading == "Features" && t.Slug.EndsWith("-features"));
+		toc.Should().Contain(t => t.Heading == "Enhancements" && t.Slug.EndsWith("-enhancements"));
+	}
+}
+
+public class ChangelogEnhancementsOnlyOmitsFeaturesSectionTests(ITestOutputHelper output) : DirectiveTest<ChangelogBlock>(
+	output,
+	"""
+	:::{changelog}
+	:::
+	"""
+)
+{
+	protected override void AddToFileSystem(MockFileSystem fileSystem) =>
+		fileSystem.AddFile(
+			"docs/changelog/bundles/9.3.6.yaml",
+			new MockFileData(
+				"""
+			products:
+			- product: elasticsearch
+			  target: 9.3.6
+			entries:
+			- title: Faster existing query
+			  type: enhancement
+			  products:
+			  - product: elasticsearch
+			    target: 9.3.6
+			"""
+			)
+		);
+
+	[Fact]
+	public void RendersEnhancements() => Html.Should().Contain(">Enhancements<");
+
+	[Fact]
+	public void OmitsEmptyFeaturesSection() => Html.Should().NotContain(">Features<");
+
+	[Fact]
+	public void TocOmitsFeatures()
+	{
+		var toc = Block!.GeneratedTableOfContent.ToList();
+		toc.Should().NotContain(t => t.Heading == "Features");
+		toc.Should().Contain(t => t.Heading == "Enhancements");
+	}
+}
+
+public class ChangelogFeaturesOnlyOmitsEnhancementsSectionTests(ITestOutputHelper output) : DirectiveTest<ChangelogBlock>(
+	output,
+	"""
+	:::{changelog}
+	:::
+	"""
+)
+{
+	protected override void AddToFileSystem(MockFileSystem fileSystem) =>
+		fileSystem.AddFile(
+			"docs/changelog/bundles/9.4.0.yaml",
+			new MockFileData(
+				"""
+			products:
+			- product: elasticsearch
+			  target: 9.4.0
+			entries:
+			- title: Entirely new API
+			  type: feature
+			  products:
+			  - product: elasticsearch
+			    target: 9.4.0
+			"""
+			)
+		);
+
+	[Fact]
+	public void RendersFeatures() => Html.Should().Contain(">Features<");
+
+	[Fact]
+	public void OmitsEmptyEnhancementsSection() => Html.Should().NotContain(">Enhancements<");
+}

--- a/tests/Elastic.Markdown.Tests/Directives/ChangelogHideLinksTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/ChangelogHideLinksTests.cs
@@ -453,7 +453,7 @@ public class ChangelogLinksWithMergedBundlesTests : DirectiveTest<ChangelogBlock
 	{
 		var section = Block!.GeneratedTableOfContent.Single(t => t.Level == 3);
 
-		section.Slug.Should().Be("elasticsearchkibana-2025-08-05-features-enhancements");
+		section.Slug.Should().Be("elasticsearchkibana-2025-08-05-features");
 		Html.Should().Contain($"id=\"{section.Slug}\"");
 	}
 

--- a/tests/Elastic.Markdown.Tests/Directives/ChangelogHighlightsOptionTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/ChangelogHighlightsOptionTests.cs
@@ -78,7 +78,7 @@ public class ChangelogHighlightsOptionDefaultOffTests : DirectiveTest<ChangelogB
 	[Fact]
 	public void StillRendersHighlightedEntryUnderTypeSection()
 	{
-		Html.Should().Contain("Features and enhancements");
+		Html.Should().Contain("Features");
 		Html.Should().Contain("Highlighted feature");
 		Html.Should().Contain("Regular feature");
 		Html.Should().Contain("Fixes");
@@ -118,7 +118,7 @@ public class ChangelogHighlightsOptionEnabledTests : DirectiveTest<ChangelogBloc
 	[Fact]
 	public void DuplicatesHighlightedEntryInTypeSection()
 	{
-		Html.Should().Contain("Features and enhancements");
+		Html.Should().Contain("Features");
 		Html.Should().Contain("Highlighted feature");
 		Html.Should().Contain("Regular feature");
 	}
@@ -157,7 +157,7 @@ public class ChangelogHighlightsOptionWithTypeAllTests : DirectiveTest<Changelog
 	{
 		Html.Should().Contain("Highlights");
 		Html.Should().Contain("Breaking changes");
-		Html.Should().Contain("Features and enhancements");
+		Html.Should().Contain("Features");
 	}
 }
 
@@ -218,7 +218,7 @@ public class ChangelogHighlightsLegacyTypeHighlightTests : DirectiveTest<Changel
 	[Fact]
 	public void RendersDefaultTypeSectionsNotHighlightsOnly()
 	{
-		Html.Should().Contain("Features and enhancements");
+		Html.Should().Contain("Features");
 		Html.Should().Contain("Highlighted feature");
 		Html.Should().NotContain("id=\"elasticsearch-9.3.0-highlights\"");
 	}
@@ -300,7 +300,7 @@ public class ChangelogKeepHighlightDescriptionsTests : DirectiveTest<ChangelogBl
 	[Fact]
 	public void StillRendersTitlesInTypeSections()
 	{
-		Html.Should().Contain("Features and enhancements");
+		Html.Should().Contain("Features");
 		Html.Should().Contain("Highlighted feature");
 		Html.Should().Contain("Regular feature");
 	}

--- a/tests/Elastic.Markdown.Tests/Directives/ChangelogTocFilteringTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/ChangelogTocFilteringTests.cs
@@ -94,7 +94,7 @@ public class ChangelogPublishBlockerFiltersTocTests : DirectiveTest<ChangelogBlo
 	public void TocIncludesFeaturesSection()
 	{
 		var tocItems = Block!.GeneratedTableOfContent.ToList();
-		tocItems.Should().Contain(t => t.Heading == "Features and enhancements");
+		tocItems.Should().Contain(t => t.Heading == "Features");
 	}
 
 	[Fact]
@@ -123,7 +123,7 @@ public class ChangelogPublishBlockerFiltersTocTests : DirectiveTest<ChangelogBlo
 	{
 		Html.Should().Contain("Documentation");
 		Html.Should().Contain("Other changes");
-		Html.Should().Contain("Features and enhancements");
+		Html.Should().Contain("Features");
 	}
 }
 
@@ -193,7 +193,7 @@ public class ChangelogHideFeaturesFiltersTocTests : DirectiveTest<ChangelogBlock
 	public void TocRetainsVisibleFeaturesSection()
 	{
 		var tocItems = Block!.GeneratedTableOfContent.ToList();
-		tocItems.Should().Contain(t => t.Heading == "Features and enhancements");
+		tocItems.Should().Contain(t => t.Heading == "Features");
 	}
 
 	[Fact]
@@ -207,7 +207,7 @@ public class ChangelogHideFeaturesFiltersTocTests : DirectiveTest<ChangelogBlock
 	public void AnchorsRetainVisibleFeaturesSection()
 	{
 		var anchors = Block!.GeneratedAnchors.ToList();
-		anchors.Should().Contain(a => a.Contains("features-enhancements"));
+		anchors.Should().Contain(a => a.Contains("features"));
 	}
 
 	[Fact]
@@ -215,7 +215,7 @@ public class ChangelogHideFeaturesFiltersTocTests : DirectiveTest<ChangelogBlock
 	{
 		Html.Should().NotContain("Other changes");
 		Html.Should().NotContain("Hidden other change");
-		Html.Should().Contain("Features and enhancements");
+		Html.Should().Contain("Features");
 		Html.Should().Contain("Visible feature");
 	}
 }
@@ -371,7 +371,7 @@ public class ChangelogCombinedFiltersFilterTocTests : DirectiveTest<ChangelogBlo
 	public void TocRetainsUnfilteredSection()
 	{
 		var tocItems = Block!.GeneratedTableOfContent.ToList();
-		tocItems.Should().Contain(t => t.Heading == "Features and enhancements");
+		tocItems.Should().Contain(t => t.Heading == "Features");
 	}
 
 	[Fact]
@@ -385,7 +385,7 @@ public class ChangelogCombinedFiltersFilterTocTests : DirectiveTest<ChangelogBlo
 	[Fact]
 	public void HtmlMatchesTocAndAnchors()
 	{
-		Html.Should().Contain("Features and enhancements");
+		Html.Should().Contain("Features");
 		Html.Should().Contain("Visible feature");
 		Html.Should().Contain("Documentation");
 		Html.Should().Contain("Docs entry blocked by type");
@@ -483,7 +483,7 @@ public class ChangelogPublishBlockerAreaFiltersTocTests : DirectiveTest<Changelo
 	public void TocIncludesFeaturesSection()
 	{
 		var tocItems = Block!.GeneratedTableOfContent.ToList();
-		tocItems.Should().Contain(t => t.Heading == "Features and enhancements");
+		tocItems.Should().Contain(t => t.Heading == "Features");
 	}
 
 	[Fact]
@@ -492,7 +492,7 @@ public class ChangelogPublishBlockerAreaFiltersTocTests : DirectiveTest<Changelo
 		var anchors = Block!.GeneratedAnchors.ToList();
 		anchors.Should().Contain(a => a.Contains("-docs"));
 		anchors.Should().Contain(a => a.EndsWith("-other"));
-		anchors.Should().Contain(a => a.Contains("features-enhancements"));
+		anchors.Should().Contain(a => a.Contains("features"));
 	}
 }
 
@@ -658,7 +658,7 @@ public class ChangelogMultipleBundlesTocFilteringTests : DirectiveTest<Changelog
 	public void FirstVersionRetainsFeaturesInToc()
 	{
 		var tocItems = Block!.GeneratedTableOfContent.ToList();
-		tocItems.Should().Contain(t => t.Heading == "Features and enhancements");
+		tocItems.Should().Contain(t => t.Heading == "Features");
 	}
 
 	[Fact]

--- a/tests/Elastic.Markdown.Tests/Directives/ChangelogTypeFilterTests.cs
+++ b/tests/Elastic.Markdown.Tests/Directives/ChangelogTypeFilterTests.cs
@@ -89,7 +89,7 @@ public class ChangelogTypeFilterDefaultTests : DirectiveTest<ChangelogBlock>
 	[Fact]
 	public void DefaultBehaviorShowsFeatures()
 	{
-		Html.Should().Contain("Features and enhancements");
+		Html.Should().Contain("Features");
 		Html.Should().Contain("New feature");
 	}
 
@@ -199,7 +199,7 @@ public class ChangelogTypeFilterAllTests : DirectiveTest<ChangelogBlock>
 	[Fact]
 	public void ShowsAllEntryTypes()
 	{
-		Html.Should().Contain("Features and enhancements");
+		Html.Should().Contain("Features");
 		Html.Should().Contain("New feature");
 		Html.Should().Contain(">Fixes<");
 		Html.Should().Contain("Bug fix");
@@ -303,7 +303,7 @@ public class ChangelogTypeFilterBreakingChangeTests : DirectiveTest<ChangelogBlo
 	[Fact]
 	public void ExcludesOtherTypes()
 	{
-		Html.Should().NotContain("Features and enhancements");
+		Html.Should().NotContain("Features");
 		Html.Should().NotContain("New feature");
 		Html.Should().NotContain("Known issues");
 		Html.Should().NotContain("Known issue");
@@ -379,7 +379,7 @@ public class ChangelogTypeFilterDeprecationTests : DirectiveTest<ChangelogBlock>
 	[Fact]
 	public void ExcludesOtherTypes()
 	{
-		Html.Should().NotContain("Features and enhancements");
+		Html.Should().NotContain("Features");
 		Html.Should().NotContain("New feature");
 	}
 }
@@ -453,7 +453,7 @@ public class ChangelogTypeFilterKnownIssueTests : DirectiveTest<ChangelogBlock>
 	[Fact]
 	public void ExcludesOtherTypes()
 	{
-		Html.Should().NotContain("Features and enhancements");
+		Html.Should().NotContain("Features");
 		Html.Should().NotContain("New feature");
 	}
 }
@@ -511,7 +511,7 @@ public class ChangelogTypeFilterInvalidTests : DirectiveTest<ChangelogBlock>
 	[Fact]
 	public void DefaultBehaviorIsApplied()
 	{
-		Html.Should().Contain("Features and enhancements");
+		Html.Should().Contain("Features");
 		Html.Should().Contain("New feature");
 		Html.Should().NotContain("Breaking changes");
 	}
@@ -567,7 +567,7 @@ public class ChangelogTypeFilterCaseInsensitiveTests : DirectiveTest<ChangelogBl
 	[Fact]
 	public void ShowsAllTypes()
 	{
-		Html.Should().Contain("Features and enhancements");
+		Html.Should().Contain("Features");
 		Html.Should().Contain("Breaking changes");
 	}
 }
@@ -638,7 +638,7 @@ public class ChangelogTypeFilterWithSubsectionsTests : DirectiveTest<ChangelogBl
 	[Fact]
 	public void ShowsAllTypesWithSubsections()
 	{
-		Html.Should().Contain("Features and enhancements");
+		Html.Should().Contain("Features");
 		Html.Should().Contain("Search feature");
 		Html.Should().Contain("Indexing feature");
 		Html.Should().Contain("Breaking changes");
@@ -695,7 +695,7 @@ public class ChangelogTypeFilterGeneratedAnchorsTests : DirectiveTest<ChangelogB
 		var anchors = Block!.GeneratedAnchors.ToList();
 
 		anchors.Should().NotContain(a => a.Contains("breaking-changes"));
-		anchors.Should().NotContain(a => a.Contains("features-enhancements"));
+		anchors.Should().NotContain(a => a.Contains("features"));
 	}
 }
 
@@ -750,7 +750,7 @@ public class ChangelogTypeFilterTableOfContentsTests : DirectiveTest<ChangelogBl
 
 		tocItems.Should().NotContain(t => t.Heading == "Deprecations");
 		tocItems.Should().Contain(t => t.Heading == "9.3.0" && t.Level == 2);
-		tocItems.Should().NotContain(t => t.Heading == "Features and enhancements");
+		tocItems.Should().NotContain(t => t.Heading == "Features");
 	}
 }
 


### PR DESCRIPTION
## Summary

Instead of the current "Features and enhancements" section that is created in the `changelog render` command output and the changelog directive, this PR generates separate "Features" and "Enhancements" sections.

Similar to the handling of the "Highlights" section, there's an option in the changelog directive to show each changelog's description too.

## Details

`feature` and `enhancement` now render as separate **Features** and **Enhancements** sections. Empty sections are still omitted, so a patch release with only enhancements will not show a Features heading.

`:description-visibility:` accepts comma-separated tokens, including `keep-feature-descriptions`. You can combine overlays:

```markdown
:description-visibility: keep-feature-descriptions, keep-highlight-descriptions
```

Deep links that used `-features-enhancements` need to move to `-features` / `-enhancements`. That is documented in `docs/syntax/changelog.md`.

With `:dropdowns:` set, "Features" uses the same `{dropdown}` rendering as "Highlights". Without that option, "Features" stay flat bullets. "Enhancements" and the other list sections are unchanged.

Area headers show only when `:subsections:` is also set. That applies to "Features", "Highlights", and the other dropdown sections (breaking changes still group by subtype).

## Tests

When I change the Cloud Serverless release notes to use this new option:

```md
:::{changelog}
:cdn: cloud-serverless
:highlights:
:description-visibility:  keep-highlight-descriptions, keep-feature-descriptions
:link-visibility: keep-links
:::
```

... it renders like this:

<img width="1730" height="1109" alt="image" src="https://github.com/user-attachments/assets/76e22578-217e-425e-aecc-196d9a8a32b2" />

If I drop the `keep-feature-descriptions` clause from the directive, it looks like this:

<img width="1739" height="905" alt="image" src="https://github.com/user-attachments/assets/568b4165-0a11-442a-bd45-5466d2ee8410" />

If I add the `:dropdowns:` clause, it looks like this:

<img width="1694" height="1127" alt="image" src="https://github.com/user-attachments/assets/0edfdaac-b1a2-411d-8157-0390ecbe7017" />

If I also add the `:subsections:` clause, that works too:

<img width="1706" height="933" alt="image" src="https://github.com/user-attachments/assets/0c43af41-6b79-4959-8da4-32b8884efebe" />


## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: Cursor Grok 4.6
