### PR TITLE
Footer: put privacy choices after the trademark copy

### DIFF
--- a/config/assembler.yml
+++ b/config/assembler.yml
@@ -25,7 +25,6 @@ environments:
       ASSEMBLER_API_EXPLORER: true
       NAVIGATION_PREVIEW: false
       PAGE_FEEDBACK: true
-      PRIVACY_CONSENT: true
     website_search_url: https://staging-website.elastic.co/search/elastic-website-search.js
   edge:
     uri: https://d34ipnu52o64md.cloudfront.net

--- a/src/Elastic.Documentation.Configuration/Builder/FeatureFlags.cs
+++ b/src/Elastic.Documentation.Configuration/Builder/FeatureFlags.cs
@@ -44,8 +44,6 @@ public class FeatureFlags(Dictionary<string, bool> initFeatureFlags)
 
 	public bool PageFeedbackEnabled { get => IsEnabled("page-feedback"); set => _featureFlags["page-feedback"] = value; }
 
-	public bool PrivacyConsentEnabled { get => IsEnabled("privacy-consent"); set => _featureFlags["privacy-consent"] = value; }
-
 	private bool IsEnabled(string key)
 	{
 		var envKey = $"FEATURE_{key.ToUpperInvariant().Replace('-', '_')}";

--- a/src/Elastic.Documentation.Site/Layout/_AssemblerFooter.cshtml
+++ b/src/Elastic.Documentation.Site/Layout/_AssemblerFooter.cshtml
@@ -22,23 +22,6 @@
 				<li>
 					<a class="underline hover:text-white" href="https://www.elastic.co/sitemap">Sitemap</a>
 				</li>
-				@if (Model.Features.PrivacyConsentEnabled)
-				{
-					<li>
-						<a class="underline hover:text-white iubenda-cs-uspr-link" href="#">Notice at Collection</a>
-					</li>
-					<li>
-						<a class="underline hover:text-white iubenda-cs-preferences-link inline-flex items-center" href="#">
-							<svg class="w-8 mr-1.5" width="30" height="14" viewBox="0 0 30 14" aria-hidden="true" focusable="false">
-								<path fill-rule="evenodd" fill="#FFFFFF" d="M7.4 12.8h6.8l3.1-11.6H7.4C4.2 1.2 1.6 3.8 1.6 7s2.6 5.8 5.8 5.8z"/>
-								<path fill-rule="evenodd" fill="#0066FF" d="M22.6 0H7.4a7 7 0 0 0 0 14h15.2a7 7 0 0 0 0-14zM1.6 7A5.8 5.8 0 0 1 7.4 1.2h9.9L14.2 12.8H7.4A5.8 5.8 0 0 1 1.6 7z"/>
-								<path fill="#FFFFFF" d="M24.6 4a.55.55 0 0 1 0 .8L22.5 7l2.2 2.2a.55.55 0 0 1-.8.8L21.7 7.8 19.5 10a.55.55 0 0 1-.8-.8L20.8 7l-2.2-2.2a.55.55 0 0 1 .8-.8l2.2 2.2L23.8 4a.55.55 0 0 1 .8 0z"/>
-								<path fill="#0066FF" d="M12.7 4.1a.55.55 0 0 1 .1.8L8.6 9.8a.55.55 0 0 1-.7-.1L5.4 7.7a.55.55 0 0 1 .8-.8L8 8.6l3.8-4.5a.55.55 0 0 1 .9 0z"/>
-							</svg>
-							Your Privacy Choices
-						</a>
-					</li>
-				}
 			</ul>
 			<p class="mt-4">
 				© @(DateTime.Today.Year) Elasticsearch B.V. All Rights Reserved.
@@ -50,6 +33,19 @@
 			</p>
 			<p class="mt-4">
 				Elasticsearch is a trademark of Elasticsearch B.V., registered in the U.S. and in other countries. Apache, Apache Lucene, Apache Hadoop, Hadoop, HDFS and the yellow elephant logo are trademarks of the Apache Software Foundation in the United States and/or other countries.
+			</p>
+			<p class="mt-4">
+				<a class="underline hover:text-white iubenda-cs-uspr-link" href="#">Notice at Collection</a>
+				|
+				<a class="underline hover:text-white iubenda-cs-preferences-link inline-flex items-center" href="#">
+					Your Privacy Choices
+					<svg class="w-8 ml-1.5" width="30" height="14" viewBox="0 0 30 14" aria-hidden="true" focusable="false">
+						<path fill-rule="evenodd" fill="#FFFFFF" d="M7.4 12.8h6.8l3.1-11.6H7.4C4.2 1.2 1.6 3.8 1.6 7s2.6 5.8 5.8 5.8z"/>
+						<path fill-rule="evenodd" fill="#0066FF" d="M22.6 0H7.4a7 7 0 0 0 0 14h15.2a7 7 0 0 0 0-14zM1.6 7A5.8 5.8 0 0 1 7.4 1.2h9.9L14.2 12.8H7.4A5.8 5.8 0 0 1 1.6 7z"/>
+						<path fill="#FFFFFF" d="M24.6 4a.55.55 0 0 1 0 .8L22.5 7l2.2 2.2a.55.55 0 0 1-.8.8L21.7 7.8 19.5 10a.55.55 0 0 1-.8-.8L20.8 7l-2.2-2.2a.55.55 0 0 1 .8-.8l2.2 2.2L23.8 4a.55.55 0 0 1 .8 0z"/>
+						<path fill="#0066FF" d="M12.7 4.1a.55.55 0 0 1 .1.8L8.6 9.8a.55.55 0 0 1-.7-.1L5.4 7.7a.55.55 0 0 1 .8-.8L8 8.6l3.8-4.5a.55.55 0 0 1 .9 0z"/>
+					</svg>
+				</a>
 			</p>
 		</div>
 	</div>

--- a/tests/Elastic.Documentation.Build.Tests/FeatureFlagsTests.cs
+++ b/tests/Elastic.Documentation.Build.Tests/FeatureFlagsTests.cs
@@ -82,45 +82,4 @@ public class FeatureFlagsTests
 			features.Set(key, value);
 		features.AssemblerApiExplorerEnabled.Should().BeFalse();
 	}
