### PR TITLE
Landing page: hide the empty mobile hamburger

### DIFF
--- a/src/Elastic.Documentation.Site/Assets/styles.css
+++ b/src/Elastic.Documentation.Site/Assets/styles.css
@@ -129,10 +129,13 @@ body {
 				max-height 0.3s ease;
 		}
 
+		#toc-nav.sidebar-nav {
+			box-sizing: border-box;
+			padding-top: 24px;
+		}
+
 		@media (width >= 1280px) {
 			#toc-nav.sidebar-nav {
-				box-sizing: border-box;
-				padding-top: 24px;
 				padding-bottom: 24px;
 			}
 		}

--- a/src/Elastic.Documentation.Site/_ViewModels.cs
+++ b/src/Elastic.Documentation.Site/_ViewModels.cs
@@ -72,6 +72,23 @@ public record GlobalLayoutViewModel
 		}
 	}
 
+	/// <summary>
+	/// True when the mobile pages drawer has something to show: a nav tree,
+	/// or (with <c>navigation-preview</c>) section tabs or a version picker.
+	/// </summary>
+	public bool HasMobilePagesNavContent
+	{
+		get
+		{
+			if (!string.IsNullOrWhiteSpace(NavigationHtml))
+				return true;
+			if (!Features.NavigationPreviewEnabled)
+				return false;
+			var hasTopNavLinks = TopNav?.Items.OfType<TopNavLinkItem>().Any() == true;
+			return hasTopNavLinks || ShowVersionDropdown;
+		}
+	}
+
 	public string? VersionDropdownSerializedModel { get; init; }
 
 	public string? CurrentVersion { get; init; }

--- a/src/Elastic.Markdown/Layout/_TableOfContents.cshtml
+++ b/src/Elastic.Markdown/Layout/_TableOfContents.cshtml
@@ -3,10 +3,10 @@
 @using Microsoft.AspNetCore.Html
 @inherits RazorSlice<Elastic.Markdown.MarkdownLayoutViewModel>
 <aside class="sidebar md:block w-full lg:max-w-65 order-1 lg:order-2">
-	<nav id="toc-nav" class="sidebar-nav lg:h-full flex lg:block items-center justify-start md:justify-start gap-4 simple-scrollbar">
+	<nav id="toc-nav" class="sidebar-nav lg:h-full flex flex-row-reverse justify-between items-center md:flex-row md:justify-start lg:block gap-4 simple-scrollbar">
 		@if (Model.ShowVersionDropdown && !Model.Features.NavigationPreviewEnabled)
 		{
-			<div class="mb-4">
+			<div class="lg:mb-4">
 				<version-dropdown data-testid="docs-version-dropdown" all-versions-url="@Model.AllVersionsUrl" current-version='@(Model.CurrentVersion)' items='@(new HtmlString(Model.VersionDropdownSerializedModel))'>
 					<div class="h-8">@*height of dropdown button*@</div>
 				</version-dropdown>
@@ -20,7 +20,7 @@
 		@if (Model.RenderHamburgerIcon)
 		{
 			@* ReSharper disable once Html.IdNotResolved *@
-			<label role="button" class="md:hidden cursor-pointer mt-3" for="pages-nav-hamburger">
+			<label role="button" class="md:hidden cursor-pointer" for="pages-nav-hamburger">
 				<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
 					stroke="currentColor" class="size-6">
 					<path stroke-linecap="round" stroke-linejoin="round"

--- a/src/Elastic.Markdown/Page/Index.cshtml
+++ b/src/Elastic.Markdown/Page/Index.cshtml
@@ -14,7 +14,6 @@
 	{
 		DocsBuilderVersion = ShortId.Create(BuildContext.Version),
 		Layout = Model.CurrentDocument.YamlFrontMatter?.Layout,
-		RenderHamburgerIcon = Model.CurrentDocument.YamlFrontMatter?.Layout != MarkdownPageLayout.LandingPage,
 		DocSetName = Model.DocSetName,
 		Title = $"{Model.Title} | {Model.SiteName}",
 		Description = Model.Description,

--- a/src/Elastic.Markdown/_Layout.cshtml
+++ b/src/Elastic.Markdown/_Layout.cshtml
@@ -92,27 +92,6 @@
 		</div>
 	}
 
-	private async Task RenderLanding()
-	{
-		<div class="relative">
-			<input type="checkbox" class="hidden" id="pages-nav-hamburger">
-			@if (!string.IsNullOrWhiteSpace(Model.NavigationHtml) || Model.TopNav is not null || Model.ShowVersionDropdown)
-			{
-				@* ReSharper disable once Html.IdNotResolved *@
-				<label role="button" class="absolute left-4 top-3 z-10 md:hidden cursor-pointer" for="pages-nav-hamburger">
-					<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
-					     stroke="currentColor" class="size-6">
-						<path stroke-linecap="round" stroke-linejoin="round"
-						      d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25H12"/>
-					</svg>
-				</label>
-			}
-			@await RenderPartialAsync(_LandingPage.Create(Model))
-			<div class="md:hidden">
-				@await RenderPartialAsync(_PagesNav.Create(Model))
-			</div>
-		</div>
-	}
 }
 
 @if (RenderHeaderAndFooter)
@@ -134,7 +113,7 @@
 		await RenderPartialAsync(_NotFound.Create(Model));
 		break;
 	case MarkdownPageLayout.LandingPage:
-		await RenderLanding();
+		await RenderPartialAsync(_LandingPage.Create(Model));
 		break;
 	case MarkdownPageLayout.Archive:
 		await RenderPartialAsync(_Archive.Create(Model));

--- a/src/Elastic.Markdown/_Layout.cshtml
+++ b/src/Elastic.Markdown/_Layout.cshtml
@@ -92,6 +92,30 @@
 		</div>
 	}
 
