### PR TITLE
Remove the HTMX GET cache-buster query string

### DIFF
--- a/src/Elastic.ApiExplorer/Infrastructure/ApiViewModel.cs
+++ b/src/Elastic.ApiExplorer/Infrastructure/ApiViewModel.cs
@@ -7,7 +7,6 @@ using Elastic.ApiExplorer.Operations;
 using Elastic.Documentation;
 using Elastic.Documentation.Configuration;
 using Elastic.Documentation.Configuration.Assembler;
-using Elastic.Documentation.Extensions;
 using Elastic.Documentation.Navigation;
 using Elastic.Documentation.Site;
 using Elastic.Documentation.Site.FileProviders;
@@ -81,7 +80,6 @@ public abstract class ApiViewModel(ApiRenderContext context)
 
 		return new()
 		{
-			DocsBuilderVersion = ShortId.Create(BuildContext.Version),
 			DocSetName = "Api Explorer",
 			Description = "",
 			Title = documentTitle,

--- a/src/Elastic.Codex/CodexViewModel.cs
+++ b/src/Elastic.Codex/CodexViewModel.cs
@@ -6,7 +6,6 @@ using Elastic.Codex.Navigation;
 using Elastic.Documentation;
 using Elastic.Documentation.Configuration;
 using Elastic.Documentation.Configuration.Assembler;
-using Elastic.Documentation.Extensions;
 using Elastic.Documentation.Navigation;
 using Elastic.Documentation.Site;
 using Elastic.Documentation.Site.FileProviders;
@@ -68,7 +67,6 @@ public abstract class CodexViewModel(CodexRenderContext context)
 	public GlobalLayoutViewModel CreateGlobalLayoutModel(IReadOnlyList<CodexBreadcrumb>? codexBreadcrumbs = null) =>
 		new()
 		{
-			DocsBuilderVersion = ShortId.Create(BuildContext.Version),
 			DocSetName = CodexNavigation.NavigationTitle,
 			Description = "Elastic Internal Docs",
 			CurrentNavigationItem = CurrentNavigationItem,

--- a/src/Elastic.Codex/Page/Index.cshtml
+++ b/src/Elastic.Codex/Page/Index.cshtml
@@ -1,7 +1,6 @@
 @using System.Text.Json
 @using Elastic.Documentation
 @using Elastic.Documentation.Configuration
-@using Elastic.Documentation.Extensions
 @using Elastic.Markdown.Myst.Components
 @using Markdig
 @using ViewModelSerializerContext = Elastic.Markdown.Page.ViewModelSerializerContext
@@ -24,7 +23,6 @@
 
 	public MarkdownLayoutViewModel LayoutModel => new()
 	{
-		DocsBuilderVersion = ShortId.Create(BuildContext.Version),
 		Layout = Model.CurrentDocument.YamlFrontMatter?.Layout,
 		RenderHamburgerIcon = Model.CurrentDocument.YamlFrontMatter?.Layout != MarkdownPageLayout.LandingPage,
 		DocSetName = Model.DocSetName,

--- a/src/Elastic.Documentation.Site/Assets/main.ts
+++ b/src/Elastic.Documentation.Site/Assets/main.ts
@@ -32,7 +32,7 @@ import {
 } from './web-components/shared/htmx/utils'
 import 'htmx-ext-head-support'
 import 'htmx-ext-preload'
-import { $, $optional, $$optional } from 'select-dom'
+import { $optional, $$optional } from 'select-dom'
 import { UAParser } from 'ua-parser-js'
 
 // Injected at build time from MinVer
@@ -329,36 +329,6 @@ document.body.addEventListener(
         // On previews, a generic 404 page is shown.
         if (event.detail.xhr.status === 404) {
             window.location.assign(event.detail.pathInfo.requestPath)
-        }
-    }
-)
-
-// We add a query string to the get request to make sure the requested page is up to date
-const docsBuilderVersion = $('body').dataset.docsBuilderVersion
-document.body.addEventListener(
-    'htmx:configRequest',
-    function (event: HtmxEvent) {
-        if (event.detail.verb === 'get' && docsBuilderVersion) {
-            event.detail.parameters['v'] = docsBuilderVersion
-        }
-    }
-)
-
-// Here we need to strip the v parameter from the URL so
-// that the browser doesn't show the v parameter in the address bar
-document.body.addEventListener(
-    'htmx:beforeHistoryUpdate',
-    function (event: HtmxEvent) {
-        const params = new URLSearchParams(
-            event.detail.history.path.split('?')[1] ?? ''
-        )
-        params.delete('v')
-        const pathWithoutQueryString = event.detail.history.path.split('?')[0]
-        if (params.size === 0) {
-            event.detail.history.path = pathWithoutQueryString
-        } else {
-            event.detail.history.path =
-                pathWithoutQueryString + '?' + params.toString()
         }
     }
 )

--- a/src/Elastic.Documentation.Site/_GlobalLayout.cshtml
+++ b/src/Elastic.Documentation.Site/_GlobalLayout.cshtml
@@ -11,7 +11,6 @@
 	hx-history="false"
 	class="group/body text-ink has-[#primary-nav-hamburger:checked]:overflow-hidden min-h-screen build-type-@(Model.BuildType.ToString().ToLowerInvariant())@(Model.Features.AirGappedEnabled ? " air-gapped" : "")@(Model.Features.NavigationPreviewEnabled ? " navigation-preview" : "")"
 	hx-ext="preload, head-support"
-	data-docs-builder-version="@Model.DocsBuilderVersion"
 	hx-boost="true"
 	hx-push-url="true"
 	hx-target="#main-container"

--- a/src/Elastic.Documentation.Site/_ViewModels.cs
+++ b/src/Elastic.Documentation.Site/_ViewModels.cs
@@ -37,7 +37,6 @@ public record CodexBreadcrumb(string Title, string? Url);
 
 public record GlobalLayoutViewModel
 {
-	public required string DocsBuilderVersion { get; init; }
 	public required string DocSetName { get; init; }
 	public string Title { get; set; } = "Elastic Documentation";
 	public required string Description { get; init; }

--- a/src/Elastic.Documentation.Site/synthetics/journeys/navigation-test.journey.ts
+++ b/src/Elastic.Documentation.Site/synthetics/journeys/navigation-test.journey.ts
@@ -234,8 +234,8 @@ journey('navigation test', ({ page, params }) => {
             a.textContent = 'api'
             document.querySelector('#content-container')?.appendChild(a)
         }, apiUrl)
-        // A full page load is a navigation request; an htmx request would be an
-        // XHR carrying the ?v= cache-buster. Status doesn't matter (404 locally).
+        // A full page load is a navigation request; an htmx request would be XHR.
+        // Status doesn't matter (404 locally).
         const [request] = await Promise.all([
             page.waitForRequest((req) => req.url().startsWith(apiUrl), {
                 timeout: 30000,
@@ -243,6 +243,5 @@ journey('navigation test', ({ page, params }) => {
             page.locator('#synthetic-api-link').click(),
         ])
         expect(request.isNavigationRequest()).toBe(true)
-        expect(new URL(request.url()).searchParams.has('v')).toBe(false)
     })
 })

--- a/src/Elastic.Markdown/Page/Index.cshtml
+++ b/src/Elastic.Markdown/Page/Index.cshtml
@@ -1,7 +1,6 @@
 @using System.Text.Json
 @using Elastic.Documentation
 @using Elastic.Documentation.Configuration
-@using Elastic.Documentation.Extensions
 @using Elastic.Documentation.Site
 @using Elastic.Markdown
 @using Elastic.Markdown.Myst.Components
@@ -12,7 +11,6 @@
 @functions {
 	public MarkdownLayoutViewModel LayoutModel => new()
 	{
-		DocsBuilderVersion = ShortId.Create(BuildContext.Version),
 		Layout = Model.CurrentDocument.YamlFrontMatter?.Layout,
 		RenderHamburgerIcon = Model.CurrentDocument.YamlFrontMatter?.Layout != MarkdownPageLayout.LandingPage,
 		DocSetName = Model.DocSetName,

--- a/tests/Elastic.ApiExplorer.Tests/ApiPagesNavRenderingTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/ApiPagesNavRenderingTests.cs
@@ -101,7 +101,6 @@ public partial class ApiPagesNavRenderingTests
 		);
 		return new()
 		{
-			DocsBuilderVersion = "test",
 			DocSetName = "Api Explorer",
 			Description = string.Empty,
 			CurrentNavigationItem = new LandingNavigationItem(navigationUrl).Index,

--- a/tests/Elastic.ApiExplorer.Tests/ApiTocRenderingTests.cs
+++ b/tests/Elastic.ApiExplorer.Tests/ApiTocRenderingTests.cs
@@ -50,7 +50,6 @@ public class ApiTocRenderingTests
 		var navigationItem = new LandingNavigationItem("/api/doc/elasticsearch/v9/").Index;
 		var model = new ApiLayoutViewModel
 		{
-			DocsBuilderVersion = "test",
 			DocSetName = "Api Explorer",
 			Description = string.Empty,
 			CurrentNavigationItem = navigationItem,

--- a/tests/Navigation.Tests/Rendering/SecondaryNavRenderingTests.cs
+++ b/tests/Navigation.Tests/Rendering/SecondaryNavRenderingTests.cs
@@ -302,7 +302,6 @@ public class SecondaryNavRenderingTests(ITestOutputHelper output) : Documentatio
 
 		var model = new GlobalLayoutViewModel
 		{
-			DocsBuilderVersion = "test",
 			DocSetName = "test",
 			Description = "",
 			CurrentNavigationItem = currentNavItem,

--- a/tests/Navigation.Tests/Rendering/TableOfContentsRenderingTests.cs
+++ b/tests/Navigation.Tests/Rendering/TableOfContentsRenderingTests.cs
@@ -60,7 +60,6 @@ public class TableOfContentsRenderingTests(ITestOutputHelper output) : Documenta
 
 		var model = new MarkdownLayoutViewModel
 		{
-			DocsBuilderVersion = "test",
 			DocSetName = "test",
 			Description = "",
 			CurrentNavigationItem = currentNavItem,


### PR DESCRIPTION
HTMX navigation no longer appends a builder-version `?v=` query string. Request URLs match the page URL, and the same key no longer overwrites search's product-version filter.

**Affects:** Site UI, API reference, Codex builds

**Prompt summary:** Remove the HTMX GET `?v=` cache-buster. It existed for out-of-band swap cache invalidation that no longer applies.

## Why

HTMX GET requests append a builder-version `v` query string so caches do not serve stale HTML during out-of-band swaps. Navigation now uses `hx-boost` on `#main-container`. HTMX history is already off, and static assets already use a content hash. The same `v` key overwrites the product-version filter on full-page search.

## What

#### HTMX request URLs

Boosted GET requests no longer receive a builder-version `v` parameter. History updates no longer strip that parameter. The request URL and the address bar stay aligned with the page URL.

#### Layout model

The layout no longer carries `DocsBuilderVersion` or `data-docs-builder-version`. Markdown, Codex, and API pages stop hashing the builder version into every view model.

#### Synthetics

The `/docs/api` journey still asserts a full page load through `isNavigationRequest()`. It no longer treats a missing `v` parameter as proof the click was not HTMX.

## Verify

```bash
cd src/Elastic.Documentation.Site && npm run test && npm run compile:check
dotnet test tests/Navigation.Tests/
dotnet test tests/Elastic.ApiExplorer.Tests/
```

**Out of scope:** Search still uses `?v=` for the product version. Static files still use `?v={contentHash}`.

Made with [Cursor](https://cursor.com)