-
-	[Fact]
-	public void PrivacyConsentEnabled_DefaultsToFalse()
-	{
-		var flags = new FeatureFlags([]);
-
-		flags.PrivacyConsentEnabled.Should().BeFalse();
-	}
-
-	[Fact]
-	public void StagingEnvironment_EnablesPrivacyConsent()
-	{
-		var config = AssemblyConfiguration.Create(
-			new ConfigurationFileProvider(new TestLoggerFactory(null), new ConfigurationFileSystem())
-		);
-		var environment = config.Environments["staging"];
-
-		environment.FeatureFlags.Should().ContainKey("PRIVACY_CONSENT").WhoseValue.Should().BeTrue();
-
-		var features = new FeatureFlags([]);
-		foreach (var (key, value) in environment.FeatureFlags)
-			features.Set(key, value);
-		features.PrivacyConsentEnabled.Should().BeTrue();
-		features.AssemblerApiExplorerEnabled.Should().BeTrue();
-	}
-
-	[Fact]
-	public void ProdEnvironment_DoesNotEnablePrivacyConsent()
-	{
-		var config = AssemblyConfiguration.Create(
-			new ConfigurationFileProvider(new TestLoggerFactory(null), new ConfigurationFileSystem())
-		);
-		var prod = config.Environments["prod"];
-
-		prod.FeatureFlags.Should().NotContainKey("PRIVACY_CONSENT");
-
-		var features = new FeatureFlags([]);
-		foreach (var (key, value) in prod.FeatureFlags)
-			features.Set(key, value);
-		features.PrivacyConsentEnabled.Should().BeFalse();
-	}
 }

--- a/tests/Elastic.Documentation.Configuration.Tests/UseNavigationPreviewTests.cs
+++ b/tests/Elastic.Documentation.Configuration.Tests/UseNavigationPreviewTests.cs
@@ -100,7 +100,6 @@ public class UseNavigationPreviewTests
 		flags.WebsiteSearchEnabled.Should().BeFalse();
 		flags.AirGappedEnabled.Should().BeFalse();
 		flags.PrimaryNavEnabled.Should().BeFalse();
-		flags.PrivacyConsentEnabled.Should().BeFalse();
 	}
 
 	[Fact]