+	private async Task RenderLanding()
+	{
+		<div class="relative">
+			@if (Model.HasMobilePagesNavContent)
+			{
+				<input type="checkbox" class="hidden" id="pages-nav-hamburger">
+				<label role="button" class="absolute left-4 top-3 z-10 md:hidden cursor-pointer" for="pages-nav-hamburger">
+					<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
+					     stroke="currentColor" class="size-6">
+						<path stroke-linecap="round" stroke-linejoin="round"
+						      d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25H12"/>
+					</svg>
+				</label>
+			}
+			@await RenderPartialAsync(_LandingPage.Create(Model))
+			@if (Model.HasMobilePagesNavContent)
+			{
+				<div class="md:hidden">
+					@await RenderPartialAsync(_PagesNav.Create(Model))
+				</div>
+			}
+		</div>
+	}
+
 }
 
 @if (RenderHeaderAndFooter)
@@ -113,7 +137,7 @@
 		await RenderPartialAsync(_NotFound.Create(Model));
 		break;
 	case MarkdownPageLayout.LandingPage:
-		await RenderPartialAsync(_LandingPage.Create(Model));
+		await RenderLanding();
 		break;
 	case MarkdownPageLayout.Archive:
 		await RenderPartialAsync(_Archive.Create(Model));

--- a/tests/Navigation.Tests/Rendering/LandingLayoutRenderingTests.cs
+++ b/tests/Navigation.Tests/Rendering/LandingLayoutRenderingTests.cs
@@ -10,6 +10,7 @@ using Elastic.Documentation.Configuration.Builder;
 using Elastic.Documentation.Configuration.Toc;
 using Elastic.Documentation.Configuration.Versions;
 using Elastic.Documentation.Navigation;
+using Elastic.Documentation.Navigation.Assembler;
 using Elastic.Documentation.Navigation.Tests.Isolation;
 using Elastic.Documentation.Site;
 using Elastic.Documentation.Site.FileProviders;
@@ -24,32 +25,47 @@ public class LandingLayoutRenderingTests(ITestOutputHelper output) : Documentati
 	[Fact]
 	public async Task LandingPage_OmitsEmptyMobileHamburger()
 	{
-		var html = await RenderLanding();
+		var html = await RenderLanding(navigationPreviewEnabled: false);
 
 		html.Should().Contain("Elastic Docs");
 		html.Should().NotContain("pages-nav-hamburger");
 		html.Should().NotContain("id=\"pages-nav\"");
 	}
 
