### PR TITLE
[DOCS] Update links to changelog types and subtypes

### DIFF
--- a/docs/cli/changelog/cmd-note.md
+++ b/docs/cli/changelog/cmd-note.md
@@ -17,7 +17,7 @@ Files are named `note-{slug}.yml`. Each product lists `products[].versions` — 
   A short, user-facing headline (max 80 characters). Required.
 
 : `--type`
-  The type of change. For valid values, see [ChangelogEntryType.cs](https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ChangelogEntryType.cs). Required.
+  The type of change. For valid values, see [ChangelogEntryType.cs](https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ReleaseNotes/ChangelogEntryType.cs). Required.
 
 : `--description`
   Additional information (max 600 characters). Optional.

--- a/docs/data/release-notes/_snippets/changelog-fields.md
+++ b/docs/data/release-notes/_snippets/changelog-fields.md
@@ -9,7 +9,7 @@ title:
 type: 
 
 # A required string that contains the type of change.
-# For the acceptable values, refer to https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ChangelogEntryType.cs
+# For the acceptable values, refer to https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ReleaseNotes/ChangelogEntryType.cs
 products:
 
 # A required array of objects that denote the affected products.
@@ -77,5 +77,5 @@ prs:
 subtype:
 
 # An optional string that applies only to breaking changes and further subdivides that type.
-# For the acceptable values, refer to https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ChangelogEntrySubtype.cs
+# For the acceptable values, refer to https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ReleaseNotes/ChangelogEntrySubtype.cs
 ```

--- a/docs/data/release-notes/configure-ref.md
+++ b/docs/data/release-notes/configure-ref.md
@@ -264,7 +264,7 @@ Also controls how the `changelog add` command maps GitHub labels to various chan
 :::
 
 :::{note}
-Type and subtype values must match the available values defined in [ChangelogEntryType.cs](https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ChangelogEntryType.cs) and [ChangelogEntrySubtype.cs](https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ChangelogEntrySubtype.cs).
+Type and subtype values must match the available values defined in [ChangelogEntryType.cs](https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ReleaseNotes/ChangelogEntryType.cs) and [ChangelogEntrySubtype.cs](https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ReleaseNotes/ChangelogEntrySubtype.cs).
 :::
 
 The following example demonstrates some GitHub label mappings in the `pivot` section of the changelog configuration file:

--- a/docs/data/release-notes/configure.md
+++ b/docs/data/release-notes/configure.md
@@ -9,7 +9,7 @@ You can then set up a changelog configuration file to make the content workflow 
 
 1. Optional: Choose the GitHub labels that you'll use to automatically derive some changelog fields.
 
-    1. Create labels for _types_. The supported types are defined in [ChangelogEntryType.cs](https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ChangelogEntryType.cs). At a minimum, add labels for the `feature`, `bug-fix`, and `breaking-change` types.
+    1. Create labels for _types_. The supported types are defined in [ChangelogEntryType.cs](https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ReleaseNotes/ChangelogEntryType.cs). At a minimum, add labels for the `feature`, `bug-fix`, and `breaking-change` types.
 
     1. Create labels for _products_. If your repo only pertains to a single product or you don't want to use labels to accomplish this classification, this step is not required.
 

--- a/docs/data/release-notes/create.md
+++ b/docs/data/release-notes/create.md
@@ -108,7 +108,7 @@ For content guidelines, go to [Changelogs](https://www.elastic.co/docs/contribut
 Some of the fields in the schema accept only a specific set of values:
 
 - Product values must exist in [products.yml](https://github.com/elastic/docs-builder/blob/main/config/products.yml).
-- Type, subtype, and lifecycle values must match the available values defined in [ChangelogEntryType.cs](https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ChangelogEntryType.cs), [ChangelogEntrySubtype.cs](https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ChangelogEntrySubtype.cs), and [Lifecycle.cs](https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/Lifecycle.cs) respectively.
+- Type, subtype, and lifecycle values must match the available values defined in [ChangelogEntryType.cs](https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ReleaseNotes/ChangelogEntryType.cs), [ChangelogEntrySubtype.cs](https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ReleaseNotes/ChangelogEntrySubtype.cs), and [Lifecycle.cs](https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/Lifecycle.cs) respectively.
 
 You can further limit the possible values with the [products](/data/release-notes/configure-ref.md#products) and [lifecycles](/data/release-notes/configure-ref.md#lifecycles) options in the changelog configuration file.
 :::


### PR DESCRIPTION
This PR fixes some links to the changelog type and subtype definitions, since at some point they moved to a new `ReleaseNotes` subdirectory.