--- a/tests/Navigation.Tests/Rendering/FooterRenderingTests.cs
+++ b/tests/Navigation.Tests/Rendering/FooterRenderingTests.cs
@@ -18,29 +18,30 @@ namespace Elastic.Documentation.Navigation.Tests.Rendering;
 public class FooterRenderingTests(ITestOutputHelper output) : DocumentationSetNavigationTestBase(output)
 {
 	[Fact]
-	public async Task AssemblerFooter_FlagOff_OmitsIubendaPrivacyChoiceLinks()
+	public async Task AssemblerFooter_RendersIubendaLinksAfterTrademarkCopy()
 	{
-		var html = await RenderAssemblerFooter(privacyConsentEnabled: false);
-
-		html.Should().Contain("privacy-statement");
-		html.Should().NotContain("iubenda-cs-uspr-link");
-		html.Should().NotContain("Notice at Collection");
-		html.Should().NotContain("iubenda-cs-preferences-link");
-		html.Should().NotContain("Your Privacy Choices");
-	}
-
-	[Fact]
-	public async Task AssemblerFooter_FlagOn_RendersIubendaPrivacyChoiceLinks()
-	{
-		var html = await RenderAssemblerFooter(privacyConsentEnabled: true);
+		var html = await RenderAssemblerFooter();
 
 		html.Should().Contain("iubenda-cs-uspr-link");
 		html.Should().Contain("Notice at Collection");
 		html.Should().Contain("iubenda-cs-preferences-link");
 		html.Should().Contain("Your Privacy Choices");
+		html.Should().Contain("privacy-statement");
+
+		html
+			.IndexOf("Elasticsearch is a trademark", StringComparison.Ordinal)
+			.Should()
+			.BeLessThan(html.IndexOf("Notice at Collection", StringComparison.Ordinal));
+		html.IndexOf("</ul>", StringComparison.Ordinal).Should().BeLessThan(html.IndexOf("Notice at Collection", StringComparison.Ordinal));
+
+		var preferences = html.IndexOf("iubenda-cs-preferences-link", StringComparison.Ordinal);
+		var choices = html.IndexOf("Your Privacy Choices", preferences, StringComparison.Ordinal);
+		var svg = html.IndexOf("<svg", preferences, StringComparison.Ordinal);
+		choices.Should().BeGreaterThan(-1);
+		svg.Should().BeGreaterThan(choices);
 	}
 
-	private async Task<string> RenderAssemblerFooter(bool privacyConsentEnabled)
+	private async Task<string> RenderAssemblerFooter()
 	{
 		var fileSystem = new MockFileSystem();
 		fileSystem.AddDirectory("/docs");
@@ -58,7 +59,7 @@ public class FooterRenderingTests(ITestOutputHelper output) : DocumentationSetNa
 			UrlPathPrefix = "/docs",
 			CanonicalBaseUrl = null,
 			AllowIndexing = false,
-			Features = new FeatureFlags(privacyConsentEnabled ? new Dictionary<string, bool> { ["privacy-consent"] = true } : []),
+			Features = new FeatureFlags([]),
 			GoogleTagManager = new GoogleTagManagerConfiguration(),
 			Optimizely = new OptimizelyConfiguration(),
 			StaticFileContentHashProvider = new StaticFileContentHashProvider(new EmbeddedOrPhysicalFileProvider(context)),

--- a/tests/Navigation.Tests/Rendering/FooterRenderingTests.cs
+++ b/tests/Navigation.Tests/Rendering/FooterRenderingTests.cs
@@ -27,11 +27,13 @@ public class FooterRenderingTests(ITestOutputHelper output) : DocumentationSetNa
 		html.Should().Contain("iubenda-cs-preferences-link");
 		html.Should().Contain("Your Privacy Choices");
 		html.Should().Contain("privacy-statement");
+		html.Should().Contain("Elasticsearch is a trademark");
 
-		html
-			.IndexOf("Elasticsearch is a trademark", StringComparison.Ordinal)
-			.Should()
-			.BeLessThan(html.IndexOf("Notice at Collection", StringComparison.Ordinal));
+		var trademark = html.IndexOf("Elasticsearch is a trademark", StringComparison.Ordinal);
+		var notice = html.IndexOf("Notice at Collection", StringComparison.Ordinal);
+		trademark.Should().BeGreaterThan(-1);
+		notice.Should().BeGreaterThan(-1);
+		trademark.Should().BeLessThan(notice);
 		html.IndexOf("</ul>", StringComparison.Ordinal).Should().BeLessThan(html.IndexOf("Notice at Collection", StringComparison.Ordinal));
 
 		var preferences = html.IndexOf("iubenda-cs-preferences-link", StringComparison.Ordinal);

--- a/tests/Navigation.Tests/Rendering/FooterRenderingTests.cs
+++ b/tests/Navigation.Tests/Rendering/FooterRenderingTests.cs
@@ -37,10 +37,16 @@ public class FooterRenderingTests(ITestOutputHelper output) : DocumentationSetNa
 		html.IndexOf("</ul>", StringComparison.Ordinal).Should().BeLessThan(html.IndexOf("Notice at Collection", StringComparison.Ordinal));
 
 		var preferences = html.IndexOf("iubenda-cs-preferences-link", StringComparison.Ordinal);
-		var choices = html.IndexOf("Your Privacy Choices", preferences, StringComparison.Ordinal);
-		var svg = html.IndexOf("<svg", preferences, StringComparison.Ordinal);
-		choices.Should().BeGreaterThan(-1);
-		svg.Should().BeGreaterThan(choices);
+		preferences.Should().BeGreaterThan(-1);
+		var anchorEnd = html.IndexOf("</a>", preferences, StringComparison.Ordinal);
+		anchorEnd.Should().BeGreaterThan(preferences);
+		var preferencesLink = html[preferences..anchorEnd];
+		preferencesLink.Should().Contain("Your Privacy Choices");
+		preferencesLink.Should().Contain("<svg");
+		preferencesLink
+			.IndexOf("Your Privacy Choices", StringComparison.Ordinal)
+			.Should()
+			.BeLessThan(preferencesLink.IndexOf("<svg", StringComparison.Ordinal));
 	}
 
 	private async Task<string> RenderAssemblerFooter()


### PR DESCRIPTION
## Why

- The assembled /docs footer showed Notice at Collection and Your Privacy Choices in the left legal list.
- Production elastic.co puts those controls in the right-hand footnote, after the trademark paragraph, with the CCPA icon after the label.
- Staging already proved the links work, so a feature flag is no longer needed.

## What

- Always render the Iubenda links in the assembler footer footnote.
- Remove `PRIVACY_CONSENT` / `PrivacyConsentEnabled`.

## Notes

- Isolated and Codex footers are unchanged.
- `config/assembler.yml` only drops the staging flag key. Sibling flags stay as they are.


Made with [Cursor](https://cursor.com)