-	private async Task<string> RenderLanding()
+	[Fact]
+	public async Task LandingPage_WithNavigationPreview_RendersMobileDrawer()
+	{
+		var html = await RenderLanding(navigationPreviewEnabled: true);
+
+		html.Should().Contain("pages-nav-hamburger");
+		html.Should().Contain("id=\"pages-nav\"");
+		html.Should().Contain("secondary-nav-mobile-menu");
+		html.Should().Contain("<version-dropdown");
+	}
+
+	private async Task<string> RenderLanding(bool navigationPreviewEnabled)
 	{
 		var fileSystem = new MockFileSystem();
 		fileSystem.AddDirectory("/docs");
 		var context = CreateContext(fileSystem);
+		var siteRoot = new MockSiteNavigationRoot(new TopNavRenderModel([new TopNavLinkItem("Reference", "/docs/reference/", false)]));
+		var currentNavItem = new StubNavigationItem("/docs/") { Parent = siteRoot };
 
 		var model = new MarkdownLayoutViewModel
 		{
 			DocsBuilderVersion = "test",
 			DocSetName = "test",
 			Description = "",
-			CurrentNavigationItem = new StubNavigationItem("/docs/"),
+			CurrentNavigationItem = currentNavItem,
 			Previous = null,
 			Next = null,
 			NavigationHtml = "",
 			UrlPathPrefix = "/docs",
 			CanonicalBaseUrl = null,
 			AllowIndexing = false,
-			Features = new FeatureFlags([]),
+			Features = navigationPreviewEnabled
+				? new FeatureFlags(new Dictionary<string, bool> { ["navigation-preview"] = true })
+				: new FeatureFlags([]),
 			GoogleTagManager = new GoogleTagManagerConfiguration(),
 			Optimizely = new OptimizelyConfiguration(),
 			StaticFileContentHashProvider = new StaticFileContentHashProvider(new EmbeddedOrPhysicalFileProvider(context)),
@@ -84,5 +100,21 @@ public class LandingLayoutRenderingTests(ITestOutputHelper output) : Documentati
 		public INodeNavigationItem<INavigationModel, INavigationItem>? Parent { get; set; }
 		public bool Hidden => false;
 		public int NavigationIndex { get; set; }
+	}
+
+	private sealed class MockSiteNavigationRoot(
+		TopNavRenderModel? topNav
+	) : INodeNavigationItem<INavigationModel, INavigationItem>, ISiteNavigationRoot
+	{
+		public TopNavRenderModel? TopNav { get; } = topNav;
+		public string Id => "mock-site";
+		public string Url => "/";
+		public string NavigationTitle => "Mock Site";
+		public IRootNavigationItem<INavigationModel, INavigationItem> NavigationRoot => null!;
+		public INodeNavigationItem<INavigationModel, INavigationItem>? Parent { get; set; }
+		public bool Hidden => false;
+		public int NavigationIndex { get; set; }
+		public ILeafNavigationItem<INavigationModel> Index => null!;
+		public IReadOnlyCollection<INavigationItem> NavigationItems => [];
 	}
 }

--- a/tests/Navigation.Tests/Rendering/LandingLayoutRenderingTests.cs
+++ b/tests/Navigation.Tests/Rendering/LandingLayoutRenderingTests.cs
@@ -10,7 +10,6 @@ using Elastic.Documentation.Configuration.Builder;
 using Elastic.Documentation.Configuration.Toc;
 using Elastic.Documentation.Configuration.Versions;
 using Elastic.Documentation.Navigation;
-using Elastic.Documentation.Navigation.Assembler;
 using Elastic.Documentation.Navigation.Tests.Isolation;
 using Elastic.Documentation.Site;
 using Elastic.Documentation.Site.FileProviders;
@@ -37,15 +36,13 @@ public class LandingLayoutRenderingTests(ITestOutputHelper output) : Documentati
 		var fileSystem = new MockFileSystem();
 		fileSystem.AddDirectory("/docs");
 		var context = CreateContext(fileSystem);
-		var siteRoot = new MockSiteNavigationRoot(new TopNavRenderModel([new TopNavLinkItem("Reference", "/docs/reference/", false)]));
-		var currentNavItem = new StubNavigationItem("/docs/") { Parent = siteRoot };
 
 		var model = new MarkdownLayoutViewModel
 		{
 			DocsBuilderVersion = "test",
 			DocSetName = "test",
 			Description = "",
-			CurrentNavigationItem = currentNavItem,
+			CurrentNavigationItem = new StubNavigationItem("/docs/"),
 			Previous = null,
 			Next = null,
 			NavigationHtml = "",
@@ -68,7 +65,6 @@ public class LandingLayoutRenderingTests(ITestOutputHelper output) : Documentati
 			Breadcrumbs = [],
 			PageTocItems = [],
 			Layout = MarkdownPageLayout.LandingPage,
-			RenderHamburgerIcon = false,
 			VersioningSystem = new VersioningSystem
 			{
 				Id = VersioningSystemId.Stack,
@@ -88,21 +84,5 @@ public class LandingLayoutRenderingTests(ITestOutputHelper output) : Documentati
 		public INodeNavigationItem<INavigationModel, INavigationItem>? Parent { get; set; }
 		public bool Hidden => false;
 		public int NavigationIndex { get; set; }
-	}
-
-	private sealed class MockSiteNavigationRoot(
-		TopNavRenderModel? topNav
-	) : INodeNavigationItem<INavigationModel, INavigationItem>, ISiteNavigationRoot
-	{
-		public TopNavRenderModel? TopNav { get; } = topNav;
-		public string Id => "mock-site";
-		public string Url => "/";
-		public string NavigationTitle => "Mock Site";
-		public IRootNavigationItem<INavigationModel, INavigationItem> NavigationRoot => null!;
-		public INodeNavigationItem<INavigationModel, INavigationItem>? Parent { get; set; }
-		public bool Hidden => false;
-		public int NavigationIndex { get; set; }
-		public ILeafNavigationItem<INavigationModel> Index => null!;
-		public IReadOnlyCollection<INavigationItem> NavigationItems => [];
 	}
 }

--- a/tests/Navigation.Tests/Rendering/LandingLayoutRenderingTests.cs
+++ b/tests/Navigation.Tests/Rendering/LandingLayoutRenderingTests.cs
@@ -1,0 +1,108 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO.Abstractions.TestingHelpers;
+using AwesomeAssertions;
+using Elastic.Documentation;
+using Elastic.Documentation.Configuration.Assembler;
+using Elastic.Documentation.Configuration.Builder;
+using Elastic.Documentation.Configuration.Toc;
+using Elastic.Documentation.Configuration.Versions;
+using Elastic.Documentation.Navigation;
+using Elastic.Documentation.Navigation.Assembler;
+using Elastic.Documentation.Navigation.Tests.Isolation;
+using Elastic.Documentation.Site;
+using Elastic.Documentation.Site.FileProviders;
+using Elastic.Documentation.Versions;
+using Elastic.Markdown;
+using RazorSlices;
+
+namespace Elastic.Documentation.Navigation.Tests.Rendering;
+
+public class LandingLayoutRenderingTests(ITestOutputHelper output) : DocumentationSetNavigationTestBase(output)
+{
+	[Fact]
+	public async Task LandingPage_OmitsEmptyMobileHamburger()
+	{
+		var html = await RenderLanding();
+
+		html.Should().Contain("Elastic Docs");
+		html.Should().NotContain("pages-nav-hamburger");
+		html.Should().NotContain("id=\"pages-nav\"");
+	}
+
+	private async Task<string> RenderLanding()
+	{
+		var fileSystem = new MockFileSystem();
+		fileSystem.AddDirectory("/docs");
+		var context = CreateContext(fileSystem);
+		var siteRoot = new MockSiteNavigationRoot(new TopNavRenderModel([new TopNavLinkItem("Reference", "/docs/reference/", false)]));
+		var currentNavItem = new StubNavigationItem("/docs/") { Parent = siteRoot };
+
+		var model = new MarkdownLayoutViewModel
+		{
+			DocsBuilderVersion = "test",
+			DocSetName = "test",
+			Description = "",
+			CurrentNavigationItem = currentNavItem,
+			Previous = null,
+			Next = null,
+			NavigationHtml = "",
+			UrlPathPrefix = "/docs",
+			CanonicalBaseUrl = null,
+			AllowIndexing = false,
+			Features = new FeatureFlags([]),
+			GoogleTagManager = new GoogleTagManagerConfiguration(),
+			Optimizely = new OptimizelyConfiguration(),
+			StaticFileContentHashProvider = new StaticFileContentHashProvider(new EmbeddedOrPhysicalFileProvider(context)),
+			BuildType = BuildType.Assembler,
+			ShowVersionDropdown = true,
+			AllVersionsUrl = "/docs/release-versioning/all-versions",
+			CurrentVersion = "9.5.3",
+			VersionDropdownSerializedModel = "[]",
+			GithubEditUrl = null,
+			MarkdownUrl = "/docs/index.md",
+			HideEditThisPage = true,
+			ReportIssueUrl = null,
+			Breadcrumbs = [],
+			PageTocItems = [],
+			Layout = MarkdownPageLayout.LandingPage,
+			RenderHamburgerIcon = false,
+			VersioningSystem = new VersioningSystem
+			{
+				Id = VersioningSystemId.Stack,
+				Base = new SemVersion(9, 0, 0),
+				Current = new SemVersion(9, 5, 3)
+			},
+			Cta = Cta.Default
+		};
+
+		return await _Layout.Create(model).RenderAsync(cancellationToken: TestContext.Current.CancellationToken);
+	}
+
+	private sealed record StubNavigationItem(string Url) : INavigationItem
+	{
+		public string NavigationTitle => "stub";
+		public IRootNavigationItem<INavigationModel, INavigationItem> NavigationRoot => null!;
+		public INodeNavigationItem<INavigationModel, INavigationItem>? Parent { get; set; }
+		public bool Hidden => false;
+		public int NavigationIndex { get; set; }
+	}
+
+	private sealed class MockSiteNavigationRoot(
+		TopNavRenderModel? topNav
+	) : INodeNavigationItem<INavigationModel, INavigationItem>, ISiteNavigationRoot
+	{
+		public TopNavRenderModel? TopNav { get; } = topNav;
+		public string Id => "mock-site";
+		public string Url => "/";
+		public string NavigationTitle => "Mock Site";
+		public IRootNavigationItem<INavigationModel, INavigationItem> NavigationRoot => null!;
+		public INodeNavigationItem<INavigationModel, INavigationItem>? Parent { get; set; }
+		public bool Hidden => false;
+		public int NavigationIndex { get; set; }
+		public ILeafNavigationItem<INavigationModel> Index => null!;
+		public IReadOnlyCollection<INavigationItem> NavigationItems => [];
+	}
+}

--- a/tests/Navigation.Tests/Rendering/TableOfContentsRenderingTests.cs
+++ b/tests/Navigation.Tests/Rendering/TableOfContentsRenderingTests.cs
@@ -29,7 +29,9 @@ public class TableOfContentsRenderingTests(ITestOutputHelper output) : Documenta
 
 		html.Should().Contain("<version-dropdown");
 		html.Should().Contain("data-testid=\"docs-version-dropdown\"");
-		html.Should().Contain("<div class=\"mb-4\">");
+		html.Should().Contain("flex-row-reverse");
+		html.Should().Contain("justify-between");
+		html.Should().Contain("<div class=\"lg:mb-4\">");
 		html.Should().NotContain("hidden md:block");
 	}
 


### PR DESCRIPTION
The docs landing page no longer shows a hamburger that opens an empty drawer. Article pages keep the hamburger on the left of the version picker, and the picker sits 24px under the secondary nav at every width.

**Affects:** Site UI, Navigation

**Prompt summary:** Hide the empty hamburger on the docs landing page. Later asks on the same branch keep that hamburger when `navigation-preview` fills the drawer, put it left of the version picker, and add space between the secondary nav and the version picker.

## Why

The assembler site-root nav HTML is always empty. The landing layout still rendered a hamburger when `TopNav` or the version dropdown existed, so the drawer opened blank with `navigation-preview` off. When that flag is on, the same drawer holds section and version controls, so landing needs the hamburger. On article pages the TOC row did not reverse on small screens, and `#toc-nav` only padded from 1280px up, so the version picker sat flush on the secondary nav at laptop widths.

## What

#### Landing hamburger
The landing hamburger renders only when the mobile drawer has content: non-empty `NavigationHtml`, or `navigation-preview` with top-nav links or a version dropdown. Flag-off landing stays empty-hamburger-free.

#### Mobile TOC row
The TOC row uses `flex-row-reverse` below `md` so the hamburger is on the left and the version picker is on the right. Both controls share one baseline.

#### Version picker spacing
`#toc-nav` now has 24px top padding at every width, matching the breadcrumbs. Below 1280px the picker no longer sits on the secondary nav border.

#### Tests
Landing layout tests cover the empty-hamburger case and the `navigation-preview` drawer. TOC tests assert the reversed row.

## Verify

```bash
dotnet test tests/Navigation.Tests/ --filter "FullyQualifiedName~LandingLayoutRenderingTests|FullyQualifiedName~TableOfContentsRenderingTests"
```

On an article page, check a phone width and a window around 1100px: hamburger left of the version picker, 24px under the secondary nav. On `/` with `navigation-preview` off, there is no hamburger.

**Out of scope:** Article pages still open the pages-nav drawer from the TOC hamburger. Flag-off landing has no mobile pages-nav entry point.